### PR TITLE
fix(raft): make 'get_group0_members' work correctly when raft disabled

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3080,9 +3080,20 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         # ]
         #
         # 4th element is needed only
+        #
+        # And if was not found (raft disbled):
+        # [
+        #   ""
+        #   "value"
+        #   "-------"
+        #   ""
+        #   "(0 rows)"
+        # ]
         if not result or len(result) <= 3:
             return []
         raft_group0_id = result[3].strip()
+        if not raft_group0_id or "0 rows" in raft_group0_id:
+            return []
 
         result = self.run_cqlsh(
             f"select server_id, can_vote from system.raft_state where group_id = {raft_group0_id} and disposition = 'CURRENT'",


### PR DESCRIPTION
Recently merged PR [1] added logic where we compare group0 and token ring members.
And the problem with it is that it fails when 'raft' feature is disabled and group0 is empty.

So, fix it by proper handling of group0 emptyness.

[1] https://github.com/scylladb/scylla-cluster-tests/pull/5928

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
