### PR TITLE
fix(toggle Ldap authorization): Use pause-resume Ldap container

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1150,9 +1150,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                        'ldap_bind_dn': '',
                        'ldap_bind_passwd': ''}
 
-        def destroy_ldap_container():
-            ContainerManager.destroy_container(self.tester.localhost, 'ldap')
-
         def remove_ldap_configuration_from_node(node):
             with node.remote_scylla_yaml() as scylla_yaml:
                 for key in ldap_config:
@@ -1166,13 +1163,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         InfoEvent(message='Disable LDAP Authorization Configuration').publish()
         for node in self.cluster.nodes:
             remove_ldap_configuration_from_node(node)
-        destroy_ldap_container()
+        self.log.info('Will now pause the LDAP container')
+        ContainerManager.pause_container(self.tester.localhost, 'ldap')
 
         self.log.debug('Will wait few minutes with LDAP disabled, before re-enabling it')
         time.sleep(600)
-
-        def create_ldap_container():
-            self.tester.configure_ldap(self.tester.localhost)
 
         def add_ldap_configuration_to_node(node):
             node.refresh_ip_address()
@@ -1180,8 +1175,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 scylla_yaml.update(ldap_config)
             node.restart_scylla_server()
 
-        InfoEvent(message='Re-enable LDAP Authorization Configuration').publish()
-        create_ldap_container()
+        self.log.info('Will now resume the LDAP container')
+        ContainerManager.unpause_container(self.tester.localhost, 'ldap')
         for node in self.cluster.nodes:
             add_ldap_configuration_to_node(node)
 


### PR DESCRIPTION
	In order to avoid flakiness of formerly used destroy/create Ldap container.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
