### PR TITLE
fix(yaml): Update c-s parametes for multidc schema-topology test

### DIFF
--- a/data_dir/cs_multidc_si_lcs.yaml
+++ b/data_dir/cs_multidc_si_lcs.yaml
@@ -56,8 +56,8 @@ queries:
     cql: select * from keyspace1.standard2 where key=?
     fields: samerow
   si_read1:
-    cql: select * from keyspace1.sec_ind_c2 where c2 = ? LIMIT 1
+    cql: select * from keyspace1.standard2 where c2 = ? LIMIT 1
     fields: samerow
   si_read2:
-    cql: select * from keyspace1.sec_ind_c3 where c3 = ? LIMIT 1
+    cql: select * from keyspace1.standard2 where c3 = ? LIMIT 1
     fields: samerow

--- a/data_dir/cs_mv_si_keyspace1.yaml
+++ b/data_dir/cs_mv_si_keyspace1.yaml
@@ -71,8 +71,8 @@ queries:
     cql: select * from keyspace1.sort_by_c4 where c4 = ? LIMIT 1
     fields: samerow
   si_read1:
-    cql: select * from keyspace1.sec_ind_c2 where c2 = ? LIMIT 1
+    cql: select * from keyspace1.standard2 where c2 = ? LIMIT 1
     fields: samerow
   si_read2:
-    cql: select * from keyspace1.sec_ind_c3 where c3 = ? LIMIT 1
+    cql: select * from keyspace1.standard2 where c3 = ? LIMIT 1
     fields: samerow

--- a/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
@@ -1,12 +1,12 @@
 test_duration: 800
 
-prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3,eu-west-2scylla_node_west=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-                     "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(write=1)' n=3000000 -port jmx=6868 -mode cql3 native -rate threads=40 -log interval=5"
+prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3,eu-west-2scylla_node_west=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(5) size=FIXED(16)' -log interval=5",
+                     "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(insert=1)' n=3000000 -mode cql3 native -rate threads=40 -log interval=5"
                     ]
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3,eu-west-2scylla_node_west=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3,eu-west-2scylla_node_west=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-             "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(write=1,read=1,si_read1=1,si_read2=1)' duration=700m -port jmx=6868 -mode cql3 native -rate threads=40 -log interval=5",
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3,eu-west-2scylla_node_west=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(16)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3,eu-west-2scylla_node_west=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(16)' -log interval=5",
+             "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(insert=1,read=1,si_read1=1,si_read2=1)' duration=700m -mode cql3 native -rate threads=40 -log interval=5",
              ]
 
 n_db_nodes: '5 5'
@@ -20,12 +20,12 @@ nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
 nemesis_selector: [["topology_changes"],["schema_changes"]]
 nemesis_interval: 10
 nemesis_filter_seeds: false
+nemesis_during_prepare: false
 
 seeds_num: 3
 round_robin: true
 
 server_encrypt: true
 internode_encryption: 'dc'
-intra_node_comm_public: true
 
 user_prefix: 'parallel-topology-schema-changes-multidc-12h'


### PR DESCRIPTION
Job with longevity-multidc-parallel-topology-schema-changes-12h.yaml
failed due c-s command incorrect parameters.

fix query for si in c-s profile with correct usage. before c-s failed
with error request non-existent table

fix operation name for c-s user profile

Decrease dataset size to avoid possible large partition warnings
and c-s failing during parallel nemesis running. Similar errors
were seen in longevity-parallel-topology-schema-changes-12h job

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
