### PR TITLE
fix(cluster): do not install python for cqlsh

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1994,12 +1994,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         else:
             additional_pkgs = 'xfsprogs mdadm'
 
-        # scylla current cqlsh still need python2 to work
-        if self.distro.is_ubuntu18:
-            additional_pkgs += ' python2.7'
-        else:
-            additional_pkgs += ' python2'
-
         # Offline install does't provide openjdk-8, it has to be installed in advance
         # https://github.com/scylladb/scylla-jmx/issues/127
         if self.is_rhel_like():


### PR DESCRIPTION
we started to use a cqlsh which does not support
python2 anymore since https://github.com/scylladb/scylladb/pull/13328,
and scylla-cqlsh does support relocatable python3 in its `install.sh`,
see
https://github.com/scylladb/scylla-cqlsh/commit/3eef722c8c63f0494bac3c2edcbffeef37477648.
so there is no need to install python2 or python3 for cqlsh
anymore.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
