### PR TITLE
fix(Ldap event): Fix regex pattern of the connection-reset filtering

### DIFF
--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -91,8 +91,8 @@ DatabaseLogEvent.add_subevent_type("SEMAPHORE_TIME_OUT", severity=Severity.WARNI
                                    regex="semaphore_timed_out")
 # The below ldap-connection-reset is dependent on https://github.com/scylladb/scylla-enterprise/issues/2710
 DatabaseLogEvent.add_subevent_type("LDAP_CONNECTION_RESET", severity=Severity.WARNING,
-                                   regex=r"ldap_connection - Seastar read failed: std::system_error \(error system:104, "
-                                         r"recv: Connection reset by peer\)")
+                                   regex=r".*ldap_connection - Seastar read failed: std::system_error \(error system:104, "
+                                         r"recv: Connection reset by peer\).*")
 # This scylla WARNING includes "exception" word and reported as ERROR. To prevent it I add the subevent below and locate
 # it before DATABASE_ERROR. Message example:
 # storage_proxy - Failed to apply mutation from 10.0.2.108#8: exceptions::mutation_write_timeout_exception


### PR DESCRIPTION
	The LDAP_CONNECTION_RESET was missing ".*" prefix + suffix.
	Refs: https://github.com/scylladb/scylla-enterprise/issues/2710

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
