### PR TITLE
fix(test-cases/nemesis): use public IPs when we use extra NIC

### DIFF
--- a/jenkins-pipelines/nemesis/longevity-5gb-1h-BlockNetworkMonkey-aws.jenkinsfile
+++ b/jenkins-pipelines/nemesis/longevity-5gb-1h-BlockNetworkMonkey-aws.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/nemesis/longevity-5gb-1h-BlockNetworkMonkey.yaml'
-
+    test_config: 'test-cases/nemesis/longevity-5gb-1h-BlockNetworkMonkey.yaml',
+    ip_ssh_connections: 'public'
 )

--- a/jenkins-pipelines/nemesis/longevity-5gb-1h-BlockNetworkMonkey-azure.jenkinsfile
+++ b/jenkins-pipelines/nemesis/longevity-5gb-1h-BlockNetworkMonkey-azure.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'azure',
     region: 'eastus',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/nemesis/longevity-5gb-1h-BlockNetworkMonkey.yaml'
-
+    test_config: 'test-cases/nemesis/longevity-5gb-1h-BlockNetworkMonkey.yaml',
+    ip_ssh_connections: 'public'
 )

--- a/jenkins-pipelines/nemesis/longevity-5gb-1h-RandomInterruptionNetworkMonkey-aws.jenkinsfile
+++ b/jenkins-pipelines/nemesis/longevity-5gb-1h-RandomInterruptionNetworkMonkey-aws.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/nemesis/longevity-5gb-1h-RandomInterruptionNetworkMonkey.yaml'
-
+    test_config: 'test-cases/nemesis/longevity-5gb-1h-RandomInterruptionNetworkMonkey.yaml',
+    ip_ssh_connections: 'public'
 )

--- a/jenkins-pipelines/nemesis/longevity-5gb-1h-RandomInterruptionNetworkMonkey-azure.jenkinsfile
+++ b/jenkins-pipelines/nemesis/longevity-5gb-1h-RandomInterruptionNetworkMonkey-azure.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'azure',
     region: 'eastus',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/nemesis/longevity-5gb-1h-RandomInterruptionNetworkMonkey.yaml'
-
+    test_config: 'test-cases/nemesis/longevity-5gb-1h-RandomInterruptionNetworkMonkey.yaml',
+    ip_ssh_connections: 'public'
 )

--- a/jenkins-pipelines/nemesis/longevity-5gb-1h-StopStartInterfacesNetworkMonkey-aws.jenkinsfile
+++ b/jenkins-pipelines/nemesis/longevity-5gb-1h-StopStartInterfacesNetworkMonkey-aws.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/nemesis/longevity-5gb-1h-StopStartInterfacesNetworkMonkey.yaml'
-
+    test_config: 'test-cases/nemesis/longevity-5gb-1h-StopStartInterfacesNetworkMonkey.yaml',
+    ip_ssh_connections: 'public'
 )

--- a/jenkins-pipelines/nemesis/longevity-5gb-1h-StopStartInterfacesNetworkMonkey-azure.jenkinsfile
+++ b/jenkins-pipelines/nemesis/longevity-5gb-1h-StopStartInterfacesNetworkMonkey-azure.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'azure',
     region: 'eastus',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/nemesis/longevity-5gb-1h-StopStartInterfacesNetworkMonkey.yaml'
-
+    test_config: 'test-cases/nemesis/longevity-5gb-1h-StopStartInterfacesNetworkMonkey.yaml',
+    ip_ssh_connections: 'public'
 )

--- a/test-cases/nemesis/longevity-5gb-1h-BlockNetworkMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-BlockNetworkMonkey.yaml
@@ -19,6 +19,7 @@ instance_type_loader: 'c5.large'
 azure_instance_type_loader: 'Standard_F2s_v2'
 
 extra_network_interface: true
+ip_ssh_connections: 'public'  # need to use public IPs because extra NIC is in the same subnet as default one.
 
 nemesis_class_name: 'BlockNetworkMonkey'
 nemesis_interval: 3

--- a/test-cases/nemesis/longevity-5gb-1h-RandomInterruptionNetworkMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RandomInterruptionNetworkMonkey.yaml
@@ -19,6 +19,7 @@ instance_type_loader: 'c5.large'
 azure_instance_type_loader: 'Standard_F2s_v2'
 
 extra_network_interface: true
+ip_ssh_connections: 'public'  # need to use public IPs because extra NIC is in the same subnet as default one.
 
 nemesis_class_name: 'RandomInterruptionNetworkMonkey'
 nemesis_interval: 3

--- a/test-cases/nemesis/longevity-5gb-1h-StopStartInterfacesNetworkMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-StopStartInterfacesNetworkMonkey.yaml
@@ -19,6 +19,7 @@ instance_type_loader: 'c5.large'
 azure_instance_type_loader: 'Standard_F2s_v2'
 
 extra_network_interface: true
+ip_ssh_connections: 'public'  # need to use public IPs because extra NIC is in the same subnet as default one.
 
 nemesis_class_name: 'StopStartInterfacesNetworkMonkey'
 nemesis_interval: 3


### PR DESCRIPTION
The individual nemesis jobs was introduced in 5.2, but networking nemeses actually not tested because of test misconfiguration (these nemeses require extra NIC)
The first release we actually try to run them is 2023.1 and it failed because of another test misconfiguration: they require public IP SSH connections.

Examples: 
* False positive run (5.2):  https://jenkins.scylladb.com/view/scylla-5.2/job/scylla-5.2/job/nemesis/job/longevity-5gb-1h-BlockNetworkMonkey-aws-test/4/
* Failed run (2023.1): https://jenkins.scylladb.com/view/enterprise-2023.1/job/enterprise-2023.1/job/nemesis/job/longevity-5gb-1h-BlockNetworkMonkey-aws-test/3/
* Fixed and passed run (staging): https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/evgeniy/job/longevity-5gb-1h-BlockNetworkMonkey-aws-test/5/


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
