### PR TITLE
fix(k8s): do not raise error stopping dynamic loader during tearDown

### DIFF
--- a/sdcm/remote/kubernetes_cmd_runner.py
+++ b/sdcm/remote/kubernetes_cmd_runner.py
@@ -481,8 +481,7 @@ class KubernetesPodWatcher(KubernetesRunner):
                     "'log reader' socket is '%s'.",
                     pod_name, "closed" if self.process.closed else "open")
                 self._stop_pod()
-                raise InterruptedError(
-                    "The '%s' pod execution was interrupted by the 'tearDown'" % pod_name)
+                return
             if self.process.closed:
                 LOGGER.warning(
                     "'stop()' method is called for the '%s' pod, which is running "


### PR DESCRIPTION
The existing raise of the 'InterruptedError' exception during the 'stop' method is useless when called by the fact of the tearDown process beginning.
So, remove the 'raise InterruptedError' part and just return the control when pod gets stopped.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
