### PR TITLE
fix(udf): replace xwasm with wasm

### DIFF
--- a/data_dir/c-s_uda_udf.yaml
+++ b/data_dir/c-s_uda_udf.yaml
@@ -65,9 +65,9 @@ queries:
   lua_var_length_counter:
     cql: "SELECT ks.lua_var_length_counter(c7_text) AS result FROM ks.uda_udf LIMIT 10"
     fields: samerow
-  xwasm_plus:
-    cql: "SELECT ks.xwasm_plus(c2_int, c3_int) AS result FROM ks.uda_udf LIMIT 10"
+  wasm_plus:
+    cql: "SELECT ks.wasm_plus(c2_int, c3_int) AS result FROM ks.uda_udf LIMIT 10"
     fields: samerow
-  xwasm_div:
-    cql: "SELECT ks.xwasm_div(c2_int, c3_int) AS result FROM ks.uda_udf LIMIT 10"
+  wasm_div:
+    cql: "SELECT ks.wasm_div(c2_int, c3_int) AS result FROM ks.uda_udf LIMIT 10"
     fields: samerow

--- a/sdcm/utils/udf.py
+++ b/sdcm/utils/udf.py
@@ -45,7 +45,7 @@ class UDF(BaseModel):
     args: str
     called_on_null_input_returns: str
     return_type: str
-    language: Literal["lua", "xwasm"]
+    language: Literal["lua", "wasm"]
     script: str
 
     def get_create_query(self, ks: str, create_or_replace: bool = True) -> str:

--- a/sdcm/utils/udf_scripts/wasm_div.yaml
+++ b/sdcm/utils/udf_scripts/wasm_div.yaml
@@ -1,20 +1,19 @@
-# UDF script: UDF identity function compiled from the following cpp code:
-# int simple_return(int i) {return i;}
-# with the following clang command: clang -O2 --target=wasm32 --no-standard-libraries -Wl,--export-all -Wl,--no-entry simple_return.cpp -o simple_return.wasm
+# UDF script: divides two integers
 
-
-name: 'xwasm_simple_return_int'
-args: '(acc tuple<int, int>)'
+name: 'wasm_div'
+args: '(quotient int, dividend int)'
 called_on_null_input_returns: 'NULL'
 return_type: 'int'
-language: 'xwasm'
+language: 'wasm'
 script: |-
   (module
   (type (;0;) (func))
-  (type (;1;) (func (param i32) (result i32)))
+  (type (;1;) (func (param i32 i32) (result i32)))
   (func $__wasm_call_ctors (type 0))
-  (func $xwasm_simple_return_int (type 1) (param i32) (result i32)
-    local.get 0)
+  (func $div (type 1) (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    i32.div_s)
   (table (;0;) 1 1 funcref)
   (memory (;0;) 2)
   (global (;0;) (mut i32) (i32.const 66560))
@@ -26,7 +25,7 @@ script: |-
   (global (;6;) i32 (i32.const 1))
   (export "memory" (memory 0))
   (export "__wasm_call_ctors" (func $__wasm_call_ctors))
-  (export "xwasm_simple_return_int" (func $xwasm_simple_return_int))
+  (export "wasm_div" (func $div))
   (export "__dso_handle" (global 1))
   (export "__data_end" (global 2))
   (export "__global_base" (global 3))

--- a/sdcm/utils/udf_scripts/wasm_div_fin.yaml
+++ b/sdcm/utils/udf_scripts/wasm_div_fin.yaml
@@ -1,10 +1,10 @@
 # UDF script: UDF function for a final UDA function - takes state tuple and returns a float from the division of the state tuples integers
 
-name: 'xwasm_div_fin'
+name: 'wasm_div_fin'
 args: '(acc tuple<int, int>)'
 called_on_null_input_returns: 'NULL'
 return_type: 'float'
-language: 'xwasm'
+language: 'wasm'
 script: |-
   (module
   (type (;0;) (func (param i64) (result i64)))
@@ -102,6 +102,6 @@ script: |-
   (memory (;0;) 2)
   (global (;0;) i32 (i32.const 1024))
   (export "memory" (memory 0))
-  (export "xwasm_div_fin" (func 0))
+  (export "wasm_div_fin" (func 0))
   (export "_scylla_abi" (global 0))
   (data (;0;) (i32.const 1024) "\01\00\00\00"))

--- a/sdcm/utils/udf_scripts/wasm_plus.yaml
+++ b/sdcm/utils/udf_scripts/wasm_plus.yaml
@@ -1,19 +1,19 @@
-# UDF script: divides two integers
+# UDF script: returns the string length of the provided text var
 
-name: 'xwasm_div'
-args: '(quotient int, dividend int)'
+name: 'wasm_plus'
+args: '(input1 int, input2 int)'
 called_on_null_input_returns: 'NULL'
 return_type: 'int'
-language: 'xwasm'
+language: 'wasm'
 script: |-
   (module
   (type (;0;) (func))
   (type (;1;) (func (param i32 i32) (result i32)))
   (func $__wasm_call_ctors (type 0))
-  (func $div (type 1) (param i32 i32) (result i32)
-    local.get 0
+  (func $plus (type 1) (param i32 i32) (result i32)
     local.get 1
-    i32.div_s)
+    local.get 0
+    i32.add)
   (table (;0;) 1 1 funcref)
   (memory (;0;) 2)
   (global (;0;) (mut i32) (i32.const 66560))
@@ -25,7 +25,7 @@ script: |-
   (global (;6;) i32 (i32.const 1))
   (export "memory" (memory 0))
   (export "__wasm_call_ctors" (func $__wasm_call_ctors))
-  (export "xwasm_div" (func $div))
+  (export "wasm_plus" (func $plus))
   (export "__dso_handle" (global 1))
   (export "__data_end" (global 2))
   (export "__global_base" (global 3))

--- a/sdcm/utils/udf_scripts/wasm_plus_acc.yaml
+++ b/sdcm/utils/udf_scripts/wasm_plus_acc.yaml
@@ -1,10 +1,10 @@
 # UDF script: returns a tuple with the accumulator incremented by arg and counter incremented by 1
 
-name: 'xwasm_plus_acc'
+name: 'wasm_plus_acc'
 args: '(acc tuple<int, int>, arg int)'
 called_on_null_input_returns: 'NULL'
 return_type: 'tuple <int, int>'
-language: 'xwasm'
+language: 'wasm'
 script: |-
   (module
   (type (;0;) (func (param i64 i64) (result i64)))
@@ -146,6 +146,6 @@ script: |-
   (memory (;0;) 2)
   (global (;0;) i32 (i32.const 1024))
   (export "memory" (memory 0))
-  (export "xwasm_plus_acc" (func 0))
+  (export "wasm_plus_acc" (func 0))
   (export "_scylla_abi" (global 0))
   (data (;0;) (i32.const 1024) "\01\00\00\00"))

--- a/sdcm/utils/udf_scripts/wasm_simple_return_int.yaml
+++ b/sdcm/utils/udf_scripts/wasm_simple_return_int.yaml
@@ -1,19 +1,20 @@
-# UDF script: returns the string length of the provided text var
+# UDF script: UDF identity function compiled from the following cpp code:
+# int simple_return(int i) {return i;}
+# with the following clang command: clang -O2 --target=wasm32 --no-standard-libraries -Wl,--export-all -Wl,--no-entry simple_return.cpp -o simple_return.wasm
 
-name: 'xwasm_plus'
-args: '(input1 int, input2 int)'
+
+name: 'wasm_simple_return_int'
+args: '(acc tuple<int, int>)'
 called_on_null_input_returns: 'NULL'
 return_type: 'int'
-language: 'xwasm'
+language: 'wasm'
 script: |-
   (module
   (type (;0;) (func))
-  (type (;1;) (func (param i32 i32) (result i32)))
+  (type (;1;) (func (param i32) (result i32)))
   (func $__wasm_call_ctors (type 0))
-  (func $plus (type 1) (param i32 i32) (result i32)
-    local.get 1
-    local.get 0
-    i32.add)
+  (func $wasm_simple_return_int (type 1) (param i32) (result i32)
+    local.get 0)
   (table (;0;) 1 1 funcref)
   (memory (;0;) 2)
   (global (;0;) (mut i32) (i32.const 66560))
@@ -25,7 +26,7 @@ script: |-
   (global (;6;) i32 (i32.const 1))
   (export "memory" (memory 0))
   (export "__wasm_call_ctors" (func $__wasm_call_ctors))
-  (export "xwasm_plus" (func $plus))
+  (export "wasm_simple_return_int" (func $wasm_simple_return_int))
   (export "__dso_handle" (global 1))
   (export "__data_end" (global 2))
   (export "__global_base" (global 3))

--- a/test-cases/features/uda_udf.yaml
+++ b/test-cases/features/uda_udf.yaml
@@ -1,7 +1,7 @@
 test_duration: 90
 
 prepare_write_cmd: "cassandra-stress user profile=/tmp/c-s_uda_udf.yaml ops'(insert=1)' cl=QUORUM duration=2m -mode native cql3 -rate threads=10"
-stress_cmd: ["cassandra-stress user profile=/tmp/c-s_uda_udf.yaml ops'(my_avg=1, lua_var_length_counter=33, xwasm_plus=33, xwasm_div=32)' cl=QUORUM duration=30m -mode native cql3 -rate threads=20"]
+stress_cmd: ["cassandra-stress user profile=/tmp/c-s_uda_udf.yaml ops'(my_avg=1, lua_var_length_counter=33, wasm_plus=33, wasm_div=32)' cl=QUORUM duration=30m -mode native cql3 -rate threads=20"]
 
 n_db_nodes: 3
 n_loaders: 1

--- a/uda_udf_test.py
+++ b/uda_udf_test.py
@@ -85,12 +85,12 @@ class UDAUDFTest(ClusterTester):
                            query=f"SELECT {self.KEYSPACE_NAME}.lua_var_length_counter(c7_text) AS result "
                                  f"FROM {self.KEYSPACE_NAME}.{self.CF_NAME} LIMIT 1",
                            verifier_func=lambda c2, c3, c7, query_response: len(c7) == query_response.result),
-            UDVerification(name="xwasm_plus",
-                           query=f"SELECT {self.KEYSPACE_NAME}.xwasm_plus(c2_int, c3_int) AS result "
+            UDVerification(name="wasm_plus",
+                           query=f"SELECT {self.KEYSPACE_NAME}.wasm_plus(c2_int, c3_int) AS result "
                                  f"FROM {self.KEYSPACE_NAME}.{self.CF_NAME} LIMIT 1",
                            verifier_func=lambda c2, c3, c7, query_response: c2 + c3 == query_response.result),
-            UDVerification(name="xwasm_div",
-                           query=f"SELECT {self.KEYSPACE_NAME}.xwasm_div(c2_int, c3_int) AS result "
+            UDVerification(name="wasm_div",
+                           query=f"SELECT {self.KEYSPACE_NAME}.wasm_div(c2_int, c3_int) AS result "
                                  f"FROM {self.KEYSPACE_NAME}.{self.CF_NAME} LIMIT 1",
                            verifier_func=lambda c2, c3, c7, query_response: c2 // c3 == query_response.result)
         ]

--- a/unit_tests/test_uda.py
+++ b/unit_tests/test_uda.py
@@ -85,19 +85,19 @@ class TestUDA(TestCase):
 
     def test_load_uda_from_yaml(self):
         expected_create_string = "CREATE AGGREGATE testing.my_uda(int) " \
-                                 "SFUNC xwasm_plus " \
+                                 "SFUNC wasm_plus " \
                                  "STYPE int " \
-                                 "REDUCEFUNC xwasm_plus " \
-                                 "FINALFUNC xwasm_simple_return_int " \
+                                 "REDUCEFUNC wasm_plus " \
+                                 "FINALFUNC wasm_simple_return_int " \
                                  "INITCOND (0, 0);"
 
         data = {
             "name": "my_uda",
             "args": "int",
             "return_type": "int",
-            "accumulator_udf_name": "xwasm_plus",
-            "reduce_udf_name": "xwasm_plus",
-            "final_udf_name": "xwasm_simple_return_int",
+            "accumulator_udf_name": "wasm_plus",
+            "reduce_udf_name": "wasm_plus",
+            "final_udf_name": "wasm_simple_return_int",
             "initial_condition": "(0, 0)"
         }
 

--- a/unit_tests/test_udf.py
+++ b/unit_tests/test_udf.py
@@ -27,12 +27,12 @@ class TestUDF(TestCase):
         "script": "return #var"
     }
 
-    MOCK_XWASM_UDF_VALS = {
-        "name": 'xwasm_plus',
+    MOCK_WASM_UDF_VALS = {
+        "name": 'wasm_plus',
         "args": '(input1 int, input2 int)',
         "called_on_null_input_returns": 'NULL',
         "return_type": 'int',
-        "language": 'xwasm',
+        "language": 'wasm',
         "script": r"""(module
 (type (;0;) (func))
 (type (;1;) (func (param i32 i32) (result i32)))
@@ -52,7 +52,7 @@ class TestUDF(TestCase):
 (global (;6;) i32 (i32.const 1))
 (export "memory" (memory 0))
 (export "__wasm_call_ctors" (func $__wasm_call_ctors))
-(export "xwasm_plus" (func $plus))
+(export "wasm_plus" (func $plus))
 (export "__dso_handle" (global 1))
 (export "__data_end" (global 2))
 (export "__global_base" (global 3))
@@ -115,10 +115,10 @@ class TestUDF(TestCase):
         for key, value in expected_vals.items():
             self.assertEqual(value, getattr(udf, key), f"Did not find expected value for {key} in the udf class.")
 
-    def test_loading_udfs_with_xwasm_scripts(self):
-        expected_vals = self.MOCK_XWASM_UDF_VALS.copy()
+    def test_loading_udfs_with_wasm_scripts(self):
+        expected_vals = self.MOCK_WASM_UDF_VALS.copy()
 
-        udf_yaml_filename = "./sdcm/utils/udf_scripts/xwasm_plus.yaml"
+        udf_yaml_filename = "./sdcm/utils/udf_scripts/wasm_plus.yaml"
         udf = UDF.from_yaml(udf_yaml_filename)
 
         self.assertIsNotNone(udf)


### PR DESCRIPTION
Since 5.3 we use `wasm` instead `xwasm`. And `xwasm` script type does not work anymore.

Replace all `xwasm` occurrences with `wasm`.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
