### PR TITLE
fix(k8s): switch to use and test manager 3.1

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -17,7 +17,7 @@ eks_nodegroup_role_arn: 'arn:aws:iam::797456418907:role/helm-test-worker-nodes-N
 eks_vpc_cni_version: 'v1.12.6-eksbuild.1'
 
 scylla_version: '5.2.1'
-scylla_mgmt_agent_version: '3.0.0'
+scylla_mgmt_agent_version: '3.1.0'
 k8s_cert_manager_version: '1.8.0'
 
 k8s_deploy_monitoring: false
@@ -58,7 +58,7 @@ k8s_instance_type_auxiliary: 't3.large'
 #       '--blocked-reactor-notify-ms 100' cannot be set, because it gets set by operator itself
 append_scylla_args: '--abort-on-lsa-bad-alloc 1 --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'
 docker_image: ''
-mgmt_docker_image: 'scylladb/scylla-manager:3.0.0'
+mgmt_docker_image: 'scylladb/scylla-manager:3.1.0'
 
 backup_bucket_backend: 's3'
 backup_bucket_location: 'minio-bucket'

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -19,8 +19,8 @@ k8s_n_auxiliary_nodes: 2
 k8s_instance_type_auxiliary: 'n1-standard-2'
 
 scylla_version: '5.2.1'
-scylla_mgmt_agent_version: '3.0.0'
-mgmt_docker_image: 'scylladb/scylla-manager:3.0.0'
+scylla_mgmt_agent_version: '3.1.0'
+mgmt_docker_image: 'scylladb/scylla-manager:3.1.0'
 
 # NOTE: If 'k8s_scylla_operator_docker_image' not set then the one from helm chart will be used.
 # To test nightly builds define it like this: 'scylladb/scylla-operator:nightly'

--- a/defaults/k8s_local_kind_config.yaml
+++ b/defaults/k8s_local_kind_config.yaml
@@ -5,8 +5,8 @@ n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
 
 scylla_version: '5.2.1'
-scylla_mgmt_agent_version: '3.0.0'
-mgmt_docker_image: 'scylladb/scylla-manager:3.0.0'
+scylla_mgmt_agent_version: '3.1.0'
+mgmt_docker_image: 'scylladb/scylla-manager:3.1.0'
 
 # NOTE: If 'k8s_scylla_operator_docker_image' not set then the one from helm chart will be used.
 # To test nightly builds define it like this: 'scylladb/scylla-operator:nightly'

--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -202,12 +202,10 @@ def test_scylla_cluster_monitoring_type_platform(db_cluster: ScyllaPodCluster):
 #       - '2.3.x' and ''2.4.x' are not covered as old ones.
 @pytest.mark.requires_mgmt
 @pytest.mark.parametrize("manager_version", (
-    "3.0.0",
-    "2.6.3",
+    "3.0.2",
+    "3.1.0",
 ))
 def test_mgmt_repair(db_cluster, manager_version):
-    if manager_version == "2.6.3":
-        raise pytest.skip("Disabled due to the https://github.com/scylladb/scylla-manager/issues/3156")
     reinstall_scylla_manager(db_cluster, manager_version)
 
     # Run manager repair operation
@@ -229,12 +227,10 @@ def test_mgmt_repair(db_cluster, manager_version):
 #       - '2.3.x' and ''2.4.x' are not covered as old ones.
 @pytest.mark.requires_mgmt
 @pytest.mark.parametrize("manager_version", (
-    "2.6.3",
-    "3.0.0",
+    "3.0.2",
+    "3.1.0",
 ))
 def test_mgmt_backup(db_cluster, manager_version):
-    if manager_version == "2.6.3":
-        raise pytest.skip("Disabled due to the https://github.com/scylladb/scylla-manager/issues/3156")
     reinstall_scylla_manager(db_cluster, manager_version)
 
     # Run manager backup operation


### PR DESCRIPTION
* add functional test of manager 3.1
* remove testing of manager 2.6
* default all k8s runs to use manager 3.1

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
