### PR TITLE
improvement(stress): add datacenter to c-s command for multi DC test

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3221,11 +3221,13 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
             grouped_by_region[node.region].append(node)
         return grouped_by_region
 
-    def get_datacenter_name_per_region(self):
+    def get_datacenter_name_per_region(self, db_nodes=None):
         datacenter_name_per_region = {}
-        for region, nodes in self.nodes_by_region().items():
-            status = nodes[0].get_nodes_status()
-            datacenter_name_per_region[region] = status[nodes[0]]['dc']
+        for region, nodes in self.nodes_by_region(nodes=db_nodes).items():
+            if status := nodes[0].get_nodes_status():
+                datacenter_name_per_region[region] = status[nodes[0]]['dc']
+            else:
+                LOGGER.error("Failed to get nodes status from node %s", nodes[0])
 
         return datacenter_name_per_region
 

--- a/unit_tests/dummy_remote.py
+++ b/unit_tests/dummy_remote.py
@@ -18,7 +18,7 @@ import shutil
 import logging
 
 from sdcm.remote import LocalCmdRunner
-from sdcm.cluster import BaseNode, BaseScyllaCluster
+from sdcm.cluster import BaseNode, BaseCluster, BaseScyllaCluster
 
 
 class DummyOutput:
@@ -70,7 +70,8 @@ class LocalNode(BaseNode):
         pass
 
 
-class LocalLoaderSetDummy:
+class LocalLoaderSetDummy(BaseCluster):
+    # pylint: disable=super-init-not-called,abstract-method
     def __init__(self, nodes=None):
         self.name = "LocalLoaderSetDummy"
         self.nodes = nodes if nodes is not None else [LocalNode("loader_node", parent_cluster=self)]

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -504,6 +504,9 @@ class TestNodetoolStatus(unittest.TestCase):
         datacenter_name_per_region = db_cluster.get_datacenter_name_per_region()
         assert datacenter_name_per_region == {'east-us': 'eastus', 'west-us': 'westus'}
 
+        datacenter_name_per_region = db_cluster.get_datacenter_name_per_region(db_nodes=[node1])
+        assert datacenter_name_per_region == {'east-us': 'eastus'}
+
     def test_can_get_nodetool_status_ipv6(self):  # pylint: disable=no-self-use
         resp = "\n".join(["Datacenter: eu-north",
                           "====================",


### PR DESCRIPTION
Cassandra-stress load, when is running on multi DC cluster, sends the requests to one DC only, where loader is located.
It happens because the default load balancing policy in scylla-tools-java is DCAwareRoundRobinPolicy which prefers nodes in the local datacenter. Unless all local nodes are tried, it will not send queries to other nodes in remote DC. If a local datacenter name is not provided the policy will default to the datacenter of the first node it is connected to.

We want that the requests will be sent to all nodes in all datacenters evenly. This commit add datacenter parameter to cassandra stress command

Issue: https://github.com/scylladb/java-driver/issues/211

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
