### PR TITLE
fix(upgrade_test): shim-signed package removal workaround

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -159,6 +159,8 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             scylla_yaml_updates.update({"enable_sstables_mc_format": True})
 
         InfoEvent(message='Upgrading a Node').publish()
+        # because of scylladb/scylla-enterprise#2818 we are for now adding this workaround
+        node.remoter.sudo("apt-get remove shim-signed -y --allow-remove-essential")
         node.upgrade_system()
 
         # We assume that if update_db_packages is not empty we install packages from there.


### PR DESCRIPTION
since scylladb/scylla-enterprise#2818 is happening on one of our base versions, we need to do this
"manual" removal, so test won't fail.
i expect that, once scylladb/scylla-enterprise#2818 will be fixed, we can revert this commit.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
