### PR TITLE
fix(manager): bumping manager version

### DIFF
--- a/defaults/manager_versions.yaml
+++ b/defaults/manager_versions.yaml
@@ -7,6 +7,14 @@ manager_repos_by_version:
     ubuntu18: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
     ubuntu20: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
     ubuntu22: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
+  "3.1":
+    centos7: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.1.repo'
+    centos8: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.1.repo'
+    debian10: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/debian/scylladb-manager-3.1.list'
+    debian11: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/debian/scylladb-manager-3.1.list'
+    ubuntu18: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.1.list'
+    ubuntu20: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.1.list'
+    ubuntu22: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.1.list'
   "3.0":
     centos7: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.0.repo'
     centos8: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.0.repo'
@@ -15,13 +23,6 @@ manager_repos_by_version:
     ubuntu18: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.0-bionic.list'
     ubuntu20: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.0-focal.list'
     ubuntu22: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.0-focal.list'
-  "2.6":
-    centos7: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo'
-    centos8: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo'
-    debian10: 'http://downloads.scylladb.com/deb/debian/scylladb-manager-2.6-buster.list'
-    debian11: 'http://downloads.scylladb.com/deb/debian/scylladb-manager-2.6.list'
-    ubuntu18: 'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6-bionic.list'
-    ubuntu20: 'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6-focal.list'
 
 scylla_backend_repo_by_version:
   "2021":

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -6,7 +6,7 @@ ip_ssh_connections: 'private'
 
 scylla_repo: ''
 
-manager_version: '3.0'
+manager_version: '3.1'
 manager_scylla_backend_version: '2022'
 # Notice: that centos (default monitor), ubuntu 22, ubuntu 20 and debian 11 monitors use 2022, while debian 10 ubuntu 18 use 2021, since we support both
 


### PR DESCRIPTION
manager 3.1 was recently released, and then
we want to start using it in our regular tests.
For it, i added the repository list of manager
3.1, and changed the `test_default.yaml` to
use it.
also, removing 2.6, as we support last 2
versions only.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
