### PR TITLE
Add longevity pipelines to extend GCP coverage

### DIFF
--- a/jenkins-pipelines/longevity-150gb-asymmetric-cluster-12h-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-150gb-asymmetric-cluster-12h-gce.jenkinsfile
@@ -7,5 +7,5 @@ longevityPipeline(
     backend: 'gce',
     region: 'us-east1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml'
+    test_config: '''["test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml", "configurations/db-nodes-shards-random.yaml"]'''
 )

--- a/jenkins-pipelines/longevity-200gb-48h-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-200gb-48h-gce.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'gce',
+    region: 'us-east1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml'
+
+)

--- a/jenkins-pipelines/longevity-5tb-1day-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-5tb-1day-gce.jenkinsfile
@@ -7,5 +7,6 @@ longevityPipeline(
     backend: 'gce',
     region: 'us-east1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml'
+    test_config: 'test-cases/longevity/longevity-5TB-1day.yaml'
+
 )

--- a/jenkins-pipelines/longevity-alternator-200gb-48h-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-alternator-200gb-48h-gce.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'gce',
+    region: 'us-east1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/longevity/longevity-alternator-200GB-48h.yaml',
+
+    email_recipients: 'qa@scylladb.com'
+)

--- a/jenkins-pipelines/longevity-alternator-200gb-48h-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-alternator-200gb-48h-gce.jenkinsfile
@@ -8,6 +8,4 @@ longevityPipeline(
     region: 'us-east1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-alternator-200GB-48h.yaml',
-
-    email_recipients: 'qa@scylladb.com'
 )

--- a/jenkins-pipelines/longevity-large-partition-200k-pks-4days-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-200k-pks-4days-gce.jenkinsfile
@@ -6,6 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'gce',
     region: 'us-east1',
-    test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml'
+    test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
+    test_config: 'test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml'
+
 )

--- a/jenkins-pipelines/longevity-large-partition-8h-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-8h-gce.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'gce',
+    region: 'us-east1',
+    test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
+    test_config: 'test-cases/longevity/longevity-large-partition-8h.yaml'
+
+)

--- a/jenkins-pipelines/longevity-lwt-24h-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-24h-gce.jenkinsfile
@@ -6,6 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'gce',
     region: 'us-east1',
-    test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml'
+    test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
+    test_config: 'test-cases/longevity/longevity-lwt-basic-24h.yaml'
+
 )

--- a/jenkins-pipelines/longevity-multi-keyspaces-60h-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-multi-keyspaces-60h-gce.jenkinsfile
@@ -6,6 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'gce',
     region: 'us-east1',
-    test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml'
+    test_name: 'longevity_test.LongevityTest.test_batch_custom_time',
+    test_config: 'test-cases/longevity/longevity-multi-keyspaces.yaml'
+
 )

--- a/jenkins-pipelines/longevity-mv-si-24h-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-mv-si-24h-gce.jenkinsfile
@@ -7,5 +7,6 @@ longevityPipeline(
     backend: 'gce',
     region: 'us-east1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml'
+    test_config: 'test-cases/longevity/longevity-mv-si-24h.yaml'
+
 )

--- a/jenkins-pipelines/longevity-mv-si-4days-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-mv-si-4days-gce.jenkinsfile
@@ -7,5 +7,6 @@ longevityPipeline(
     backend: 'gce',
     region: 'us-east1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml'
+    test_config: 'test-cases/longevity/longevity-mv-si-4days.yaml'
+
 )

--- a/jenkins-pipelines/longevity-topology-changes-24h-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-topology-changes-24h-gce.jenkinsfile
@@ -6,6 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'gce',
     region: 'us-east1',
+    availability_zone: 'a,b,c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml'
+    test_config: '''["test-cases/longevity/longevity-topology-changes-24h.yaml"]''',
 )

--- a/jenkins-pipelines/longevity-topology-changes-3h-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-topology-changes-3h-gce.jenkinsfile
@@ -6,6 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'gce',
     region: 'us-east1',
+    availability_zone: 'a,b,c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml'
+    test_config: '''["test-cases/longevity/longevity-topology-changes-3h.yaml"]''',
 )

--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -7,7 +7,7 @@ n_loaders: 2
 n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
-gce_instance_type_db: 'n1-highmem-16'
+gce_instance_type_db: 'n2-highmem-16'
 gce_instance_type_loader: 'e2-standard-4'
 azure_instance_type_db: 'Standard_L8s_v3'
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 10}']

--- a/test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml
+++ b/test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml
@@ -9,6 +9,7 @@ n_loaders: 1
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.4xlarge'
+gce_instance_type_db: 'n2-highmem-16'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_selector: ['limited']
@@ -26,3 +27,5 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
+
+use_preinstalled_scylla: true

--- a/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
@@ -21,7 +21,7 @@ n_monitor_nodes: 1
 seeds_num: 2
 
 instance_type_db: 'i3.4xlarge'
-gce_instance_type_db: 'n1-highmem-16'
+gce_instance_type_db: 'n2-highmem-16'
 gce_n_local_ssd_disk_db: 16
 azure_instance_type_db: 'Standard_L16s_v3'
 

--- a/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -11,6 +11,9 @@ n_monitor_nodes: 1
 
 instance_type_db: 'i3.4xlarge'
 azure_instance_type_db: 'Standard_L16s_v3'
+gce_instance_type_db: 'n1-highmem-32'
+
+use_preinstalled_scylla: true
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_selector: ['limited']

--- a/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -11,9 +11,7 @@ n_monitor_nodes: 1
 
 instance_type_db: 'i3.4xlarge'
 azure_instance_type_db: 'Standard_L16s_v3'
-gce_instance_type_db: 'n1-highmem-32'
-
-use_preinstalled_scylla: true
+gce_instance_type_db: 'n2-highmem-16'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_selector: ['limited']
@@ -31,3 +29,5 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
+
+use_preinstalled_scylla: true

--- a/test-cases/longevity/longevity-5TB-1day.yaml
+++ b/test-cases/longevity/longevity-5TB-1day.yaml
@@ -1,0 +1,49 @@
+test_duration: 1360
+prepare_write_cmd: ["cassandra-stress write cl=QUORUM n=275050075 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=150 -col 'size=FIXED(200) n=FIXED(25)' -pop seq=1..275050075",
+                    "cassandra-stress write cl=QUORUM n=275050075 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=150 -col 'size=FIXED(200) n=FIXED(25)' -pop seq=275050076..550100150",
+                    "cassandra-stress write cl=QUORUM n=275050075 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=150 -col 'size=FIXED(200) n=FIXED(25)' -pop seq=550100151..825150225",
+                    "cassandra-stress write cl=QUORUM n=275050075 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=150 -col 'size=FIXED(200) n=FIXED(25)' -pop seq=825150226..1100200300"]
+
+stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=1200m -schema 'replication(factor=3)' -mode cql3 native -rate threads=100 -pop seq=1..550100150  -log interval=5 -col 'size=FIXED(200) n=FIXED(25)'",
+             "cassandra-stress mixed cl=QUORUM duration=1200m -schema 'replication(factor=3)' -mode cql3 native -rate threads=100 -pop seq=550100151..1100200300  -log interval=5 -col 'size=FIXED(200) n=FIXED(25)'",
+             "cassandra-stress user profile=/tmp/mv_synchronous_updates_on_standard.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=1200m -mode cql3 native -rate threads=10"]
+
+
+stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=1200m -mode cql3 native  -rate threads=10 -pop seq=1..1100200300  -log interval=5 -col 'size=FIXED(200) n=FIXED(25)'" ]
+
+
+run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "random", "interval": 120}']
+round_robin: true
+
+n_db_nodes: 4
+n_loaders: 4
+n_monitor_nodes: 1
+seeds_num: 2
+
+instance_type_db: 'i3.4xlarge'
+gce_instance_type_db: 'n2-highmem-32'
+gce_n_local_ssd_disk_db: 24
+azure_instance_type_db: 'Standard_L16s_v3'
+
+instance_type_loader: 'c5.4xlarge'
+gce_instance_type_loader: 'c2-standard-16'
+
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_seed: '031'
+nemesis_interval: 30
+nemesis_filter_seeds: false
+
+
+user_prefix: 'longevity-5TB'
+space_node_threshold: 644245094
+server_encrypt: true
+client_encrypt: true
+
+authenticator: 'PasswordAuthenticator'
+authenticator_user: 'cassandra'
+authenticator_password: 'cassandra'
+authorizer: 'CassandraAuthorizer'
+
+nemesis_during_prepare: false
+use_preinstalled_scylla: true

--- a/test-cases/longevity/longevity-alternator-200GB-48h.yaml
+++ b/test-cases/longevity/longevity-alternator-200GB-48h.yaml
@@ -38,7 +38,8 @@ n_db_nodes: 4
 # Instance types
 instance_type_db: 'i3.4xlarge'
 azure_instance_type_db: 'Standard_L16s_v3'
-gce_instance_type_db: 'n1-highmem-32'
+gce_instance_type_db: 'n2-highmem-32'
+gce_n_local_ssd_disk_db: 16
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '007'

--- a/test-cases/longevity/longevity-alternator-200GB-48h.yaml
+++ b/test-cases/longevity/longevity-alternator-200GB-48h.yaml
@@ -32,10 +32,13 @@ round_robin: true
 dynamodb_primarykey_type: HASH_AND_RANGE
 
 n_loaders: 4
-instance_type_db: 'i3.4xlarge'
-azure_instance_type_db: 'Standard_L16s_v3'
 n_monitor_nodes: 1
 n_db_nodes: 4
+
+# Instance types
+instance_type_db: 'i3.4xlarge'
+azure_instance_type_db: 'Standard_L16s_v3'
+gce_instance_type_db: 'n1-highmem-32'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '007'
@@ -57,3 +60,5 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
+
+use_preinstalled_scylla: true

--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -61,6 +61,8 @@ n_monitor_nodes: 1
 round_robin: true
 
 instance_type_db: 'i3en.3xlarge'
+gce_instance_type_db: 'n2-highmem-16'
+gce_n_local_ssd_disk_db: 24
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '016'
@@ -74,3 +76,5 @@ stop_test_on_stress_failure: false
 
 
 run_fullscan: ['{"mode": "partition", "ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 100000, "validate_data": true}']
+
+use_preinstalled_scylla: true

--- a/test-cases/longevity/longevity-large-partition-8h.yaml
+++ b/test-cases/longevity/longevity-large-partition-8h.yaml
@@ -42,6 +42,7 @@ round_robin: true
 
 instance_type_db: 'i3.2xlarge'
 azure_instance_type_db: 'Standard_L8s_v3'
+gce_instance_type_db: 'n1-highmem-32'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '015'
@@ -52,3 +53,5 @@ user_prefix: 'longevity-large-partitions-8h'
 space_node_threshold: 644245094
 
 run_fullscan: ['{"mode": "partition", "ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 5555, "validate_data": true}']
+
+use_preinstalled_scylla: true

--- a/test-cases/longevity/longevity-large-partition-8h.yaml
+++ b/test-cases/longevity/longevity-large-partition-8h.yaml
@@ -42,7 +42,8 @@ round_robin: true
 
 instance_type_db: 'i3.2xlarge'
 azure_instance_type_db: 'Standard_L8s_v3'
-gce_instance_type_db: 'n1-highmem-32'
+gce_instance_type_db: 'n2-highmem-8'
+gce_n_local_ssd_disk_db: 8
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '015'

--- a/test-cases/longevity/longevity-lwt-basic-24h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-24h.yaml
@@ -11,6 +11,8 @@ n_monitor_nodes: 1
 round_robin: true
 
 instance_type_db: 'i3.2xlarge'
+gce_instance_type_db: 'n2-highmem-8'
+gce_n_local_ssd_disk_db: 8
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '021'
@@ -19,3 +21,5 @@ nemesis_during_prepare: false
 space_node_threshold: 64424
 
 user_prefix: 'longevity-lwt-24h'
+
+use_preinstalled_scylla: true

--- a/test-cases/longevity/longevity-multi-keyspaces.yaml
+++ b/test-cases/longevity/longevity-multi-keyspaces.yaml
@@ -21,6 +21,9 @@ n_loaders: 10
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.8xlarge'
+gce_instance_type_db: 'n2-highmem-64'
+gce_n_local_ssd_disk_db: 16
+
 root_disk_size_db: 60 # twice as as default, cause each keyspace generate lots of logs
 instance_type_loader: 'c5.4xlarge'
 root_disk_size_monitor: 100
@@ -31,3 +34,5 @@ user_prefix: 'longevity-1000-keyspaces'
 # TODO: remove when https://github.com/scylladb/scylla-tools-java/issues/175 resolved
 stop_test_on_stress_failure: false
 use_prepared_loaders: true
+
+use_preinstalled_scylla: true

--- a/test-cases/longevity/longevity-mv-si-4days.yaml
+++ b/test-cases/longevity/longevity-mv-si-4days.yaml
@@ -15,6 +15,8 @@ n_loaders: 2
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.4xlarge'
+gce_instance_type_db: 'n2-highmem-32'
+gce_n_local_ssd_disk_db: 16
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '023'
@@ -23,3 +25,5 @@ nemesis_interval: 30
 user_prefix: 'longevity-mv-si-4d'
 
 space_node_threshold: 644245
+
+use_preinstalled_scylla: true

--- a/test-cases/longevity/longevity-topology-changes-3h.yaml
+++ b/test-cases/longevity/longevity-topology-changes-3h.yaml
@@ -19,6 +19,9 @@ n_loaders: 2
 n_monitor_nodes: 1
 
 instance_type_db: 'i4i.8xlarge'
+gce_instance_type_db: 'n2-highmem-32'
+gce_n_local_ssd_disk_db: 16
+
 round_robin: true
 
 nemesis_class_name: 'SisyphusMonkey'
@@ -34,3 +37,5 @@ user_prefix: 'longevity-topologychanges-asymetric-shards-3h'
 space_node_threshold: 64424
 
 db_nodes_shards_selection: "random"
+
+use_preinstalled_scylla: true


### PR DESCRIPTION
### This is the first PR for extending GCE coverage

Based on task: https://github.com/scylladb/qa-tasks/issues/1134

### Add pipelines in this PR:

1. longevity-200gb-48h-gce.jenkinsfile
2. longevity-150gb-asymmetric-cluster-12h-gce.jenkinsfile
3. longevity-large-partition-8h-gce.jenkinsfile
4. longevity-large-partition-200k-pks-2days-aws-i4i-gce.jenkinsfile
5. longevity-alternator-200gb-48h-gce.jenkinsfile
6. longevity-lwt-24h-gce.jenkinsfile
7. longevity-multi-keyspaces-60h-gce.jenkinsfile (Use even 64 cores)
8. longevity-topology-changes-3h-gce.jenkinsfile (Duplicate it and extend it to run 24h also for aws)
9. longevity-topology-changes-24h-gce.jenkinsfile 
10. longevity-mv-si-4days-gce.jenkinsfile (Duplicate it and decrease it to run 24h)
11. longevity-mv-si-24h-gce.jenkinsfile

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
