### PR TITLE
fix(search_max_througput): stop iteration on 0 num of loaders

### DIFF
--- a/performance_search_max_throughput_test.py
+++ b/performance_search_max_throughput_test.py
@@ -139,10 +139,15 @@ class MaximumPerformanceSearchTest(PerformanceRegressionTest):
                     self.log.info("Decrease number of stress processes")
                     stress_num -= stress_num_step
                     if stress_num < 1:
+                        self.log.info("No processes left for run. Stop test")
                         break
                 else:
                     self.log.info("Decrease number of loaders and back to start num of process")
-                    self.loaders.nodes = original_nodes_list[:len(self.loaders.nodes) - num_loaders_step]
+                    new_num_of_nodes = len(self.loaders.nodes) - num_loaders_step
+                    if new_num_of_nodes < 1:
+                        self.log.info("No loaders left for run. Stop test")
+                        break
+                    self.loaders.nodes = original_nodes_list[:new_num_of_nodes]
                     stress_num = origin_stress_num
 
                 threads = (best_result["total_threads"] // (len(self.loaders.nodes) * stress_num)) - threads_step


### PR DESCRIPTION
If configuration parameters set so, that on next step num of loaders become 0, test could be terminated with error Division by 0:

c:sdcm.sct_events.file_logger p:ERROR >
threads = (best_result["total_threads"] // (len(self.loaders.nodes) * stress_num)) - threads_step p:ERROR > ZeroDivisionError: integer division or modulo by zero

when counting number of loaders for next iteration, if num of loaders become 0 or less break the test.

job: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/Raya/job/perf-search-best-throughput-config-test-copy/7/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
