### PR TITLE
fix(install_gsutil_dependencies): install gsutil with apt-get

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -89,26 +89,15 @@ class BackupFunctionsMixIn(LoaderUtilsMixin):
         self._run_cmd_with_retry(executor=node.remoter.sudo, cmd=shell_script_cmd(cmd))
 
     def install_gsutil_dependencies(self, node):
-        def is_dir_exists(path):
-            shell = dedent(f"""
-            if [ -d {path} ]
-            then
-                exit 0
-            else
-                exit 1
-            fi
+        if node.is_ubuntu() or node.is_debian():
+            cmd = dedent("""
+                echo 'deb https://packages.cloud.google.com/apt cloud-sdk main' | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+                curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+                sudo apt-get update && sudo apt-get install google-cloud-cli
             """)
-            result = node.remoter.sudo(shell, ignore_status=True)
-            return result.exited == 0
-
-        sdk_directory_path = '$HOME/google-cloud-sdk'
-        if not is_dir_exists(path=sdk_directory_path):
-            self._run_cmd_with_retry(executor=node.remoter.run, cmd=shell_script_cmd("""\
-                        curl https://sdk.cloud.google.com > install.sh
-                        bash install.sh --disable-prompts
-                    """))
         else:
-            self.log.info("gsutil dependencies are now pre-installed, no need to install them on {}".format(node))
+            raise NotImplementedError("At the moment, we only support debian installation")
+        self._run_cmd_with_retry(executor=node.remoter.run, cmd=shell_script_cmd(cmd))
 
     def install_azcopy_dependencies(self, node):
         self._run_cmd_with_retry(executor=node.remoter.sudo, cmd=shell_script_cmd("""\


### PR DESCRIPTION
Previously, we installed gsutil with an install script. However, this method is no longer functioning. As such, we replaced it and now use apt-get to install gsutil.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
