### PR TITLE
fix(oracle version): use latest 2021.1 version

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -114,7 +114,7 @@ authenticator_password: ''
 # gemini defaults
 n_test_oracle_db_nodes: 1
 gemini_seed: 0
-oracle_scylla_version: '5.0.10'
+oracle_scylla_version: '2021.1.15'
 append_scylla_args_oracle: '--enable-cache false'
 
 # cassandra-stress defaults

--- a/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
@@ -31,4 +31,4 @@ stress_cdclog_reader_cmd: "cdc-stressor -duration 215m -stream-query-round-durat
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i3.8xlarge'
-oracle_scylla_version: "2022.1.5"
+oracle_scylla_version: "2021.1.15"

--- a/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
@@ -23,4 +23,4 @@ gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i3.8xlarge'
-oracle_scylla_version: "2022.1.5"
+oracle_scylla_version: "2021.1.15"

--- a/test-cases/gemini/gemini-basic-3h-ics.yaml
+++ b/test-cases/gemini/gemini-basic-3h-ics.yaml
@@ -21,4 +21,4 @@ gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i3.8xlarge'
-oracle_scylla_version: "2022.1.5"
+oracle_scylla_version: "2021.1.15"

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -440,7 +440,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
     @pytest.mark.integration
     def test_16_default_oracle_scylla_version_eu_west_1(self):
-        ami_4_6_9 = "ami-0daa3e4e3d314d2b3"
+        ami_2021_1_15 = "ami-0dfb316a2cc0ab399"
 
         os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb'
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
@@ -451,7 +451,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 
-        self.assertEqual(conf.get('ami_id_db_oracle'), ami_4_6_9)
+        self.assertEqual(conf.get('ami_id_db_oracle'), ami_2021_1_15)
 
     def test_16_oracle_scylla_version_us_east_1(self):
         ami_4_6_3 = "ami-09c658571b2d46d18"

--- a/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.yaml
@@ -22,7 +22,7 @@ instance_provision: 'spot'
 
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
 
-scylla_version: 5.0.10
+scylla_version: 2021.1.15
 scylla_mgmt_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo'
 
 post_behavior_db_nodes: "destroy"

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -499,14 +499,14 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method
 
 class IntegrationTests(unittest.TestCase):
     get_scylla_ami_version_output = ObjectDict(**{
-        'Architecture': 'x86_64', 'CreationDate': '2022-10-13T11:10:59.000Z',
-        'ImageId': 'ami-0daa3e4e3d314d2b3', 'ImageLocation': '797456418907/ScyllaDB 5.0.10',
+        'Architecture': 'x86_64', 'CreationDate': '2022-10-13T13:17:17.000Z',
+        'ImageId': 'ami-0dfb316a2cc0ab399', 'ImageLocation': '797456418907/ScyllaDB Enterprise 2021.1.15',
         'ImageType': 'machine', 'Public': True, 'OwnerId': '797456418907',
         'PlatformDetails': 'Linux/UNIX', 'UsageOperation': 'RunInstances',
         'State': 'available', 'BlockDeviceMappings': [
             {'DeviceName': '/dev/sda1',
              'Ebs': {'DeleteOnTermination': True,
-                     'SnapshotId': 'snap-0a2df75621efaf18c',
+                     'SnapshotId': 'snap-0717a2bee0a38bc84',
                      'VolumeSize': 30,
                      'VolumeType': 'gp2',
                      'Encrypted': False}},
@@ -526,19 +526,19 @@ class IntegrationTests(unittest.TestCase):
              'VirtualName': 'ephemeral6'},
             {'DeviceName': '/dev/sdi',
              'VirtualName': 'ephemeral7'}],
-        'Description': 'ScyllaDB 5.0.10', 'EnaSupport': True, 'Hypervisor': 'xen',
-        'Name': 'ScyllaDB 5.0.10', 'RootDeviceName': '/dev/sda1', 'RootDeviceType': 'ebs',
+        'Description': 'ScyllaDB Enterprise 2021.1.15', 'EnaSupport': True, 'Hypervisor': 'xen',
+        'Name': 'ScyllaDB Enterprise 2021.1.15', 'RootDeviceName': '/dev/sda1', 'RootDeviceType': 'ebs',
         'Tags': [
-            {'Key': 'ScyllaMachineImageVersion', 'Value': '5.0.10-20221009.a36534e106b-1'},
-            {'Key': 'ScyllaPython3Version', 'Value': '5.0.10-0.20221009.18e7a4603-1'},
+            {'Key': 'ScyllaMachineImageVersion', 'Value': '2021.1.15-20221011.82741b636ba-1'},
+            {'Key': 'ScyllaPython3Version', 'Value': '2021.1.15-20221011.82741b636ba-1'},
             {'Key': 'user_data_format_version', 'Value': '2'},
-            {'Key': 'ScyllaToolsVersion', 'Value': '5.0.10-0.20221009.18e7a4603-1'},
-            {'Key': 'ScyllaJMXVersion', 'Value': '5.0.10-0.20221009.18e7a4603-1'},
-            {'Key': 'branch', 'Value': 'branch-5.0'},
-            {'Key': 'scylla-git-commit', 'Value': '18e7a46038379e566619197eb11c1f650bfec2be'},
-            {'Key': 'build-tag', 'Value': 'jenkins-scylla-4.6-ami-63'},
-            {'Key': 'ScyllaVersion', 'Value': '5.0.10-0.20221009.18e7a4603-1'},
-            {'Key': 'build-id', 'Value': '94'}
+            {'Key': 'ScyllaToolsVersion', 'Value': '2021.1.15-20221011.82741b636ba-1'},
+            {'Key': 'ScyllaJMXVersion', 'Value': '2021.1.15-20221011.82741b636ba-1'},
+            {'Key': 'branch', 'Value': 'branch-2021.1'},
+            {'Key': 'scylla-git-commit', 'Value': '3d8c23d0b20af12302608c6286ace0c3dc070828'},
+            {'Key': 'build-tag', 'Value': 'jenkins-enterprise-2021.1-promote-release-213'},
+            {'Key': 'ScyllaVersion', 'Value': '2021.1.15-20221011.82741b636ba-1'},
+            {'Key': 'build-id', 'Value': '213'}
         ], 'VirtualizationType': 'hvm'})
 
     @property


### PR DESCRIPTION
right now, older images were deleted, hence we
had to change to use newer images, but the concept of the oracle is to use the oldest version possible to compare the results.
per @roydahan 's request, moving it to use
latest 2021.1 version (that is 2021.1.15).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
