### PR TITLE
feature(gemini): update gemini to 1.8.4

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -208,7 +208,7 @@ stress_image:
   nosqlbench: 'scylladb/hydra-loaders:nosqlbench-4.15.49'
   cassandra-stress: '' # default would be same version as scylla under test
   scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.18'
-  gemini: 'scylladb/hydra-loaders:gemini-v1.8.2'
+  gemini: 'scylladb/hydra-loaders:gemini-v1.8.4'
   alternator-dns: 'scylladb/hydra-loaders:alternator-dns-0.1'
   cdc-stresser: 'scylladb/hydra-loaders:cdc-stresser-20210630'
   kcl: 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC'

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -681,7 +681,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                          {'alternator-dns': 'scylladb/hydra-loaders:alternator-dns-0.1',
                           'cassandra-stress': 'scylla-bench',
                           'cdc-stresser': 'scylladb/hydra-loaders:cdc-stresser-A',
-                          'gemini': 'scylladb/hydra-loaders:gemini-v1.8.2',
+                          'gemini': 'scylladb/hydra-loaders:gemini-v1.8.4',
                           'ndbench': 'scylladb/hydra-loaders:ndbench-jdk8-A',
                           'nosqlbench': 'scylladb/hydra-loaders:nosqlbench-A',
                           'scylla-bench': 'scylladb/something',
@@ -689,7 +689,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                           'kcl': 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC',
                           'harry': 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816'})
 
-        self.assertEqual(conf.get('stress_image.gemini'), 'scylladb/hydra-loaders:gemini-v1.8.2')
+        self.assertEqual(conf.get('stress_image.gemini'), 'scylladb/hydra-loaders:gemini-v1.8.4')
         self.assertEqual(conf.get('stress_image.non-exist'), None)
 
         self.assertEqual(conf.get('stress_read_cmd'), ['cassandra_stress', 'cassandra_stress'])


### PR DESCRIPTION
Many fixes recently were introduced to Gemini and it was released.

Update default Gemini version to 1.8.4

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
