### PR TITLE
fix(longevity-counters-multidc): unping scylla-bench

### DIFF
--- a/test-cases/longevity/longevity-counters-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-multidc.yaml
@@ -23,9 +23,3 @@ nemesis_add_node_cnt: 3
 
 server_encrypt: true
 internode_encryption: 'dc'
-
-use_legacy_cluster_init: false
-
-# pin s-b version to mitigate https://github.com/scylladb/scylla-bench/issues/114
-stress_image:
-  scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.3'


### PR DESCRIPTION
the case was pinned to older s-b cause of: scylladb/scylla-bench#114 but since then we implemented s-b retires that should fix most of the of the timeout observed in 2023.1 run.

Ref: https://github.com/scylladb/scylla-bench/issues/114

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
