### PR TITLE
fix(sla auth): change function parameter type

### DIFF
--- a/longevity_sla_test.py
+++ b/longevity_sla_test.py
@@ -31,11 +31,11 @@ class LongevitySlaTest(LongevityTest):
             # Add index (shares position in the self.service_level_shares list) to role and service level names to do
             # it unique and prevent failure when try to create role/SL with same name
             for index, shares in enumerate(self.service_level_shares):
-                self.roles.append(create_sla_auth(session=session, shares=shares, index=index))
+                self.roles.append(create_sla_auth(session=session, shares=shares, index=str(index)))
 
             if self.params.get("run_fullscan"):
                 self.fullscan_role = create_sla_auth(session=session, shares=self.FULLSCAN_SERVICE_LEVEL_SHARES,
-                                                     index=0)
+                                                     index='0')
 
         add_sla_credentials_to_stress_cmds(workload_names=['prepare_write_cmd', 'stress_cmd', 'stress_read_cmd'],
                                            roles=self.roles, params=self.params,

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -97,7 +97,7 @@ from sdcm.wait import wait_for
 from test_lib.compaction import CompactionStrategy, get_compaction_strategy, get_compaction_random_additional_params, \
     get_gc_mode, GcMode
 from test_lib.cql_types import CQLTypeBuilder
-from test_lib.sla import ServiceLevel
+from test_lib.sla import ServiceLevel, DEFAULT_USER, DEFAULT_USER_PASSWORD, SERVICE_LEVEL_NAME_TEMPLATE
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1539,8 +1539,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         role = self.tester.roles[0]
 
-        with self.cluster.cql_connection_patient(node=self.cluster.nodes[0], user=self.tester.DEFAULT_USER,
-                                                 password=self.tester.DEFAULT_USER_PASSWORD) as session:
+        with self.cluster.cql_connection_patient(node=self.cluster.nodes[0], user=DEFAULT_USER,
+                                                 password=DEFAULT_USER_PASSWORD) as session:
             self.log.info("Drop service level %s", role.attached_service_level_name)
             removed_shares = role.attached_service_level.shares
             role.attached_service_level.session = session
@@ -1551,8 +1551,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             finally:
                 role.attach_service_level(
                     ServiceLevel(session=session,
-                                 name=self.tester.SERVICE_LEVEL_NAME_TEMPLATE % (
-                                     removed_shares, random.randint(0, 10)),
+                                 name=SERVICE_LEVEL_NAME_TEMPLATE % (removed_shares, str(random.randint(0, 10))),
                                  shares=removed_shares).create())
 
     def refresh_nodes_ip_and_reconfigure_monitor(self, nodes: list = None):

--- a/test_lib/sla.py
+++ b/test_lib/sla.py
@@ -14,9 +14,9 @@ LOGGER = logging.getLogger(__name__)
 
 DEFAULT_USER = "cassandra"
 DEFAULT_USER_PASSWORD = "cassandra"
-STRESS_ROLE_NAME_TEMPLATE = 'role%s_%d'
+STRESS_ROLE_NAME_TEMPLATE = 'role%s_%s'
 STRESS_ROLE_PASSWORD_TEMPLATE = 'rolep%s'
-SERVICE_LEVEL_NAME_TEMPLATE = 'sl%s_%d'
+SERVICE_LEVEL_NAME_TEMPLATE = 'sl%s_%s'
 
 
 def sla_result_to_dict(sla_result):
@@ -353,7 +353,7 @@ class User(UserRoleBase):
         return self
 
 
-def create_sla_auth(session, shares: int, index: int) -> Role:
+def create_sla_auth(session, shares: int, index: str) -> Role:
     role = Role(session=session, name=STRESS_ROLE_NAME_TEMPLATE % (shares or '', index),
                 password=STRESS_ROLE_PASSWORD_TEMPLATE % shares or '', login=True).create()
     role.attach_service_level(ServiceLevel(session=session, name=SERVICE_LEVEL_NAME_TEMPLATE % (shares or '', index),


### PR DESCRIPTION
Upgrade test with sla failed, because index pass to function creating Role as str, while it expected int.

It happened because of the https://github.com/scylladb/scylla-cluster-tests/pull/5950 was backported into 2022.2 but https://github.com/scylladb/scylla-cluster-tests/pull/5868 was not backported.

We do not intend to backport https://github.com/scylladb/scylla-cluster-tests/pull/5868 meanwhile. This commit changes 'index' parameter type to 'str'

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
