### PR TITLE
fix(indexes.py): fix regex for filter event

### DIFF
--- a/sdcm/utils/nemesis_utils/indexes.py
+++ b/sdcm/utils/nemesis_utils/indexes.py
@@ -121,7 +121,7 @@ def drop_index(session, ks, index_name) -> None:
     InfoEvent(message=f"Starting dropping index: {ks}.{index_name}").publish()
     with EventsFilter(
             event_class=DatabaseLogEvent.DATABASE_ERROR,
-            regex="Error applying view update",
+            regex=".*view - Error applying view update to.*",
             extra_time_to_expiration=180,  # errors can happen only within few minutes after index drop scylladb/#12977
     ):
         session.execute(f'DROP INDEX {ks}.{index_name}')


### PR DESCRIPTION
Filtering of `Error applying view update` for short period after dropping index is not working correctly due missing wildcards.

Fix by adding wildcards to begin&end of filter regex.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
