### PR TITLE
fix(sct_config): do not check AZ num for K8S

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2058,6 +2058,8 @@ class SCTConfiguration(dict):
             "Nemesis cannot run when 'nemesis_filter_seeds' is true and seeds number is equal to nodes number"
 
     def _validate_number_of_db_nodes_divides_by_az_number(self):
+        if self.get("cluster_backend").startswith("k8s"):
+            return
         az_count = len(self.get('availability_zone').split(',')) if self.get('availability_zone') else 1
         for nodes_num in [int(i) for i in str(self.get('n_db_nodes')).split(' ')]:
             assert nodes_num % az_count == 0, \

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -802,6 +802,20 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
         self.assertIn("should be divisible by number of availability zones", str(context.exception))
 
+    def test_29_number_of_nodes_per_az_may_not_be_divisable_by_number_of_az_on_k8s(self):
+        os.environ['SCT_N_DB_NODES'] = '3'
+        os.environ['SCT_REGION_NAME'] = 'eu-north-1'
+        os.environ['SCT_AVAILABILITY_ZONE'] = 'b,c'
+        os.environ['SCT_CLUSTER_BACKEND'] = 'k8s-eks'
+        os.environ['SCT_SCYLLA_VERSION'] = "5.2.0"
+        os.environ['SCT_K8S_SCYLLA_OPERATOR_HELM_REPO'] = (
+            'https://storage.googleapis.com/scylla-operator-charts/latest')
+        os.environ['SCT_K8S_SCYLLA_OPERATOR_CHART_VERSION'] = 'latest'
+        conf = sct_config.SCTConfiguration()
+        conf.verify_configuration()
+        self.assertEqual(conf.get('n_db_nodes'), 3)
+        self.assertEqual(conf.get('availability_zone'), 'b,c')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Recently was added check for the numbers of AZs and DB nodes (https://github.com/scylladb/scylla-cluster-tests/pull/6055). 
The K8S backends are different and specifically EKS one requires at least 2 AZs to be configured.
Only the first AZ will be used for node provisioning. 
So, knowing that, skip the AZ num check on K8S backends.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
