### PR TITLE
fix(nemesis.py): Remove retry of adding a new node

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1188,7 +1188,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if not ContainerManager.is_running(self.tester.localhost, 'ldap'):
             raise LdapNotRunning("LDAP server was supposed to be running, but it is not")
 
-    @retrying(n=3, sleep_time=60, allowed_exceptions=(NodeSetupFailed, NodeSetupTimeout))
     def _add_and_init_new_cluster_node(self, old_node_ip=None, host_id=None,
                                        timeout=MAX_TIME_WAIT_FOR_NEW_NODE_UP, rack=0):
         """When old_node_ip or host_id are not None then replacement node procedure is initiated"""


### PR DESCRIPTION
	Retry adding a new node is problematic.
	It caused a failure of grow-shrink-cluster nemesis.
	Refs: https://github.com/scylladb/scylla-cluster-tests/issues/5415

Refs: https://github.com/scylladb/scylla-cluster-tests/issues/5415
[ICS Longevity 1TB Argus](https://argus.scylladb.com/test/d0b1d90e-dd6a-4a7c-96c3-3d31a43fc892/runs?additionalRuns[]=0e842a26-6b62-4164-ad08-513974539d88)
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
