### PR TITLE
feature(multi-az): adapt provision step to multi-az

### DIFF
--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -663,10 +663,10 @@ class MonitorSetEKS(MonitorSetAWS):
         pass
 
     # NOTE: setting and filtering of the "MonitorId" tag is needed for the multi-tenant setup.
-    def _get_instances(self, dc_idx):
+    def _get_instances(self, dc_idx, az_idx=None):
+        # az_idx is not used as we specify az's for k8s cluster while we don't create instances in multi-az.
         if not self.monitor_id:
             raise ValueError("'monitor_id' must exist")
-
         ec2 = ec2_client.EC2ClientWrapper(region_name=self.region_names[dc_idx],
                                           spot_max_price_percentage=self.params.get('spot_max_price'))
         results = list_instances_aws(

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1981,6 +1981,8 @@ class SCTConfiguration(dict):
         self._validate_seeds_number()
         if self.get('n_db_nodes'):
             self._validate_nemesis_can_run_on_non_seed()
+            self._validate_number_of_db_nodes_divides_by_az_number()
+
         if 'extra_network_interface' in self and len(self.region_names) >= 2:
             raise ValueError("extra_network_interface isn't supported for multi region use cases")
         self._check_partition_range_with_data_validation_correctness()
@@ -2058,6 +2060,12 @@ class SCTConfiguration(dict):
         num_of_db_nodes = sum([int(i) for i in str(self.get('n_db_nodes')).split(' ')]) + int(self.get('add_node_cnt'))
         assert num_of_db_nodes > seeds_num, \
             "Nemesis cannot run when 'nemesis_filter_seeds' is true and seeds number is equal to nodes number"
+
+    def _validate_number_of_db_nodes_divides_by_az_number(self):
+        az_count = len(self.get('availability_zone').split(',')) if self.get('availability_zone') else 1
+        for nodes_num in [int(i) for i in str(self.get('n_db_nodes')).split(' ')]:
+            assert nodes_num % az_count == 0, \
+                f"Number of db nodes ({nodes_num}) should be divisible by number of availability zones ({az_count})"
 
     def _check_per_backend_required_values(self, backend: str):
         if backend in self.available_backends:

--- a/sdcm/sct_provision/aws/instance_parameters_builder.py
+++ b/sdcm/sct_provision/aws/instance_parameters_builder.py
@@ -82,12 +82,7 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
 
     @property
     def Placement(self) -> Optional[AWSPlacementInfo]:  # pylint: disable=invalid-name
-        """
-        If only one AZ is configured let's restrict it via placement option
-        """
-        if len(self._availability_zones) != 1:
-            return None
-        return AWSPlacementInfo(AvailabilityZone=self._region_name + self._availability_zones[0])
+        return AWSPlacementInfo(AvailabilityZone=self._region_name + self._availability_zones[self.availability_zone])
 
     @property
     def UserData(self) -> Optional[str]:  # pylint: disable=invalid-name

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -307,19 +307,19 @@ def get_ec2_network_configuration(regions: list[str], availability_zones: list[s
             assert sct_subnet, f"No SCT subnet configured for {region}! Run 'hydra prepare-aws-region'"
             region_subnets.append(sct_subnet.subnet_id)
 
-            security_groups = []
-            sct_sg = aws_region.sct_security_group
-            assert sct_sg, f"No SCT security group configured for {region}! Run 'hydra prepare-aws-region'"
-            security_groups.append(sct_sg.group_id)
+        security_groups = []
+        sct_sg = aws_region.sct_security_group
+        assert sct_sg, f"No SCT security group configured for {region}! Run 'hydra prepare-aws-region'"
+        security_groups.append(sct_sg.group_id)
 
-            if params.get('intra_node_comm_public') or params.get('ip_ssh_connections') == 'public':
-                test_config = TestConfig()
-                test_id = test_config.test_id()
+        if params.get('intra_node_comm_public') or params.get('ip_ssh_connections') == 'public':
+            test_config = TestConfig()
+            test_id = test_config.test_id()
 
-                test_sg = aws_region.provide_sct_test_security_group(test_id)
-                security_groups.append(test_sg.group_id)
+            test_sg = aws_region.provide_sct_test_security_group(test_id)
+            security_groups.append(test_sg.group_id)
 
-            ec2_security_group_ids.append(security_groups)
+        ec2_security_group_ids.append(security_groups)
 
     return ec2_security_group_ids, ec2_subnet_ids
 

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -708,8 +708,10 @@ def aws_tags_to_dict(tags_list):
             tags_dict[item["Key"]] = item["Value"]
     return tags_dict
 
+# pylint: disable=too-many-arguments
 
-def list_instances_aws(tags_dict=None, region_name=None, running=False, group_as_region=False, verbose=False):
+
+def list_instances_aws(tags_dict=None, region_name=None, running=False, group_as_region=False, verbose=False, availability_zone=None):
     """
     list all instances with specific tags AWS
 
@@ -718,6 +720,7 @@ def list_instances_aws(tags_dict=None, region_name=None, running=False, group_as
     :param running: get all running instances
     :param group_as_region: if True the results would be grouped into regions
     :param verbose: if True will log progress information
+    :param availability_zone: availability zone letter (e.g. 'a', 'b', 'c')
 
     :return: instances dict where region is a key
     """
@@ -747,6 +750,11 @@ def list_instances_aws(tags_dict=None, region_name=None, running=False, group_as
         else:
             instances[curr_region_name] = [i for i in instances[curr_region_name]
                                            if not i['State']['Name'] == 'terminated']
+    if availability_zone is not None:
+        # filter by availability zone (a, b, c, etc.)
+        for curr_region_name in instances:
+            instances[curr_region_name] = [i for i in instances[curr_region_name]
+                                           if i['Placement']['AvailabilityZone'] == curr_region_name + availability_zone]
     if not group_as_region:
         instances = list(itertools.chain(*list(instances.values())))  # flatten the list of lists
         total_items = len(instances)

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -790,6 +790,18 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                 "field 'validate_data' must be an instance of <class 'bool'>, but got 'no'\n\t" \
                 "field 'full_scan_aggregates_operation_limit' must be an instance of <class 'int'>, but got 'a'"
 
+    def test_28_number_of_nodes_per_az_must_be_divisable_by_number_of_az(self):
+        os.environ['SCT_N_DB_NODES'] = '3 3 2'
+        os.environ['SCT_REGION_NAME'] = 'eu-west-1 eu-west-2 us-east-1'
+        os.environ['SCT_AVAILABILITY_ZONE'] = 'a,b,c'
+        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = "['ami-06f919eb', 'ami-06f919eb', 'ami-06f919eb']"
+        with self.assertRaises(AssertionError) as context:
+            conf = sct_config.SCTConfiguration()
+            conf.verify_configuration()
+
+        self.assertIn("should be divisible by number of availability zones", str(context.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -206,11 +206,11 @@ def call(Map pipelineParams) {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {
                                     timeout(time: 30, unit: 'MINUTES') {
-                                        if ((params.backend == 'aws' || params.backend == 'azure') && !params.availability_zone.contains(',')) {
+                                        if (params.backend == 'aws' || params.backend == 'azure') {
                                             provisionResources(params, builder.region)
                                         } else {
                                             sh """
-                                                echo 'Skipping because non-AWS/Azure backends and multi-az are not supported'
+                                                echo 'Skipping because non-AWS/Azure backends are not supported'
                                             """
                                         }
                                         completed_stages['provision_resources'] = true


### PR DESCRIPTION
Currently provision step is disabled in pipeline when using multi-az
because it is not supporting this feature.

Adapt AWS provision to support multi-az and enable back provision step.

refs: https://github.com/scylladb/qa-tasks/issues/1070

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
