### PR TITLE
fix(k8s-upgrade): change base and target version to enterprise

### DIFF
--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -1,5 +1,5 @@
 instance_provision: 'on_demand'
-gce_datacenter: 'us-east1-b'
+gce_datacenter: 'us-east1'
 gce_network: 'qa-vpc'
 gce_image_username: 'scylla-test'
 

--- a/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-k8s-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-k8s-eks.jenkinsfile
@@ -5,8 +5,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingOperatorUpgradePipeline(
     backend: 'k8s-eks',
     region: 'eu-north-1',
-    base_versions: '["4.3.2"]',
-    new_version: '4.4.1',
+    base_versions: '["2022.1.6"]',
+    new_version: '2022.2.7',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',
     test_config: 'test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml',
     availability_zone: 'a,b',

--- a/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-k8s-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-k8s-gke.jenkinsfile
@@ -5,8 +5,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingOperatorUpgradePipeline(
     backend: 'k8s-gke',
     region: 'us-east1',
-    base_versions: '["4.1.5"]',
-    new_version: '4.2.1',
+    base_versions: '["2022.1.6"]',
+    new_version: '2022.2.7',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',
     test_config: 'test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml',
 )

--- a/jenkins-pipelines/operator/upgrade/upgrade-scylla-k8s-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-scylla-k8s-eks.jenkinsfile
@@ -5,8 +5,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingOperatorUpgradePipeline(
     backend: 'k8s-eks',
     region: 'eu-north-1',
-    base_versions: '["4.4.0"]',
-    new_version: '4.4.1',
+    base_versions: '["2022.1.6"]',
+    new_version: '2022.2.7',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',
     test_config: 'test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml',
     availability_zone: 'a,b',

--- a/jenkins-pipelines/operator/upgrade/upgrade-scylla-k8s-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-scylla-k8s-gke.jenkinsfile
@@ -5,8 +5,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingOperatorUpgradePipeline(
     backend: 'k8s-gke',
     region: 'us-east1',
-    base_versions: '["4.2.0"]',
-    new_version: '4.2.1',
+    base_versions: '["2022.1.6"]',
+    new_version: '2022.2.7',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',
     test_config: 'test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml',
 )

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -19,7 +19,7 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('region', '')}",
                description: 'Supported: us-east-1 | eu-west-1 | eu-west-2 | eu-north-1 | eu-central-1 | us-west-2 | random (randomly select region)',
                name: 'region')
-            string(defaultValue: "a",
+            string(defaultValue: "${pipelineParams.get('availability_zone', 'a')}",
                description: 'Availability zone',
                name: 'availability_zone')
             string(defaultValue: "${pipelineParams.get('base_versions', '')}",


### PR DESCRIPTION
since operartor 1.8 was are testing mainly the enterprise images, and we should change the default of the test to the latest verisons we want to be using.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
