### PR TITLE
fix(tox): use config syntax compatible for 3.x and 4.x versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,8 @@ sitepackages = False
 
 [testenv]
 envdir = {toxworkdir}/{envname}
-passenv = HOME PYTEST_* SCT_*
-whitelist_externals = *
+passenv = HOME,PYTEST_*,SCT_*
+allowlist_externals = *
 commands =
     python -m pip install --upgrade pip>=9.0.0 setuptools wheel
     pip install -r requirements.in


### PR DESCRIPTION
The current `tox.ini` config was written for the `3.23.x` versions. It is pretty old versions. Now we have `4.5.x`.
So, update the `tox.ini` config to support both due to the following reason:
- `LTS Ubuntu 22` has `tox` package, but it is of the `3.21.x` version
- We can install any `tox` package version from sources such as `4.5.1`

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
