### PR TITLE
test(custom profile): Add support in upgrade and longevity tests

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -123,6 +123,7 @@ stress_multiplier_r: 1
 stress_multiplier_m: 1
 keyspace_num: 1
 cs_user_profiles: []
+prepare_cs_user_profiles: []
 cs_duration: '50m'
 batch_size: 1
 pre_create_schema: false

--- a/jenkins-pipelines/longevity-10gb-3h-gce-custom-d1.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h-gce-custom-d1.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'gce',
+    region: 'us-east1',
+    test_name: 'gemini_test.GeminiTest.test_random_load',
+    test_config: 'test-cases/custom/longevity-10gb-3h-custom-d1.yaml'
+)

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -94,6 +94,9 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
         self.run_pre_create_keyspace()
         self.run_pre_create_schema()
 
+        if prepare_cs_user_profiles := self.params.get('prepare_cs_user_profiles'):
+            self._pre_create_templated_user_schema(cs_user_profiles=prepare_cs_user_profiles)
+
         if scan_operation_params := self._get_scan_operation_params():
             for scan_param in scan_operation_params:
                 self.log.info("Starting fullscan operation thread with the following params: %s", scan_param)
@@ -361,11 +364,11 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
                               scylla_encryption_options=scylla_encryption_options,
                               compaction=compaction_strategy, sstable_size=sstable_size)
 
-    def _pre_create_templated_user_schema(self, batch_start=None, batch_end=None):
+    def _pre_create_templated_user_schema(self, batch_start=None, batch_end=None, cs_user_profiles=None):
         # pylint: disable=too-many-locals
         user_profile_table_count = self.params.get(  # pylint: disable=invalid-name
             'user_profile_table_count') or 0
-        cs_user_profiles = self.params.get('cs_user_profiles')
+        cs_user_profiles = cs_user_profiles or self.params.get('cs_user_profiles')
         # read user-profile
         for profile_file in cs_user_profiles:
             with open(profile_file, encoding="utf-8") as fobj:
@@ -382,6 +385,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
                     session.execute(keyspace_definition)
                 except AlreadyExists:
                     self.log.debug("keyspace [{}] exists".format(keyspace_name))
+                self._pre_create_advanced_user_schema(profile_file=profile_file)
 
                 if batch_start is not None and batch_end is not None:
                     table_range = range(batch_start, batch_end)
@@ -403,6 +407,29 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
                             session.execute(query)
                         except (AlreadyExists, InvalidRequest) as exc:
                             self.log.debug('extra definition for [{}] exists [{}]'.format(table_name, str(exc)))
+
+    def _pre_create_advanced_user_schema(self, profile_file: str):
+        """
+        Search a user-profile file.
+        Look for a commented line containing "advanced_schema_file"
+        If found - open the file found and run commands for its definitions, like UDT.
+        """
+        with open(profile_file, encoding="utf-8") as fobj:
+            content = fobj.readlines()
+        advanced_schema_file = [line.lstrip('#').strip() for line in content if
+                                line.find('advanced_schema_file:') > 0]
+        # Looking for a line of: # advanced_schema_file: scylla-qa-internal/custom_d1/advanced_schema_file.yaml
+        if advanced_schema_file:
+            advanced_schema_file = advanced_schema_file[0].split()[1]
+        with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0]) as session:
+            with open(advanced_schema_file, encoding="utf-8") as fobj:
+                advanced_schema_yaml = yaml.safe_load(fobj)
+            udt_definition = advanced_schema_yaml['udt_definition']
+            for cql_cmd in udt_definition.strip().splitlines():
+                try:
+                    session.execute(cql_cmd)
+                except AlreadyExists as error:
+                    self.log.debug("Type already exists: %s", error)
 
     def _flush_all_nodes(self):
         """

--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -13,6 +13,8 @@
 
 import logging
 import os
+import re
+import tempfile
 import uuid
 import random
 import json
@@ -23,7 +25,7 @@ from sdcm.utils.common import FileFollowerThread
 from sdcm.sct_events.loaders import GeminiStressEvent, GeminiStressLogEvent
 from sdcm.stress_thread import DockerBasedStressThread
 from sdcm.utils.docker_remote import RemoteDocker
-
+from sdcm.utils.user_profile import get_json_file_content
 
 LOGGER = logging.getLogger(__name__)
 
@@ -61,6 +63,7 @@ class GeminiEventsPublisher(FileFollowerThread):
 class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes
 
     DOCKER_IMAGE_PARAM_NAME = "stress_image.gemini"
+    SCHEMA_REGEX = r'--schema (.*\.json)'
 
     def __init__(self, test_cluster, oracle_cluster, loaders, stress_cmd, timeout=None, params=None):  # pylint: disable=too-many-arguments
         super().__init__(loader_set=loaders, stress_cmd=stress_cmd, timeout=timeout, params=params)
@@ -70,12 +73,32 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
         self.gemini_commands = []
         self.gemini_request_timeout = 180
         self.gemini_connect_timeout = 120
+        self.docker = None
 
     @property
     def gemini_result_file(self):
         if not self._gemini_result_file:
             self._gemini_result_file = os.path.join("/", "gemini_result_{}.log".format(uuid.uuid4()))
         return self._gemini_result_file
+
+    def _update_schema_file_path_and_stress_cmd(self) -> str:
+        """
+        If Gemini command uses '--schema' parameter:
+          1. copy the schema file from runner to loader /tmp directory.
+          2. Update this new path in the gemini cmd string.
+        """
+        stress_cmd = self.stress_cmd.strip()
+        if gemini_schema := re.search(self.SCHEMA_REGEX, stress_cmd):
+            gemini_schema_file_path = gemini_schema.group(1)
+            schema_content = get_json_file_content(json_file_path=gemini_schema_file_path)
+            gemini_schema_file_name = os.path.basename(gemini_schema_file_path)
+            dest_path = os.path.join('/tmp', gemini_schema_file_name)
+            with tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8') as tmp_file:
+                json.dump(schema_content, tmp_file)
+                tmp_file.flush()
+                self.docker.send_files(tmp_file.name, dest_path)
+            stress_cmd = re.sub(self.SCHEMA_REGEX, f"--schema {dest_path}", stress_cmd)
+        return stress_cmd
 
     def _generate_gemini_command(self):
         seed = self.params.get('gemini_seed')
@@ -84,9 +107,9 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
             seed = random.randint(1, 100)
         test_nodes = ",".join(self.test_cluster.get_node_cql_ips())
         oracle_nodes = ",".join(self.oracle_cluster.get_node_cql_ips()) if self.oracle_cluster else None
-
+        stress_cmd = self._update_schema_file_path_and_stress_cmd()
         cmd = "./{} --test-cluster={} --outfile {} --seed {} --request-timeout {}s --connect-timeout {}s ".format(
-            self.stress_cmd.strip(),
+            stress_cmd,
             test_nodes,
             self.gemini_result_file,
             seed,
@@ -105,9 +128,9 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
         if self.stress_num > 1:
             cpu_options = f'--cpuset-cpus="{cpu_idx}"'
 
-        docker = cleanup_context = RemoteDocker(loader, self.docker_image_name,
-                                                extra_docker_opts=f'{cpu_options} --label shell_marker={self.shell_marker}'
-                                                                  f' --network=host --entrypoint=""')
+        self.docker = cleanup_context = RemoteDocker(loader, self.docker_image_name,
+                                                     extra_docker_opts=f'{cpu_options} --label shell_marker={self.shell_marker}'
+                                                                       f' --network=host --entrypoint=""')
 
         if not os.path.exists(loader.logdir):
             os.makedirs(loader.logdir, exist_ok=True)
@@ -122,12 +145,12 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
             try:
                 publisher.event_id = gemini_stress_event.event_id
                 gemini_stress_event.log_file_name = log_file_name
-                result = docker.run(cmd=gemini_cmd,
-                                    timeout=self.timeout,
-                                    ignore_status=False,
-                                    log_file=log_file_name,
-                                    retry=0,
-                                    )
+                result = self.docker.run(cmd=gemini_cmd,
+                                         timeout=self.timeout,
+                                         ignore_status=False,
+                                         log_file=log_file_name,
+                                         retry=0,
+                                         )
                 # sleep to gather all latest log messages
                 time.sleep(5)
             except Exception as details:  # pylint: disable=broad-except
@@ -142,11 +165,11 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
                     gemini_stress_event.add_result(result=result)
                     gemini_stress_event.severity = Severity.WARNING
 
-            local_gemini_result_file = os.path.join(docker.node.logdir, os.path.basename(self.gemini_result_file))
-            results_copied = docker.receive_files(src=self.gemini_result_file, dst=local_gemini_result_file)
+            local_gemini_result_file = os.path.join(self.docker.node.logdir, os.path.basename(self.gemini_result_file))
+            results_copied = self.docker.receive_files(src=self.gemini_result_file, dst=local_gemini_result_file)
             assert results_copied, "gemini results aren't available, did gemini even run ?"
 
-        return docker, result, local_gemini_result_file
+        return self.docker, result, local_gemini_result_file
 
     def get_gemini_results(self):
         parsed_results = []

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1085,7 +1085,9 @@ class SCTConfiguration(dict):
 
         # PerformanceRegressionUserProfilesTest
         dict(name="cs_user_profiles", env="SCT_CS_USER_PROFILES", type=str_or_list,
-             help=""),
+             help="cassandra-stress user-profiles list. Executed in test step"),
+        dict(name="prepare_cs_user_profiles", env="SCT_PREPARE_CS_USER_PROFILES", type=str_or_list,
+             help="cassandra-stress user-profiles list. Executed in prepare step"),
         dict(name="cs_duration", env="SCT_CS_DURATION", type=str,
              help=""),
         dict(name="cs_debug", env="SCT_CS_DEBUG", type=boolean,

--- a/sdcm/utils/user_profile.py
+++ b/sdcm/utils/user_profile.py
@@ -14,6 +14,7 @@
 """ This module keeps utilities that help to extract schema definition and stress commands from user profile """
 from __future__ import absolute_import, annotations
 
+import json
 import os
 import re
 
@@ -128,3 +129,15 @@ def get_profile_content(stress_cmd):
     with open(cs_profile, encoding="utf-8") as yaml_stream:
         profile = yaml.safe_load(yaml_stream)
     return cs_profile, profile
+
+
+def get_json_file_content(json_file_path: str) -> dict:
+    """
+    Getting a content of a json file
+    :return: a dict with json data
+    """
+    if not os.path.exists(json_file_path):
+        raise FileNotFoundError('json file {} not found'.format(json_file_path))
+    with open(json_file_path, encoding="utf-8") as json_stream:
+        json_content = json.load(json_stream)
+    return json_content

--- a/test-cases/custom/longevity-10gb-3h-custom-d1.yaml
+++ b/test-cases/custom/longevity-10gb-3h-custom-d1.yaml
@@ -1,0 +1,27 @@
+test_duration: 300
+n_db_nodes: 3
+n_test_oracle_db_nodes: 1
+n_loaders: 1
+n_monitor_nodes: 1
+
+gemini_cmd: "gemini -d --duration 3h --warmup 5m --schema scylla-qa-internal/custom_d1/posts_no_map.json \
+-c 50 -m mixed -f --non-interactive --cql-features normal \
+--max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
+--async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \
+--replication-strategy \"{'class': 'NetworkTopologyStrategy', 'replication_factor': '3'}\" \
+--oracle-replication-strategy \"{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}\""
+
+gce_instance_type_db: 'n1-highmem-2'
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_seed: '111'
+nemesis_interval: 5
+
+user_prefix: 'longevity-3h-custom-d1'
+
+gce_n_local_ssd_disk_db: 2
+gce_pd_ssd_disk_size_db: 750
+
+stress_image:
+  gemini: 'scylladb/hydra-loaders:gemini-v1.8.6'
+
+use_preinstalled_scylla: true

--- a/test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml
+++ b/test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml
@@ -1,0 +1,36 @@
+test_duration: 360
+
+# workloads
+# Customer profiles directory path is: scylla-qa-internal/customer-profile/cust_d
+
+# To be used in keyspace_entire_test:
+cs_duration: '300m'  # TODO: measure new upgrade test duration and adjust this one.
+cs_user_profiles:
+    - scylla-qa-internal/custom_d1/write_stress_during_entire_test.yaml
+# write_stress_during_entire_test: cassandra-stress user no-warmup profile=/tmp/write_stress_during_entire_test.yaml  ops'(insert=1,read=2)' cl=ALL n=5000000 -mode cql3 native -rate threads=1000 -pop seq=1..5000000
+
+# To be used in keyspace_custom_preload:
+prepare_cs_user_profiles:
+    - scylla-qa-internal/custom_d1/stress_before_upgrade.yaml
+#stress_before_upgrade: cassandra-stress user no-warmup profile=/tmp/stress_before_upgrade.yaml  ops'(insert=1)' cl=ALL n=5000000 -mode cql3 native -rate threads=1000 -pop seq=1..5000000
+
+n_db_nodes: 4
+n_loaders: 1
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.2xlarge'
+
+user_prefix: 'rolling-upgrade-custom-d1'
+
+server_encrypt: true
+authenticator: 'PasswordAuthenticator'
+authenticator_user: 'cassandra'
+authenticator_password: 'cassandra'
+
+recover_system_tables: true
+
+append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1'
+
+use_mgmt: false
+
+use_prepared_loaders: true

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -104,7 +104,7 @@ def recover_conf(node):
             r'test -e $conf.backup && sudo cp -v $conf.backup $conf; done')
 
 
-# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-instance-attributes, too-many-public-methods
 class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
     """
     Test a Scylla cluster upgrade.
@@ -774,6 +774,107 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         InfoEvent(message='Step10 - Verify that gemini did not failed during upgrade').publish()
         if self.version_cdc_support():
             self.verify_gemini_results(queue=gemini_thread)
+
+        InfoEvent(message='all nodes were upgraded, and last workaround is verified.').publish()
+
+    def test_custom_profile_rolling_upgrade(self):  # pylint: disable=too-many-locals,too-many-statements
+        """
+        Run a load of a custom profile.
+        Upgrade half of nodes in the cluster, and run rollback.
+        Upgrade all nodes to new version in the end.
+        """
+        InfoEvent(message='Running a prepare load for the initial custom data').publish()
+        prepare_cs_user_profiles = self.params.get('prepare_cs_user_profiles')
+        stress_before_upgrade = self.run_cs_user_profiles(cs_profiles=prepare_cs_user_profiles)
+        self.verify_stress_thread(cs_thread_pool=stress_before_upgrade)
+
+        # write workload during entire test
+        InfoEvent(message='Starting write workload during entire test').publish()
+        cs_user_profiles = self.params.get('cs_user_profiles')
+        entire_write_thread_pool = self.run_cs_user_profiles(cs_profiles=cs_user_profiles)
+
+        # Let to write_stress_during_entire_test complete the schema changes
+        self.metric_has_data(
+            metric_query='sct_cassandra_stress_write_gauge{type="ops", keyspace="keyspace_entire_test"}', n=10)
+
+        # generate random order to upgrade
+        nodes_num = len(self.db_cluster.nodes)
+        # prepare an array containing the indexes
+        indexes = list(range(nodes_num))
+        # shuffle it so we will upgrade the nodes in a random order
+        random.shuffle(indexes)
+
+        with ignore_upgrade_schema_errors():
+
+            step = 'Step1 - Upgrade First Node '
+            InfoEvent(message=step).publish()
+            # upgrade first node
+            self.db_cluster.node_to_upgrade = self.db_cluster.nodes[indexes[0]]
+            InfoEvent(message='Upgrade Node %s begin' % self.db_cluster.node_to_upgrade.name).publish()
+            self.upgrade_node(self.db_cluster.node_to_upgrade)
+            InfoEvent(message='Upgrade Node %s ended' % self.db_cluster.node_to_upgrade.name).publish()
+            self.db_cluster.node_to_upgrade.check_node_health()
+
+            InfoEvent(message='after upgraded one node').publish()
+            self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
+                                                          step=step+' - after upgraded one node')
+
+            step = 'Step2 - Upgrade Second Node '
+            InfoEvent(message=step).publish()
+            # upgrade second node
+            self.db_cluster.node_to_upgrade = self.db_cluster.nodes[indexes[1]]
+            InfoEvent(message='Upgrade Node %s begin' % self.db_cluster.node_to_upgrade.name).publish()
+            self.upgrade_node(self.db_cluster.node_to_upgrade)
+            InfoEvent(message='Upgrade Node %s ended' % self.db_cluster.node_to_upgrade.name).publish()
+            self.db_cluster.node_to_upgrade.check_node_health()
+
+            self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
+                                                          step=step+' - after upgraded two nodes')
+
+            InfoEvent(message='Step3 - Rollback Second Node ').publish()
+            # rollback second node
+            InfoEvent(message='Rollback Node %s begin' % self.db_cluster.nodes[indexes[1]].name).publish()
+            self.rollback_node(self.db_cluster.nodes[indexes[1]])
+            InfoEvent(message='Rollback Node %s ended' % self.db_cluster.nodes[indexes[1]].name).publish()
+            self.db_cluster.nodes[indexes[1]].check_node_health()
+
+        step = 'Step4 - Verify data during mixed cluster mode '
+        InfoEvent(message=step).publish()
+        InfoEvent(message='Repair the first upgraded Node').publish()
+        self.db_cluster.nodes[indexes[0]].run_nodetool(sub_cmd='repair')
+        self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
+                                                      step=step)
+
+        with ignore_upgrade_schema_errors():
+
+            step = 'Step5 - Upgrade rest of the Nodes '
+            InfoEvent(message=step).publish()
+            for i in indexes[1:]:
+                self.db_cluster.node_to_upgrade = self.db_cluster.nodes[i]
+                InfoEvent(message='Upgrade Node %s begin' % self.db_cluster.node_to_upgrade.name).publish()
+                self.upgrade_node(self.db_cluster.node_to_upgrade)
+                InfoEvent(message='Upgrade Node %s ended' % self.db_cluster.node_to_upgrade.name).publish()
+                self.db_cluster.node_to_upgrade.check_node_health()
+                self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
+                                                              step=step)
+
+        InfoEvent(message='Step6 - Verify stress results after upgrade ').publish()
+        InfoEvent(message='Waiting for stress threads to complete after upgrade').publish()
+
+        self.verify_stress_thread(cs_thread_pool=entire_write_thread_pool)
+
+        InfoEvent(message='Step7 - Upgrade sstables to latest supported version ').publish()
+        # figure out what is the last supported sstable version
+        self.expected_sstable_format_version = self.get_highest_supported_sstable_version()
+
+        # run 'nodetool upgradesstables' on all nodes and check/wait for all file to be upgraded
+        upgradesstables = self.db_cluster.run_func_parallel(func=self.upgradesstables_if_command_available)
+
+        # only check sstable format version if all nodes had 'nodetool upgradesstables' available
+        if all(upgradesstables):
+            InfoEvent(message='Upgrading sstables if new version is available').publish()
+            tables_upgraded = self.db_cluster.run_func_parallel(func=self.wait_for_sstable_upgrade)
+            assert all(tables_upgraded), "Failed to upgrade the sstable format {}".format(tables_upgraded)
 
         InfoEvent(message='all nodes were upgraded, and last workaround is verified.').publish()
 


### PR DESCRIPTION
	A new test with a basic flow, that could be used with
	custom-profile specific configuration and workload.
	It pre-loads custom dataset by initial load.
	The test runs additional custom profile load during the upgrade/rollback.
	It verifies the basic dataset after all nodes are upgraded.
Task: https://github.com/scylladb/qa-tasks/issues/21

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
