### PR TITLE
fix(spot price): increase max spot price to 80% of on_demand price

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -1,5 +1,5 @@
 instance_provision: 'spot'
-spot_max_price: 0.60
+spot_max_price: 0.80
 instance_provision_fallback_on_demand: false
 region_name:
   - eu-west-1


### PR DESCRIPTION
Too often we are unable to request spot instances due to high prices. As such, we've decided to increase the maximum price we will pay for a spot instance from 60% of the price of an on demand node to 80%.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
