### PR TITLE
fix(parallel topology changes): c-s command is wrong

### DIFF
--- a/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
@@ -1,12 +1,12 @@
 test_duration: 800
 
 prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3,eu-west-2scylla_node_west=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-                     "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(write=1)' -port jmx=6868 -mode cql3 native -rate threads=40 n=3000000 -log interval=5"
+                     "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(write=1)' n=3000000 -port jmx=6868 -mode cql3 native -rate threads=40 -log interval=5"
                     ]
 
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3,eu-west-2scylla_node_west=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3,eu-west-2scylla_node_west=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-             "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(write=1,read=1,si_read1=1,si_read2=1)' -port jmx=6868 -mode cql3 native -rate threads=40 duration=700m -log interval=5",
+             "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(write=1,read=1,si_read1=1,si_read2=1)' duration=700m -port jmx=6868 -mode cql3 native -rate threads=40 -log interval=5",
              ]
 
 n_db_nodes: '5 5'


### PR DESCRIPTION
the `user-profile` command used in this test has
2 wrong placements, one in the prepare, and one in stress command.
the `n=3000000` and `duration=700m` are not supposed to be part of the `-rate` parameter of the c-s command, hence failed in the test.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
