### PR TITLE
fix(argus): properly check the node type

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -308,7 +308,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def _add_node_to_argus(self):
         try:
             client = self.test_config.argus_client()
-            shards = -1 if "db-node" in self.instance_name else self.cpu_cores
+            shards = -1 if "db" in self.node_type else self.cpu_cores
             client.create_resource(
                 name=self.name,
                 resource_type=self.node_type,
@@ -325,7 +325,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def update_shards_in_argus(self):
         try:
             client = self.test_config.argus_client()
-            shards = self.scylla_shards if "db-node" in self.instance_name else self.cpu_cores
+            shards = self.scylla_shards if "db" in self.node_type else self.cpu_cores
             shards = int(shards) if shards else 0
             client.update_shards_for_resource(name=self.name, new_shards=shards)
         except Exception:  # pylint: disable=broad-except

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1943,6 +1943,10 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
 
 
 class BaseScyllaPodContainer(BasePodContainer):  # pylint: disable=abstract-method,too-many-public-methods
+    @cached_property
+    def node_type(self) -> str:
+        return 'db'
+
     def restart(self):
         pass
 
@@ -2135,6 +2139,10 @@ class BaseScyllaPodContainer(BasePodContainer):  # pylint: disable=abstract-meth
 class LoaderPodContainer(BasePodContainer):
     TEMPLATE_PATH = LOADER_POD_CONFIG_PATH
 
+    @cached_property
+    def node_type(self) -> str:
+        return 'loader'
+
     def __init__(self, name: str, parent_cluster: PodCluster,
                  node_prefix: str = "node", node_index: int = 1,
                  base_logdir: Optional[str] = None, dc_idx: int = 0, rack=0):
@@ -2177,6 +2185,10 @@ class LoaderPodContainer(BasePodContainer):
 
 class LoaderStsContainer(BasePodContainer):
     TEMPLATE_PATH = LOADER_STS_CONFIG_PATH
+
+    @cached_property
+    def node_type(self) -> str:
+        return 'loader'
 
     def terminate_k8s_host(self):
         raise NotImplementedError()

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2163,6 +2163,7 @@ class LoaderPodContainer(BasePodContainer):
             namespace=self.parent_cluster.namespace,
             environ=environ,
         )
+        self._add_node_to_argus()
 
     def _init_remoter(self, ssh_login_info):
         pass

--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -669,10 +669,6 @@ class LocalMinimalScyllaPodContainer(BaseScyllaPodContainer):
     def restart(self):
         self.host_remoter.run(f"docker restart {self.docker_id}")
 
-    @cached_property
-    def node_type(self) -> 'str':
-        return 'db'
-
     def terminate_k8s_node(self):
         raise NotImplementedError("Not supported on local K8S backends")
 


### PR DESCRIPTION
Use `node_type` attr of node objects to detect their type instead of using `instance_name` one.
It will allow to avoid following error on K8S backends:
    
      > Traceback (most recent call last):
      >   File "%project-path%/sdcm/cluster.py", line 328, in update_shards_in_argus
      >     shards = self.scylla_shards if "db-node" in self.instance_name else self.cpu_cores
      >   File "%project-path%/sdcm/cluster_k8s/__init__.py", line 2014, in instance_name
      >     return self.node_name
      >   File "/usr/local/lib/python3.10/functools.py", line 970, in __get__
      >     val = self.func(instance)
      >   File "%project-path%/sdcm/cluster_k8s/__init__.py", line 2010, in node_name
      >     return self._pod.spec.node_name
      > AttributeError: 'NoneType' object has no attribute 'spec'
      > Encountered an unhandled exception while interacting with Argus \
        < t:2023-03-30 14:15:50,232 f:cluster.py      l:332  c:sdcm.cluster \
          p:ERROR > Encountered an unhandled exception while interacting with Argus

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
