### PR TITLE
fix(Argus): Fix for Create Argus Test Run step

### DIFF
--- a/vars/createArgusTestRun.groovy
+++ b/vars/createArgusTestRun.groovy
@@ -2,14 +2,13 @@
 
 def call(Map params) {
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
-
     sh """#!/bin/bash
         set -xe
 
         echo "Creating Argus test run ..."
 
         export SCT_CLUSTER_BACKEND="${params.backend}"
-        export SCT_CONFIG_FILES="${test_config}"
+        export SCT_CONFIG_FILES=${test_config}
 
         ./docker/env/hydra.sh create-argus-test-run
 

--- a/vars/finishArgusTestRun.groovy
+++ b/vars/finishArgusTestRun.groovy
@@ -11,7 +11,7 @@ def call(Map params, RunWrapper currentBuild) {
     echo "Finishing Argus test run ..."
 
     export SCT_CLUSTER_BACKEND="${params.backend}"
-    export SCT_CONFIG_FILES="${test_config}"
+    export SCT_CONFIG_FILES=${test_config}
 
     ./docker/env/hydra.sh finish-argus-test-run --jenkins-status "${test_status}"
 


### PR DESCRIPTION
fix ussue https://github.com/scylladb/scylla-cluster-tests/issues/6205 ARM artifacts are failing on Create Argus Test Run stage

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
