### PR TITLE
fix(argus.py): Handle TypeError exception in is_uuid as well

### DIFF
--- a/sdcm/utils/argus.py
+++ b/sdcm/utils/argus.py
@@ -26,7 +26,7 @@ def is_uuid(uuid) -> bool:
     try:
         UUID(uuid)
         return True
-    except (ValueError, AttributeError):
+    except (ValueError, AttributeError, TypeError):
         return False
 
 


### PR DESCRIPTION
 Handle TypeError exception is_uuid that happened during hydra clean-resources --user <user> command


```
  File "/Users/roy/git/scylla/scylla-cluster-tests/sdcm/utils/argus.py", line 27, in is_uuid
    UUID(uuid)
  File "/Users/roy/.pyenv/versions/3.10.0/lib/python3.10/uuid.py", line 171, in __init__
    raise TypeError('one of the hex, bytes, bytes_le, fields, '
TypeError: one of the hex, bytes, bytes_le, fields, or int arguments must be given

```


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
