### PR TITLE
fix(k8s-local): do not run docker images cache in 'reuse setup' cases

### DIFF
--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -388,6 +388,8 @@ class MinimalClusterBase(KubernetesCluster, metaclass=abc.ABCMeta):  # pylint: d
             self.stop_k8s_software()
             self.start_k8s_software()
         self.create_kubectl_config()
+        if self.test_config.REUSE_CLUSTER:
+            return
         self.on_deploy_completed()
 
 


### PR DESCRIPTION
In local K8S setups we have the step where we load docker images once and then push it into the K8S nodes which are running as docker containers.

But the problem with it is that we run it even when we reuse an existing setup.
At first, it is totally redundant action.
At second, it takes significant time.

So, cache docker images only on newly created setups.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
