### PR TITLE
feature(artifact_test): testing the output of perftune.py

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -29,6 +29,7 @@ from sdcm.utils.housekeeping import HousekeepingDB
 from sdcm.utils.common import get_latest_scylla_release, ScyllaProduct
 from sdcm.utils.decorators import retrying
 from sdcm.utils.issues import SkipPerIssues
+from sdcm.utils.perftune_validator import PerftuneOutputChecker
 from utils.scylla_doctor import ScyllaDoctor
 
 STRESS_CMD: str = "/usr/bin/cassandra-stress"
@@ -446,6 +447,10 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
                                                             expected_status_code=expected_housekeeping_status_code,
                                                             new_row_expected=True,
                                                             backend=backend)
+
+        with self.subTest("Check the output of perftune.py"):
+            perftune_checker = PerftuneOutputChecker(self.node, backend)
+            perftune_checker.compare_perftune_results()
 
         if backend == 'docker':
             with self.subTest("Check docker latest tags"):

--- a/defaults/perftune_results.json
+++ b/defaults/perftune_results.json
@@ -1,0 +1,179 @@
+{
+  "aws":
+  {
+    "x86_64": {
+      "2": {
+        "get-cpu-mask": "0x00000003",
+        "get-irq-cpu-mask": "0x00000003",
+        "dump-options-file": {"cpu_mask": "0x00000003", "irq_cpu_mask": "0x00000003"}
+      },
+      "4": {
+        "get-cpu-mask": "0x0000000f",
+        "get-irq-cpu-mask": "0x0000000f",
+        "dump-options-file": {"cpu_mask": "0x0000000f", "irq_cpu_mask": "0x0000000f"}
+      },
+      "8": {
+        "get-cpu-mask": "0x000000fe",
+        "get-irq-cpu-mask": "0x00000001",
+        "dump-options-file": {"cpu_mask": "0x000000ff", "irq_cpu_mask": "0x00000001"}
+      },
+      "12": {
+        "get-cpu-mask": "0x00000fbe",
+        "get-irq-cpu-mask": "0x00000041",
+        "dump-options-file": {"cpu_mask": "0x00000fff", "irq_cpu_mask": "0x00000041"}
+      },
+      "16": {
+        "get-cpu-mask": "0x0000fefe",
+        "get-irq-cpu-mask": "0x00000101",
+        "dump-options-file": {"cpu_mask": "0x0000ffff", "irq_cpu_mask": "0x00000101"}
+      },
+      "24": {
+        "get-cpu-mask": "0x00ffeffe",
+        "get-irq-cpu-mask": "0x00001001",
+        "dump-options-file": {"cpu_mask": "0x00ffffff", "irq_cpu_mask": "0x00001001"}
+      },
+      "32": {
+        "get-cpu-mask": "0xfffefffe",
+        "get-irq-cpu-mask": "0x00010001",
+        "dump-options-file": {"cpu_mask": "0xffffffff", "irq_cpu_mask": "0x00010001"}
+      },
+      "48": {
+        "get-cpu-mask": "0x0000ffff,0xfcfffffc",
+        "get-irq-cpu-mask": "0x03000003",
+        "dump-options-file": {"cpu_mask": "0x0000ffff,0xffffffff", "irq_cpu_mask": "0x03000003"}
+      },
+      "64": {
+        "get-cpu-mask": "0xfffffffc,0xfffffffc",
+        "get-irq-cpu-mask": "0x00000003,0x00000003",
+        "dump-options-file": {"cpu_mask": "0xffffffff,0xffffffff", "irq_cpu_mask": "0x00000003,0x00000003"}
+      },
+      "96": {
+        "get-cpu-mask": "0xfffffcff,0xfffcffff,0xfcfffffc",
+        "get-irq-cpu-mask": "0x00000300,0x00030000,0x03000003",
+        "dump-options-file": {"cpu_mask": "0xffffffff,0xffffffff,0xffffffff", "irq_cpu_mask": "0x00000300,0x00030000,0x03000003"}
+      },
+      "128": {
+        "get-cpu-mask": "0xfffffffc,0xfffffffc,0xfffffffc,0xfffffffc",
+        "get-irq-cpu-mask": "0x00000003,0x00000003,0x00000003,0x00000003",
+        "dump-options-file": {"cpu_mask": "0xffffffff,0xffffffff,0xffffffff,0xffffffff", "irq_cpu_mask": "0x00000003,0x00000003,0x00000003,0x00000003"}
+      }
+    },
+    "aarch64": {
+      "4": {
+        "get-cpu-mask": "0x0000000f",
+        "get-irq-cpu-mask": "0x0000000f",
+        "dump-options-file": {"cpu_mask": "0x0000000f", "irq_cpu_mask": "0x0000000f"}
+      },
+      "8": {
+        "get-cpu-mask": "0x000000fe",
+        "get-irq-cpu-mask": "0x00000001",
+        "dump-options-file": {"cpu_mask": "0x000000ff", "irq_cpu_mask": "0x00000001"}
+      },
+      "16": {
+        "get-cpu-mask": "0x0000fffe",
+        "get-irq-cpu-mask": "0x00000001",
+        "dump-options-file": {"cpu_mask": "0x0000ffff", "irq_cpu_mask": "0x00000001"}
+      },
+      "32": {
+        "get-cpu-mask": "0xfffffffc",
+        "get-irq-cpu-mask": "0x00000003",
+        "dump-options-file": {"cpu_mask": "0xffffffff", "irq_cpu_mask": "0x00000001"}
+      },
+      "64": {
+        "get-cpu-mask": "0xffffffff,0xfffffff0",
+        "get-irq-cpu-mask": "0x0000000f",
+        "dump-options-file": {"cpu_mask": "0xffffffff,0xffffffff", "irq_cpu_mask": "0x0000000f"}
+      }
+    }
+  },
+  "gce":
+  {
+    "x86_64": {
+      "2": {
+        "get-cpu-mask": "0x00000003",
+        "get-irq-cpu-mask": "0x00000003",
+        "dump-options-file": {"cpu_mask": "0x00000003", "irq_cpu_mask": "0x00000003"}
+      },
+      "4": {
+        "get-cpu-mask": "0x0000000f",
+        "get-irq-cpu-mask": "0x0000000f",
+        "dump-options-file": {"cpu_mask": "0x0000000f", "irq_cpu_mask": "0x0000000f"}
+      },
+      "8": {
+        "get-cpu-mask": "0x000000fe",
+        "get-irq-cpu-mask": "0x00000001",
+        "dump-options-file": {"cpu_mask": "0x000000ff", "irq_cpu_mask": "0x00000001"}
+      },
+      "16": {
+        "get-cpu-mask": "0x0000fefe",
+        "get-irq-cpu-mask": "0x00000101",
+        "dump-options-file": {"cpu_mask": "0x0000ffff", "irq_cpu_mask": "0x00000101"}
+      },
+      "32": {
+        "get-cpu-mask": "0xfffefffe",
+        "get-irq-cpu-mask": "0x00010001",
+        "dump-options-file": {"cpu_mask": "0xffffffff", "irq_cpu_mask": "0x00010001"}
+      },
+      "48": {
+        "get-cpu-mask": "0x0000ffef,0xfeffeffe",
+        "get-irq-cpu-mask": "0x00000010,0x01001001",
+        "dump-options-file": {"cpu_mask": "0x0000ffff,0xffffffff", "irq_cpu_mask": "0x00000010,0x01001001"}
+      },
+      "64": {
+        "get-cpu-mask": "0xfffefffe,0xfffefffe",
+        "get-irq-cpu-mask": "0x00010001,0x00010001",
+        "dump-options-file": {"cpu_mask": "0xffffffff,0xffffffff", "irq_cpu_mask": "0x00010001,0x00010001"}
+      },
+      "80": {
+        "get-cpu-mask": "0x0000ffff,0xcffffcff,0xffcffffc",
+        "get-irq-cpu-mask": "0x30000300,0x00300003",
+        "dump-options-file": {"cpu_mask": "0x0000ffff,0xffffffff,0xffffffff", "irq_cpu_mask": "0x30000300,0x00300003"}
+      },
+      "96": {
+        "get-cpu-mask": "0xfffffcff,0xfffcffff,0xfcfffffc",
+        "get-irq-cpu-mask": "0x00000300,0x00030000,0x03000003",
+        "dump-options-file": {"cpu_mask": "0xffffffff,0xffffffff,0xffffffff", "irq_cpu_mask": "0x00000300,0x00030000,0x03000003"}
+      },
+      "128": {
+        "get-cpu-mask": "0xfffffffc,0xfffffffc,0xfffffffc,0xfffffffc",
+        "get-irq-cpu-mask": "0x00000003,0x00000003,0x00000003,0x00000003",
+        "dump-options-file": {"cpu_mask": "0xffffffff,0xffffffff,0xffffffff,0xffffffff", "irq_cpu_mask": "0x00000003,0x00000003,0x00000003,0x00000003"}
+      }
+    }
+  },
+  "azure":
+  {
+    "x86_64": {
+      "8": {
+        "get-cpu-mask": "0x000000fe",
+        "get-irq-cpu-mask": "0x00000001",
+        "dump-options-file": {"cpu_mask": "0x000000ff", "irq_cpu_mask": "0x00000001"}
+      },
+      "16": {
+        "get-cpu-mask": "0x0000fffc",
+        "get-irq-cpu-mask": "0x00000003",
+        "dump-options-file": {"cpu_mask": "0x0000ffff", "irq_cpu_mask": "0x00000003"}
+      },
+      "32": {
+        "get-cpu-mask": "0xfffffffc",
+        "get-irq-cpu-mask": "0x00000003",
+        "dump-options-file": {"cpu_mask": "0xffffffff", "irq_cpu_mask": "0x00000003"}
+      },
+      "48": {
+        "get-cpu-mask": "0x0000ffff,0xfffffff0",
+        "get-irq-cpu-mask": "0x0000000f",
+        "dump-options-file": {"cpu_mask": "0x0000ffff,0xffffffff", "irq_cpu_mask": "0x0000000f"}
+      },
+      "64": {
+        "get-cpu-mask": "0xfffffffc,0xfffffffc",
+        "get-irq-cpu-mask": "0x00000003,0x00000003",
+        "dump-options-file": {"cpu_mask": "0xffffffff,0xffffffff", "irq_cpu_mask": "0x00000003,0x00000003"}
+      },
+      "80": {
+        "get-cpu-mask": "0x0000ffff,0xfffff0ff,0xfffffff0",
+        "get-irq-cpu-mask": "0x00000f00,0x0000000f",
+        "dump-options-file": {"cpu_mask": "0x0000ffff,0xffffffff,0xffffffff", "irq_cpu_mask": "0x00000f00,0x0000000f"}
+      }
+    }
+  }
+}

--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -130,6 +130,7 @@ InstanceStatusEvent.REBOOT: WARNING
 InstanceStatusEvent.POWER_OFF: WARNING
 CompactionEvent: NORMAL
 ScyllaHousekeepingServiceEvent: ERROR
+PerftuneResultEvent: ERROR
 GceInstanceEvent: ERROR
 WorkloadPrioritisationEvent.CpuNotHighEnough: ERROR
 WorkloadPrioritisationEvent.RatioValidationEvent: ERROR

--- a/sdcm/sct_events/system.py
+++ b/sdcm/sct_events/system.py
@@ -172,6 +172,17 @@ class TestStepEvent(ContinuousEvent):
         return fmt
 
 
+class PerftuneResultEvent(InformationalEvent):
+    def __init__(self, message: str, severity: Severity):
+        super().__init__(severity=severity)
+
+        self.message = message
+
+    @property
+    def msgfmt(self) -> str:
+        return super().msgfmt + ": message={0.message}"
+
+
 class InfoEvent(SctEvent):
     def __init__(self, message: str, severity=Severity.NORMAL):
         super().__init__(severity=severity)

--- a/sdcm/utils/perftune_validator.py
+++ b/sdcm/utils/perftune_validator.py
@@ -1,0 +1,197 @@
+import json
+import logging
+import random
+import traceback
+import yaml
+
+from sdcm.sct_events import Severity
+from sdcm.sct_events.system import PerftuneResultEvent
+
+
+# https://docs.scylladb.com/stable/operating-scylla/admin-tools/perftune.html
+
+
+PERFTUNE_LOCATION = "/opt/scylladb/scripts/perftune.py"
+TEMP_PERFTUNE_YAML_PATH = "/tmp/perftune.yaml"
+PERFTUNE_EXPECTED_RESULTS_PATH = "defaults/perftune_results.json"
+
+
+def get_machine_architecture_type(node):
+    result = node.remoter.run("uname -m")
+    return result.stdout.strip()
+
+
+def get_number_of_cpu_cores(node) -> int:
+    result = node.remoter.run("grep -c ^processor /proc/cpuinfo")
+    cores_num = int(result.stdout)
+    return cores_num
+
+
+def get_default_mode(node):
+    number_of_cores = get_number_of_cpu_cores(node=node)
+    if number_of_cores <= 4:
+        return "mq"
+    elif number_of_cores <= 8:
+        return "sq"
+    elif number_of_cores <= 32:
+        return "sq_split"
+    return None
+
+
+class PerftuneExpectedResult:
+    def __init__(self, cluster_backend, number_of_cpu_cores, nic_name, architecture="x86_64"):
+        self.nic_name = nic_name
+        with open(PERFTUNE_EXPECTED_RESULTS_PATH, encoding="utf-8") as expected_results_file:
+            expected_results_dict_all_instances = json.loads(expected_results_file.read())
+        self.expected_results_for_instance = \
+            expected_results_dict_all_instances[cluster_backend][architecture][str(number_of_cpu_cores)]
+
+    def get_expected_cpu_mask(self) -> str:
+        return self.expected_results_for_instance.get("get-cpu-mask")
+
+    def get_expected_irq_cpu_mask(self) -> str:  # Only if the command available:
+        return self.expected_results_for_instance.get("get-irq-cpu-mask")
+
+    def get_expected_options_file_contents(self) -> dict:
+        base_result_dict = self.expected_results_for_instance.get("dump-options-file")
+        attach_values = {
+            "nic": [self.nic_name],
+            "irq_core_auto_detection_ratio": 16,
+            "tune": ["net"]
+        }
+        base_result_dict.update(attach_values)
+        return base_result_dict
+
+
+class PerftuneExecutor:
+    def __init__(self, node, nic_name):
+        self.node = node
+        self.nic_name = nic_name
+
+    def get_cpu_mask(self) -> str:
+        result = self.node.remoter.run(f"{PERFTUNE_LOCATION} --tune net --nic {self.nic_name} --get-cpu-mask")
+        return result.stdout.strip()
+
+    def get_irq_cpu_mask(self) -> str:
+        result = self.node.remoter.run(f"{PERFTUNE_LOCATION} --tune net --nic {self.nic_name} --get-irq-cpu-mask")
+        return result.stdout.strip()
+
+    def get_options_file_contents(self, use_temp_file=False, mode="", override_irq_cpu_mask="") -> dict:
+        cmd = f"{PERFTUNE_LOCATION} --tune net --nic {self.nic_name} --dump-options-file"
+        if mode:
+            cmd += f" --mode {mode}"
+        if use_temp_file:
+            cmd += f" --options-file {TEMP_PERFTUNE_YAML_PATH}"
+        if override_irq_cpu_mask:
+            cmd += f" --irq-cpu-mask {override_irq_cpu_mask}"
+        result = self.node.remoter.run(cmd)
+        result_as_yaml = yaml.safe_load(result.stdout)
+        return result_as_yaml
+
+    def create_temp_perftune_yaml(self, yaml_dict) -> None:
+        self.node.remoter.run(f"touch {TEMP_PERFTUNE_YAML_PATH}")
+        with self.node._remote_yaml(path=TEMP_PERFTUNE_YAML_PATH, sudo=False) as temp_yaml:  # pylint: disable=protected-access
+            temp_yaml.update(yaml_dict)
+
+
+class PerftuneOutputChecker:  # pylint: disable=too-few-public-methods
+    def __init__(self, node, cluster_backend):
+        self.log = logging.getLogger(self.__class__.__name__)
+        self.node = node
+        nic_name = node.get_nic_devices()[0]
+        self.executor = PerftuneExecutor(node, nic_name)
+        self.expected_result = PerftuneExpectedResult(cluster_backend, get_number_of_cpu_cores(node), nic_name,
+                                                      architecture=get_machine_architecture_type(node))
+
+    def compare_cpu_mask(self) -> None:
+        cpu_mask = self.executor.get_cpu_mask()
+        if cpu_mask != self.expected_result.get_expected_cpu_mask():
+            PerftuneResultEvent(
+                message=f"Mismatched results when testing the output of the 'get-cpu-mask' command on {self.node}"
+                        f"\nActual result: '{cpu_mask}'"
+                        f"\nExpected output: '{self.expected_result.get_expected_cpu_mask()}'",
+                severity=Severity.ERROR).publish()
+
+    def compare_irq_cpu_mask(self) -> None:
+        irq_cpu_mask = self.executor.get_irq_cpu_mask()
+        if irq_cpu_mask != self.expected_result.get_expected_irq_cpu_mask():
+            PerftuneResultEvent(
+                message=f"Mismatched results when testing the output of the 'get-irq-cpu-mask' command on "
+                        f"{self.node}"
+                        f"\nActual result: '{irq_cpu_mask}'"
+                        f"\nExpected output: '{self.expected_result.get_expected_irq_cpu_mask()}'",
+                severity=Severity.ERROR).publish()
+
+    def compare_default_option_file(self, option_file_dict) -> None:
+        if option_file_dict != self.expected_result.get_expected_options_file_contents():
+            PerftuneResultEvent(
+                message=f"Mismatched results when testing the output of the 'dump-options-file' command on "
+                        f"{self.node}"
+                        f"\nActual result: '{option_file_dict}'"
+                        f"\nExpected output: '{self.expected_result.get_expected_options_file_contents()}'",
+                severity=Severity.ERROR).publish()
+
+    def compare_option_file_yaml_with_temp_yaml_copy(self, option_file_dict) -> None:
+        temp_perftune_yaml_content_dict = self.executor.get_options_file_contents(use_temp_file=True)
+        if temp_perftune_yaml_content_dict != option_file_dict:
+            PerftuneResultEvent(
+                message=f"Mismatched results when comparing the output of the 'dump-options-file' command to "
+                        f"the content of the generated perftune.yaml file on {self.node}"
+                        f"\nActual result: '{temp_perftune_yaml_content_dict}'"
+                        f"\nExpected output: '{option_file_dict}'",
+                severity=Severity.ERROR).publish()
+
+    @staticmethod
+    def _generate_new_irq_cpu_mask_string(mask_int_values) -> str:
+        new_masks = []
+        for mask_value in mask_int_values:
+            random_irq_int_value = random.randint(0, mask_value)
+            # The irq_cpu_mask cannot be greater than the cpu_mask, since it is a part of it
+            new_mask_string = "{0:x}".format(random_irq_int_value)  # converting back to base 16
+            padded_new_mask_string = f"0x{new_mask_string.rjust(8, '0')}"  # Padding
+            new_masks.append(padded_new_mask_string)
+        return ",".join(new_masks)
+
+    @staticmethod
+    def get_mask_int_values(complete_mask_string) -> list:
+        split_masks = complete_mask_string.split(",")
+        numerical_values = []
+        for mask_string in split_masks:
+            num_value = int(mask_string, base=16)
+            numerical_values.append(num_value)
+        return numerical_values
+
+    def compare_option_file_with_overridden_irq_cpu_mask_param(self, option_file_dict) -> None:
+        current_cpu_mask = option_file_dict["cpu_mask"]
+        cpu_mask_int_values = self.get_mask_int_values(current_cpu_mask)
+        random_irq_cpu_mask_string = self._generate_new_irq_cpu_mask_string(cpu_mask_int_values)
+        altered_option_file_contents = self.executor.get_options_file_contents(
+            override_irq_cpu_mask=random_irq_cpu_mask_string)
+        if altered_option_file_contents["irq_cpu_mask"] != random_irq_cpu_mask_string:
+            PerftuneResultEvent(
+                message=f"Despite overriding the irq_cpu_mask param, its value is was not altered properly in the "
+                        f"output of the 'dump-options-file' command on node {self.node}",
+                severity=Severity.ERROR).publish()
+
+    def compare_perftune_results(self) -> None:
+        PerftuneResultEvent(
+            message="Checking the output of perftune.py",
+            severity=Severity.NORMAL).publish()
+        try:
+            self.compare_cpu_mask()
+            self.compare_irq_cpu_mask()
+            default_mode = get_default_mode(self.node)
+            override_irq_cpu_mask = None
+            if not default_mode:
+                override_irq_cpu_mask = self.expected_result.get_expected_irq_cpu_mask()
+            option_file_dict = self.executor.get_options_file_contents(mode=default_mode,
+                                                                       override_irq_cpu_mask=override_irq_cpu_mask)
+            self.compare_default_option_file(option_file_dict)
+            self.executor.create_temp_perftune_yaml(yaml_dict=option_file_dict)
+            self.compare_option_file_yaml_with_temp_yaml_copy(option_file_dict)
+            self.compare_option_file_with_overridden_irq_cpu_mask_param(option_file_dict)
+        except Exception as error:  # pylint: disable=broad-except  # noqa: BLE001
+            PerftuneResultEvent(
+                message=f"Unexpected error when verifying the output of Perftune: {error}",
+                severity=Severity.ERROR).publish()
+            self.log.error(traceback.format_exc())


### PR DESCRIPTION
perftune.py is a script within seastar (which is a part of scylla_setup)
that configures several system parameters, like the amount of CPU cores that
are designated to handle IRQ, and which are not.

I have recorded the expected results as of master 20230717.567b4536892f
in defaults/perftune_results.json, and the test will compare them to
the output of the script.

https://github.com/scylladb/scylla-enterprise/issues/2909

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
