### PR TITLE
fix(10gb-3h-gce-longevity): Modify test duration to avoid timeout

### DIFF
--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -1,4 +1,4 @@
-test_duration: 240
+test_duration: 255
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5"
              ]
 


### PR DESCRIPTION
	Test failed because it waited for a decommission nemesis.
	Increasing test duration can workaround the problem.
	(or alternatively decrease both test and stress duration a bit)

Increasing duration from 240 to 255 as in master. still not sure it'll work until tested.
2021.1 release doc:
https://docs.google.com/document/d/1R98ZCheWfKnGl16bZEkiFPX6juvbU-IB-Ontd1nH3q8/edit?disco=AAAAzpgnPTY

Failure:
```
2023-06-21 11:44:48.115: (TestTimeoutEvent Severity.CRITICAL), Test started at 2023-06-21 08:22:03, reached it's timeout (240 minute)
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
