### PR TITLE
fix(AddRemoveDcNemesis): fix on simulated racks

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4032,7 +4032,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             scylla_yml.rpc_address = new_node.ip_address
             scylla_yml.seed_provider = [SeedProvider(class_name='org.apache.cassandra.locator.SimpleSeedProvider',
                                                      parameters=[{"seeds": self.tester.db_cluster.seed_nodes_ips}])]
-            if scylla_yml.endpoint_snitch.endswith("GossipingPropertyFileSnitch"):
+            if self.cluster.params.get("endpoint_snitch").endswith("GossipingPropertyFileSnitch"):
                 rackdc_value = {"dc": "add_remove_nemesis_dc"}
             else:
                 rackdc_value = {"dc_suffix": "_nemesis_dc"}


### PR DESCRIPTION
Problem is with detection - which is based on `scylla.yaml` taken from new node which has default setting - and failing to detect `GossipingPropertyFileSnitch` is used.

Use test param `endpoint_snitch` which should be always valid (even when using simulated racks) for detection of endpoint snitch.

fixes: #6236

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
