### PR TITLE
fix(LatencyPerfAnalyzer): Fix query search parameter

### DIFF
--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -235,11 +235,11 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
 
         LOGGER.debug("ES QUERY: %s", query)
         test_results = self._es.search(  # pylint: disable=unexpected-keyword-arg; pylint doesn't understand Elasticsearch code
-            index="latency-during-ops-mixed",
-            doc_type='test_stats',
+            index=self._es_index,
+            doc_type=self._es_doc_type,
             q=query,
             filter_path=filter_path,
-            size=1000)
+            size=self._limit)
         if not test_results:
             self.log.warning("No results found for query: %s", query)
             return []


### PR DESCRIPTION
Each perf test with nemesis uses its own index in ES. Query was hardcoded with index for mixed tests.
Fix query search parameters for getting results perf test with right index.

PR: https://github.com/scylladb/scylla-cluster-tests/pull/4883 was not backported to perf-v14 branch. Backporting it now 
will cause conficts. Easy way is merge to branch-perf-v14 new PR.

PR is only for branch-perf-v14

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
