### PR TITLE
fix(jepsen-test): remove `use_legacy_cluster_init`

### DIFF
--- a/test-cases/jepsen/jepsen.yaml
+++ b/test-cases/jepsen/jepsen.yaml
@@ -14,7 +14,6 @@ n_monitor_nodes: 1
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'debian-buster'
 user_prefix: 'jepsen'
-use_legacy_cluster_init: true
 scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylla-4.6-buster.list'
 jepsen_scylla_repo: 'https://github.com/scylladb/jepsen.git'
 jepsen_test_count: 5

--- a/test-cases/jepsen/jepsen_with_raft.yaml
+++ b/test-cases/jepsen/jepsen_with_raft.yaml
@@ -14,7 +14,6 @@ n_monitor_nodes: 1
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'debian-buster'
 user_prefix: 'jepsen'
-use_legacy_cluster_init: true
 jepsen_scylla_repo: 'https://github.com/scylladb/jepsen.git'
 jepsen_test_count: 5
 jepsen_test_run_policy: any


### PR DESCRIPTION
this legecy cluster init doesn't work anymore
and would fail with the following:

```
[shard 0] init - Startup failed: std::runtime_error (Node 10.142.0.39 has
  gossip status=UNKNOWN. Try fixing it before adding new node to the cluster.)
```

### Testing

together with https://github.com/scylladb/jepsen/pull/17, jepsen was passing 
in: https://jenkins.scylladb.com/job/scylla-master/job/jepsen/job/jepsen-test-all/172/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
