### PR TITLE
fix(check_latency_during_ops): build histogram data ony when needed

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3032,19 +3032,19 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                                                           'email_recipients'),
                                                                       events=get_events_grouped_by_category(
                                                                           _registry=self.events_processes_registry))
-        workload = self._test_index.split("-")[-1]
-        histogram_total_data = self.get_cs_range_histogram(stress_operation=workload,
-                                                           start_time=start_time,
-                                                           end_time=end_time)
-        histogram_data_by_interval = self.get_cs_range_histogram_by_interval(stress_operation=workload,
-                                                                             start_time=start_time,
-                                                                             end_time=end_time)
         with open(self.latency_results_file, encoding="utf-8") as file:
             latency_results = json.load(file)
         self.log.debug('latency_results were loaded from file %s and its result is %s',
                        self.latency_results_file, latency_results)
         benchmarks_results = self.db_cluster.get_node_benchmarks_results() if self.db_cluster else {}
         if latency_results and self.create_stats:
+            workload = self._test_index.split("-")[-1]
+            histogram_total_data = self.get_cs_range_histogram(stress_operation=workload,
+                                                               start_time=start_time,
+                                                               end_time=end_time)
+            histogram_data_by_interval = self.get_cs_range_histogram_by_interval(stress_operation=workload,
+                                                                                 start_time=start_time,
+                                                                                 end_time=end_time)
             latency_results["summary"] = {"hdr_summary": histogram_total_data,
                                           "hdr": histogram_data_by_interval}
             latency_results = calculate_latency(latency_results)


### PR DESCRIPTION
When running tests where we don't want to store stats (e.g. `features-limit-streaming-io-test`), histogram data generation code fails with error:
```
workload = self._test_index.split("-")[-1]
AttributeError: 'NoneType' object has no attribute 'split'
```
It looks that this code is needed only when `self.create_stats` is `True`.

Fix by running histogram generation exec code only when needed.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
