### PR TITLE
fix(azure-artifacts): make shard aware port public

### DIFF
--- a/sdcm/provision/security.py
+++ b/sdcm/provision/security.py
@@ -19,6 +19,7 @@ class ScyllaOpenPorts(Enum):
     GRAFANA = 3000
     CQL = 9042
     CQL_SSL = 9142
+    CQL_SHARD_AWARE = 19042
     NODE_EXPORTER = 9100
     ALTERNATOR = 8080
     PROMETHEUS = 9090


### PR DESCRIPTION
since we are using public address for azure artifact test cause we are running it from AWS jenkins worker having this port not open seems to be slowing
cassandra-stress since failing to connect to this port for every extra smp is slowing it even more.

## Testing
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-azure-image-test/39/ - default instance
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-azure-image-test/40/ - 80 CPU instance 
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-azure-image-test/41/ - with only this commit

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
