### PR TITLE
fix(k8s-eks): use proper disk sizes for Scylla pods

### DIFF
--- a/configurations/operator/perf-regression-latency-and-throughput-multitenant-2-clients.yaml
+++ b/configurations/operator/perf-regression-latency-and-throughput-multitenant-2-clients.yaml
@@ -1,6 +1,9 @@
 test_duration: 540
 user_prefix: 'perf-regrn-lat-and-thpt-2-clients'
 
+# NOTE: K8S Scylla nodes have 3.5Tb disk size
+k8s_scylla_disk_gi: 1745
+
 # NOTE: deploy 8 K8S nodes of the 'loader' type and then create 4 loader pods per DB cluster
 n_loaders: 8
 k8s_n_loader_pods_per_cluster: 4

--- a/configurations/operator/perf-regression-latency-and-throughput-multitenant-7-clients.yaml
+++ b/configurations/operator/perf-regression-latency-and-throughput-multitenant-7-clients.yaml
@@ -1,6 +1,9 @@
 test_duration: 600
 user_prefix: 'perf-regrn-lat-and-thpt-7-clients'
 
+# NOTE: K8S Scylla nodes have 3.5Tb disk size
+k8s_scylla_disk_gi: 498
+
 # NOTE: deploy 28 K8S nodes of the 'loader' type and then create 4 loader pod per DB cluster
 n_loaders: 28
 k8s_n_loader_pods_per_cluster: 4

--- a/configurations/operator/perf-regression-latency-multitenant-2-clients.yaml
+++ b/configurations/operator/perf-regression-latency-multitenant-2-clients.yaml
@@ -1,6 +1,9 @@
 test_duration: 540
 user_prefix: 'perf-regression-latency-2-clients'
 
+# NOTE: K8S Scylla nodes have 3.5Tb disk size
+k8s_scylla_disk_gi: 1745
+
 # NOTE: deploy 8 K8S nodes of the 'loader' type and then create 4 loader pods per DB cluster
 n_loaders: 8
 k8s_n_loader_pods_per_cluster: 4

--- a/configurations/operator/perf-regression-latency-multitenant-7-clients.yaml
+++ b/configurations/operator/perf-regression-latency-multitenant-7-clients.yaml
@@ -1,6 +1,9 @@
 test_duration: 600
 user_prefix: 'perf-regression-latency-7-clients'
 
+# NOTE: K8S Scylla nodes have 3.5Tb disk size
+k8s_scylla_disk_gi: 498
+
 # NOTE: deploy 28 K8S nodes of the 'loader' type and then create 4 loader pod per DB cluster
 n_loaders: 28
 k8s_n_loader_pods_per_cluster: 4

--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -26,7 +26,7 @@ k8s_enable_performance_tuning: true
 k8s_loader_cluster_name: 'sct-loaders'
 k8s_scylla_cluster_name: 'sct-cluster'
 k8s_scylla_datacenter: 'us-east1-b'
-k8s_scylla_disk_gi: 500
+k8s_scylla_disk_gi: 3490
 # NOTE: use any of the following pairs:
 #   'k8s_scylla_disk_class=local-raid-disks'   and 'k8s_local_volume_provisioner_type=static'
 #   'k8s_scylla_disk_class=scylladb-local-xfs' and 'k8s_local_volume_provisioner_type=dynamic'

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-multitenant.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-multitenant.yaml
@@ -17,6 +17,8 @@ k8s_deploy_monitoring: false
 
 n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
+# NOTE: K8S Scylla nodes have 3.5Tb disk size
+k8s_scylla_disk_gi: 1745
 
 n_monitor_nodes: 1
 


### PR DESCRIPTION
Before, when we were using `static local volume provisioner`, the disk usage was not limited and a test run could use whole disk space even if PVCs for Scylla pods were having a lower limit than the real disk capacity.

When we switched to the `dynamic local volume provisioner` the PVC size limit started making the effect not allowing to use storage more than configured.

The default value of 500Gi becomes not enough in some cases. For example the `large collections` one.

So, configure the Scylla pods storage to be `k8s_scylla_disk_gi: 3490` by default which is close to the real disk available capacity (`3.5Tb`). Update the multitenant configurations separately
based on the number of tenants.

It will allow us to avoid the following error:

    Compacting of 3 sstables interrupted due to: \
        storage_io_error (Storage I/O error: 28: No space left on device)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
