### PR TITLE
test(upgrade): support upgrade from OSS to Enterprise with SLA

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -813,10 +813,14 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
 
         roles = []
         service_level_shares = self.params.get("service_level_shares")
+        # OSS Scylla version does not support "shares" option for Service Level
+        if service_level_shares and not self.db_cluster.nodes[0].is_enterprise:
+            service_level_shares = [None for _ in service_level_shares]
+
         with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0], user=loader_utils.DEFAULT_USER,
                                                     password=loader_utils.DEFAULT_USER_PASSWORD) as session:
             for index, shares in enumerate(service_level_shares):
-                roles.append(create_sla_auth(session=session, shares=shares, index=index))
+                roles.append(create_sla_auth(session=session, shares=shares, index=str(index)))
 
         self.add_sla_credentials_to_stress_cmds(workload_names=workloads_with_sla, roles=roles,
                                                 params=self.params, parent_class_name=self.__class__.__name__)


### PR DESCRIPTION
Upgrade from 5.1 failed because SLA in OSS does not support "shares" option.

Adapt the upgrade test do not use shares for OSS version.

Test passed:
https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/rolling-upgrade-with-sla/24/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
