### PR TITLE
fix(provision): fix duplicate provisioning after mult-az intro

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3153,7 +3153,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
     Cluster of Node objects.
     """
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
     def __init__(self, cluster_uuid=None, cluster_prefix='cluster', node_prefix='node', n_nodes=3, params=None,
                  region_names=None, node_type=None, extra_network_interface=False, add_nodes=True):
         self.extra_network_interface = extra_network_interface
@@ -3198,11 +3198,20 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         if add_nodes:
             if isinstance(n_nodes, list):
                 for dc_idx, num in enumerate(n_nodes):
-                    for az_index in range(num):
-                        self.add_nodes(1, dc_idx=dc_idx, rack=az_index % azs, enable_auto_bootstrap=self.auto_bootstrap)
+                    # spread nodes evenly across AZ's
+                    nodes_per_az = [0]*azs
+                    for idx in range(num):
+                        nodes_per_az[idx % azs] += 1
+                    for az_index in range(azs):
+                        self.add_nodes(nodes_per_az[az_index], dc_idx=dc_idx, rack=az_index,
+                                       enable_auto_bootstrap=self.auto_bootstrap)
             elif isinstance(n_nodes, int):  # legacy type
-                for az_index in range(n_nodes):
-                    self.add_nodes(1, rack=az_index % azs, enable_auto_bootstrap=self.auto_bootstrap)
+                # spread nodes evenly across AZ's
+                nodes_per_az = [0] * azs
+                for idx in range(n_nodes):
+                    nodes_per_az[idx % azs] += 1
+                for az_index in range(azs):
+                    self.add_nodes(nodes_per_az[az_index], rack=az_index, enable_auto_bootstrap=self.auto_bootstrap)
             else:
                 raise ValueError('Unsupported type: {}'.format(type(n_nodes)))
             self.run_node_benchmarks()

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -340,7 +340,8 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         return ec2_user_data
 
     def _create_or_find_instances(self, count, ec2_user_data, dc_idx, az_idx=0):
-        if self.nodes:
+        nodes = [node for node in self.nodes if node.dc_idx == dc_idx]
+        if nodes:
             return self._create_instances(count, ec2_user_data, dc_idx, az_idx)
         if self.test_config.REUSE_CLUSTER:
             instances = self._get_instances(dc_idx)


### PR DESCRIPTION
When running `self.add_nodes` multiple times, the second run does not find provisioned instances because `self.nodes` is not empty anymore. It was not an issue before multi-az support because it was executed just once (except multi-dc, where probably we had this issue before).

When single az is provided, `self.add_nodes` will be called just like it was before. Issue with multidc is not fixed - this will be tackled in separate PR.

fixes: #6041

Second commit:
fix(multi-dc): fix double provision in multi-dc
In multidc scenario `self.add_nodes` is executed once per dc.
`_create_or_find_instances` when executed for second time finds
`self.nodes` is not empty, provisions new instances.

Filter nodes by dc in `_create_or_find_instances` so it tries to detect
instances for each dc before creating ones.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/5996

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
