### PR TITLE
fix(unit test): typo in run_fullscan mode

### DIFF
--- a/internal_test_data/negative_fullscan_param.yaml
+++ b/internal_test_data/negative_fullscan_param.yaml
@@ -1,2 +1,2 @@
 run_fullscan: ['{"mode": "table", "ks_cf": "keyspace1.standard1", "interval": 1}',
-               '{"mode": "agggregate", "ks_cf": 1, "interval": 1, "full_scan_aggregates_operation_limit": "a", "validate_data": "no"}',]
+               '{"mode": "aggregate", "ks_cf": 1, "interval": 1, "full_scan_aggregates_operation_limit": "a", "validate_data": "no"}',]


### PR DESCRIPTION
Fix typo in run_fullscan mode.
Was: agggregate.
Fixed to: aggregate

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
