### PR TITLE
fix(list images): avoid getting exception

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2056,13 +2056,13 @@ def get_ami_tags(ami_id, region_name):
     scylla_images_ec2_resource = get_scylla_images_ec2_resource(region_name=region_name)
     new_test_image = scylla_images_ec2_resource.Image(ami_id)
     new_test_image.reload()
-    if new_test_image and new_test_image.meta.data:
+    if new_test_image and new_test_image.meta.data and new_test_image.tags:
         return {i['Key']: i['Value'] for i in new_test_image.tags}
     else:
         ec2_resource: EC2ServiceResource = boto3.resource('ec2', region_name=region_name)
         test_image = ec2_resource.Image(ami_id)
         test_image.reload()
-        if test_image and test_image.tags and test_image.meta.data:
+        if test_image and test_image.meta.data and test_image.tags:
             return {i['Key']: i['Value'] for i in test_image.tags}
         else:
             return {}


### PR DESCRIPTION
since moved to check new releng account for
the images that will be created in there in
the near future, we are experiencing still
exceptions when there are no tags (but for
some reason, there was meta.data), so the
idea is to also check if there are tags, so
we won't try to "list them" whem they don't
exist.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
