### PR TITLE
feature(jupyter): added example jupyter notebooks

### DIFF
--- a/jupyter/functional-test.ipynb
+++ b/jupyter/functional-test.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Jupyter notebook example to play with functional tests on k8s backend\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ[\"BUILD_USER_EMAIL\"] = \"sct.tester@scylladb.com\"\n",
+    "os.environ[\"BUILD_ID\"] = \"123\"\n",
+    "os.environ[\"SCT_CLUSTER_BACKEND\"] = \"k8s-local-kind\"\n",
+    "os.environ[\"SCT_CONFIG_FILES\"] = \"test-cases/scylla-operator/functional.yaml\"\n",
+    "os.environ[\"SCT_SCYLLA_VERSION\"] = \"2022.2.0\"\n",
+    "os.environ[\"SCT_K8S_USE_CHAOS_MESH\"] = \"True\"\n",
+    "os.environ[\"SCT_REGION_NAME\"] = \"eu-west-1\"\n",
+    "os.environ[\"SCT_USE_MGMT\"] = \"True\"\n",
+    "os.environ[\"SCT_N_DB_NODES\"] = \"3\"\n",
+    "os.environ[\"SCT_N_LOADERS\"] = \"1\"\n",
+    "os.environ[\"SCT_N_MONITORS_NODES\"] = \"0\"\n",
+    "assert os.environ[\"BUILD_USER_EMAIL\"] != \"sct.tester@scylladb.com\", \"please use your own email so resources are tracked properly\"\n",
+    "\n",
+    "# logging configuration, for jupyter only (sct logs are intact)\n",
+    "import logging\n",
+    "\n",
+    "LOGGER = logging.getLogger(__name__)\n",
+    "LOGGER.setLevel(logging.DEBUG)\n",
+    "consoleHandler = logging.StreamHandler()\n",
+    "consoleHandler.setLevel(logging.DEBUG)\n",
+    "formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')\n",
+    "consoleHandler.setFormatter(formatter)\n",
+    "LOGGER.addHandler(consoleHandler)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from functional_tests.scylla_operator.libs.auxiliary import ScyllaOperatorFunctionalClusterTester\n",
+    "from sdcm import sct_abs_path\n",
+    "\n",
+    "os.chdir(sct_abs_path(relative_filename=\"\"))\n",
+    "tester_inst = ScyllaOperatorFunctionalClusterTester()\n",
+    "tester_inst.setUpClass()\n",
+    "tester_inst.setUp()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now to recover to original state and get cluster,can iterate over `db_cluster` fixture, which will yield a `ScyllaPodCluster` object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from functional_tests.scylla_operator.conftest import _bring_cluster_back_to_original_state\n",
+    "\n",
+    "\n",
+    "def db_cluster(tester: ScyllaOperatorFunctionalClusterTester):\n",
+    "    if not tester.healthy_flag:\n",
+    "        raise RuntimeError('cluster is not healthy, skipping rest of the tests')\n",
+    "\n",
+    "    with tester.db_cluster.scylla_config_map() as scylla_config_map:\n",
+    "        original_scylla_config_map = scylla_config_map\n",
+    "    original_scylla_cluster_spec = tester.db_cluster.get_scylla_cluster_plain_value('/spec')\n",
+    "\n",
+    "    if dataset_name := tester.db_cluster.params.get(\"k8s_functional_test_dataset\"):\n",
+    "        tester.db_cluster.wait_for_nodes_up_and_normal(nodes=tester.db_cluster.nodes,\n",
+    "                                                       verification_node=tester.db_cluster.nodes[0])\n",
+    "        tester.db_cluster.wait_for_init(node_list=tester.db_cluster.nodes, wait_for_db_logs=True)\n",
+    "        tester.db_cluster.prefill_cluster(dataset_name)\n",
+    "    yield tester.db_cluster\n",
+    "\n",
+    "    if tester.healthy_flag:\n",
+    "        _bring_cluster_back_to_original_state(\n",
+    "            tester,\n",
+    "            config_map=original_scylla_config_map,\n",
+    "            original_scylla_cluster_spec=original_scylla_cluster_spec\n",
+    "        )\n",
+    "\n",
+    "cluster = db_cluster(tester_inst).__next__()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Play with it like in provision-test, or run some functional test:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from functional_tests.scylla_operator.test_functional import test_listen_address\n",
+    "\n",
+    "test_listen_address(cluster)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/jupyter/provision-test.ipynb
+++ b/jupyter/provision-test.ipynb
@@ -1,0 +1,153 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "provision-test longevity for interactive play with sct cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ[\"BUILD_USER_EMAIL\"] = \"sct.tester@scylladb.com\"\n",
+    "os.environ[\"BUILD_ID\"] = \"123\"\n",
+    "os.environ[\"SCT_CLUSTER_BACKEND\"] = \"aws\"\n",
+    "os.environ[\"SCT_CONFIG_FILES\"] = \"test-cases/PR-provision-test.yaml\"\n",
+    "os.environ[\"SCT_SCYLLA_VERSION\"] = \"2022.2.0\"\n",
+    "os.environ[\"SCT_REGION_NAME\"] = \"eu-west-1\"\n",
+    "os.environ[\"SCT_USE_MGMT\"] = \"False\"\n",
+    "os.environ[\"SCT_N_DB_NODES\"] = \"3\"\n",
+    "os.environ[\"SCT_N_LOADERS\"] = \"1\"\n",
+    "os.environ[\"SCT_N_MONITORS_NODES\"] = \"0\"\n",
+    "assert os.environ[\"BUILD_USER_EMAIL\"] != \"sct.tester@scylladb.com\", \"please use your own email so resources are tracked properly\"\n",
+    "\n",
+    "# logging configuration, for jupyter only (sct logs are intact)\n",
+    "import logging\n",
+    "\n",
+    "LOGGER = logging.getLogger(__name__)\n",
+    "LOGGER.setLevel(logging.DEBUG)\n",
+    "consoleHandler = logging.StreamHandler()\n",
+    "consoleHandler.setLevel(logging.DEBUG)\n",
+    "formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')\n",
+    "consoleHandler.setFormatter(formatter)\n",
+    "LOGGER.addHandler(consoleHandler)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from longevity_test import LongevityTest\n",
+    "import os\n",
+    "\n",
+    "from sdcm import sct_abs_path\n",
+    "\n",
+    "os.chdir(sct_abs_path(relative_filename=\"\"))\n",
+    "tester_inst = LongevityTest()\n",
+    "tester_inst.setUpClass()\n",
+    "tester_inst.setUp()\n",
+    "cluster = tester_inst.db_cluster\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now it is possible to play interactively with cluster. E.g.:\n",
+    "\n",
+    "```\n",
+    "res = cluster.nodes[0].remoter.run(\"nodetool status\")\n",
+    "res.stdout\n",
+    "```\n",
+    "Remember, imported code can't be reimported - when changed, need to reload jupyter kernel.\n",
+    "A way to workaround it, use inheritance and override methods. E.g.:\n",
+    "```\n",
+    "from sdcm.nemesis import Nemesis\n",
+    "\n",
+    "\n",
+    "class DemoNemesis(Nemesis):\n",
+    "    disruptive = True\n",
+    "    networking = False\n",
+    "    run_with_gemini = False\n",
+    "\n",
+    "    def disrupt(self):\n",
+    "        self._disrupt_demo()\n",
+    "\n",
+    "    def _disrupt_demo(self):\n",
+    "        print(\"starting demo nemesis\")\n",
+    "\n",
+    "    def update_stats(self, disrupt, status=True, data=None):\n",
+    "        if not data:\n",
+    "            data = {}\n",
+    "        key = {True: 'runs', False: 'failures'}\n",
+    "        if disrupt not in self.stats:\n",
+    "            self.stats[disrupt] = {'runs': [], 'failures': [], 'cnt': 0}\n",
+    "        self.stats[disrupt][key[status]].append(data)\n",
+    "        self.stats[disrupt]['cnt'] += 1\n",
+    "        self.log.debug('Update nemesis info with: %s', data)\n",
+    "        if self.tester.create_stats:\n",
+    "            self.tester.update({'nemesis': self.stats})\n",
+    "        if self.es_publisher:\n",
+    "            self.es_publisher.publish(disrupt_name=disrupt, status=status, data=data)\n",
+    "\n",
+    "demo_nemesis = DemoNemesis(tester_inst, termination_event=None)\n",
+    "demo_nemesis.disrupt()\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To be able to play cluster object methods interactively, just create function that uses `self` as first argument and assign `cluster` to it. When having working example, copy-paste method to cluster with proper indent. E.g.:\n",
+    "```\n",
+    "from typing import List\n",
+    "\n",
+    "\n",
+    "def get_non_system_ks_cf_list(self, db_node, filter_out_table_with_counter=False, filter_out_mv=False, filter_empty_tables=True) -> List[str]:\n",
+    "    ks_cf_list = self.get_any_ks_cf_list(db_node, filter_out_table_with_counter=filter_out_table_with_counter,\n",
+    "                                       filter_out_mv=filter_out_mv, filter_empty_tables=filter_empty_tables,\n",
+    "                                       filter_out_system=True, filter_out_cdc_log_tables=True)\n",
+    "    return [\"some_non_system_table\"] + ks_cf_list\n",
+    "\n",
+    "get_non_system_ks_cf_list(cluster, cluster.nodes[0])\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/jupyter/readme.md
+++ b/jupyter/readme.md
@@ -1,0 +1,87 @@
+# What is Jupyter Notebook/Jupyterlab
+
+## Jupyter Notebook
+
+Jupyter Notebook is an open-source web application that allows you to create and share interactive documents containing live code, equations, visualizations, and narrative text. It is primarily used for data analysis, scientific computing, and machine learning.
+
+The core component of Jupyter Notebook is the Notebook itself, which is a JSON file containing an ordered list of cells. There are several types of cells:
+
+1. Code cells: These cells contain executable code, and when run, they display the output (e.g., text, plots, or tables) directly below the cell.
+2. Markdown cells: These cells contain formatted text written in Markdown, a lightweight markup language. You can use them to provide explanations, add equations using LaTeX, or create section headings to organize your work.
+3. Raw cells: These cells contain plain text that is not processed by the Notebook, and they're often used for code or text that should be included in the final document but not executed or rendered.
+
+Jupyter Notebooks provide several advantages:
+
+1. Interactive computing: They enable you to iteratively write and test your code, making debugging and experimentation much easier.
+2. Collaboration: You can share your Notebooks with others, allowing them to reproduce your results, modify your code, or provide feedback.
+3. Documentation: Combining code, visualizations, and narrative text in one place allows you to create comprehensive, self-contained, and understandable documents.
+
+## Jupyterlab
+
+JupyterLab is the next-generation web-based interface for Project Jupyter, providing a flexible and extensible environment for working with Jupyter Notebooks, code editors, and data visualization tools. It features a customizable user interface with multiple panels and tabs, an integrated text editor, a file explorer, terminal access, and a robust extension system. JupyterLab enhances the Jupyter Notebook experience, catering to users who require a more comprehensive workspace for data science, machine learning, or software development tasks.
+
+# How to use it for SCT development
+
+The main benefit of using Notebook is that it is interactive - so once test cluster is created you can play with it interactively, create new code, test it, correct and run over and over again without need to start whole framework again.
+
+## Steps
+
+Steps explain how to use it on SCT runner. There’s also possibility to run it locally when using k8s cluster (steps are similar, or you can use Jupyter Notebook support in Pycharm Professional or VS Code)
+
+1. Create sct-runner and log in to it with ssh
+
+    ```bash
+    create sct-runner
+    hydra create-runner-instance -r eu-west-1 -z a -c aws -t xxxxxxxx-aef7-4257-b7f5-f45b980abaaa -d 600
+    ssh -i ~/.ssh/scylla-qa-ec2 ubuntu@<sct-runner-ip>
+    ```
+    Next steps run on SCT-runner
+2. Git clone SCT
+
+    ```bash
+    cd ~
+    git clone https://github.com/scylladb/scylla-cluster-tests.git
+    ```
+
+3. Configure AWS credentials
+
+    ```bash
+    aws configure
+    # answer questions
+    ```
+
+4. Install and run Jupyterlab
+
+    ```bash
+    cd scylla-cluster-tests
+    docker/env/hydra.sh /bin/bash
+    # inside the container:
+    pip install jupyterlab
+    cd ~/scylla-cluster-tests/
+    python -m jupyterlab --NotebookApp.token=''
+    ```
+
+5. Example output with connection details when token is provided (or `--NotebookApp.token` removed from command):
+
+    ```bash
+    To access the server, open this file in a browser:
+            file:///home/ubuntu/.local/share/jupyter/runtime/jpserver-12-open.html
+        Or copy and paste one of these URLs:
+            http://localhost:8888/lab?token=bc1217d11fe892bb2c5a2f496e2ddab6639d7458b0b624da
+            http://127.0.0.1:8888/lab?token=bc1217d11fe892bb2c5a2f496e2ddab6639d7458b0b624
+    ```
+
+6. On local machine create ssh tunnel to jupyterlab
+
+    ```bash
+    # create ssh tunnel
+    ssh -N -f -L 127.0.0.1:8888:127.0.0.1:8888 -i ~/.ssh/scylla-qa-ec2 ubuntu@<sct-runner-ip>
+    ```
+
+7. Open web browser (or attach to Pycharm) this link:
+
+    `http://localhost:8888/lab` or url from the output
+
+7. Example use
+
+    Run example jupyter notebooks in this directory


### PR DESCRIPTION
When developing new code for SCT its important to try and test new code on live cluster. But running whole test for each change takes long time and is not efficient.

Provide example jupyter notebooks to enable quick and easy way to interactively play with cluster and try new code in SCT.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
