### PR TITLE
improvement(thrpt-perf): allow to change the number of stress threads

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -491,13 +491,14 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         """
         # run a write workload
         base_cmd_w = self.params.get('stress_cmd_w')
+        stress_multiplier = self.params.get('stress_multiplier')
         # create new document in ES with doc_id = test_id + timestamp
         # allow to correctly save results for future compare
         self.create_test_stats(doc_id_with_timestamp=True)
         self.run_fstrim_on_all_db_nodes()
         # run a workload
-        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_w, stress_num=2, keyspace_num=1,
-                                              stats_aggregate_cmds=False)
+        stress_queue = self.run_stress_thread(
+            stress_cmd=base_cmd_w, stress_num=stress_multiplier, stats_aggregate_cmds=False)
         results = self.get_stress_results(queue=stress_queue)
 
         self.build_histogram(PerformanceTestWorkload.WRITE, PerformanceTestType.THROUGHPUT)
@@ -514,6 +515,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         """
 
         base_cmd_r = self.params.get('stress_cmd_r')
+        stress_multiplier = self.params.get('stress_multiplier')
         self.run_fstrim_on_all_db_nodes()
         # run a write workload
         self.preload_data()
@@ -525,7 +527,8 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         self.wait_no_compactions_running(n=240, sleep_time=180)
         self.run_fstrim_on_all_db_nodes()
         # run a read workload
-        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_r, stress_num=2, stats_aggregate_cmds=False)
+        stress_queue = self.run_stress_thread(
+            stress_cmd=base_cmd_r, stress_num=stress_multiplier, stats_aggregate_cmds=False)
         results = self.get_stress_results(queue=stress_queue)
 
         self.build_histogram(PerformanceTestWorkload.READ, PerformanceTestType.THROUGHPUT)
@@ -542,6 +545,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         """
 
         base_cmd_m = self.params.get('stress_cmd_m')
+        stress_multiplier = self.params.get('stress_multiplier')
         self.run_fstrim_on_all_db_nodes()
         # run a write workload as a preparation
         self.preload_data()
@@ -552,7 +556,8 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         # wait compactions will be finished
         self.wait_no_compactions_running(n=240, sleep_time=180)
         self.run_fstrim_on_all_db_nodes()
-        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_m, stress_num=2, stats_aggregate_cmds=False)
+        stress_queue = self.run_stress_thread(
+            stress_cmd=base_cmd_m, stress_num=stress_multiplier, stats_aggregate_cmds=False)
         results = self.get_stress_results(queue=stress_queue)
 
         self.build_histogram(PerformanceTestWorkload.MIXED, PerformanceTestType.THROUGHPUT)

--- a/test-cases/performance/perf-regression-throughput-125gb.yaml
+++ b/test-cases/performance/perf-regression-throughput-125gb.yaml
@@ -9,6 +9,7 @@ prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=31250000 -schema 
 stress_cmd_w: "cassandra-stress write no-warmup cl=ALL n=125000000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..125000000"
 stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..125000000,62500000,125000000)' "
 stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..125000000,62500000,125000000)' "
+stress_multiplier: 2
 
 n_db_nodes: 3
 n_loaders: 4

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -4,6 +4,7 @@ stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema '
 prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM n=30000000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=100 -pop seq=1..30000000"
 stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -mode cql3 native -rate threads=100 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
 stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -mode cql3 native -rate threads=100 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
+stress_multiplier: 2
 
 # NOTE: following is needed for the K8S case
 k8s_loader_run_type: 'static'


### PR DESCRIPTION
For the moment in the `test_write`, `test_read` and `test_mixed` throughput performance tests we use hardcoded number of stress threads as `2`.
Reuse the existing `stress_multiplier` config option for it to be able to change the value gracefully.
The need to have different value comes out of the serverless clusters testing where we utilize too few vCPUs and use only 1 loader thread to measure it's perf.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
