### PR TITLE
fix(ycsb 100M rows): print kernel callstacks

### DIFF
--- a/test-cases/performance/ycsb/perf-base.yaml
+++ b/test-cases/performance/ycsb/perf-base.yaml
@@ -56,6 +56,8 @@ authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
 
+print_kernel_callstack: true
+
 user_prefix: 'perf-ycsb-latency-nemesis'
 email_subject_postfix: 'YCSB workloads'
 store_perf_results: true


### PR DESCRIPTION
the parameter was missing from the test config file, making some errors to be printed to the logs, and
making some of the tests to be marked as failed.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
