### PR TITLE
fix(health_events): add retry and did not raise exception

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3020,6 +3020,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             return
         self.remoter.run(f"sudo kill -s SIGHUP {pid}")
 
+    @retrying(n=5, sleep_time=5, raise_on_exceeded=False)
     def get_token_ring_members(self) -> list[dict[str, str]]:
         token_ring_members = []
         self.log.debug("Get token ring members")
@@ -3039,6 +3040,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self.log.debug("Token ring members %s", token_ring_members)
         return token_ring_members
 
+    @retrying(n=5, sleep_time=5, raise_on_exceeded=False)
     def get_group0_members(self) -> list[dict[str, str]]:
         self.log.debug("Get group0 members")
         group0_members = []


### PR DESCRIPTION
Nemesis thread in the https://jenkins.scylladb.com/job/enterprise-2023.1/job/longevity/job/ longevity_mv_synchronous_updates-12h/3/ test failed due to 'get_group0_members' timeout.

Add retry decorator and did not raise exception on 'get_group0_members' and 'get_token_ring_members' during node health check.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
