### PR TITLE
fix(k8s-manager): implement `delete_task`

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -218,6 +218,8 @@ def test_mgmt_repair(db_cluster, manager_version):
     assert task_final_status == TaskStatus.DONE, 'Task: {} final status is: {}.'.format(
         mgr_task.id, str(mgr_task.status))
 
+    mgr_cluster.delete_task(task=mgr_task)
+
 
 # NOTE: Scylla manager versions notes:
 #       - '2.6.3' is broken: https://github.com/scylladb/scylla-manager/issues/3156
@@ -245,6 +247,8 @@ def test_mgmt_backup(db_cluster, manager_version):
     assert mgr_task, "Failed to create backup task"
     status = mgr_task.wait_and_get_final_status(timeout=7200, step=5, only_final=True)
     assert TaskStatus.DONE == status
+
+    mgr_cluster.delete_task(task=mgr_task)
 
 
 def test_drain_kubernetes_node_then_replace_scylla_node(db_cluster):

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2592,6 +2592,28 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
             content_type=JSON_PATCH_TYPE
         )
 
+    def remove_scylla_cluster_value(self, path: str, element_name: str):
+        element_list = self.get_scylla_cluster_value(path) or []
+        found_index = None
+        for index, item in enumerate(element_list):
+            if item.get("name") == element_name:
+                found_index = index
+                break
+        else:
+            raise ValueError(f"{element_name} wasn't found in {path}")
+
+        self._k8s_scylla_cluster_api.patch(
+            body=[
+                {
+                    "op": "remove",
+                    "path": f"{path}/{found_index}",
+                }
+            ],
+            name=self.scylla_cluster_name,
+            namespace=self.namespace,
+            content_type=JSON_PATCH_TYPE
+        )
+
     @property
     def scylla_restart_required(self) -> bool:
         return self.k8s_cluster.scylla_restart_required

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -706,7 +706,8 @@ class ManagerCluster(ScyllaManagerBase):
             cmd += " --ssl-user-cert-file {} --ssl-user-key-file {}".format(SSL_USER_CERT_FILE, SSL_USER_KEY_FILE)
         self.sctool.run(cmd=cmd, is_verify_errorless_result=True)
 
-    def delete_task(self, task_id):
+    def delete_task(self, task: ManagerTask):
+        task_id = task.id
         if self.sctool.is_v3_cli:
             cmd = "stop --delete {} -c {}".format(task_id, self.id)
         else:
@@ -719,7 +720,7 @@ class ManagerCluster(ScyllaManagerBase):
         repair_tasks_list = self.repair_task_list
         if repair_tasks_list:
             automatic_repair_task = repair_tasks_list[0]
-            self.delete_task(automatic_repair_task.id)
+            self.delete_task(automatic_repair_task)
 
     @property
     def _cluster_list(self):

--- a/sdcm/mgmt/operator.py
+++ b/sdcm/mgmt/operator.py
@@ -21,6 +21,7 @@ from sdcm.mgmt.cli import (
     ManagerCluster,
     RepairTask,
     ScyllaManagerTool,
+    ManagerTask,
 )
 from sdcm.mgmt.common import TaskStatus
 from sdcm.wait import wait_for
@@ -387,8 +388,13 @@ class OperatorManagerCluster(ManagerCluster):
     def update(self, name=None, host=None, client_encrypt=None):
         raise NotImplementedError()
 
-    def delete_task(self, task_id):
-        raise NotImplementedError()
+    def delete_task(self, task: ManagerTask) -> None:
+        LOGGER.debug("deleting task [%s - %s]", task.__class__.__name__, task.id)
+        name = task.id.split('/')[-1]
+        if isinstance(task, RepairTask):
+            self.scylla_cluster.remove_scylla_cluster_value('/spec/repairs', element_name=name)
+        if isinstance(task, BackupTask):
+            self.scylla_cluster.remove_scylla_cluster_value('/spec/backups', element_name=name)
 
 
 class ScyllaManagerToolOperator(ScyllaManagerTool):

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2619,9 +2619,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         deleted_tasks = []
         existing_backup_tasks = mgr_cluster.backup_task_list
         for backup_task in existing_backup_tasks:
-            if backup_task.status in [TaskStatus.NEW, TaskStatus.RUNNING, TaskStatus.STARTING]:
+            if backup_task.status in [TaskStatus.NEW, TaskStatus.RUNNING, TaskStatus.STARTING, TaskStatus.ERROR]:
                 deleted_tasks.append(backup_task.id)
-                mgr_cluster.delete_task(backup_task.id)
+                mgr_cluster.delete_task(backup_task)
         if deleted_tasks:
             self.log.warning("Deleted the following backup tasks before the nemesis starts: %s",
                              ", ".join(deleted_tasks))


### PR DESCRIPTION
Some recent changes to backup nemesis are now trying the clear existing tasks, but it wasn't implemented, and failing like:

```
Traceback (most recent call last):
  File ".../sdcm/nemesis.py", line 4425, in wrapper
    result = method(*args[1:], **kwargs)
  File ".../sdcm/nemesis.py", line 2611, in disrupt_mgmt_backup
    self._mgmt_backup(backup_specific_tables=False)
  File ".../sdcm/nemesis.py", line 2643, in _mgmt_backup
    self._delete_existing_backups(mgr_cluster)
  File ".../sdcm/nemesis.py", line 2619, in _delete_existing_backups
    mgr_cluster.delete_task(backup_task.id)
  File ".../sdcm/mgmt/operator.py", line 391, in delete_task
    raise NotImplementedError()
NotImplementedError
```

we now can lookup the cluster spec for those task
and remove them from cluster spec

### Testing
- [x] - GKE - https://argus.scylladb.com/test/6029a44f-fc6a-4bcd-92d5-68dd4b856770/runs?additionalRuns[]=2c482219-f28b-4baa-8b6b-dbaa1a707ab3 
- [x] - EKS -https://argus.scylladb.com/test/baef620d-147b-4f29-99be-54fe724d5ca5/runs?additionalRuns[]=892b4a47-8c67-4544-9883-f6b9c7e287a7

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
