### PR TITLE
feature(nemesis): Added manager restore nemesis

### DIFF
--- a/data_dir/nemesis.yml
+++ b/data_dir/nemesis.yml
@@ -107,6 +107,10 @@
   - disruptive = False
   - kubernetes = True
   - limited = True
+- disrupt_mgmt_restore:
+  - disruptive = True
+  - kubernetes = False
+  - limited = True
 - disrupt_modify_table:
   - disruptive = False
   - kubernetes = True

--- a/data_dir/nemesis_classes.yml
+++ b/data_dir/nemesis_classes.yml
@@ -30,6 +30,7 @@
 - MgmtBackup
 - MgmtBackupSpecificKeyspaces
 - MgmtRepair
+- MgmtRestore
 - ModifyTableMonkey
 - MultipleHardRebootNodeMonkey
 - NemesisSequence

--- a/defaults/manager_persistent_snapshots.yaml
+++ b/defaults/manager_persistent_snapshots.yaml
@@ -1,18 +1,79 @@
 aws:
-  snapshots:
-    10:
-      snapshot_tag: 'sm_20230223105105UTC'
-      expected_timeout: 1800  # 30 minutes
-      keyspace_name: "10gb_sizetiered"
-      confirmation_stress_command: "cassandra-stress read cl=QUORUM n=10485760 -schema 'keyspace=10gb_sizetiered replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..10485760"
-    100:
-      snapshot_tag: 'sm_20230223130733UTC'
-      expected_timeout: 9000  # 150 minutes
-      keyspace_name: "100gb_sizetiered"
-      confirmation_stress_command: "cassandra-stress read cl=QUORUM n=104857600 -schema 'keyspace=100gb_sizetiered replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..104857600"
-    2048:
-      snapshot_tag: 'sm_20230226074656UTC'
-      expected_timeout: 66000  # 1100 minutes
-      keyspace_name: "2tb_sizetiered"
-      confirmation_stress_command: "cassandra-stress read cl=QUORUM n=2147483648 -schema 'keyspace=2tb_sizetiered replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=100 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..2147483648"
   bucket: "manager-backup-tests-permanent-snapshots-us-east-1"
+  snapshots:
+    5:
+      'sm_20230702185929UTC':
+        expected_timeout: 900  # 15 minutes
+        keyspace_name: "5gb_sizetiered_2022_2"
+        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=5242880 -schema 'keyspace=5gb_sizetiered_2022_2 replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..5242880"
+        scylla_version: "2022.2.9"
+        number_of_nodes: 5
+      'sm_20230702201949UTC':
+        expected_timeout: 900  # 15 minutes
+        keyspace_name: "5gb_sizetiered_2022_1"
+        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=5242880 -schema 'keyspace=5gb_sizetiered_2022_1 replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..5242880"
+        scylla_version: "2022.1.7"
+        number_of_nodes: 5
+      'sm_20230702190638UTC':
+        expected_timeout: 900  # 15 minutes
+        keyspace_name: "5gb_sizetiered_5_2"
+        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=5242880 -schema 'keyspace=5gb_sizetiered_5_2 replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..5242880"
+        scylla_version: "5.2.3"
+        number_of_nodes: 5
+    10:
+      'sm_20230223105105UTC':
+        expected_timeout: 1800  # 30 minutes
+        keyspace_name: "10gb_sizetiered"
+        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=10485760 -schema 'keyspace=10gb_sizetiered replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..10485760"
+        scylla_version: "5.1.6"
+        number_of_nodes: 3
+      'sm_20230702173347UTC':
+        expected_timeout: 1800  # 30 minutes
+        keyspace_name: "10gb_sizetiered_2022_2"
+        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=10485760 -schema 'keyspace=10gb_sizetiered_2022_2 replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..10485760"
+        scylla_version: "2022.2.9"
+        number_of_nodes: 4
+      'sm_20230702173940UTC':
+        expected_timeout: 1800  # 30 minutes
+        keyspace_name: "10gb_sizetiered_2022_1"
+        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=10485760 -schema 'keyspace=10gb_sizetiered_2022_1 replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..10485760"
+        scylla_version: "2022.1.7"
+        number_of_nodes: 4
+      'sm_20230702173329UTC':
+        expected_timeout: 1800  # 30 minutes
+        keyspace_name: "10gb_sizetiered_5_2"
+        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=10485760 -schema 'keyspace=10gb_sizetiered_5_2 replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..10485760"
+        scylla_version: "5.2.3"
+        number_of_nodes: 4
+    100:
+      'sm_20230223130733UTC':
+        expected_timeout: 9000  # 150 minutes
+        keyspace_name: "100gb_sizetiered"
+        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=104857600 -schema 'keyspace=100gb_sizetiered replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..104857600"
+        scylla_version: "5.1.6"
+        number_of_nodes: 3
+      'sm_20230702235739UTC':
+        expected_timeout: 9000  # 150 minutes
+        keyspace_name: "100gb_sizetiered_2022_2"
+        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=104857600 -schema 'keyspace=100gb_sizetiered_2022_2 replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..104857600"
+        scylla_version: "2022.2.9"
+        number_of_nodes: 4
+      'sm_20230703000641UTC':
+        expected_timeout: 9000  # 150 minutes
+        keyspace_name: "100gb_sizetiered_2022_1"
+        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=104857600 -schema 'keyspace=100gb_sizetiered_2022_1 replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..104857600"
+        scylla_version: "2022.1.7"
+        number_of_nodes: 4
+      'sm_20230703000157UTC':
+        expected_timeout: 9000  # 150 minutes
+        keyspace_name: "100gb_sizetiered_5_2"
+        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=104857600 -schema 'keyspace=100gb_sizetiered_5_2 replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..104857600"
+        scylla_version: "5.2.3"
+        number_of_nodes: 4
+    2048:
+      'sm_20230226074656UTC':
+        expected_timeout: 66000  # 1100 minutes
+        keyspace_name: "2tb_sizetiered"
+        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=2147483648 -schema 'keyspace=2tb_sizetiered replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=100 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..2147483648"
+        scylla_version: "5.1.6"
+        number_of_nodes: 3

--- a/defaults/manager_persistent_snapshots.yaml
+++ b/defaults/manager_persistent_snapshots.yaml
@@ -1,79 +1,68 @@
 aws:
   bucket: "manager-backup-tests-permanent-snapshots-us-east-1"
-  snapshots:
+  confirmation_stress_template: "cassandra-stress read cl=QUORUM n={num_of_rows} -schema 'keyspace={keyspace_name} replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq={sequence_start}..{sequence_end}"
+  snapshots_sizes:
     5:
-      'sm_20230702185929UTC':
-        expected_timeout: 900  # 15 minutes
-        keyspace_name: "5gb_sizetiered_2022_2"
-        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=5242880 -schema 'keyspace=5gb_sizetiered_2022_2 replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..5242880"
-        scylla_version: "2022.2.9"
-        number_of_nodes: 5
-      'sm_20230702201949UTC':
-        expected_timeout: 900  # 15 minutes
-        keyspace_name: "5gb_sizetiered_2022_1"
-        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=5242880 -schema 'keyspace=5gb_sizetiered_2022_1 replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..5242880"
-        scylla_version: "2022.1.7"
-        number_of_nodes: 5
-      'sm_20230702190638UTC':
-        expected_timeout: 900  # 15 minutes
-        keyspace_name: "5gb_sizetiered_5_2"
-        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=5242880 -schema 'keyspace=5gb_sizetiered_5_2 replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..5242880"
-        scylla_version: "5.2.3"
-        number_of_nodes: 5
+      number_of_rows: 5242880
+      expected_timeout: 900  # 15 minutes
+      snapshots:
+        'sm_20230702185929UTC':
+          keyspace_name: "5gb_sizetiered_2022_2"
+          scylla_version: "2022.2.9"
+          number_of_nodes: 5
+        'sm_20230702201949UTC':
+          keyspace_name: "5gb_sizetiered_2022_1"
+          scylla_version: "2022.1.7"
+          number_of_nodes: 5
+        'sm_20230702190638UTC':
+          keyspace_name: "5gb_sizetiered_5_2"
+          scylla_version: "5.2.3"
+          number_of_nodes: 5
     10:
-      'sm_20230223105105UTC':
-        expected_timeout: 1800  # 30 minutes
-        keyspace_name: "10gb_sizetiered"
-        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=10485760 -schema 'keyspace=10gb_sizetiered replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..10485760"
-        scylla_version: "5.1.6"
-        number_of_nodes: 3
-      'sm_20230702173347UTC':
-        expected_timeout: 1800  # 30 minutes
-        keyspace_name: "10gb_sizetiered_2022_2"
-        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=10485760 -schema 'keyspace=10gb_sizetiered_2022_2 replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..10485760"
-        scylla_version: "2022.2.9"
-        number_of_nodes: 4
-      'sm_20230702173940UTC':
-        expected_timeout: 1800  # 30 minutes
-        keyspace_name: "10gb_sizetiered_2022_1"
-        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=10485760 -schema 'keyspace=10gb_sizetiered_2022_1 replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..10485760"
-        scylla_version: "2022.1.7"
-        number_of_nodes: 4
-      'sm_20230702173329UTC':
-        expected_timeout: 1800  # 30 minutes
-        keyspace_name: "10gb_sizetiered_5_2"
-        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=10485760 -schema 'keyspace=10gb_sizetiered_5_2 replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..10485760"
-        scylla_version: "5.2.3"
-        number_of_nodes: 4
+      number_of_rows: 10485760
+      expected_timeout: 1800  # 30 minutes
+      snapshots:
+        'sm_20230223105105UTC':
+          keyspace_name: "10gb_sizetiered"
+          scylla_version: "5.1.6"
+          number_of_nodes: 3
+        'sm_20230702173347UTC':
+          keyspace_name: "10gb_sizetiered_2022_2"
+          scylla_version: "2022.2.9"
+          number_of_nodes: 4
+        'sm_20230702173940UTC':
+          keyspace_name: "10gb_sizetiered_2022_1"
+          scylla_version: "2022.1.7"
+          number_of_nodes: 4
+        'sm_20230702173329UTC':
+          keyspace_name: "10gb_sizetiered_5_2"
+          scylla_version: "5.2.3"
+          number_of_nodes: 4
     100:
-      'sm_20230223130733UTC':
-        expected_timeout: 9000  # 150 minutes
-        keyspace_name: "100gb_sizetiered"
-        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=104857600 -schema 'keyspace=100gb_sizetiered replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..104857600"
-        scylla_version: "5.1.6"
-        number_of_nodes: 3
-      'sm_20230702235739UTC':
-        expected_timeout: 9000  # 150 minutes
-        keyspace_name: "100gb_sizetiered_2022_2"
-        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=104857600 -schema 'keyspace=100gb_sizetiered_2022_2 replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..104857600"
-        scylla_version: "2022.2.9"
-        number_of_nodes: 4
-      'sm_20230703000641UTC':
-        expected_timeout: 9000  # 150 minutes
-        keyspace_name: "100gb_sizetiered_2022_1"
-        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=104857600 -schema 'keyspace=100gb_sizetiered_2022_1 replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..104857600"
-        scylla_version: "2022.1.7"
-        number_of_nodes: 4
-      'sm_20230703000157UTC':
-        expected_timeout: 9000  # 150 minutes
-        keyspace_name: "100gb_sizetiered_5_2"
-        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=104857600 -schema 'keyspace=100gb_sizetiered_5_2 replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..104857600"
-        scylla_version: "5.2.3"
-        number_of_nodes: 4
+      number_of_rows: 104857600
+      expected_timeout: 9000  # 150 minutes
+      snapshots:
+        'sm_20230223130733UTC':
+          keyspace_name: "100gb_sizetiered"
+          scylla_version: "5.1.6"
+          number_of_nodes: 3
+        'sm_20230702235739UTC':
+          keyspace_name: "100gb_sizetiered_2022_2"
+          scylla_version: "2022.2.9"
+          number_of_nodes: 4
+        'sm_20230703000641UTC':
+          keyspace_name: "100gb_sizetiered_2022_1"
+          scylla_version: "2022.1.7"
+          number_of_nodes: 4
+        'sm_20230703000157UTC':
+          keyspace_name: "100gb_sizetiered_5_2"
+          scylla_version: "5.2.3"
+          number_of_nodes: 4
     2048:
-      'sm_20230226074656UTC':
-        expected_timeout: 66000  # 1100 minutes
-        keyspace_name: "2tb_sizetiered"
-        confirmation_stress_command: "cassandra-stress read cl=QUORUM n=2147483648 -schema 'keyspace=2tb_sizetiered replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  -rate threads=100 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..2147483648"
-        scylla_version: "5.1.6"
-        number_of_nodes: 3
+      number_of_rows: 2147483648
+      expected_timeout: 66000  # 1100 minutes
+      snapshots:
+        'sm_20230226074656UTC':
+          keyspace_name: "2tb_sizetiered"
+          scylla_version: "5.1.6"
+          number_of_nodes: 3

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4691,7 +4691,9 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.scylla_manager_node, scylla_cluster=self)
         if host_ip is None:
             host_ip = self.nodes[0].ip_address
-        return manager_tool.add_cluster(name=cluster_name, host=host_ip, auth_token=self.scylla_manager_auth_token)
+        credentials = self.get_db_auth()  # pylint: disable=no-member
+        return manager_tool.add_cluster(name=cluster_name, host=host_ip, auth_token=self.scylla_manager_auth_token,
+                                        credentials=credentials)
 
     def is_additional_data_volume_used(self) -> bool:
         """return true if additional data volume is configured

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -953,12 +953,16 @@ class ScyllaManagerTool(ScyllaManagerBase):
         return [[n, n.ip_address] for n in db_cluster.nodes]
 
     def add_cluster(self, name, host=None, db_cluster=None, client_encrypt=None, disable_automatic_repair=True,  # pylint: disable=too-many-arguments
-                    auth_token=None):
+                    auth_token=None, credentials=None):
         """
         :param name: cluster name
         :param host: cluster node IP
         :param db_cluster: scylla cluster
         :param client_encrypt: is TSL client encryption enable/disable
+        :param disable_automatic_repair: when a cluster is added to the manager, a repair task is created automatically.
+         This param removes that task.
+        :param auth_token: a token used to authenticate requests to the Agent
+        :param credentials: a tuple of the username and password that are used to access the cluster.
         :return: ManagerCluster
 
         Add a cluster to manager
@@ -1001,6 +1005,9 @@ class ScyllaManagerTool(ScyllaManagerBase):
                 if client_encrypt or db_node.is_client_encrypt:
                     cmd += " --ssl-user-cert-file {} --ssl-user-key-file {}".format(SSL_USER_CERT_FILE,
                                                                                     SSL_USER_KEY_FILE)
+        if credentials:
+            username, password = credentials
+            cmd += f" --username {username} --password {password}"
         res_cluster_add = self.sctool.run(cmd, parse_table_res=False)
         if not res_cluster_add or 'Cluster added' not in res_cluster_add.stderr:
             raise ScyllaManagerError("Encountered an error on 'sctool cluster add' command response: {}".format(

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -10,6 +10,12 @@ DEFAULT_TASK_TIMEOUT = 7200  # 2 hours
 LOGGER = logging.getLogger(__name__)
 
 
+def get_persistent_snapshots():  # Snapshot sizes (dict keys) are in GB
+    with open("defaults/manager_persistent_snapshots.yaml", encoding="utf-8") as mgmt_snapshot_yaml:
+        persistent_manager_snapshots_dict = yaml.safe_load(mgmt_snapshot_yaml)
+    return persistent_manager_snapshots_dict
+
+
 def get_distro_name(distro_object):
     known_distro_dict = {
         Distro.AMAZON2: "centos7",

--- a/sdcm/mgmt/operator.py
+++ b/sdcm/mgmt/operator.py
@@ -421,7 +421,7 @@ class ScyllaManagerToolOperator(ScyllaManagerTool):
         raise NotImplementedError()
 
     def add_cluster(self, name, host=None, db_cluster=None, client_encrypt=None, disable_automatic_repair=True,
-                    auth_token=None):
+                    auth_token=None, credentials=None):
         raise NotImplementedError()
 
     def upgrade(self, scylla_mgmt_upgrade_to_repo):

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -65,8 +65,7 @@ from sdcm.cluster_k8s import (
 from sdcm.db_stats import PrometheusDBStats
 from sdcm.log import SDCMAdapter
 from sdcm.logcollector import save_kallsyms_map
-from sdcm.mgmt import TaskStatus
-from sdcm.mgmt.common import ScyllaManagerError
+from sdcm.mgmt.common import TaskStatus, ScyllaManagerError, get_persistent_snapshots
 from sdcm.nemesis_publisher import NemesisElasticSearchPublisher
 from sdcm.paths import SCYLLA_YAML_PATH
 from sdcm.prometheus import nemesis_metrics_obj
@@ -2700,6 +2699,65 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_mgmt_backup(self):
         self._mgmt_backup(backup_specific_tables=False)
 
+    def disrupt_mgmt_restore(self):
+        def get_total_scylla_partition_size():
+            result = self.cluster.nodes[0].remoter.run("df -k | grep /var/lib/scylla")  # Size in KB
+            free_space_size = int(result.stdout.split()[1]) / 1024 ** 2  # Converting to GB
+            return free_space_size
+
+        def choose_snapshot(snapshots_dict):
+            snapshot_groups_by_size = snapshots_dict["snapshots"]
+            total_partition_size = get_total_scylla_partition_size()
+            all_snapshot_sizes = sorted(list(snapshot_groups_by_size.keys()), reverse=True)
+            fitting_snapshot_sizes = [size for size in all_snapshot_sizes if total_partition_size / size >= 20]
+            if self.tester.test_duration < 1000:
+                # Since verifying the restored data takes a long time, the nemesis limits the size of the restored
+                # backup based on the test duration
+                fitting_snapshot_sizes = [size for size in fitting_snapshot_sizes if size < 50]
+            # The restore should not take more than 5% of the space total space in /var/lib/scylla
+            assert fitting_snapshot_sizes, "There's not enough space for any snapshot restoration"
+            self.use_nemesis_seed()
+            chosen_snapshot_size = random.choice(fitting_snapshot_sizes)
+            snapshot_tag = random.choice(list(snapshot_groups_by_size[chosen_snapshot_size].keys()))
+            snapshot_info = snapshot_groups_by_size[chosen_snapshot_size][snapshot_tag]
+            return snapshot_tag, snapshot_info
+
+        if not (self.cluster.params.get('use_mgmt') or self.cluster.params.get('use_cloud_manager')):
+            raise UnsupportedNemesis('Scylla-manager configuration is not defined!')
+        if self.cluster.params.get('cluster_backend') != 'aws':
+            raise UnsupportedNemesis("The restore test only supports AWS at the moment")
+        mgr_cluster = self.cluster.get_cluster_manager()
+        cluster_backend = self.cluster.params.get('cluster_backend')
+        persistent_manager_snapshots_dict = get_persistent_snapshots()
+        target_bucket = persistent_manager_snapshots_dict[cluster_backend]["bucket"]
+        chosen_snapshot_tag, chosen_snapshot_info = choose_snapshot(persistent_manager_snapshots_dict[cluster_backend])
+
+        self.log.info("Restoring the keyspace %s", chosen_snapshot_info["keyspace_name"])
+        location_list = [f"{self.cluster.params.get('backup_bucket_backend')}:{target_bucket}"]
+        test_keyspaces = self.cluster.get_test_keyspaces()
+        if chosen_snapshot_info["keyspace_name"] not in test_keyspaces:
+            self.log.info("Restoring the schema of the keyspace '%s'", chosen_snapshot_info["keyspace_name"])
+            restore_task = mgr_cluster.create_restore_task(restore_schema=True, location_list=location_list,
+                                                           snapshot_tag=chosen_snapshot_tag)
+            restore_task.wait_and_get_final_status(step=10, timeout=120)
+            assert restore_task.status == TaskStatus.DONE, f'Schema restoration of {chosen_snapshot_tag} has failed!'
+            self.cluster.restart_scylla()  # After schema restoration, you should restart the nodes
+
+        restore_task = mgr_cluster.create_restore_task(restore_data=True,
+                                                       location_list=location_list, snapshot_tag=chosen_snapshot_tag)
+        restore_task.wait_and_get_final_status(step=30, timeout=chosen_snapshot_info["expected_timeout"])
+        assert restore_task.status == TaskStatus.DONE, f'Data restoration of {chosen_snapshot_tag} has failed!'
+
+        mgr_task = mgr_cluster.create_repair_task()
+        task_final_status = mgr_task.wait_and_get_final_status(timeout=chosen_snapshot_info["expected_timeout"])
+        assert task_final_status == TaskStatus.DONE, 'Task: {} final status is: {}.'.format(
+            mgr_task.id, str(mgr_task.status))
+
+        stress_command = chosen_snapshot_info["confirmation_stress_command"]
+        read_thread = self.tester.run_stress_thread(stress_cmd=stress_command, round_robin=True,
+                                                    stop_test_on_failure=False)
+        self.tester.verify_stress_thread(cs_thread_pool=read_thread)
+
     def _delete_existing_backups(self, mgr_cluster):
         deleted_tasks = []
         existing_backup_tasks = mgr_cluster.backup_task_list
@@ -5205,6 +5263,15 @@ class MgmtBackupSpecificKeyspaces(Nemesis):
 
     def disrupt(self):
         self.disrupt_mgmt_backup_specific_keyspaces()
+
+
+class MgmtRestore(Nemesis):
+    disruptive = True
+    kubernetes = True
+    limited = True
+
+    def disrupt(self):
+        self.disrupt_mgmt_restore()
 
 
 class MgmtRepair(Nemesis):

--- a/unit_tests/test_nemesis_sisyphus.py
+++ b/unit_tests/test_nemesis_sisyphus.py
@@ -71,7 +71,7 @@ def test_list_all_available_nemesis(generate_file=True):
     disruption_list, disruptions_dict, disruption_classes = sisyphus.get_list_of_disrupt_methods(
         subclasses_list=subclasses, export_properties=True)
 
-    assert len(disruption_list) == 77
+    assert len(disruption_list) == 78
 
     if generate_file:
         with open('data_dir/nemesis.yml', 'w', encoding="utf-8") as outfile1:


### PR DESCRIPTION
Since manager 3.1, manager now supports restoring previously created backups. In this PR I added a new manager restore nemesis, that restores data from previously created snapshots (seen in manager_persistent_snapshots.yaml)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
