### PR TITLE
fix(upgrade_test): index for sla role should be int

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -828,7 +828,7 @@ class UpgradeTest(FillDatabaseData):
         with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0], user=DEFAULT_USER,
                                                     password=DEFAULT_USER_PASSWORD) as session:
             for index, shares in enumerate(service_level_shares):
-                roles.append(create_sla_auth(session=session, shares=shares, index=str(index)))
+                roles.append(create_sla_auth(session=session, shares=shares, index=index))
 
         add_sla_credentials_to_stress_cmds(workload_names=workloads_with_sla, roles=roles,
                                            params=self.params, parent_class_name=self.__class__.__name__)


### PR DESCRIPTION
Upgrade test with sla failed, because index pass to function creating Role as str, while it expected int.

File "/home/ubuntu/scylla-cluster-tests/test_lib/sla.py", line 357,
in create_sla_auth role = Role(session=session, name=STRESS_ROLE_NAME_TEMPLATE % (shares or '', index),
TypeError: %d format: a real number is required, not str

job failed: https://jenkins.scylladb.com/job/enterprise-2022.2/job/rolling-upgrade/job/rolling-upgrade-with-sla-test/10/


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
