### PR TITLE
feature(chaos-mesh): added network interruption failures

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2949,7 +2949,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         now = time.time()
         results = prometheus_stats.query(query=query, start=now - 600, end=now)
         assert results, "no results for node_network_receive_bytes_total metric in Prometheus "
-        avg_bitrate_per_node = max([float(avg_rate) for _, avg_rate in results[0]["values"]])
+        received_bytes_over_time = [float(avg_rate) for _, avg_rate in results[0]["values"]]
+        avg_bitrate_per_node = (received_bytes_over_time[-1] - received_bytes_over_time[0]) / 600
         avg_mpbs_per_node = avg_bitrate_per_node / 1024 / 1024
 
         if avg_mpbs_per_node > 10:


### PR DESCRIPTION
With chaos-mesh it is possible to introduce network failures using `NetworkChaos` experiment. We want to use it in K8s tests.

Introduce 4 chaos-mesh failures: packet loss, corruption, network delay and limit bandwidth.
Adapt `RandomInterruptionNetworkMonkey` to use it when on k8s.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
