### PR TITLE
fix(ICS SAG): 4 loaders + i4i.4xlarge. Added is_compaction_running

### DIFF
--- a/test-cases/features/ics_space_amplification_goal_test.yaml
+++ b/test-cases/features/ics_space_amplification_goal_test.yaml
@@ -6,14 +6,18 @@ prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=250000000 -schema
                     "cassandra-stress write no-warmup cl=ALL n=250000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=200 -col 'size=FIXED(200) n=FIXED(5)' -pop seq=500000001..750000000",
                     "cassandra-stress write no-warmup cl=ALL n=250000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=200 -col 'size=FIXED(200) n=FIXED(5)' -pop seq=750000001..1000000000"]
 
-stress_cmd: ["cassandra-stress write no-warmup cl=QUORUM n=1000000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=20 -col 'size=FIXED(200) n=FIXED(5)' -pop seq=1..1000000000"]
+stress_cmd: ["cassandra-stress write no-warmup cl=QUORUM n=250000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=200 -col 'size=FIXED(200) n=FIXED(5)' -pop seq=1..250000000",
+                    "cassandra-stress write no-warmup cl=QUORUM n=250000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=200 -col 'size=FIXED(200) n=FIXED(5)' -pop seq=250000001..500000000",
+                    "cassandra-stress write no-warmup cl=QUORUM n=250000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=200 -col 'size=FIXED(200) n=FIXED(5)' -pop seq=500000001..750000000",
+                    "cassandra-stress write no-warmup cl=QUORUM n=250000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=200 -col 'size=FIXED(200) n=FIXED(5)' -pop seq=750000001..1000000000"]
+
 round_robin: true
 
 n_db_nodes: 3
 n_loaders: 4
 n_monitor_nodes: 1
 
-instance_type_db: 'i3.4xlarge'
+instance_type_db: 'i4i.4xlarge'
 
 nemesis_class_name: 'NoOpMonkey'
 user_prefix: 'ics-space-amplification'


### PR DESCRIPTION
	fix(ICS SAG): 4 loaders + i4i.4xlarge. Added is_compaction_running
	In order to put more load on compactions,
	the stress now uses 4 loaders instead of 1.
	the first test-cycle of no-sag is removed as well.
        Added a major compaction between test cycles.
        Added an assertion of used-capacity before cycle starts.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
