### PR TITLE
feature(multi-az): add possibility to simulate racks

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -222,3 +222,4 @@ custom_es_index: ''
 run_fullscan: []
 
 stress_step_duration: '15m'
+simulated_racks: 0

--- a/jenkins-pipelines/longevity-cdc-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/longevity-cdc-100gb-4h.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
-    availability_zone: 'a,b,c',
+    availability_zone: 'a',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-cdc-100gb-4h.yaml'
 

--- a/jenkins-pipelines/longevity-counters-multidc.jenkinsfile
+++ b/jenkins-pipelines/longevity-counters-multidc.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    availability_zone: 'a,b,c',
+    availability_zone: 'a',
     region: '''["eu-west-1", "us-west-2", "us-east-1"]''',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-counters-multidc.yaml'

--- a/jenkins-pipelines/longevity-topology-changes-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-topology-changes-3h.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
-    availability_zone: 'a,b,c',
+    availability_zone: 'a',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-topology-changes-3h.yaml"]''',
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3650,8 +3650,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     rack = 0
                 self.set_target_node(rack=rack, is_seed=is_seed, allow_only_last_node_in_rack=True)
             else:
-                racks_count = len(self.tester.params.get("availability_zone").split(","))
-                rack_idx = rack if rack is not None else idx % racks_count
+                rack_idx = rack if rack is not None else idx % self.cluster.racks_count
                 # if rack is not specified, round-robin racks
                 self.set_target_node(is_seed=is_seed, dc_idx=dc_idx, rack=rack_idx)
             self.log.info("Next node will be removed %s", self.target_node)
@@ -3679,12 +3678,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if rack is None and self._is_it_on_kubernetes():
             rack = 0
         add_nodes_number = self.tester.params.get('nemesis_add_node_cnt')
-        racks_count = len(self.tester.params.get("availability_zone").split(","))
         self.log.info("Start grow cluster on %s nodes", add_nodes_number)
         InfoEvent(message=f"Start grow cluster on {add_nodes_number} nodes").publish()
         for idx in range(add_nodes_number):
             # if rack is not specified, round-robin racks to spread nodes evenly
-            rack_idx = rack if rack is not None else idx % racks_count
+            rack_idx = rack if rack is not None else idx % self.cluster.racks_count
             InfoEvent(message=f'GrowCluster - Add New node to {rack_idx} rack').publish()
             added_node = self.add_new_node(rack=rack_idx)
             self.unset_current_running_nemesis(added_node)

--- a/sdcm/snitch_configuration.py
+++ b/sdcm/snitch_configuration.py
@@ -1,0 +1,90 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2023 ScyllaDB
+
+import re
+from typing import List, Type
+
+
+class SnitchConfig:  # pylint: disable=too-few-public-methods
+    """Keeps all snitch-related settings and function to apply them"""
+    SNITCH_NAME = ""
+
+    def __init__(self, node: "sdcm.cluster.BaseNode", datacenters: List[str]):
+        self._node = node
+        self._is_multi_dc = len(datacenters) > 1
+        self._rack = node.rack
+        self._datacenter = datacenters[node.dc_idx]
+        self._dc_prefix = self._get_dc_prefix()
+        self._dc_suffix = self._get_dc_suffix()
+
+    def _get_dc_prefix(self) -> str:
+        if self._datacenter.endswith("-1"):
+            # from files in the repo we can see -1 is dropped, but docs don't mention it and sometimes there are discrepancies in repo
+            return self._datacenter[:-2]
+        return self._datacenter
+
+    def _get_dc_suffix(self) -> str:
+        if self._is_multi_dc:
+            ret = re.findall('-([a-z]+).*-', self._datacenter)
+            if ret:
+                dc_suffix = 'scylla_node_{}'.format(ret[0])
+            else:
+                dc_suffix = self._dc_prefix.replace('-', '_')
+            return dc_suffix
+        else:
+            return ""
+
+    def apply(self) -> bool:
+        """
+        Apply snitch configuration to the node (only in cassandra-rackdc.properties, scylla.yaml must be updated separately.).
+
+        Returns `True` if require Scylla restart to make the effect.
+        """
+        requires_restart = False
+        properties = {name: str(getattr(self, name)).lower() for name in dir(self)
+                      if isinstance(getattr(self.__class__, name, None), property)}
+        with self._node.remote_cassandra_rackdc_properties() as properties_file:
+            if properties:
+                requires_restart = True
+            properties_file.update(**properties)
+        return requires_restart
+
+
+class GossipingPropertyFileSnitchConfig(SnitchConfig):
+
+    @property
+    def dc(self) -> str:
+        return f"{self._dc_prefix}{self._dc_suffix}"
+
+    @property
+    def rack(self) -> str:
+        return f"RACK{self._rack}"
+
+    @property
+    def prefer_local(self) -> bool:
+        return True
+
+
+class Ec2SnitchConfig(SnitchConfig):
+
+    @property
+    def dc_suffix(self):
+        return self._dc_suffix
+
+
+def get_snitch_config_class(params: dict) -> Type[SnitchConfig]:
+    if params.get('simulated_racks') > 1:
+        return GossipingPropertyFileSnitchConfig
+    if params.get('cluster_backend') == 'aws':
+        return Ec2SnitchConfig
+    return SnitchConfig  # default, basically doing nothing

--- a/sdcm/utils/properties.py
+++ b/sdcm/utils/properties.py
@@ -46,7 +46,7 @@ def deserialize(data: Union[str, TextIO]) -> PropertiesDict:
         data = data.read()
     output = PropertiesDict()
     for line in data.splitlines():
-        if line.lstrip()[0] == '#':
+        if not line.strip() or line.lstrip()[0] == '#':
             output[line] = None
             continue
         line = line.split('=', 1)

--- a/test-cases/longevity/longevity-cdc-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-4h.yaml
@@ -7,12 +7,13 @@ stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile.yaml ops
               "cassandra-stress user no-warmup profile=/tmp/cdc_profile_preimage_postimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=200m -mode cql3 native -rate threads=100"
              ]
 
-availability_zone: 'a,b,c'
+availability_zone: 'a'
 n_db_nodes: 6
 n_loaders: 2
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.4xlarge'
+simulated_racks: 3
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '009'

--- a/test-cases/longevity/longevity-counters-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-multidc.yaml
@@ -4,11 +4,12 @@ pre_create_keyspace: "CREATE KEYSPACE scylla_bench WITH replication = {'class': 
 stress_cmd:      "scylla-bench -workload=uniform -mode=counter_update -replication-factor=3 -partition-count=1000 -clustering-row-count=10 -concurrency 1024 -duration 360m -validate-data"
 stress_read_cmd: "scylla-bench -workload=uniform -mode=counter_read   -replication-factor=3 -partition-count=1000 -clustering-row-count=10 -concurrency 512 -duration 360m -validate-data"
 
-availability_zone: 'a,b,c'
+availability_zone: 'a'
 n_db_nodes: '3 3 3'
 n_loaders:  '1 1 1'
 n_monitor_nodes: 1
 
+simulated_racks: 3
 instance_type_db: 'i3.2xlarge'
 
 user_prefix: longevity-counters-multidc

--- a/test-cases/longevity/longevity-topology-changes-3h.yaml
+++ b/test-cases/longevity/longevity-topology-changes-3h.yaml
@@ -12,7 +12,8 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replicatio
              "scylla-bench -workload=sequential -mode=read  -replication-factor=3 -partition-count=50 -clustering-row-count=10000 -clustering-row-size=uniform:1024..8192 -concurrency=25 -connection-count=25 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=180m",
              ]
 
-availability_zone: 'a,b,c'
+availability_zone: 'a'
+simulated_racks: 3
 n_db_nodes: 3
 n_loaders: 2
 n_monitor_nodes: 1


### PR DESCRIPTION
Tests running in multi-az environments generate additional
network-traffic costs. We can simulate racks with
`GossipingPropertyFileSnitch` snitch and provision instances in
one az to avoid them.

Apply `GossipingPropertyFileSnitch` to the nodes and make provisioning
to provision instances only in one az, but configure nodes snitch to
simulate multi-az environment.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
