### PR TITLE
fix(install_scylla): use install_package for software-properties-common

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1906,11 +1906,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 self.remoter.run('sudo apt-get install -y openjdk-8-jre-headless')
                 self.remoter.run('sudo update-java-alternatives --jre-headless -s java-1.8.0-openjdk-amd64')
             elif self.distro.is_ubuntu:
-                install_prereqs = dedent("""
-                    export DEBIAN_FRONTEND=noninteractive
-                    apt-get install software-properties-common -y
-                """)
-                self.remoter.run('sudo bash -cxe "%s"' % install_prereqs)
+                self.install_package(package_name="software-properties-common")
             elif self.is_debian8():
                 self.remoter.run("sudo sed -i -e 's/jessie-updates/stable-updates/g' /etc/apt/sources.list")
                 self.remoter.run(


### PR DESCRIPTION
Since the installation command occasionally fails due to the dkpg lock being occupied, I replaced the apt-get command call with the BaseNode.install_package method, that is capable of waiting for the dkpg lock to be released.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
