### PR TITLE
fix(sct_config): `get_scylla_gce_images_versions` filters

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1666,12 +1666,7 @@ class SCTConfiguration(dict):
                     gce_image = get_branched_gce_images(scylla_version=scylla_version)[0]
                 else:
                     # gce_image.name format examples: scylla-4-3-6 or scylla-enterprise-2021-1-2
-                    scylla_version_substr = f"scylla-{scylla_version.replace('.', '-')}"
-                    for gce_image in get_scylla_gce_images_versions():
-                        if gce_image.name.replace("-enterprise", "").startswith(scylla_version_substr):
-                            break
-                    else:
-                        raise ValueError(f"GCE images for {scylla_version=} not found")
+                    gce_image = get_scylla_gce_images_versions(version=scylla_version)[0]
                 self.log.debug("Found GCE image %s for scylla_version='%s'", gce_image.name, scylla_version)
                 self["gce_image_db"] = gce_image.extra["selfLink"]
             elif not self.get("azure_image_db") and self.get("cluster_backend") == "azure":


### PR DESCRIPTION
they were wrongly used in sct_config `__init__`,
making us list every image, and "manually" filter
by searching for the version number, while the
function that does that list, has a much better
filtering mechanism.
We are in recent 5.2 upgrade jobs having problem
of the version did not change, as we are finding
the very last release candidate (`5.2.1`) and
starting from it (as a GCE pre-installed image).
we should be checking for last already released
one, and it will give us exactly what we need.
this test (pre-installed images on GCE) was
recently added (this is the 1st version using it).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
