### PR TITLE
fix(azure-artifact): support public address in `cql_ip_address`

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -831,6 +831,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     @cached_property
     def cql_ip_address(self):
+        if self.test_config.IP_SSH_CONNECTIONS == 'public':
+            return self.ip_address
         with self.remote_scylla_yaml() as scylla_yaml:
             return scylla_yaml.broadcast_rpc_address if scylla_yaml.broadcast_rpc_address else self.ip_address
 


### PR DESCRIPTION
since 506c0bd353907a1b883e87355593c570c1bed84c azure artifacts are working with public address, but some of SCT around connecting to CQL isn't supporting correctly the public option.

## Testing

- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-azure-image-test/20/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
