### PR TITLE
feature(k8s): k8s client based scylla pod logger

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1093,6 +1093,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self._db_log_reader_thread.stop()
         if self._alert_manager and self._alert_manager.is_alive():
             self._alert_manager.stop()
+        if self._journal_thread:
+            self._journal_thread.stop(timeout=5)
 
     @log_run_info
     def wait_till_tasks_threads_are_stopped(self, timeout: float = 120):

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1756,7 +1756,7 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
         return self.parent_cluster.k8s_cluster.params.get('k8s_scylla_datacenter')
 
     def start_journal_thread(self):
-        self._journal_thread = get_system_logging_thread(logs_transport="kubectl",
+        self._journal_thread = get_system_logging_thread(logs_transport="k8s_client",
                                                          node=self,
                                                          target_log_file=self.system_log)
         if self._journal_thread:


### PR DESCRIPTION
Currently we use `kubectl` based pod logger which sometimes causes problems because stops updating logs. This causes various issues, as ScyllaDB logs are needed by nemesis and to detect failures.

Switch to k8s python client based logger as it was proven to be more reliable.

refs: https://github.com/scylladb/qa-tasks/issues/979

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
