### PR TITLE
fix(perf-1tb): Increase test duration

### DIFF
--- a/jenkins-pipelines/perf-regression-latency-1TB-ebs-gp3-volumes.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-1TB-ebs-gp3-volumes.jenkinsfile
@@ -8,7 +8,5 @@ perfRegressionParallelPipeline(
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/ebs/ebs-gp3-2v-4tb-16k-iops.yaml"]''',
-    sub_tests: ["test_latency"],
-
-    timeout: [time: 500, unit: "MINUTES"]
+    sub_tests: ["test_latency"]
 )

--- a/jenkins-pipelines/perf-regression-latency-1TB-ebs-volumes.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-1TB-ebs-volumes.jenkinsfile
@@ -8,7 +8,5 @@ perfRegressionParallelPipeline(
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/ebs/ebs-gp2-2v-4tb.yaml"]''',
-    sub_tests: ["test_latency"],
-
-    timeout: [time: 500, unit: "MINUTES"]
+    sub_tests: ["test_latency"]
 )

--- a/jenkins-pipelines/perf-regression-latency-1TB.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-1TB.jenkinsfile
@@ -8,7 +8,5 @@ perfRegressionParallelPipeline(
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: """["test-cases/performance/perf-regression-latency-1TB.yaml"]""",
-    sub_tests: ["test_latency"],
-
-    timeout: [time: 500, unit: "MINUTES"]
+    sub_tests: ["test_latency"]
 )

--- a/jenkins-pipelines/perf-regression-latency-non-shard-aware-1TB.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-non-shard-aware-1TB.jenkinsfile
@@ -9,7 +9,5 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
     sub_tests: ["test_latency"],
-    test_email_title: "non-shard-aware",
-
-    timeout: [time: 500, unit: "MINUTES"]
+    test_email_title: "non-shard-aware"
 )

--- a/jenkins-pipelines/perf-regression-latency-shard-aware-1TB.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-shard-aware-1TB.jenkinsfile
@@ -7,9 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/perf-loaders-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
     sub_tests: ["test_latency"],
-    test_email_title: "shard-aware",
-
-    timeout: [time: 500, unit: "MINUTES"]
+    test_email_title: "shard-aware"
 )

--- a/test-cases/performance/perf-regression-latency-1TB.yaml
+++ b/test-cases/performance/perf-regression-latency-1TB.yaml
@@ -1,4 +1,4 @@
-test_duration: 400
+test_duration: 550
 
 prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=250000000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..250000000",
                     "cassandra-stress write no-warmup cl=ALL n=250000000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=250000001..500000000",


### PR DESCRIPTION
Increase test duration for performance latency 1TB tests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
