### PR TITLE
improvement(grafana): properly calculate nodes number in K8S's grafana

### DIFF
--- a/data_dir/scylla-dash-per-server-nemesis.master.json
+++ b/data_dir/scylla-dash-per-server-nemesis.master.json
@@ -229,7 +229,7 @@
         "pluginVersion": "8.5.2",
         "targets": [
           {
-            "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
+            "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\", endpoint!=\"node-exporter\"})",
             "intervalFactor": 1,
             "legendFormat": "Total Nodes",
             "refId": "A",
@@ -305,7 +305,7 @@
         "pluginVersion": "8.5.2",
         "targets": [
           {
-            "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
+            "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\", endpoint!=\"node-exporter\"}==0) OR vector(0)",
             "intervalFactor": 1,
             "legendFormat": "Unreachable",
             "refId": "A",


### PR DESCRIPTION
Prometheus deployed by Scylla operator uses 2 scrapes on each Scylla pod.
So, filter out second one in the node count dashboards to avoid doubled values.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
