### PR TITLE
fix(alternator): fix three nemesis with ignore_ycsb_connection_refused

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -590,6 +590,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             return
         self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
+    @decorate_with_context(ignore_ycsb_connection_refused)
     def disrupt_stop_start_scylla_server(self):  # pylint: disable=invalid-name
         self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
         self.target_node.start_scylla_server(verify_up=True, verify_down=False)
@@ -1115,6 +1116,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         # try to save the node
         self.repair_nodetool_rebuild()
 
+    @decorate_with_context(ignore_ycsb_connection_refused)
     def disrupt_nodetool_drain(self):
         result = self.target_node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True)
         self.target_node.run_nodetool("status", ignore_status=True, verbose=True,
@@ -1524,6 +1526,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 new_node.set_seed_flag(True)
                 self.cluster.update_seed_provider()
 
+    @decorate_with_context(ignore_ycsb_connection_refused)
     def disrupt_kill_scylla(self):
         self._kill_scylla_daemon()
 


### PR DESCRIPTION
During test: longevity-alternator-200gb-48h-gce

Two nemesis where we need to ignore connection_refused
```
[Thread-13] ERROR site.ycsb.db.DynamoDBClient  -com.amazonaws.SdkClientException: Unable to execute HTTP request: Connect to alternator:8080 [alternator/10.142.0.26] failed: Connection refused (Connection refused)
```

spotted on:
disrupt_stop_start_scylla_server
disrupt_kill_scylla

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
