### PR TITLE
fix(get_group0_members): re-raise the exception to make retry work

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3064,6 +3064,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.log.error(err_msg)
             InfoEvent(message=err_msg, severity=Severity.ERROR).publish()
 
+            raise
+
         self.log.debug("Group0 members: %s", group0_members)
         return group0_members
 


### PR DESCRIPTION
The retry for this method was introduced in the PR https://github.com/scylladb/scylla-cluster-tests/pull/6039
Since most of the code of `get_group0_members` is placed in `try` block any possible exception is concealed inside the `except` block and does not go outside.
So the `retrying` decorator never has a reason to start retrying.
Added `raise` for the exception to trigger the retry for the method.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
