### PR TITLE
fix(mgmt_upgrade_test): discover the format of next_run before parsing

### DIFF
--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -205,10 +205,11 @@ def wait_until_task_finishes_return_details(task, wait=True, timeout=1000, step=
                                              identifier=latest_run_id)
     duration = task.sctool.get_table_value(parsed_table=task_history, column_name="duration",
                                            identifier=latest_run_id)
-    if task.sctool.is_v3_cli:
-        next_run_time = time_diff_string_to_datetime(time_diff_string=task.next_run)
+    next_run_time = task.next_run
+    if next_run_time.startswith("in "):
+        next_run_time = time_diff_string_to_datetime(time_diff_string=next_run_time)  # in 23h59m49s
     else:
-        next_run_time = time_string_to_datetime(task.next_run)
+        next_run_time = time_string_to_datetime(next_run_time)  # 14 Jun 23 15:41:00 UTC
     if task.sctool.is_v3_cli:
         end_time = time_diff_string_to_datetime(time_diff_string=duration, base_time_string=start_time)
     else:


### PR DESCRIPTION
In manager 3.0, the format of 'next run' time of a task from a simple timestamp to a string indicating the time remaining until the next run. Now, in manager 3.1.1, the format seem to have been revereted back. To pervent further confusion, I will now check the format the 'next run' value before parsing it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
