### PR TITLE
fix(_terminate_node): Filter error abort request upon node termination

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -75,7 +75,7 @@ from sdcm.sct_events import Severity
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.decorators import raise_event_on_failure
 from sdcm.sct_events.filters import DbEventsFilter, EventsSeverityChangerFilter, EventsFilter
-from sdcm.sct_events.group_common_events import (ignore_alternator_client_errors, ignore_no_space_errors,
+from sdcm.sct_events.group_common_events import (ignore_abort_requested_errors, ignore_alternator_client_errors, ignore_no_space_errors,
                                                  ignore_scrub_invalid_errors, ignore_view_error_gate_closed_exception,
                                                  ignore_stream_mutation_fragments_errors,
                                                  ignore_ycsb_connection_refused, decorate_with_context,
@@ -1216,6 +1216,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         return new_node
 
     @decorate_with_context(ignore_ycsb_connection_refused)
+    @decorate_with_context(ignore_abort_requested_errors)
     def _terminate_cluster_node(self, node):
         self.cluster.terminate_node(node)
         self.monitoring_set.reconfigure_scylla_monitoring()


### PR DESCRIPTION
DBErrors `torage_proxy - .* to read from keyspace1.standard1: abort requested` could happen during terminate_and_replace_node. Such error were seen during perf latency with operations. Add filter to ignore such errors

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
