### PR TITLE
fix(upgrade test): do not specfiy -a when "nodetools upgradesstables"

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -379,7 +379,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             node.remoter.sudo(
                 f"cp {main_dir / filename} {main_dir / subdir / filename}")
 
-            node.run_nodetool(sub_cmd="upgradesstables", args="-a")
+            node.run_nodetool(sub_cmd="upgradesstables")
         if queue:
             queue.put(upgradesstables_available)
             queue.task_done()


### PR DESCRIPTION
`-a` is the short form of `--include-all-sstables`, which instruct the tool and in turn scylla to compact *all* sstables no matter if their format version is identical to the latest format version. at the time of writing, it is "me". by default, nodetool does exclude sstables of current version from being compacted.

in https://github.com/scylladb/scylladb/issues/14548, we found that scylla took almost 6 hours to complete this command. and it compacted more than 873GiB data in total. this behavior is expected. but the use case is not very popular. as the whole point of "nodetools upgradesstables" is to upgrade the sstable format from an old one the the latest one supported by scylla.

so, in this change, we just drop the `-a` option from the `nodetool upgradesstables` command line.

Fixes #6334
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
