### PR TITLE
fix(images account): ScyllaDB images are moving account

### DIFF
--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -18,11 +18,13 @@ from typing import List, Dict, Literal
 
 import boto3
 from botocore.exceptions import ClientError
+from mypy_boto3_ec2 import EC2ServiceResource
 
 from sdcm.utils.decorators import retrying
 from sdcm.utils.aws_region import AwsRegion
 from sdcm.wait import wait_for
 from sdcm.test_config import TestConfig
+from sdcm.keystore import KeyStore
 
 LOGGER = logging.getLogger(__name__)
 ARM_ARCH_PREFIXES = ('im4', 'is4', 'a1.', 'inf', 'm6', 'c6', 'r6', 'm7', 'c7', 'r7')
@@ -365,3 +367,19 @@ def get_arch_from_instance_type(instance_type: str) -> AwsArchType:
     if any((prefix in instance_type for prefix in ARM_ARCH_PREFIXES)):
         return 'arm64'
     return 'x86_64'
+
+
+def get_scylla_images_ec2_client(region_name: str) -> EC2ServiceResource:
+    session = boto3.Session()
+    sts = session.client("sts")
+    role_info = KeyStore().get_json('aws_images_role.json')
+    response = sts.assume_role(
+        RoleArn=role_info['role_arn'],
+        RoleSessionName=role_info['role_session_name'],
+    )
+
+    new_session = boto3.Session(aws_access_key_id=response['Credentials']['AccessKeyId'],
+                                aws_secret_access_key=response['Credentials']['SecretAccessKey'],
+                                aws_session_token=response['Credentials']['SessionToken'])
+
+    return new_session.resource("ec2", region_name=region_name)

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -70,7 +70,8 @@ from sdcm.provision.azure.provisioner import AzureProvisioner
 from sdcm.sct_events import Severity
 from sdcm.sct_events.system import CpuNotHighEnoughEvent, SoftTimeoutEvent
 from sdcm.utils.argus import ArgusError, get_argus_client, terminate_resource_in_argus
-from sdcm.utils.aws_utils import EksClusterCleanupMixin, AwsArchType
+from sdcm.utils.aws_utils import EksClusterCleanupMixin, AwsArchType, get_scylla_images_ec2_client
+
 from sdcm.utils.ssh_agent import SSHAgent
 from sdcm.utils.decorators import retrying
 from sdcm import wait
@@ -86,7 +87,7 @@ from sdcm.utils.context_managers import environment
 LOGGER = logging.getLogger('utils')
 DEFAULT_AWS_REGION = "eu-west-1"
 DOCKER_CGROUP_RE = re.compile("/docker/([0-9a-f]+)")
-SCYLLA_AMI_OWNER_ID = "797456418907"
+SCYLLA_AMI_OWNER_ID_LIST = ["797456418907", "158855661827"]
 SCYLLA_GCE_IMAGES_PROJECT = "scylla-images"
 
 
@@ -1498,14 +1499,19 @@ def get_scylla_ami_versions(region_name: str, arch: AwsArchType = 'x86_64', vers
         return _SCYLLA_AMI_CACHE[region_name]
 
     ec2_resource: EC2ServiceResource = boto3.resource('ec2', region_name=region_name)
-    _SCYLLA_AMI_CACHE[region_name] = sorted(
-        ec2_resource.images.filter(
-            Owners=[SCYLLA_AMI_OWNER_ID, ],
+    images = []
+    for client, owner in zip((ec2_resource, get_scylla_images_ec2_client(region_name=region_name)),
+                             SCYLLA_AMI_OWNER_ID_LIST):
+        images += client.images.filter(
+            Owners=[owner],
             Filters=[
                 {'Name': 'name', 'Values': [name_filter]},
                 {'Name': 'architecture', 'Values': [arch]},
             ],
-        ),
+        )
+
+    _SCYLLA_AMI_CACHE[region_name] = sorted(
+        images,
         key=lambda x: x.creation_date,
         reverse=True,
     )
@@ -1856,13 +1862,20 @@ def get_branched_ami(scylla_version: str, region_name: str, arch: AwsArchType = 
 
     LOGGER.info("Looking for AMIs match [%s]", scylla_version)
     ec2_resource: EC2ServiceResource = boto3.resource("ec2", region_name=region_name)
-    if build_id not in ("latest", "all",):
-        images = [
-            ec2_resource.images.filter(Filters=filters + [{'Name': 'tag:build-id', 'Values': [build_id, ], }]),
-            ec2_resource.images.filter(Filters=filters + [{'Name': 'tag:build_id', 'Values': [build_id, ], }]),
-        ]
-    else:
-        images = [ec2_resource.images.filter(Filters=filters), ]
+    images = []
+
+    for client, owner in zip((ec2_resource, get_scylla_images_ec2_client(region_name=region_name)),
+                             SCYLLA_AMI_OWNER_ID_LIST):
+        if build_id not in ("latest", "all",):
+            images += [
+                client.images.filter(Owners=[owner],
+                                     Filters=filters + [{'Name': 'tag:build-id', 'Values': [build_id, ], }]),
+                client.images.filter(Owners=[owner],
+                                     Filters=filters + [{'Name': 'tag:build_id', 'Values': [build_id, ], }]),
+            ]
+        else:
+            images += [client.images.filter(Owners=[owner], Filters=filters), ]
+
     images = sorted(itertools.chain.from_iterable(images), key=lambda x: x.creation_date, reverse=True)
     images = [image for image in images if not (image.name.startswith('debug-') or '-debug-' in image.name)]
 
@@ -2025,8 +2038,7 @@ def get_branched_gce_images(
 def ami_built_by_scylla(ami_id: str, region_name: str) -> bool:
     ec2_resource = boto3.resource("ec2", region_name=region_name)
     image = ec2_resource.Image(ami_id)
-    image.load()
-    return image.owner_id == SCYLLA_AMI_OWNER_ID
+    return image.owner_id in SCYLLA_AMI_OWNER_ID_LIST
 
 
 @lru_cache()


### PR DESCRIPTION
since for reporting purpose, new ScyllaDB images
created by Releng are going to be created under
Releng's sub-account, other than the main account. For this, SCT needs to add support for it, but as
we still have all images up until now created in the main account, we need to continue to support it.
This fix will allow us to use any, new or old
images, in any branch, so we will always have the
ability to run new and old images.

Fixes: #6163
Refs: scylladb/scylla-pkg#3312

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
