### PR TITLE
fix(cluster): install openjdk-11 for offline install

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1994,18 +1994,18 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         else:
             additional_pkgs = 'xfsprogs mdadm'
 
-        # Offline install does't provide openjdk-8, it has to be installed in advance
+        # Offline install does't provide openjdk-11, it has to be installed in advance
         # https://github.com/scylladb/scylla-jmx/issues/127
         if self.is_rhel_like():
-            self.remoter.run(f'sudo yum install -y java-1.8.0-openjdk {additional_pkgs}')
+            self.remoter.run(f'sudo yum install -y java-11-openjdk-headless {additional_pkgs}')
         elif self.distro.is_sles:
             raise Exception("Offline install on SLES isn't supported")
         elif self.distro.is_debian10 or self.distro.is_debian11:
             self.remoter.run(f'sudo apt-get install -y openjdk-11-jre-headless {additional_pkgs}')
         else:
-            self.remoter.run(f'sudo apt-get install -y openjdk-8-jre-headless {additional_pkgs}')
+            self.remoter.run(f'sudo apt-get install -y openjdk-11-jre-headless {additional_pkgs}')
             self.remoter.run('sudo update-java-alternatives --jre-headless '
-                             '-s java-1.8.0-openjdk-${dpkg-architecture -q DEB_BUILD_ARCH}')
+                             '-s java-1.11.0-openjdk-${dpkg-architecture -q DEB_BUILD_ARCH}')
 
         package_version_cmds_v2 = dedent("""
             tar -xzO --wildcards -f ./unified_package.tar.gz .relocatable_package_version


### PR DESCRIPTION
since we bumped the jre used by scylla-jmx from openjdk-8 to openjdk-11, and we started to check for jre-11. despite that scylla-jmx still works with jre-8, jre-11 is the recommended JRE for running scylla-jmx, let's use openjdk-11 for testing offline installation.

please note, https://github.com/scylladb/scylla-jmx/pull/198 was also created to address this issue. but in the long run, this fix is a better one. as it's always desirable to use a better supported jre in testing.

Refs https://github.com/scylladb/scylla-jmx/issues/127
Fixes https://github.com/scylladb/scylladb/issues/13414
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
