### PR TITLE
fix(cluster): Add checks for raft disabling

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -122,6 +122,7 @@ from sdcm.utils.remote_logger import get_system_logging_thread
 from sdcm.utils.scylla_args import ScyllaArgParser
 from sdcm.utils.file import File
 from sdcm.utils import cdc
+from sdcm.utils.raft import get_raft_mode
 from sdcm.coredump import CoredumpExportSystemdThread
 from sdcm.keystore import KeyStore
 from sdcm.paths import (
@@ -187,10 +188,6 @@ class NodeStayInClusterAfterDecommission(Exception):
 
 class NodeCleanedAfterDecommissionAborted(Exception):
     """ raise after decommission aborted and node cleaned from group0(Raft)"""
-
-
-class Group0MembersNotConsistenWithTokenRingMembers(Exception):
-    """ raise if set of group0 members differs from Tokein Ring members after removing Ghost members"""
 
 
 def prepend_user_prefix(user_prefix: str, base_name: str):
@@ -644,6 +641,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 return node_seeds.split(',')
             else:
                 raise Exception('Seeds not found in the scylla.yaml')
+
+    @cached_property
+    def raft(self):
+        return get_raft_mode(self)
 
     @staticmethod
     def is_kubernetes() -> bool:
@@ -2575,7 +2576,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         nodes_status = self.get_nodes_status()
         peers_details = self.get_peers_info() or {}
         gossip_info = self.get_gossip_info() or {}
-        group0_members = self.get_group0_members()
+        group0_members = self.raft.get_group0_members()
         tokenring_members = self.get_token_ring_members()
 
         return itertools.chain(
@@ -3024,8 +3025,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     @retrying(n=5, sleep_time=5, raise_on_exceeded=False)
     def get_token_ring_members(self) -> list[dict[str, str]]:
-        token_ring_members = []
         self.log.debug("Get token ring members")
+        token_ring_members = []
         token_ring_members_cmd = 'curl -s -X GET --header "Content-Type: application/json" --header ' \
             '"Accept: application/json" "http://127.0.0.1:10000/storage_service/host_id"'
         result = self.remoter.run(token_ring_members_cmd, ignore_status=True, verbose=True)
@@ -3034,40 +3035,12 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         try:
             result_json = json.loads(result.stdout)
         except Exception as exc:  # pylint: disable=broad-except
-            self.log.warning("Failed to parse response %s", exc)
+            self.log.warning("Error getting token-ring data: %s", exc)
             return []
 
         for member in result_json:
             token_ring_members.append({"host_id": member.get("value"), "ip_address": member.get("key")})
-        self.log.debug("Token ring members %s", token_ring_members)
         return token_ring_members
-
-    @retrying(n=5, sleep_time=5, raise_on_exceeded=False)
-    def get_group0_members(self) -> list[dict[str, str]]:
-        self.log.debug("Get group0 members")
-        group0_members = []
-        try:
-            with self.parent_cluster.cql_connection_patient_exclusive(node=self) as session:
-                row = session.execute("select value from system.scylla_local where key = 'raft_group0_id'").one()
-                if not row:
-                    return []
-                raft_group0_id = row.value
-
-                rows = session.execute(f"select server_id, can_vote from system.raft_state  \
-                                       where group_id = {raft_group0_id} and disposition = 'CURRENT'").all()
-
-                for row in rows:
-                    group0_members.append({"host_id": str(row.server_id),
-                                           "voter": row.can_vote})
-        except Exception as exc:  # pylint: disable=broad-except
-            err_msg = f"Get group0 members failed with error: {exc}"
-            self.log.error(err_msg)
-            InfoEvent(message=err_msg, severity=Severity.ERROR).publish()
-
-            raise
-
-        self.log.debug("Group0 members: %s", group0_members)
-        return group0_members
 
 
 class FlakyRetryPolicy(RetryPolicy):
@@ -4616,7 +4589,11 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             verification_node = random.choice(undecommission_nodes)
             node_ip_list = get_node_ip_list(verification_node)
 
-        missing_host_ids = self.diff_token_ring_group0_members(verification_node)
+        missing_host_ids = verification_node.raft.diff_token_ring_group0_members()
+
+        if not missing_host_ids:
+            self.log.debug("Node %s returned to tokenring, but stay non-voter. Add its host-id for remove")
+            missing_host_ids = verification_node.raft.get_group0_non_voters()
 
         decommission_done = list(node.follow_system_log(
             patterns=['DECOMMISSIONING: done'], start_from_beginning=True))
@@ -4642,7 +4619,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             self.terminate_node(node)  # pylint: disable=no-member
             self.test_config.tester_obj().monitors.reconfigure_scylla_monitoring()
             self.log.debug("Node %s was terminated", node.name)
-            self.clean_group0_garbage(verification_node, raise_exception=True)
+            verification_node.raft.clean_group0_garbage(raise_exception=True)
             LOGGER.error("Decommission for node %s was aborted", node)
             raise NodeCleanedAfterDecommissionAborted(f"Decommission for node {node} was aborted")
 
@@ -4654,35 +4631,6 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         with adaptive_timeout(operation=Operations.DECOMMISSION, node=node):
             node.run_nodetool("decommission", timeout=timeout, retry=0)
         self.verify_decommission(node)
-
-    def clean_group0_garbage(self, node: BaseNode, raise_exception: bool = False):
-        InfoEvent("Clean host ids from group0").publish()
-        host_ids = self.diff_token_ring_group0_members(node)
-        if not host_ids:
-            self.log.debug("Node could return to token ring but not yet bootstrap")
-            # Add host id which cann't vote after decommission was aborted because it is already terminated")
-            host_ids = [member['host_id'] for member in node.get_group0_members() if not member['voter']]
-        while host_ids:
-            removing_host_id = host_ids.pop(0)
-            ingore_dead_nodes_opt = f"--ignore-dead-nodes {','.join(host_ids)}" if host_ids else ""
-
-            result = node.run_nodetool(f"removenode {removing_host_id} {ingore_dead_nodes_opt}",
-                                       ignore_status=True,
-                                       verbose=True,
-                                       retry=3)
-            if not result.ok:
-                self.log.error("Removenode with host_id %s failed with %s",
-                               removing_host_id, result.stdout + result.stderr)
-            if not host_ids:
-                break
-
-        if missing_host_ids := self.diff_token_ring_group0_members(node):
-            token_ring_members = node.get_token_ring_members()
-            group0_members = node.get_group0_members()
-            error_msg = f"Token ring {token_ring_members} and group0 {group0_members} are differs on: {missing_host_ids}"
-            self.log.error(error_msg)
-            if raise_exception:
-                raise Group0MembersNotConsistenWithTokenRingMembers(error_msg)
 
     @property
     def scylla_manager_node(self) -> BaseNode:
@@ -4746,16 +4694,6 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
         self.log.info("DB nodes CPU modes: %s", results)
         return results
-
-    def diff_token_ring_group0_members(self, node: BaseNode) -> list[str]:
-        self.log.debug("Compare token ring and group0 members")
-        group0_members = node.get_group0_members()
-        group0_members_ids = {member["host_id"] for member in group0_members}
-        token_ring_members = node.get_token_ring_members()
-        token_ring_member_ids = {member["host_id"] for member in token_ring_members}
-        self.log.debug("Token rings members ids: %s", token_ring_member_ids)
-        self.log.debug("Group0 members ids: %s", group0_members_ids)
-        return list(group0_members_ids - token_ring_member_ids)
 
 
 class BaseLoaderSet():

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -122,6 +122,7 @@ from sdcm.keystore import KeyStore
 from sdcm.utils.latency import calculate_latency, analyze_hdr_percentiles
 from sdcm.utils.csrangehistogram import CSHistogramTagTypes, CSWorkloadTypes, make_cs_range_histogram_summary, \
     make_cs_range_histogram_summary_by_interval
+from sdcm.utils.raft.common import validate_raft_on_nodes
 
 
 CLUSTER_CLOUD_IMPORT_ERROR = ""
@@ -853,6 +854,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         for db_cluster in self.db_clusters_multitenant:
             if db_cluster:
                 db_cluster.validate_seeds_on_all_nodes()
+                validate_raft_on_nodes(nodes=db_cluster.nodes)
 
     def set_system_auth_rf(self, db_cluster=None):
         if not db_cluster:

--- a/sdcm/utils/health_checker.py
+++ b/sdcm/utils/health_checker.py
@@ -268,7 +268,11 @@ def check_schema_agreement_in_gossip_and_peers(node, retries: int = CHECK_NODE_H
 def check_group0_tokenring_consistency(group0_members: list[dict[str, str]],
                                        tokenring_members: list[dict[str, str]],
                                        current_node) -> HealthEventsGenerator:
-    LOGGER.debug("Check all nodes in group0 are voters")
+    if not current_node.raft.is_enabled:
+        LOGGER.debug("Raft feature is disabled on node %s (host_id=%s)", current_node.name, current_node.host_id)
+        return
+    LOGGER.debug("Check group0 and tokenring consistency on node %s (host_id=%s)...",
+                 current_node.name, current_node.host_id)
     token_ring_node_ids = [member["host_id"] for member in tokenring_members]
     for member in group0_members:
         if member["voter"] and member["host_id"] in token_ring_node_ids:
@@ -284,3 +288,5 @@ def check_group0_tokenring_consistency(group0_members: list[dict[str, str]],
             node=current_node.name,
             error=error_message,
         )
+    LOGGER.debug("Group0 and token-ring are consistent on node %s (host_id=%s)...",
+                 current_node.name, current_node.host_id)

--- a/sdcm/utils/raft/common.py
+++ b/sdcm/utils/raft/common.py
@@ -1,0 +1,31 @@
+import logging
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class RaftException(Exception):
+    """Raise if raft feature mode differs on nodes"""
+
+
+def validate_raft_on_nodes(nodes: list["BaseNode"]) -> None:
+    LOGGER.debug("Check that raft is enabled on all the nodes")
+    raft_enabled_on_nodes = [node.raft.is_enabled for node in nodes]
+    if len(set(raft_enabled_on_nodes)) != 1:
+        raise RaftException("Raft configuration is not the same on all the nodes")
+
+    if not all(raft_enabled_on_nodes):
+        LOGGER.debug("Raft feature is disabled)")
+        return
+    LOGGER.debug("Raft feature is enabled)")
+    LOGGER.debug("Check raft feature status on nodes")
+    nodes_raft_status = []
+    for node in nodes:
+        if raft_ready := node.raft.is_ready():
+            nodes_raft_status.append(raft_ready)
+            continue
+        LOGGER.error("Node %s has raft status: %s", node.name, node.raft.get_status())
+    if not all(nodes_raft_status):
+        raise RaftException("Raft is not ready")
+
+    LOGGER.debug("Raft is ready!")


### PR DESCRIPTION
Some jobs for 5.2 could run with raft disabled.
In this case group0 is empty and not need to check consistency of group0 and tokenring

Add new method to get status of raft (is_enabled, is_ready) if raft is disabled, group0_members will be empty, and consistency check will be skipped

Failed jobs: 
- https://jenkins.scylladb.com/job/enterprise-2023.1/job/upgrade-with-raft/job/rolling-upgrade-ubuntu22.04-with-raft-test/4/
- https://jenkins.scylladb.com/job/enterprise-2023.1/job/disabled_raft/job/longevity-1tb-7days-test/3/


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
