### PR TITLE
fix(replication_strategy): use python driver for cql command

### DIFF
--- a/sdcm/utils/replication_strategy_utils.py
+++ b/sdcm/utils/replication_strategy_utils.py
@@ -26,7 +26,8 @@ class ReplicationStrategy:  # pylint: disable=too-few-public-methods
 
     def apply(self, node: BaseNode, keyspace: str):
         cql = f"ALTER KEYSPACE {keyspace} WITH replication = {self}"
-        node.run_cqlsh(cql)
+        with node.parent_cluster.cql_connection_patient(node) as session:
+            session.execute(cql)
 
 
 class SimpleReplicationStrategy(ReplicationStrategy):

--- a/unit_tests/test_replication_strategy_utils.py
+++ b/unit_tests/test_replication_strategy_utils.py
@@ -34,10 +34,29 @@ class TestReplicationStrategies:
         assert str(strategy) == "{'class': 'NetworkTopologyStrategy', 'DC1': 2, 'DC2': 8}"
 
 
+class Cluster:  # pylint: disable=unused-argument,too-few-public-methods
+    class Session:
+        @staticmethod
+        def execute(cql):
+            if 'some error' in cql:
+                raise AttributeError("found some error")
+            print(cql)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    @staticmethod
+    def cql_connection_patient(node):
+        return Cluster.Session()
+
+
 class Node():  # pylint: disable=too-few-public-methods
 
     def __init__(self):
-        pass
+        self.parent_cluster = Cluster()
 
     def run_cqlsh(self, cql):  # pylint: disable=no-self-use
         if 'some error' in cql:


### PR DESCRIPTION
Non-root artifacts tests doesn't have cqlsh and failed to apply Alter table query. Also  cqlsh could failed by timeout.

Switch to use python driver for executing queries

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
