### PR TITLE
feature(EaR-KMS): Add tests for EaR AWS KMS service

### DIFF
--- a/configurations/kms-ear.yaml
+++ b/configurations/kms-ear.yaml
@@ -7,3 +7,5 @@ append_scylla_yaml: |
       kms_test:
           master_key: 'alias/kms_encryption_test'
           aws_region: 'us-east-1'
+
+append_scylla_args: '--logger-log-level kms=trace'

--- a/configurations/kms-ear.yaml
+++ b/configurations/kms-ear.yaml
@@ -1,0 +1,9 @@
+
+scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'KmsKeyProviderFactory', 'kms_host': 'kms_test'}"
+
+# config kms_hosts for AWS KMS service account
+append_scylla_yaml: |
+  kms_hosts:
+      kms_test:
+          master_key: 'alias/kms_encryption_test'
+          aws_region: 'us-east-1'

--- a/jenkins-pipelines/EaR-longevity-kms-200gb-6h.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-kms-200gb-6h.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml", "configurations/kms-ear.yaml"]'''
+
+)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1595,6 +1595,14 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 self.parent_cluster.proposed_scylla_yaml,
                 self.proposed_scylla_yaml
             )
+            is_kms = bool(scylla_yml.kms_hosts)
+
+        if is_kms:
+            # Hack for overriding issue https://github.com/scylladb/scylla-enterprise/issues/2792
+            # TODO: should be remove once a proper fix is implemented
+            self.remoter.sudo("find /opt/scylladb/ -iname *libp11-kit.so* | sudo xargs rm",
+                              verbose=True, ignore_status=True)
+            self.install_package("p11-kit")
 
         self.process_scylla_args(append_scylla_args)
 

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -332,6 +332,7 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods
     system_key_directory: str = None  # None
     system_info_encryption: dict = None  # None
     kmip_hosts: dict = None  # None
+    kms_hosts: dict = None  # None
 
     def dict(  # pylint: disable=arguments-differ
         self,

--- a/sdcm/remote/remote_file.py
+++ b/sdcm/remote/remote_file.py
@@ -32,7 +32,7 @@ def read_to_stringio(fobj):
 # pylint: disable=too-many-locals,too-many-arguments
 @contextlib.contextmanager
 def remote_file(remoter, remote_path, serializer=StringIO.getvalue, deserializer=read_to_stringio, sudo=False,
-                preserve_ownership=True, preserve_permissions=True):
+                preserve_ownership=True, preserve_permissions=True, log_change=True):
     filename = os.path.basename(remote_path)
     local_tempfile = os.path.join(tempfile.mkdtemp(prefix='sct'), filename)
     if preserve_ownership:
@@ -60,7 +60,8 @@ def remote_file(remoter, remote_path, serializer=StringIO.getvalue, deserializer
         with open(local_tempfile, "w", encoding="utf-8") as fobj:
             fobj.write(content)
 
-        LOGGER.debug("New content of `%s':\n%s", remote_path, content)
+        if log_change:
+            LOGGER.debug("New content of `%s':\n%s", remote_path, content)
 
         remote_tempfile = remoter.run("mktemp").stdout.strip()
         remote_tempfile_move_cmd = f"mv '{remote_tempfile}' '{remote_path}'"

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -270,6 +270,7 @@ class ScyllaYamlTest(unittest.TestCase):
                 'key_cache_save_period': None,
                 'key_cache_size_in_mb': None,
                 'kmip_hosts': None,
+                'kms_hosts': None,
                 'large_memory_allocation_warning_threshold': None,
                 'ldap_attr_role': None,
                 'ldap_bind_dn': None,


### PR DESCRIPTION
Scylla added a support for AWS KMS to be used with
the enterprise feature of Encryption-at-Rest.

* adding new test configuration yaml for it
* support it in scylla.yaml

### Testing
- [x] - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/EaR-longevity-kms-200gb-6h-test/2/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
