### PR TITLE
fix(rolling-upgrade.yaml): set gemini version to 1.7.8

### DIFF
--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -48,5 +48,5 @@ gemini_cmd: "gemini -d --duration 2h \
 --replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" \
 --table-options \"cdc={'enabled': true}\" --test-username cassandra --test-password cassandra"
 gemini_seed: 66
-gemini_version: 'latest'
+gemini_version: '1.7.8'
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used


### PR DESCRIPTION
Since there is a consistent issue using the latest gemini version, we set the version to the one used in the latest stable run, 1.7.8

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
