### PR TITLE
Change auth rf with fix

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -24,7 +24,6 @@ db_nodes_shards_selection: 'default'
 scylla_linux_distro: 'ubuntu-focal'
 scylla_linux_distro_loader: 'centos'
 ssh_transport: 'libssh2'
-system_auth_rf: 3
 
 monitor_branch: 'branch-4.3'
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -88,7 +88,6 @@
 | **<a href="#user-content-authenticator_user" name="authenticator_user">authenticator_user</a>**  | the username if PasswordAuthenticator is used | N/A | SCT_AUTHENTICATOR_USER
 | **<a href="#user-content-authenticator_password" name="authenticator_password">authenticator_password</a>**  | the password if PasswordAuthenticator is used | N/A | SCT_AUTHENTICATOR_PASSWORD
 | **<a href="#user-content-authorizer" name="authorizer">authorizer</a>**  | which authorizer scylla will use AllowAllAuthorizer/CassandraAuthorizer | N/A | SCT_AUTHORIZER
-| **<a href="#user-content-system_auth_rf" name="system_auth_rf">system_auth_rf</a>**  | Replication factor will be set to system_auth | 3 | SCT_SYSTEM_AUTH_RF
 | **<a href="#user-content-service_level_shares" name="service_level_shares">service_level_shares</a>**  | List if service level shares - how many server levels to create and test. Uses in SLA test.list of int, like: [100, 200] | [1000] | SCT_SERVICE_LEVEL_SHARES
 | **<a href="#user-content-alternator_port" name="alternator_port">alternator_port</a>**  | Port to configure for alternator in scylla.yaml | N/A | SCT_ALTERNATOR_PORT
 | **<a href="#user-content-dynamodb_primarykey_type" name="dynamodb_primarykey_type">dynamodb_primarykey_type</a>**  | Type of dynamodb table to create with range key or not, can be:<br>HASH,HASH_AND_RANGE | HASH | SCT_DYNAMODB_PRIMARYKEY_TYPE

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -494,9 +494,6 @@ class SCTConfiguration(dict):
         dict(name="sla", env="SCT_SLA", type=boolean,
              help="run SLA nemeses if the test is SLA only"),
 
-        dict(name="system_auth_rf", env="SCT_SYSTEM_AUTH_RF", type=int,
-             help="Replication factor will be set to system_auth"),
-
         dict(name="service_level_shares", env="SCT_SERVICE_LEVEL_SHARES", type=list,
              help="List if service level shares - how many server levels to create and test. Uses in SLA test."
                   "list of int, like: [100, 200]"),

--- a/test-cases/PR-provision-test-docker.yaml
+++ b/test-cases/PR-provision-test-docker.yaml
@@ -17,5 +17,4 @@ user_prefix: 'PR-provision-docker'
 
 use_mgmt: false
 
-system_auth_rf: 0
 monitor_swap_size: 0

--- a/test-cases/PR-provision-test.yaml
+++ b/test-cases/PR-provision-test.yaml
@@ -12,7 +12,6 @@ n_loaders: 1
 instance_type_db: 'i3.large'
 n_monitor_nodes: 1
 n_db_nodes: 3
-system_auth_rf: 0
 
 nemesis_class_name: NonDisruptiveMonkey
 nemesis_interval: 1

--- a/test-cases/artifacts/amazon2.yaml
+++ b/test-cases/artifacts/amazon2.yaml
@@ -14,7 +14,6 @@ nemesis_class_name: 'NoOpMonkey'
 region_name: 'eu-west-1'
 scylla_linux_distro: 'centos'
 scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
-system_auth_rf: 1
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-amazon2'

--- a/test-cases/artifacts/ami.yaml
+++ b/test-cases/artifacts/ami.yaml
@@ -14,5 +14,4 @@ region_name: 'us-east-1'
 scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-ami'
-system_auth_rf: 1
 aws_fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/azure-image.yaml
+++ b/test-cases/artifacts/azure-image.yaml
@@ -16,7 +16,6 @@ n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 test_duration: 60
 user_prefix: 'artifacts-azure-image'
-system_auth_rf: 1
 
 # since running from runner in AWS, we need the address to be publicly available
 intra_node_comm_public: true

--- a/test-cases/artifacts/centos7.yaml
+++ b/test-cases/artifacts/centos7.yaml
@@ -16,4 +16,3 @@ scylla_linux_distro: 'centos'
 scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 user_prefix: 'artifacts-centos7'
-system_auth_rf: 1

--- a/test-cases/artifacts/centos8-selinux.yaml
+++ b/test-cases/artifacts/centos8-selinux.yaml
@@ -16,5 +16,4 @@ scylla_linux_distro: 'centos'
 scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 user_prefix: 'artifacts-centos8-selinux'
-system_auth_rf: 1
 append_scylla_setup_args: '--no-selinux-setup'

--- a/test-cases/artifacts/centos8.yaml
+++ b/test-cases/artifacts/centos8.yaml
@@ -16,4 +16,3 @@ scylla_linux_distro: 'centos'
 scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 user_prefix: 'artifacts-centos8'
-system_auth_rf: 1

--- a/test-cases/artifacts/debian10.yaml
+++ b/test-cases/artifacts/debian10.yaml
@@ -20,4 +20,3 @@ scylla_apt_keys:
   - 'D0A112E067426AB2'  # ScyllaDB Package Signing Key 2022 <security@scylladb.com>
 test_duration: 60
 user_prefix: 'artifacts-debian10'
-system_auth_rf: 1

--- a/test-cases/artifacts/debian11.yaml
+++ b/test-cases/artifacts/debian11.yaml
@@ -20,4 +20,3 @@ scylla_apt_keys:
   - 'D0A112E067426AB2'  # ScyllaDB Package Signing Key 2022 <security@scylladb.com>
 test_duration: 60
 user_prefix: 'artifacts-debian11'
-system_auth_rf: 1

--- a/test-cases/artifacts/docker.yaml
+++ b/test-cases/artifacts/docker.yaml
@@ -9,4 +9,3 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'ubuntu'
 test_duration: 60
 user_prefix: 'artifacts-docker'
-system_auth_rf: 1

--- a/test-cases/artifacts/gce-image-persistent-disk.yaml
+++ b/test-cases/artifacts/gce-image-persistent-disk.yaml
@@ -16,4 +16,3 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-gce-image-pd'
-system_auth_rf: 1

--- a/test-cases/artifacts/gce-image.yaml
+++ b/test-cases/artifacts/gce-image.yaml
@@ -16,4 +16,3 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-gce-image'
-system_auth_rf: 1

--- a/test-cases/artifacts/oel76.yaml
+++ b/test-cases/artifacts/oel76.yaml
@@ -17,5 +17,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-oel76'
-system_auth_rf: 1
 aws_fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/oel81.yaml
+++ b/test-cases/artifacts/oel81.yaml
@@ -17,5 +17,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-oel81'
-system_auth_rf: 1
 aws_fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/rhel7.yaml
+++ b/test-cases/artifacts/rhel7.yaml
@@ -16,4 +16,3 @@ scylla_linux_distro: 'centos'
 scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 user_prefix: 'artifacts-rhel7'
-system_auth_rf: 1

--- a/test-cases/artifacts/rhel8.yaml
+++ b/test-cases/artifacts/rhel8.yaml
@@ -16,4 +16,3 @@ scylla_linux_distro: 'centos'
 scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 user_prefix: 'artifacts-rhel8'
-system_auth_rf: 1

--- a/test-cases/artifacts/rocky8.yaml
+++ b/test-cases/artifacts/rocky8.yaml
@@ -16,4 +16,3 @@ scylla_linux_distro: 'centos'
 scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 user_prefix: 'artifacts-rocky8'
-system_auth_rf: 1

--- a/test-cases/artifacts/rocky9.yaml
+++ b/test-cases/artifacts/rocky9.yaml
@@ -15,6 +15,5 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-rocky9'
-system_auth_rf: 1
 
 user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/test-cases/artifacts/ubuntu2004.yaml
+++ b/test-cases/artifacts/ubuntu2004.yaml
@@ -20,4 +20,3 @@ scylla_apt_keys:
   - 'D0A112E067426AB2'  # ScyllaDB Package Signing Key 2022 <security@scylladb.com>
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2004'
-system_auth_rf: 1

--- a/test-cases/artifacts/ubuntu2204.yaml
+++ b/test-cases/artifacts/ubuntu2204.yaml
@@ -15,4 +15,3 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'ubuntu-jammy'
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2204'
-system_auth_rf: 1

--- a/test-cases/load/admission_control_overload_test.yaml
+++ b/test-cases/load/admission_control_overload_test.yaml
@@ -11,4 +11,3 @@ instance_type_db: 'i3.large'
 instance_type_loader: 'c5.4xlarge'
 instance_type_monitor: 't3.small'
 user_prefix: 'overload_admission_control'
-system_auth_rf: 1

--- a/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.yaml
@@ -12,7 +12,6 @@ n_loaders: 1
 instance_type_db: 'i3.large'
 n_monitor_nodes: 1
 n_db_nodes: 3
-system_auth_rf: 0
 
 nemesis_class_name: NonDisruptiveMonkey
 nemesis_interval: 1

--- a/unit_tests/test_data/test_scylla_yaml_builders/artifact_amazon2.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/artifact_amazon2.yaml
@@ -14,7 +14,6 @@ nemesis_class_name: 'NoOpMonkey'
 region_name: 'eu-west-1'
 scylla_linux_distro: 'centos'
 scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
-system_auth_rf: 1
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-amazon2'


### PR DESCRIPTION
Replication strategy for system_auth should be set for number of nodes
in cluster and with appropriate Replication Strategy.
See: https://docs.scylladb.com/stable/operating-scylla/security/authentication.html

removed all system_auth_rf from conf files

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
