### PR TITLE
improvement(Materialized View): Add-remove MV nemesis

### DIFF
--- a/data_dir/nemesis.yml
+++ b/data_dir/nemesis.yml
@@ -22,6 +22,10 @@
   - disruptive = False
   - schema_changes = True
   - free_tier_set = True
+- disrupt_add_remove_mv:
+  - disruptive = True
+  - schema_changes = True
+  - free_tier_set = True
 - disrupt_decommission_streaming_err:
   - disruptive = True
   - topology_changes = True

--- a/data_dir/nemesis_classes.yml
+++ b/data_dir/nemesis_classes.yml
@@ -10,6 +10,7 @@
 - CorruptThenRepairMonkey
 - CorruptThenScrubMonkey
 - CreateIndexNemesis
+- AddRemoveMvNemesis
 - DecommissionMonkey
 - DecommissionSeedNode
 - DecommissionStreamingErrMonkey

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -101,7 +101,8 @@ from sdcm.utils.k8s.chaos_mesh import MemoryStressExperiment, IOFaultChaosExperi
 from sdcm.utils.ldap import SASLAUTHD_AUTHENTICATOR, LdapServerType
 from sdcm.utils.loader_utils import DEFAULT_USER, DEFAULT_USER_PASSWORD, SERVICE_LEVEL_NAME_TEMPLATE
 from sdcm.utils.nemesis_utils.indexes import get_random_column_name, create_index, \
-    wait_for_index_to_be_built, verify_query_by_index_works, drop_index
+    wait_for_index_to_be_built, verify_query_by_index_works, drop_index, get_partition_key_name, \
+    wait_for_view_to_be_built, drop_materialized_view
 from sdcm.utils.replication_strategy_utils import temporary_replication_strategy_setter, \
     NetworkTopologyReplicationStrategy, ReplicationStrategy, SimpleReplicationStrategy
 from sdcm.utils.sstable.load_utils import SstableLoadUtils
@@ -4126,6 +4127,44 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             finally:
                 drop_index(session, ks, index_name)
 
+    def disrupt_add_remove_mv(self):
+        """
+        Create a Materialized view on an existing table while a node is down.
+        Take node up and run a repair.
+        Verify the MV can be used in a query.
+        Finally, drop the MV.
+        """
+        node1, node2 = self.cluster.nodes[:2]
+        self.log.info("Stopping Scylla on node1")
+        ks_cfs = self.cluster.get_non_system_ks_cf_list(db_node=node2, filter_empty_tables=True, filter_out_mv=True)
+        if not ks_cfs:
+            raise UnsupportedNemesis(
+                'Non-system keyspace and table are not found. nemesis can\'t be run')
+        ks_name, base_table_name = random.choice(ks_cfs).split('.')
+        view_name = f'{base_table_name}_view'
+        node1.stop_scylla()
+        with self.cluster.cql_connection_patient(node2) as session:
+            partition_key_name = get_partition_key_name(session=session, ks=ks_name, cf=base_table_name)
+            column = f'"{get_random_column_name(session=session, ks=ks_name, cf=base_table_name)}"'
+            InfoEvent(message=f'Create a materialized-view for table {ks_name}.{base_table_name}').publish()
+            try:
+                self.tester.create_materialized_view(ks_name, base_table_name, view_name, [column],
+                                                     [partition_key_name], session,
+                                                     mv_columns=[column, partition_key_name])
+            except Exception as error:  # pylint: disable=broad-except
+                self.log.warning('Failed creating a materialized view: %s', error)
+                raise
+            try:
+                self.log.info("Starting Scylla on node1")
+                node1.start_scylla()
+                node1.run_nodetool(sub_cmd="repair -pr")
+                wait_for_view_to_be_built(self.target_node, ks_name, view_name, timeout=7200)
+                session.execute(SimpleStatement(f'SELECT * FROM {ks_name}.{view_name} limit 1', fetch_size=10))
+                sleep_for_percent_of_duration(self.tester.test_duration * 60, percent=1,
+                                              min_duration=300, max_duration=2400)
+            finally:
+                drop_materialized_view(session, ks_name, view_name)
+
 
 def disrupt_method_wrapper(method, is_exclusive=False):  # pylint: disable=too-many-statements
     """
@@ -5509,3 +5548,13 @@ class CreateIndexNemesis(Nemesis):
 
     def disrupt(self):
         self.disrupt_create_index()
+
+
+class AddRemoveMvNemesis(Nemesis):
+
+    disruptive = True
+    schema_changes = True
+    free_tier_set = True
+
+    def disrupt(self):
+        self.disrupt_add_remove_mv()

--- a/test-cases/nemesis/longevity-5gb-1h-AddRemoveMvNemesis.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-AddRemoveMvNemesis.yaml
@@ -1,0 +1,31 @@
+test_duration: 90
+
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+             ]
+
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1
+seeds_num: 3
+
+instance_type_db: 'i4i.large'
+gce_instance_type_db: 'n1-highmem-2'
+gce_instance_type_loader: 'e2-standard-2'
+azure_instance_type_db: 'Standard_L8s_v3'
+instance_type_loader: 'c5.large'
+azure_instance_type_loader: 'Standard_F2s_v2'
+
+nemesis_class_name: 'AddRemoveMvNemesis'
+nemesis_interval: 3
+nemesis_filter_seeds: false
+nemesis_during_prepare: true
+
+gce_n_local_ssd_disk_db: 1
+
+user_prefix: 'longevity-5gb-1h-AddRemoveMvNemesis'
+
+server_encrypt: true
+client_encrypt: true

--- a/unit_tests/test_nemesis.py
+++ b/unit_tests/test_nemesis.py
@@ -229,6 +229,7 @@ class TestSisyphusMonkeyNemesisFilter:
             "disrupt_modify_table",
             "disrupt_toggle_table_gc_mode",
             "disrupt_create_index",
+            "disrupt_add_remove_mv",
         ]
 
     @pytest.fixture(autouse=True)

--- a/unit_tests/test_nemesis_sisyphus.py
+++ b/unit_tests/test_nemesis_sisyphus.py
@@ -71,7 +71,7 @@ def test_list_all_available_nemesis(generate_file=True):
     disruption_list, disruptions_dict, disruption_classes = sisyphus.get_list_of_disrupt_methods(
         subclasses_list=subclasses, export_properties=True)
 
-    assert len(disruption_list) == 76
+    assert len(disruption_list) == 77
 
     if generate_file:
         with open('data_dir/nemesis.yml', 'w', encoding="utf-8") as outfile1:


### PR DESCRIPTION
	Select an existing user-table and create a materialized-view
	when a node is down.

Task: https://github.com/scylladb/qa-tasks/issues/1012
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
