### PR TITLE
fix(manager debian 10): update ami id

### DIFF
--- a/configurations/manager/debian10.yaml
+++ b/configurations/manager/debian10.yaml
@@ -1,4 +1,4 @@
-ami_id_monitor: 'ami-07d02ee1eeb0c996c'  # Debian buster image - debian-10-amd64-20210208-542
+ami_id_monitor: 'ami-074f8bbb689b1c1a0'  # Debian buster image - debian-10-amd64-20230601-1398
 ami_monitor_user: 'admin'
 
 manager_scylla_backend_version: '2021'  # Notice: Uses 2021.1, while other (newer deb) use 2022, since we support both


### PR DESCRIPTION
Since the previous ami was deprecated, I've replaced it with a newer, supported image

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
