### PR TITLE
fix(create_keyspace): assign value to the replication_strategy variable

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2218,7 +2218,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 if replication_factor == 0:
                     replication_strategy = LocalReplicationStrategy()
                 else:
-                    NetworkTopologyReplicationStrategy(default_rf=replication_factor)
+                    replication_strategy = NetworkTopologyReplicationStrategy(default_rf=replication_factor)
             else:
                 replication_strategy = NetworkTopologyReplicationStrategy(**replication_factor)
 


### PR DESCRIPTION
When the replication_factor's type is an int, but is not equal to zero, a NetworkTopologyReplicationStrategy instance is created, but it is not assigned to the replication_strategy param, leaving it empty. This commit amends that.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
