### PR TITLE
fix(_destroy_data_and_restart_scylla): fail properly when all non system tables are empty

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3519,7 +3519,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         """
         try:
             result = session.execute(SimpleStatement(f"SELECT * FROM {table_name}", fetch_size=10))
-            return bool(len(result.one())), None
+            return result and bool(len(result.one())), None
 
         except Exception as exc:  # pylint: disable=broad-except
             self.log.warning(f'Failed to get rows from {table_name} table. Error: {exc}')

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1057,7 +1057,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 if len(tables) > 20:
                     break
 
-        if not tables and errors:
+        if not tables:
             raise ValueError(
                 f'A non-empty user table is not found. Nemesis can\'t run. Got errors of: {errors}')
 


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
