### PR TITLE
fix(snitch): don't update snitch properties when no need

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -71,7 +71,7 @@ from sdcm.remote.remote_file import remote_file, yaml_file_to_dict, dict_to_yaml
 from sdcm import wait, mgmt
 from sdcm.sct_config import SCTConfiguration
 from sdcm.sct_events.continuous_event import ContinuousEventsRegistry
-from sdcm.snitch_configuration import get_snitch_config_class
+from sdcm.snitch_configuration import SnitchConfig
 from sdcm.utils import properties
 from sdcm.utils.adaptive_timeouts import Operations, adaptive_timeout
 from sdcm.utils.benchmarks import ScyllaClusterBenchmarkManager
@@ -4364,8 +4364,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             if self.test_config.BACKTRACE_DECODING:
                 node.install_scylla_debuginfo()
 
-            snitch_config = get_snitch_config_class(self.params)
-            snitch_config(node=node, datacenters=self.datacenter).apply()  # pylint: disable=no-member
+            if self.test_config.MULTI_REGION or self.params.get('simulated_racks') > 1:
+                SnitchConfig(node=node, datacenters=self.datacenter).apply()  # pylint: disable=no-member
             node.config_setup(append_scylla_args=self.get_scylla_args())
 
             self._scylla_post_install(node, install_scylla, nic_devname)


### PR DESCRIPTION
In case we cassandra-rackdc.propertie does not need to be updated skip update of cassandra-rackdc.properties file.

Also removed code related different snitches - as acutally there are only 2 options: Multi-dc and simulated racks situation

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
