### PR TITLE
fix(multidc tests): create loader in each region

### DIFF
--- a/test-cases/longevity/longevity-counters-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-multidc.yaml
@@ -5,7 +5,7 @@ stress_cmd:      "scylla-bench -workload=uniform -mode=counter_update -replicati
 stress_read_cmd: "scylla-bench -workload=uniform -mode=counter_read   -replication-factor=3 -partition-count=1000 -clustering-row-count=10 -concurrency 512 -duration 360m -validate-data"
 
 n_db_nodes: '3 3 3'
-n_loaders:  3
+n_loaders:  '1 1 1'
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.2xlarge'

--- a/test-cases/longevity/longevity-lwt-24h-multidc.yaml
+++ b/test-cases/longevity/longevity-lwt-24h-multidc.yaml
@@ -4,7 +4,7 @@ stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml o
 stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml ops'(select=1)' cl=SERIAL duration=1350m -mode native cql3 -rate threads=800" ]
 
 n_db_nodes: '4 3 2'
-n_loaders: 3
+n_loaders: '1 1 1'
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.8xlarge'


### PR DESCRIPTION
The default load balancing policy in scylla-tools-java is DCAwareRoundRobinPolicy which prefers nodes in the local datacenter. Unless all local nodes are tried, it will not send queries to other nodes in remote DC.

Prevent issue: https://github.com/scylladb/java-driver/issues/211

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
