### PR TITLE
fix(ics-toggle-large-partition): Set job running 24h

### DIFF
--- a/test-cases/enterprise-features/ics/longevity/ics-longevity-toggle-strategy-large-partitions-24h.yaml
+++ b/test-cases/enterprise-features/ics/longevity/ics-longevity-toggle-strategy-large-partitions-24h.yaml
@@ -1,4 +1,13 @@
+test_duration: 1600
+
 compaction_strategy: 'IncrementalCompactionStrategy'
 nemesis_class_name: 'ToggleTableIcsMonkey'
 nemesis_interval: 30
 user_prefix: 'ics-longevity-toggle-strategy-large-partitions-1d'
+
+stress_read_cmd: [
+                  "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=1000 -clustering-row-count=200000 -clustering-row-size=uniform:10..10240 -partition-offset=1001 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -iterations=20 -timeout=90s",
+                  "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=250 -clustering-row-count=100000 -clustering-row-size=uniform:3072..5120 -concurrency=10 -connection-count=10 -rows-per-request=10 -consistency-level=quorum -iterations=26 -timeout=300s -validate-data",
+                  "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=1000 -clustering-row-count=100000 -clustering-row-size=uniform:3072..5120 -rows-per-request=10 -consistency-level=quorum -timeout=90s -concurrency=100 -connection-count=100 -iterations=0 -duration=1440m",
+                  "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=1000 -clustering-row-count=200000 -clustering-row-size=uniform:10..10240 -rows-per-request=10 -consistency-level=quorum -timeout=90s -partition-offset=1001 -concurrency=100 -connection-count=100 -iterations=0 -duration=1440m"
+                 ]


### PR DESCRIPTION
Job 'ics-longevity-toggle-strategy-large-partitions-24h.jenkinsfile' should run 24 hours, but run 4d. this happened because job use 2 config yamls, and duration is set in first one.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
