### PR TITLE
fix(common.py):set GCE filter for new image name

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1444,7 +1444,11 @@ def get_scylla_gce_images_versions(project: str = SCYLLA_GCE_IMAGES_PROJECT, ver
         filters = "(family eq 'scylla(-enterprise)?')(name ne .+-build-.+)"
 
         if version and version != "all":
-            filters += f"(name eq '.*scylla(-enterprise)?-{version.replace('.', '-')}.*')"
+            filters += f"(name eq 'scylla(db)?(-enterprise)?-{version.replace('.', '-')}"
+            if 'rc' not in version:
+                filters += "(-\\d)?(\\d)?(\\d)?(-rc)?(\\d)?(\\d)?')"
+            else:
+                filters += "')"
 
         compute_engine = get_gce_driver()
         _SCYLLA_GCE_IMAGE_CACHE.extend(sorted(


### PR DESCRIPTION
Following the changes made in
https://github.com/scylladb/scylla-pkg/commit/7308e0a56352f96e089d64d203079111309091a3, 
the Hydra search for gce promoted image is wrong

Adjusting the filter so it will support both prefixes (Scylla and Scylladb)

