### PR TITLE
fix(event): ignore raft transfer snapshot error

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -49,6 +49,7 @@ DatabaseLogEvent.COMPACTION_STOPPED: NORMAL
 DatabaseLogEvent.RPC_CONNECTION: WARNING
 DatabaseLogEvent.DATABASE_ERROR: ERROR
 DatabaseLogEvent.STACKTRACE: ERROR
+DatabaseLogEvent.RAFT_TRANSFER_SNAPSHOT_ERROR: WARNING
 IndexSpecialColumnErrorEvent: ERROR
 CassandraHarryEvent.failure: CRITICAL
 CassandraHarryEvent.error: ERROR

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -45,6 +45,7 @@ class DatabaseLogEvent(LogEvent, abstract=True):
     RUNTIME_ERROR: Type[LogEventProtocol]
     FILESYSTEM_ERROR: Type[LogEventProtocol]
     STACKTRACE: Type[LogEventProtocol]
+    RAFT_TRANSFER_SNAPSHOT_ERROR: Type[LogEventProtocol]
     DISK_ERROR: Type[LogEventProtocol]
     COMPACTION_STOPPED: Type[LogEventProtocol]
 
@@ -123,6 +124,10 @@ DatabaseLogEvent.add_subevent_type("DISK_ERROR", severity=Severity.ERROR,
                                    regex=r"storage_service - .*due to I\/O errors.*Disk error: std::system_error")
 DatabaseLogEvent.add_subevent_type("STACKTRACE", severity=Severity.ERROR,
                                    regex="stacktrace")
+# scylladb/scylladb#12972
+DatabaseLogEvent.add_subevent_type("RAFT_TRANSFER_SNAPSHOT_ERROR", severity=Severity.WARNING,
+                                   regex=r"raft - \[[\w-]*\] Transferring snapshot to [\w-]* "
+                                         r"failed with: seastar::rpc::remote_verb_error \(connection is closed\)")
 
 # REACTOR_STALLED must be above BACKTRACE as it has "Backtrace" in its message
 DatabaseLogEvent.add_subevent_type("REACTOR_STALLED", mixin=ReactorStalledMixin, severity=Severity.DEBUG,
@@ -166,6 +171,7 @@ SYSTEM_ERROR_EVENTS = (
     DatabaseLogEvent.FILESYSTEM_ERROR(),
     DatabaseLogEvent.DISK_ERROR(),
     DatabaseLogEvent.STACKTRACE(),
+    DatabaseLogEvent.RAFT_TRANSFER_SNAPSHOT_ERROR(),
 
     # REACTOR_STALLED must be above BACKTRACE as it has "Backtrace" in its message
     DatabaseLogEvent.REACTOR_STALLED(),


### PR DESCRIPTION
Due to https://github.com/scylladb/scylladb/issues/12972 SCT test fails. But this issue is not severe and should not cause failure of the test.

Reduce severity of `raft - transfer snapshot error` to `WARNING` as per developers request until issue is fixed.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
