### PR TITLE
fix(data validator): ignore data validator for parallel nemeses test

### DIFF
--- a/longevity_lwt_test.py
+++ b/longevity_lwt_test.py
@@ -50,12 +50,12 @@ class LWTLongevityTest(LongevityTest):
         time.sleep(300)
 
         # Data validation can be run when no nemesis, that almost not happens in case of parallel nemesis.
-        # If we even will catch period when no nemesis are running, it may happens that the nemesis will start on the
+        # If we even will catch period when no nemesis are running, it may happen that the nemesis will start in the
         # middle of data validation and fail it
         if self.db_cluster.nemesis_count > 1:
             self.data_validator = MagicMock()
             self.data_validator.keyspace_name = None
-            DataValidatorEvent.DataValidator(severity=Severity.WARNING,
+            DataValidatorEvent.DataValidator(severity=Severity.NORMAL,
                                              message="Test runs with parallel nemesis. Data validator is disabled."
                                              ).publish()
         else:
@@ -63,9 +63,9 @@ class LWTLongevityTest(LongevityTest):
                                                          user_profile_name='c-s_lwt',
                                                          base_table_partition_keys=self.BASE_TABLE_PARTITION_KEYS)
 
-        self.data_validator.copy_immutable_expected_data()
-        self.data_validator.copy_updated_expected_data()
-        self.data_validator.save_count_rows_for_deletion()
+            self.data_validator.copy_immutable_expected_data()
+            self.data_validator.copy_updated_expected_data()
+            self.data_validator.save_count_rows_for_deletion()
 
         # Run nemesis during stress as it was stopped before copy expected data
         if self.params.get('nemesis_during_prepare'):
@@ -87,7 +87,7 @@ class LWTLongevityTest(LongevityTest):
     def validate_data(self):
         node = self.db_cluster.nodes[0]
         if not (keyspace := self.data_validator.keyspace_name):
-            DataValidatorEvent.DataValidator(severity=Severity.WARNING,
+            DataValidatorEvent.DataValidator(severity=Severity.NORMAL,
                                              message="Failed fo get keyspace name. Data validator is disabled."
                                              ).publish()
             return


### PR DESCRIPTION
1. If test runs with parallel nemesis, do not try get keyspace name from data_validator and do not run the validation. Now the message is got in the log: 
```
sdcm.nemesis.DisruptiveMonkey: Data validator error: expected string or bytes-like object
```
The fix same as https://github.com/scylladb/scylla-cluster-tests/pull/5890

2. Fix few typos
3. Set severity to NORMAL for 'Data Validator is disabled' event

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
