### PR TITLE
fix(microbenchmarking): Switch to use new index

### DIFF
--- a/sdcm/microbenchmarking.py
+++ b/sdcm/microbenchmarking.py
@@ -43,6 +43,8 @@ setup_stdout_logger()
 LOGGER = logging.getLogger("microbenchmarking")
 LOGGER.setLevel(logging.DEBUG)
 
+MICROBENCHMARK_INDEX_NAME = 'microbenchmarkingv2'
+
 
 @contextlib.contextmanager
 def chdir(dirname=None):
@@ -80,7 +82,7 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
     submetrics = {'frag/s': ['mad f/s', 'max f/s', 'min f/s']}
 
     def __init__(self, email_recipients, db_version=None):
-        super().__init__(es_index="microbenchmarking", es_doc_type="microbenchmark", email_recipients=email_recipients,
+        super().__init__(es_index=MICROBENCHMARK_INDEX_NAME, es_doc_type="microbenchmark", email_recipients=email_recipients,
                          email_template_fp="results_microbenchmark.html", query_limit=10000, logger=LOGGER)
         self.hostname = socket.gethostname()
         self._run_date_pattern = "%Y-%m-%d_%H:%M:%S"


### PR DESCRIPTION
Switch to use new index for microbenchmarking tests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
