### PR TITLE
fix(gemini): set gemini base image to debian

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -206,7 +206,7 @@ stress_image:
   nosqlbench: 'scylladb/hydra-loaders:nosqlbench-4.15.49'
   cassandra-stress: '' # default would be same version as scylla under test
   scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.16'
-  gemini: 'scylladb/hydra-loaders:gemini-1.7.8'
+  gemini: 'scylladb/hydra-loaders:gemini-1.7.8-minideb'
   alternator-dns: 'scylladb/hydra-loaders:alternator-dns-0.1'
   cdc-stresser: 'scylladb/hydra-loaders:cdc-stresser-20210630'
   kcl: 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC'

--- a/docker/gemini/Dockerfile
+++ b/docker/gemini/Dockerfile
@@ -11,9 +11,9 @@ RUN curl -LO https://s3.amazonaws.com/downloads.scylladb.com/gemini/${version}/g
     tar -xvf gemini_${version}_Linux_x86_64.tar.gz ;\
     chmod a+x gemini
 
-FROM busybox
+FROM bitnami/minideb:bullseye
 
-ENV PATH="/bin:/sbin:/gemini"
+ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/gemini"
 COPY --from=builder /gemini /gemini
 
 WORKDIR /gemini

--- a/docker/gemini/README.md
+++ b/docker/gemini/README.md
@@ -1,5 +1,5 @@
 ```
-export GEMINI_VERSION=1.7.6
+export GEMINI_VERSION=1.7.8
 export GEMINI_DOCKER_IMAGE=scylladb/hydra-loaders:gemini-$GEMINI_VERSION
 docker build . -t ${GEMINI_DOCKER_IMAGE} --build-arg version=$GEMINI_VERSION
 docker push ${GEMINI_DOCKER_IMAGE}

--- a/docker/gemini/image
+++ b/docker/gemini/image
@@ -1,1 +1,1 @@
-scylladb/hydra-loaders:gemini-1.7.8
+scylladb/hydra-loaders:gemini-1.7.8-minideb

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -178,13 +178,13 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
     def test_12_scylla_version_ami(self):
         os.environ.pop('SCT_AMI_ID_DB_SCYLLA', None)
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_SCYLLA_VERSION'] = '4.6.3'
+        os.environ['SCT_SCYLLA_VERSION'] = '5.1.8'
 
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 
-        self.assertEqual(conf.get('ami_id_db_scylla'), 'ami-03d8b6dcd63bd4e24 ami-09c658571b2d46d18')
+        self.assertEqual(conf.get('ami_id_db_scylla'), 'ami-0e8a0f4016294654a ami-0554f19f2ba89f446')
 
     @pytest.mark.integration
     @staticmethod
@@ -287,18 +287,18 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
     def test_13_scylla_version_ami_branch(self):  # pylint: disable=invalid-name
         os.environ.pop('SCT_AMI_ID_DB_SCYLLA', None)
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_SCYLLA_VERSION'] = 'branch-5.0:32'
+        os.environ['SCT_SCYLLA_VERSION'] = 'branch-5.1:32'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 
-        self.assertEqual(conf.get('ami_id_db_scylla'), 'ami-076a213c791dc19cd ami-0625f2d18e05bf206')
+        self.assertEqual(conf.get('ami_id_db_scylla'), 'ami-01eb9abb50c383ff9 ami-0897d6d6d87bed868')
 
     @pytest.mark.integration
     def test_13_scylla_version_ami_branch_latest(self):  # pylint: disable=invalid-name
         os.environ.pop('SCT_AMI_ID_DB_SCYLLA', None)
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_SCYLLA_VERSION'] = 'branch-4.2:latest'
+        os.environ['SCT_SCYLLA_VERSION'] = 'branch-5.1:latest'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
@@ -605,13 +605,13 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
     def test_20_user_data_format_version_aws(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_SCYLLA_VERSION'] = 'master:latest'
-        os.environ['SCT_ORACLE_SCYLLA_VERSION'] = '4.6.0'
+        os.environ['SCT_ORACLE_SCYLLA_VERSION'] = '5.1.8'
         os.environ['SCT_DB_TYPE'] = 'mixed_scylla'
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
         conf.verify_configuration_urls_validity()
         self.assertEqual(conf['user_data_format_version'], '3')
-        self.assertEqual(conf['oracle_user_data_format_version'], '2')
+        self.assertEqual(conf['oracle_user_data_format_version'], '3')
 
     @pytest.mark.integration
     def test_20_user_data_format_version_aws_2(self):

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -681,7 +681,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                          {'alternator-dns': 'scylladb/hydra-loaders:alternator-dns-0.1',
                           'cassandra-stress': 'scylla-bench',
                           'cdc-stresser': 'scylladb/hydra-loaders:cdc-stresser-A',
-                          'gemini': 'scylladb/hydra-loaders:gemini-1.7.8',
+                          'gemini': 'scylladb/hydra-loaders:gemini-1.7.8-minideb',
                           'ndbench': 'scylladb/hydra-loaders:ndbench-jdk8-A',
                           'nosqlbench': 'scylladb/hydra-loaders:nosqlbench-A',
                           'scylla-bench': 'scylladb/something',
@@ -689,7 +689,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                           'kcl': 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC',
                           'harry': 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816'})
 
-        self.assertEqual(conf.get('stress_image.gemini'), 'scylladb/hydra-loaders:gemini-1.7.8')
+        self.assertEqual(conf.get('stress_image.gemini'), 'scylladb/hydra-loaders:gemini-1.7.8-minideb')
         self.assertEqual(conf.get('stress_image.non-exist'), None)
 
         self.assertEqual(conf.get('stress_read_cmd'), ['cassandra_stress', 'cassandra_stress'])


### PR DESCRIPTION
Currently we use `busybox` for gemini base image. Busybox uses different C standard library implementation and this may lead to some unknown errors.

Switch base image to `minideb` for Gemini so we can exclude this kind of errors from possible culprits of our problems with container segfaults when using Gemini.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
