### PR TITLE
improvement(individual nemesis): Remove compaction strategy from test yaml

### DIFF
--- a/test-cases/nemesis/longevity-5gb-1h-AbortRepairMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-AbortRepairMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-AddDropColumnMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-AddDropColumnMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-AddRemoveDcNemesis.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-AddRemoveDcNemesis.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-AddRemoveRackNemesis.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-AddRemoveRackNemesis.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-BlockNetworkMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-BlockNetworkMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-CDCStressorMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-CDCStressorMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-ClusterRollingRestart.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ClusterRollingRestart.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-ClusterRollingRestartRandomOrder.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ClusterRollingRestartRandomOrder.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-CorruptThenRebuildMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-CorruptThenRebuildMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-CorruptThenRepairMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-CorruptThenRepairMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-CorruptThenScrubMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-CorruptThenScrubMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-DecommissionMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DecommissionMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-DecommissionSeedNode.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DecommissionSeedNode.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-DecommissionStreamingErrMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DecommissionStreamingErrMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-DeleteByPartitionsMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DeleteByPartitionsMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-DeleteByRowsRangeMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DeleteByRowsRangeMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-DeleteOverlappingRowRangesMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DeleteOverlappingRowRangesMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-DrainKubernetesNodeThenDecommissionAndAddScyllaNode.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DrainKubernetesNodeThenDecommissionAndAddScyllaNode.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-DrainKubernetesNodeThenReplaceScyllaNode.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DrainKubernetesNodeThenReplaceScyllaNode.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-DrainerMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DrainerMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-EnospcAllNodesMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-EnospcAllNodesMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-EnospcMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-EnospcMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-GrowShrinkClusterNemesis.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-GrowShrinkClusterNemesis.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-HardRebootNodeMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-HardRebootNodeMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-LoadAndStreamMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-LoadAndStreamMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-MajorCompactionMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-MajorCompactionMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-MemoryStressMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-MemoryStressMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-MgmtBackup.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-MgmtBackup.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-MgmtBackupSpecificKeyspaces.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-MgmtBackupSpecificKeyspaces.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-MgmtRepair.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-MgmtRepair.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-ModifyTableMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ModifyTableMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-MultipleHardRebootNodeMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-MultipleHardRebootNodeMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-NemesisSequence.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-NemesisSequence.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-NoCorruptRepairMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-NoCorruptRepairMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-NodeRestartWithResharding.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-NodeRestartWithResharding.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-NodeTerminateAndReplace.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-NodeTerminateAndReplace.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-NodeToolCleanupMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-NodeToolCleanupMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-OperatorNodeReplace.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-OperatorNodeReplace.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-OperatorNodetoolFlushAndReshard.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-OperatorNodetoolFlushAndReshard.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-PauseLdapNemesis.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-PauseLdapNemesis.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-RandomInterruptionNetworkMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RandomInterruptionNetworkMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-RebuildStreamingErrMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RebuildStreamingErrMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-RefreshBigMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RefreshBigMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-RefreshMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RefreshMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-RejectNodeExporterNetworkMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RejectNodeExporterNetworkMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-RejectThriftNetworkMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RejectThriftNetworkMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-RemoveServiceLevelMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RemoveServiceLevelMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-RepairStreamingErrMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RepairStreamingErrMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-ResetLocalSchemaMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ResetLocalSchemaMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-RollingRestartConfigChangeInternodeCompression.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RollingRestartConfigChangeInternodeCompression.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-ScyllaKillMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ScyllaKillMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-SlaDecreaseSharesDuringLoad.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-SlaDecreaseSharesDuringLoad.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-SlaIncreaseSharesByAttachAnotherSlDuringLoad.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-SlaIncreaseSharesByAttachAnotherSlDuringLoad.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-SlaIncreaseSharesDuringLoad.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-SlaIncreaseSharesDuringLoad.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-SlaReplaceUsingDetachDuringLoad.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-SlaReplaceUsingDetachDuringLoad.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-SlaReplaceUsingDropDuringLoad.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-SlaReplaceUsingDropDuringLoad.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-SlaSevenSlWithMaxSharesDuringLoad.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-SlaSevenSlWithMaxSharesDuringLoad.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-SnapshotOperations.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-SnapshotOperations.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-SoftRebootNodeMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-SoftRebootNodeMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-SslHotReloadingNemesis.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-SslHotReloadingNemesis.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-StartStopCleanupCompaction.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-StartStopCleanupCompaction.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-StartStopMajorCompaction.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-StartStopMajorCompaction.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-StartStopScrubCompaction.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-StartStopScrubCompaction.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-StartStopValidationCompaction.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-StartStopValidationCompaction.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-StopStartInterfacesNetworkMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-StopStartInterfacesNetworkMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-StopStartMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-StopStartMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-StopWaitStartMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-StopWaitStartMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-SwitchBetweenPasswordAuthAndSaslauthdAuth.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-SwitchBetweenPasswordAuthAndSaslauthdAuth.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-TerminateAndRemoveNodeMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-TerminateAndRemoveNodeMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-TerminateKubernetesHostThenDecommissionAndAddScyllaNode.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-TerminateKubernetesHostThenDecommissionAndAddScyllaNode.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-TerminateKubernetesHostThenReplaceScyllaNode.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-TerminateKubernetesHostThenReplaceScyllaNode.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-ToggleCDCMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ToggleCDCMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-ToggleGcModeMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ToggleGcModeMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-ToggleLdapConfiguration.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ToggleLdapConfiguration.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-ToggleTableIcsMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ToggleTableIcsMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-TopPartitions.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-TopPartitions.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-TruncateLargeParititionMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-TruncateLargeParititionMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-TruncateMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-TruncateMonkey.yaml
@@ -1,9 +1,9 @@
 test_duration: 90
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
              ]
 
 n_db_nodes: 3


### PR DESCRIPTION

Removing the explicit setting of compaction strategy in the individual nemesis test yamls in order to test other compaction strategies like ICS which is the default in enterprise releases.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
