### PR TITLE
fix(load_and_stream): fix log followers

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1572,8 +1572,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                                                                                         test_data=test_data)
             for sstables_info, load_on_node in map_files_to_node:
                 SstableLoadUtils.upload_sstables(load_on_node, test_data=sstables_info, table_name="standard1")
-                system_log_follower = SstableLoadUtils.run_load_and_stream(load_on_node)
-                SstableLoadUtils.validate_load_and_stream_status(load_on_node, system_log_follower)
+                start_log_follower, done_log_follower = SstableLoadUtils.run_load_and_stream(load_on_node)
+                SstableLoadUtils.validate_load_and_stream_status(load_on_node, start_log_follower, done_log_follower)
 
     # pylint: disable=too-many-statements
     def disrupt_nodetool_refresh(self, big_sstable: bool = False):

--- a/unit_tests/test_utils_common.py
+++ b/unit_tests/test_utils_common.py
@@ -212,7 +212,8 @@ class TestSstableLoadUtils(unittest.TestCase):
                 f"Expected {case['expected_result']} elements, got {len(map_files_to_node)}"
 
     def test_load_and_stream_status(self):
-        patterns = [SstableLoadUtils.LOAD_AND_STREAM_DONE_EXPR.format('keyspace1', 'standard1'),
-                    SstableLoadUtils.LOAD_AND_STREAM_RUN_EXPR]
-        system_log_follower = self.node.follow_system_log(start_from_beginning=True, patterns=patterns)
-        SstableLoadUtils.validate_load_and_stream_status(self.node, system_log_follower)
+        system_log_follower = self.node.follow_system_log(start_from_beginning=True, patterns=[
+                                                          SstableLoadUtils.LOAD_AND_STREAM_RUN_EXPR])
+        done_log_follower = self.node.follow_system_log(start_from_beginning=True, patterns=[
+            SstableLoadUtils.LOAD_AND_STREAM_DONE_EXPR.format('keyspace1', 'standard1')])
+        SstableLoadUtils.validate_load_and_stream_status(self.node, system_log_follower, done_log_follower)


### PR DESCRIPTION
In case `load_and_stream` finish too quickly we get into error when we get ending stream log line when getting lines to verify if it started. In that case wait for ending will fail as `done` line has already been consumed.

Fix is about splitting log follower to 2: one for start and another for done - so waiting for start will not consume lines about stream is done.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
