### PR TITLE
improvement(grafana): use more correct SCT grafana dashboard structure

### DIFF
--- a/data_dir/scylla-dash-per-server-nemesis.master.json
+++ b/data_dir/scylla-dash-per-server-nemesis.master.json
@@ -1,5 +1,21 @@
 {
-  "dashboard": {
+    "uid": "grafana",
+    "title": "[$test_name] Scylla Per Server Metrics Nemesis Master",
+    "version": 1,
+    "schemaVersion": 36,
+    "timezone": "utc",
+    "fiscalYearStartMonth": 0,
+    "weekStart": "",
+    "refresh": false,
+    "editable": true,
+    "liveNow": false,
+    "style": "dark",
+    "graphTooltip": 1,
+    "iteration": 1660573895324,
+    "tags": [
+      "master"
+    ],
+    "links": [],
     "annotations": {
       "list": [
         {
@@ -138,12 +154,6 @@
         }
       ]
     },
-    "editable": true,
-    "fiscalYearStartMonth": 0,
-    "graphTooltip": 1,
-    "iteration": 1660573895324,
-    "links": [],
-    "liveNow": false,
     "panels": [
       {
         "class": "text_panel",
@@ -7588,12 +7598,6 @@
         }
       }
     ],
-    "refresh": false,
-    "schemaVersion": 36,
-    "style": "dark",
-    "tags": [
-      "master"
-    ],
     "templating": {
       "list": [
         {
@@ -7862,10 +7866,5 @@
         "7d",
         "30d"
       ]
-    },
-    "timezone": "utc",
-    "title": "[$test_name] Scylla Per Server Metrics Nemesis Master",
-    "version": 1,
-    "weekStart": ""
-  }
+    }
 }


### PR DESCRIPTION
The grafana version that is used by the scylla-operator refuses to import our json file with the SCT dashboard returning following error:

  Dashboard title cannot be empty

So, update the json file doing following steps:
- Remove first-level '"dashboard": {...}' wrapper-parameter.
- Add first-level '"uid": "grafana"' parameter.
- Move all the small first-level parameters to the top of the file for easier/faster reading.

After it we will be able to import that file to the both used grafana versions - SCT's and scylla-operator's ones.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
