### PR TITLE
fix(Argus): use  set_test_id_only in sct.py

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1692,7 +1692,7 @@ def create_argus_test_run():
         if not params.get('test_id'):
             LOGGER.error("test_id is not set")
             return
-        test_config.set_test_id(params.get('test_id'))
+        test_config.set_test_id_only(params.get('test_id'))
         test_config.init_argus_client(params)
         test_config.argus_client().submit_sct_run(
             job_name=get_job_name(),
@@ -1715,7 +1715,7 @@ def finish_argus_test_run(jenkins_status):
         if not params.get('test_id'):
             LOGGER.error("test_id is not set")
             return
-        test_config.set_test_id(params.get('test_id'))
+        test_config.set_test_id_only(params.get('test_id'))
         test_config.init_argus_client(params)
         status = test_config.argus_client().get_status()
         if status in [TestStatus.PASSED, TestStatus.FAILED]:


### PR DESCRIPTION
use set_test_id_only instead of set_test_id to do not
touch logging and rewrite "latest" symlink  during
create-argus-test-run and finish-argus-test-run
because it is not SCT run

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
