### PR TITLE
fix(yaml): Add config yaml to disable speculative retry

### DIFF
--- a/configurations/disable_speculative_retry.yaml
+++ b/configurations/disable_speculative_retry.yaml
@@ -1,0 +1,1 @@
+post_prepare_cql_cmds: "ALTER TABLE keyspace1.standard1 WITH speculative_retry = 'NONE'"


### PR DESCRIPTION
For performance tests speculative retry could affect on max throughput. Disable it on scylla server side with new additional config yaml for keyspace1.standard1 table, created by c-s performance tests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
