### PR TITLE
fix(disrupt_decommission_streaming_err): skip failure log

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -221,6 +221,12 @@ def ignore_stream_mutation_fragments_errors():
             regex=r".*storage_proxy \- exception during mutation write.*gate_closed_exception",
             extra_time_to_expiration=30
         ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*storage_service \- .*Operation failed",
+            extra_time_to_expiration=30
+        ))
         yield
 
 


### PR DESCRIPTION
Since RBNO is enabled, this nemesis is generating those logs:
```
scylla[5576]:  [shard  0] storage_service - decommission[aa9a834d-99b1-4af8-9267-cec699bb5140]:
Operation failed, sync_nodes={10.4.0.45, 10.4.3.213, 10.4.3.145, 10.4.1.131, 10.4.2.77,
10.4.2.119}: std::runtime_error ({shard 0: std::runtime_error (Failed to repair for
keyspace=alternator_usertable, cf=usertable, range=(-7819559552726985616, -7814482230290657926]),
 shard 1: std::runtime_error (Failed to repair for keyspace=alternator_usertable, cf=usertable,
 range=(-8277937157109075297, -8260575255900646513]), shard 2: std::runtime_error (Failed to
 repair for keyspace=alternator_usertable, cf=usertable, range=(-7814091121065622595,
 -7810918921443784702]), shard 3: std::runtime_error (Failed to repair for
 keyspace=alternator_usertable, cf=usertable, range=(-7920656420086354667, -7913393766828895675]),
 shard 4: std::runtime_error (Failed to repair for keyspace=alternator_usertable, cf=usertable,
 range=(-8217905152047068797, -8180520229346198706]), shard 5: std::runtime_error (Failed to
repair for keyspace=alternator_usertable, cf=usertable, range=(-8217905152047068797,
-8180520229346198706]), shard 6: std::runtime_error (Failed to repair for
keyspace=alternator_usertable, cf=usertable, range=(-8053837487533107823, -8014098015270410936]),
...
```

This error is expected, since we are delebritly failing the operation

Fixes: #5926

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
