### PR TITLE
fix(k8s): enable alpha TLS feature for operator after upgrade

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -795,6 +795,12 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             namespace=SCYLLA_OPERATOR_NAMESPACE,
             values=values,
         ))
+        if self.params.get('k8s_enable_tls') and ComparableScyllaOperatorVersion(
+                self._scylla_operator_chart_version.split("-")[0]) >= "1.8.0":
+            patch_cmd = ('patch deployment scylla-operator --type=json -p=\'[{"op": "add",'
+                         '"path": "/spec/template/spec/containers/0/args/-", '
+                         '"value": "--feature-gates=AutomaticTLSCertificates=true" }]\' ')
+            self.kubectl(patch_cmd, namespace=SCYLLA_OPERATOR_NAMESPACE)
         time.sleep(5)
         self.kubectl("rollout status deployment scylla-operator",
                      namespace=SCYLLA_OPERATOR_NAMESPACE)


### PR DESCRIPTION
We enable it only on the scylla-operator deployment from scratch. 
But it also must be enabled after it's upgrade.
Without it, we get following error:
```
  OSError: [Errno 8] Tried connecting to [('13.49.200.202', 9142)]. \
    Last error: EOF occurred in violation of protocol (_ssl.c:997)
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
