### PR TITLE
fix(network nemeses jobs): add right configuration

### DIFF
--- a/test-cases/nemesis/longevity-5gb-1h-BlockNetworkMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-BlockNetworkMonkey.yaml
@@ -18,6 +18,8 @@ azure_instance_type_db: 'Standard_L8s_v3'
 instance_type_loader: 'c5.large'
 azure_instance_type_loader: 'Standard_F2s_v2'
 
+extra_network_interface: true
+
 nemesis_class_name: 'BlockNetworkMonkey'
 nemesis_interval: 3
 nemesis_filter_seeds: false

--- a/test-cases/nemesis/longevity-5gb-1h-RandomInterruptionNetworkMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RandomInterruptionNetworkMonkey.yaml
@@ -18,6 +18,8 @@ azure_instance_type_db: 'Standard_L8s_v3'
 instance_type_loader: 'c5.large'
 azure_instance_type_loader: 'Standard_F2s_v2'
 
+extra_network_interface: true
+
 nemesis_class_name: 'RandomInterruptionNetworkMonkey'
 nemesis_interval: 3
 nemesis_filter_seeds: false

--- a/test-cases/nemesis/longevity-5gb-1h-StopStartInterfacesNetworkMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-StopStartInterfacesNetworkMonkey.yaml
@@ -18,6 +18,8 @@ azure_instance_type_db: 'Standard_L8s_v3'
 instance_type_loader: 'c5.large'
 azure_instance_type_loader: 'Standard_F2s_v2'
 
+extra_network_interface: true
+
 nemesis_class_name: 'StopStartInterfacesNetworkMonkey'
 nemesis_interval: 3
 nemesis_filter_seeds: false


### PR DESCRIPTION
all these network nemeses required an extra network interface to run, and they were missing from the
default configuration, and this PR is adding this
required extra network interface.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
