### PR TITLE
fix(adaptive_timeouts): fix missing test_id in ES

### DIFF
--- a/sdcm/utils/adaptive_timeouts/load_info_store.py
+++ b/sdcm/utils/adaptive_timeouts/load_info_store.py
@@ -11,7 +11,9 @@
 #
 # Copyright (c) 2023 ScyllaDB
 import logging
+import time
 import uuid
+from datetime import datetime
 from functools import cached_property
 import re
 from typing import Any
@@ -172,7 +174,6 @@ class ESAdaptiveTimeoutStore(AdaptiveTimeoutStore):
     def __init__(self):
         try:
             self._es = ES()
-            self._test_id = TestConfig.test_id()
             self._index = "sct-adaptive-timeouts"
         except Exception as exc:  # pylint: disable=broad-except
             LOGGER.warning("Couldn't initialize ESAdaptiveTimeoutStore: %s", exc)
@@ -182,7 +183,8 @@ class ESAdaptiveTimeoutStore(AdaptiveTimeoutStore):
     def store(self, metrics: dict[str, Any], operation: str, duration: float, timeout: float,
               timeout_occurred: bool):
         body = metrics
-        body["test_id"] = self._test_id
+        body["test_id"] = TestConfig.test_id()
+        body["end_time"] = datetime.utcfromtimestamp(time.time())
         body["operation"] = operation
         body["duration"] = duration
         body["timeout"] = timeout


### PR DESCRIPTION
`test_id` is not stored in ES because `ESAdaptiveTimeoutStore` is initialized early, before `TestConfig.test_id` is set.

Get valid `test_id` when storing data.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
