### PR TITLE
fix(upgrade_test): workaround for shim-signed for deb only

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -160,7 +160,8 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
 
         InfoEvent(message='Upgrading a Node').publish()
         # because of scylladb/scylla-enterprise#2818 we are for now adding this workaround
-        node.remoter.sudo("apt-get remove shim-signed -y --allow-remove-essential")
+        if node.distro.is_ubuntu:
+            node.remoter.sudo("apt-get remove shim-signed -y --allow-remove-essential")
         node.upgrade_system()
 
         # We assume that if update_db_packages is not empty we install packages from there.


### PR DESCRIPTION
we are right now running this command to every
upgrade test, but RHEL like distros are not suffering from this problem, so adding a check, and running
it for Ubuntu only.


a try of it is running [here](https://jenkins.scylladb.com/job/scylla-staging/job/fabio/job/shim-signed/job/upgrade-ubuntu22-shim-signed/2/)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
