### PR TITLE
ci(serverless): add configs for testing 1 and 2 vcpus Scylla clusters

### DIFF
--- a/configurations/operator/perf-serverless-thrpt-1vcpu.yaml
+++ b/configurations/operator/perf-serverless-thrpt-1vcpu.yaml
@@ -1,0 +1,18 @@
+email_subject_postfix: 'Scylla-Cloud backend'
+email_recipients: ['scylla-perf-results@scylladb.com', 'operator@scylladb.com']
+
+k8s_scylla_cluster_name: "sct-perf-thrpt-1vcpu"
+user_prefix: "perf-thrpt-1vcpu"
+
+n_loaders: 1
+stress_multiplier: 1
+instance_type_loader: 'c5.2xlarge'
+round_robin: true
+# https://github.com/scylladb/scylla-cluster-tests/issues/5883
+use_hdr_cs_histogram: false
+
+# NOTE: following are tmp values for testing 1vCPUs/8GbRAM single serverless Scylla cluster
+prepare_write_cmd: "cassandra-stress write no-warmup cl=ALL n=25165824 -schema 'replication(factor=3)' -rate threads=170 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..25165824 -mode cql3 native"
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=30m -schema 'replication(factor=3)' -rate threads=170 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..25165824,12582912,503316)' -mode cql3 native"
+stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=30m -schema 'replication(factor=3)' -rate threads=275 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..25165824,12582912,503316)' -mode cql3 native"
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=30m -schema 'replication(factor=3)' -rate threads=215 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..25165824,12582912,503316)' -mode cql3 native"

--- a/configurations/operator/perf-serverless-thrpt-2vcpu.yaml
+++ b/configurations/operator/perf-serverless-thrpt-2vcpu.yaml
@@ -1,0 +1,18 @@
+email_subject_postfix: 'Scylla-Cloud backend'
+email_recipients: ['scylla-perf-results@scylladb.com', 'operator@scylladb.com']
+
+k8s_scylla_cluster_name: "sct-perf-thrpt-2vcpus"
+user_prefix: "perf-thrpt-2vcpus"
+
+n_loaders: 1
+stress_multiplier: 1
+instance_type_loader: 'c5.2xlarge'
+round_robin: true
+# https://github.com/scylladb/scylla-cluster-tests/issues/5883
+use_hdr_cs_histogram: false
+
+# NOTE: following are tmp values for testing 2vCPUs/16GbRAM single serverless Scylla cluster
+prepare_write_cmd: "cassandra-stress write no-warmup cl=ALL n=50331648 -schema 'replication(factor=3)' -mode cql3 native -rate threads=340 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..50331648"
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=30m -schema 'replication(factor=3)' -mode cql3 native -rate threads=340 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..50331648,25165824,1006632)' "
+stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=30m -schema 'replication(factor=3)' -mode cql3 native -rate threads=550 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..50331648,25165824,1006632)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=30m -schema 'replication(factor=3)' -mode cql3 native -rate threads=430 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..50331648,25165824,1006632)' "


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
