### PR TITLE
ubuntu2004.yaml: update scylla_repo path

### DIFF
--- a/test-cases/artifacts/ubuntu2004.yaml
+++ b/test-cases/artifacts/ubuntu2004.yaml
@@ -13,7 +13,7 @@ n_loaders: 0
 n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'ubuntu-focal'
-scylla_repo: 'http://downloads.scylladb.com/deb/unstable/unified/master/latest/scylladb-master/scylla.list'
+scylla_repo: 'http://downloads.scylladb.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list'
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2004'
 system_auth_rf: 1


### PR DESCRIPTION
as part of **cloud-resources cleanup** the path `'downloads.scylladb.com/deb/unstable'` was removed.
This path not in use since 2021.

unified-deb job failed in **artifacts-ubuntu2004-test** with ValueError: `'http://downloads.scylladb.com/deb/unstable/unified/master/latest/scylladb-master/scylla.list' doesn't point to a file stored in S3`
link to jobs: 
https://jenkins.scylladb.com/job/enterprise-2021.1/job/unified-deb/276/
https://jenkins.scylladb.com/job/enterprise-2021.1/job/artifacts/job/artifacts-ubuntu2004-test/269/

this PR updating the `scylla_repo` path to:
'http://downloads.scylladb.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list'

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
