### PR TITLE
fix(k8s): make raft checks work on K8S

### DIFF
--- a/sdcm/utils/raft/__init__.py
+++ b/sdcm/utils/raft/__init__.py
@@ -207,8 +207,12 @@ class NoRaft(RaftFeatureOperations):
 
 def get_raft_mode(node) -> Raft | NoRaft:
     with node.remote_scylla_yaml() as scylla_yaml:
-        node.log.debug("consistent_cluster_management : %s", scylla_yaml.consistent_cluster_management)
-        return Raft(node) if scylla_yaml.consistent_cluster_management else NoRaft(node)
+        if node.is_kubernetes():
+            consistent_cluster_management = scylla_yaml.get('consistent_cluster_management')
+        else:
+            consistent_cluster_management = scylla_yaml.consistent_cluster_management
+        node.log.debug("consistent_cluster_management : %s", consistent_cluster_management)
+        return Raft(node) if consistent_cluster_management else NoRaft(node)
 
 
 __all__ = ["get_raft_mode",


### PR DESCRIPTION
Due to the K8S specifics we do not use the `ScyllaYaml` class.
So, when common code assumes we use it we get the following error:

    'dict' object has no attribute 'consistent_cluster_management'

The reason for it is that we use completely different approach in K8S.
So, fix the newly introduced raft handling code [1] to work with K8S.

[1] https://github.com/scylladb/scylla-cluster-tests/pull/6015

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
