### PR TITLE
fix(event filter): exclude 'libabsl' from stacktrace regex

### DIFF
--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -123,7 +123,7 @@ DatabaseLogEvent.add_subevent_type("FILESYSTEM_ERROR", severity=Severity.ERROR,
 DatabaseLogEvent.add_subevent_type("DISK_ERROR", severity=Severity.ERROR,
                                    regex=r"storage_service - .*due to I\/O errors.*Disk error: std::system_error")
 DatabaseLogEvent.add_subevent_type("STACKTRACE", severity=Severity.ERROR,
-                                   regex="stacktrace")
+                                   regex=r'^(?!.*libabsl).*stacktrace')
 # scylladb/scylladb#12972
 DatabaseLogEvent.add_subevent_type("RAFT_TRANSFER_SNAPSHOT_ERROR", severity=Severity.WARNING,
                                    regex=r"raft - \[[\w-]*\] Transferring snapshot to [\w-]* "


### PR DESCRIPTION
	SCT incorrectly reports error events for
	standard log lines of the libabsl module.
	It should be filtered out.
some scylla log prints, like in the case of core dump, generates a line like:
```
Found module libabsl_stacktrace.so.2206.0.0 with build-id: 0c356bbf44c196a8964e52aba16bd6fb494dbd9e
Metadata for module libabsl_stacktrace.so.2206.0.0 owned by FDO found: {
```
As a result, an SCT error message is created:
```
2023-05-18 05:32:17.821: (DatabaseLogEvent Severity.ERROR) period_type=one-time event_id=59f779b0-60e4-4558-8860-56f615e04d0c: type=STACKTRACE regex=stacktrace line_number=53393 node=longevity-10gb-3h-2023-1-db-node-17516d2f-0-6
Found module libabsl_stacktrace.so.2206.0.0 with build-id: 0c356bbf44c196a8964e52aba16bd6fb494dbd9e
```
[argus](https://argus.scylladb.com/test/23a9f4cc-4d94-42d4-a427-6ece4fd9a487/runs?additionalRuns[]=17516d2f-2f70-4947-a58d-1810bcc129f9)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
