### PR TITLE
feature(stress): automatic dc names for NetworkStrategy

### DIFF
--- a/configurations/manager/200gb_dataset.yaml
+++ b/configurations/manager/200gb_dataset.yaml
@@ -2,4 +2,4 @@ test_duration: 1200
 
 instance_type_db: 'i3.xlarge'
 
-stress_cmd: "cassandra-stress write cl=QUORUM n=200200300 -schema 'replication(strategy=NetworkTopologyStrategy,us-eastscylla_node_east=2,us-west-2scylla_node_west=1)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=400200300..600400600"
+stress_cmd: "cassandra-stress write cl=QUORUM n=200200300 -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=2,<dc1>=1)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=400200300..600400600"

--- a/data_dir/c-s_lwt_big_data_multidc.yaml
+++ b/data_dir/c-s_lwt_big_data_multidc.yaml
@@ -6,7 +6,7 @@ keyspace: cqlstress_lwt_example
 
 # The CQL for creating a keyspace (optional if it already exists)
 keyspace_definition: |
-  CREATE KEYSPACE IF NOT EXISTS cqlstress_lwt_example WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 3, 'us-west-2scylla_node_west': 2, 'us-eastscylla_node_east': 1};
+  CREATE KEYSPACE IF NOT EXISTS cqlstress_lwt_example WITH replication = {'class': 'NetworkTopologyStrategy', '<dc0>': 3, '<dc1>': 2, '<dc2>': 1};
 
 # Table name
 table: blogposts

--- a/data_dir/cdc_profile_multidc.yaml
+++ b/data_dir/cdc_profile_multidc.yaml
@@ -2,7 +2,7 @@ keyspace: cdc_test
 
 keyspace_definition: |
 
-  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 3, 'us-eastscylla_node_east': 2}  AND durable_writes = true;
+  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', '<dc0>': 3, '<dc1>': 2}  AND durable_writes = true;
 
 table: test_table
 

--- a/data_dir/cdc_profile_multidc_postimage.yaml
+++ b/data_dir/cdc_profile_multidc_postimage.yaml
@@ -2,7 +2,7 @@ keyspace: cdc_test
 
 keyspace_definition: |
 
-  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 2, 'us-eastscylla_node_east': 3}  AND durable_writes = true;
+  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', '<dc0>': 2, '<dc1>': 3}  AND durable_writes = true;
 
 table: test_table_postimage
 

--- a/data_dir/cdc_profile_multidc_preimage.yaml
+++ b/data_dir/cdc_profile_multidc_preimage.yaml
@@ -2,7 +2,7 @@ keyspace: cdc_test
 
 keyspace_definition: |
 
-  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 2, 'us-eastscylla_node_east': 3}  AND durable_writes = true;
+  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', '<dc0>': 2, '<dc1>': 3}  AND durable_writes = true;
 
 table: test_table_preimage
 

--- a/data_dir/cdc_profile_multidc_preimage_postimage.yaml
+++ b/data_dir/cdc_profile_multidc_preimage_postimage.yaml
@@ -2,7 +2,7 @@ keyspace: cdc_test
 
 keyspace_definition: |
 
-  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 3, 'us-eastscylla_node_east': 2}  AND durable_writes = true;
+  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', '<dc0>': 3, '<dc1>': 2}  AND durable_writes = true;
 
 table: test_table_preimage_postimage
 

--- a/data_dir/cs_multidc_mv_lcs.yaml
+++ b/data_dir/cs_multidc_mv_lcs.yaml
@@ -3,7 +3,7 @@
 keyspace: keyspace1
 
 keyspace_definition: |
-  CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west1scylla_node_west1': 3,'eu-west2scylla_node_west2': 3}
+  CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', '<dc0>': 3,'<dc1>': 3}
 
 table: standard2
 

--- a/data_dir/cs_multidc_si_lcs.yaml
+++ b/data_dir/cs_multidc_si_lcs.yaml
@@ -3,7 +3,7 @@
 keyspace: keyspace1
 
 keyspace_definition: |
-  CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 3,'eu-west-2scylla_node_west': 3}
+  CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', '<dc0>': 3,'<dc1>': 3}
 
 table: standard2
 

--- a/data_dir/cs_mv_si_keyspace1.yaml
+++ b/data_dir/cs_mv_si_keyspace1.yaml
@@ -3,7 +3,7 @@
 keyspace: keyspace1
 
 keyspace_definition: |
-  CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};
+  CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};
 
 table: standard2
 

--- a/internal_test_data/multi_region_dc_test_case.yaml
+++ b/internal_test_data/multi_region_dc_test_case.yaml
@@ -1,4 +1,4 @@
-stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(strategy=NetworkTopologyStrategy,us-eastscylla_node_east=2,us-west-2scylla_node_west=1)' -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
+stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=2,<dc1>=1)' -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
 region_name: 'eu-west-1 us-east-1'
 n_db_nodes: '2 1'
 n_loaders: 1

--- a/sdcm/utils/loader_utils.py
+++ b/sdcm/utils/loader_utils.py
@@ -140,10 +140,14 @@ class LoaderUtilsMixin:
         for cmd in cmds:
             # pylint: disable=no-member
             with self.db_cluster.cql_connection_patient(node) as session:
+                self.log.debug("Execute cql command: %s", cmd)
                 session.execute(cmd)
 
     def _pre_create_keyspace(self):
         cmds = self.params.get('pre_create_keyspace')
+        if not isinstance(cmds, list):
+            cmds = [cmds]
+        cmds = [self.db_cluster.replace_dc_placeholders_with_dc_names(cmd) for cmd in cmds]
         self._run_cql_commands(cmds)
 
     def run_post_prepare_cql_cmds(self):

--- a/test-cases/features/add-new-dc.yaml
+++ b/test-cases/features/add-new-dc.yaml
@@ -1,4 +1,4 @@
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=20900 -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=8 -pop seq=1..20900 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=20900 -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=8 -pop seq=1..20900 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
 
 stress_cmd: ["cassandra-stress read cl=LOCAL_QUORUM duration=20m -mode cql3 native -rate threads=8 -pop seq=1..20900 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
              "cassandra-stress write cl=LOCAL_QUORUM duration=20m -mode cql3 native -rate threads=8 -pop seq=1..20900 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"

--- a/test-cases/features/google-cloud-snitch-multi-dc.yaml
+++ b/test-cases/features/google-cloud-snitch-multi-dc.yaml
@@ -1,6 +1,6 @@
 test_duration: 100
 
-stress_cmd: cassandra-stress write cl=QUORUM duration=20m -schema 'replication(strategy=NetworkTopologyStrategy,us-east1scylla_node_east=3,us-west1scylla_node_west=3)' -mode cql3 native -rate threads=1000 -pop seq=1..100000000000
+stress_cmd: cassandra-stress write cl=QUORUM duration=20m -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=3,<dc1>=3)' -mode cql3 native -rate threads=1000 -pop seq=1..100000000000
 
 ip_ssh_connections: 'public'
 intra_node_comm_public: true

--- a/test-cases/longevity/longevity-cdc-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-4h.yaml
@@ -1,6 +1,6 @@
 test_duration: 290
 
-pre_create_keyspace: "CREATE KEYSPACE cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west': '3'}  AND durable_writes = true;"
+pre_create_keyspace: "CREATE KEYSPACE cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', '<dc0>': '3'}  AND durable_writes = true;"
 stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=200m -mode cql3 native -rate threads=100",
               "cassandra-stress user no-warmup profile=/tmp/cdc_profile_preimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=200m -mode cql3 native -rate threads=100",
               "cassandra-stress user no-warmup profile=/tmp/cdc_profile_postimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=200m -mode cql3 native -rate threads=100",

--- a/test-cases/longevity/longevity-counters-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-multidc.yaml
@@ -1,6 +1,6 @@
 test_duration: 500
 
-pre_create_keyspace: "CREATE KEYSPACE scylla_bench WITH replication = {'class': 'NetworkTopologyStrategy', 'us-eastscylla_node_east': '3', 'us-west-2scylla_node_west': '3', 'eu-westscylla_node_west': '3'};"
+pre_create_keyspace: "CREATE KEYSPACE scylla_bench WITH replication = {'class': 'NetworkTopologyStrategy', '<dc0>': '3', '<dc1>': '3', '<dc2>': '3'};"
 stress_cmd:      "scylla-bench -workload=uniform -mode=counter_update -replication-factor=3 -partition-count=1000 -clustering-row-count=10 -concurrency 1024 -duration 360m -validate-data"
 stress_read_cmd: "scylla-bench -workload=uniform -mode=counter_read   -replication-factor=3 -partition-count=1000 -clustering-row-count=10 -concurrency 512 -duration 360m -validate-data"
 

--- a/test-cases/longevity/longevity-multidc-parallel-network-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-network-schema-changes-12h.yaml
@@ -1,11 +1,11 @@
 test_duration: 800
 
-prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,eu-west1scylla_node_west1=3,eu-west2scylla_node_west2=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=3,<dc1>=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
                      "cassandra-stress user profile=/tmp/cs_multidc_mv_lcs.yaml ops'(write=1)' -port jmx=6868 -mode cql3 native -rate threads=40 n=3000000 -log interval=5"
                     ]
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,eu-west1scylla_node_west=3,eu-west2scylla_node_west=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,eu-west1scylla_node_west=3,eu-west2scylla_node_west=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=3,<dc1>=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=3,<dc1>=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
              "cassandra-stress user profile=/tmp/cs_multidc_mv_lcs.yaml ops'(write=1,read=1,mv_read1=1,mv_read2=1)' -port jmx=6868 -mode cql3 native -rate threads=40 duration=700m -log interval=5",
              ]
 

--- a/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
@@ -1,11 +1,11 @@
 test_duration: 800
 
-prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3,eu-west-2scylla_node_west=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=3,<dc1>=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
                      "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(write=1)' n=3000000 -port jmx=6868 -mode cql3 native -rate threads=40 -log interval=5"
                     ]
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3,eu-west-2scylla_node_west=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3,eu-west-2scylla_node_west=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=3,<dc1>=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=3,<dc1>=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
              "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(write=1,read=1,si_read1=1,si_read2=1)' duration=700m -port jmx=6868 -mode cql3 native -rate threads=40 -log interval=5",
              ]
 

--- a/test-cases/longevity/longevity-topology-changes-3h.yaml
+++ b/test-cases/longevity/longevity-topology-changes-3h.yaml
@@ -1,12 +1,12 @@
 test_duration: 260
 
-pre_create_keyspace: "CREATE KEYSPACE scylla_bench WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': '3'};"
-prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+pre_create_keyspace: "CREATE KEYSPACE scylla_bench WITH replication = {'class': 'NetworkTopologyStrategy', '<dc0>': '3'};"
+prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=50 -clustering-row-count=10000 -clustering-row-size=uniform:1024..8192 -concurrency=25 -connection-count=25 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s"
                     ]
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
 
              "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=50 -clustering-row-count=10000 -clustering-row-size=uniform:1024..8192 -concurrency=25 -connection-count=25 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=180m",
              "scylla-bench -workload=sequential -mode=read  -replication-factor=3 -partition-count=50 -clustering-row-count=10000 -clustering-row-size=uniform:1024..8192 -concurrency=25 -connection-count=25 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=180m",

--- a/test-cases/manager/manager-regression-multiDC-gce.yaml
+++ b/test-cases/manager/manager-regression-multiDC-gce.yaml
@@ -1,7 +1,7 @@
 test_duration: 360
 
-stress_cmd: "cassandra-stress write cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,us-east1scylla_node_east=2,us-west1scylla_node_west=1)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
-stress_read_cmd: "cassandra-stress read cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,us-east1scylla_node_east=2,us-west1scylla_node_west=1)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
+stress_cmd: "cassandra-stress write cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=2,<dc1>=1)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
+stress_read_cmd: "cassandra-stress read cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=2,<dc1>=1)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
 
 n_db_nodes: "2 1"
 n_loaders: 1

--- a/test-cases/manager/manager-regression-multiDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-multiDC-set-distro.yaml
@@ -1,7 +1,7 @@
 test_duration: 240
 
-stress_cmd: "cassandra-stress write cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,us-eastscylla_node_east=2,us-west-2scylla_node_west=1)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
-stress_read_cmd: "cassandra-stress read cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,us-eastscylla_node_east=2,us-west-2scylla_node_west=1)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
+stress_cmd: "cassandra-stress write cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=2,<dc1>=1)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
+stress_read_cmd: "cassandra-stress read cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=2,<dc1>=1)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
 
 instance_type_db: 'i3.large'
 instance_type_loader: 'c5.large'

--- a/test-cases/upgrades/multi-dc-rolling-upgrade.yaml
+++ b/test-cases/upgrades/multi-dc-rolling-upgrade.yaml
@@ -1,8 +1,8 @@
 test_duration: 360
 # Workloads
-stress_before_upgrade: cassandra-stress write no-warmup cl=ALL n=10100200 -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3,eu-west-2scylla_node_west=3) compression=LZ4Compressor compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native compression=lz4 -rate threads=1000 -pop seq=1..10100200 -log interval=5
-stress_during_entire_upgrade: cassandra-stress write no-warmup cl=QUORUM n=20100200 -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3,eu-west-2scylla_node_west=3) compression=LZ4Compressor compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native compression=lz4 -rate threads=60 -pop seq=10100201..30200400 -log interval=5
-stress_after_cluster_upgrade: cassandra-stress read no-warmup cl=ONE n=30200400 -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3,eu-west-2scylla_node_west=3) compression=LZ4Compressor' -mode cql3 native compression=lz4 -rate threads=1000 -pop seq=1..30200400 -log interval=5
+stress_before_upgrade: cassandra-stress write no-warmup cl=ALL n=10100200 -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=3,<dc1>=3) compression=LZ4Compressor compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native compression=lz4 -rate threads=1000 -pop seq=1..10100200 -log interval=5
+stress_during_entire_upgrade: cassandra-stress write no-warmup cl=QUORUM n=20100200 -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=3,<dc1>=3) compression=LZ4Compressor compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native compression=lz4 -rate threads=60 -pop seq=10100201..30200400 -log interval=5
+stress_after_cluster_upgrade: cassandra-stress read no-warmup cl=ONE n=30200400 -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=3,<dc1>=3) compression=LZ4Compressor' -mode cql3 native compression=lz4 -rate threads=1000 -pop seq=1..30200400 -log interval=5
 
 instance_type_db: 'i3.2xlarge'
 n_db_nodes: '3 3'

--- a/unit_tests/dummy_remote.py
+++ b/unit_tests/dummy_remote.py
@@ -85,12 +85,20 @@ class LocalLoaderSetDummy(BaseCluster):
     def is_kubernetes():
         return False
 
+    @staticmethod
+    def replace_dc_placeholders_with_dc_names(cmd):
+        datacenter_names = ['datacenter1']
+        for idx, dc in enumerate(datacenter_names):
+            cmd = cmd.replace(f"<dc{idx}>", dc)
+        return cmd
+
 
 class LocalScyllaClusterDummy(BaseScyllaCluster):
     # pylint: disable=super-init-not-called
     def __init__(self):
         self.name = "LocalScyllaClusterDummy"
         self.params = {}
+        self.datacenter_names = ["datacenter1"]
 
     @staticmethod
     def get_db_auth():

--- a/unit_tests/test_cassandra_stress_thread.py
+++ b/unit_tests/test_cassandra_stress_thread.py
@@ -27,7 +27,7 @@ def test_01_cassandra_stress(request, docker_scylla, params):
     loader_set = LocalLoaderSetDummy()
 
     cmd = (
-        """cassandra-stress write cl=ONE duration=1m -schema 'replication(factor=1) """
+        """cassandra-stress write cl=ONE duration=1m -schema 'replication(strategy=NetworkTopologyStrategy,<dc0>=1) """
         """compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native """
         """-rate threads=10 -pop seq=1..10000000 -log interval=5"""
     )


### PR DESCRIPTION
When we use NetworkTopologyStrategy in stress commands we currently
hardcode datacenter names. This leads to failed tests when executed in
different regions.

Make dc names to be replaced dynamically so we don't face this issue
anymore. Use placeholders like `<dcX>` in c-s, precreate_schema and
profile files.

refs: https://github.com/scylladb/scylla-cluster-tests/issues/5969

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
