### PR TITLE
feature(SisyphusNemesis): add network interruptions to kubernetes filter

### DIFF
--- a/data_dir/nemesis.yml
+++ b/data_dir/nemesis.yml
@@ -16,14 +16,14 @@
   - run_with_gemini = False
   - limited = True
   - topology_changes = True
+- disrupt_add_remove_mv:
+  - disruptive = True
+  - schema_changes = True
+  - free_tier_set = True
 - disrupt_corrupt_then_scrub:
   - disruptive = False
 - disrupt_create_index:
   - disruptive = False
-  - schema_changes = True
-  - free_tier_set = True
-- disrupt_add_remove_mv:
-  - disruptive = True
   - schema_changes = True
   - free_tier_set = True
 - disrupt_decommission_streaming_err:
@@ -91,6 +91,9 @@
   - disruptive = False
   - kubernetes = True
   - limited = True
+- disrupt_maximum_allowed_sls_with_max_shares_during_load:
+  - disruptive = False
+  - sla = True
 - disrupt_memory_stress:
   - disruptive = True
   - free_tier_set = True
@@ -118,10 +121,12 @@
   - disruptive = True
   - networking = True
   - run_with_gemini = False
+  - kubernetes = True
 - disrupt_network_random_interruptions:
   - disruptive = True
   - networking = True
   - run_with_gemini = False
+  - kubernetes = True
 - disrupt_network_reject_node_exporter:
   - disruptive = True
   - networking = True
@@ -181,6 +186,7 @@
   - topology_changes = True
 - disrupt_remove_service_level_while_load:
   - disruptive = True
+  - sla = True
 - disrupt_repair_streaming_err:
   - disruptive = True
 - disrupt_replace_scylla_node_on_kubernetes:
@@ -222,9 +228,6 @@
   - disruptive = True
   - networking = False
   - run_with_gemini = False
-- disrupt_seven_sl_with_max_shares_during_load:
-  - disruptive = False
-  - sla = True
 - disrupt_show_toppartitions:
   - disruptive = False
   - kubernetes = True

--- a/data_dir/nemesis_classes.yml
+++ b/data_dir/nemesis_classes.yml
@@ -1,6 +1,7 @@
 - AbortRepairMonkey
 - AddDropColumnMonkey
 - AddRemoveDcNemesis
+- AddRemoveMvNemesis
 - AddRemoveRackNemesis
 - BlockNetworkMonkey
 - CDCStressorMonkey
@@ -10,7 +11,6 @@
 - CorruptThenRepairMonkey
 - CorruptThenScrubMonkey
 - CreateIndexNemesis
-- AddRemoveMvNemesis
 - DecommissionMonkey
 - DecommissionSeedNode
 - DecommissionStreamingErrMonkey
@@ -54,9 +54,9 @@
 - SlaDecreaseSharesDuringLoad
 - SlaIncreaseSharesByAttachAnotherSlDuringLoad
 - SlaIncreaseSharesDuringLoad
+- SlaMaximumAllowedSlsWithMaxSharesDuringLoad
 - SlaReplaceUsingDetachDuringLoad
 - SlaReplaceUsingDropDuringLoad
-- SlaSevenSlWithMaxSharesDuringLoad
 - SnapshotOperations
 - SoftRebootNodeMonkey
 - SslHotReloadingNemesis

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5325,6 +5325,7 @@ class RandomInterruptionNetworkMonkey(Nemesis):
     disruptive = True
     networking = True
     run_with_gemini = False
+    kubernetes = True
 
     def disrupt(self):
         self.disrupt_network_random_interruptions()
@@ -5334,6 +5335,7 @@ class BlockNetworkMonkey(Nemesis):
     disruptive = True
     networking = True
     run_with_gemini = False
+    kubernetes = True
 
     def disrupt(self):
         self.disrupt_network_block()


### PR DESCRIPTION
Recently we added support of 2 NetworkInterruptions nemesis in kubernetes, but we didn't enebled them in `kubernetes` nemesis filter.

This commit adds 2 network interruption nemesis to `kubernetes` filter.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
