### PR TITLE
fix(k8s): use proper K8S class attr for getting memory limit value

### DIFF
--- a/functional_tests/scylla_operator/libs/helpers.py
+++ b/functional_tests/scylla_operator/libs/helpers.py
@@ -185,11 +185,11 @@ def verify_resharding_on_k8s(db_cluster: ScyllaPodCluster, cpus: Union[str, int,
         "/spec/datacenter/racks/0/resources", {
             "limits": {
                 "cpu": cpus,
-                "memory": db_cluster.k8s_cluster.calculated_memory_limit,
+                "memory": db_cluster.k8s_cluster.scylla_memory_limit,
             },
             "requests": {
                 "cpu": cpus,
-                "memory": db_cluster.k8s_cluster.calculated_memory_limit,
+                "memory": db_cluster.k8s_cluster.scylla_memory_limit,
             },
         })
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1288,11 +1288,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             "/spec/datacenter/racks/0/resources", {
                 "limits": {
                     "cpu": cpus,
-                    "memory": self.cluster.k8s_cluster.calculated_memory_limit,
+                    "memory": self.cluster.k8s_cluster.scylla_memory_limit,
                 },
                 "requests": {
                     "cpu": cpus,
-                    "memory": self.cluster.k8s_cluster.calculated_memory_limit,
+                    "memory": self.cluster.k8s_cluster.scylla_memory_limit,
                 },
             })
 
@@ -3698,7 +3698,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if not self._is_chaos_mesh_initialized():
             raise UnsupportedNemesis(
                 "Chaos Mesh is not installed. Set 'k8s_use_chaos_mesh' config option to 'true'")
-        memory_limit = self.cluster.k8s_cluster.calculated_memory_limit
+        memory_limit = self.cluster.k8s_cluster.scylla_memory_limit
         # If a container's memory usage increases too quickly the OOM killer is invoked
         # so reduce ramp to ~2GB/s: time_to_reach = memory (in GB) /2
         time_to_reach_secs = int(convert_memory_value_from_k8s_to_units(memory_limit)/2)


### PR DESCRIPTION
Recently merged PR [1] replaced `calculated_memory_limit` attr with the `scylla_memory_limit`.
And the old values were not replaced with the new one in several places. So, replace it.

[1] https://github.com/scylladb/scylla-cluster-tests/pull/5960

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
