### PR TITLE
fix(test): fix oracle instance type for gemini tests

### DIFF
--- a/sdcm/sct_provision/aws/cluster.py
+++ b/sdcm/sct_provision/aws/cluster.py
@@ -250,7 +250,7 @@ class DBCluster(ClusterBase):
 class OracleDBCluster(ClusterBase):
     _NODE_TYPE = 'oracle-db'
     _NODE_PREFIX = 'oracle'
-    _INSTANCE_TYPE_PARAM_NAME = 'instance_type_db'
+    _INSTANCE_TYPE_PARAM_NAME = 'instance_type_db_oracle'
     _NODE_NUM_PARAM_NAME = 'n_test_oracle_db_nodes'
     _INSTANCE_PARAMS_BUILDER = OracleScyllaInstanceParamsBuilder
     _USER_PARAM = 'ami_db_scylla_user'


### PR DESCRIPTION
We use the same VM size for oracle db for gemini based tests. While oracle db should be bigger to handle load without effort.

Fix param name used to pick VM size for oracle db.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
