### PR TITLE
fix(microbenchmarking): pass es index as cli parameter

### DIFF
--- a/unit_tests/test_microbenchmarking.py
+++ b/unit_tests/test_microbenchmarking.py
@@ -65,10 +65,12 @@ class MicroBenchmarkingResultsAnalyzerMock(MicroBenchmarkingResultsAnalyzer):
 
 class TestMBM(unittest.TestCase):  # pylint: disable=too-many-public-methods
     def setUp(self):
-        self.mbra = MicroBenchmarkingResultsAnalyzerMock(email_recipients=('alex.bykov@scylladb.com', ))
+        self.mbra = MicroBenchmarkingResultsAnalyzerMock(email_recipients=(
+            'alex.bykov@scylladb.com', ), es_index="microbenchmarking")
         self.mbra.hostname = 'godzilla.cloudius-systems.com'
         self.cwd = os.path.join(os.path.dirname(__file__), '..', 'sdcm')
         self.mbra.test_run_date = "2019-06-27_11:39:40"
+        self.es_index = "microbenchmarking"
 
     @staticmethod
     def get_result_obj(path):
@@ -271,7 +273,8 @@ class TestMBM(unittest.TestCase):  # pylint: disable=too-many-public-methods
                                '--results-path', result_path,
                                '--email-recipients', 'alex.bykov@scylladb.com',
                                '--report-path', html_report,
-                               '--hostname', self.mbra.hostname],
+                               '--hostname', self.mbra.hostname,
+                               "--es-index", self.es_index],
                               cwd=self.cwd,
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE) as ps:


### PR DESCRIPTION
After changing es index for microbenchmarking test resutls, unit tests start failing. Unit test try to get response from file and if not it try to get data from ES. But after changing ES index return results are empty.

Add new cli parameter for microbenchmarking to pass ES index name to work with.

unit tests are passed

Fixes: #6144

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
