### PR TITLE
fix(upgrade): fix InfoEvent message in test_generic_cluster_upgrade

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -859,7 +859,8 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
 
         # Rollback all nodes that where upgraded (not necessarily in the same order)
         random.shuffle(upgraded_nodes)
-        InfoEvent(message='Upgraded Nodes to be rollback are: %s' % upgraded_nodes).publish()
+        InfoEvent(message='Upgraded Nodes to be rollback are: %s' %
+                  ", ".join(node.name for node in upgraded_nodes)).publish()
         for node in upgraded_nodes:
             self._start_and_wait_for_node_rollback(node, step=next(step))
 


### PR DESCRIPTION
Info event prints node python object instead of node name:

```
message=Upgraded Nodes to be rollback are: [<sdcm.cluster_gce.GCENode object at 0x7f413c697dc0>,
 <sdcm.cluster_gce.GCENode object at 0x7f413c622110>]
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
