### PR TITLE
fix(perf_search_best_config): use base threads if counted thread is 0

### DIFF
--- a/performance_search_max_throughput_test.py
+++ b/performance_search_max_throughput_test.py
@@ -151,7 +151,7 @@ class MaximumPerformanceSearchTest(PerformanceRegressionTest):
                     stress_num = origin_stress_num
 
                 threads = (best_result["total_threads"] // (len(self.loaders.nodes) * stress_num)) - threads_step
-                threads = 10 * round(threads / 10)
+                threads = 10 * round(threads / 10) or start_threads
                 decrease_loaders_num = False
 
             if current_result["op rate"] < best_result["op rate"] / 2:


### PR DESCRIPTION
number of threads for c-s command calculated on each iteration when num of loaders or processes is changed. One of edge case,num of threads for next stage could be equal 0 when
 when calculated on initial setup and current results.

example one of the run:



Number of Loaders | Number of Processes | Threads per process | Total Threads | Ops(kOps) | Latency 95th | Latency 99th
-- | -- | -- | -- | -- | -- | --
8 | 8 | 75 | 4800 | 214564.0 | 191.32 | 408.62
8 | 8 | 90 | 5760 | 211362.0 | 239.0 | 506.27
8 | 7 | 90 | 5040 | 215340.0 | 202.1 | 432.19
8 | 6 | 90 | 4320 | 217705.0 | 172.74 | 356.76
8 | 5 | 90 | 3600 | 217984.0 | 138.17 | 294.63
8 | 4 | 90 | 2880 | 219265.0 | 102.84 | 219.63
8 | 3 | 90 | 2160 | 218587.0 | 69.82 | 148.78
8 | 2 | 90 | 1440 | 221269.0 | 34.2 | 77.83
8 | 1 | 90 | 720 | 231511.0 | 4.79 | 8.7
8 | 1 | 105 | 840 | 233275.0 | 5.88 | 22.26
7 | 8 | 0 | 0 | 0.0 | 0 | 0

Calculated threads per process = 0 was got based on initial config and found best results.





## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
