### PR TITLE
fix(provisioner): fix after multi-az

### DIFF
--- a/sdcm/sct_provision/aws/cluster.py
+++ b/sdcm/sct_provision/aws/cluster.py
@@ -192,11 +192,12 @@ class ClusterBase(BaseModel):
             provisioner=AWSInstanceProvisioner(),
         ).provision_plan
 
-    def _instance_parameters(self, region_id: int) -> AWSInstanceParams:
+    def _instance_parameters(self, region_id: int, availability_zone: int = 0) -> AWSInstanceParams:
         params_builder = self._INSTANCE_PARAMS_BUILDER(  # pylint: disable=not-callable
             params=self.params,
             region_id=region_id,
-            user_data_raw=self._user_data
+            user_data_raw=self._user_data,
+            availability_zone=availability_zone,
         )
         return AWSInstanceParams(**params_builder.dict(exclude_none=True, exclude_unset=True, exclude_defaults=True))
 
@@ -205,7 +206,7 @@ class ClusterBase(BaseModel):
             return []
         total_instances_provisioned = []
         for region_id in range(len(self._regions_with_nodes)):
-            instance_parameters = self._instance_parameters(region_id=region_id)
+            instance_parameters = self._instance_parameters(region_id=region_id, availability_zone=0)
             node_tags = self._node_tags(region_id=region_id)
             node_names = self._node_names(region_id=region_id)
             node_count = self._node_nums[region_id]

--- a/sdcm/sct_provision/aws/instance_parameters_builder.py
+++ b/sdcm/sct_provision/aws/instance_parameters_builder.py
@@ -29,6 +29,7 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
     params: Union[SCTConfiguration, dict] = Field(as_dict=False)
     region_id: int = Field(as_dict=False)
     user_data_raw: Union[str, UserDataBuilderBase] = Field(as_dict=False)
+    availability_zone: int = 0
 
     _INSTANCE_TYPE_PARAM_NAME: str = None
     _IMAGE_ID_PARAM_NAME: str = None
@@ -113,7 +114,7 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
         return self.params.get('availability_zone').split(',')
 
     @cached_property
-    def _ec2_network_configuration(self) -> Tuple[List[str], List[str]]:
+    def _ec2_network_configuration(self) -> Tuple[List[str], List[List[str]]]:
         return get_ec2_network_configuration(
             regions=self.params.region_names,
             availability_zones=self._availability_zones,
@@ -131,7 +132,7 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
     @property
     def _network_interface_params(self):
         return {
-            'SubnetId': self._ec2_subnet_ids[self.region_id],  # pylint: disable=invalid-sequence-index
+            'SubnetId': self._ec2_subnet_ids[self.region_id][self.availability_zone],  # pylint: disable=invalid-sequence-index
             'Groups': self._ec2_security_group_ids[self.region_id],  # pylint: disable=invalid-sequence-index
         }
 


### PR DESCRIPTION
Recent merge of multi-az support broke provisioner.

Add basic support for this change in provisioner step.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
