### PR TITLE
fix(perf_stress): Split stress multiplier by stress workload

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -118,6 +118,9 @@ append_scylla_args_oracle: '--enable-cache false'
 
 # cassandra-stress defaults
 stress_multiplier: 1
+stress_multiplier_w: 1
+stress_multiplier_r: 1
+stress_multiplier_m: 1
 keyspace_num: 1
 cs_user_profiles: []
 cs_duration: '50m'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -224,7 +224,10 @@
 | **<a href="#user-content-cassandra_stress_population_size" name="cassandra_stress_population_size">cassandra_stress_population_size</a>**  |  | 1000000 | SCT_CASSANDRA_STRESS_POPULATION_SIZE
 | **<a href="#user-content-cassandra_stress_threads" name="cassandra_stress_threads">cassandra_stress_threads</a>**  |  | 1000 | SCT_CASSANDRA_STRESS_THREADS
 | **<a href="#user-content-add_node_cnt" name="add_node_cnt">add_node_cnt</a>**  |  | 1 | SCT_ADD_NODE_CNT
-| **<a href="#user-content-stress_multiplier" name="stress_multiplier">stress_multiplier</a>**  |  | 1 | SCT_STRESS_MULTIPLIER
+| **<a href="#user-content-stress_multiplier" name="stress_multiplier">stress_multiplier</a>**  | Number of cassandra-stress processes | 1 | SCT_STRESS_MULTIPLIER
+| **<a href="#user-content-stress_multiplier_w" name="stress_multiplier_w">stress_multiplier_w</a>**  | Number of cassandra-stress processes for write workload | 1 | SCT_STRESS_MULTIPLIER_W
+| **<a href="#user-content-stress_multiplier_r" name="stress_multiplier_r">stress_multiplier_r</a>**  | Number of cassandra-stress processes for read workload | 1 | SCT_STRESS_MULTIPLIER_R
+| **<a href="#user-content-stress_multiplier_m" name="stress_multiplier_m">stress_multiplier_m</a>**  | Number of cassandra-stress processes for mixed workload | 1 | SCT_STRESS_MULTIPLIER_M
 | **<a href="#user-content-run_fullscan" name="run_fullscan">run_fullscan</a>**  | A list of dictionaries describing the parameters for the fullscan operations to be run. Each dictionary describes a separate thread to be spawned. Possible modes include: "table" for regular full table scans, "partition" for fullscans targeting partitions, "aggregate" for aggregate operations and "random" for a random selection of the former modes. | N/A | SCT_RUN_FULLSCAN
 | **<a href="#user-content-keyspace_num" name="keyspace_num">keyspace_num</a>**  |  | 1 | SCT_KEYSPACE_NUM
 | **<a href="#user-content-round_robin" name="round_robin">round_robin</a>**  |  | N/A | SCT_ROUND_ROBIN

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -507,10 +507,13 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         # run a write workload
         base_cmd_w = self.params.get('stress_cmd_w')
         stress_multiplier = self.params.get('stress_multiplier')
+        if stress_multiplier_w := self.params.get("stress_multiplier_w"):
+            stress_multiplier = stress_multiplier_w
         # create new document in ES with doc_id = test_id + timestamp
         # allow to correctly save results for future compare
         self.create_test_stats(doc_id_with_timestamp=True)
         self.run_fstrim_on_all_db_nodes()
+
         # run a workload
         stress_queue = self.run_stress_thread(
             stress_cmd=base_cmd_w, stress_num=stress_multiplier, stats_aggregate_cmds=False)
@@ -531,6 +534,8 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
 
         base_cmd_r = self.params.get('stress_cmd_r')
         stress_multiplier = self.params.get('stress_multiplier')
+        if stress_multiplier_r := self.params.get("stress_multiplier_r"):
+            stress_multiplier = stress_multiplier_r
         self.run_fstrim_on_all_db_nodes()
         # run a write workload
         self.preload_data()
@@ -561,6 +566,8 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
 
         base_cmd_m = self.params.get('stress_cmd_m')
         stress_multiplier = self.params.get('stress_multiplier')
+        if stress_multiplier_m := self.params.get("stress_multiplier_m"):
+            stress_multiplier = stress_multiplier_m
         self.run_fstrim_on_all_db_nodes()
         # run a write workload as a preparation
         self.preload_data()

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -965,7 +965,13 @@ class SCTConfiguration(dict):
 
         # LongevityTest
         dict(name="stress_multiplier", env="SCT_STRESS_MULTIPLIER", type=int,
-             help=""),
+             help="Number of cassandra-stress processes"),
+        dict(name="stress_multiplier_w", env="SCT_STRESS_MULTIPLIER_W", type=int,
+             help="Number of cassandra-stress processes for write workload"),
+        dict(name="stress_multiplier_r", env="SCT_STRESS_MULTIPLIER_R", type=int,
+             help="Number of cassandra-stress processes for read workload"),
+        dict(name="stress_multiplier_m", env="SCT_STRESS_MULTIPLIER_M", type=int,
+             help="Number of cassandra-stress processes for mixed workload"),
         dict(name="run_fullscan", env="SCT_RUN_FULLSCAN", type=list,
              help=""),
         dict(name="run_full_partition_scan", env="SCT_run_full_partition_scan", type=str,

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -4,7 +4,9 @@ stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema '
 prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM n=30000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=100 -pop seq=1..30000000"
 stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=50m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=100 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
 stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=50m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=100 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
-stress_multiplier: 2
+stress_multiplier_w: 2
+stress_multiplier_r: 2
+stress_multiplier_m: 2
 
 # NOTE: following is needed for the K8S case
 k8s_loader_run_type: 'static'


### PR DESCRIPTION
Depend on stress workload, number of processes could give different max throughput. Split stress multiplier on 3 w,r,m. This will allow to configure different number of stress process on loader instance for write, read, mixed independently.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
