### PR TITLE
fix(get_group0_members): Use python-driver instead cqlsh

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3045,57 +3045,18 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self.log.debug("Get group0 members")
         group0_members = []
         try:
+            with self.parent_cluster.cql_connection_patient_exclusive(node=self) as session:
+                row = session.execute("select value from system.scylla_local where key = 'raft_group0_id'").one()
+                if not row:
+                    return []
+                raft_group0_id = row.value
 
-            result = self.run_cqlsh("select value from system.scylla_local where key = 'raft_group0_id'",
-                                    split=True, num_retry_on_failure=3)
-            # run_cqlsh return splitted ouput if data was found:
-            # [
-            #   ""
-            #   "value"
-            #   "----------"
-            #   "<value> "
-            #   ""
-            #   "Rows ..."
-            # ]
-            #
-            # 4th element is needed only
-            #
-            # And if was not found (raft disbled):
-            # [
-            #   ""
-            #   "value"
-            #   "-------"
-            #   ""
-            #   "(0 rows)"
-            # ]
-            if not result or len(result) <= 3:
-                return []
-            raft_group0_id = result[3].strip()
-            if not raft_group0_id or "0 rows" in raft_group0_id:
-                return []
+                rows = session.execute(f"select server_id, can_vote from system.raft_state  \
+                                       where group_id = {raft_group0_id} and disposition = 'CURRENT'").all()
 
-            result = self.run_cqlsh(
-                f"select server_id, can_vote from system.raft_state where group_id = {raft_group0_id} and disposition = 'CURRENT'",
-                split=True)
-            # run_cqlsh return splitted ouput if data was found:
-            # [
-            #   ""
-            #   "server_id | can_vote"
-            #   "----------"
-            #   "<value1> | True"
-            #   "<value2> | False"
-            #   ""
-            #   "Rows ..."
-            # ]
-            #
-            # Start parsing from 4th line
-
-            for line in result[3:]:
-                member = line.split("|")
-                if not member or len(member) != 2:
-                    break
-                group0_members.append({"host_id": member[0].strip(),
-                                       "voter": member[1].strip() == "True"})
+                for row in rows:
+                    group0_members.append({"host_id": str(row.server_id),
+                                           "voter": row.can_vote})
         except Exception as exc:  # pylint: disable=broad-except
             err_msg = f"Get group0 members failed with error: {exc}"
             self.log.error(err_msg)


### PR DESCRIPTION
for nonroot installation we don't have cqlsh in path. switch to use driver for getting group0 members instead cqlsh

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
