### PR TITLE
test(custom_profile_d): Longevity with custom_d profile

### DIFF
--- a/jenkins-pipelines/longevity-user-profile-d.jenkinsfile
+++ b/jenkins-pipelines/longevity-user-profile-d.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_sla_test.LongevitySlaTest.test_custom_time',
+    test_config: 'test-cases/longevity/longevity-user-profile-d.yaml'
+
+)

--- a/longevity_sla_test.py
+++ b/longevity_sla_test.py
@@ -29,12 +29,17 @@ class LongevitySlaTest(LongevityTest, loader_utils.LoaderUtilsMixin):
         self.roles = []
 
     def test_custom_time(self):
+        is_enterprise = self.db_cluster.nodes[0].is_enterprise
         with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0], user=loader_utils.DEFAULT_USER,
                                                     password=loader_utils.DEFAULT_USER_PASSWORD) as session:
             # Add index (shares position in the self.service_level_shares list) to role and service level names to do
             # it unique and prevent failure when try to create role/SL with same name
+
             for index, shares in enumerate(self.service_level_shares):
-                self.roles.append(create_sla_auth(session=session, shares=shares, index=str(index)))
+                self.roles.append(create_sla_auth(session=session,
+                                                  shares=shares,
+                                                  index=str(index),
+                                                  attach_service_level=is_enterprise))
 
             if self.params.get("run_fullscan"):
                 self.fullscan_role = create_sla_auth(session=session, shares=self.FULLSCAN_SERVICE_LEVEL_SHARES,
@@ -43,7 +48,7 @@ class LongevitySlaTest(LongevityTest, loader_utils.LoaderUtilsMixin):
         # Wait for all SLs are propagated to all nodes
         for role in self.roles + [self.fullscan_role]:
             # self.fullscan_role may be None if "run_fullscan" is not defined
-            if role:
+            if role and is_enterprise:
                 with adaptive_timeout(Operations.SERVICE_LEVEL_PROPAGATION, node=self.db_cluster.nodes[0], timeout=15,
                                       service_level_for_test_step="MAIN_SERVICE_LEVEL"):
                     SlaUtils().wait_for_service_level_propagated(cluster=self.db_cluster, service_level=role.attached_service_level)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1992,6 +1992,8 @@ class SCTConfiguration(dict):
                             if len(option) < 2:
                                 continue
                             profile_path = option[1]
+                            if 'scylla-qa-internal' in profile_path:
+                                continue
                             if not profile_path.startswith('/tmp'):
                                 raise ValueError(f"Stress command parameter '{param_name}' contains wrong path "
                                                  f"'{profile_path}' to profile, it should be formed in following "

--- a/sdcm/utils/user_profile.py
+++ b/sdcm/utils/user_profile.py
@@ -119,7 +119,10 @@ def get_profile_content(stress_cmd):
     """
 
     cs_profile = re.search(r'profile=(.*\.yaml)', stress_cmd).group(1)
-    sct_cs_profile = os.path.join(os.path.dirname(__file__), '../../', 'data_dir', os.path.basename(cs_profile))
+    if "scylla-qa-internal" in cs_profile:
+        sct_cs_profile = os.path.join(os.path.dirname(__file__), '../../', cs_profile)
+    else:
+        sct_cs_profile = os.path.join(os.path.dirname(__file__), '../../', 'data_dir', os.path.basename(cs_profile))
     if os.path.exists(sct_cs_profile):
         cs_profile = sct_cs_profile
     elif not os.path.exists(cs_profile):
@@ -128,3 +131,9 @@ def get_profile_content(stress_cmd):
     with open(cs_profile, encoding="utf-8") as yaml_stream:
         profile = yaml.safe_load(yaml_stream)
     return cs_profile, profile
+
+
+def replace_scylla_qa_internal_path(stress_cmd: str, loader_path: str):
+    stress_cmd = re.sub(r"profile=scylla-qa-internal\/\S*",
+                        f" profile={loader_path} ", stress_cmd)
+    return stress_cmd

--- a/test-cases/longevity/longevity-user-profile-d.yaml
+++ b/test-cases/longevity/longevity-user-profile-d.yaml
@@ -1,0 +1,32 @@
+test_duration: 360
+
+service_level_shares: [1000]
+
+prepare_write_cmd:  ["cassandra-stress user profile=scylla-qa-internal/profile-d/profile-top.yaml no-warmup 'ops(insert=1)' n=35104000 -mode cql3 native <sla credentials 0> -rate threads=96"]
+
+stress_cmd: ["cassandra-stress user profile=scylla-qa-internal/profile-d/profile-cache.yaml     'ops(readq=1)'  cl=LOCAL_QUORUM no-warmup duration=4h -mode cql3 native <sla credentials 0> -rate fixed=615/s threads=32   ",
+             "cassandra-stress user profile=scylla-qa-internal/profile-d/profile-cold-read.yaml 'ops(readq=1)'  cl=LOCAL_QUORUM no-warmup duration=4h -mode cql3 native <sla credentials 0> -rate fixed=7329/s threads=96  ",
+             "cassandra-stress user profile=scylla-qa-internal/profile-d/profile-write.yaml     'ops(insert=1)' cl=LOCAL_QUORUM no-warmup duration=4h -mode cql3 native <sla credentials 0> -rate fixed=41880/s threads=32 "]
+
+n_db_nodes: 3
+n_loaders: 3
+n_monitor_nodes: 1
+availability_zone: 'a,b,c'
+
+
+
+round_robin: true
+
+instance_type_db: 'i3en.6xlarge'
+instance_type_loader: 'c5.4xlarge'
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_seed: '018'
+nemesis_interval: 15
+
+user_prefix: 'longevity-user-profile-d'
+
+authenticator: 'PasswordAuthenticator'
+authenticator_user: 'cassandra'
+authenticator_password: 'cassandra'
+authorizer: 'CassandraAuthorizer'

--- a/test_lib/sla.py
+++ b/test_lib/sla.py
@@ -419,10 +419,11 @@ class User(UserRoleBase):
         return self
 
 
-def create_sla_auth(session, shares: int, index: str, superuser: bool = True) -> Role:
+def create_sla_auth(session, shares: int, index: str, superuser: bool = True, attach_service_level: bool = True) -> Role:
     role = Role(session=session, name=STRESS_ROLE_NAME_TEMPLATE % (shares or '', index),
                 password=STRESS_ROLE_PASSWORD_TEMPLATE % shares or '', login=True, superuser=superuser).create()
-    role.attach_service_level(ServiceLevel(session=session, name=SERVICE_LEVEL_NAME_TEMPLATE % (shares or '', index),
-                                           shares=shares).create())
+    if attach_service_level:
+        role.attach_service_level(ServiceLevel(session=session, name=SERVICE_LEVEL_NAME_TEMPLATE % (shares or '', index),
+                                               shares=shares).create())
 
     return role


### PR DESCRIPTION
Add new longevity with specific custom payload
 which allow to reproduce issue scylladb/scylladb#12562
    
Specific keyspace defined in c-s profile yamls.
C-s run payload run under specific user. Specific
user is added using sla utils. If scylla is OSS, then
just roles will be added and c-s will run with defined
role, if scylla is enterprise, then  full WLP will
be used.


task: https://github.com/scylladb/qa-tasks/issues/974

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
