### PR TITLE
fix(k8sLogger): fix stop logger when stream is closed

### DIFF
--- a/sdcm/utils/remote_logger.py
+++ b/sdcm/utils/remote_logger.py
@@ -467,6 +467,7 @@ class K8sClientLogger(LoggerBase):  # pylint: disable=too-many-instance-attribut
                 self._log.debug("Stream from pod %s logs has been closed, "
                                 "waiting for %s seconds and trying to reconnect",
                                 self._pod_name, self.RECONNECT_DELAY)
+                self._stream = None
                 if self._termination_event.is_set():
                     return
                 time.sleep(self.RECONNECT_DELAY)


### PR DESCRIPTION
In case stream is closed, stopping logger fails on opening socket as fp is not opened.

Fix is to clear `_stream` when we know it is already closed.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/6191

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
