### PR TITLE
fix(sct-runner): call the correct API for deletion

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -837,7 +837,12 @@ class GceSctRunner(SctRunner):  # pylint: disable=too-many-instance-attributes
 
     @staticmethod
     def terminate_sct_runner_instance(sct_runner_info: SctRunnerInfo) -> None:
-        sct_runner_info.instance.destroy()
+        instance = sct_runner_info.instance
+        instances_client, info = get_gce_compute_instances_client()
+        res = instances_client.delete(instance=instance.name,
+                                      project=info['project_id'],
+                                      zone=instance.zone.split('/')[-1])
+        res.done()
 
 
 class AzureSctRunner(SctRunner):


### PR DESCRIPTION
as part of 43e4973c375233d2672c4a8a43b4a93ecc6caba0 when libcloud was remove, the `.destory()` call was left in sct_runner, and was failing to clean runners like this:

```
Terminate [gce/us-east1-d] sct-runner-1-6-instance-ffeb15d5,
launched at June 09, 2023, 01:08:40 UTC, keep: 16, keep_action:
terminate, public IPs are ['35.231.187.71']

Exception raised during termination of [gce/us-east1-d] sct-runner-1-6-instance-ffeb15d5,
launched at June 09, 2023, 01:08:40 UTC, keep: 16, keep_action: terminate,
public IPs are ['35.231.187.71']: Unknown field for Instance: destroy
```

replaced it with the correct call for deleting an instance.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
