### PR TITLE
fix(k8s-perf): set correct PVC size for K8S thrpt tests

### DIFF
--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -8,6 +8,7 @@ stress_multiplier: 2
 
 # NOTE: following is needed for the K8S case
 k8s_loader_run_type: 'static'
+k8s_scylla_disk_gi: 1760
 
 n_db_nodes: 3
 n_loaders: 4


### PR DESCRIPTION
In the K8S throughput tests we use smaller instance type then in all other EKS tests.
So, we should redefine the disk size there which must be smaller than the default value.
Without it the Scylla PVC won't be scheduled breaking Scylla pods provisioning.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
