### PR TITLE
fix(k8s): set Scylla storage size in 14 tenants longevity

### DIFF
--- a/test-cases/scylla-operator/longevity-scylla-operator-12h-multitenant-14-clients.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-12h-multitenant-14-clients.yaml
@@ -13,6 +13,9 @@ max_events_severities: ['CassandraStressLogEvent.TooManyHintsInFlight=WARNING']
 
 k8s_tenants_num: 14
 
+# NOTE: K8S Scylla nodes have 3.5Tb disk size
+k8s_scylla_disk_gi: 249
+
 # NOTE: we disable second type of monitoring - K8S based one. It is redundant while we use standalone ones.
 k8s_deploy_monitoring: false
 


### PR DESCRIPTION
In case of 14 tenants setup we should use at most '1/14' of the available storage. Available is 3.5Tb, so, set 249Gb for each of 14 tenants to make it possible to work with reserved storage.

9029b271c61e5c9d6e62b3c6f178516ee1be7fb3 changed this only for the perf tests, and missed the longvities

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
