### PR TITLE
fix(k8s): remove redundant dc setup in node_setup

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2661,10 +2661,6 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
     def node_setup(self, node: BaseScyllaPodContainer, verbose: bool = False, timeout: int = 3600):
         if self.test_config.BACKTRACE_DECODING:
             node.install_scylla_debuginfo()
-
-        if self.test_config.MULTI_REGION:
-            node.datacenter_setup(self.datacenter)  # pylint: disable=no-member
-
         self.node_config_setup()
 
     @cached_property


### PR DESCRIPTION
On k8s we still don't support multi-dc but we already have some code to setup cassandra-rackdc.properties file with some values that possibly don't work.

Remove redundant code so there's no need to update it on refactor.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
