### PR TITLE
Count reactor stall

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1734,5 +1734,6 @@ cli.add_command(sct_ssh.copy_cmd)
 cli.add_command(sct_ssh.attach_test_sg_cmd)
 cli.add_command(sct_ssh.ssh_cmd)
 
+
 if __name__ == '__main__':
     cli.main(prog_name="hydra")

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -299,7 +299,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.configure_remote_logging()
         self.start_task_threads()
         self._init_port_mapping()
-
         self.set_keep_alive()
         if self.node_type == "db" and not self.is_kubernetes() \
                 and self.parent_cluster.params.get("print_kernel_callstack"):

--- a/sdcm/reactor_stall_decoder.py
+++ b/sdcm/reactor_stall_decoder.py
@@ -1,0 +1,132 @@
+import json
+import logging
+import re
+
+from pathlib import Path
+from collections import defaultdict
+
+
+LOGGER = logging.getLogger(__name__)
+DECODED_STALLS_DIR_NAME = "operations_reactor_stalls"
+REACTOR_STALL_MS_REGEXP = re.compile(r" (\d+) ms")
+
+
+class ReactorStallExtractor:  # pylint: disable=too-few-public-methods
+
+    DISRUPTION_EVENT = "DisruptionEvent"
+    INFO_EVENT = "InfoEvent"
+    STEADY_STATE = "SteadyState"
+
+    def __init__(self,
+                 working_dir: str | Path,
+                 raw_events_file: str | Path):
+        base_dir = self._convert_str_to_path(working_dir)
+        self.raw_events_file = self._convert_str_to_path(raw_events_file)
+        self.store_dir = base_dir.joinpath(DECODED_STALLS_DIR_NAME)
+        self.reactor_stalls_per_operation = defaultdict(dict)
+
+    @staticmethod
+    def _convert_str_to_path(value: str | Path) -> Path:
+        if isinstance(value, str):
+            return Path(value)
+        return value
+
+    def _extract_reactor_stalls_events_by_nemesis(self):
+        with open(self.raw_events_file, 'r', encoding='utf-8') as raw_events_file_content:
+            current_operation = self.STEADY_STATE
+            reactor_stall_per_node = defaultdict(list)
+            for line in raw_events_file_content:
+                event = json.loads(line)
+
+                if (event['base'] == 'InfoEvent' and 'TEST_END' in event['message']) \
+                   or (event['base'] == self.DISRUPTION_EVENT
+                        and event['nemesis_name'] == "RunUniqueSequence"
+                       and event["period_type"] == "end"):
+                    if current_operation in self.reactor_stalls_per_operation:
+                        self.reactor_stalls_per_operation[current_operation].update(reactor_stall_per_node)
+                    else:
+                        self.reactor_stalls_per_operation[current_operation] = reactor_stall_per_node
+                    break
+
+                if event['base'] == self.DISRUPTION_EVENT:
+                    self.reactor_stalls_per_operation[current_operation] = reactor_stall_per_node
+                    reactor_stall_per_node = defaultdict(list)
+                    if event['period_type'] == 'begin':
+                        current_operation = event['nemesis_name']
+                    if event['period_type'] == 'end':
+                        current_operation = f"{self.STEADY_STATE}_after_{event['nemesis_name']}"
+                    continue
+
+                if event['base'] == 'DatabaseLogEvent' and event['type'].strip() == 'REACTOR_STALLED':
+                    node_name = self._parse_node_name(event['node'])
+                    reactor_stall_per_node[node_name].append(event['line'])
+
+    @staticmethod
+    def _parse_node_name(name: str):
+        try:
+            return name.split(" ")[1]
+        except IndexError:
+            return name
+
+    def _save_per_operation_by_node(self):
+        for operation, node_data in self.reactor_stalls_per_operation.items():
+            operation_dir = self.store_dir.joinpath(operation)
+            operation_dir.mkdir(exist_ok=True, parents=True)
+            for node in node_data:
+                node_file = operation_dir.joinpath(node)
+                if not node_data[node]:
+                    continue
+                with open(node_file, 'w', encoding='utf-8') as encoded_stall_file:
+                    encoded_stall_file.write('\n'.join(node_data[node]))
+
+    def extract_reactor_stall_by_nemesis(self):
+        self._extract_reactor_stalls_events_by_nemesis()
+        self._save_per_operation_by_node()
+
+
+class ReactorStallCounter:  # pylint: disable=too-few-public-methods
+    stall_ms_intervals = [15, 30, 50, 100]
+
+    def __init__(self, working_dir: str | Path):
+        self.working_dir = Path(working_dir)
+        self._stats = {}
+
+    def count(self):
+        reactor_stall_dir = self.working_dir / DECODED_STALLS_DIR_NAME
+        for operation_dir in reactor_stall_dir.iterdir():
+            self._stats[operation_dir.name] = {}
+
+            for node_path in operation_dir.iterdir():
+                with open(node_path, encoding="utf-8") as node_file:
+                    for line in node_file:
+                        if match := REACTOR_STALL_MS_REGEXP.search(line):
+                            reactor_stall_value = int(match.group(1))
+                            self._check_ms_interval(operation_dir.name, reactor_stall_value)
+        self._sort()
+        return self._stats
+
+    def _check_ms_interval(self, operation: str, stall_ms: int):
+        for up_border in self.stall_ms_intervals:
+            if stall_ms < up_border:
+                if up_border not in self._stats[operation]:
+                    self._stats[operation][up_border] = 1
+                self._stats[operation][up_border] += 1
+                break
+        else:
+            if stall_ms not in self._stats[operation]:
+                self._stats[operation][stall_ms] = 1
+            self._stats[operation][stall_ms] += 1
+
+    def _sort(self):
+        sorted_stats = {}
+        for operation, data in self._stats.items():
+            if not data:
+                continue
+            keys = sorted(data.keys())
+            sorted_stats[operation] = {key: data[key] for key in keys}
+        self._stats = sorted_stats
+
+
+def count_reactor_stalls_per_operation(working_dir: str | Path, raw_events_file: str | Path):
+    ReactorStallExtractor(working_dir, raw_events_file).extract_reactor_stall_by_nemesis()
+    return ReactorStallCounter(working_dir).count()

--- a/sdcm/report_templates/results_latency_during_ops_short.html
+++ b/sdcm/report_templates/results_latency_during_ops_short.html
@@ -212,5 +212,19 @@
             </table>
         </div>
     {% endif %}
+    {% if reactor_stalls_stats %}
+        {% for operation, data in reactor_stalls_stats.items() %}
+            <div>
+                <span style="font-weight: bold;">{{ operation }} :</span>
+                {% set counts = 0 %}
+                <li>
+                    {% for ms, number in data.items() %}
+                        <ul>less or equal {{ ms }} ms: {{ number }}</ul>
+                    {% endfor %}
+                </li>
+                <span>Total: {{ data.values()|sum() }}</span>
+            </div>
+        {% endfor %}
+    {% endif %}
 
 {% endblock %}

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -391,7 +391,7 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
         except Exception as exc:  # pylint: disable=broad-except
             LOGGER.error("Compare results failed: %s", exc)
 
-    def check_regression(self, test_id, data, is_gce=False, node_benchmarks=None):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
+    def check_regression(self, test_id, data, is_gce=False, node_benchmarks=None, reactor_stalls_stats=None):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements, too-many-arguments
         doc = self.get_test_by_id(test_id)
         full_test_name = doc["_source"]["test_details"]["test_name"]
         test_name = full_test_name.split('.')[-1]  # Example: longevity_test.LongevityTest.test_custom_time
@@ -446,6 +446,7 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
             job_url=doc['_source']['test_details'].get('job_url', ""),
             node_benchmarks=node_benchmarks,
             best_stat_per_version=best_results_per_nemesis,
+            reactor_stalls_stats=reactor_stalls_stats
         )
         attachment_file = [
             self.save_html_to_file(results,
@@ -683,7 +684,8 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
     # pylint: disable=too-many-arguments
     def check_regression(self, test_id, is_gce=False, email_subject_postfix=None,
                          use_wide_query=False, lastyear=False,
-                         node_benchmarks=None):
+                         node_benchmarks=None,
+                         reactor_stalls_stats=None):
         """
         Get test results by id, filter similar results and calculate max values for each version,
         then compare with max in the test version and all the found versions.
@@ -830,6 +832,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
             "events_summary": events_summary,
             "last_events": last_events,
             "node_benchmarks": node_benchmarks,
+            "reactor_stall_stats": reactor_stalls_stats
         }
         self.log.debug('Regression analysis:')
         self.log.debug(PP.pformat(results))

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -269,7 +269,7 @@ def list_logs_by_test_id(test_id):
     log_types = ['db-cluster', 'monitor-set', 'loader-set', 'sct', 'jepsen-data', 'siren-manager-set',
                  'prometheus', 'grafana', 'kubernetes', 'job', 'monitoring_data_stack', 'event', 'output', 'error',
                  'summary', 'warning', 'critical', 'normal', 'debug', 'left_processes', 'email_data', 'corrupted-sstables',
-                 'sstables']
+                 'sstables', 'operations_reactor_stalls']
 
     results = []
 


### PR DESCRIPTION
For performance tests latency-with-operation it is required to
count number of reactor stalls operations per nemesis

If reactor stall event happened during operation/nemesis, it will be added to file
under dir with Operation/Nemesis name, if reactor stall event between operations,
it will be added to file under dir with name SteadyState

Then reactor stalls will be counted for each operations

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
