### PR TITLE
fix(get_group0_members): catch exception for cql commands

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3042,56 +3042,63 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def get_group0_members(self) -> list[dict[str, str]]:
         self.log.debug("Get group0 members")
         group0_members = []
-        result = self.run_cqlsh("select value from system.scylla_local where key = 'raft_group0_id'",
-                                split=True, num_retry_on_failure=3)
-        # run_cqlsh return splitted ouput if data was found:
-        # [
-        #   ""
-        #   "value"
-        #   "----------"
-        #   "<value> "
-        #   ""
-        #   "Rows ..."
-        # ]
-        #
-        # 4th element is needed only
-        #
-        # And if was not found (raft disbled):
-        # [
-        #   ""
-        #   "value"
-        #   "-------"
-        #   ""
-        #   "(0 rows)"
-        # ]
-        if not result or len(result) <= 3:
-            return []
-        raft_group0_id = result[3].strip()
-        if not raft_group0_id or "0 rows" in raft_group0_id:
-            return []
+        try:
 
-        result = self.run_cqlsh(
-            f"select server_id, can_vote from system.raft_state where group_id = {raft_group0_id} and disposition = 'CURRENT'",
-            split=True)
-        # run_cqlsh return splitted ouput if data was found:
-        # [
-        #   ""
-        #   "server_id | can_vote"
-        #   "----------"
-        #   "<value1> | True"
-        #   "<value2> | False"
-        #   ""
-        #   "Rows ..."
-        # ]
-        #
-        # Start parsing from 4th line
+            result = self.run_cqlsh("select value from system.scylla_local where key = 'raft_group0_id'",
+                                    split=True, num_retry_on_failure=3)
+            # run_cqlsh return splitted ouput if data was found:
+            # [
+            #   ""
+            #   "value"
+            #   "----------"
+            #   "<value> "
+            #   ""
+            #   "Rows ..."
+            # ]
+            #
+            # 4th element is needed only
+            #
+            # And if was not found (raft disbled):
+            # [
+            #   ""
+            #   "value"
+            #   "-------"
+            #   ""
+            #   "(0 rows)"
+            # ]
+            if not result or len(result) <= 3:
+                return []
+            raft_group0_id = result[3].strip()
+            if not raft_group0_id or "0 rows" in raft_group0_id:
+                return []
 
-        for line in result[3:]:
-            member = line.split("|")
-            if not member or len(member) != 2:
-                break
-            group0_members.append({"host_id": member[0].strip(),
-                                   "voter": member[1].strip() == "True"})
+            result = self.run_cqlsh(
+                f"select server_id, can_vote from system.raft_state where group_id = {raft_group0_id} and disposition = 'CURRENT'",
+                split=True)
+            # run_cqlsh return splitted ouput if data was found:
+            # [
+            #   ""
+            #   "server_id | can_vote"
+            #   "----------"
+            #   "<value1> | True"
+            #   "<value2> | False"
+            #   ""
+            #   "Rows ..."
+            # ]
+            #
+            # Start parsing from 4th line
+
+            for line in result[3:]:
+                member = line.split("|")
+                if not member or len(member) != 2:
+                    break
+                group0_members.append({"host_id": member[0].strip(),
+                                       "voter": member[1].strip() == "True"})
+        except Exception as exc:  # pylint: disable=broad-except
+            err_msg = f"Get group0 members failed with error: {exc}"
+            self.log.error(err_msg)
+            InfoEvent(message=err_msg, severity=Severity.ERROR).publish()
+
         self.log.debug("Group0 members: %s", group0_members)
         return group0_members
 


### PR DESCRIPTION
run_cqlsh command could failed during getting group0 members and raised exception failed the nemesis thread during cluster health validation.

Process exception raised in get_group0_members and publish appropriate event

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
