### PR TITLE
fix(cluster): support case where `availability_zone` not defined

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3123,7 +3123,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         self.added_password_suffix = False
         self.node_benchmark_manager = ScyllaClusterBenchmarkManager()
         self.racks_count = simulated_racks if (simulated_racks := self.params.get("simulated_racks")) else len(
-            self.params.get("availability_zone").split(","))
+            self.params.get("availability_zone").split(",")) if self.params.get("availability_zone") else 1
 
         if self.test_config.REUSE_CLUSTER:
             # get_node_ips_param should be defined in child


### PR DESCRIPTION
in operator functional test we have cases that `availability_zone` is not defined and an it was failing like this:

```
test_functional.py::test_mgmt_backup[3.0.0]
...
        self.racks_count = simulated_racks if (simulated_racks :=
            self.params.get("simulated_racks")) else len(
>           self.params.get("availability_zone").split(","))
E       AttributeError: 'NoneType' object has no attribute 'split'
```

fixed the asumption in this case, that `availability_zone` would be defined.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
