### PR TITLE
fix(CreateIndexNemesis): skip querying by index if null value

### DIFF
--- a/sdcm/utils/nemesis_utils/indexes.py
+++ b/sdcm/utils/nemesis_utils/indexes.py
@@ -69,6 +69,7 @@ def verify_query_by_index_works(session, ks, cf, column) -> None:
         return
     match type(value).__name__:
         case "str" | "datetime":
+            value = str(value).replace("'", "''")
             value = f"'{value}'"
         case "bytes":
             value = "0x" + value.hex()


### PR DESCRIPTION
When querying base table column to have value to query by index, result may return None value. This makes query to have 'WHERE = None' which is not correct syntax. Scylla does not support putting 'is null' in where clause either.

Fix is about skipping query by index in that case.

commit 2:
When querying by index value may contain ' sign. In that case it must be
escaped to properly format the query.

Fix is by properly escaping ' character from value in where clause.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
