### PR TITLE
fix(wait.py): make 'wait_for_log_lines' print proper error msgs

### DIFF
--- a/sdcm/wait.py
+++ b/sdcm/wait.py
@@ -151,4 +151,4 @@ def wait_for_log_lines(node, start_line_patterns, end_line_patterns, start_timeo
             ended = any(end_follower)
         if not ended:
             raise TimeoutError(
-                f"timeout occurred while waiting for end log line ({start_line_patterns} on node: {node.name}")
+                f"timeout occurred while waiting for end log line ({end_line_patterns} on node: {node.name}")


### PR DESCRIPTION
If `wait_for_log_lines` function fails to find `end_line_patterns` in logs then it print wrong error message specifying there the `start_line_patterns`.
So, fix it by printing correct info.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
