### PR TITLE
fix(major compaction nemesis): increase adaptive timeout to 8000

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1547,7 +1547,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 thread.result()
 
     def disrupt_major_compaction(self):
-        with adaptive_timeout(Operations.MAJOR_COMPACT, self.target_node, timeout=7200):
+        with adaptive_timeout(Operations.MAJOR_COMPACT, self.target_node, timeout=8000):
             self.target_node.run_nodetool("compact")
 
     def disrupt_load_and_stream(self):


### PR DESCRIPTION
	major compaction original value of 7200 was
	exceeded and took ~ 7600 seconds in multi-keyspace test.
	Increasing it to - 8000.

multi keyspace test failed with:
```
2023-06-15 23:47:47.913: (SoftTimeoutEvent Severity.ERROR) period_type=one-time event_id=6851da21-7222-4bc2-8fa8-426405e38520 during_nemesis=MajorCompaction, source=SoftTimeout message=operation 'MAJOR_COMPACT' took 7693.749301671982s and soft-timeout was set to 7200s
Traceback (most recent call last):
File "/usr/local/lib/python3.10/threading.py", line 966, in _bootstrap
self._bootstrap_inner()
File "/usr/local/lib/python3.10/threading.py", line 1009, in _bootstrap_inner
self.run()
File "/usr/local/lib/python3.10/threading.py", line 946, in run
self._target(*self._args, **self._kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/sct_events/decorators.py", line 26, in wrapper
return func(*args, **kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 389, in run
self.disrupt()
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 5454, in disrupt
self.call_next_nemesis()
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 1813, in call_next_nemesis
self.execute_disrupt_method(disrupt_method=self.disruptions_list.pop())
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 1741, in execute_disrupt_method
disrupt_method()
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 4367, in wrapper
result = method(*args[1:], **kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 1547, in disrupt_major_compaction
with adaptive_timeout(Operations.MAJOR_COMPACT, self.target_node, timeout=7200):
File "/usr/local/lib/python3.10/contextlib.py", line 142, in __exit__
next(self.gen)
File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/adaptive_timeouts/__init__.py", line 78, in adaptive_timeout
SoftTimeoutEvent(operation=operation.name, soft_timeout=timeout, duration=duration).publish_or_dump()
```
[Argus](https://argus.scylladb.com/test/cffc9f80-7fc6-4550-8805-749a6dac56c6/runs?additionalRuns[]=47a7ae39-4f63-4199-be07-82f331b335c0)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
