### PR TITLE
Revert "improvement(large partitions): Set random clustering order for s-b table

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -106,7 +106,6 @@
 | **<a href="#user-content-nemesis_sequence_sleep_between_ops" name="nemesis_sequence_sleep_between_ops">nemesis_sequence_sleep_between_ops</a>**  | Sleep interval between nemesis operations for use in unique_sequence nemesis kind of tests | N/A | SCT_NEMESIS_SEQUENCE_SLEEP_BETWEEN_OPS
 | **<a href="#user-content-nemesis_during_prepare" name="nemesis_during_prepare">nemesis_during_prepare</a>**  | Run nemesis during prepare stage of the test | True | SCT_NEMESIS_DURING_PREPARE
 | **<a href="#user-content-nemesis_seed" name="nemesis_seed">nemesis_seed</a>**  | A seed number in order to repeat nemesis sequence as part of SisyphusMonkey | N/A | SCT_NEMESIS_SEED
-| **<a href="#user-content-cql_schema_seed" name="cql_schema_seed">cql_schema_seed</a>**  | A seed number in order to repeat CQL schema configuration | N/A | SCT_CQL_SCHEMA_SEED
 | **<a href="#user-content-nemesis_add_node_cnt" name="nemesis_add_node_cnt">nemesis_add_node_cnt</a>**  | Add/remove nodes during GrowShrinkCluster nemesis | 1 | SCT_NEMESIS_ADD_NODE_CNT
 | **<a href="#user-content-cluster_target_size" name="cluster_target_size">cluster_target_size</a>**  | Used for scale test: max size of the cluster | N/A | SCT_CLUSTER_TARGET_SIZE
 | **<a href="#user-content-space_node_threshold" name="space_node_threshold">space_node_threshold</a>**  | Space node threshold before starting nemesis (bytes)<br>The default value is 6GB (6x1024^3 bytes)<br>This value is supposed to reproduce<br>https://github.com/scylladb/scylla/issues/1140 | N/A | SCT_SPACE_NODE_THRESHOLD

--- a/longevity_large_partition_test.py
+++ b/longevity_large_partition_test.py
@@ -12,9 +12,7 @@ class LargePartitionLongevityTest(LongevityTest):
 
     def pre_create_large_partitions_schema(self, compaction_strategy=CompactionStrategy.SIZE_TIERED.value):
         node = self.db_cluster.nodes[0]
-        table_setup_seed = self.params.get('cql_schema_seed')
-        create_table_query = create_scylla_bench_table_query(compaction_strategy=compaction_strategy,
-                                                             seed=table_setup_seed)
+        create_table_query = create_scylla_bench_table_query(compaction_strategy=compaction_strategy)
         with self.db_cluster.cql_connection_patient(node) as session:
             # pylint: disable=no-member
             session.execute("""

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -561,9 +561,6 @@ class SCTConfiguration(dict):
              type=int, k8s_multitenancy_supported=True,
              help="""A seed number in order to repeat nemesis sequence as part of SisyphusMonkey"""),
 
-        dict(name="cql_schema_seed", env="SCT_CQL_SCHEMA_SEED", type=int,
-             help="""A seed number in order to repeat CQL schema configuration"""),
-
         dict(name="nemesis_add_node_cnt",
              env="SCT_NEMESIS_ADD_NODE_CNT",
              type=int, k8s_multitenancy_supported=True,

--- a/test-cases/longevity/longevity-large-partition-2days.yaml
+++ b/test-cases/longevity/longevity-large-partition-2days.yaml
@@ -23,8 +23,6 @@ instance_type_db: 'i4i.4xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '156'
-# Set cql_schema_seed in order to get: "CLUSTERING ORDER BY (ck ASC)"
-cql_schema_seed: '930'
 instance_type_loader: 'c5n.4xlarge'
 round_robin: true
 nemesis_interval: 30

--- a/test_lib/scylla_bench_tools.py
+++ b/test_lib/scylla_bench_tools.py
@@ -1,29 +1,27 @@
 import logging
-import random
 
 LOGGER = logging.getLogger(__name__)
 
 
-def create_scylla_bench_table_query(compaction_strategy=None, seed: int = None):
+def create_scylla_bench_table_query(compaction_strategy=None):
     """
 
     :return: cql create table query for scylla-bench
     """
-    seed = seed or random.randint(0, 1000)
-    clustering_order = random.Random(seed).choice(['ASC', 'DESC'])
-    compaction_strategy_option = "AND compaction = {{'class': '{}'}}".format(
+
+    compaction_strategy_option = "AND compaction = {{'class': '{}'}};".format(
         compaction_strategy) if compaction_strategy else ""
-    scylla_bench_table_query = f"""
+    scylla_bench_table_query = """
                     CREATE TABLE IF NOT EXISTS scylla_bench.test (
                     pk bigint,
                     ck bigint,
                     v blob,
                     PRIMARY KEY (pk, ck)
-                ) WITH CLUSTERING ORDER BY (ck {clustering_order})
+                ) WITH CLUSTERING ORDER BY (ck ASC)
                     AND bloom_filter_fp_chance = 0.01
-                    AND caching = {{'keys': 'ALL', 'rows_per_partition': 'ALL'}}
+                    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
                     AND comment = ''
-                    AND compression = {{}}
+                    AND compression = {}
 
                     AND crc_check_chance = 1.0
                     AND dclocal_read_repair_chance = 0.0
@@ -34,7 +32,5 @@ def create_scylla_bench_table_query(compaction_strategy=None, seed: int = None):
                     AND min_index_interval = 128
                     AND read_repair_chance = 0.0
                     AND speculative_retry = 'NONE'
-                    {compaction_strategy_option};
-                    """
-    LOGGER.debug("Generated a create-table query with a seed of [%s]: %s", seed, scylla_bench_table_query)
+                    """ + compaction_strategy_option
     return scylla_bench_table_query


### PR DESCRIPTION
This reverts commit 21ff073b98ba035c64b21ff79b97cf520fec419e.
Reason: https://github.com/scylladb/scylla-cluster-tests/issues/6098

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
