### PR TITLE
fix(loader-setup): install/update epel to avoid install issues

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4645,6 +4645,10 @@ class BaseLoaderSet():
                 self.log.info("Swap file for the loader is not configured")
             else:
                 node.create_swap_file(swap_size)
+
+        if node.distro.is_rhel_like:
+            node.install_epel()
+
         # update repo cache and system after system is up
         node.update_repo_cache()
 


### PR DESCRIPTION
Seems that recently we remove that call of EPEL install, and since we have image that has EPEL already this might be on connectivity issue, this is a workaround for not building the images without the EPEL.

this is the failure we've seen recently (at least five times)
```
sdcm.remote.libssh2_client.exceptions.UnexpectedExit: Encountered a bad command exit code!
Command: 'sudo yum install -y wget'
Exit code: 1
Stdout:
Loaded plugins: fastestmirror
Determining fastest mirrors
Stderr:
5. Configure the failing repository to be skipped, if it is unavailable.
Note that yum will try to contact the repo. when it runs most commands,
so will have to try and fail each time (and thus. yum will be be much
slower). If it is a very temporary problem though, this is often a nice
compromise:
yum-config-manager --save --setopt=<repoid>.skip_if_unavailable=true
Cannot retrieve metalink for repository: epel/x86_64. Please verify its path and try again
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
