### PR TITLE
fix(events_processes): stop logging on getting the process

### DIFF
--- a/sdcm/sct_events/events_processes.py
+++ b/sdcm/sct_events/events_processes.py
@@ -152,11 +152,12 @@ class EventsProcessesRegistry:
 
     def get_events_process(self, name: str) -> EventsProcess:
         with self._registry_dict_lock:
-            LOGGER.debug("Get process `%s' from %s", name, self)
+            # this happens too many times during SCT run, leaving it for when debugging is needed
+            # LOGGER.debug("Get process `%s' from %s", name, self)
             return self._registry_dict.get(name)
 
     def __str__(self):
-        return f"{type(self).__name__}[lod_dir={self.log_dir},id=0x{id(self):x},default={self.default}]"
+        return f"{type(self).__name__}[log_dir={self.log_dir},id=0x{id(self):x},default={self.default}]"
 
 
 _EVENTS_PROCESSES_LOCK = threading.RLock()


### PR DESCRIPTION
those logs are getting printed on each events that is created and they don't add any helpful information, commenting them out.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
