### PR TITLE
fix(add_remove_dc): fix dc name when GossipingPropertyFileSnitch is used

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -69,7 +69,6 @@ from sdcm.nemesis_publisher import NemesisElasticSearchPublisher
 from sdcm.paths import SCYLLA_YAML_PATH
 from sdcm.prometheus import nemesis_metrics_obj
 from sdcm.provision.scylla_yaml import SeedProvider
-from sdcm.remote import shell_script_cmd
 from sdcm.remote.libssh2_client.exceptions import UnexpectedExit as Libssh2UnexpectedExit
 from sdcm.sct_events import Severity
 from sdcm.sct_events.database import DatabaseLogEvent
@@ -3946,8 +3945,12 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             scylla_yml.rpc_address = new_node.ip_address
             scylla_yml.seed_provider = [SeedProvider(class_name='org.apache.cassandra.locator.SimpleSeedProvider',
                                                      parameters=[{"seeds": self.tester.db_cluster.seed_nodes_ips}])]
-        new_node.remoter.sudo(shell_script_cmd(
-            "echo dc_suffix=_nemesis_dc >> /etc/scylla/cassandra-rackdc.properties"))
+            if scylla_yml.endpoint_snitch.endswith("GossipingPropertyFileSnitch"):
+                rackdc_value = {"dc": "add_remove_nemesis_dc"}
+            else:
+                rackdc_value = {"dc_suffix": "_nemesis_dc"}
+        with new_node.remote_cassandra_rackdc_properties() as properties_file:
+            properties_file.update(**rackdc_value)
         self.cluster.wait_for_init(node_list=[new_node], timeout=900,
                                    check_node_health=False)
         self.cluster.wait_for_nodes_up_and_normal(nodes=[new_node])


### PR DESCRIPTION
When using simulated racks we use GossipingPropertyFileSnitch, in that case `dc_suffix` from `cassandra-rackdc.properties` is not used causing AddRemoveDC nemesis to fail.

Detect snitch and use proper parameter in `cassandra-rackdc.properties`.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
