### PR TITLE
fix(test_config): wait for logdir symlink removed

### DIFF
--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -98,6 +98,13 @@ class TestConfig(metaclass=Singleton):  # pylint: disable=too-many-public-method
             latest_symlink = os.path.join(base, "latest")
             if os.path.islink(latest_symlink):
                 os.remove(latest_symlink)
+
+                @retrying(n=10, sleep_time=0.5, allowed_exceptions=(AssertionError,))
+                def wait_for_removed():
+                    if os.path.islink(latest_symlink):
+                        raise AssertionError(f"symlink {latest_symlink} is not removed")
+
+                wait_for_removed()
             os.symlink(os.path.relpath(logdir, base), latest_symlink)
             LOGGER.info("Symlink `%s' updated to `%s'", latest_symlink, logdir)
         return logdir


### PR DESCRIPTION
added wait_for_removed inline fuctuion to make sure that symlink is removed before create it again

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
