### PR TITLE
fix(wait_for): Support stop wait_for by event

### DIFF
--- a/sdcm/exceptions.py
+++ b/sdcm/exceptions.py
@@ -59,3 +59,11 @@ class BootstrapStreamErrorFailure(Exception):  # pylint: disable=too-few-public-
 
 class KillNemesis(BaseException):
     """Exception that would be raised, when a nemesis thread is killed at teardown of the test"""
+
+
+class WaitForTimeoutError(Exception):
+    """Exception that would be raised timeout exceeded in wait.wait_for function"""
+
+
+class ExitByEventError(Exception):
+    """Exception that would be raised if wait.wait_for stopped by event"""


### PR DESCRIPTION
During prepare new nemesis BootstrapStreaming error, for some case it is need to stop wait_for function ealier and don't wait whole timeout

example when you expect that bootstrap will failed and you can find appropriate error in log, but not need to raise any exception or critical event, wait for db up will continue to wait while port will be available

For such case it will be good to have flag, if it is set, than stop wait_for function

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- ~[ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- ~[ ] I have updated the Readme/doc folder accordingly (if needed)~
