### PR TITLE
fix(k8s): make static loaders work again

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2949,7 +2949,7 @@ class LoaderPodCluster(cluster.BaseLoaderSet, PodCluster):
 
     @property
     def pod_selector(self):
-        return 'loader-name'
+        return 'loader-cluster-name'
 
     def node_setup(self,
                    node: BasePodContainer,


### PR DESCRIPTION
The `fix(k8s): make pod waiters use pod selectors` commit in the (https://github.com/scylladb/scylla-cluster-tests/pull/6130) PR made 
the `static` loaders be broken by using wrong selector. 
The common label between `dynamic` and `static` loaders is `loader-cluster-name`
not `loader-name` which exists only in `dynamic` case.

The labels may be checked by looking at the config files located at
the `sdcm/k8s_configs/loaders/` directory and `metadata.labels` field.

So, use proper loaders pod selector which will work in both cases.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
