### PR TITLE
fix(k8s): enable kernel.perf_event_paranoid=0

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -857,6 +857,13 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
                 "disabled": False,
                 "ingressClassName": "haproxy",
             }}}
+        # NOTE: '5578536' value is defined in the scylla repo here:
+        #       dist/common/sysctl.d/99-scylla-aio.conf
+        #       It is the same for the 4.3.x , 4.4.x and 4.5.x versions
+        sysctls = ["fs.aio-max-nr=5578536", ]
+        if self.params.get('print_kernel_callstack'):
+            sysctls += ["kernel.perf_event_paranoid=0", ]
+
         return HelmValues({
             'nameOverride': '',
             'fullnameOverride': cluster_name,
@@ -882,10 +889,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             'cpuset': True,
             'hostNetworking': False,
             'automaticOrphanedNodeCleanup': True,
-            # NOTE: '5578536' value is defined in the scylla repo here:
-            #       dist/common/sysctl.d/99-scylla-aio.conf
-            #       It is the same for the 4.3.x , 4.4.x and 4.5.x versions
-            'sysctls': ["fs.aio-max-nr=5578536"],
+            'sysctls': sysctls,
             'serviceMonitor': {
                 'create': False
             },


### PR DESCRIPTION
since recently we enabled `print_kernel_callstack` by default k8s setup need to enable `perf_event_paranoid` in order for it to work correctly.

Close: #6018

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
