### PR TITLE
fix(disrupt_mgmt_repair): Add task progress string on task failure

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2669,8 +2669,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         mgr_cluster = self.cluster.get_cluster_manager()
         mgr_task = mgr_cluster.create_repair_task()
         task_final_status = mgr_task.wait_and_get_final_status(timeout=86400)  # timeout is 24 hours
-        assert task_final_status == TaskStatus.DONE, 'Task: {} final status is: {}.'.format(
-            mgr_task.id, str(mgr_task.status))
+        assert task_final_status == TaskStatus.DONE,\
+            f'Task: {mgr_task.id} final status is: {str(mgr_task.status)}.\nTask progress string: ' \
+            f'{mgr_task.progress_string(parse_table_res=False, is_verify_errorless_result=True).stdout}'
         self.log.info('Task: {} is done.'.format(mgr_task.id))
 
     def disrupt_abort_repair(self):


### PR DESCRIPTION
Added the full task progress string to the assert message when the task did not end successfully, so the reason for the repair failure will be clearer.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
