### PR TITLE
feature(add_remove_mv): add soft timeout for create mv

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4347,8 +4347,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 raise UnsupportedNemesis(  # pylint: disable=raise-missing-from
                     "Tried to create already existing index. See log for details")
             try:
-                with adaptive_timeout(operation=Operations.CREATE_INDEX, node=self.target_node, timeout=7200) as timeout:
-                    wait_for_index_to_be_built(self.target_node, ks, index_name, timeout=timeout)
+                with adaptive_timeout(operation=Operations.CREATE_INDEX, node=self.target_node, timeout=7200):
+                    wait_for_index_to_be_built(self.target_node, ks, index_name, timeout=18000)
                 verify_query_by_index_works(session, ks, cf, column)
                 sleep_for_percent_of_duration(self.tester.test_duration * 60, percent=1,
                                               min_duration=300, max_duration=2400)
@@ -4404,7 +4404,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     self.log.info("Starting Scylla on node %s", self.target_node.name)
                     self.target_node.start_scylla()
                     self.target_node.run_nodetool(sub_cmd="repair -pr")
-                    wait_for_view_to_be_built(self.target_node, ks_name, view_name, timeout=7200)
+                    with adaptive_timeout(operation=Operations.CREATE_MV, node=self.target_node, timeout=7200):
+                        wait_for_view_to_be_built(self.target_node, ks_name, view_name, timeout=18000)
                     session.execute(SimpleStatement(f'SELECT * FROM {ks_name}.{view_name} limit 1', fetch_size=10))
                     sleep_for_percent_of_duration(self.tester.test_duration * 60, percent=1,
                                                   min_duration=300, max_duration=2400)

--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -39,6 +39,7 @@ class Operations(Enum):
     DECOMMISSION = ("decommission", _get_decommission_timeout, ())
     NEW_NODE = ("new_node", _get_soft_timeout, ("timeout",))
     CREATE_INDEX = ("create_index", _get_soft_timeout, ("timeout",))
+    CREATE_MV = ("create_mv", _get_soft_timeout, ("timeout",))
     MAJOR_COMPACT = ("major_compact", _get_soft_timeout, ("timeout",))
     REPAIR = ("repair", _get_soft_timeout, ("timeout",))
     REBUILD = ("rebuild", _get_soft_timeout, ("timeout",))


### PR DESCRIPTION
`add_remove_mv` nemesis fails sometimes with timeout. We would like to know how much time create mv took but still fail if it exceeds 2h.

Added `adaptive_timeout` for this operation with 2h soft timeout and 5h of hard timeout.
Also increased `create_index` hard timeout to 5h.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
