### PR TITLE
fix(k8s-ci): use the same `cluster_name` in all K8S monitoring methods

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -155,7 +155,8 @@ def test_rolling_restart_cluster(db_cluster):
 
 
 def _scylla_cluster_monitoring_ckecks(db_cluster: ScyllaPodCluster, monitoring_type: str):
-    k8s_cluster, cluster_name, namespace = db_cluster.k8s_cluster, db_cluster.name, db_cluster.namespace
+    k8s_cluster = db_cluster.k8s_cluster
+    cluster_name, namespace = db_cluster.scylla_cluster_name, db_cluster.namespace
 
     # NOTE: deploy prometheus operator if absent
     k8s_cluster.deploy_prometheus_operator()


### PR DESCRIPTION
In K8S functional tests we use `db_cluster.name` attr for the
`ScyllaDBMonitoring` object name, but in the
`check_kubernetes_monitoring_health` method we automatically pick up
the `db_cluster.scylla_cluster_name`. Both are different in CI.
    
So, fix the K8S monitoring functional tests to use the same attribute
as the health checker does.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [c] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
