### PR TITLE
improvement(longevity): change DB instance type in lwt-multidc-24h

### DIFF
--- a/test-cases/longevity/longevity-lwt-24h-multidc.yaml
+++ b/test-cases/longevity/longevity-lwt-24h-multidc.yaml
@@ -7,7 +7,7 @@ n_db_nodes: '4 3 2'
 n_loaders: '1 1 1'
 n_monitor_nodes: 1
 
-instance_type_db: 'i3.8xlarge'
+instance_type_db: 'i4i.4xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '018'


### PR DESCRIPTION
After we start to use LOCAL_QUORUM and LOCAL_SERIAL in the longevity-lwt-24h-multidc the Load became very low - max 15% CPU.
Change DB instance type to smaller type

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
