### PR TITLE
fix(decommission): don't retry command on network errors

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4648,7 +4648,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
     def decommission(self, node: BaseNode, timeout: int | float = None):
         with adaptive_timeout(operation=Operations.DECOMMISSION, node=node):
-            node.run_nodetool("decommission", timeout=timeout)
+            node.run_nodetool("decommission", timeout=timeout, retry=0)
         self.verify_decommission(node)
 
     def clean_group0_garbage(self, node: BaseNode, raise_exception: bool = False):


### PR DESCRIPTION
Since decomission is block for reentrancy, there not point of retring this operation, it would fail with:

```
nodetool: Scylla API server HTTP POST to URL '/storage_service/decommission'
failed: std::runtime_error (Operation decommission is in progress, try again)
```

the sequence to stop decommission, is diffrent and being tested on it's own in a diffrent nemesis.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
