### PR TITLE
improvement(cluster): find datacenter according to region

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3242,6 +3242,14 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
             grouped_by_region[node.region].append(node)
         return grouped_by_region
 
+    def get_datacenter_name_per_region(self):
+        datacenter_name_per_region = {}
+        for region, nodes in self.nodes_by_region().items():
+            status = nodes[0].get_nodes_status()
+            datacenter_name_per_region[region] = status[nodes[0]]['dc']
+
+        return datacenter_name_per_region
+
     def send_file(self, src, dst, verbose=False):
         for loader in self.nodes:
             loader.remoter.send_files(src=src, dst=dst, verbose=verbose)

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -424,8 +424,19 @@ class TestBaseMonitorSet(unittest.TestCase):
 
 class NodetoolDummyNode(BaseNode):  # pylint: disable=abstract-method
 
-    def __init__(self, resp):  # pylint: disable=super-init-not-called
+    def __init__(self, resp, myregion=None, myname=None):  # pylint: disable=super-init-not-called
         self.resp = resp
+        self.myregion = myregion
+        self.myname = myname
+        self.parent_cluster = None
+
+    @property
+    def region(self):
+        return self.myregion
+
+    @property
+    def name(self):
+        return self.myname
 
     def run_nodetool(self, *args, **kwargs):  # pylint: disable=unused-argument
         return Result(exited=0, stderr="", stdout=self.resp)
@@ -439,6 +450,10 @@ class DummyScyllaCluster(BaseScyllaCluster, BaseCluster):  # pylint: disable=abs
         self.name = 'dummy_cluster'
         self.added_password_suffix = False
         self.log = logging.getLogger(self.name)
+
+    def get_ip_to_node_map(self):
+        """returns {ip: node} map for all nodes in cluster to get node by ip"""
+        return {node.myname: node for node in self.nodes}
 
 
 class TestNodetoolStatus(unittest.TestCase):
@@ -464,6 +479,30 @@ class TestNodetoolStatus(unittest.TestCase):
                             'host_id': 'e5bcb094-e4de-43aa-8dc9-b1bf74b3b346', 'rack': '1a'},
                            '10.0.198.153': {'state': 'UN', 'load': '?', 'tokens': '256', 'owns': '?',
                                             'host_id': 'fba174cd-917a-40f6-ab62-cc58efaaf301', 'rack': '1a'}}}
+
+    def test_datacenter_name_per_region(self):  # pylint: disable=no-self-use
+        resp = "\n".join(["Datacenter: eastus",
+                          "==================",
+                          "Status=Up/Down",
+                          "|/ State=Normal/Leaving/Joining/Moving",
+                          "--  Address   Load       Tokens       Owns    Host ID                               Rack",
+                          "UN  10.0.59.34    21.71 GB   256          ?       e5bcb094-e4de-43aa-8dc9-b1bf74b3b346  1a",
+                          "UN  10.0.198.153  ?          256          ?       fba174cd-917a-40f6-ab62-cc58efaaf301  1a",
+                          "Datacenter: westus",
+                          "==================",
+                          "Status=Up/Down",
+                          "|/ State=Normal/Leaving/Joining/Moving",
+                          "--  Address   Load       Tokens       Owns    Host ID                               Rack",
+                          "UN  10.1.59.34    21.71 GB   256          ?       e5bcb094-e4de-43aa-8dc9-b1bf74546346  2a"
+                          ]
+                         )
+        node1 = NodetoolDummyNode(resp=resp, myregion="east-us", myname="10.0.59.34")
+        node2 = NodetoolDummyNode(resp=resp, myregion="east-us", myname="10.0.198.153")
+        node3 = NodetoolDummyNode(resp=resp, myregion="west-us", myname='10.1.59.34')
+        db_cluster = DummyScyllaCluster([node1, node2, node3])
+        node1.parent_cluster = node2.parent_cluster = node3.parent_cluster = db_cluster
+        datacenter_name_per_region = db_cluster.get_datacenter_name_per_region()
+        assert datacenter_name_per_region == {'east-us': 'eastus', 'west-us': 'westus'}
 
     def test_can_get_nodetool_status_ipv6(self):  # pylint: disable=no-self-use
         resp = "\n".join(["Datacenter: eu-north",


### PR DESCRIPTION
Create mapping `region  - <datacenter name>`.
Datacenter name can be found from 'nodetool status' output. Receive it is possible for DB node only.
We can use this mapping, for example, when need to find in which datacenter a loader is located. It may be helpfull in multi DC tests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
