### PR TITLE
Repo parallel schema topology changes 12h

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1598,18 +1598,21 @@ class FileFollowerIterator():  # pylint: disable=too-few-public-methods
     def __iter__(self):
         with open(self.filename, encoding="utf-8") as input_file:
             line = ''
+            poller = select.poll()  # pylint: disable=no-member
+            registered = False
             while not self.thread_obj.stopped():
-                poller = select.poll()  # pylint: disable=no-member
-                poller.register(input_file, select.POLLIN)  # pylint: disable=no-member
+                if not registered:
+                    poller.register(input_file, select.POLLIN)  # pylint: disable=no-member
+                    registered = True
                 if poller.poll(100):
                     line += input_file.readline()
                 if not line or not line.endswith('\n'):
                     time.sleep(0.1)
                     continue
                 poller.unregister(input_file)
+                registered = False
                 yield line
                 line = ''
-            yield line
 
 
 class FileFollowerThread():

--- a/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
@@ -1,16 +1,15 @@
 test_duration: 800
 
-prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=100 -clustering-row-count=5000                       -clustering-row-size=uniform:1024..4096 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s",
-                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=100 -clustering-row-count=5000 -partition-offset=101 -clustering-row-size=uniform:4096..8192 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s"
+prepare_write_cmd:  [
+                     "cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80  -pop seq=1..20971521 -col 'n=FIXED(10) size=FIXED(128)' -log interval=10",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=250 -clustering-row-count=1000 -clustering-row-size=uniform:1024..4096 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=5 -timeout=60s -retry-number=30 -retry-interval=500ms,1s",
                     ]
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=720m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=720m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-             "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=50 -clustering-row-count=2500 -partition-offset=51  -clustering-row-size=uniform:1024..4096  -concurrency=10  -connection-count=10  -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=700m",
-             "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=50 -clustering-row-count=2500 -partition-offset=151 -clustering-row-size=uniform:4096..8192  -concurrency=10  -connection-count=10  -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=700m",
-             "scylla-bench -workload=sequential -mode=read  -replication-factor=3 -partition-count=50 -clustering-row-count=5000 -partition-offset=11  -clustering-row-size=uniform:1024..4096   -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=700m -validate-data",
-             "scylla-bench -workload=sequential -mode=read  -replication-factor=3 -partition-count=50 -clustering-row-count=5000 -partition-offset=121 -clustering-row-size=uniform:4096..8192   -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=700m -validate-data"
+stress_cmd: [
+             "cassandra-stress write cl=QUORUM duration=720m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate 'threads=40 throttle=15000/s' -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(128)' -log interval=10 -errors 'retries=30 ignore'",
+             "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=50 -clustering-row-count=1000 -partition-offset=11 -clustering-row-size=uniform:1024..4096  -concurrency=20  -connection-count=20  -consistency-level=quorum -rows-per-request=50 -timeout=60s -retry-number=30 -retry-interval=500ms,1s -iterations 0 -duration=700m -max-rate 1000",
+             "cassandra-stress read  cl=QUORUM duration=720m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate 'threads=40 throttle=15000/s' -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(128)' -log interval=10 -errors 'retries=30 ignore'",
+             "scylla-bench -workload=sequential -mode=read  -replication-factor=3 -partition-count=50 -clustering-row-count=1000 -partition-offset=41 -clustering-row-size=uniform:1024..4096   -concurrency=20 -connection-count=20  -consistency-level=quorum -rows-per-request=50 -timeout=60s -retry-number=30 -retry-interval=500ms,1s -iterations 0 -duration=700m -max-rate 1000"
 
              ]
 
@@ -22,8 +21,11 @@ instance_type_db: 'i3en.xlarge'
 
 nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
 nemesis_selector: [["topology_changes"],["schema_changes"]]
+
+
 nemesis_interval: 10
 nemesis_filter_seeds: false
+nemesis_during_prepare: false
 
 user_prefix: 'longevity-parallel-topology-schema-12h'
 space_node_threshold: 64424


### PR DESCRIPTION
Thanks to @dkropachev  who help to investigate the memory leakage and send a fix for FileFollowerIterator.
Also changed stress commands
Fix Add_remove_MV to run with parallel nemesis mode

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
