### PR TITLE
fix(k8s): make `fstrim_scylla_disks` work correctly

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2214,7 +2214,7 @@ class BaseScyllaPodContainer(BasePodContainer):  # pylint: disable=abstract-meth
             scylla_disk_path = "/mnt/raid-disks/disk0/"
             namespace = "default"
         else:
-            pods_selector = "app.kubernetes.io/instance=local-csi-driver"
+            pods_selector = "app.kubernetes.io/name=local-csi-driver"
             scylla_disk_path = "/mnt/persistent-volumes"
             namespace = "local-csi-driver"
         podnames = self.parent_cluster.k8s_cluster.kubectl(


### PR DESCRIPTION
ac8279770a6167feeb1f4142735eaccc6b3ee063 changed `fstrim_scylla_disks` implementation to support `k8s_local_volume_provisioner_type=dynamic` but it's selectors were not quite accurate.

this fixes them, and add support the output of the command to be newline seperated correctly

when it was failing it was failing like this:
```
Running command "kubectl --cache-dir=... --namespace=local-csi-driver
   exec -ti  -- sh -c 'fstrim -v /mnt/persistent-volumes'"...

error: pod, type/name or --filename must be specified
```

### Testing
- [ ] - https://jenkins.scylladb.com/job/scylla-operator/job/operator-1.9/job/performance/job/perf-regression-throughput-eks/3/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
