### PR TITLE
fix(k8s): run only one 'node.init()' method at once

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -97,6 +97,7 @@ ANY_KUBERNETES_RESOURCE = Union[  # pylint: disable=invalid-name
     Resource, ResourceField, ResourceInstance, ResourceList, Subresource,
 ]
 NAMESPACE_CREATION_LOCK = Lock()
+NODE_INIT_LOCK = Lock()
 
 CERT_MANAGER_TEST_CONFIG = sct_abs_path("sdcm/k8s_configs/cert-manager-test.yaml")
 LOADER_POD_CONFIG_PATH = sct_abs_path("sdcm/k8s_configs/loaders/pod.yaml")
@@ -2282,7 +2283,9 @@ class PodCluster(cluster.BaseCluster):
                                       node_index=node_index,
                                       dc_idx=dc_idx,
                                       rack=rack)
-        node.init()
+        # NOTE: use lock to avoid hanging running in a multitenant setup
+        with NODE_INIT_LOCK:
+            node.init()
         return node
 
     def add_nodes(self,


### PR DESCRIPTION
Recently we found out that K8S multitenant setup fails due to multiple threads (3-10 out of 14).
And the point of hanging is the `node.init()` method which gets called 42 times in a narrow time range running 14 tenants.

So, make run only 1 at a time using the lock mechanism.

Fixes: #6095

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
