### PR TITLE
fix(nonroot-artifcat-test): fix the location of cqlsh

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -317,9 +317,8 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
         with self.subTest("check Scylla server after installation"):
             self.check_scylla()
 
-        if not self.node.is_nonroot_install:
-            with self.subTest("check cqlsh installation"):
-                self.check_cqlsh()
+        with self.subTest("check cqlsh installation"):
+            self.check_cqlsh()
 
         # We don't install any time sync service in docker, so the test is unnecessary:
         # https://github.com/scylladb/scylla/tree/master/dist/docker/etc/supervisord.conf.d

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2747,14 +2747,14 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                       auth_params=auth_params, use_keyspace=use_keyspace, timeout=timeout,
                       connect_timeout=connect_timeout, ssl_params=ssl_params)
 
+        cqlsh_cmd = self.add_install_prefix('/usr/bin/cqlsh')
         if self.is_cqlsh_support_cloud_bundle:
             connection_bundle_file = self.parent_cluster.connection_bundle_file
             target_connection_bundle_file = str(Path('/tmp/') / connection_bundle_file.name)
             self.remoter.send_files(str(connection_bundle_file), target_connection_bundle_file)
 
-            return f'cqlsh {options} -e "{command}" --cloudconf {target_connection_bundle_file}'
-        return 'cqlsh {options} -e "{command}" {host} {port}'.format(options=options, command=command, host=host,
-                                                                     port=port)
+            return f'{cqlsh_cmd} {options} -e "{command}" --cloudconf {target_connection_bundle_file}'
+        return f'{cqlsh_cmd} {options} -e "{command}" {host} {port}'
 
     def run_cqlsh(self, cmd, keyspace=None, port=None, timeout=120, verbose=True, split=False, target_db_node=None,
                   connect_timeout=60, num_retry_on_failure=1):


### PR DESCRIPTION
Since in nonroot install cqlsh isn't on the path, we need to point to the exact location of it to make it work

Fixes: #6017

## Testing

- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-ubuntu2004-test/24/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
