### PR TITLE
test(customer profile): An upgrade test for customer profile

### DIFF
--- a/test-cases/upgrades/customer-profile/rolling-upgrade-cust-d.yaml
+++ b/test-cases/upgrades/customer-profile/rolling-upgrade-cust-d.yaml
@@ -1,0 +1,31 @@
+test_duration: 360
+
+# workloads
+# Customer profiles directory path is: scylla-qa-internal/customer-profile/cust_d
+
+# To be used in keyspace_entire_test:
+write_stress_during_entire_test: cassandra-stress user no-warmup profile=/tmp/write_stress_during_entire_test.yaml  ops'(insert=1,read=2)' cl=ALL n=5000000 -mode cql3 native -rate threads=1000 -pop seq=1..5000000
+
+# To be used in keyspace_customer_preload:
+stress_before_upgrade: cassandra-stress user no-warmup profile=/tmp/stress_before_upgrade.yaml  ops'(insert=1)' cl=ALL n=5000000 -mode cql3 native -rate threads=1000 -pop seq=1..5000000
+
+n_db_nodes: 4
+n_loaders: 1
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.2xlarge'
+
+user_prefix: 'rolling-upgrade-cust-d'
+
+server_encrypt: true
+authenticator: 'PasswordAuthenticator'
+authenticator_user: 'cassandra'
+authenticator_password: 'cassandra'
+
+recover_system_tables: true
+
+append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1'
+
+use_mgmt: false
+
+use_prepared_loaders: true

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -96,7 +96,7 @@ def recover_conf(node):
             r'test -e $conf.backup && sudo cp -v $conf.backup $conf; done')
 
 
-# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-instance-attributes, too-many-public-methods
 class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
     """
     Test a Scylla cluster upgrade.
@@ -759,6 +759,107 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         InfoEvent(message='Step10 - Verify that gemini did not failed during upgrade').publish()
         if self.version_cdc_support():
             self.verify_gemini_results(queue=gemini_thread)
+
+        InfoEvent(message='all nodes were upgraded, and last workaround is verified.').publish()
+
+    def test_customer_profile_rolling_upgrade(self):  # pylint: disable=too-many-locals,too-many-statements
+        """
+        Run a load of a customer profile.
+        Upgrade half of nodes in the cluster, and run rollback.
+        Upgrade all nodes to new version in the end.
+        """
+        # TODO: customer-profile yaml files should either be copied to data_dir or sent directly to loader /tmp.
+        InfoEvent(message='Running a prepare load for the initial customer data').publish()
+        stress_before_upgrade = self.run_stress_thread(stress_cmd=self.params.get('stress_before_upgrade'))
+        self.verify_stress_thread(stress_before_upgrade)
+
+        # write workload during entire test
+        InfoEvent(message='Starting write workload during entire test').publish()
+        write_stress_during_entire_test = self.params.get('write_stress_during_entire_test')
+        entire_write_thread_pool = self.run_stress_thread(stress_cmd=write_stress_during_entire_test)
+
+        # Let to write_stress_during_entire_test complete the schema changes
+        self.metric_has_data(
+            metric_query='sct_cassandra_stress_write_gauge{type="ops", keyspace="keyspace_entire_test"}', n=10)
+
+        # generate random order to upgrade
+        nodes_num = len(self.db_cluster.nodes)
+        # prepare an array containing the indexes
+        indexes = list(range(nodes_num))
+        # shuffle it so we will upgrade the nodes in a random order
+        random.shuffle(indexes)
+
+        with ignore_upgrade_schema_errors():
+
+            step = 'Step1 - Upgrade First Node '
+            InfoEvent(message=step).publish()
+            # upgrade first node
+            self.db_cluster.node_to_upgrade = self.db_cluster.nodes[indexes[0]]
+            InfoEvent(message='Upgrade Node %s begin' % self.db_cluster.node_to_upgrade.name).publish()
+            self.upgrade_node(self.db_cluster.node_to_upgrade)
+            InfoEvent(message='Upgrade Node %s ended' % self.db_cluster.node_to_upgrade.name).publish()
+            self.db_cluster.node_to_upgrade.check_node_health()
+
+            InfoEvent(message='after upgraded one node').publish()
+            self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
+                                                          step=step+' - after upgraded one node')
+
+            step = 'Step2 - Upgrade Second Node '
+            InfoEvent(message=step).publish()
+            # upgrade second node
+            self.db_cluster.node_to_upgrade = self.db_cluster.nodes[indexes[1]]
+            InfoEvent(message='Upgrade Node %s begin' % self.db_cluster.node_to_upgrade.name).publish()
+            self.upgrade_node(self.db_cluster.node_to_upgrade)
+            InfoEvent(message='Upgrade Node %s ended' % self.db_cluster.node_to_upgrade.name).publish()
+            self.db_cluster.node_to_upgrade.check_node_health()
+
+            self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
+                                                          step=step+' - after upgraded two nodes')
+
+            InfoEvent(message='Step3 - Rollback Second Node ').publish()
+            # rollback second node
+            InfoEvent(message='Rollback Node %s begin' % self.db_cluster.nodes[indexes[1]].name).publish()
+            self.rollback_node(self.db_cluster.nodes[indexes[1]])
+            InfoEvent(message='Rollback Node %s ended' % self.db_cluster.nodes[indexes[1]].name).publish()
+            self.db_cluster.nodes[indexes[1]].check_node_health()
+
+        step = 'Step4 - Verify data during mixed cluster mode '
+        InfoEvent(message=step).publish()
+        InfoEvent(message='Repair the first upgraded Node').publish()
+        self.db_cluster.nodes[indexes[0]].run_nodetool(sub_cmd='repair')
+        self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
+                                                      step=step)
+
+        with ignore_upgrade_schema_errors():
+
+            step = 'Step5 - Upgrade rest of the Nodes '
+            InfoEvent(message=step).publish()
+            for i in indexes[1:]:
+                self.db_cluster.node_to_upgrade = self.db_cluster.nodes[i]
+                InfoEvent(message='Upgrade Node %s begin' % self.db_cluster.node_to_upgrade.name).publish()
+                self.upgrade_node(self.db_cluster.node_to_upgrade)
+                InfoEvent(message='Upgrade Node %s ended' % self.db_cluster.node_to_upgrade.name).publish()
+                self.db_cluster.node_to_upgrade.check_node_health()
+                self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
+                                                              step=step)
+
+        InfoEvent(message='Step6 - Verify stress results after upgrade ').publish()
+        InfoEvent(message='Waiting for stress threads to complete after upgrade').publish()
+
+        self.verify_stress_thread(entire_write_thread_pool)
+
+        InfoEvent(message='Step7 - Upgrade sstables to latest supported version ').publish()
+        # figure out what is the last supported sstable version
+        self.expected_sstable_format_version = self.get_highest_supported_sstable_version()
+
+        # run 'nodetool upgradesstables' on all nodes and check/wait for all file to be upgraded
+        upgradesstables = self.db_cluster.run_func_parallel(func=self.upgradesstables_if_command_available)
+
+        # only check sstable format version if all nodes had 'nodetool upgradesstables' available
+        if all(upgradesstables):
+            InfoEvent(message='Upgrading sstables if new version is available').publish()
+            tables_upgraded = self.db_cluster.run_func_parallel(func=self.wait_for_sstable_upgrade)
+            assert all(tables_upgraded), "Failed to upgrade the sstable format {}".format(tables_upgraded)
 
         InfoEvent(message='all nodes were upgraded, and last workaround is verified.').publish()
 


### PR DESCRIPTION
	A new test with a basic flow, that could be used with
	customer-profile specific configuration and workload.
	It pre-loads customer dataset by initial load.
	Then runs additional customer profile load during the upgrade/rollback.
	It verifies the basic dataset after all nodes are upgraded.
Task: https://github.com/scylladb/qa-tasks/issues/21

This PR is NOT ready for review. It's currently only for discussing suggested flow.
If it's agreed, then the code could be continue optimised, removing duplications, etc.
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
