### PR TITLE
refactor(CSRangeHistogram): Refactor csrangehistogram builders

### DIFF
--- a/sdcm/loader.py
+++ b/sdcm/loader.py
@@ -20,7 +20,7 @@ from typing import NamedTuple
 
 from sdcm.prometheus import NemesisMetrics
 from sdcm.utils.common import FileFollowerThread, convert_metric_to_ms
-from sdcm.utils.csrangehistogram import CSRangeHistogramBuilder, CSHistogramTags, CSRangeHistogramSummary
+from sdcm.utils.csrangehistogram import CSHistogramTags, CSWorkloadTypes, make_cs_range_histogram_summary_from_log_line
 
 LOGGER = logging.getLogger(__name__)
 
@@ -196,9 +196,8 @@ class CassandraStressHDRExporter(StressExporter):
                                   self.cpu_idx, name, self.keyspace).set(value)
 
     def split_line(self, line: str) -> list:
-        histogram = CSRangeHistogramBuilder.build_from_log_line(log_line=line,
-                                                                hst_log_start_time=self.log_start_time)
-        summary_data = CSRangeHistogramSummary(histogram).get_summary_for_operation(self.stress_operation)[0]
+        summary_data = make_cs_range_histogram_summary_from_log_line(
+            workload=CSWorkloadTypes(self.stress_operation), log_line=line, hst_log_start_time=self.log_start_time)
         self.hdr_tag, percentiles = summary_data.popitem()
         return list(percentiles.values())
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -119,7 +119,8 @@ from sdcm.utils.gce_utils import get_gce_services
 from sdcm.utils.auth_context import temp_authenticator
 from sdcm.keystore import KeyStore
 from sdcm.utils.latency import calculate_latency, analyze_hdr_percentiles
-from sdcm.utils.csrangehistogram import CSRangeHistogramBuilder, CSRangeHistogramSummary, CSHistogramTagTypes
+from sdcm.utils.csrangehistogram import CSHistogramTagTypes, CSWorkloadTypes, make_cs_range_histogram_summary, \
+    make_cs_range_histogram_summary_by_interval
 
 
 CLUSTER_CLOUD_IMPORT_ERROR = ""
@@ -3579,10 +3580,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             return {}
         self.log.info("Build HDR histogram with start time: %s, end time: %s; for operation: %s",
                       start_time, end_time, stress_operation)
-        range_histogram = CSRangeHistogramBuilder.build_histogram_from_dir(base_path=self.loaders.logdir,
-                                                                           start_time=start_time,
-                                                                           end_time=end_time)
-        histogram_data = CSRangeHistogramSummary(range_histogram, tag_type).get_summary_for_operation(stress_operation)
+        histogram_data = make_cs_range_histogram_summary(
+            workload=CSWorkloadTypes(stress_operation),
+            base_path=self.loaders.logdir, start_time=start_time, end_time=end_time,
+            tag_type=tag_type)
         return histogram_data[0] if histogram_data else {}
 
     def get_cs_range_histogram_by_interval(
@@ -3593,8 +3594,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             return []
         self.log.info("Build HDR histogram with start time: %s, end time: %s, time interval: %s for operation: %s",
                       start_time, end_time, time_interval, stress_operation)
-        range_histograms = CSRangeHistogramBuilder.build_histograms_range_with_interval(path=self.loaders.logdir,
-                                                                                        start_time=start_time,
-                                                                                        end_time=end_time,
-                                                                                        interval=time_interval)
-        return CSRangeHistogramSummary(range_histograms, tag_type).get_summary_for_operation(stress_operation)
+        return make_cs_range_histogram_summary_by_interval(
+            workload=CSWorkloadTypes(stress_operation),
+            path=self.loaders.logdir, start_time=start_time, end_time=end_time,
+            interval=time_interval, tag_type=tag_type)

--- a/sdcm/utils/csrangehistogram.py
+++ b/sdcm/utils/csrangehistogram.py
@@ -2,24 +2,20 @@ import glob
 import os.path
 import sys
 import logging
-
+import multiprocessing
 from typing import Any
 from enum import Enum
 from dataclasses import asdict, dataclass, make_dataclass
-from functools import partial
+from concurrent.futures.process import ProcessPoolExecutor
 
 from hdrh.histogram import HdrHistogram
 from hdrh.log import HistogramLogReader
 
 LOGGER = logging.getLogger(__file__)
 
+PROCESS_LIMIT = multiprocessing.cpu_count()
 TIME_INTERVAL = 600
 PERCENTILES = [50, 90, 95, 99, 99.9, 99.99, 99.999]
-UNTAGGED_KEY = "untagged"
-
-
-def generate_percentile_name(percentile: int):
-    return f"percentile_{percentile}".replace(".", "_")
 
 
 class CSHistogramTags(Enum):
@@ -27,273 +23,320 @@ class CSHistogramTags(Enum):
     READ = "READ-rt"
 
 
-class CSHistogramThroughputTags(Enum):
-    WRITE = "WRITE-st"
-    READ = "READ-st"
-
-
 class CSHistogramTagTypes(Enum):
     LATENCY = 0
     THROUGHPUT = 1
 
 
+class CSWorkloadTypes(Enum):
+    WRITE = "write"
+    READ = "read"
+    MIXED = "mixed"
+
+
+def make_cs_range_histogram_summary(  # pylint: disable=too-many-arguments,unused-argument
+        workload: CSWorkloadTypes, pattern: str = "", base_path="", start_time: int | float = 0, end_time: int | float = sys.maxsize,
+        absolute_time: bool = True, tag_type: CSHistogramTagTypes = CSHistogramTagTypes.LATENCY) -> list[dict[str, dict[str, int]]]:
+    """
+    Build Range Histogram Summary with time interval (start_time, end_time)
+    from provided hdr log file.
+    For timestamps is used absolute time in ms since epoch start
+    """
+    builder = _CSRangeHistogramBuilder(workload, tag_type, start_time, end_time)
+    if pattern:
+        builder.cs_files_pattern = pattern
+    builder.absolute_time = absolute_time
+    return builder.build_histogram_summary(base_path)
+
+
+def make_cs_range_histogram_summary_by_interval(  # pylint: disable=too-many-arguments,unused-argument
+        workload: CSWorkloadTypes, path: str, start_time: int | float, end_time: int | float, interval=TIME_INTERVAL,
+        absolute_time=True, tag_type: CSHistogramTagTypes = CSHistogramTagTypes.LATENCY) -> list[dict[str, dict[str, int]]]:
+    """
+    Build set of time range histograms (as list) from
+    single file or files search by pattern in provided
+    dir path for time range (start_time, end_time) with
+    interval 'interval'. each Time range histogram will
+    have results with time duration 'interval'.
+    """
+    builder = _CSRangeHistogramBuilder(workload, tag_type, start_time, end_time)
+    builder.absolute_time = absolute_time
+    return builder.build_histograms_summary_with_interval(path, interval)
+
+
+def make_cs_range_histogram_summary_from_log_line(
+        workload: CSWorkloadTypes, log_line: str, hst_log_start_time: float,
+        tag_type: CSHistogramTagTypes = CSHistogramTagTypes.LATENCY) -> dict[str, dict[str, int]]:
+    """
+    Build time range histogram Summary from singe hdr log file line
+    log line example:
+    #[BaseTime: 1665956621.000 (seconds since epoch)]
+    #[StartTime: 1665956621.000 (seconds since epoch), Sun Oct 16 21:43:41 UTC 2022]
+    "StartTimestamp","Interval_Length","Interval_Max","Interval_Compressed_Histogram"
+    Tag=READ-st,0.000,4.999,20.726,HISTFAAAA9d42jVUMY/kN...
+    """
+    builder = _CSRangeHistogramBuilder(workload, tag_type)
+    return builder.build_from_log_line(log_line, hst_log_start_time)
+
+
+class _CSHistogramThroughputTags(Enum):
+    WRITE = "WRITE-st"
+    READ = "READ-st"
+
+
+_CSHISTOGRAM_TAGS_MAPPING = {
+    CSHistogramTagTypes.LATENCY: {
+        CSWorkloadTypes.WRITE: [CSHistogramTags.WRITE],
+        CSWorkloadTypes.READ: [CSHistogramTags.READ],
+        CSWorkloadTypes.MIXED: [
+            CSHistogramTags.WRITE,
+            CSHistogramTags.READ
+        ]
+    },
+    CSHistogramTagTypes.THROUGHPUT: {
+        CSWorkloadTypes.WRITE: [_CSHistogramThroughputTags.WRITE],
+        CSWorkloadTypes.READ: [_CSHistogramThroughputTags.READ],
+        CSWorkloadTypes.MIXED: [
+            _CSHistogramThroughputTags.WRITE,
+            _CSHistogramThroughputTags.READ
+        ]
+    }
+}
+
+
 @dataclass
-class HistorgramSummaryBase:
+class _HistorgramSummaryBase:
     start_time: str
     end_time: str
     stddev: float
 
 
-HistorgramSummary = make_dataclass("HistorgramSummary",
-                                   [(generate_percentile_name(perc), float) for perc in PERCENTILES],
-                                   bases=(HistorgramSummaryBase,))
+def _generate_percentile_name(percentile: int):
+    return f"percentile_{percentile}".replace(".", "_")
 
 
-class CSHistogram(HdrHistogram):
+_HistorgramSummary = make_dataclass("HistorgramSummary",
+                                    [(_generate_percentile_name(perc), float) for perc in PERCENTILES],
+                                    bases=(_HistorgramSummaryBase,))
+
+
+class _CSHistogram(HdrHistogram):
     LOWEST = 1
     HIGHEST = 24 * 3600_000_000_000
     SIGNIFICANT = 3
 
     def __init__(self, *args, **kwargs):
-        super().__init__(lowest_trackable_value=CSHistogram.LOWEST,
-                         highest_trackable_value=CSHistogram.HIGHEST,
-                         significant_figures=CSHistogram.SIGNIFICANT, *args, **kwargs)
+        super().__init__(lowest_trackable_value=_CSHistogram.LOWEST,
+                         highest_trackable_value=_CSHistogram.HIGHEST,
+                         significant_figures=_CSHistogram.SIGNIFICANT, *args, **kwargs)
 
 
 @dataclass
-class CSRangeHistogram:
+class _CSRangeHistogram:
     start_time: float
     end_time: float
-    histograms: dict[str, CSHistogram]
+    hdr_tag: str | None
+    histogram: _CSHistogram | None
 
 
-class CSRangeHistogramBuilder:
-    """
-        It is namespace for methods for
-        building Time range Histogram from
-        c-s hdr logs
-    """
+class _CSRangeHistogramBuilder:
+    def __init__(self, workload: CSWorkloadTypes, tag_type: CSHistogramTagTypes,
+                 start_time: int = 0,
+                 end_time: int = sys.maxsize):
+        self.workload = workload
+        self.tag_type = tag_type
+        if self.workload and self.tag_type:
+            self.hdr_tags = [w.value for w in _CSHISTOGRAM_TAGS_MAPPING[tag_type][workload]]
+        self.start_time = start_time
+        self.end_time = end_time
 
-    CS_HDR_FILE_WC = "*/cs-hdr-*.hdr"
+# defaults
+        self.cs_files_pattern = "*/cs-hdr-*.hdr"
+        self.absolute_time = True
+
+    def build_histogram_summary(self, path: str) -> list[dict[str, dict[str, int]]]:
+        """
+        Build Range Histogram Summary from provided hdr logs files path
+        """
+        with ProcessPoolExecutor(max_workers=len(self.hdr_tags)) as executor:
+            futures = [
+                executor.submit(self.build_histogram_summary_by_tag, path, tag) for tag in self.hdr_tags]
+        scan_results = {}
+        for future in futures:
+            if result := future.result():
+                scan_results.update(result)
+        return [scan_results]
+
+    def build_histograms_summary_with_interval(self, path: str, interval=TIME_INTERVAL) -> list[dict[str, dict[str, int]]]:  # pylint: disable=too-many-locals
+        """
+        Build Several Range Histogram Summaries from provided hdr logs files path splitted by interval
+        """
+        start_ts = int(self.start_time)
+        end_ts = int(self.end_time)
+        if end_ts - start_ts < TIME_INTERVAL:
+            window_step = int(end_ts - start_ts)
+        else:
+            window_step = interval or TIME_INTERVAL
+
+        futures = []
+        interval_num = 0
+        start_intervals = range(start_ts, end_ts, window_step)
+
+        max_workers = len(start_intervals)*len(self.hdr_tags)
+        max_workers = PROCESS_LIMIT if max_workers > PROCESS_LIMIT else max_workers
+
+        with ProcessPoolExecutor(max_workers=max_workers) as executor:
+            for start_interval in start_intervals:
+                end_interval = end_ts if start_interval + window_step > end_ts else start_interval + window_step
+                for hdr_tag in self.hdr_tags:
+                    futures.append(executor.submit(self._build_histograms_summary_with_interval_by_tag,
+                                                   path, hdr_tag, start_interval, end_interval, interval_num))
+                interval_num += 1
+            results = {}
+            for future in futures:
+                if res := future.result():
+                    if res["interval_num"] not in results:
+                        results[res["interval_num"]] = {}
+                    results[res["interval_num"]].update(res["result"])
+
+        keys = list(results.keys())
+        keys.sort()
+        summary = []
+        for key in keys:
+            summary.append(results[key])
+        return summary
+
+    def build_from_log_line(self, log_line: str, hst_log_start_time: float) -> dict[str, dict[str, int]] | None:
+        """
+        Build Range Histogram Summary from provided log_line
+        """
+        tag, start, interval_len, _, encoded_hist = log_line.split(",")
+        tag = tag.split("=")[-1]
+        if tag not in self.hdr_tags:
+            raise TypeError(f"build_from_log_line: log_line has tag {tag} but expected one of {self.hdr_tags}")
+        hst_start_ts = hst_log_start_time + float(start)
+        hst_end_ts = hst_start_ts + float(interval_len)
+        histogram = _CSHistogram()
+        histogram.set_tag(tag)
+        histogram.set_start_time_stamp(hst_start_ts)
+        histogram.set_end_time_stamp(hst_end_ts)
+        histogram.decode_and_add(encoded_hist)
+
+        histogram = _CSRangeHistogram(start_time=hst_start_ts,
+                                      end_time=hst_end_ts,
+                                      histogram=histogram,
+                                      hdr_tag=tag)
+
+        return _CSRangeHistogramBuilder._get_summary_for_operation_by_hdr_tag(histogram)
+
+    def _build_histogram_from_file(self, hdr_file: str, hdr_tag: str) -> _CSRangeHistogram:
+        if not os.path.exists(hdr_file):
+            LOGGER.error("File doesn't exists: %s", hdr_file)
+            return _CSRangeHistogram(start_time=0, end_time=0, histogram=None, hdr_tag=None)
+
+        hdr_reader = HistogramLogReader(hdr_file, _CSHistogram())
+        histogram = _CSHistogram()
+        histogram.set_tag(hdr_tag)
+        while True:
+            next_hist = hdr_reader.get_next_interval_histogram(range_start_time_sec=self.start_time,
+                                                               range_end_time_sec=self.end_time,
+                                                               absolute=self.absolute_time)
+            if not next_hist:
+                break
+            tag = next_hist.get_tag()
+            if tag == hdr_tag:
+                if histogram.get_start_time_stamp() == 0:
+                    histogram.set_start_time_stamp(next_hist.get_start_time_stamp())
+                histogram.add(next_hist)
+
+        return _CSRangeHistogram(start_time=self.start_time,
+                                 end_time=self.end_time,
+                                 histogram=histogram, hdr_tag=histogram.get_tag())
+
+    def _get_list_of_hdr_files(self, base_path: str) -> list[str]:
+        """
+            find all hdr log file by pattern like glob wc
+            in profided by base_path dir.
+        """
+        if not base_path:
+            base_path = os.path.abspath(os.path.curdir)
+        hdr_files = []
+        for hdr_file in glob.glob(self.cs_files_pattern, root_dir=base_path, recursive=True):
+            hdr_files.append(os.path.join(base_path, hdr_file))
+        return hdr_files
 
     @staticmethod
-    def build_histogram_from_dir(pattern: str = "", base_path="",
-                                 start_time: float = 0,
-                                 end_time: int = sys.maxsize,
-                                 absolute_time: bool = True) -> CSRangeHistogram:
+    def _merge_range_histograms(range_histograms: list[_CSRangeHistogram]) -> _CSRangeHistogram:
+        """
+            Merge several time range histogram to one containg summary result.
+        """
+        if not range_histograms:
+            return _CSRangeHistogram(start_time=0, end_time=0, histogram=None, hdr_tag=None)
+
+        final_hst = range_histograms.pop(0)
+        for hst in range_histograms:
+            assert final_hst.hdr_tag == hst.hdr_tag, "histograms with different hdr tags cannot be merged"
+            final_hst.histogram.add(hst.histogram)
+
+            final_hst.start_time = min(final_hst.start_time, hst.start_time)
+            final_hst.end_time = max(final_hst.end_time, hst.end_time)
+        return final_hst
+
+    def _build_histogram_from_dir(self, base_path: str, hdr_tag: str, ) -> _CSRangeHistogram:
         """
             search in dir from 'base_path' with provided pattern or
             default global pattern 'CS_HDR_FILE_WC' hdr log files
             and build Range Histogram with time interval (start_time, end_time)
             For timestamps is used absolute time in ms since epoch start
         """
-        collected_histograms: list[CSRangeHistogram] = []
-        hdr_files = CSRangeHistogramBuilder.get_list_of_hdr_files(pattern, base_path)
+        collected_histograms: list[_CSRangeHistogram] = []
+        hdr_files = self._get_list_of_hdr_files(base_path)
         for hdr_file in hdr_files:
-            file_range_histogram = CSRangeHistogramBuilder.build_histogram_from_file(hdr_file,
-                                                                                     start_time,
-                                                                                     end_time,
-                                                                                     absolute_time=absolute_time)
+            file_range_histogram = self._build_histogram_from_file(hdr_file, hdr_tag)
             collected_histograms.append(file_range_histogram)
-        return CSRangeHistogramBuilder.merge_range_histograms(collected_histograms)
+        return self._merge_range_histograms(collected_histograms)
 
     @staticmethod
-    def build_histogram_from_file(hdr_file: str,
-                                  start_time: float = 0,
-                                  end_time: int = sys.maxsize,
-                                  absolute_time: bool = True) -> CSRangeHistogram:
-        """
-        Build Range Histogram with time interval (start_time, end_time)
-        from provided hdr log file.
-        For timestamps is used absolute time in ms since epoch start
-        """
-        if not os.path.exists(hdr_file):
-            LOGGER.error("File doesn't exists: %s", hdr_file)
-            return CSRangeHistogram(start_time=0, end_time=0, histograms={})
-
-        histograms: dict[str, CSHistogram] = {}
-        hdr_reader = HistogramLogReader(hdr_file, CSHistogram())
-        end_time = end_time or sys.maxsize
-        while True:
-            next_hist = hdr_reader.get_next_interval_histogram(range_start_time_sec=start_time,
-                                                               range_end_time_sec=end_time,
-                                                               absolute=absolute_time)
-            if not next_hist:
-                break
-            tag = next_hist.get_tag()
-            if not tag:
-                tag = UNTAGGED_KEY
-
-            if tag not in histograms.keys():
-                histograms[tag] = CSHistogram()
-                histograms[tag].set_tag(tag)
-            if histograms[tag].get_start_time_stamp() == 0:
-                histograms[tag].set_start_time_stamp(next_hist.get_start_time_stamp())
-            histograms[tag].add(next_hist)
-
-        return CSRangeHistogram(start_time=start_time,
-                                end_time=end_time,
-                                histograms=histograms)
+    def _get_summary_for_operation_by_hdr_tag(histogram: _CSRangeHistogram) -> dict[str, dict[str, int]] | None:
+        if parsed_summary := _CSRangeHistogramBuilder._convert_raw_histogram(histogram.histogram, histogram.start_time,
+                                                                             histogram.end_time):
+            return {histogram.hdr_tag[:-3]: asdict(parsed_summary)}
+        return None
 
     @staticmethod
-    def build_histograms_range_with_interval(path: str,
-                                             start_time: int | float, end_time: int | float,
-                                             interval=TIME_INTERVAL, absolute_time=True) -> list[CSRangeHistogram]:
-        """
-            Build set of time range histogrmas (as list) from
-            single file or files search by pattern in provided
-            dir path for time range (start_time, end_time) with
-            interval 'interval'. each Time range histogram will
-            have results with time duration 'interval'.
-        """
-
-        start_ts = int(start_time)
-        end_ts = int(end_time)
-        summary = []
-
-        if end_ts - start_ts < TIME_INTERVAL:
-            window_step = int(end_ts - start_ts)
-        else:
-            window_step = interval or TIME_INTERVAL
-
-        if os.path.exists(path) and os.path.isfile(path):
-            build_range_histogram = partial(CSRangeHistogramBuilder.build_histogram_from_file,
-                                            hdr_file=path,
-                                            absolute_time=absolute_time)
-        elif os.path.exists(path) and os.path.isdir(path):
-            build_range_histogram = partial(CSRangeHistogramBuilder.build_histogram_from_dir,
-                                            base_path=path,
-                                            absolute_time=absolute_time)
-        else:
-            return summary
-
-        for start_interval in range(start_ts, end_ts, window_step):
-            end_interval = end_ts if start_interval + window_step > end_ts else start_interval + window_step
-            range_histograms = build_range_histogram(start_time=start_interval, end_time=end_interval)
-            if not range_histograms.histograms:
-                continue
-            summary.append(range_histograms)
-
-        return summary
-
-    @staticmethod
-    def build_from_log_line(log_line: str, hst_log_start_time: float):
-        """
-        build time range histogram from singe hdr log file line
-        log line example:
-        #[BaseTime: 1665956621.000 (seconds since epoch)]
-        #[StartTime: 1665956621.000 (seconds since epoch), Sun Oct 16 21:43:41 UTC 2022]
-        "StartTimestamp","Interval_Length","Interval_Max","Interval_Compressed_Histogram"
-        Tag=READ-st,0.000,4.999,20.726,HISTFAAAA9d42jVUMY/kN...
-        """
-        tag, start, interval_len, _, encoded_hist = log_line.split(",")
-        tag = tag.split("=")[-1]
-        hst_start_ts = hst_log_start_time + float(start)
-        hst_end_ts = hst_start_ts + float(interval_len)
-        histogram = CSHistogram()
-        histogram.set_tag(tag)
-        histogram.set_start_time_stamp(hst_start_ts)
-        histogram.set_end_time_stamp(hst_end_ts)
-        histogram.decode_and_add(encoded_hist)
-
-        return CSRangeHistogram(start_time=hst_start_ts,
-                                end_time=hst_end_ts,
-                                histograms={tag: histogram})
-
-    @staticmethod
-    def get_list_of_hdr_files(pattern: str, base_path: str) -> list[str]:
-        """
-            find all hdr log file by pattern like glob wc
-            in profided by base_path dir.
-        """
-        if not pattern:
-            pattern = CSRangeHistogramBuilder.CS_HDR_FILE_WC
-        if not base_path:
-            base_path = os.path.abspath(os.path.curdir)
-        hdr_files = []
-        for hdr_file in glob.glob(pattern, root_dir=base_path, recursive=True):
-            hdr_files.append(os.path.join(base_path, hdr_file))
-        return hdr_files
-
-    @staticmethod
-    def merge_range_histograms(range_histograms: list[CSRangeHistogram]) -> CSRangeHistogram:
-        """
-            Merge several time range histogram to one containg summary result.
-        """
-        if not range_histograms:
-            return CSRangeHistogram(start_time=0, end_time=0, histograms={})
-
-        final_hst = range_histograms.pop(0)
-        for hst in range_histograms:
-            for tag in hst.histograms.keys():
-                if tag not in final_hst.histograms:
-                    final_hst.histograms[tag] = CSHistogram()
-                final_hst.histograms[tag].add(hst.histograms[tag])
-
-            final_hst.start_time = min(final_hst.start_time, hst.start_time)
-            final_hst.end_time = max(final_hst.end_time, hst.end_time)
-
-        return final_hst
-
-
-class CSRangeHistogramSummary:
-    """
-    Class to convert raw time range histograms
-    built with CSRangeHistogramBuider's methods
-    to dataclass or dict for better presentation
-    data
-    """
-
-    def __init__(self, histograms: CSRangeHistogram | list[CSRangeHistogram],
-                 tag_type: CSHistogramTagTypes = CSHistogramTagTypes.LATENCY):
-        if not isinstance(histograms, list):
-            histograms = [histograms]
-
-        self._range_histograms = histograms
-
-        if tag_type == CSHistogramTagTypes.THROUGHPUT:
-            self.cs_histogram_type_tags = CSHistogramThroughputTags
-        else:
-            self.cs_histogram_type_tags = CSHistogramTags
-
-        self.cs_operation_tag_mapping = {
-            "write": {self.cs_histogram_type_tags.WRITE: "WRITE"},
-            "read": {self.cs_histogram_type_tags.READ: "READ"},
-            "mixed": {
-                self.cs_histogram_type_tags.WRITE: "WRITE",
-                self.cs_histogram_type_tags.READ: "READ"
-            }
-        }
-
-    @staticmethod
-    def convert_raw_histogram(histogram: CSHistogram,
-                              base_start_ts: float = 0.0,
-                              base_end_ts: float = 0.0) -> "HistorgramSummary":
+    def _convert_raw_histogram(histogram: _CSHistogram,
+                               base_start_ts: float = 0.0,
+                               base_end_ts: float = 0.0) -> "_HistorgramSummary":
         percentiles_data = {}
+        if percentiles := histogram.get_percentile_to_value_dict(PERCENTILES):
+            for perc, value in percentiles.items():
+                percentiles_data[_generate_percentile_name(perc)] = round(value / 1_000_000, 2)
 
-        for perc, value in histogram.get_percentile_to_value_dict(PERCENTILES).items():
-            percentiles_data[generate_percentile_name(perc)] = round(value / 1_000_000, 2)
+            return _HistorgramSummary(
+                start_time=histogram.get_start_time_stamp() or base_start_ts,
+                end_time=histogram.get_end_time_stamp() or base_end_ts,
+                stddev=histogram.get_stddev(),
+                **percentiles_data)
+        return None
 
-        return HistorgramSummary(
-            start_time=histogram.get_start_time_stamp() or base_start_ts,
-            end_time=histogram.get_end_time_stamp() or base_end_ts,
-            stddev=histogram.get_stddev(),
-            **percentiles_data)
+    def build_histogram_summary_by_tag(self, path: str, hdr_tag: str) -> dict[str, dict[str, int]] | None:
+        if os.path.exists(path) and os.path.isfile(path):
+            histogram = self._build_histogram_from_file(
+                hdr_file=path, hdr_tag=hdr_tag)
+        elif os.path.exists(path) and os.path.isdir(path):
+            histogram = self._build_histogram_from_dir(
+                base_path=path, hdr_tag=hdr_tag)
+        else:
+            return None
 
-    def get_summary_for_operation(self, workload: str) -> list[dict[str, Any]]:
-        return self._parse_range_histogram_for_workload(workload)
+        return _CSRangeHistogramBuilder._get_summary_for_operation_by_hdr_tag(histogram)
 
-    def _parse_range_histogram_for_workload(self, workload: str) -> list[dict[str, Any]]:
-        converted_histograms = []
-        if workload not in self.cs_operation_tag_mapping:
-            return converted_histograms
+    @staticmethod
+    def _build_histograms_summary_with_interval_by_tag(path: str, hdr_tag: str, start_interval: int,
+                                                       end_interval: int, interval_num: int) -> dict[str, Any] | None:
 
-        for hst in self._range_histograms:
-            summary = {}
-            for tag, operation in self.cs_operation_tag_mapping[workload].items():
-                if tag.value in hst.histograms.keys():
-                    parsed_summary = self.convert_raw_histogram(hst.histograms[tag.value], hst.start_time, hst.end_time)
-                    summary.update({operation: asdict(parsed_summary)})
-            if summary:
-                converted_histograms.append(summary)
-        return converted_histograms
+        result = _CSRangeHistogramBuilder(None, None, start_interval,
+                                          end_interval).build_histogram_summary_by_tag(path, hdr_tag)
+        if result:
+            return {"interval_num": interval_num, "result": result}
+        return None


### PR DESCRIPTION
- Create public interfaces (functions) and hide internal logic
previously module usage looks like a call of 2 static functions from 2 different classes : 
```
histogram = CSRangeHistogramBuilder.build_from_log_line(log_line=line,
                                                                hst_log_start_time=self.log_start_time)
        summary_data = CSRangeHistogramSummary(histogram).get_summary_for_operation(self.stress_operation)[0]
```

now module has only 3 public functions on the module level. all other stuff is internal. usage is just  call of 1 function:
```
summary_data = make_cs_range_histogram_summary_from_log_line(
            workload=CSWorkloadTypes(self.stress_operation), log_line=line, hst_log_start_time=self.log_start_time)
```
- Improve performance
during profiling was found that the calling method HdrHistogram.add takes about 90% of the running time and internal logic was
build  all HdrHistograms from files  -> make Histogram Summaries based on provided tags tags(WRITE-rt, READ-rt, WRITE-st, READ-st) 

the new algorithm has 2 main improvements:
1) do not build HdrHistograms only for requested tags 
2) parallel "building HdrHistograms ->  make Histogram Summary" work per tag(in make_cs_range_histogram_summary) and "per tag"*"per interval"(in make_cs_range_histogram_summary_by_interval) 


performance test results on SCT runner (2 cores) data from mixed latency 650gb test

start_time=1679355093.7567518, end_time=1679357489.6676207 ~ 2000s
new 68.613 seconds
old 185.282 seconds

start_time=1679355093.7567518, end_time=1679367489.6676207 ~ 12000s
new 313.234 seconds
old 877.644 seconds

so 2.7-2.8 times speed increase in the slow case: latency(according to discussion with @aleksbykov) in small throughput tests speed should be the same due to the histogram file containing only 1 tag

task: https://github.com/scylladb/qa-tasks/issues/1058

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
