### PR TITLE
improvement(k8s): allow to configure the auxiliary nodes instance type

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -46,6 +46,8 @@ n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
 k8s_n_auxiliary_nodes: 3
 
+k8s_instance_type_auxiliary: 't3.large'
+
 # TODO: add '--abort-on-seastar-bad-alloc' arg to the 'append_scylla_args' option when
 #       following operator bug gets fixed: https://github.com/scylladb/scylla-operator/issues/991
 #       '--blocked-reactor-notify-ms 100' cannot be set, because it gets set by operator itself

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -15,6 +15,8 @@ n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
 k8s_n_auxiliary_nodes: 2
 
+k8s_instance_type_auxiliary: 'n1-standard-2'
+
 # '4.3.0' version doesn't work with GKE: https://github.com/scylladb/scylla/issues/8032
 scylla_version: '4.5.3'
 scylla_mgmt_agent_version: '3.0.0'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -201,6 +201,7 @@
 | **<a href="#user-content-k8s_loader_cluster_name" name="k8s_loader_cluster_name">k8s_loader_cluster_name</a>**  |  | N/A | SCT_K8S_LOADER_CLUSTER_NAME
 | **<a href="#user-content-k8s_n_loader_pods_per_cluster" name="k8s_n_loader_pods_per_cluster">k8s_n_loader_pods_per_cluster</a>**  | Number of loader pods per loader cluster. | N/A | SCT_K8S_N_LOADER_PODS_PER_CLUSTER
 | **<a href="#user-content-k8s_loader_run_type" name="k8s_loader_run_type">k8s_loader_run_type</a>**  | Defines how the loader pods must run. It may be either 'static' (default, run stress command on the constantly existing idle pod having reserved resources, perf-oriented) or 'dynamic' (run stress commad in a separate pod as main thread and get logs in a searate retryable API call not having resource reservations). | dynamic | SCT_K8S_LOADER_RUN_TYPE
+| **<a href="#user-content-k8s_instance_type_auxiliary" name="k8s_instance_type_auxiliary">k8s_instance_type_auxiliary</a>**  | Instance type for the nodes of the K8S auxiliary/default node pool. | N/A | SCT_K8S_INSTANCE_TYPE_AUXILIARY
 | **<a href="#user-content-mini_k8s_version" name="mini_k8s_version">mini_k8s_version</a>**  |  | N/A | SCT_MINI_K8S_VERSION
 | **<a href="#user-content-k8s_cert_manager_version" name="k8s_cert_manager_version">k8s_cert_manager_version</a>**  |  | N/A | SCT_K8S_CERT_MANAGER_VERSION
 | **<a href="#user-content-k8s_minio_storage_size" name="k8s_minio_storage_size">k8s_minio_storage_size</a>**  |  | 10Gi | SCT_K8S_MINIO_STORAGE_SIZE

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -885,6 +885,8 @@ class SCTConfiguration(dict):
                   "existing idle pod having reserved resources, perf-oriented) or "
                   "'dynamic' (run stress commad in a separate pod as main thread and get logs "
                   "in a searate retryable API call not having resource reservations)."),
+        dict(name="k8s_instance_type_auxiliary", env="SCT_K8S_INSTANCE_TYPE_AUXILIARY", type=str,
+             help="Instance type for the nodes of the K8S auxiliary/default node pool."),
 
         dict(name="mini_k8s_version", env="SCT_MINI_K8S_VERSION", type=str,
              help=""),

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1453,7 +1453,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             gce_network=self.params.get("gce_network"),
             services=services,
             user_prefix=self.params.get("user_prefix"),
-            gce_instance_type='n1-standard-2',
+            gce_instance_type=self.params.get('k8s_instance_type_auxiliary'),
             n_nodes=self.params.get('k8s_n_auxiliary_nodes'),
             params=self.params,
             gce_datacenter=gce_datacenter,
@@ -1621,7 +1621,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 name=self.k8s_cluster.AUXILIARY_POOL_NAME,
                 # NOTE: It should have at least 5 vCPU to be able to hold all the pods
                 num_nodes=self.params.get('k8s_n_auxiliary_nodes'),
-                instance_type="t3.large",
+                instance_type=self.params.get('k8s_instance_type_auxiliary'),
                 disk_size=40,
                 role_arn=self.k8s_cluster.nodegroup_role_arn,
                 k8s_cluster=self.k8s_cluster),


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
