### PR TITLE
fix(k8s): use newer K8S version in K8S platform upgrade tests

### DIFF
--- a/test-cases/scylla-operator/kubernetes-platform-upgrade.yaml
+++ b/test-cases/scylla-operator/kubernetes-platform-upgrade.yaml
@@ -34,6 +34,3 @@ k8s_scylla_operator_docker_image: ''  # default value from the Helm chart will b
 
 use_mgmt: false
 user_prefix: 'kubernetes-platform-upgrade'
-
-# TODO: remove it when version '1.25' becomes available in the EKS platform
-eks_cluster_version: '1.23'


### PR DESCRIPTION
Latest scylla-operator supports K8S `v1.24+`
So, remove old leftover which was setting the EKS version to be `1.23` for K8S platform upgrade tests.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
