### PR TITLE
test(longevity): remove multi-rack from longevity topology changes

### DIFF
--- a/jenkins-pipelines/longevity-topology-changes-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-topology-changes-3h.jenkinsfile
@@ -6,7 +6,6 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
-    availability_zone: 'a,b,c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-topology-changes-3h.yaml"]''',
 

--- a/test-cases/longevity/longevity-topology-changes-3h.yaml
+++ b/test-cases/longevity/longevity-topology-changes-3h.yaml
@@ -12,8 +12,7 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replicatio
              "scylla-bench -workload=sequential -mode=read  -replication-factor=3 -partition-count=50 -clustering-row-count=10000 -clustering-row-size=uniform:1024..8192 -concurrency=25 -connection-count=25 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=180m",
              ]
 
-availability_zone: 'a,b,c'
-n_db_nodes: 3
+n_db_nodes: 4
 n_loaders: 2
 n_monitor_nodes: 1
 
@@ -24,9 +23,8 @@ nemesis_class_name: 'SisyphusMonkey'
 nemesis_selector: ['topology_changes']
 nemesis_interval: 5
 nemesis_filter_seeds: false
-nemesis_add_node_cnt: 3
 
-seeds_num: 3
+seeds_num: 2
 
 
 user_prefix: 'longevity-topologychanges-asymetric-shards-3h'


### PR DESCRIPTION
There's an issue with longevity-topology-changes-3h scenario when
multi-az is set up.

We want to track this issue in master branch so disabling multi-az from
2023.1 release to not causing failures in it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
