### PR TITLE
feature(cassandra-harry): Allow harry to run longer

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -210,7 +210,7 @@ stress_image:
   alternator-dns: 'scylladb/hydra-loaders:alternator-dns-0.1'
   cdc-stresser: 'scylladb/hydra-loaders:cdc-stresser-20210630'
   kcl: 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC'
-  harry: 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816'
+  harry: 'scylladb/hydra-loaders:cassandra-harry-jdk11-20230406'
 
 service_level_shares: [1000]
 

--- a/docker/cassandra-harry/Dockerfile
+++ b/docker/cassandra-harry/Dockerfile
@@ -6,9 +6,13 @@ RUN apt -y update && apt -y install make \
 
 FROM openjdk:11 as app
 COPY --from=builder /cassandra-harry /cassandra-harry
+COPY external.yaml /cassandra-harry/conf/external.yaml
+COPY logback-dtest.xml /cassandra-harry/test/conf/logback-dtest.xml
 
 RUN sed -i '2s;^;HARRY_HOME=/cassandra-harry\n;'  /cassandra-harry/scripts/cassandra-harry
 RUN sed -i 's/external-.*-SNAPSHOT.jar/external-*-SNAPSHOT.jar/' /cassandra-harry/scripts/cassandra-harry
 RUN ln -svf /cassandra-harry/scripts/cassandra-harry /usr/bin/cassandra-harry
+RUN ln -svf /dev/null /cassandra-harry/validation.log
+RUN ln -svf /dev/null /cassandra-harry/operation.log
 
 WORKDIR /cassandra-harry

--- a/docker/cassandra-harry/external.yaml
+++ b/docker/cassandra-harry/external.yaml
@@ -1,0 +1,112 @@
+#   Licensed to the Apache Software Foundation (ASF) under one
+#   or more contributor license agreements.  See the NOTICE file
+#   distributed with this work for additional information
+#   regarding copyright ownership.  The ASF licenses this file
+#   to you under the Apache License, Version 2.0 (the
+#   "License"); you may not use this file except in compliance
+#   with the License.  You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+seed: 1596731732524
+
+# Default schema provider generates random schema
+schema_provider:
+  default: {}
+
+# Clock is a component responsible for mapping _logical_ timestamps to _real-time_ ones.
+#
+# When reproducing test failures, and for validation purposes, a snapshot of such clock can
+# be taken to map a real-time timestamp from the value retrieved from the database in order
+# to map it back to the logical timestamp of the operation that wrote this value.
+clock:
+  approximate_monotonic:
+    history_size: 7300
+    epoch_length: 1
+    epoch_time_unit: "SECONDS"
+
+drop_schema: false
+create_schema: true
+truncate_table: true
+
+# System under test: a Cassandra node or cluster. Default implementation is in_jvm (in-jvm DTest cluster).
+# Harry also supports external clusters.
+system_under_test:
+  external:
+    contact_points: 127.0.0.1
+    port: 9042
+    username: null
+    password: null
+
+# Partition descriptor selector controls how partitions is selected based on the current logical
+# timestamp. Default implementation is a sliding window of partition descriptors that will visit
+# one partition after the other in the window `slide_after_repeats` times. After that will
+# retire one partition descriptor, and pick one instead of it.
+partition_descriptor_selector:
+  default:
+    window_size: 10
+    slide_after_repeats: 100
+
+# Clustering descriptor selector controls how clusterings are picked within the partition:
+# how many rows there can be in a partition, how many rows will be visited for a logical timestamp,
+# how many operations there will be in batch, what kind of operations there will and how often
+# each kind of operation is going to occur.
+clustering_descriptor_selector:
+  default:
+    modifications_per_lts:
+      type: "constant"
+      constant: 2
+    rows_per_modification:
+      type: "constant"
+      constant: 2
+    operation_kind_weights:
+      DELETE_RANGE: 1
+      DELETE_SLICE: 1
+      DELETE_ROW: 1
+      DELETE_COLUMN: 1
+      DELETE_PARTITION: 1
+      DELETE_COLUMN_WITH_STATICS: 1
+      INSERT_WITH_STATICS: 50
+      INSERT: 50
+      UPDATE_WITH_STATICS: 50
+      UPDATE: 50
+    column_mask_bitsets: null
+    max_partition_size: 1000
+
+# Runner is a is a component that schedules operations that change the cluster (system under test)
+# and model state.
+runner:
+  sequential:
+    run_time: 2
+    run_time_unit: "HOURS"
+
+    visitors:
+      - logging:
+          row_visitor:
+            mutating: {}
+      - sampler:
+          sample_partitions: 10
+      - parallel_validate_recent_partitions:
+          partition_count: 100
+          queries_per_partition: 2
+          concurrency: 20
+          model:
+            quiescent_checker: {}
+      - validate_all_partitions:
+          concurrency: 20
+          model:
+            quiescent_checker: {}
+
+metric_reporter:
+  no_op: {}
+
+data_tracker:
+  locking:
+    max_seen_lts: -1
+    max_complete_lts: -1

--- a/docker/cassandra-harry/image
+++ b/docker/cassandra-harry/image
@@ -1,1 +1,1 @@
-scylladb/hydra-loaders:cassandra-harry-jdk11-20220816
+scylladb/hydra-loaders:cassandra-harry-jdk11-20230406

--- a/docker/cassandra-harry/logback-dtest.xml
+++ b/docker/cassandra-harry/logback-dtest.xml
@@ -1,0 +1,76 @@
+<!--
+  ~  Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+<configuration debug="false" scan="true" scanPeriod="60 seconds">
+  <define name="instance_id" class="org.apache.cassandra.distributed.impl.InstanceIDDefiner" />
+
+  <!-- Shutdown hook ensures that async appender flushes -->
+  <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook"/>
+
+  <appender name="INSTANCEFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+
+    <file>./build/test/logs/${cassandra.testtag}/TEST-${suitename}.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+      <fileNamePattern>./build/test/logs/${cassandra.testtag}/TEST-${suitename}.log.%i.gz</fileNamePattern>
+      <minIndex>1</minIndex>
+      <maxIndex>20</maxIndex>
+    </rollingPolicy>
+
+    <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+      <maxFileSize>20MB</maxFileSize>
+    </triggeringPolicy>
+
+    <encoder>
+      <pattern>%-5level [%thread] ${instance_id} %date{ISO8601} %msg%n</pattern>
+    </encoder>
+    <immediateFlush>false</immediateFlush>
+  </appender>
+
+  <appender name="INSTANCEASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
+    <discardingThreshold>0</discardingThreshold>
+    <maxFlushTime>0</maxFlushTime>
+    <queueSize>1024</queueSize>
+    <appender-ref ref="INSTANCEFILE"/>
+  </appender>
+
+  <appender name="INSTANCESTDERR" target="System.err" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%-5level %date{HH:mm:ss,SSS} %msg%n</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>INFO</level>
+    </filter>
+  </appender>
+
+  <appender name="INSTANCESTDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%-5level [%thread] ${instance_id} %date{ISO8601} %F:%L - %msg%n</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>INFO</level>
+    </filter>
+  </appender>
+
+  <logger name="org.apache.hadoop" level="WARN"/>
+
+  <root level="DEBUG">
+    <appender-ref ref="INSTANCEASYNCFILE" />
+    <appender-ref ref="INSTANCESTDERR" />
+    <appender-ref ref="INSTANCESTDOUT" />
+  </root>
+</configuration>

--- a/jenkins-pipelines/longevity-harry-24h.jenkinsfile
+++ b/jenkins-pipelines/longevity-harry-24h.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/longevity/longevity-harry-24h.yaml'
+
+)

--- a/test-cases/longevity/longevity-harry-24h.yaml
+++ b/test-cases/longevity/longevity-harry-24h.yaml
@@ -1,0 +1,17 @@
+test_duration: 1560
+stress_cmd: ["cassandra-harry -run-time 24 -run-time-unit HOURS"]
+
+n_db_nodes: 6
+n_loaders: 1
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.large'
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_selector: ['!disruptive']
+nemesis_seed: '301'
+nemesis_interval: 5
+
+user_prefix: 'longevity-harry-24h'
+space_node_threshold: 64424
+use_mgmt: false

--- a/test-cases/longevity/longevity-harry-2h.yaml
+++ b/test-cases/longevity/longevity-harry-2h.yaml
@@ -7,8 +7,6 @@ n_monitor_nodes: 1
 
 instance_type_db: 'i3.large'
 
-root_disk_size_loader: 80 # enlarge loader disk, cause of cassandra-harry operation.log that can't be disabled
-
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '001'
 nemesis_interval: 2


### PR DESCRIPTION
cassandra-harry creates `validation.log` and `operations.log` which
store all the queries executed. This makes disk quickly fill up so
we can't run it for long.

Create `validation.log` and `operations.log` symbolic links to
`/dev/null` so disk is not filled up and can run longer.
Additionally set logger to INFO level instead of DEBUG.
Also rebuild of docker image caused update of cassandra-harry binaries
with some new features commited in Mar 14, 2023 in harry's repo.
Due to that needed to modify `external.yaml` config file to have random
schema.

Add 24h test with cassandra-harry.

refs: https://github.com/scylladb/qa-tasks/issues/906

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
