### PR TITLE
fix(add_remove_dc): wait for rebuild

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1567,8 +1567,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                                                                                         test_data=test_data)
             for sstables_info, load_on_node in map_files_to_node:
                 SstableLoadUtils.upload_sstables(load_on_node, test_data=sstables_info, table_name="standard1")
-                start_log_follower, done_log_follower = SstableLoadUtils.run_load_and_stream(load_on_node)
-                SstableLoadUtils.validate_load_and_stream_status(load_on_node, start_log_follower, done_log_follower)
+                SstableLoadUtils.run_load_and_stream(load_on_node)
 
     # pylint: disable=too-many-statements
     def disrupt_nodetool_refresh(self, big_sstable: bool = False):

--- a/unit_tests/test_wait.py
+++ b/unit_tests/test_wait.py
@@ -1,8 +1,27 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2023 ScyllaDB
+# pylint: disable=all
+
 from __future__ import absolute_import
 import logging
+import threading
+import time
 import unittest
 
-from sdcm.wait import wait_for
+import pytest
+
+from sdcm.cluster import BaseNode
+from sdcm.wait import wait_for, wait_for_log_lines
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -59,3 +78,78 @@ class TestSdcmWait(unittest.TestCase):
 
         self.assertEqual(wait_for(callback, timeout=2, step=0.5, arg1=1, arg2=3, throw_exc=False), 'what ever')
         self.assertEqual(len(calls), 1)
+
+
+class DummyNode(BaseNode):
+    name = "node_1"
+    system_log = ""
+
+    def __init__(self, log_path):
+        self.system_log = log_path
+
+
+def write_to_file(filename, lines):
+    for line in lines:
+        with open(filename, 'a') as f:
+            f.write(f"{line}\n")
+        time.sleep(0.01)
+
+
+class TestWaitForLogLines:
+
+    def test_can_wait_for_log_start_line_and_end_line(self, tmp_path):
+        file_path = tmp_path/"wait_for_log_lines_1.log"
+        node = DummyNode(log_path=file_path)
+        lines = [" [shard  0] repair - rebuild_with_repair: started with keyspaces=drop_table_during_repair",
+                 "some line in between",
+                 "[shard  0] repair - rebuild_with_repair: finished with keyspaces=drop_table_during_repair"]
+        write_thread = threading.Thread(target=write_to_file, args=(file_path, lines))
+        write_thread.daemon = True
+        file_path.touch()
+        with wait_for_log_lines(node=node, start_line_patterns=["rebuild.*started with keyspaces="],
+                                end_line_patterns=["rebuild.*finished with keyspaces="],
+                                start_timeout=3, end_timeout=5):
+            write_thread.start()
+
+    def test_wait_for_log_timeout_when_no_start_line(self, tmp_path):
+        file_path = tmp_path / "wait_for_log_lines_1.log"
+        node = DummyNode(log_path=file_path)
+        lines = ["end", "cde", "end"]  # no start line provided
+        t = threading.Thread(target=write_to_file, args=(file_path, lines))
+        t.daemon = True
+        file_path.touch()
+        with pytest.raises(TimeoutError, match="timeout occurred while waiting for start log line"), \
+                wait_for_log_lines(node=node, start_line_patterns=["start"], end_line_patterns=["end"], start_timeout=0.3, end_timeout=1):
+            t.start()
+
+    def test_wait_for_log_timeout_when_no_end_line(self, tmp_path):
+        file_path = tmp_path / "wait_for_log_lines_1.log"
+        node = DummyNode(log_path=file_path)
+        lines = ["start", "cde", "start"]  # no start line provided
+        t = threading.Thread(target=write_to_file, args=(file_path, lines))
+        t.daemon = True
+        file_path.touch()
+        with pytest.raises(TimeoutError, match="timeout occurred while waiting for end log line"), \
+                wait_for_log_lines(node=node, start_line_patterns=["start"], end_line_patterns=["end"], start_timeout=0.1, end_timeout=0.3):
+            t.start()
+
+    def test_wait_for_log_reraises_exception(self, tmp_path):
+        file_path = tmp_path / "wait_for_log_lines_1.log"
+        node = DummyNode(log_path=file_path)
+        lines = ["start", "cde", "end"]  # no start line provided
+        t = threading.Thread(target=write_to_file, args=(file_path, lines))
+        t.daemon = True
+        file_path.touch()
+        with pytest.raises(ValueError, match="dummy error"), \
+                wait_for_log_lines(node=node, start_line_patterns=["start"], end_line_patterns=["end"], start_timeout=0.1, end_timeout=0.3):
+            t.start()
+            raise ValueError('dummy error')
+
+    def test_wait_for_log_reraises_exception_and_timeout_error(self, tmp_path):
+        file_path = tmp_path / "wait_for_log_lines_1.log"
+        node = DummyNode(log_path=file_path)
+        file_path.touch()
+        with pytest.raises(TimeoutError, match="timeout occurred while waiting for start log line") as exc_info, \
+                wait_for_log_lines(node=node, start_line_patterns=["start"], end_line_patterns=["end"], start_timeout=0.1, end_timeout=0.3):
+            raise ValueError('dummy error')
+        assert "ValueError" in str(exc_info.getrepr())


### PR DESCRIPTION
There are situations where ssh connection is dropped while rebuild. This leads to start decommission while rebuild is in progress (e.g. in `add_remove_dc`) - failing decommission and leaving dangling db node.

Workaround ssh issue by explicitly waiting for rebuild to finish, so decommission can be triggered.

To achieve that, new context manager `wait_for_log_lines` was created, where provided db node and regex patterns to wait for (start regex and end pattern can be provided separately). See unit tests for examples.

refs: scylladb/scylladb#14004

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
