### PR TITLE
improvement(k8s): allow to set cpu and memory limits for Scylla pods

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -194,6 +194,8 @@
 | **<a href="#user-content-k8s_functional_test_dataset" name="k8s_functional_test_dataset">k8s_functional_test_dataset</a>**  | Defines whether dataset uses for pre-fill cluster in functional test. Defined in sdcm.utils.sstable.load_inventory. Expected values: BIG_SSTABLE_MULTI_COLUMNS_DATA, MULTI_COLUMNS_DATA | N/A | SCT_K8S_FUNCTIONAL_TEST_DATASET
 | **<a href="#user-content-k8s_scylla_datacenter" name="k8s_scylla_datacenter">k8s_scylla_datacenter</a>**  |  | N/A | SCT_K8S_SCYLLA_DATACENTER
 | **<a href="#user-content-k8s_scylla_rack" name="k8s_scylla_rack">k8s_scylla_rack</a>**  |  | N/A | SCT_K8S_SCYLLA_RACK
+| **<a href="#user-content-k8s_scylla_cpu_limit" name="k8s_scylla_cpu_limit">k8s_scylla_cpu_limit</a>**  | The CPU limit that will be set for each Scylla cluster deployed in K8S. If not set, then will be autocalculated. Example: '500m' or '2' | N/A | SCT_K8S_SCYLLA_CPU_LIMIT
+| **<a href="#user-content-k8s_scylla_memory_limit" name="k8s_scylla_memory_limit">k8s_scylla_memory_limit</a>**  | The memory limit that will be set for each Scylla cluster deployed in K8S. If not set, then will be autocalculated. Example: '16384Mi' | N/A | SCT_K8S_SCYLLA_MEMORY_LIMIT
 | **<a href="#user-content-k8s_scylla_cluster_name" name="k8s_scylla_cluster_name">k8s_scylla_cluster_name</a>**  |  | N/A | SCT_K8S_SCYLLA_CLUSTER_NAME
 | **<a href="#user-content-k8s_n_scylla_pods_per_cluster" name="k8s_n_scylla_pods_per_cluster">k8s_n_scylla_pods_per_cluster</a>**  | Number of loader pods per loader cluster. | 3 | K8S_N_SCYLLA_PODS_PER_CLUSTER
 | **<a href="#user-content-k8s_scylla_disk_gi" name="k8s_scylla_disk_gi">k8s_scylla_disk_gi</a>**  |  | N/A | SCT_K8S_SCYLLA_DISK_GI

--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -831,7 +831,7 @@ def test_nodetool_flush_and_reshard(db_cluster: ScyllaPodCluster):
 
     # Calculate new value for the CPU cores dedicated for Scylla pods
     current_cpus = convert_cpu_value_from_k8s_to_units(
-        db_cluster.k8s_cluster.calculated_cpu_limit)
+        db_cluster.k8s_cluster.scylla_cpu_limit)
     new_cpus = current_cpus + 1 if current_cpus <= 1 else current_cpus - 1
     new_cpus = convert_cpu_units_to_k8s_value(new_cpus)
 
@@ -844,4 +844,4 @@ def test_nodetool_flush_and_reshard(db_cluster: ScyllaPodCluster):
         verify_resharding_on_k8s(db_cluster, new_cpus)
     finally:
         # Return the cpu count back and wait for the resharding begin and finish
-        verify_resharding_on_k8s(db_cluster, db_cluster.k8s_cluster.calculated_cpu_limit)
+        verify_resharding_on_k8s(db_cluster, db_cluster.k8s_cluster.scylla_cpu_limit)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1348,7 +1348,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         # Calculate new value for the CPU cores dedicated for Scylla pods
         current_cpus = convert_cpu_value_from_k8s_to_units(
-            self.cluster.k8s_cluster.calculated_cpu_limit)
+            self.cluster.k8s_cluster.scylla_cpu_limit)
         if current_cpus <= 1:
             new_cpus = current_cpus + 1
         else:

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -857,9 +857,16 @@ class SCTConfiguration(dict):
 
         dict(name="k8s_scylla_datacenter", env="SCT_K8S_SCYLLA_DATACENTER", type=str,
              help=""),
-
         dict(name="k8s_scylla_rack", env="SCT_K8S_SCYLLA_RACK", type=str,
              help=""),
+        dict(name="k8s_scylla_cpu_limit", env="SCT_K8S_SCYLLA_CPU_LIMIT",
+             type=str, k8s_multitenancy_supported=True,
+             help="The CPU limit that will be set for each Scylla cluster deployed in K8S. "
+                  "If not set, then will be autocalculated. Example: '500m' or '2'"),
+        dict(name="k8s_scylla_memory_limit", env="SCT_K8S_SCYLLA_MEMORY_LIMIT",
+             type=str, k8s_multitenancy_supported=True,
+             help="The memory limit that will be set for each Scylla cluster deployed in K8S. "
+                  "If not set, then will be autocalculated. Example: '16384Mi'"),
 
         dict(name="k8s_scylla_cluster_name", env="SCT_K8S_SCYLLA_CLUSTER_NAME", type=str,
              help=""),


### PR DESCRIPTION
Add following new config options:
- k8s_scylla_cpu_limit
- k8s_scylla_memory_limit

Which, when defined, will be applied to each Scylla pod. Also, these options are suitable for multitenant configuration.

Examples:
1) Single tenant:
```
  k8s_scylla_cpu_limit: '500m'  # 0.5 vCPU
  k8s_scylla_memory_limit: '16384Mi'  # 16Gb
```
2) 2 tenants:
```
  k8s_scylla_cpu_limit: ['500m', '1500m']  # 0.5 and 1.5 vCPUs
  k8s_scylla_memory_limit: ['4096Mi', '12288Mi']  # 4Gb and 12Gb
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
