### PR TITLE
Revert networktopologyreplication for system auth

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -24,6 +24,7 @@ db_nodes_shards_selection: 'default'
 scylla_linux_distro: 'ubuntu-focal'
 scylla_linux_distro_loader: 'centos'
 ssh_transport: 'libssh2'
+system_auth_rf: 3
 
 monitor_branch: 'branch-4.3'
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -88,6 +88,7 @@
 | **<a href="#user-content-authenticator_user" name="authenticator_user">authenticator_user</a>**  | the username if PasswordAuthenticator is used | N/A | SCT_AUTHENTICATOR_USER
 | **<a href="#user-content-authenticator_password" name="authenticator_password">authenticator_password</a>**  | the password if PasswordAuthenticator is used | N/A | SCT_AUTHENTICATOR_PASSWORD
 | **<a href="#user-content-authorizer" name="authorizer">authorizer</a>**  | which authorizer scylla will use AllowAllAuthorizer/CassandraAuthorizer | N/A | SCT_AUTHORIZER
+| **<a href="#user-content-system_auth_rf" name="system_auth_rf">system_auth_rf</a>**  | Replication factor will be set to system_auth | 3 | SCT_SYSTEM_AUTH_RF
 | **<a href="#user-content-service_level_shares" name="service_level_shares">service_level_shares</a>**  | List if service level shares - how many server levels to create and test. Uses in SLA test.list of int, like: [100, 200] | [1000] | SCT_SERVICE_LEVEL_SHARES
 | **<a href="#user-content-alternator_port" name="alternator_port">alternator_port</a>**  | Port to configure for alternator in scylla.yaml | N/A | SCT_ALTERNATOR_PORT
 | **<a href="#user-content-dynamodb_primarykey_type" name="dynamodb_primarykey_type">dynamodb_primarykey_type</a>**  | Type of dynamodb table to create with range key or not, can be:<br>HASH,HASH_AND_RANGE | HASH | SCT_DYNAMODB_PRIMARYKEY_TYPE

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -494,6 +494,9 @@ class SCTConfiguration(dict):
         dict(name="sla", env="SCT_SLA", type=boolean,
              help="run SLA nemeses if the test is SLA only"),
 
+        dict(name="system_auth_rf", env="SCT_SYSTEM_AUTH_RF", type=int,
+             help="Replication factor will be set to system_auth"),
+
         dict(name="service_level_shares", env="SCT_SERVICE_LEVEL_SHARES", type=list,
              help="List if service level shares - how many server levels to create and test. Uses in SLA test."
                   "list of int, like: [100, 200]"),

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -123,7 +123,6 @@ from sdcm.keystore import KeyStore
 from sdcm.utils.latency import calculate_latency, analyze_hdr_percentiles
 from sdcm.utils.csrangehistogram import CSHistogramTagTypes, CSWorkloadTypes, make_cs_range_histogram_summary, \
     make_cs_range_histogram_summary_by_interval
-from sdcm.utils.replication_strategy_utils import NetworkTopologyReplicationStrategy
 from sdcm.utils.raft.common import validate_raft_on_nodes
 
 
@@ -867,21 +866,19 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             # TODO: move this skip to siren-tools when possible
             self.log.warning("Skipping this function due this job run from Siren cloud!")
             return
-        node = self.db_cluster.nodes[0]
-        nodes_by_region = self.db_cluster.nodes_by_region()
-        datacenters = {}
-        for region in nodes_by_region:
-            dc_name = self.db_cluster.get_nodetool_info(nodes_by_region[region][0])['Data Center']
-            datacenters.update({dc_name: len(nodes_by_region[region])})
-        self.log.debug("Number of nodes by datacenter %s", datacenters)
-        NetworkTopologyReplicationStrategy(**datacenters).apply(node, "system_auth")
-        res = node.run_cqlsh('DESC KEYSPACE system_auth',
-                             num_retry_on_failure=3)
-        self.log.debug("system_auth description: %s", res.stdout)
-        self.log.info('repair system_auth keyspace ...')
-        for node in self.db_cluster.nodes:
-            node.run_nodetool(sub_cmd="repair system_auth")
-        self.log.info('repair system_auth keyspace done')
+        # change RF of system_auth
+        system_auth_rf = self.params.get('system_auth_rf')
+        if system_auth_rf > 1 and not self.test_config.REUSE_CLUSTER:
+            self.log.info('change RF of system_auth to %s', system_auth_rf)
+            node = db_cluster.nodes[0]
+            credentials = db_cluster.get_db_auth()
+            username, password = credentials if credentials else (None, None)
+            with db_cluster.cql_connection_patient(node, user=username, password=password) as session:
+                session.execute("ALTER KEYSPACE system_auth WITH replication = "
+                                "{'class': 'org.apache.cassandra.locator.SimpleStrategy', "
+                                "'replication_factor': %s};" % system_auth_rf)
+            self.log.info('repair system_auth keyspace ...')
+            node.run_nodetool(sub_cmd="repair", args="-- system_auth")
 
     @cache
     def pre_create_alternator_tables(self):

--- a/test-cases/PR-provision-test-docker.yaml
+++ b/test-cases/PR-provision-test-docker.yaml
@@ -17,4 +17,5 @@ user_prefix: 'PR-provision-docker'
 
 use_mgmt: false
 
+system_auth_rf: 0
 monitor_swap_size: 0

--- a/test-cases/PR-provision-test.yaml
+++ b/test-cases/PR-provision-test.yaml
@@ -12,6 +12,7 @@ n_loaders: 1
 instance_type_db: 'i3.large'
 n_monitor_nodes: 1
 n_db_nodes: 3
+system_auth_rf: 0
 
 nemesis_class_name: NonDisruptiveMonkey
 nemesis_interval: 1

--- a/test-cases/artifacts/amazon2.yaml
+++ b/test-cases/artifacts/amazon2.yaml
@@ -14,6 +14,7 @@ nemesis_class_name: 'NoOpMonkey'
 region_name: 'eu-west-1'
 scylla_linux_distro: 'centos'
 scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
+system_auth_rf: 1
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-amazon2'

--- a/test-cases/artifacts/ami.yaml
+++ b/test-cases/artifacts/ami.yaml
@@ -14,4 +14,5 @@ region_name: 'us-east-1'
 scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-ami'
+system_auth_rf: 1
 aws_fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/azure-image.yaml
+++ b/test-cases/artifacts/azure-image.yaml
@@ -16,6 +16,7 @@ n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 test_duration: 60
 user_prefix: 'artifacts-azure-image'
+system_auth_rf: 1
 
 # since running from runner in AWS, we need the address to be publicly available
 intra_node_comm_public: true

--- a/test-cases/artifacts/centos7.yaml
+++ b/test-cases/artifacts/centos7.yaml
@@ -16,3 +16,4 @@ scylla_linux_distro: 'centos'
 scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 user_prefix: 'artifacts-centos7'
+system_auth_rf: 1

--- a/test-cases/artifacts/centos8-selinux.yaml
+++ b/test-cases/artifacts/centos8-selinux.yaml
@@ -16,4 +16,5 @@ scylla_linux_distro: 'centos'
 scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 user_prefix: 'artifacts-centos8-selinux'
+system_auth_rf: 1
 append_scylla_setup_args: '--no-selinux-setup'

--- a/test-cases/artifacts/centos8.yaml
+++ b/test-cases/artifacts/centos8.yaml
@@ -16,3 +16,4 @@ scylla_linux_distro: 'centos'
 scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 user_prefix: 'artifacts-centos8'
+system_auth_rf: 1

--- a/test-cases/artifacts/debian10.yaml
+++ b/test-cases/artifacts/debian10.yaml
@@ -20,3 +20,4 @@ scylla_apt_keys:
   - 'D0A112E067426AB2'  # ScyllaDB Package Signing Key 2022 <security@scylladb.com>
 test_duration: 60
 user_prefix: 'artifacts-debian10'
+system_auth_rf: 1

--- a/test-cases/artifacts/debian11.yaml
+++ b/test-cases/artifacts/debian11.yaml
@@ -20,3 +20,4 @@ scylla_apt_keys:
   - 'D0A112E067426AB2'  # ScyllaDB Package Signing Key 2022 <security@scylladb.com>
 test_duration: 60
 user_prefix: 'artifacts-debian11'
+system_auth_rf: 1

--- a/test-cases/artifacts/docker.yaml
+++ b/test-cases/artifacts/docker.yaml
@@ -9,3 +9,4 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'ubuntu'
 test_duration: 60
 user_prefix: 'artifacts-docker'
+system_auth_rf: 1

--- a/test-cases/artifacts/gce-image-persistent-disk.yaml
+++ b/test-cases/artifacts/gce-image-persistent-disk.yaml
@@ -16,3 +16,4 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-gce-image-pd'
+system_auth_rf: 1

--- a/test-cases/artifacts/gce-image.yaml
+++ b/test-cases/artifacts/gce-image.yaml
@@ -16,3 +16,4 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-gce-image'
+system_auth_rf: 1

--- a/test-cases/artifacts/oel76.yaml
+++ b/test-cases/artifacts/oel76.yaml
@@ -17,4 +17,5 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-oel76'
+system_auth_rf: 1
 aws_fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/oel81.yaml
+++ b/test-cases/artifacts/oel81.yaml
@@ -17,4 +17,5 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-oel81'
+system_auth_rf: 1
 aws_fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/rhel7.yaml
+++ b/test-cases/artifacts/rhel7.yaml
@@ -16,3 +16,4 @@ scylla_linux_distro: 'centos'
 scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 user_prefix: 'artifacts-rhel7'
+system_auth_rf: 1

--- a/test-cases/artifacts/rhel8.yaml
+++ b/test-cases/artifacts/rhel8.yaml
@@ -16,3 +16,4 @@ scylla_linux_distro: 'centos'
 scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 user_prefix: 'artifacts-rhel8'
+system_auth_rf: 1

--- a/test-cases/artifacts/rocky8.yaml
+++ b/test-cases/artifacts/rocky8.yaml
@@ -16,3 +16,4 @@ scylla_linux_distro: 'centos'
 scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 user_prefix: 'artifacts-rocky8'
+system_auth_rf: 1

--- a/test-cases/artifacts/rocky9.yaml
+++ b/test-cases/artifacts/rocky9.yaml
@@ -15,5 +15,6 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-rocky9'
+system_auth_rf: 1
 
 user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/test-cases/artifacts/ubuntu2004.yaml
+++ b/test-cases/artifacts/ubuntu2004.yaml
@@ -20,3 +20,4 @@ scylla_apt_keys:
   - 'D0A112E067426AB2'  # ScyllaDB Package Signing Key 2022 <security@scylladb.com>
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2004'
+system_auth_rf: 1

--- a/test-cases/artifacts/ubuntu2204.yaml
+++ b/test-cases/artifacts/ubuntu2204.yaml
@@ -15,3 +15,4 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'ubuntu-jammy'
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2204'
+system_auth_rf: 1

--- a/test-cases/load/admission_control_overload_test.yaml
+++ b/test-cases/load/admission_control_overload_test.yaml
@@ -11,3 +11,4 @@ instance_type_db: 'i3.large'
 instance_type_loader: 'c5.4xlarge'
 instance_type_monitor: 't3.small'
 user_prefix: 'overload_admission_control'
+system_auth_rf: 1

--- a/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.yaml
@@ -12,6 +12,7 @@ n_loaders: 1
 instance_type_db: 'i3.large'
 n_monitor_nodes: 1
 n_db_nodes: 3
+system_auth_rf: 0
 
 nemesis_class_name: NonDisruptiveMonkey
 nemesis_interval: 1

--- a/unit_tests/test_data/test_scylla_yaml_builders/artifact_amazon2.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/artifact_amazon2.yaml
@@ -14,6 +14,7 @@ nemesis_class_name: 'NoOpMonkey'
 region_name: 'eu-west-1'
 scylla_linux_distro: 'centos'
 scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
+system_auth_rf: 1
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-amazon2'


### PR DESCRIPTION
We found these commits to cause problems in various tests. E.g. errors:

`<stdin>:1:OperationTimedOut: errors={'Connection defunct by heartbeat': 'Client request timeout. See Session.execute[_async](timeout)'}, last_host=[40.76.197.20:9042](http://40.76.197.20:9042/)`
and for nonroot installs cant find cqlsh

Reverting it so we can proceed with tests and fix it later.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
