### PR TITLE
fix(log event): print current running nemesis only

### DIFF
--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -232,6 +232,11 @@ class SctEvent:
             if not running_disruption_events:
                 return
 
+            # Issue https://github.com/scylladb/scylla-cluster-tests/issues/5974.
+            # Prevent printing previously running nemeses
+            if len(running_disruption_events) == 1:
+                self.subcontext = []
+
             for nemesis in running_disruption_events:
                 # To prevent multiplying of subcontext for LogEvent
                 if nemesis not in self.subcontext:


### PR DESCRIPTION
CassandraStressLogEvent has event_id of its parent CassandraStressEvent (one cassandra-stress command). cassandra-stress command may run on backgraund during entire test and while a lot of nemeses.

If a few CassandraStressLogEvent.ERROR happened during cassandra-stress command but in time of different nemeses, CassandraStressLogEvent.during_nemesis will keep list of all nemeses when errors happened.

Refs: https://github.com/scylladb/scylla-cluster-tests/issues/5974

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
