### PR TITLE
fix(add_rm_mv): Don't stop node when parallel nemesis runs

### DIFF
--- a/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
@@ -17,7 +17,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i3en.xlarge'
 
 nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
-nemesis_selector: [["topology_changes"],["schema_changes"]]
+nemesis_selector: [["topology_changes"],["!disruptive","schema_changes"]]
 nemesis_interval: 10
 nemesis_filter_seeds: false
 nemesis_during_prepare: false

--- a/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
@@ -20,7 +20,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i4i.2xlarge'
 
 nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
-nemesis_selector: [["topology_changes"],["schema_changes"]]
+nemesis_selector: [["topology_changes"],["schema_changes","!disruptive"]]
 nemesis_interval: 10
 nemesis_filter_seeds: false
 nemesis_during_prepare: false


### PR DESCRIPTION
When nemesises run in paralel, nemesis Add_Remove_MV stop node for while. This could cause the error upon adding new node by another nemesis (Decommission, GrowShrink). Because with raft feature when new node is added to cluster, all nodes should be in UN state.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
