### PR TITLE
fix(unit_test): prevent logging from raising exceptions after tests

### DIFF
--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -142,3 +142,14 @@ def fixture_params(request: pytest.FixtureRequest):
 @pytest.fixture(scope='function', autouse=True)
 def fixture_cleanup_continuous_events_registry():
     ContinuousEventsRegistry().cleanup_registry()
+
+
+def pytest_sessionfinish():
+    # pytest's capsys is enabled by default, see
+    # https://docs.pytest.org/en/7.1.x/how-to/capture-stdout-stderr.html.
+    # but pytest closes its internal stream for capturing the stdout and
+    # stderr, so we are not able to write the logger anymore once the test
+    # session finishes. see https://github.com/pytest-dev/pytest/issues/5577,
+    # to silence the warnings, let's just prevent logging from raising
+    # exceptions.
+    logging.raiseExceptions = False


### PR DESCRIPTION
pytest's capsys just closes the stdout when done with tests. there are issues tracking this problem, see pytest-dev/pytest#5577 . but we adds a handler which redirect the logging messages to stdout. so, once pytest finishes testing, exceptions are raised when writing logging messages, like
```
22:37:20    File "/usr/local/lib/python3.10/logging/__init__.py", line 1101, in emit
22:37:20      stream.write(msg + self.terminator)
22:37:20  ValueError: I/O operation on closed file.
```
so, in this change, `logging.raiseExceptions` is disabled when pytest's session finishes.

Fixes #6000

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
