### PR TITLE
fix(artifacts): remove defaults for Scylla repos/machine images

### DIFF
--- a/test-cases/artifacts/amazon2.yaml
+++ b/test-cases/artifacts/amazon2.yaml
@@ -13,7 +13,6 @@ n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 region_name: 'eu-west-1'
 scylla_linux_distro: 'centos'
-scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-amazon2'

--- a/test-cases/artifacts/ami.yaml
+++ b/test-cases/artifacts/ami.yaml
@@ -1,4 +1,3 @@
-ami_id_db_scylla: 'ami-067787e9ea5433c78'
 root_disk_size_db: 50
 backtrace_decoding: false
 cluster_backend: 'aws'

--- a/test-cases/artifacts/azure-image.yaml
+++ b/test-cases/artifacts/azure-image.yaml
@@ -2,7 +2,6 @@ cluster_backend: 'azure'
 azure_region_name: "eastus"
 use_preinstalled_scylla: true
 backtrace_decoding: false
-azure_image_db: ''
 azure_instance_type_db: 'Standard_L8s_v3'
 #azure_root_disk_type_db: 'pd-ssd'  # todo: need more research if needed
 #root_disk_size_db: 50

--- a/test-cases/artifacts/centos7.yaml
+++ b/test-cases/artifacts/centos7.yaml
@@ -13,6 +13,5 @@ n_loaders: 0
 n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'centos'
-scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 user_prefix: 'artifacts-centos7'

--- a/test-cases/artifacts/centos8-selinux.yaml
+++ b/test-cases/artifacts/centos8-selinux.yaml
@@ -13,7 +13,6 @@ n_loaders: 0
 n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'centos'
-scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 user_prefix: 'artifacts-centos8-selinux'
 append_scylla_setup_args: '--no-selinux-setup'

--- a/test-cases/artifacts/centos8.yaml
+++ b/test-cases/artifacts/centos8.yaml
@@ -13,6 +13,5 @@ n_loaders: 0
 n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'centos'
-scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 user_prefix: 'artifacts-centos8'

--- a/test-cases/artifacts/debian10.yaml
+++ b/test-cases/artifacts/debian10.yaml
@@ -13,7 +13,6 @@ n_loaders: 0
 n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'debian-buster'
-scylla_repo: 'http://downloads.scylladb.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list'
 scylla_apt_keys:
   # When will use manager 2.6, need to remove this commit because it's a workaround to make artifacts works
   - '5E08FBD8B5D6EC9C'  # ScyllaDB Package Signing Key 2020 <security@scylladb.com>

--- a/test-cases/artifacts/debian11.yaml
+++ b/test-cases/artifacts/debian11.yaml
@@ -13,7 +13,6 @@ n_loaders: 0
 n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'debian-bullseye'
-scylla_repo: 'http://downloads.scylladb.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list'
 scylla_apt_keys:
   # When will use manager 2.6, need to remove this commit because it's a workaround to make artifacts works
   - '5E08FBD8B5D6EC9C'  # ScyllaDB Package Signing Key 2020 <security@scylladb.com>

--- a/test-cases/artifacts/docker.yaml
+++ b/test-cases/artifacts/docker.yaml
@@ -1,6 +1,5 @@
 backtrace_decoding: false
 cluster_backend: 'docker'
-docker_image: 'scylladb/scylla'
 logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0

--- a/test-cases/artifacts/gce-image.yaml
+++ b/test-cases/artifacts/gce-image.yaml
@@ -1,7 +1,6 @@
 cluster_backend: 'gce'
 use_preinstalled_scylla: true
 backtrace_decoding: false
-gce_image_db: 'https://www.googleapis.com/compute/alpha/projects/skilled-adapter-452/global/images/4570757709553864209'
 gce_instance_type_db: 'n1-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50

--- a/test-cases/artifacts/oel76.yaml
+++ b/test-cases/artifacts/oel76.yaml
@@ -13,7 +13,6 @@ n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 region_name: 'eu-west-1'
 scylla_linux_distro: 'centos'
-scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-oel76'

--- a/test-cases/artifacts/oel81.yaml
+++ b/test-cases/artifacts/oel81.yaml
@@ -13,7 +13,6 @@ n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 region_name: 'eu-west-1'
 scylla_linux_distro: 'centos'
-scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-oel81'

--- a/test-cases/artifacts/rhel7.yaml
+++ b/test-cases/artifacts/rhel7.yaml
@@ -13,6 +13,5 @@ n_loaders: 0
 n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'centos'
-scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 user_prefix: 'artifacts-rhel7'

--- a/test-cases/artifacts/rhel8.yaml
+++ b/test-cases/artifacts/rhel8.yaml
@@ -13,6 +13,5 @@ n_loaders: 0
 n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'centos'
-scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 user_prefix: 'artifacts-rhel8'

--- a/test-cases/artifacts/rocky8.yaml
+++ b/test-cases/artifacts/rocky8.yaml
@@ -13,6 +13,5 @@ n_loaders: 0
 n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'centos'
-scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.3.repo'
 test_duration: 60
 user_prefix: 'artifacts-rocky8'

--- a/test-cases/artifacts/ubuntu2004.yaml
+++ b/test-cases/artifacts/ubuntu2004.yaml
@@ -13,7 +13,6 @@ n_loaders: 0
 n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'ubuntu-focal'
-scylla_repo: 'http://downloads.scylladb.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list'
 scylla_apt_keys:
   # When will use manager 2.6, need to remove this commit because it's a workaround to make artifacts works
   - '5E08FBD8B5D6EC9C'  # ScyllaDB Package Signing Key 2020 <security@scylladb.com>


### PR DESCRIPTION
Remove default values for repos and machine images to avoid situations when we run artifacts tests against wrong Scylla version.

By Roy/Israel request.

Fixes #3566

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
