### PR TITLE
improvement(cleanup): remove redundancy from the 'clean-resources'

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -283,18 +283,19 @@ def clean_resources(ctx, post_behavior, user, test_id, logdir, dry_run, backend)
     else:
         os.environ['SCT_CLUSTER_BACKEND'] = backend
 
+    config = SCTConfiguration()
     if post_behavior:
         click.echo(f"Use {logdir} as a logdir")
-        clean_func = partial(clean_resources_according_post_behavior, config=SCTConfiguration(), logdir=logdir)
+        clean_func = partial(clean_resources_according_post_behavior, config=config, logdir=logdir)
     else:
-        clean_func = clean_cloud_resources
+        clean_func = partial(clean_cloud_resources, config=config)
 
     if dry_run:
         click.echo("Make a dry-run")
 
     for param in params:
         clean_func(param, dry_run=dry_run)
-        click.echo(f"Resources for {param} have cleaned")
+        click.echo(f"Cleanup for the {param} resources has been finished")
 
 
 @cli.command('list-resources', help='list tagged instances in cloud (AWS/GCE/Azure)')

--- a/sdcm/provision/azure/provisioner.py
+++ b/sdcm/provision/azure/provisioner.py
@@ -82,13 +82,18 @@ class AzureProvisioner(Provisioner):  # pylint: disable=too-many-instance-attrib
             return ""
 
     @classmethod
-    def discover_regions(cls, test_id: str = "", azure_service: AzureService = AzureService(), **kwargs) -> List["AzureProvisioner"]:
+    def discover_regions(cls, test_id: str = "", regions: list = None,
+                         azure_service: AzureService = AzureService(), **kwargs) -> List["AzureProvisioner"]:
         # pylint: disable=arguments-differ,unused-argument
         """Discovers provisioners for in each region for given test id.
 
         If test_id is not provided, it discovers all related to SCT provisioners."""
-        all_resource_groups: List[ResourceGroup] = [rg for rg in azure_service.resource.resource_groups.list()
-                                                    if rg.name.startswith("SCT-")]
+
+        all_resource_groups: List[ResourceGroup] = [
+            rg
+            for rg in azure_service.resource.resource_groups.list()
+            if rg.name.startswith("SCT-") and (rg.location in regions if regions else True)
+        ]
         if test_id:
             provisioner_params = [(test_id, rg.location, cls._get_az_from_name(rg), azure_service)
                                   for rg in all_resource_groups if test_id in rg.name]


### PR DESCRIPTION
For the moment each cleanup code does much more API calls than it is really needed.

So, improve the `clean-resources` logic the following ways:
- Run cleanup only on a backend that was used by a test run.
- Use only one GCE project.
- Run K8S cleanup before the VMs one.
- Combine different node types cleanups into one.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
