### PR TITLE
fix(200k-pk-i4i): Additional nodes capacity to resolve storage shortage

### DIFF
--- a/jenkins-pipelines/longevity-large-partition-200k-pks-2days-aws-i4i.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-200k-pks-2days-aws-i4i.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
-    test_config: '["test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml", "configurations/aws/i4i_4xlarge.yaml"]'
+    test_config: "test-cases/longevity/longevity-large-partition-200k_pks-2days-i4i.yaml"
 
 )

--- a/test-cases/longevity/longevity-large-partition-200k_pks-2days-i4i.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-2days-i4i.yaml
@@ -1,0 +1,72 @@
+test_duration: 3240
+
+bench_run: true
+max_partitions_in_test_table: 1000
+partition_range_with_data_validation: 0-250
+prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=250 -clustering-row-count=100000 -clustering-row-size=uniform:3072..5120 -concurrency=10 -connection-count=10 -rows-per-request=10 -consistency-level=quorum -timeout=90s -validate-data" ,
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=250 -clustering-row-count=100000 -partition-offset=251 -clustering-row-size=uniform:3072..5120 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=90s",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=250 -clustering-row-count=100000 -partition-offset=501 -clustering-row-size=uniform:3072..5120 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=90s",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=250 -clustering-row-count=100000 -partition-offset=751 -clustering-row-size=uniform:3072..5120 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=90s"
+                    ]
+prepare_verify_cmd: ["scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -rows-per-request=10 -consistency-level=quorum -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=15 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=31 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=46 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=61 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=76 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=91 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=106 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=121 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=136 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=151 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=166 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=181 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=196 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=211 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=25 -clustering-row-count=100000 -partition-offset=226 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data"
+                    ]
+
+stress_cmd: [
+"scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=300 -clustering-row-count=200000 -clustering-row-size=uniform:10..10240 -partition-offset=1001 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=90s",
+             "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=300 -clustering-row-count=200000 -clustering-row-size=uniform:10..10240 -partition-offset=1301 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=90s",
+             "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=400 -clustering-row-count=200000 -clustering-row-size=uniform:10..10240 -partition-offset=1601 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=90s",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -rows-per-request=10 -consistency-level=quorum -timeout=90s -iterations 5 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=15 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 5 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=31 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 5 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=46 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 5 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=61 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 5 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=76 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 5 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=91 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 5 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=106 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 5 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=121 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 5 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=136 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 5 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=151 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 5 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=42 -clustering-row-count=100000 -partition-offset=166 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 5 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=43 -clustering-row-count=100000 -partition-offset=208 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 5 -validate-data"
+            ]
+
+stress_read_cmd: [
+                  "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=1000 -clustering-row-count=200000 -clustering-row-size=uniform:10..10240 -partition-offset=1001 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -iterations=10 -timeout=90s",
+                  "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=250 -clustering-row-count=100000 -clustering-row-size=uniform:3072..5120 -concurrency=10 -connection-count=10 -rows-per-request=10 -consistency-level=quorum -iterations=13 -timeout=300s -validate-data",
+                  "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=1000 -clustering-row-count=100000 -clustering-row-size=uniform:3072..5120 -rows-per-request=10 -consistency-level=quorum -timeout=90s -concurrency=100 -connection-count=100 -iterations=0 -duration=40h",
+                  "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=1000 -clustering-row-count=200000 -clustering-row-size=uniform:10..10240 -rows-per-request=10 -consistency-level=quorum -timeout=90s -partition-offset=1001 -concurrency=100 -connection-count=100 -iterations=0 -duration=40h"
+                 ]
+
+n_db_nodes: 5
+n_loaders: 4
+n_monitor_nodes: 1
+
+round_robin: true
+
+instance_type_db: 'i4i.8xlarge'
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_seed: '016'
+nemesis_interval: 30
+
+user_prefix: 'longevity-large-partitions-200k-pks-2d-i4i'
+
+stop_test_on_stress_failure: false
+
+
+run_fullscan: ['{"mode": "partition", "ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 100000, "validate_data": true}']


### PR DESCRIPTION
       fix(200k-pk-i4i): Additional capacity to resolve storage shortage
    
            Cluster failed due to lack of disk space, using i4i.4xlarge.
            Changing to i4i.8xlarge may solve the issue.
    
            Refs: https://github.com/scylladb/scylladb/issues/12790

Refs: https://github.com/scylladb/scylladb/issues/12790
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
