### PR TITLE
fix(readme): removed old instruction for argus

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,6 @@ To run SCT tests locally run following::
     pyenv virtualenv 3.10.0 sct310
     pyenv activate sct310
     pip install -r requirements.in
-    pip install -e git+https://github.com/bentsi/argus#egg=argus
 
 
 


### PR DESCRIPTION
We get argus directly from pypi. 
There is no need to install anything extra.
Just removed the old command from readme file.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
