### PR TITLE
fix(mgmt_cli_test): Properly check if gsutil is installed

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -89,21 +89,11 @@ class BackupFunctionsMixIn(LoaderUtilsMixin):
         self._run_cmd_with_retry(executor=node.remoter.sudo, cmd=shell_script_cmd(cmd))
 
     def install_gsutil_dependencies(self, node):
-        def is_dir_exists(path):
-            shell = dedent(f"""
-            if [ -d {path} ]
-            then
-                exit 0
-            else
-                exit 1
-            fi
-            """)
-            result = node.remoter.sudo(shell, ignore_status=True)
+        def is_gsutil_installed():
+            result = node.remoter.run("gsutil -v", ignore_status=True)
             return result.exited == 0
-
-        sdk_directory_path = '$HOME/google-cloud-sdk'
-        if not is_dir_exists(path=sdk_directory_path):
-            self._run_cmd_with_retry(executor=node.remoter.run, cmd=shell_script_cmd("""\
+        if not is_gsutil_installed():
+            self._run_cmd_with_retry(executor=node.remoter.sudo, cmd=shell_script_cmd("""\
                         curl https://sdk.cloud.google.com > install.sh
                         bash install.sh --disable-prompts
                     """))


### PR DESCRIPTION
Previously, we checked if gsutil was installed based on whether or not the $HOME/google-cloud-sdk directory existed, which turned out to be an incorrect way of verifying that. Instead, we will now try to check gsutil's version.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
