### PR TITLE
improvement(manager): Use i4i instances for all aws (small) scenarios

### DIFF
--- a/test-cases/manager/manager-regression-ipv6.yaml
+++ b/test-cases/manager/manager-regression-ipv6.yaml
@@ -2,7 +2,7 @@ test_duration: 120
 
 stress_cmd: "cassandra-stress write cl=QUORUM n=4000000 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
 
-instance_type_db: 'i3.large'
+instance_type_db: 'i4i.large'
 instance_type_loader: 'c5.large'
 
 region_name: 'eu-west-1'

--- a/test-cases/manager/manager-regression-multiDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-multiDC-set-distro.yaml
@@ -3,7 +3,7 @@ test_duration: 240
 stress_cmd: "cassandra-stress write cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,us-eastscylla_node_east=2,us-west-2scylla_node_west=1)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
 stress_read_cmd: "cassandra-stress read cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,us-eastscylla_node_east=2,us-west-2scylla_node_west=1)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
 
-instance_type_db: 'i3.large'
+instance_type_db: 'i4i.large'
 instance_type_loader: 'c5.large'
 
 region_name: 'us-east-1 us-west-2'

--- a/test-cases/manager/manager-repair-control.yaml
+++ b/test-cases/manager/manager-repair-control.yaml
@@ -11,7 +11,7 @@ round_robin: true
 
 hinted_handoff: 'disabled'  # Turned off so it would not interfere with the creation of missing rows and with the repair
 
-instance_type_db: 'i3.2xlarge'
+instance_type_db: 'i4i.2xlarge'
 instance_type_loader: 'c5.2xlarge'
 
 n_db_nodes: 9

--- a/test-cases/manager/manager-repair-intensity-multiple-repaired-nodes.yaml
+++ b/test-cases/manager/manager-repair-intensity-multiple-repaired-nodes.yaml
@@ -11,7 +11,7 @@ round_robin: true
 
 hinted_handoff: 'disabled'  # Turned off so it would not interfere with the creation of missing rows and with the repair
 
-instance_type_db: 'i3.2xlarge'
+instance_type_db: 'i4i.2xlarge'
 instance_type_loader: 'c5.2xlarge'
 
 n_db_nodes: 9

--- a/test-cases/manager/manager-repair-intensity-single-repaired-nodes.yaml
+++ b/test-cases/manager/manager-repair-intensity-single-repaired-nodes.yaml
@@ -11,7 +11,7 @@ round_robin: true
 
 hinted_handoff: 'disabled'  # Turned off so it would not interfere with the creation of missing rows and with the repair
 
-instance_type_db: 'i3.2xlarge'
+instance_type_db: 'i4i.2xlarge'
 instance_type_loader: 'c5.2xlarge'
 
 n_db_nodes: 6


### PR DESCRIPTION
Recently, the manager test jobs have been failing consistently due to spot terminations and due to our spot price being too low. Since i4i have a much lower Frequency of interruption than i3 instances (<5% as opposed to >20%) I altered all of the automatically triggered jobs to use i4i (db) instances.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
