### PR TITLE
fix(nemesis.py): Remove the 120% allocation from disrupt_memory_stress

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3834,9 +3834,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.target_node.remoter.sudo('snap install stress-ng')
         else:
             raise UnsupportedNemesis(f"{self.target_node.distro} OS not supported!")
-        self.log.info('Try to allocate 120% available memory, the allocated memory will be swaped out')
-        self.target_node.remoter.run(
-            "stress-ng --vm-bytes $(awk '/MemAvailable/{printf \"%d\\n\", $2 * 1.2;}' < /proc/meminfo)k --vm-keep -m 1 -t 100")
 
         self.log.info('Try to allocate 90% total memory, the allocated memory will be swaped out')
         self.target_node.remoter.run(


### PR DESCRIPTION
	The 120% allocation causes various failures.
	Better to keep the 90% allocation test only.
	Fixes:  #6143
Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/6143
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
