### PR TITLE
test(data operation): add data operation thread

### DIFF
--- a/data_dir/data_operation_default.yaml
+++ b/data_dir/data_operation_default.yaml
@@ -1,0 +1,48 @@
+keyspace: data_operation_ks
+
+table: data_operation_cf
+
+table_definition: |
+
+  CREATE TABLE data_operation_cf (
+    username int,
+    first_name int,
+    last_name text,
+    password text,
+    email text,
+    last_access timestamp,
+    PRIMARY KEY(username, first_name)
+  );
+
+extra_definitions:
+  - CREATE MATERIALIZED VIEW data_operation_ks.data_operation_cf_by_password AS SELECT * FROM data_operation_ks.data_operation_cf WHERE password IS NOT NULL and username IS NOT NULL and first_name IS NOT NULL PRIMARY KEY (password, first_name, username);
+  - CREATE MATERIALIZED VIEW data_operation_ks.data_operation_cf_by_last_name AS SELECT * FROM data_operation_ks.data_operation_cf WHERE last_name IS NOT NULL and username IS NOT NULL and first_name IS NOT NULL PRIMARY KEY (last_name, first_name, username);
+
+columnspec:
+  - name: username
+    population: seq(1..10000)
+  - name: first_name
+    cluster: uniform(1..2000)         #under each username we will have max 2000 posts
+  - name: last_name
+    size: uniform(1..32)
+  - name: password
+    size: fixed(80) # sha-512
+    cluster: uniform(1..200)         #under each username we will have max 2000 posts
+  - name: email
+    size: uniform(16..50)
+
+insert:
+  partitions: fixed(10)
+  select:    fixed(10)/1000
+  batchtype: UNLOGGED
+
+queries:
+  read1:
+    cql: select * from data_operation_ks.data_operation_cf where username = ? and first_name = ? LIMIT 10
+    fields: samerow
+  read2:
+    cql: select * from data_operation_ks.data_operation_cf_by_password where username = ? and first_name = ? and password = ? LIMIT 1
+    fields: samerow
+  read3:
+    cql: select * from data_operation_ks.data_operation_cf_by_last_name where username = ? and first_name = ? and last_name = ? LIMIT 1
+    fields: samerow

--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -135,3 +135,5 @@ ScyllaSysconfigSetupEvent: NORMAL
 TestStepEvent: ERROR
 CpuNotHighEnoughEvent: ERROR
 HWPerforanceEvent: CRITICAL
+DataOperationsEvent: CRITICAL
+DataOperationsCaseEvent: CRITICAL

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -132,6 +132,9 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
         self.run_pre_create_keyspace()
         self.run_pre_create_schema()
 
+        if self.params.get("data_operation_ks_class"):
+            self.run_data_operations_thread()
+
         if scan_operation_params := self._get_scan_operation_params():
             for scan_param in scan_operation_params:
                 self.log.info("Starting fullscan operation thread with the following params: %s", scan_param)

--- a/sdcm/data_operations/data_operation.py
+++ b/sdcm/data_operations/data_operation.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python
+import logging
+import random
+import time
+import traceback
+from functools import cached_property
+from threading import Thread, Event
+
+from cassandra import ConsistencyLevel
+
+from sdcm.sct_events import Severity
+from sdcm.sct_events.database import DataOperationsEvent, DataOperationsCaseEvent
+from sdcm.sct_events.decorators import raise_event_on_failure
+from sdcm.sct_events.system import InfoEvent
+from sdcm.utils.database_query_utils import fetch_all_rows
+from sdcm.utils.user_profile import get_profile_content, get_table_by_stress_cmd, get_keyspace_by_stress_cmd
+
+
+class ResurrectionDataFound(Exception):
+    pass
+
+
+class NoDataFound(Exception):
+    pass
+
+
+class SchemaHelpers:
+    """
+    This class keeps test schema helpers, getter for names of keyspace, table, view
+    """
+    DEFAULT_STRESS_WRITE_COMMAND = ("cassandra-stress user profile=/tmp/data_operation_default.yaml n=100000 ops'(insert=10)' cl=QUORUM "
+                                    "-mode native cql3 -rate threads=30")
+
+    def __init__(self, tester, stress_cmd: str = DEFAULT_STRESS_WRITE_COMMAND):
+        self.main_stress_cmd = stress_cmd
+        _, self.main_profile_content = get_profile_content(stress_cmd=stress_cmd)
+        self.tester = tester
+        self.cluster = tester.db_cluster
+
+    @staticmethod
+    def session_execute(session, query: str, consistency_level: int = ConsistencyLevel.QUORUM, timeout: int = 120):
+        session.default_consistency_level = consistency_level
+        return session.execute(query, timeout=timeout)
+
+    @cached_property
+    def keyspace_name(self):
+        return get_keyspace_by_stress_cmd(stress_cmd=self.main_stress_cmd, profile_content=self.main_profile_content)
+
+    @cached_property
+    def table_name(self):
+        return get_table_by_stress_cmd(stress_cmd=self.main_stress_cmd, profile_content=self.main_profile_content)
+
+    @cached_property
+    def view_names(self):
+        with self.cluster.cql_connection_patient(self.cluster.nodes[0]) as session:
+            query = (f"select view_name from system_schema.views where keyspace_name='{self.keyspace_name}' and "
+                     f"base_table_name = '{self.table_name}' ALLOW FILTERING")
+            result = list(self.session_execute(session=session, query=query))
+
+            return [row.view_name for row in result] if result else None
+
+    @cached_property
+    def partition_keys(self):
+        with self.cluster.cql_connection_patient(self.cluster.nodes[0]) as session:
+            session.default_consistency_level = ConsistencyLevel.QUORUM
+            query = (f"select column_name from system_schema.columns where keyspace_name='{self.keyspace_name}' "
+                     f"and table_name='{self.table_name}' and kind = 'partition_key' ALLOW FILTERING")
+            result = list(self.session_execute(session=session, query=query))
+
+            return [row.column_name for row in result] if result else None
+
+    @cached_property
+    def clustering_key(self):
+        with self.cluster.cql_connection_patient(self.cluster.nodes[0]) as session:
+            session.default_consistency_level = ConsistencyLevel.QUORUM
+            query = (f"select column_name from system_schema.columns where keyspace_name='{self.keyspace_name}' "
+                     f"and table_name='{self.table_name}' and kind = 'clustering' ALLOW FILTERING")
+            result = list(self.session_execute(session=session, query=query))
+
+            return [row.column_name for row in result][0] if result else None
+
+    def create_default_keyspace_query(self, replication_factor):
+        self.tester.create_keyspace(keyspace_name=self.keyspace_name,
+                                    replication_factor=replication_factor)
+
+
+class DataOperations:
+    """
+    This class presents functions that perform data changes, for example: delete data from partition
+    """
+
+    def __init__(self, schema_helpers: SchemaHelpers, interval: int):
+        self.schema_helpers = schema_helpers
+        self.log = logging.getLogger(self.__class__.__name__)
+        self.interval = interval
+
+    def get_unique_partition_values(self, partitions_amount: int):
+        if not self.schema_helpers.partition_keys:
+            raise ValueError(f"Failed to get partition keys. Maybe the table "
+                             f"{self.schema_helpers.keyspace_name}.{self.schema_helpers.table_name} is empty")
+
+        pks_str = ", ".join(self.schema_helpers.partition_keys)
+        with self.schema_helpers.cluster.cql_connection_patient(self.schema_helpers.cluster.nodes[0],
+                                                                keyspace=self.schema_helpers.keyspace_name) as session:
+            session.default_consistency_level = ConsistencyLevel.QUORUM
+            query = f"select distinct {pks_str} from {self.schema_helpers.table_name}"
+            unique_partitions = list(self.schema_helpers.session_execute(session=session, query=query))
+            self.log.debug("Partitions in the %s table: %s", self.schema_helpers.table_name, len(unique_partitions))
+
+        if not unique_partitions:
+            raise NoDataFound(
+                f"Not found data in the {self.schema_helpers.keyspace_name}.{self.schema_helpers.table_name}")
+
+        return [unique_partitions[random.randint(0, len(unique_partitions))] for _ in range(partitions_amount)]
+
+    def get_max_clustering_value_in_partition(self, where_condition: list) -> dict:
+        max_clustering_value = {}
+        if not (clustering_key := self.schema_helpers.clustering_key):
+            InfoEvent("There is no clustering key in the table. The maximum clustering value in partition can not be found",
+                      severity=Severity.NORMAL).publish()
+            return max_clustering_value
+
+        with self.schema_helpers.cluster.cql_connection_patient(self.schema_helpers.cluster.nodes[0],
+                                                                keyspace=self.schema_helpers.keyspace_name) as session:
+            session.default_consistency_level = ConsistencyLevel.QUORUM
+            cmd = f"select {clustering_key} as clustering_key from {self.schema_helpers.table_name} " \
+                  f"where %s order by {clustering_key} desc limit 1"
+            for where_clause in where_condition:
+                result = list(session.execute(cmd % where_clause, timeout=300))
+                if result:
+                    max_clustering_value[where_clause] = {"ck_name": clustering_key, "value": result[0].clustering_key}
+
+            if not result:
+                raise NoDataFound(
+                    f"Not found data for partition in the {self.schema_helpers.keyspace_name}.{self.schema_helpers.table_name}")
+
+        return max_clustering_value
+
+    @staticmethod
+    def build_where_condition(columns: list, values: list):
+        where_condition = []
+        for row_data in values:
+            # The WHERE condition is built for numeric column type
+            where_condition.append(" and ".join(f"{one[0]} = {one[1]}" for one in zip(columns, row_data)))
+
+        return where_condition
+
+    def delete_partition(self, where_condition_to_delete):
+        self.log.debug("Delete partitions: %s", where_condition_to_delete)
+        with self.schema_helpers.cluster.cql_connection_patient(self.schema_helpers.cluster.nodes[0],
+                                                                keyspace=self.schema_helpers.keyspace_name) as session:
+            for row in where_condition_to_delete:
+                query = f"delete from {self.schema_helpers.table_name} where {row}"
+                self.log.debug("Delete query: %s", query)
+                self.schema_helpers.session_execute(session=session, query=query, timeout=300)
+        self.log.debug("Partitions '%s' have been deleted", where_condition_to_delete)
+
+    def query_one_partition(self, where_condition_to_delete, session):
+        # TODO: add ALLOW FILTERING when need only?
+        query = f"select count(*) from %s where {where_condition_to_delete} ALLOW FILTERING"
+        # Search for resurrection rows in the table
+        rows = fetch_all_rows(session=session, default_fetch_size=1000, statement=query %
+                              self.schema_helpers.table_name, timeout=240)
+        self.log.debug("Table %s has rows when filtered by '%s': %s",
+                       self.schema_helpers.table_name, where_condition_to_delete, rows)
+        if rows and rows[0].count > 0:
+            raise ResurrectionDataFound(f"Found resurrection data in the table {self.schema_helpers.table_name}. "
+                                        f"Partition: %s", where_condition_to_delete)
+
+        for view in self.schema_helpers.view_names:
+            # Search for resurrection rows in the view
+            rows = fetch_all_rows(session=session, default_fetch_size=1000, statement=query % view, timeout=240)
+            self.log.debug("View %s has rows when filtered by '%s': %s", view, where_condition_to_delete, rows)
+            if rows and rows[0].count > 0:
+                raise ResurrectionDataFound(
+                    f"Found resurrection data in the view {view}. Partition: %s", where_condition_to_delete)
+
+    def validate_deleted_rows_not_resurrected(self, where_condition_to_delete):
+        with self.schema_helpers.cluster.cql_connection_patient(self.schema_helpers.cluster.nodes[0],
+                                                                keyspace=self.schema_helpers.keyspace_name) as session:
+            for row in where_condition_to_delete:
+                self.query_one_partition(where_condition_to_delete=row, session=session)
+
+    def count_rows(self, entity: str, limit: int = 1000):
+        try:
+            with self.schema_helpers.tester.db_cluster.cql_connection_patient(self.schema_helpers.tester.db_cluster.nodes[0],
+                                                                              keyspace=self.schema_helpers.keyspace_name) as session:
+                # Check if there are enough rows in the table or need to write more data
+                query = f"select count(*) as cnt from {entity} LIMIT {limit}"
+                self.log.debug("Run select query: %s", query)
+                result = self.schema_helpers.session_execute(session=session, query=query, timeout=300)
+                self.log.debug(
+                    "Rows in the %s.%s: %s", self.schema_helpers.keyspace_name, self.schema_helpers.table_name, result.one().cnt)
+                return result.one().cnt
+        except Exception as err:  # pylint: disable=broad-except
+            self.log.error("Failed query: %s. Error: %s", query, err)
+            return None
+
+    def delete_full_partition(self, partitions_amount_to_delete: int = 3):
+        with DataOperationsCaseEvent(case="DeleteFullPartition") as case_event:
+            try:
+                partition_values = self.get_unique_partition_values(partitions_amount=partitions_amount_to_delete)
+                where_condition = self.build_where_condition(columns=self.schema_helpers.partition_keys,
+                                                             values=partition_values)
+                self.log.debug("Where condition for delete: %s", where_condition)
+                self.delete_partition(where_condition_to_delete=where_condition)
+                time.sleep(self.interval)
+                self.validate_deleted_rows_not_resurrected(where_condition_to_delete=where_condition)
+            except Exception as error:  # pylint: disable=broad-except
+                self.log.error(traceback.format_exc())
+                case_event.severity = Severity.CRITICAL if isinstance(error, ResurrectionDataFound) else Severity.ERROR
+                case_event.message = str(error)
+
+    def delete_half_partition(self, partitions_amount_to_delete: int = 1):
+        with DataOperationsCaseEvent(case="DeleteHalfPartition") as case_event:
+            try:
+                partition_values = self.get_unique_partition_values(partitions_amount=partitions_amount_to_delete)
+                where_condition = self.build_where_condition(columns=self.schema_helpers.partition_keys,
+                                                             values=partition_values)
+                max_clustering_values = self.get_max_clustering_value_in_partition(where_condition=where_condition)
+                if not max_clustering_values:
+                    return
+
+                where_condition_to_delete = []
+                for pk_clause, clustering_value in max_clustering_values.items():
+                    where_condition_to_delete.append(f" {pk_clause} and "
+                                                     f"{clustering_value['ck_name']} > {int(clustering_value['value'] / 2)}")
+
+                self.log.debug("Where condition for delete: %s", where_condition_to_delete)
+
+                self.delete_partition(where_condition_to_delete=where_condition_to_delete)
+                time.sleep(self.interval)
+                self.validate_deleted_rows_not_resurrected(where_condition_to_delete=where_condition_to_delete)
+                return
+            except Exception as error:  # pylint: disable=broad-except
+                self.log.error(traceback.format_exc())
+                case_event.severity = Severity.CRITICAL if isinstance(error, ResurrectionDataFound) else Severity.ERROR
+                case_event.message = str(error)
+                return
+
+
+# pylint: disable=too-many-instance-attributes
+class DataOperationThread(Thread):
+    """
+    Run thread with data manipulations during entire test. Sleep between operations.
+    For now one operation is supported: delete full partition
+    """
+    DEFAULT_INTERVAL_BETWEEN_OPERATIONS_SEC = 900
+
+    def __init__(self, tester, thread_name: str):
+        self.tester = tester
+        self.interval = self.DEFAULT_INTERVAL_BETWEEN_OPERATIONS_SEC
+        self.schema_helpers = SchemaHelpers(tester=self.tester)
+        self.data_operations = DataOperations(schema_helpers=self.schema_helpers, interval=self.interval)
+        # parameter "data_operation_ks_class" defined as:
+        #  - {'replication_factor': 3}
+        #  OR
+        #  - {'replication_factor': ['eu-westscylla_node_west': 3, 'us-west-2scylla_node_west': 2]}
+        ks_class = self.tester.params.get("data_operation_ks_class")
+        self.schema_helpers.create_default_keyspace_query(replication_factor=ks_class["replication_factor"])
+        self.duration_sec = self.tester.params.get('test_duration') * 60
+        self.log = logging.getLogger(self.__class__.__name__)
+        self.scenarios = [self.data_operations.delete_full_partition, self.data_operations.delete_half_partition]
+        # TODO: decrease gc_grace_seconds?
+        self.tester.run_stress(stress_cmd=self.schema_helpers.DEFAULT_STRESS_WRITE_COMMAND)
+        super().__init__(daemon=True)
+        self.name = f"{self.__class__.__name__}_{thread_name}"
+        self.termination_event = Event()
+
+    @raise_event_on_failure
+    def run(self):
+        end_time = time.time() + self.duration_sec
+
+        with DataOperationsEvent() as do_event:
+            try:
+
+                while time.time() < end_time and not self.termination_event.is_set():
+                    rows_number = self.data_operations.count_rows(entity=self.schema_helpers.table_name)
+                    if not rows_number or rows_number < 1000:
+                        # Run pre-fill data
+                        self.tester.run_stress(stress_cmd=self.schema_helpers.DEFAULT_STRESS_WRITE_COMMAND)
+
+                    time.sleep(self.interval)
+                    # TODO: save all removed data and validate few times during the run
+                    self.scenarios[random.randint(0, len(self.scenarios) - 1)]()
+
+            except Exception as error:  # pylint: disable=broad-except
+                self.log.error(traceback.format_exc())
+                do_event.severity = Severity.CRITICAL if isinstance(error, ResurrectionDataFound) else Severity.ERROR
+                do_event.message = str(error)
+
+    def stop(self):
+        self.termination_event.set()

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -472,6 +472,13 @@ class SCTConfiguration(dict):
         dict(name="ssh_transport", env="SSH_TRANSPORT", type=str,
              help="""Set type of ssh library to use. Could be 'fabric' (default) or 'libssh2'"""),
 
+        dict(name="data_operation_ks_class", env="SCT_DATA_OPERATION_KS_CLASS", type=dict,
+             help="""Keyspace definition for data operation thread. Example:
+                     {'replication_factor': 3}
+                     OR
+                     {'replication_factor': ['eu-westscylla_node_west': 3, 'us-west-2scylla_node_west': 2]}
+                     """),
+
         # Scylla command line arguments options
         dict(name="experimental_features", env="SCT_EXPERIMENTAL_FEATURES", type=list,
              help="unlock specified experimental features"),
@@ -1870,6 +1877,16 @@ class SCTConfiguration(dict):
         if self.get("use_dns_names"):
             if cluster_backend not in ("aws",):
                 raise ValueError(f"use_dns_names is not supported for {cluster_backend} backend")
+
+        # 17 Validate run_fullscan parmeters
+        if data_operation_ks_class := self.get("data_operation_ks_class"):
+            if not data_operation_ks_class:
+                raise ValueError(
+                    f"data_operation_ks_class parameter must be not empty, but got: {data_operation_ks_class}")
+
+            if "replication_factor" not in data_operation_ks_class:
+                raise ValueError(f"data_operation_ks_class parameter is wrong defined. Expected 'replication_factor value' "
+                                 f"but got: {data_operation_ks_class}. Example: {'replication_factor': 3}")
 
     def log_config(self):
         self.log.info(self.dump_config())

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -437,6 +437,33 @@ class ScyllaYamlUpdateEvent(InformationalEvent):
         return super().msgfmt + ": message={0.message}"
 
 
+class DataOperationsEvent(ContinuousEvent):
+    def __init__(self, message: Optional[str] = None, severity=Severity.NORMAL, publish_event=True):
+        self.message = message
+        super().__init__(publish_event=publish_event, severity=severity)
+
+    @property
+    def msgfmt(self):
+        fmt = super().msgfmt
+        if self.message:
+            fmt += ": message={0.message}"
+        return fmt
+
+
+class DataOperationsCaseEvent(ContinuousEvent):
+    def __init__(self, case: str, message: Optional[str] = None, severity=Severity.NORMAL, publish_event=True):
+        self.case = case
+        self.message = message
+        super().__init__(publish_event=publish_event, severity=severity)
+
+    @property
+    def msgfmt(self):
+        fmt = super().msgfmt + ": case={0.case}"
+        if self.message:
+            fmt += " message={0.message}"
+        return fmt
+
+
 SCYLLA_DATABASE_CONTINUOUS_EVENTS = [
     ScyllaServerStatusEvent,
     BootstrapEvent,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -55,6 +55,7 @@ from sdcm.cluster_aws import LoaderSetAWS
 from sdcm.cluster_aws import MonitorSetAWS
 from sdcm.cluster_k8s import mini_k8s, gke, eks
 from sdcm.cluster_k8s.eks import MonitorSetEKS
+from sdcm.data_operations.data_operation import DataOperationThread
 from sdcm.provision.azure.provisioner import AzureProvisioner
 from sdcm.provision.provisioner import provisioner_factory
 from sdcm.scan_operation_thread import ScanOperationThread
@@ -2153,6 +2154,14 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             the ScanOperationThread
         """
         ScanOperationThread(thread_params=fullscan_params, thread_name=thread_name).start()
+
+    def run_data_operations_thread(self, thread_name: str = "DataOperations"):
+        """
+        Run thread that performs changes in the data in its own keyspace in parallel with test nemeses.
+        Current operations are row deletions.
+        Operations may be added in the future
+        """
+        DataOperationThread(tester=self, thread_name=thread_name).start()
 
     def run_tombstone_gc_verification_thread(self, duration=None, interval=600, propagation_delay_in_seconds=3600, **kwargs):
         """Run a thread of tombstones gc verification.

--- a/sdcm/utils/user_profile.py
+++ b/sdcm/utils/user_profile.py
@@ -64,7 +64,15 @@ def get_view_name_from_stress_cmd(mv_create_cmd, name_substr):
     return find_mv_name.group(1) if find_mv_name else None
 
 
-def get_view_name_from_user_profile(params, stress_cmds_part: str, search_for_user_profile: str, view_name_substr: str):
+def get_view_name_by_stress_cmd(stress_cmd: str, view_name_substr: str, profile_content: dict = None):
+    if not profile_content:
+        _, profile_content = get_profile_content(stress_cmd)
+
+    mv_cmd = get_view_cmd_from_profile(profile_content, view_name_substr)
+    return get_view_name_from_stress_cmd(mv_cmd[0], view_name_substr)
+
+
+def get_view_name_by_test_yaml(params, stress_cmds_part: str, search_for_user_profile: str, view_name_substr: str):
     """
     Get materialized view name from user profile defined in the test yaml.
     It may be used when we want query from materialized view that was created during running user profile
@@ -74,12 +82,16 @@ def get_view_name_from_user_profile(params, stress_cmds_part: str, search_for_us
     if not stress_cmd:
         return ""
 
-    _, profile = get_profile_content(stress_cmd[0])
-    mv_cmd = get_view_cmd_from_profile(profile, view_name_substr)
-    return get_view_name_from_stress_cmd(mv_cmd[0], view_name_substr)
+    return get_view_name_by_stress_cmd(stress_cmd=stress_cmd[0], view_name_substr=view_name_substr)
 
 
-def get_keyspace_from_user_profile(params, stress_cmds_part: str, search_for_user_profile: str):
+def get_keyspace_by_stress_cmd(stress_cmd: str, profile_content: dict = None):
+    if not profile_content:
+        _, profile_content = get_profile_content(stress_cmd)
+    return profile_content['keyspace']
+
+
+def get_keyspace_by_test_yaml(params, stress_cmds_part: str, search_for_user_profile: str):
     """
      Get keyspace name from user profile defined in the test yaml.
      Example:
@@ -91,11 +103,16 @@ def get_keyspace_from_user_profile(params, stress_cmds_part: str, search_for_use
     if not stress_cmd:
         return ""
 
-    _, profile = get_profile_content(stress_cmd[0])
-    return profile['keyspace']
+    return get_keyspace_by_stress_cmd(stress_cmd=stress_cmd[0])
 
 
-def get_table_from_user_profile(params, stress_cmds_part: str, search_for_user_profile: str):
+def get_table_by_stress_cmd(stress_cmd: str, profile_content: dict = None):
+    if not profile_content:
+        _, profile_content = get_profile_content(stress_cmd)
+    return profile_content['table']
+
+
+def get_table_by_test_yaml(params, stress_cmds_part: str, search_for_user_profile: str):
     """
      Get table name from user profile defined in the test yaml.
      Example:
@@ -107,8 +124,7 @@ def get_table_from_user_profile(params, stress_cmds_part: str, search_for_user_p
     if not stress_cmd:
         return ""
 
-    _, profile = get_profile_content(stress_cmd[0])
-    return profile['table']
+    return get_table_by_stress_cmd(stress_cmd=stress_cmd[0])
 
 
 def get_profile_content(stress_cmd):

--- a/test-cases/longevity/longevity-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-100gb-4h.yaml
@@ -28,3 +28,5 @@ pre_create_schema: True
 sstable_size: 100
 
 hinted_handoff: 'enabled'
+
+data_operation_ks_class: {'replication_factor': 3}

--- a/unit_tests/test_sct_events_database.py
+++ b/unit_tests/test_sct_events_database.py
@@ -17,7 +17,8 @@ import re
 from sdcm.sct_events import Severity
 from sdcm.sct_events.base import LogEvent
 from sdcm.sct_events.database import \
-    DatabaseLogEvent, FullScanEvent, IndexSpecialColumnErrorEvent, TOLERABLE_REACTOR_STALL, SYSTEM_ERROR_EVENTS
+    DatabaseLogEvent, FullScanEvent, IndexSpecialColumnErrorEvent, TOLERABLE_REACTOR_STALL, SYSTEM_ERROR_EVENTS, DataOperationsEvent, \
+    DataOperationsCaseEvent
 
 
 class TestDatabaseLogEvent(unittest.TestCase):
@@ -137,3 +138,42 @@ class TestIndexSpecialColumnErrorEvent(unittest.TestCase):
         self.assertEqual(str(event),
                          "(IndexSpecialColumnErrorEvent Severity.ERROR) period_type=one-time "
                          "event_id=ac449879-485a-4b06-8596-3fbe58881093: message=m1")
+
+
+class TestDataOperationsEvent(unittest.TestCase):
+    def test_data_operation_event(self):
+        event = DataOperationsEvent(message="m1", publish_event=False)
+        event.event_id = "3c8e2362-a987-4eff-953f-9cd1ad2017e5"
+        event.begin_event()
+        self.assertEqual(
+            str(event),
+            "(DataOperationsEvent Severity.NORMAL) period_type=begin event_id=3c8e2362-a987-4eff-953f-9cd1ad2017e5: message=m1"
+        )
+
+        event.duration = 20.325
+        event.end_event()
+        self.assertEqual(
+            str(event),
+            "(DataOperationsEvent Severity.NORMAL) period_type=end event_id=3c8e2362-a987-4eff-953f-9cd1ad2017e5 duration=20.325s: "
+            "message=m1"
+        )
+
+
+class TestDataOperationsCaseEvent(unittest.TestCase):
+    def test_data_operation_event(self):
+        event = DataOperationsCaseEvent(case="delete partition", message="m1", publish_event=False)
+        event.event_id = "3c8e2362-a987-4eff-953f-9cd1ad2017e5"
+        event.begin_event()
+        self.assertEqual(
+            str(event),
+            "(DataOperationsCaseEvent Severity.NORMAL) period_type=begin event_id=3c8e2362-a987-4eff-953f-9cd1ad2017e5: "
+            "case=delete partition message=m1"
+        )
+
+        event.duration = 20.325
+        event.end_event()
+        self.assertEqual(
+            str(event),
+            "(DataOperationsCaseEvent Severity.NORMAL) period_type=end event_id=3c8e2362-a987-4eff-953f-9cd1ad2017e5 duration=20.325s: "
+            "case=delete partition message=m1"
+        )


### PR DESCRIPTION
This commit add new thread that runs different data changes in parallel with test nemeses.
Current operations are row deletions.
Separate (not main) keyspace with table and views is created for this thread.
Row deletions are performed on this thread and validated.
Operations may be added in the future.

Task: https://github.com/scylladb/qa-tasks/issues/1015

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
