### PR TITLE
fix(CreateIndexNemesis): prolong errors filter time after drop

### DIFF
--- a/sdcm/utils/nemesis_utils/indexes.py
+++ b/sdcm/utils/nemesis_utils/indexes.py
@@ -20,7 +20,7 @@ from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
 from sdcm.cluster import BaseNode
 from sdcm.sct_events import Severity
 from sdcm.sct_events.database import DatabaseLogEvent
-from sdcm.sct_events.filters import DbEventsFilter
+from sdcm.sct_events.filters import EventsFilter
 from sdcm.sct_events.system import InfoEvent
 
 LOGGER = logging.getLogger(__name__)
@@ -101,17 +101,18 @@ def verify_query_by_index_works(session, ks, cf, column) -> None:
 
 def drop_index(session, ks, index_name) -> None:
     InfoEvent(message=f"Starting dropping index: {ks}.{index_name}").publish()
-    with DbEventsFilter(
-            db_event=DatabaseLogEvent.DATABASE_ERROR,
-            line="Error applying view update"):
+    with EventsFilter(
+            event_class=DatabaseLogEvent.DATABASE_ERROR,
+            regex="Error applying view update",
+            extra_time_to_expiration=180,  # errors can happen only within few minutes after index drop scylladb/#12977
+    ):
         session.execute(f'DROP INDEX {ks}.{index_name}')
-        time.sleep(30)  # errors can happen only within several seconds after index drop #12977
 
 
 def drop_materialized_view(session, ks, view_name) -> None:
     LOGGER.info('start dropping MV: %s.%s', ks, view_name)
-    with DbEventsFilter(
-            db_event=DatabaseLogEvent.DATABASE_ERROR,
-            line="Error applying view update"):
+    with EventsFilter(
+            event_class=DatabaseLogEvent.DATABASE_ERROR,
+            regex="Error applying view update",
+            extra_time_to_expiration=180):
         session.execute(f'DROP MATERIALIZED VIEW {ks}.{view_name}')
-        time.sleep(30)  # errors can happen only within several seconds after index drop #12977


### PR DESCRIPTION
After dropping an index it is common that some nodes will report errors in logs (https://github.com/scylladb/scylladb/issues/12977) for longer period than we expected it. These errors are not severe, rather expected.

Prolong event filter for this error to 3 minutes so it is not failing the test.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
