### PR TITLE
improvement(performance regression): post_prepare_cql_cmds support

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -255,6 +255,21 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         else:
             self.log.warning("No prepare command defined in YAML!")
 
+        if post_prepare_cql_cmds := self.params.get('post_prepare_cql_cmds'):
+            self.log.debug("Execute post prepare queries: %s", post_prepare_cql_cmds)
+            self._run_cql_commands(post_prepare_cql_cmds)
+
+    def _run_cql_commands(self, cmds, node=None):
+        node = node if node else self.db_cluster.nodes[0]
+
+        if not isinstance(cmds, list):
+            cmds = [cmds]
+
+        for cmd in cmds:
+            # pylint: disable=no-member
+            with self.db_cluster.cql_connection_patient(node) as session:
+                session.execute(cmd)
+
     def run_read_workload(self, nemesis=False):
         base_cmd_r = self.params.get('stress_cmd_r')
         # create new document in ES with doc_id = test_id + timestamp

--- a/test-cases/performance/ycsb/perf-base.yaml
+++ b/test-cases/performance/ycsb/perf-base.yaml
@@ -16,6 +16,9 @@ prepare_write_cmd:
     -p scylla.coreconnections=14 -p scylla.maxconnections=14
     -p scylla.readconsistencylevel=ALL -p scylla.writeconsistencylevel=ALL
 
+# there is also post_prepare_cql_cmds option can be used in performanse tests now. Example:
+# post_prepare_cql_cmds: "ALTER TABLE keyspace1.standard1 WITH speculative_retry = 'NONE'"
+
 # --target must be set to have correct latency results for const throughput - see coordinated omission avoidance problem
 #
 # we need high concurrency per shard to at least somewhat load request queues


### PR DESCRIPTION
added post_prepare_cql_cmds option support in performance regression tests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
