### PR TITLE
fix(perf-throughput): set reactor-stall-ms to 5

### DIFF
--- a/test-cases/performance/perf-regression.100threads.30M-keys-i4i-enterprise.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys-i4i-enterprise.yaml
@@ -32,3 +32,5 @@ email_recipients: ['scylla-perf-results@scylladb.com']
 
 custom_es_index: 'performancestatsv2'
 use_hdr_cs_histogram: true
+
+append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'

--- a/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
@@ -32,3 +32,5 @@ email_recipients: ['scylla-perf-results@scylladb.com']
 
 custom_es_index: 'performancestatsv2'
 use_hdr_cs_histogram: true
+
+append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -33,3 +33,5 @@ email_recipients: ['scylla-perf-results@scylladb.com']
 
 custom_es_index: 'performancestatsv2'
 use_hdr_cs_histogram: true
+
+append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'


### PR DESCRIPTION
Upon preparing new jobs for performance throughputs was used default default reactor-stall-ms notifier setting 25ms

Set valid value: 5

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
