### PR TITLE
fix(upgrade-tests): remove scylla-cqlsh when downgrading

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -133,7 +133,6 @@ new_scylla_repo: ''
 new_version: ''
 upgrade_node_packages: ''
 test_sst3: false
-new_introduced_pkgs: ''
 recover_system_tables: false
 scylla_version: ''
 test_upgrade_from_installed_3_1_0: false

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -265,7 +265,6 @@
 | **<a href="#user-content-upgrade_node_packages" name="upgrade_node_packages">upgrade_node_packages</a>**  |  | N/A | SCT_UPGRADE_NODE_PACKAGES
 | **<a href="#user-content-test_sst3" name="test_sst3">test_sst3</a>**  |  | N/A | SCT_TEST_SST3
 | **<a href="#user-content-test_upgrade_from_installed_3_1_0" name="test_upgrade_from_installed_3_1_0">test_upgrade_from_installed_3_1_0</a>**  | Enable an option for installed 3.1.0 for work around a scylla issue if it's true | N/A | SCT_TEST_UPGRADE_FROM_INSTALLED_3_1_0
-| **<a href="#user-content-new_introduced_pkgs" name="new_introduced_pkgs">new_introduced_pkgs</a>**  |  | N/A | SCT_NEW_INTRODUCED_PKGS
 | **<a href="#user-content-recover_system_tables" name="recover_system_tables">recover_system_tables</a>**  |  | N/A | SCT_RECOVER_SYSTEM_TABLES
 | **<a href="#user-content-stress_cmd_1" name="stress_cmd_1">stress_cmd_1</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_1
 | **<a href="#user-content-stress_cmd_complex_prepare" name="stress_cmd_complex_prepare">stress_cmd_complex_prepare</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_COMPLEX_PREPARE

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1121,9 +1121,6 @@ class SCTConfiguration(dict):
         dict(name="test_upgrade_from_installed_3_1_0", env="SCT_TEST_UPGRADE_FROM_INSTALLED_3_1_0", type=boolean,
              help="Enable an option for installed 3.1.0 for work around a scylla issue if it's true"),
 
-        dict(name="new_introduced_pkgs", env="SCT_NEW_INTRODUCED_PKGS", type=str,
-             help=""),
-
         dict(name="recover_system_tables", env="SCT_RECOVER_SYSTEM_TABLES", type=boolean,
              help=""),
 


### PR DESCRIPTION
Since cqlsh is using the same files as scylla-tools was using before, on downgrade it's need to be remove first as long as there it's a downgrade to a version before cqlsh existed.

Fix: https://github.com/scylladb/scylla-cqlsh/issues/23

## Testing
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/rolling-upgrade-centos8-test/8

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
