### PR TITLE
fix(images account): new releng account images tags missing

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -578,15 +578,16 @@ def list_resources(ctx, user, test_id, get_all, get_all_running, verbose):
 @click.option('-a', '--arch',
               type=click.Choice(AwsArchType.__args__),
               default='x86_64',
-              help="architecture of the AMI (default: x86_64)")
+              help="architecture of the AMI (default: x86_64)")  # pylint: disable=too-many-locals
 def list_images(cloud_provider: str, branch: str, version: str, region: str, arch: AwsArchType):
     add_file_logger()
     version_fields = ["Backend", "Name", "ImageId", "CreationDate"]
     version_fields_with_tag_name = version_fields + ["NameTag"]
     #  TODO: align branch and version fields once scylla-pkg#2995 is resolved
     branch_specific_fields = ["BuildId", "Arch", "ScyllaVersion"]
+    account_field = ["OwnerId"]
     branch_fields = version_fields + branch_specific_fields
-    branch_fields_with_tag_name = version_fields_with_tag_name + branch_specific_fields
+    branch_fields_with_tag_name = version_fields_with_tag_name + branch_specific_fields + account_field
     if version and branch:
         click.echo("Use --version or --branch, not both.")
         return

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -369,7 +369,7 @@ def get_arch_from_instance_type(instance_type: str) -> AwsArchType:
     return 'x86_64'
 
 
-def get_scylla_images_ec2_client(region_name: str) -> EC2ServiceResource:
+def get_scylla_images_ec2_resource(region_name: str) -> EC2ServiceResource:
     session = boto3.Session()
     sts = session.client("sts")
     role_info = KeyStore().get_json('aws_images_role.json')

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1909,7 +1909,7 @@ def get_ami_images(branch: str, region: str, arch: AwsArchType) -> list:
     for ami in amis:
         tags = {i['Key']: i['Value'] for i in ami.tags}
         rows.append(["AWS", ami.name, ami.image_id, ami.creation_date, tags.get("Name"), tags.get(
-            'build-id', tags.get("build_id"))[:6], tags.get('arch'), tags.get('ScyllaVersion')])
+            'build-id', tags.get("build_id"))[:6], tags.get('arch'), tags.get('ScyllaVersion'), ami.owner_id])
 
     return rows
 

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -68,7 +68,7 @@ from sdcm.provision.azure.provisioner import AzureProvisioner
 from sdcm.sct_events import Severity
 from sdcm.sct_events.system import CpuNotHighEnoughEvent, SoftTimeoutEvent
 from sdcm.utils.argus import ArgusError, get_argus_client, terminate_resource_in_argus
-from sdcm.utils.aws_utils import EksClusterCleanupMixin, AwsArchType, get_scylla_images_ec2_client
+from sdcm.utils.aws_utils import EksClusterCleanupMixin, AwsArchType, get_scylla_images_ec2_resource
 
 from sdcm.utils.ssh_agent import SSHAgent
 from sdcm.utils.decorators import retrying
@@ -1518,7 +1518,7 @@ def get_scylla_ami_versions(region_name: str, arch: AwsArchType = 'x86_64', vers
 
     ec2_resource: EC2ServiceResource = boto3.resource('ec2', region_name=region_name)
     images = []
-    for client, owner in zip((ec2_resource, get_scylla_images_ec2_client(region_name=region_name)),
+    for client, owner in zip((ec2_resource, get_scylla_images_ec2_resource(region_name=region_name)),
                              SCYLLA_AMI_OWNER_ID_LIST):
         images += client.images.filter(
             Owners=[owner],
@@ -1872,7 +1872,7 @@ def get_branched_ami(scylla_version: str, region_name: str, arch: AwsArchType = 
     ec2_resource: EC2ServiceResource = boto3.resource("ec2", region_name=region_name)
     images = []
 
-    for client, owner in zip((ec2_resource, get_scylla_images_ec2_client(region_name=region_name)),
+    for client, owner in zip((ec2_resource, get_scylla_images_ec2_resource(region_name=region_name)),
                              SCYLLA_AMI_OWNER_ID_LIST):
         if build_id not in ("latest", "all",):
             images += [
@@ -2053,12 +2053,17 @@ def get_ami_tags(ami_id, region_name):
     :param region_name: the region to look AMIs in
     :return: dict of tags
     """
-    ec2_resource: EC2ServiceResource = boto3.resource('ec2', region_name=region_name)
-    test_image = ec2_resource.Image(ami_id)
-    if test_image.tags:
-        return {i['Key']: i['Value'] for i in test_image.tags}
+    scylla_images_ec2_resource = get_scylla_images_ec2_resource(region_name=region_name)
+    new_test_image = scylla_images_ec2_resource.Image(ami_id)
+    if new_test_image:
+        return {i['Key']: i['Value'] for i in new_test_image.tags}
     else:
-        return {}
+        ec2_resource: EC2ServiceResource = boto3.resource('ec2', region_name=region_name)
+        test_image = ec2_resource.Image(ami_id)
+        if test_image.tags:
+            return {i['Key']: i['Value'] for i in test_image.tags}
+        else:
+            return {}
 
 
 def get_db_tables(session, ks, with_compact_storage=True):


### PR DESCRIPTION
since releng is moving to create the images on another account, we have introduced the changes to list the images regardless general or releng accounts #6167, but we lack during `verify_configuration_urls_validity` the tags, as they are not listed in the general account, but only on releng account, hence we need to impersonate releng account to list the tags (as we need to validate content of `user_data_format_version` to proceed with SCT provision steps.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
