### PR TITLE
feature(audit): new short longevity with audit enabled

### DIFF
--- a/jenkins-pipelines/audit/longevity-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/audit/longevity-100gb-4h.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/audit.yaml"]''',
+)

--- a/jenkins-pipelines/audit/longevity-schema-changes-3h.jenkinsfile
+++ b/jenkins-pipelines/audit/longevity-schema-changes-3h.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-schema-changes-3h.yaml", "configurations/audit.yaml"]''',
+)

--- a/sct.py
+++ b/sct.py
@@ -1446,6 +1446,7 @@ def create_test_release_jobs_enterprise(branch, username, password, sct_branch, 
     base_job_dir = f'{branch}'
     server = JenkinsPipelines(username=username, password=password, base_job_dir=base_job_dir,
                               sct_branch_name=sct_branch, sct_repo=sct_repo)
+    base_path = f'{server.base_sct_dir}/jenkins-pipelines'
 
     server.create_directory('SCT_Enterprise_Features', 'SCT Enterprise Features')
     for group_name, match, group_desc in [
@@ -1458,11 +1459,18 @@ def create_test_release_jobs_enterprise(branch, username, password, sct_branch, 
         current_dir = f'SCT_Enterprise_Features/{group_name}'
         server.create_directory(name=current_dir, display_name=group_desc)
 
-        for jenkins_file in glob.glob(f'{server.base_sct_dir}/jenkins-pipelines/{match}.jenkinsfile'):
+        for jenkins_file in glob.glob(f'{base_path}/{match}.jenkinsfile'):
             server.create_pipeline_job(jenkins_file, current_dir)
 
-    server.create_pipeline_job(
-        f'{server.base_sct_dir}/jenkins-pipelines/longevity-in-memory-36gb-1d.jenkinsfile', 'SCT_Enterprise_Features')
+    for group_name, feature_dir, group_desc in (
+        ('Workload_Prioritization', 'workload-prioritization', 'Workload Prioritization'),
+        ('audit', 'audit', 'Audit')
+    ):
+        current_dir = f'SCT_Enterprise_Features/{group_name}'
+        server.create_directory(name=current_dir, display_name=group_desc)
+
+        for jenkins_file in glob.glob(f'{base_path}/{feature_dir}/*.jenkinsfile'):
+            server.create_pipeline_job(jenkins_file, current_dir)
 
 
 @cli.command("prepare-regions", help="Configure all required resources for SCT runs in selected cloud region")


### PR DESCRIPTION
* as a first step have a few short cases with audit enable
  by default

* add support for creating the audit folder in jenkins,
  and poplate with those audit tests


## Testing

- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/audit-longevity-100gb-4h-test/3/
- [ ] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-schema-changes-3h-test/6/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
