### PR TITLE
fix(cluster.py): make stop of threads do less redundant sleeps

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1100,13 +1100,13 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     @log_run_info
     def wait_till_tasks_threads_are_stopped(self, timeout: float = 120):
         await_bucket = []
-        if self._spot_monitoring_thread:
+        if self._spot_monitoring_thread and self._spot_monitoring_thread.is_alive():
             await_bucket.append(self._spot_monitoring_thread)
-        if self._db_log_reader_thread:
+        if self._db_log_reader_thread and self._db_log_reader_thread.is_alive():
             await_bucket.append(self._db_log_reader_thread)
-        if self._alert_manager:
+        if self._alert_manager and self._alert_manager.is_alive():
             await_bucket.append(self._alert_manager)
-        if self._decoding_backtraces_thread:
+        if self._decoding_backtraces_thread and self._decoding_backtraces_thread.is_alive():
             await_bucket.append(self._decoding_backtraces_thread)
         end_time = time.perf_counter() + timeout
         while await_bucket and end_time > time.perf_counter():


### PR DESCRIPTION
In the `wait_till_tasks_threads_are_stopped` method we check bunch of threads existence but do not check it's `is_alive` status. It leads to the redundant sleeps for each of the DB nodes.

So, check the `is_alive` status first before going to the cycle of checks and sleeps.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
