### PR TITLE
feature(aws): add suport to multi az

### DIFF
--- a/jenkins-pipelines/longevity-cdc-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/longevity-cdc-100gb-4h.jenkinsfile
@@ -6,6 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
+    availability_zone: 'a,b,c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-cdc-100gb-4h.yaml'
 

--- a/jenkins-pipelines/longevity-counters-multidc.jenkinsfile
+++ b/jenkins-pipelines/longevity-counters-multidc.jenkinsfile
@@ -5,6 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
+    availability_zone: 'a,b,c',
     region: '''["eu-west-1", "us-west-2", "us-east-1"]''',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-counters-multidc.yaml'

--- a/jenkins-pipelines/longevity-topology-changes-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-topology-changes-3h.jenkinsfile
@@ -6,6 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
+    availability_zone: 'a,b,c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-topology-changes-3h.yaml"]''',
 

--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -684,8 +684,8 @@ class MonitorSetEKS(MonitorSetAWS):
         instances = sorted(instances, key=sort_by_index)
         return [ec2.get_instance(instance['InstanceId']) for instance in instances]
 
-    def _create_instances(self, count, ec2_user_data='', dc_idx=0):
-        instances = super()._create_instances(count=count, ec2_user_data=ec2_user_data, dc_idx=dc_idx)
+    def _create_instances(self, count, ec2_user_data='', dc_idx=0, az_idx=0):
+        instances = super()._create_instances(count=count, ec2_user_data=ec2_user_data, dc_idx=dc_idx, az_idx=az_idx)
         for instance in instances:
             self._ec2_services[dc_idx].create_tags(
                 Resources=[instance.id],

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3517,11 +3517,16 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def decommission_nodes(self, add_nodes_number, rack, is_seed: Optional[Union[bool, DefaultValue]] = DefaultValue,
                            dc_idx: Optional[int] = None):
-        for _ in range(add_nodes_number):
+        for idx in range(add_nodes_number):
             if self._is_it_on_kubernetes():
+                if rack is None and self._is_it_on_kubernetes():
+                    rack = 0
                 self.set_target_node(rack=rack, is_seed=is_seed, allow_only_last_node_in_rack=True)
             else:
-                self.set_target_node(is_seed=is_seed, dc_idx=dc_idx)
+                racks_count = len(self.tester.params.get("availability_zone").split(","))
+                rack_idx = rack if rack is not None else idx % racks_count
+                # if rack is not specified, round-robin racks
+                self.set_target_node(is_seed=is_seed, dc_idx=dc_idx, rack=rack_idx)
             self.log.info("Next node will be removed %s", self.target_node)
 
             try:
@@ -3533,33 +3538,34 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                           f'{str(exc)}').publish()
 
     def disrupt_grow_shrink_cluster(self):
-        self._grow_cluster(rack=0)
-        self._shrink_cluster(rack=0)
+        self._grow_cluster(rack=None)
+        self._shrink_cluster(rack=None)
 
     def disrupt_grow_shrink_new_rack(self):
+        if not self._is_it_on_kubernetes():
+            raise UnsupportedNemesis("Adding new rack is not supported for non-k8s Scylla clusters")
         rack = max(self.cluster.racks) + 1
         self._grow_cluster(rack)
         self._shrink_cluster(rack)
 
-    def _grow_cluster(self, rack=0):
-        if rack > 0:
-            if not self._is_it_on_kubernetes():
-                raise UnsupportedNemesis("SCT rack functionality is implemented only on kubernetes")
-            self.log.info("Rack deletion is not supported on kubernetes yet. "
-                          "Please see https://github.com/scylladb/scylla-operator/issues/287")
-
+    def _grow_cluster(self, rack=None):
+        if rack is None and self._is_it_on_kubernetes():
+            rack = 0
         add_nodes_number = self.tester.params.get('nemesis_add_node_cnt')
+        racks_count = len(self.tester.params.get("availability_zone").split(","))
         self.log.info("Start grow cluster on %s nodes", add_nodes_number)
         InfoEvent(message=f"Start grow cluster on {add_nodes_number} nodes").publish()
-        for _ in range(add_nodes_number):
-            InfoEvent(message=f'GrowCluster - Add New node to {rack} rack').publish()
-            added_node = self.add_new_node(rack=rack)
+        for idx in range(add_nodes_number):
+            # if rack is not specified, round-robin racks to spread nodes evenly
+            rack_idx = rack if rack is not None else idx % racks_count
+            InfoEvent(message=f'GrowCluster - Add New node to {rack_idx} rack').publish()
+            added_node = self.add_new_node(rack=rack_idx)
             self.unset_current_running_nemesis(added_node)
             InfoEvent(message=f'GrowCluster - Done adding New node {added_node.name}').publish()
         self.log.info("Finish cluster grow")
         time.sleep(self.interval)
 
-    def _shrink_cluster(self, rack=0):
+    def _shrink_cluster(self, rack=None):
         add_nodes_number = self.tester.params.get('nemesis_add_node_cnt')
         self.log.info("Start shrink cluster by %s nodes", add_nodes_number)
         InfoEvent(message=f'Start shrink cluster by {add_nodes_number} nodes').publish()

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1312,7 +1312,8 @@ class SCTConfiguration(dict):
              help="""Use legacy cluster initialization with autobootsrap disabled and parallel node setup"""),
         dict(name="availability_zone", env="SCT_AVAILABILITY_ZONE",
              type=str,
-             help="Availability zone to use. Same for multi-region scenario."),
+             help="""Availability zone to use. Specify multiple (comma separated) to deploy resources to multi az (works on AWS).
+                  "Same for multi-region scenario."""),
         dict(name="aws_fallback_to_next_availability_zone", env="SCT_AWS_FALLBACK_TO_NEXT_AVAILABILITY_ZONE",
              type=boolean,
              help="""Try all availability zones one by one in order to maximize the chances of getting

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1600,7 +1600,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         self.k8s_cluster = eks.EksCluster(eks_cluster_version=self.params.get("eks_cluster_version"),
                                           ec2_security_group_ids=ec2_security_group_ids,
-                                          ec2_subnet_ids=ec2_subnet_ids,
+                                          ec2_subnet_ids=ec2_subnet_ids[0],
                                           credentials=self.credentials,
                                           ec2_role_arn=self.params.get("eks_role_arn"),
                                           nodegroup_role_arn=self.params.get("eks_nodegroup_role_arn"),

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -299,11 +299,13 @@ def get_ec2_network_configuration(regions: list[str], availability_zones: list[s
     ec2_security_group_ids = []
     ec2_subnet_ids = []
     for region in regions:
+        region_subnets = []
+        ec2_subnet_ids.append(region_subnets)
         aws_region = AwsRegion(region_name=region)
         for availability_zone in availability_zones:
             sct_subnet = aws_region.sct_subnet(region_az=region + availability_zone)
             assert sct_subnet, f"No SCT subnet configured for {region}! Run 'hydra prepare-aws-region'"
-            ec2_subnet_ids.append(sct_subnet.subnet_id)
+            region_subnets.append(sct_subnet.subnet_id)
 
             security_groups = []
             sct_sg = aws_region.sct_security_group

--- a/test-cases/longevity/longevity-cdc-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-4h.yaml
@@ -1,11 +1,13 @@
 test_duration: 290
 
+pre_create_keyspace: "CREATE KEYSPACE cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': '3'}  AND durable_writes = true;"
 stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=200m -mode cql3 native -rate threads=100",
               "cassandra-stress user no-warmup profile=/tmp/cdc_profile_preimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=200m -mode cql3 native -rate threads=100",
               "cassandra-stress user no-warmup profile=/tmp/cdc_profile_postimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=200m -mode cql3 native -rate threads=100",
               "cassandra-stress user no-warmup profile=/tmp/cdc_profile_preimage_postimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=200m -mode cql3 native -rate threads=100"
              ]
 
+availability_zone: 'a,b,c'
 n_db_nodes: 6
 n_loaders: 2
 n_monitor_nodes: 1
@@ -15,6 +17,7 @@ instance_type_db: 'i3.4xlarge'
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '009'
 nemesis_interval: 5
+nemesis_add_node_cnt: 3
 
 user_prefix: 'longevity-cdc-100gb-4h'
 space_node_threshold: 64424

--- a/test-cases/longevity/longevity-counters-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-multidc.yaml
@@ -4,6 +4,7 @@ pre_create_keyspace: "CREATE KEYSPACE scylla_bench WITH replication = {'class': 
 stress_cmd:      "scylla-bench -workload=uniform -mode=counter_update -replication-factor=3 -partition-count=1000 -clustering-row-count=10 -concurrency 1024 -duration 360m -validate-data"
 stress_read_cmd: "scylla-bench -workload=uniform -mode=counter_read   -replication-factor=3 -partition-count=1000 -clustering-row-count=10 -concurrency 512 -duration 360m -validate-data"
 
+availability_zone: 'a,b,c'
 n_db_nodes: '3 3 3'
 n_loaders:  3
 n_monitor_nodes: 1
@@ -17,6 +18,7 @@ space_node_threshold: 6442
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '011'
 nemesis_interval: 15
+nemesis_add_node_cnt: 3
 
 server_encrypt: true
 internode_encryption: 'dc'

--- a/test-cases/longevity/longevity-topology-changes-3h.yaml
+++ b/test-cases/longevity/longevity-topology-changes-3h.yaml
@@ -1,17 +1,19 @@
 test_duration: 260
 
-prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+pre_create_keyspace: "CREATE KEYSPACE scylla_bench WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': '3'};"
+prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=50 -clustering-row-count=10000 -clustering-row-size=uniform:1024..8192 -concurrency=25 -connection-count=25 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s"
                     ]
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
 
              "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=50 -clustering-row-count=10000 -clustering-row-size=uniform:1024..8192 -concurrency=25 -connection-count=25 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=180m",
              "scylla-bench -workload=sequential -mode=read  -replication-factor=3 -partition-count=50 -clustering-row-count=10000 -clustering-row-size=uniform:1024..8192 -concurrency=25 -connection-count=25 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=180m",
              ]
 
-n_db_nodes: 4
+availability_zone: 'a,b,c'
+n_db_nodes: 3
 n_loaders: 2
 n_monitor_nodes: 1
 
@@ -22,8 +24,9 @@ nemesis_class_name: 'SisyphusMonkey'
 nemesis_selector: ['topology_changes']
 nemesis_interval: 5
 nemesis_filter_seeds: false
+nemesis_add_node_cnt: 3
 
-seeds_num: 2
+seeds_num: 3
 
 
 user_prefix: 'longevity-topologychanges-asymetric-shards-3h'

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -206,11 +206,11 @@ def call(Map pipelineParams) {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {
                                     timeout(time: 30, unit: 'MINUTES') {
-                                        if (params.backend == 'aws' || params.backend == 'azure') {
+                                        if ((params.backend == 'aws' || params.backend == 'azure') && !params.availability_zone.contains(',')) {
                                             provisionResources(params, builder.region)
                                         } else {
                                             sh """
-                                                echo 'Skipping because non-AWS/Azure backends are not supported'
+                                                echo 'Skipping because non-AWS/Azure backends and multi-az are not supported'
                                             """
                                         }
                                         completed_stages['provision_resources'] = true


### PR DESCRIPTION
We need to support multi-az deployments in SCT to be able to cover new
test cases. Especially we aim for grow/shrink cluster tests when working
in multi-rack deployments.

Add support to multi az in AWS provisioning code (old provision). To use
multi-az, specify multiple coma-separated availability zones
(e.g. `a,b,c`).
When multi-az is specified, job's provision step is skipped.

`GrowShrinkClusterNemesis` is able to work with multi-az on AWS
backend. When `rack` is set to `None` in `discrupt_grow_shrink_cluster`,
it will be growing cluster evenly, otherwise grow only in specified rack.
Adapted 3 jobs to use multi-az on AWS.

refs: https://github.com/scylladb/qa-tasks/issues/1070

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
