### PR TITLE
fix(upgrade): remove end-line character from stdout

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -167,7 +167,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         # We assume that if update_db_packages is not empty we install packages from there.
         # In this case we don't use upgrade based on new_scylla_repo(ignored sudo yum update scylla...)
         result = node.remoter.run('scylla --version')
-        self.orig_ver = result.stdout
+        self.orig_ver = result.stdout.strip()
 
         if upgrade_node_packages:
             # update_scylla_packages
@@ -246,7 +246,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         node.start_scylla_server(verify_up_timeout=500)
         self.db_cluster.get_db_nodes_cpu_mode()
         result = node.remoter.run('scylla --version')
-        new_ver = result.stdout
+        new_ver = result.stdout.strip()
         assert self.orig_ver != new_ver, "scylla-server version isn't changed"
         self.new_ver = new_ver
         self._update_argus_upgraded_version(node, new_ver)
@@ -261,7 +261,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
 
         InfoEvent(message='Rollbacking a Node').publish()
         result = node.remoter.run('scylla --version')
-        orig_ver = result.stdout
+        orig_ver = result.stdout.strip()
         # flush all memtables to SSTables
         node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True)
         # backup the data
@@ -332,7 +332,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         node.run_scylla_sysconfig_setup()
         node.start_scylla_server(verify_up_timeout=500)
         result = node.remoter.run('scylla --version')
-        new_ver = result.stdout
+        new_ver = result.stdout.strip()
         InfoEvent(message='original scylla-server version is %s, latest: %s' % (orig_ver, new_ver)).publish()
         assert orig_ver != new_ver, "scylla-server version isn't changed"
 


### PR DESCRIPTION
Scylla version of a node is received as output of a shell command 'scylla --version'. The output includes end-line character and that breaks the InfoEvent message to the 2 lines:

:INFO  > : (InfoEvent Severity.NORMAL) message=original scylla-server version is 2023.1.0~rc6
:INFO  > , latest: 5.2.1-0.20230508.f1c45553bc29

As result only part of the message is presented in event.log Strip the output to prevent it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
