### PR TITLE
fix(schema-changes-3h): Disable hinted-handof, set i4i.2xlarge

### DIFF
--- a/test-cases/longevity/longevity-schema-changes-3h.yaml
+++ b/test-cases/longevity/longevity-schema-changes-3h.yaml
@@ -12,6 +12,7 @@ n_monitor_nodes: 1
 round_robin: true
 
 instance_type_db: 'i3en.large'
+hinted_handoff: 'disabled'  # A workaround for issues like: https://github.com/scylladb/scylla-enterprise/issues/3102
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_selector: ['schema_changes']


### PR DESCRIPTION
	This is in order to avoid various issues related to:
	'Too many in flight hints', like https://github.com/scylladb/scylla-enterprise/issues/3102
Refs: https://github.com/scylladb/scylla-enterprise/issues/3102
[Argus](https://argus.scylladb.com/test/32eea484-9fbe-48bd-a0a8-ed9e202706ad/runs?additionalRuns[]=7db11cad-2048-48e0-8e19-c416184fa6d2)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
