### PR TITLE
fix(latency_with_nemesis): Skip empty stats for nemesis

### DIFF
--- a/sdcm/report_templates/results_latency_during_ops_short.html
+++ b/sdcm/report_templates/results_latency_during_ops_short.html
@@ -75,7 +75,7 @@
                             <th rowspan="2"> Scylla build </th>
                             {% set lat_type_list = ['percentile_90', 'percentile_99'] %}
                             {% set lat_color_list = ['color_90', 'color_99'] %}
-                            {% set colspan = lat_type_list | length %}
+                            {% set colspan = workloads | length %}
                             {% for lat_type in lat_type_list %}
                                 <th colspan="{{ colspan }}">Latency {{ lat_type }}</th>
                                 <th colspan="{{ colspan }}">Steady State {{lat_type}}</th>
@@ -100,7 +100,8 @@
                                 <td> current build </td>
                                 {% for perc in lat_type_list %}
                                         {% for workload in workloads  %}
-                                            <td style="text-align: right; color: {{ cycle['hdr_summary'][workload]['color'][perc] }};"> {{ cycle['hdr_summary'][workload][perc] }} </td>
+                                            {% set color = cycle['hdr_summary'][workload]['color'][perc] %}
+                                            <td style="text-align: right;"><span style="color: {{ color }};"> {{ cycle['hdr_summary'][workload][perc] }}</span></td>
                                         {% endfor %}
                                         {% for workload in workloads  %}
                                             <td style="text-align: right;"> {{ stats["Steady State"]["hdr_summary"][workload][perc] }} </td>


### PR DESCRIPTION
If latency with nemesis job wrote currupted results to ES due to different reasons(job terminated, c-s stops running, etc), then such result could break build html report or bring error into comparing results with previous versions.

Detect such document by empty cycles status or nemesis run duration is 0 and skip them.

fix html template to correctly display columns for WRITE and read tests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
