### PR TITLE
improvement(managerPipeline): include the provision type in the trigger

### DIFF
--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -319,13 +319,15 @@ def call(Map pipelineParams) {
                                     repoParams = [
                                         [$class: 'StringParameterValue', name: 'target_scylla_mgmt_server_address', value: params.scylla_mgmt_address],
                                         [$class: 'StringParameterValue', name: 'target_scylla_mgmt_agent_address', value: params.scylla_mgmt_agent_address],
-                                        [$class: 'StringParameterValue', name: 'TARGET_MANAGER_VERSION', value: params.manager_version]
+                                        [$class: 'StringParameterValue', name: 'TARGET_MANAGER_VERSION', value: params.manager_version],
+                                        [$class: 'StringParameterValue', name: 'provision_type', value: params.provision_type]
                                     ]
                                 } else {
                                     repoParams = [
                                         [$class: 'StringParameterValue', name: 'scylla_mgmt_address', value: params.scylla_mgmt_address],
                                         [$class: 'StringParameterValue', name: 'scylla_mgmt_agent_address', value: params.scylla_mgmt_agent_address],
-                                        [$class: 'StringParameterValue', name: 'manager_version', value: params.manager_version]
+                                        [$class: 'StringParameterValue', name: 'manager_version', value: params.manager_version],
+                                        [$class: 'StringParameterValue', name: 'provision_type', value: params.provision_type]
                                     ]
                                 }
                                 triggerJob(fullJobPath, repoParams)


### PR DESCRIPTION
When the spot price is too high, we are resolt to use on demand intances. The thing is that every downstream job that is triggered afterwards by the first build will still use spot by default, and thus fail. To save the time of rebuilding all of said jobs I decided to also transfer the provision_type param in the trigger.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
