### PR TITLE
fix(k8s-gke): fix static local volume provisioner for GKE

### DIFF
--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -40,9 +40,9 @@ k8s_scylla_datacenter: 'us-east1-b'
 k8s_scylla_rack: 'us-east1'
 k8s_scylla_cluster_name: 'sct-cluster'
 k8s_scylla_disk_gi: 1100
-# NOTE: use only the following pair of options:
+# NOTE: use any of the following pairs:
+#   'k8s_scylla_disk_class=local-raid-disks'   and 'k8s_local_volume_provisioner_type=static'
 #   'k8s_scylla_disk_class=scylladb-local-xfs' and 'k8s_local_volume_provisioner_type=dynamic'
-#   The pair of options that defines the old 'static' way fails using latest K8S.
 k8s_scylla_disk_class: 'scylladb-local-xfs'
 k8s_local_volume_provisioner_type: 'dynamic'
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1091,7 +1091,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             if obj["kind"] != "DaemonSet":
                 return
             for container_data in obj["spec"]["template"]["spec"]["containers"]:
-                if container_data["name"] in ("pv-setup", "node-setup", "xfs-formatter"):
+                if container_data["name"] in ("pv-setup", "node-setup"):
                     # NOTE: disable custom node- and pv- setups using dynamic volume provisioner
                     container_data["command"] = ["/bin/bash", "-c", "--"]
                     container_data["args"] = ["while true; do sleep 3600; done"]

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -243,7 +243,7 @@ class GkeCluster(KubernetesCluster):
     @cached_property
     def allowed_labels_on_scylla_node(self) -> list:
         allowed_labels_on_scylla_node = [
-            ('app', 'xfs-formatter'),
+            ('app', 'node-setup'),
             ('app', 'static-local-volume-provisioner'),
             ('k8s-app', 'fluentbit-gke'),
             ('k8s-app', 'gke-metrics-agent'),

--- a/sdcm/k8s_configs/gke/scylla-node-prepare.yaml
+++ b/sdcm/k8s_configs/gke/scylla-node-prepare.yaml
@@ -34,19 +34,18 @@ subjects:
   name: pv-setup
   namespace: default
 ---
-# Daemonset that converts ephemeral-storage to xfs
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: xfs-formatter
+  name: node-setup
 spec:
   selector:
     matchLabels:
-      app: xfs-formatter
+      app: node-setup
   template:
     metadata:
       labels:
-        app: xfs-formatter
+        app: node-setup
     spec:
       hostPID: true
       serviceAccountName: pv-setup
@@ -56,76 +55,53 @@ spec:
         value: scylla-clusters
         effect: NoSchedule
       containers:
-      - name: xfs-formatter
-        # NOTE: sha256:8948 .. fb5c33 was built on Dec 29 2021
-        #       which includes following operator PR with required changes:
-        #           https://github.com/scylladb/scylla-operator/pull/770
-        image: docker.io/scylladb/scylla-operator@sha256:894836496e1ea8f7ea9dd4e1aa55cbd6e3aa382cfdeebc474dad96a29dfb5c33
+      # NOTE: the 'node-setup' container's script was taken from the following place:
+      #       https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/local-ssd#run-local-volume-static-provisioner
+      #       https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/blob/be7c6372/examples/gke-daemonset-raid-disks.yaml
+      - name: node-setup
+        image: gcr.io/google-containers/startup-script:v1
         securityContext:
           privileged: true
-        command:
-        - "/bin/bash"
-        - "-euExo"
-        - "pipefail"
-        - "-O"
-        - "inherit_errexit"
-        - "-c"
-        - |
-          cp -r /usr/local/lib/scylla-operator/gke/xfs-formatter /host/var/lib/
+        env:
+          - name: STARTUP_SCRIPT
+            value: |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
 
-          if [[ ! -d /host/usr/local/lib/systemd ]]; then
-            mkdir /host/usr/local/lib/systemd
-          fi
+              devices=()
+              for ssd in /dev/disk/by-id/google-local-ssd-block*; do
+                if [ -e "${ssd}" ]; then
+                  devices+=("${ssd}")
+                fi
+              done
+              if [ "${#devices[@]}" -eq 0 ]; then
+                echo "No Local NVMe SSD disks found."
+                exit 0
+              fi
 
-          if [[ ! -d /host/usr/local/lib/systemd/system ]]; then
-            mkdir /host/usr/local/lib/systemd/system
-          fi
+              seen_arrays=(/dev/md/*)
+              device=${seen_arrays[0]}
+              echo "Setting RAID array with Local SSDs on device ${device}"
+              if [ ! -e "$device" ]; then
+                device="/dev/md/0"
+                echo "y" | mdadm --create "${device}" --level=0 --force --raid-devices=${#devices[@]} "${devices[@]}"
+              fi
 
-          cp -r /usr/local/lib/scylla-operator/gke/systemd/. /host/usr/local/lib/systemd/system
+              if ! tune2fs -l "${device}" ; then
+                echo "Formatting '${device}'"
+                mkfs.xfs "${device}"
+              fi
 
-          if [[ ! -d /host/usr/local/lib/systemd/system/kube-node-configuration.service.d ]]; then
-            mkdir /host/usr/local/lib/systemd/system/kube-node-configuration.service.d
-          fi
-
-          cat<<-EOF > /host/usr/local/lib/systemd/system/kube-node-configuration.service.d/10-path.conf
-            [Service]
-            Environment="PATH=/var/lib/xfs-formatter/bin:$( chroot /host /bin/bash -c 'echo "${PATH}"' )"
-          EOF
-
-          if [[ ! -d /host/mnt/raid-disks ]]; then
-            mkdir /host/mnt/raid-disks
-          fi
-
-          if [[ ! -d /host/mnt/raid-disks/disk0 ]]; then
-            mkdir /host/mnt/raid-disks/disk0
-          fi
-          chmod a+w /host/mnt/raid-disks/disk0
-
-          chroot /host /bin/bash -euxo pipefail -O inherit_errexit -c '
-              systemctl daemon-reload
-              systemctl enable --now mnt-raid\\x2ddisks-disk0.mount
-              systemctl start xfs-formatter.service
-              journalctl -xeu xfs-formatter -f
-              '
+              mountpoint=/mnt/raid-disks/disk0
+              mkdir -p "${mountpoint}"
+              echo "Mounting '${device}' at '${mountpoint}'"
+              mount -o discard,defaults "${device}" "${mountpoint}"
+              chmod a+w "${mountpoint}"
         volumeMounts:
-        - name: hostfs
-          mountPath: /host
-          mountPropagation: Bidirectional
-        readinessProbe:
-          exec:
-            command:
-              - "chroot"
-              - "/host"
-              - "/bin/bash"
-              - "-euExo"
-              - "pipefail"
-              - "-O"
-              - "inherit_errexit"
-              - "-c"
-              - |
-                xfs_info "$( { grep -E '/mnt/raid-disks/disk0($| )' /proc/mounts || test $? = 1; } | sed -E -e 's/([^ ]+) .+/\1/' )"
-          initialDelaySeconds: 10
-          periodSeconds: 10
+          - name: hostfs
+            mountPath: /mnt/hostfs
+            mountPropagation: Bidirectional
       - name: pv-setup
         image: bitnami/kubectl:1.21.4
         imagePullPolicy: Always
@@ -163,7 +139,7 @@ spec:
 
             # Create directories for each Scylla cluster on each K8S node which will host PVs
             while true; do
-              if [[ -z $(mount | grep  "/dev/md127") ]]; then
+              if [[ -z $(mount | grep  "/dev/md0") ]]; then
                 sleep 5;
                 continue
               fi

--- a/sdcm/k8s_configs/static-local-volume-provisioner.yaml
+++ b/sdcm/k8s_configs/static-local-volume-provisioner.yaml
@@ -58,9 +58,6 @@ data:
        namePattern: pv-
        hostDir: "/mnt/raid-disks/disk0/"
        mountDir: "/mnt/raid-disks/disk0/"
-       blockCleanerCommand:
-         - /scripts/shred.sh
-         - 2
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass


### PR DESCRIPTION
To be able to run 'v1.8.x' scylla-operator on the latest K8S versions of the GKE we should support the 'static local volume provisioner' case. So, use the solution recommended by the Google:

    https://cloud.google.com/kubernetes-engine/docs/how-to/ \
        persistent-volumes/local-ssd#run-local-volume-static-provisioner

Reason: The old way of using 'xfs-formatter' is not suitable anymore due to the disk changes.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
