### PR TITLE
fix(perf-search-best-config): New parameter to pipeline

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -221,3 +221,5 @@ stop_on_hw_perf_failure: false
 custom_es_index: ''
 
 run_fullscan: []
+
+stress_step_duration: '15m'

--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -77,7 +77,10 @@ def call(Map pipelineParams) {
             string(defaultValue: '', description: 'Number of stress process per loader', name: 'n_stress_process')
             string(defaultValue: '', description: 'Number of process add/remove on each round', name: 'stress_process_step')
 
-            string(defaultValue: '', description: 'Relative difference between current and best to choose new best result', name: 'max_deviation')
+            string(defaultValue: '', description: 'Stress step duration for c-s command, ex: 15m, 3h, etc. Default value is 15 minutes',
+                   name: 'stress_step_duration')
+            string(defaultValue: '', description: 'Relative difference between current and best to choose new best result',
+                   name: 'max_deviation')
 
             string(defaultValue: '', description: 'Prepare Cassandra Stress command to run', name: 'prepare_write_cmd')
             string(defaultValue: '', description: 'Write Cassandra Stress command to run', name: 'stress_cmd_w')
@@ -86,6 +89,9 @@ def call(Map pipelineParams) {
             booleanParam(name: 'use_client_encryption',
                          defaultValue: false,
                          description: 'Enable client encryption')
+            booleanParam(name: 'use_prepared_loaders',
+                         defaultValue: true,
+                         description: 'Run c-s process in docker (False), on prepared instance(True)')
 
             string(defaultValue: "${pipelineParams.get('k8s_scylla_operator_helm_repo', 'https://storage.googleapis.com/scylla-operator-charts/latest')}",
                    description: 'Scylla Operator helm repo',
@@ -257,7 +263,12 @@ def call(Map pipelineParams) {
                                                             export SCT_STRESS_CMD_M="${params.stress_cmd_m}"
                                                         fi
 
+                                                        if [[ ! -z "${params.stress_step_duration}" ]] ; then
+                                                            export SCT_STRESS_STEP_DURATION="${params.stress_step_duration}"
+                                                        fi
+
                                                         export SCT_CLIENT_ENCRYPT=${params.use_client_encryption}
+                                                        export SCT_USE_PREPARED_LOADERS=${params.use_prepared_loaders}
 
                                                         export SCT_AVAILABILITY_ZONE="${params.availability_zone}"
 


### PR DESCRIPTION
Added 2 new parameters to be configured via pipeline parameters.
- Stress step duration: set duration for step for c-s command in format
  - 10m
  - 15m
  - 1h
- Use predefined loader instance: run c-s as process on loader instance if set as true, if false run c-s command in docker container.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
