### PR TITLE
fix(cdc-100gb): use any-region compatible replication config

### DIFF
--- a/test-cases/longevity/longevity-cdc-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-4h.yaml
@@ -1,6 +1,6 @@
 test_duration: 290
 
-pre_create_keyspace: "CREATE KEYSPACE cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west': '3'}  AND durable_writes = true;"
+pre_create_keyspace: "CREATE KEYSPACE cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '3'}  AND durable_writes = true;"
 stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=200m -mode cql3 native -rate threads=100",
               "cassandra-stress user no-warmup profile=/tmp/cdc_profile_preimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=200m -mode cql3 native -rate threads=100",
               "cassandra-stress user no-warmup profile=/tmp/cdc_profile_postimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=200m -mode cql3 native -rate threads=100",


### PR DESCRIPTION
For the moment the `longevity-cdc-100gb-4h` is configured the way that it works only in `eu-west` regions:

    replication = {'class': 'NetworkTopologyStrategy', 'eu-west': '3'}

Since we support more regions than compatible with the configuration we should use region-agnostic configuration like following:

    replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '3'}

So, update the `longevity-cdc-100gb-4h` job because it is used for testing of new patch-releases of the `branch-5.2` Scylla branch.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
