### PR TITLE
fix(stress-thread): use c-s command line adv parameter

### DIFF
--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -99,6 +99,17 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
         self.client_encrypt = client_encrypt
         self.stop_test_on_failure = stop_test_on_failure
         self.compaction_strategy = compaction_strategy
+        self._init_advanced_stress_cmd_parameters()
+
+    def _init_advanced_stress_cmd_parameters(self):
+        splitted_stress_cmd = self.stress_cmd.split(" -- ")
+        if len(splitted_stress_cmd) < 2:
+            self.stress_cmd = splitted_stress_cmd[0].strip()
+            return
+        self.stress_cmd = splitted_stress_cmd[0].strip()
+        parameters = splitted_stress_cmd[1].strip()
+        if match := re.search(r"stress-multiplier=(\d+)", parameters):
+            self.stress_num = int(match.group(1))
 
     def create_stress_cmd(self, cmd_runner, keyspace_idx, loader):  # pylint: disable=too-many-branches
         stress_cmd = self.stress_cmd


### PR DESCRIPTION
Add support advanced parametre for CassandraStressThread inside cassandra-stress command:
ex: cassandra-stress write ... -- stress-multiplier=5

additional parameteres for CassandraStressThread are passed after ' -- ' chars. First supported parameter is `stress-multiplier`, which allow to configure
number of stress process inside cassandra-stress command

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
