### PR TITLE
fix(refresh nemesis): fix folder for sstable uploading

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1562,7 +1562,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             map_files_to_node = SstableLoadUtils.distribute_test_files_to_cluster_nodes(nodes=self.cluster.nodes,
                                                                                         test_data=test_data)
             for sstables_info, load_on_node in map_files_to_node:
-                SstableLoadUtils.upload_sstables(load_on_node, test_data=sstables_info)
+                SstableLoadUtils.upload_sstables(load_on_node, test_data=sstables_info, table_name="standard1")
                 system_log_follower = SstableLoadUtils.run_load_and_stream(load_on_node)
                 SstableLoadUtils.validate_load_and_stream_status(load_on_node, system_log_follower)
 
@@ -1598,7 +1598,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             # Executing rolling refresh one by one
             shards_num = self.cluster.nodes[0].scylla_shards
             for node in self.cluster.nodes:
-                SstableLoadUtils.upload_sstables(node, test_data=test_data[0],
+                SstableLoadUtils.upload_sstables(node, test_data=test_data[0], table_name="standard1",
                                                  is_cloud_cluster=self.cluster.params.get("db_type") == 'cloud_scylla')
                 system_log_follower = SstableLoadUtils.run_refresh(node, test_data=test_data[0])
                 # NOTE: resharding happens only if we have more than 1 core.


### PR DESCRIPTION
During disrupt_nodetool_refresh the sstables for refresh may be uploaded into wrong data folder because of bug in the folder searching: the sstables is uploaded into first folder that is returned by 'ls -t'. Not always it will be 'standard1' as it should be.

Refs: https://github.com/scylladb/scylla-cluster-tests/issues/5978

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
