### PR TITLE
fix(longevity): change db instance type for MV synch test

### DIFF
--- a/test-cases/longevity/longevity-mv-synchronous-updates-12h.yaml
+++ b/test-cases/longevity/longevity-mv-synchronous-updates-12h.yaml
@@ -18,7 +18,7 @@ n_loaders: 2
 n_monitor_nodes: 1
 round_robin: true
 
-instance_type_db: 'i4i.xlarge'
+instance_type_db: 'i4i.4xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_interval: 5


### PR DESCRIPTION
DB instance type was set to 'i4i.xlarge' mistakenly for longevity-mv-synchronous-updates-12h test. It's too weak for such kind of test. Chnage it to 'i4i.4xlarge

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
