### PR TITLE
fix(test_backup_feature): correctly search a substring on assert

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -959,7 +959,7 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
                     f"The restore task is supposed to fail, since node {target_node} lacks the disk space to download" \
                     f"the snapshot files"
                 full_progress_string = restore_task.progress_string()
-                assert "not enough disk space" in full_progress_string, \
+                assert "not enough disk space" in str(full_progress_string), \
                     f"The restore failed as expected when one of the nodes was out of disk space, but with an ill " \
                     f"fitting error message: {full_progress_string}"
             finally:


### PR DESCRIPTION
as seen in multiple runs, we were getting the expected message, but the assert was wrongly searching in a list of lists, instead of a string.
The function that returned said list is called
`progress_string()` and we don't send any params to it, and the underneath call to `run()` has as a default to return it as a table, AFAICT.
as a quick fix, I'm casting the result into a string, so we can correctly check if we got the appropriate results.

examples of such failure:
https://jenkins.scylladb.com/view/scylla-manager/job/manager-3.1/job/sct-feature-test-backup/18/
https://jenkins.scylladb.com/view/scylla-manager/job/manager-3.1/job/sct-feature-test-backup-azure/13/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
