### PR TITLE
docs(README): s/on/one/

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Ask your AWS account admin to create a user and access key for AWS) and then con
     Default output format [None]:
 
 
-From here you can proceed with on of the 2 options
+From here you can proceed with one of the 2 options
 
 Option 1: Setup SCT in Docker
 -----------------------------


### PR DESCRIPTION
should read: "one of the 2 options". hence the change.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
