### PR TITLE
fix(tester.py): Submit correct amount of total events to Argus

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -512,8 +512,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             last_events = get_events_grouped_by_category(
                 limit=last_events_limit, _registry=self.events_processes_registry)
             events_sorted = []
+            events_summary = get_logger_event_summary()
             for severity, messages in last_events.items():
-                event_category = EventsInfo(severity=severity, total_events=len(messages), messages=messages)
+                event_category = EventsInfo(
+                    severity=severity, total_events=events_summary.get(severity, 0), messages=messages)
                 events_sorted.append(event_category)
             self.test_config.argus_client().submit_events(events_sorted)
         except Exception:  # pylint: disable=broad-except

--- a/unit_tests/test_tester.py
+++ b/unit_tests/test_tester.py
@@ -85,6 +85,9 @@ class ClusterTesterForTests(ClusterTester):
     def update_certificates():
         pass
 
+    def argus_finalize_test_run(self):
+        pass
+
     @property
     def elasticsearch(self):  # pylint: disable=invalid-overridden-method
         return None


### PR DESCRIPTION
This fix corrects an issue where amount of total events submitted to
Argus was amount of events requested from the events device (which would
be a 100). This is now corrected and total amount of events is now
correctly retrieved from event summary log.

Task: scylladb/qa-tasks#929

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
