### PR TITLE
fix(get_non_system_ks_cf_list): Filter out 'audit' keyspace

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3564,7 +3564,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
             for row in current_rows:
                 table_name = f"{getattr(row, column_names[0])}.{getattr(row, column_names[1])}"
 
-                if filter_out_system and getattr(row, column_names[0]).startswith(("system", "alternator_usertable")):
+                if filter_out_system and getattr(row, column_names[0]).startswith(("system", "alternator_usertable", "audit")):
                     continue
 
                 if is_column_type and (filter_out_table_with_counter and "counter" in row.type):


### PR DESCRIPTION
	'audit' is a system keyspace that wasn't filtered so
	nemesis selected it mistakingly as a user keyspace.
	Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/5963
Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/5963
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
