### PR TITLE
fix(jepsen-pipeline): add `test_name`

### DIFF
--- a/jenkins-pipelines/jepsen.jenkinsfile
+++ b/jenkins-pipelines/jepsen.jenkinsfile
@@ -5,6 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 jepsenPipeline(
     test_config: 'test-cases/jepsen/jepsen.yaml',
+    test_name: 'jepsen_test',
     provision_type: 'on_demand',
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',


### PR DESCRIPTION
PR (#5721) added one more required 'param' to the vars/createSctRunner.groovy groovy file - `test_name`
and PR (#5831) was trying to align all pipelines to have this but jepsen on didn't had `test_name` in it's pipelineParams so it was failing like the following:

```
06:05:42  Going to run './sct.py  create-runner-instance --cloud-provider gce --region us-east1
   --availability-zone a --test-id 2166dec8-3354-4c1e-9aca-b7185cf00761 --duration 905 --test-name '
...
06:05:48  Error: Option '--test-name' requires an argument.
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
