### PR TITLE
fix(manager jenkinfiles): removed outdated 'manager' parameter

### DIFF
--- a/jenkins-pipelines/manager/centos-manager-repair-control.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-repair-control.jenkinsfile
@@ -6,7 +6,6 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     params: params,
 
-    manager: true,
     backend: 'aws',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_repair_control',
     test_config: 'test-cases/manager/manager-repair-control.yaml',

--- a/jenkins-pipelines/manager/centos-manager-repair-intensity-multiple-repaired-nodes.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-repair-intensity-multiple-repaired-nodes.jenkinsfile
@@ -6,7 +6,6 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     params: params,
 
-    manager: true,
     backend: 'aws',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_repair_intensity_feature_on_multiple_node',
     test_config: 'test-cases/manager/manager-repair-intensity-multiple-repaired-nodes.yaml',

--- a/jenkins-pipelines/manager/centos-manager-repair-intensity-single-repaired-nodes.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-repair-intensity-single-repaired-nodes.jenkinsfile
@@ -6,7 +6,6 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     params: params,
 
-    manager: true,
     backend: 'aws',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_repair_intensity_feature_on_single_node',
     test_config: 'test-cases/manager/manager-repair-intensity-single-repaired-nodes.yaml',

--- a/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
@@ -4,7 +4,6 @@
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
-    manager: true,
     backend: 'aws',
     region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',

--- a/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
@@ -4,7 +4,6 @@
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
-    manager: true,
     backend: 'aws',
     region: 'us-east-1',
 

--- a/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
@@ -4,7 +4,6 @@
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
-    manager: true,
     backend: 'aws',
     region: 'us-east-1',
 

--- a/jenkins-pipelines/manager/debian11-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian11-manager-upgrade.jenkinsfile
@@ -4,7 +4,6 @@
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
-    manager: true,
     backend: 'aws',
     region: 'us-east-1',
 

--- a/jenkins-pipelines/manager/enterprise-ami-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/enterprise-ami-manager-upgrade.jenkinsfile
@@ -4,7 +4,6 @@
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
-    manager: true,
     backend: 'aws',
     region: 'us-east-1',
 

--- a/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
@@ -4,7 +4,6 @@
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
-    manager: true,
     backend: 'aws',
     region: 'us-east-1',
 

--- a/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
@@ -4,7 +4,6 @@
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
-    manager: true,
     backend: 'aws',
     region: 'us-east-1',
 


### PR DESCRIPTION
Previously, the manager pipeline supported a 'manager' param, but it was removed a while ago. Still, the parameter remained set in all of the manager test scenarios' jenkins files. I removed all of those unnecessary parameter settings.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
