### PR TITLE
fix(nemesis): match non-digit prefix sstable identifier as well

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1009,12 +1009,14 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 continue
             file_name = os.path.basename(one_file)
             # The file name like: /var/lib/scylla/data/scylla_bench/test-f60e4f30c98f11e98d46000000000002/mc-220-big-Data.db
-            # For corruption we need to remove all files that their names are started from "mc-220-" (MC format)
+            # or /var/lib/scylla/data/scylla_bench/test-f60e4f30c98f11e98d46000000000002/mc-3g6x_0sic_4r1eo23d0mkrb3fs2l-big-Data.db
+            # For corruption we need to remove all files that their names are started from "mc-220-" or "mc-3g6x_0sic_4r1eo23d0mkrb3fs2l-"
+            # (MC format)
             # Old format: "system-truncated-ka-" (system-truncated-ka-7-Data.db)
-            # Search for "<digit>-" substring
+            # Search for these prefixes
 
             try:
-                file_name_template = re.search(r"(.*-\d+)-", file_name).group(1)
+                file_name_template = re.search(r"([^-]+-[^-]+)-", file_name).group(1)
             except Exception as error:  # pylint: disable=broad-except
                 self.log.debug('File name "{file_name}" is not as expected for Scylla data files. '
                                'Search files for "{ks_cf_for_destroy}" table'.format(file_name=file_name,


### PR DESCRIPTION
we are going to introduce uuid_sstable_identifiers_enabled option to scylla. and will enable it by default. when it is enabled the sstable identifier will be represented using a timeuuid instead of an integer. so we should not try to match the identifier with "\d+" anymore.

so, in this change, we just relax the regular expression and use `[^-]+-[^-]-` for matching the sstable file prefix.

See-also: https://github.com/scylladb/scylladb/issues/14283

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
