### PR TITLE
fix(elastic): store additional CPU info in elastic

### DIFF
--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -835,6 +835,9 @@ class TestStatsMixin(Stats):
 
             setup_details["db_cluster_node_details"] = {
                 "cpu_model": output("awk -F: '/^model name/{print $2; exit}' /proc/cpuinfo"),
+                "cpu_mhz": output("awk -F: '/^cpu MHz/{print $2; exit}' /proc/cpuinfo"),
+                "cache_size": output("awk -F: '/^cache size/{print $2; exit}' /proc/cpuinfo"),
+                "flags": output("awk -F: '/^flags/{print $2; exit}' /proc/cpuinfo"),
                 "sys_info": output("uname -a"),
             }
             if scylla_conf and "scylla_args" not in setup_details:


### PR DESCRIPTION
store in elastic  cpu MHz and cache size in addition to cpu_model

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
