### PR TITLE
fix(sct.log): remove warning event from being printed

### DIFF
--- a/sdcm/db_log_reader.py
+++ b/sdcm/db_log_reader.py
@@ -46,6 +46,7 @@ class DbLogReader(Process):
         '] repair - Repair',
         'repair id [id=',
         '] stream_session - [Stream ',
+        '] storage_proxy - Exception when communicating with',
     ]
     # pylint: disable=too-many-arguments
 

--- a/sdcm/sct_events/file_logger.py
+++ b/sdcm/sct_events/file_logger.py
@@ -93,7 +93,7 @@ class EventsFileLogger(BaseEventsProcess[Tuple[str, Any], None], multiprocessing
 
         message_bin = message.encode("utf-8") + b"\n"
 
-        if event.severity != Severity.DEBUG:
+        if event.severity not in (Severity.DEBUG, Severity.WARNING):
             # Log event to the console
             tee = getattr(LOGGER, logging.getLevelName(event.log_level).lower())
             if tee and not isinstance(event, TestResultEvent):


### PR DESCRIPTION
* remove the warning events from being printed in sct.log, we have them in a seperate log if needed

* remove the `abort requested` logs from sct.log, we have too many of them, and they are not helpful for us

Ref: https://github.com/scylladb/scylladb/issues/10447

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
