### PR TITLE
feature(k8s-ingress): add logging thread

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -86,7 +86,7 @@ from sdcm.utils.decorators import log_run_info, retrying
 from sdcm.utils.decorators import timeout as timeout_wrapper
 from sdcm.utils.k8s.chaos_mesh import ChaosMesh
 from sdcm.utils.remote_logger import get_system_logging_thread, CertManagerLogger, ScyllaOperatorLogger, \
-    KubectlClusterEventsLogger, ScyllaManagerLogger, KubernetesWrongSchedulingLogger
+    KubectlClusterEventsLogger, ScyllaManagerLogger, KubernetesWrongSchedulingLogger, HaproxyIngressLogger
 from sdcm.utils.sstable.load_utils import SstableLoadUtils
 from sdcm.utils.version_utils import ComparableScyllaOperatorVersion
 from sdcm.wait import wait_for
@@ -286,6 +286,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
     _scylla_manager_journal_thread: Optional[ScyllaManagerLogger] = None
     _scylla_operator_journal_thread: Optional[ScyllaOperatorLogger] = None
     _scylla_operator_scheduling_thread: Optional[KubernetesWrongSchedulingLogger] = None
+    _haproxy_ingress_log_thread: Optional[HaproxyIngressLogger] = None
     _scylla_cluster_events_threads: Dict[str, KubectlClusterEventsLogger] = {}
 
     _scylla_operator_log_monitor_thread: Optional[ScyllaOperatorLogMonitoring] = None
@@ -429,6 +430,10 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
     def scylla_manager_log(self) -> str:
         return os.path.join(self.logdir, "scylla_manager.log")
 
+    @cached_property
+    def haproxy_ingress_log(self) -> str:
+        return os.path.join(self.logdir, "haproxy_ingress.log")
+
     def start_cert_manager_journal_thread(self) -> None:
         self._cert_manager_journal_thread = CertManagerLogger(self, self.cert_manager_log)
         self._cert_manager_journal_thread.start()
@@ -436,6 +441,10 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
     def start_scylla_manager_journal_thread(self):
         self._scylla_manager_journal_thread = ScyllaManagerLogger(self, self.scylla_manager_log)
         self._scylla_manager_journal_thread.start()
+
+    def start_haproxy_ingress_log_thread(self) -> None:
+        self._haproxy_ingress_log_thread = HaproxyIngressLogger(self, self.haproxy_ingress_log)
+        self._haproxy_ingress_log_thread.start()
 
     def set_nodeselector_for_deployments(self, pool_name: str,
                                          namespace: str = "kube-system",
@@ -1071,6 +1080,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
                 environ=environ)
         self.kubectl_wait("--all --for=condition=Ready pod",
                           namespace=INGRESS_CONTROLLER_NAMESPACE, timeout=306)
+        self.start_haproxy_ingress_log_thread()
 
     @log_run_info
     def deploy_scylla_cluster(self, node_pool: CloudK8sNodePool, namespace: str = SCYLLA_NAMESPACE,

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1157,6 +1157,7 @@ class KubernetesLogCollector(BaseSCTLogCollector):
         FileLog(name='cert_manager.log', search_locally=True),
         FileLog(name='scylla_manager.log', search_locally=True),
         FileLog(name='scylla_operator.log', search_locally=True),
+        FileLog(name='haproxy_ingress.log', search_locally=True),
         FileLog(name='*_cluster_events.log', search_locally=True),
         FileLog(name='kubectl.version', search_locally=True),
         DirLog(name='cluster-scoped-resources/*', search_locally=True),

--- a/sdcm/utils/remote_logger.py
+++ b/sdcm/utils/remote_logger.py
@@ -357,6 +357,18 @@ class ScyllaOperatorLogger(CommandClusterLoggerBase):
         return f"{cmd} >> {self._target_log_file} 2>&1"
 
 
+class HaproxyIngressLogger(CommandClusterLoggerBase):
+    restart_delay = 30
+
+    @property
+    def _logger_cmd(self) -> str:
+        cmd = self._cluster.kubectl_cmd(
+            f"logs --previous=false -f --since={int(self.time_delta)}s --all-containers=true "
+            "-l app.kubernetes.io/name=haproxy-ingress",
+            namespace="haproxy-controller")
+        return f"{cmd} >> {self._target_log_file} 2>&1"  # pylint: disable=protected-access
+
+
 class KubernetesWrongSchedulingLogger(CommandClusterLoggerBase):
     restart_delay = 120
     WRONG_SCHEDULED_PODS_MESSAGE = "Not allowed pods are scheduled on Scylla node found"


### PR DESCRIPTION
Since on long runs we might have lots of restart of the haproxy ingress, and at the end of the test we only have partial log.

this change is adding a new thread that would read the logs during the test, so we can collect all the logs from a run.

## Testing
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/functional-eks/8/


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
