### PR TITLE
fix(azure): fix clean azure resources

### DIFF
--- a/sdcm/provision/azure/provisioner.py
+++ b/sdcm/provision/azure/provisioner.py
@@ -55,7 +55,10 @@ class AzureProvisioner(Provisioner):  # pylint: disable=too-many-instance-attrib
         self._vm_provider = VirtualMachineProvider(
             self._resource_group_name, self._region, self._az, self._azure_service)
         for v_m in self._vm_provider.list():
-            self._cache[v_m.name] = self._vm_to_instance(v_m)
+            try:
+                self._cache[v_m.name] = self._vm_to_instance(v_m)
+            except KeyError as exc:
+                LOGGER.warning("Failed to cache %s instance. Probably is pending deletion. Error: %s", v_m.name, exc)
 
     @staticmethod
     def _convert_az_to_zone(availability_zone: str) -> str:


### PR DESCRIPTION
When cleaning resources after test we trigger cleanup resources multiple time. Each time AzureProvisioner tries to discover instances for given test. When VM is pending delete, additional resources like ip address might be already evicted, causing issue with building provisioner cache.

Catch those cases and show only warning instead of failing cleanup.

fixes: #5860

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
