### PR TITLE
fix(cqlsh): extend cqlsh command default timeout

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2765,7 +2765,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                                   connect_timeout=connect_timeout)
         while num_retry_on_failure:
             try:
-                cqlsh_out = self.remoter.run(cmd, timeout=timeout + 30,  # we give 30 seconds to cqlsh timeout mechanism to work
+                cqlsh_out = self.remoter.run(cmd, timeout=timeout + 120,  # we give 30 seconds to cqlsh timeout mechanism to work
                                              verbose=verbose)
                 break
             except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
Since the recent switch to newer cqlsh, seems like we are having cases of shutdown of the python-driver takes more then we are used to, and on cases it
was up to 3min, enlarging the timeout for all
cqlsh commands to workaround the issue.

Ref: https://github.com/scylladb/scylla-cqlsh/issues/32

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
