### PR TITLE
improvement(azure): add feature for cloud_provider initial support.

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -693,7 +693,8 @@ def list_repos(dist_type, dist_version):
               help='Scylla repo')
 @click.option('-d', '--linux-distro', type=str, help='Linux Distribution type')
 @click.option('-o', '--only-print-versions', type=bool, default=False, required=False, help='')
-def get_scylla_base_versions(scylla_version, scylla_repo, linux_distro, only_print_versions):  # pylint: disable=too-many-locals
+@cloud_provider_option(default="aws", required=False, help="Cloud provided to query. Defaults to aws.")
+def get_scylla_base_versions(scylla_version, scylla_repo, linux_distro, only_print_versions, cloud_provider):  # pylint: disable=too-many-locals
     """
     Upgrade test try to upgrade from multiple supported base versions, this command is used to
     get the base versions according to the scylla repo and distro type, then we don't need to hardcode
@@ -715,7 +716,7 @@ def get_scylla_base_versions(scylla_version, scylla_repo, linux_distro, only_pri
 
     # We can't detect the support versions for this distro, which shares the repo with others, eg: centos8
     # so we need to assign the start support versions for it.
-    version_detector.set_start_support_version()
+    version_detector.set_start_support_version(cloud_provider)
 
     supported_versions, version_list = version_detector.get_version_list()
     click.echo(f'Supported Versions: {supported_versions}')

--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -17,11 +17,11 @@ import unittest
 from utils.get_supported_scylla_base_versions import UpgradeBaseVersion  # pylint: disable=no-name-in-module, import-error
 
 
-def general_test(scylla_repo='', linux_distro=''):
+def general_test(scylla_repo='', linux_distro='', cloud_provider=None):
     scylla_version = None
 
     version_detector = UpgradeBaseVersion(scylla_repo, linux_distro, scylla_version)
-    version_detector.set_start_support_version()
+    version_detector.set_start_support_version(cloud_provider)
     _, version_list = version_detector.get_version_list()
     return version_list
 
@@ -35,6 +35,24 @@ class TestBaseVersion(unittest.TestCase):
         linux_distro = 'centos'
         version_list = general_test(scylla_repo, linux_distro)
         self.assertEqual(version_list, ['5.3'])
+
+    def test_ubuntu_22_azure_5_3(self):
+        scylla_repo = self.url_base + '/branch-5.3/deb/unified/2023-05-23T22:36:08Z/scylladb-5.3/scylla.list'
+        linux_distro = 'ubuntu-jammy'
+        cloud_provider = 'azure'
+        version_list = general_test(scylla_repo, linux_distro, cloud_provider)
+        self.assertEqual(version_list, ['5.2'])
+
+    def test_ubuntu_22_azure_2023_1(self):
+        scylla_repo = self.url_base +\
+            '-enterprise/enterprise-2023.1/deb/unified/2023-05-17T23:03:35Z/scylladb-2023.1/scylla.list'
+        linux_distro = 'ubuntu-jammy'
+        cloud_provider = 'azure'
+        version_list = general_test(scylla_repo, linux_distro, cloud_provider)
+        # TODO: add 2023.1 to the list below:
+        # once 2023.1 will be released, it will appear in the list below, but as it is not only on an RC,
+        # it was filtered out during `self.filter_rc_only_version(ent_base_version)`
+        self.assertEqual(version_list, ['5.2'])
 
     def test_4_5_with_centos8(self):
         scylla_repo = self.url_base + '/branch-4.5/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -18,6 +18,7 @@ LOGGER = logging.getLogger(__name__)
 supported_src_oss = {'2021.1': '4.3', '2022.1': '5.0', '2022.2': '5.1', '2023.1': '5.2', '2023.2': '5.3'}
 # If new support distro shared repo with others, we need to assign the start support versions. eg: centos8
 start_support_versions = {'centos-8': {'scylla': '4.1', 'enterprise': '2021.1'}}
+start_support_cloud_provider = {'azure': {'scylla': '5.2', 'enterprise': '2023.1'}}
 
 
 class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
@@ -52,7 +53,7 @@ class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
         LOGGER.info("Scylla product and major version used for upgrade versions listing: %s, %s", product, version)
         return product, scylla_version
 
-    def set_start_support_version(self) -> None:
+    def set_start_support_version(self, cloud_provider: str = None) -> None:
         """
         We can't detect the support versions for this distro, which shares the repo with others, eg: centos8
         so we need to assign the start support versions for it.
@@ -65,8 +66,12 @@ class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
                     f"We can't detect the support versions for this distro, which shares the repo with {self.dist_type}.")
             self.oss_start_support_version = versions_dict['scylla']
             self.ent_start_support_version = versions_dict['enterprise']
-            LOGGER.info("Support start versions set: oss=%s enterprise=%s", self.oss_start_support_version,
-                        self.ent_start_support_version)
+        backend_dict = start_support_cloud_provider.get(cloud_provider, None)
+        if backend_dict:
+            self.oss_start_support_version = backend_dict['scylla']
+            self.ent_start_support_version = backend_dict['enterprise']
+        LOGGER.info("Support start versions set: oss=%s enterprise=%s", self.oss_start_support_version,
+                    self.ent_start_support_version)
 
     def get_supported_scylla_base_versions(self, supported_versions) -> list:  # pylint: disable=too-many-branches
         """


### PR DESCRIPTION
Since 5.2 and 2023.1 will be the 1st official versions
of Scylla to support Azure (OSS and Enterprise
respectively), we needed a mechanism to add support
for it. It right now gives us a place to add
the initial supported version for different cloud
providers, if they will be added to Scylla.
So let's suppose that, for each OSS we upgrade from
previous version + current version previous released patches.
In case of Azure cloud provider, we will no do that, as
for `5.2` as an example, `5.1` doesn't officially support
Azure images... so we will know how to correctly
filter, in our upgrade jobs, what is the "oldest"
version we should use in these tests.

Relates to https://github.com/scylladb/qa-tasks/issues/1116


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
