### PR TITLE
fix(cluster): dpkg -s for checking if a package is installed

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2092,7 +2092,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if self.distro.is_rhel_like or self.distro.is_sles:
             result = self.remoter.run(f'rpm -q {self.scylla_pkg()}', verbose=False, ignore_status=True)
         elif self.distro.is_ubuntu or self.distro.is_debian:
-            result = self.remoter.run(f'dpkg-query --show {self.scylla_pkg()}', verbose=False, ignore_status=True)
+            result = self.remoter.run(f'dpkg-query --status {self.scylla_pkg()}', verbose=False, ignore_status=True)
         else:
             raise ValueError(f"Unsupported Linux distribution: {self.distro}")
         if result.exit_status == 0:


### PR DESCRIPTION
the return code of `dpkg-query --show` does not imply if a package is installed. this command fails only when the package is not found.

quote from dpkg-query(1)
```
       -W, --show [package-name-pattern...]
           Just like the --list option this will list all packages matching the given patterns. However the output can be customized using the
           --showformat option.

           The default output format gives one line per matching package, each line consisting of the package name and its installed version, separated by
           a tab.  The package name will be architecture qualified for packages with a Multi-Arch field with the value same or with a foreign
           architecture, which is an architecture that is neither the native one nor all.

       -s, --status [package-name...]
           Report status of specified packages. This just displays the entry in the installed package status database.  If no package-name is specified it
           will display all package entries in the status database (since dpkg 1.19.1).  When multiple package-name entries are listed, the requested
           status entries are separated by an empty line, with the same order as specified on the argument list.
```
and verified using

```console
$ dpkg-query --show mutt && echo yup
mutt
yup
$ dpkg-query --status mutt && echo yup
dpkg-query: package 'mutt' is not installed and no information is available
Use dpkg --info (= dpkg-deb --info) to examine archive files.
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
