### PR TITLE
fix(k8s): use latest scylla-operator by default

### DIFF
--- a/defaults/k8s_local_kind_config.yaml
+++ b/defaults/k8s_local_kind_config.yaml
@@ -11,8 +11,8 @@ mgmt_docker_image: 'scylladb/scylla-manager:3.0.0'
 # NOTE: If 'k8s_scylla_operator_docker_image' not set then the one from helm chart will be used.
 # To test nightly builds define it like this: 'scylladb/scylla-operator:nightly'
 k8s_scylla_operator_docker_image: ''
-k8s_scylla_operator_helm_repo: 'https://storage.googleapis.com/scylla-operator-charts/stable'
-k8s_scylla_operator_chart_version: 'v1.8.0'
+k8s_scylla_operator_helm_repo: 'https://storage.googleapis.com/scylla-operator-charts/latest'
+k8s_scylla_operator_chart_version: 'latest'
 k8s_cert_manager_version: '1.8.0'
 
 k8s_scylla_datacenter: 'dc-1'

--- a/test-cases/scylla-operator/functional.yaml
+++ b/test-cases/scylla-operator/functional.yaml
@@ -18,8 +18,8 @@ k8s_cert_manager_version: '1.8.0'
 # Possible values for the 'k8s_scylla_operator_helm_repo' option are following:
 # - https://storage.googleapis.com/scylla-operator-charts/latest
 # - https://storage.googleapis.com/scylla-operator-charts/stable
-k8s_scylla_operator_helm_repo: 'https://storage.googleapis.com/scylla-operator-charts/stable'
-k8s_scylla_operator_chart_version: 'v1.8.0'
+k8s_scylla_operator_helm_repo: 'https://storage.googleapis.com/scylla-operator-charts/latest'
+k8s_scylla_operator_chart_version: 'latest'
 # NOTE: If 'k8s_scylla_operator_docker_image' option is not set
 # then the one from helm chart will be used.
 k8s_scylla_operator_docker_image: ''


### PR DESCRIPTION
Because we have another feature enabled by default which is available only in the unreleased scylla-operator versions:
- setup of local disks

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
