### PR TITLE
fix(upgrade test): not retry drain operation

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -177,7 +177,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             # replace the packages
             node.remoter.run(r'rpm -qa scylla\*')
             # flush all memtables to SSTables
-            node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True)
+            node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True, retry=0)
             node.run_nodetool("snapshot")
             node.stop_scylla_server()
             # update *development* packages
@@ -196,7 +196,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             assert new_scylla_repo.startswith('http')
             node.download_scylla_repo(new_scylla_repo)
             # flush all memtables to SSTables
-            node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True)
+            node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True, retry=0)
             node.run_nodetool("snapshot")
             node.stop_scylla_server(verify_down=False)
 
@@ -263,7 +263,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         result = node.remoter.run('scylla --version')
         orig_ver = result.stdout.strip()
         # flush all memtables to SSTables
-        node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True)
+        node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True, retry=0)
         # backup the data
         node.run_nodetool("snapshot")
         node.stop_scylla_server(verify_down=False)


### PR DESCRIPTION
If `nodetool drain` is stuck and reached its timeout and retrying is initiated, it fails with error:
`Operation drain is in progress, try again`

We do not need to retry drain operation in rolling upgrade test. Example:
https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/rolling_upgrade_with_sla/6/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
