### PR TITLE
fix(sct.log): sct.log tarball is missing the test_id

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1064,7 +1064,7 @@ class PythonSCTLogCollector(BaseSCTLogCollector):
             return res.stdout.rstrip("\n").split("\n")
 
     def create_archive_and_upload(self) -> list[str]:
-        file_archives = self.archive_to_tarfile(os.path.join(self.local_dir, "sct.log"))
+        file_archives = self.archive_to_tarfile(os.path.join(self.local_dir, "sct.log"), add_test_id_to_archive=True)
         s3_links = []
         for file_archive in file_archives:
             s3_links.append(upload_archive_to_s3(file_archive, f"{self.test_id}/{self.current_run}"))


### PR DESCRIPTION
since #5892 the tarball doesn't have the test_id in it's name, it's a bit annoying when you are looking at multiple jobs at the same time, and it's not match with the test_id as it was before

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
