### PR TITLE
Revert "feature(sct-builders): use aws ASGs as Azure builders"

### DIFF
--- a/test-cases/artifacts/azure-image.yaml
+++ b/test-cases/artifacts/azure-image.yaml
@@ -17,6 +17,3 @@ nemesis_class_name: 'NoOpMonkey'
 test_duration: 60
 user_prefix: 'artifacts-azure-image'
 system_auth_rf: 1
-
-# since running from runner in AWS, we need the address to be publicly available
-intra_node_comm_public: true

--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -28,7 +28,7 @@ def call(String backend, String region=null, String datacenter=null, String loca
                           'gce-us-west1': "${gcp_project}-builders-us-west1-template",
                           'gce': "${gcp_project}-builders-us-east1-template",
                           'aws': 'aws-sct-builders-eu-west-1-v2-asg',
-                          'azure-eastus': 'aws-sct-builders-us-east-1-v2-asg']
+                          'azure-eastus': 'azure-sct-builders']
 
     def cloud_provider = getCloudProviderFromBackend(backend)
 


### PR DESCRIPTION
Reverts scylladb/scylla-cluster-tests#5769

seems like the new version of cqlsh is having issue when used with public address
so revert this work, until figured out

Ref: https://github.com/scylladb/scylla-cqlsh/issues/32

## Testing

- [ ] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-azure-image-test/22/
