### PR TITLE
fix(nemesis.py): fix skip toggle-cdc nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3854,9 +3854,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.log.debug(f"Found next tables with enabled cdc feature: {ks_tables_with_cdc}")
 
         if not ks_tables_with_cdc:
-            self.log.warning("CDC is not enabled on any table. Skipping")
-            UnsupportedNemesis("CDC is not enabled on any table. Skipping")
-            return
+            raise UnsupportedNemesis("CDC is not enabled on any table. Skipping")
 
         ks, table = random.choice(ks_tables_with_cdc).split(".")
 


### PR DESCRIPTION
	The nemesis did not raise an un-supported-nemesis exception.
	It only returned, so nemesis is marked as completed successfully.
	Fixing it to raise an exception.
[argus](https://argus.scylladb.com/test/32eea484-9fbe-48bd-a0a8-ed9e202706ad/runs?additionalRuns[]=5c106365-f5f1-4d58-b19d-98254b63934b)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
