### PR TITLE
fix(large-partitions): update config file for 4days

### DIFF
--- a/test-cases/longevity/longevity-large-partition-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-4days.yaml
@@ -2,19 +2,19 @@ test_duration: 6480
 
 bench_run: true
 
-prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=6 -clustering-row-count=10000000 -clustering-row-size=2048 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150",
-                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=6 -clustering-row-count=10000000 -partition-offset=6 -clustering-row-size=2048 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150",
-                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=7 -clustering-row-count=10000000 -partition-offset=12 -clustering-row-size=2048 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150",
-                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=7 -clustering-row-count=10000000 -partition-offset=19 -clustering-row-size=2048 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150",
-                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=7 -clustering-row-count=10000000 -partition-offset=26 -clustering-row-size=2048 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150",
-                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=7 -clustering-row-count=10000000 -partition-offset=33 -clustering-row-size=2048 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150",
-                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=7 -clustering-row-count=10000000 -partition-offset=40 -clustering-row-size=2048 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150",
-                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=7 -clustering-row-count=10000000 -partition-offset=47 -clustering-row-size=2048 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150",
-                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=6 -clustering-row-count=10000000 -partition-offset=54 -clustering-row-size=2048 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150"
+prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=6 -clustering-row-count=10000000 -clustering-row-size=2048 -concurrency=8 -rows-per-request=2000 -timeout=180s -connection-count 8 -retry-number=3 -retry-interval=40s -consistency-level=all",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=6 -clustering-row-count=10000000 -partition-offset=6 -clustering-row-size=2048 -concurrency=8 -rows-per-request=2000 -timeout=180s -connection-count 8 -retry-number=3 -retry-interval=40s -consistency-level=all",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=7 -clustering-row-count=10000000 -partition-offset=12 -clustering-row-size=2048 -concurrency=8 -rows-per-request=2000 -timeout=180s -connection-count 8 -retry-number=3 -retry-interval=40s -consistency-level=all",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=7 -clustering-row-count=10000000 -partition-offset=19 -clustering-row-size=2048 -concurrency=8 -rows-per-request=2000 -timeout=180s -connection-count 8 -retry-number=3 -retry-interval=40s -consistency-level=all",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=7 -clustering-row-count=10000000 -partition-offset=26 -clustering-row-size=2048 -concurrency=8 -rows-per-request=2000 -timeout=180s -connection-count 8 -retry-number=3 -retry-interval=40s -consistency-level=all",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=7 -clustering-row-count=10000000 -partition-offset=33 -clustering-row-size=2048 -concurrency=8 -rows-per-request=2000 -timeout=180s -connection-count 8 -retry-number=3 -retry-interval=40s -consistency-level=all",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=7 -clustering-row-count=10000000 -partition-offset=40 -clustering-row-size=2048 -concurrency=8 -rows-per-request=2000 -timeout=180s -connection-count 8 -retry-number=3 -retry-interval=40s -consistency-level=all",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=7 -clustering-row-count=10000000 -partition-offset=47 -clustering-row-size=2048 -concurrency=8 -rows-per-request=2000 -timeout=180s -connection-count 8 -retry-number=3 -retry-interval=40s -consistency-level=all",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=6 -clustering-row-count=10000000 -partition-offset=54 -clustering-row-size=2048 -concurrency=8 -rows-per-request=2000 -timeout=180s -connection-count 8 -retry-number=3 -retry-interval=40s -consistency-level=all"
 ]
-stress_cmd: ["scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=60 -clustering-row-count=10000000 -clustering-row-size=2048 -rows-per-request=2000 -timeout=180s -concurrency=700 -max-rate=64000  -duration=5760m -connection-count 500",
-             "scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=60 -clustering-row-count=10000000 -clustering-row-size=2048 -rows-per-request=2000 -timeout=180s -concurrency=700 -max-rate=64000  -duration=5760m -connection-count 500",
-             "scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=60 -clustering-row-count=10000000 -clustering-row-size=2048 -rows-per-request=2000 -timeout=180s -concurrency=700 -max-rate=64000  -duration=5760m -connection-count 500"
+stress_cmd: ["scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=60 -clustering-row-count=10000000 -clustering-row-size=2048 -rows-per-request=2000 -timeout=180s -concurrency=25 -max-rate=64000  -duration=5760m -connection-count 25 -retry-number=10 -retry-interval=40s",
+             "scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=60 -clustering-row-count=10000000 -clustering-row-size=2048 -rows-per-request=2000 -timeout=180s -concurrency=25 -max-rate=64000  -duration=5760m -connection-count 25 -retry-number=10 -retry-interval=40s",
+             "scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=60 -clustering-row-count=10000000 -clustering-row-size=2048 -rows-per-request=2000 -timeout=180s -concurrency=25 -max-rate=64000  -duration=5760m -connection-count 25 -retry-number=10 -retry-interval=40s"
 ]
 
 n_db_nodes: 4
@@ -42,5 +42,6 @@ validate_partitions: true
 table_name: "scylla_bench.test"
 primary_key_column: "pk"
 
-
-run_fullscan: ['{"mode": "random", "ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 10000000, "validate_data": true}']
+# TODO: uncomment the fullscan part when following bug gets fixed:
+#       https://github.com/scylladb/scylla-cluster-tests/issues/6056
+# run_fullscan: ['{"mode": "random", "ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 10000000, "validate_data": true}']


### PR DESCRIPTION
With current `scylla-bench` configuration in `large partitions 4d` configuration we get constant query timeouts having only up to `25% CPU load` on nodes.
So, we reach IO/net limits with some part of queries and all other just fail.
To avoid it, reduce the number of the concurrent threads.
Also, explicitly configure retries making them be absent in the `read` load and be present in the `prepare write` one.

Fixes: #5940

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
