### PR TITLE
fix(wait_for): stop using `tenacity.RetryError`

### DIFF
--- a/sdcm/wait.py
+++ b/sdcm/wait.py
@@ -28,6 +28,10 @@ LOGGER = logging.getLogger("sdcm.wait")
 R = TypeVar("R")  # pylint: disable=invalid-name
 
 
+class WaitForTimeoutError(Exception):
+    pass
+
+
 def wait_for(func, step=1, text=None, timeout=None, throw_exc=True, **kwargs):
     """
     Wrapper function to wait with timeout option.
@@ -73,7 +77,7 @@ def wait_for(func, step=1, text=None, timeout=None, throw_exc=True, **kwargs):
             LOGGER.error("last error: %r", ex)
         if throw_exc:
             if hasattr(ex, 'last_attempt') and not ex.last_attempt._result:  # pylint: disable=protected-access,no-member
-                raise tenacity.RetryError(err) from ex
+                raise WaitForTimeoutError(err) from ex
             raise
 
     return res


### PR DESCRIPTION
`tenacity.RetryError` get a future as parameter, and SCT was passing a string to it's `__init__`

causing this failure in cases of casscading `wait_for` calls:

```
res = retry(func, **kwargs)
except Exception as ex:  # pylint: disable=broad-except
err = f"Wait for: {text or func.__name__}: timeout - {timeout} seconds - expired"
LOGGER.error(err)
>           if hasattr(ex, 'last_attempt') and ex.last_attempt.exception() is not None:
E           AttributeError: 'str' object has no attribute 'exception'
```

### Testing
- [x] - https://jenkins.scylladb.com/job/scylla-operator/job/operator-1.9/job/functional/job/functional-k8s-local-kind-gce/4/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
