### PR TITLE
fix(k8s): do not run nemesis during prepare in 2 tenants longevity test

### DIFF
--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-multitenant.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-multitenant.yaml
@@ -31,6 +31,7 @@ k8s_n_auxiliary_nodes: 3
 nemesis_class_name: ['FreeTierSetMonkey', 'K8sSetMonkey']
 nemesis_interval: [5, 6]
 nemesis_seed: ['385', '543']
+nemesis_during_prepare: false
 space_node_threshold: [64424, 64423]
 
 user_prefix: 'longevity-scylla-operator-3h-multitenant'


### PR DESCRIPTION
The reason is that the prepare load almost overloads the Scylla pods and any disruption to any of the Scylla clusters will cause loader failures.
So, to avoid it disable nemesis during the 'prepare' phase which runs only for bunch of minutes.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
