### PR TITLE
fix(arm-centos8): replace deprecated ARM image

### DIFF
--- a/configurations/arm/centos8.yaml
+++ b/configurations/arm/centos8.yaml
@@ -1,5 +1,5 @@
 ami_db_scylla_user: 'centos'
-ami_id_db_scylla: 'ami-07d54ca4e98347364'
+ami_id_db_scylla: 'ami-08396399fcc3968ff' # CentOS Stream 8 aarch64 20230530
 region_name: 'eu-west-1'
 instance_type_db: 'im4gn.xlarge'
 use_preinstalled_scylla: false

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2025,6 +2025,7 @@ def get_branched_gce_images(
 def ami_built_by_scylla(ami_id: str, region_name: str) -> bool:
     ec2_resource = boto3.resource("ec2", region_name=region_name)
     image = ec2_resource.Image(ami_id)
+    image.load()
     return image.owner_id == SCYLLA_AMI_OWNER_ID
 
 

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -616,7 +616,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
     @pytest.mark.integration
     def test_20_user_data_format_version_aws_2(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-07d54ca4e98347364'  # run image which isn't scylla
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-08396399fcc3968ff'  # run image which isn't scylla
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
         conf.verify_configuration_urls_validity()


### PR DESCRIPTION
the image we were using seem to be deprated and don't show on console, and don't have it's metadata available anymore failing like:
```
  if not ami_built_by_scylla(ami_id, region_name):
File ".../sdcm/utils/common.py", line 2028, in ami_built_by_scylla
  return image.owner_id == SCYLLA_AMI_OWNER_ID
File "../boto3/resources/factory.py", line 386, in property_loader
  return self.meta.data.get(name)
AttributeError: 'NoneType' object has no attribute 'get'
```

updated form a fresh image taken from:
https://www.centos.org/download/aws-images/


### Testing
- [x] - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-centos8-arm-test/11/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
