### PR TITLE
feature(gemini): update gemini to 1.8.2

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -205,7 +205,7 @@ stress_image:
   nosqlbench: 'scylladb/hydra-loaders:nosqlbench-4.15.49'
   cassandra-stress: '' # default would be same version as scylla under test
   scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.17'
-  gemini: 'scylladb/hydra-loaders:gemini-1.8.0'
+  gemini: 'scylladb/hydra-loaders:gemini-v1.8.2'
   alternator-dns: 'scylladb/hydra-loaders:alternator-dns-0.1'
   cdc-stresser: 'scylladb/hydra-loaders:cdc-stresser-20210630'
   kcl: 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC'

--- a/docker/gemini/README.md
+++ b/docker/gemini/README.md
@@ -1,7 +1,11 @@
+Currently, when releasing a new version of Gemini, there's no need to push the image to Docker Hub.
+The image is built and pushed automatically by `goreleaser` when a new version is released.
+Docs from Gemini repo: https://github.com/scylladb/gemini/blob/master/docs/release-process.md
+Steps to release gemini :
 ```
-export GEMINI_VERSION=1.7.8
-export GEMINI_DOCKER_IMAGE=scylladb/hydra-loaders:gemini-$GEMINI_VERSION
-docker build . -t ${GEMINI_DOCKER_IMAGE} --build-arg version=$GEMINI_VERSION
-docker push ${GEMINI_DOCKER_IMAGE}
-echo "${GEMINI_DOCKER_IMAGE}" > image
+0. Make sure you have proper go installed. See the version in https://github.com/scylladb/gemini/blob/master/go.mod
+1. update changelog and tag the commit
+2. create github token with write:packages permissions here: https://github.com/settings/tokens/new
+3. export GITHUB_TOKEN="YOUR_GH_TOKEN”
+4. Run `goreleaser`from`cmd/gemini`directory
 ```

--- a/docker/gemini/image
+++ b/docker/gemini/image
@@ -1,1 +1,1 @@
-scylladb/hydra-loaders:gemini-1.8.0
+scylladb/hydra-loaders:gemini-v1.8.0

--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -74,7 +74,7 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
     @property
     def gemini_result_file(self):
         if not self._gemini_result_file:
-            self._gemini_result_file = os.path.join("/gemini", "gemini_result_{}.log".format(uuid.uuid4()))
+            self._gemini_result_file = os.path.join("/", "gemini_result_{}.log".format(uuid.uuid4()))
         return self._gemini_result_file
 
     def _generate_gemini_command(self):
@@ -85,7 +85,7 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
         test_nodes = ",".join(self.test_cluster.get_node_cql_ips())
         oracle_nodes = ",".join(self.oracle_cluster.get_node_cql_ips()) if self.oracle_cluster else None
 
-        cmd = "{} --test-cluster={} --outfile {} --seed {} --request-timeout {}s --connect-timeout {}s ".format(
+        cmd = "./{} --test-cluster={} --outfile {} --seed {} --request-timeout {}s --connect-timeout {}s ".format(
             self.stress_cmd.strip(),
             test_nodes,
             self.gemini_result_file,
@@ -106,7 +106,8 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
             cpu_options = f'--cpuset-cpus="{cpu_idx}"'
 
         docker = cleanup_context = RemoteDocker(loader, self.docker_image_name,
-                                                extra_docker_opts=f'{cpu_options} --label shell_marker={self.shell_marker} --network=host')
+                                                extra_docker_opts=f'{cpu_options} --label shell_marker={self.shell_marker}'
+                                                                  f' --network=host --entrypoint=""')
 
         if not os.path.exists(loader.logdir):
             os.makedirs(loader.logdir, exist_ok=True)

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -681,7 +681,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                          {'alternator-dns': 'scylladb/hydra-loaders:alternator-dns-0.1',
                           'cassandra-stress': 'scylla-bench',
                           'cdc-stresser': 'scylladb/hydra-loaders:cdc-stresser-A',
-                          'gemini': 'scylladb/hydra-loaders:gemini-1.8.0',
+                          'gemini': 'scylladb/hydra-loaders:gemini-v1.8.2',
                           'ndbench': 'scylladb/hydra-loaders:ndbench-jdk8-A',
                           'nosqlbench': 'scylladb/hydra-loaders:nosqlbench-A',
                           'scylla-bench': 'scylladb/something',
@@ -689,7 +689,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                           'kcl': 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC',
                           'harry': 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816'})
 
-        self.assertEqual(conf.get('stress_image.gemini'), 'scylladb/hydra-loaders:gemini-1.8.0')
+        self.assertEqual(conf.get('stress_image.gemini'), 'scylladb/hydra-loaders:gemini-v1.8.2')
         self.assertEqual(conf.get('stress_image.non-exist'), None)
 
         self.assertEqual(conf.get('stress_read_cmd'), ['cassandra_stress', 'cassandra_stress'])


### PR DESCRIPTION
Recently many changes were added to Gemini.

Update default Gemini version to 1.8.2 and fix releasing process as
docker images are now uploaded automatically upon releasing Gemini.
Because new docker image changed entrypoint and dir structure, some
adaptations were required to the way we run it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
