### PR TITLE
fix(artifacts_test.md): replace ubuntu18 to ubuntu22

### DIFF
--- a/docs/artifacts_test.md
+++ b/docs/artifacts_test.md
@@ -96,7 +96,7 @@ hydra run-test artifacts_test --backend aws --config test-cases/artifacts/oel76.
 hydra run-test artifacts_test --backend aws --config test-cases/artifacts/amazon2.yaml
 ```
 
-## Ubuntu 18.04 LTS (bionic)
+## Ubuntu 22.04 LTS (jammy)
 ```sh
 hydra run-test artifacts_test --backend gce --config test-cases/artifacts/ubuntu2204.yaml
 ```


### PR DESCRIPTION
since #6124 was merged, a small doc update was missing. this commit changes that, so we have now an updated doc with missing Ubuntu22 in place, and removing the deprecated Ubuntu18

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
