### PR TITLE
fix(createTestJobPipeline): fix enterprise job name

### DIFF
--- a/vars/createTestJobPipeline.groovy
+++ b/vars/createTestJobPipeline.groovy
@@ -37,7 +37,7 @@ def call() {
             parameterizedCron (
                 '''
                     H 01 * * 0 %branch="scylla-master/releng-testing"
-                    H 01 * * 0 %branch="enterprise"
+                    H 01 * * 0 %branch="scylla-enterprise;is_enterprise=true"
                     H 01 * * 0 %branch="scylla-master"
                 '''
             )


### PR DESCRIPTION
enterprise base name job was wrong, hence all update to new jobs did come automaticlly to enterpise folders also the `is_enterprise` flag wasn't enabled meaning the enterprise specific jobs were not created as
they should.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
