### PR TITLE
fix(Rollback): disable recover_system_tables

### DIFF
--- a/test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml
+++ b/test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml
@@ -21,7 +21,6 @@ user_prefix: 'kubernetes-scylla-upgrade'
 #authenticator: 'PasswordAuthenticator'
 #authenticator_user: 'cassandra'
 #authenticator_password: 'cassandra'
-#recover_system_tables: true
 
 # Does not work due to the lack of support, could be anabled after - https://github.com/scylladb/scylla-cluster-tests/issues/2747
 #append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1'

--- a/test-cases/upgrades/generic-rolling-upgrade.yaml
+++ b/test-cases/upgrades/generic-rolling-upgrade.yaml
@@ -19,8 +19,6 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: 'cassandra'
 authenticator_password: 'cassandra'
 
-recover_system_tables: true
-
 append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1'
 
 use_legacy_cluster_init: false

--- a/test-cases/upgrades/multi-dc-rolling-upgrade.yaml
+++ b/test-cases/upgrades/multi-dc-rolling-upgrade.yaml
@@ -20,8 +20,6 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: 'cassandra'
 authenticator_password: 'cassandra'
 
-recover_system_tables: true
-
 internode_compression: 'all'
 
 use_mgmt: false

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -27,8 +27,6 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: 'cassandra'
 authenticator_password: 'cassandra'
 
-recover_system_tables: true
-
 append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1'
 
 use_mgmt: false

--- a/unit_tests/test_data/test_scylla_yaml_builders/rolling-upgrade.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/rolling-upgrade.yaml
@@ -29,8 +29,6 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: 'cassandra'
 authenticator_password: 'cassandra'
 
-recover_system_tables: true
-
 append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1'
 
 # those are needed to be give by the job, via environment variable


### PR DESCRIPTION
set recover_system_tables option to False
due to https://github.com/scylladb/scylladb/issues/11907

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
