### PR TITLE
fix(indexes.py): fix regex for filter MV event

### DIFF
--- a/sdcm/utils/nemesis_utils/indexes.py
+++ b/sdcm/utils/nemesis_utils/indexes.py
@@ -131,6 +131,6 @@ def drop_materialized_view(session, ks, view_name) -> None:
     LOGGER.info('start dropping MV: %s.%s', ks, view_name)
     with EventsFilter(
             event_class=DatabaseLogEvent.DATABASE_ERROR,
-            regex="Error applying view update",
+            regex=".*Error applying view update.*",
             extra_time_to_expiration=180):
         session.execute(f'DROP MATERIALIZED VIEW {ks}.{view_name}')


### PR DESCRIPTION
A test running add-remove-mv previously failed with:
```
2023-06-10T01:27:49+00:00 longevity-mv-si-4d-2023-1-db-node-2c733d4e-19      !ERR | scylla[44626]:  [shard  4] view - Error applying view update to 10.4.3.75 (view: mview.users_view, base token: 559988313294457371, view token: 7837635964277591733): data_dictionary::no_such_column_family (Can't find a column family with UUID 463c73f0-0727-11ee-ad26-d9bc05da6d1d)
2023-06-10 01:27:49.352 &lt;2023-06-10 01:27:49.000&gt;: (DatabaseLogEvent Severity.ERROR) period_type=one-time event_id=8f45a7c6-8687-48e4-b62d-822cd719082f during_nemesis=DecommissionStreamingErr: type=DATABASE_ERROR regex=(^ERROR|!\s*?ERR).*\[shard.*\] line_number=394075 node=longevity-mv-si-4d-2023-1-db-node-2c733d4e-19
2023-06-10T01:27:49+00:00 longevity-mv-si-4d-2023-1-db-node-2c733d4e-19      !ERR | scylla[44626]:  [shard  4] view - Error applying view update to 10.4.3.75 (view: mview.users_view, base token: -1750437190615552532, view token: 8564386055296739902): data_dictionary::no_such_column_family (Can't find a column family with UUID 463c73f0-0727-11ee-ad26-d9bc05da6d1d)
```
MV table details:
```
2023_06_09__16_14_23_380.sct-2c733d4e.log:< t:2023-06-10 00:39:36,248 f:db_log_reader.py l:114  c:sdcm.db_log_reader   p:DEBUG > 2023-06-10T00:39:36+00:00 longevity-mv-si-4d-2023-1-db-node-2c733d4e-15     !INFO | scylla[64915]:  [shard  0] schema_tables - Creating mview.users_view id=463c73f0-0727-11ee-ad26-d9bc05da6d1d version=e0156d2a-f86c-37b9-aa9b-2ea9e89853ac
```
nemesis details:
```
disrupt_add_remove_mv | longevity-mv-si-4d-2023-1-db-node-2c733d4e-19 | Succeeded | 2023-06-10 00:37:48 | 2023-06-10 01:27:55
-- | -- | -- | -- | --
Nemesis InformationClass: SisyphusName: disrupt_add_remove_mvStatus: SucceededTarget InformationName: longevity-mv-si-4d-2023-1-db-node-2c733d4e-19Public IP: 34.241.240.18Private IP: 10.4.3.75State: terminatedShards: 14

```
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
