### PR TITLE
feature(cassandra-stress): rack aware support

### DIFF
--- a/docker/cassandra-stress/Dockerfile-src
+++ b/docker/cassandra-stress/Dockerfile-src
@@ -9,10 +9,6 @@ ENV GIT_FORK=${GIT_FORK:-https://github.com/scylladb/scylla-tools-java}
 RUN git clone -b ${BRANCH} --single-branch ${GIT_FORK}
 RUN apt -y update && apt-get -y install ant
 
-# revert of cassandra driver (without shard-aware)
-COPY .gitconfig /root/
-RUN cd scylla-tools-java && git revert 1deceb8a605e563f01ef1821d48316cea766da31 && git revert 87a98f0a85c9db8a9c7602e66d3d2cca56903cdf
-
 # build
 RUN cd scylla-tools-java && ant
 

--- a/docker/cassandra-stress/README.md
+++ b/docker/cassandra-stress/README.md
@@ -6,16 +6,16 @@ export DEB_LIST_URL=https://s3.amazonaws.com/downloads.scylladb.com/unstable/scy
 export CS_DOCKER_IMAGE=scylladb/hydra-loaders:cassandra-stress-$(date +'%Y%m%d')
 docker build . -t ${CS_DOCKER_IMAGE} -f Dockerfile-deb --build-arg DEB_LIST_URL=$DEB_LIST_URL
 docker push ${CS_DOCKER_IMAGE}
-echo "${CS_DOCKER_IMAGE}" > image
 ```
 
-### Building from source without shard aware driver (slower)
+### Building from fork source (slower)
+
+this is just example of such usage, you should point it to the fork/branch you need
 
 ```
-export BRANCH=branch-5.0
+export BRANCH=use_rack_aware
+export GIT_FORK=https://github.com/sylwiaszunejko/scylla-tools-java
 export CS_DOCKER_IMAGE=scylladb/hydra-loaders:cassandra-stress-${BRANCH}-$(date +'%Y%m%d')
-docker build . -t ${CS_DOCKER_IMAGE} -f Dockerfile
-docker build . -t ${CS_DOCKER_IMAGE} -f Dockerfile-src --build-arg BRANCH=${BRANCH}
+docker build . -t ${CS_DOCKER_IMAGE} -f Dockerfile-src --build-arg BRANCH=${BRANCH} --build-arg GIT_FORK=${GIT_FORK}
 docker push ${CS_DOCKER_IMAGE}
-echo "${CS_DOCKER_IMAGE}" > image
 ```

--- a/docker/cassandra-stress/image
+++ b/docker/cassandra-stress/image
@@ -1,1 +1,0 @@
-scylladb/hydra-loaders:cassandra-stress-20220831

--- a/jenkins-pipelines/longevity-multi-dc-rack-aware.jenkinsfile
+++ b/jenkins-pipelines/longevity-multi-dc-rack-aware.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: '''["eu-west-1", "eu-west-2"]''',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-multi-dc-rack-aware.yaml"]''',
+)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3213,6 +3213,14 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
 
         return rack_names_mapping
 
+    def get_nodes_per_datacenter_and_rack_idx(self, db_nodes: list[BaseNode] | None = None):
+        db_nodes = db_nodes if db_nodes else self.nodes
+        nodes_mapping = {}
+        for (region, rack), nodes in self.nodes_by_racks_idx_and_regions(nodes=db_nodes).items():
+            nodes_mapping[(region, rack)] = nodes
+
+        return nodes_mapping
+
     def send_file(self, src, dst, verbose=False):
         for loader in self.nodes:
             loader.remoter.send_files(src=src, dst=dst, verbose=verbose)

--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -115,7 +115,7 @@ class RemoteDocker(BaseNode):
 
     @property
     def region(self):
-        return "docker"
+        return "eu-north-1"
 
     def restart(self):
         pass

--- a/test-cases/longevity/longevity-multi-dc-rack-aware.yaml
+++ b/test-cases/longevity/longevity-multi-dc-rack-aware.yaml
@@ -1,0 +1,22 @@
+test_duration: 800
+
+prepare_write_cmd:  ["cassandra-stress write cl=LOCAL_QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+                    ]
+
+stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5 -errors retries=50",
+             "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5 -errors retries=50",
+             ]
+
+n_db_nodes: '3 3'
+n_loaders: '1 1'
+n_monitor_nodes: 1
+
+instance_type_db: 'i4i.2xlarge'
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_interval: 10
+nemesis_filter_seeds: false
+
+round_robin: false
+
+user_prefix: 'multi-dc-rackaware'

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -86,6 +86,7 @@ def fixture_docker_scylla(request: pytest.FixtureRequest):  # pylint: disable=to
     scylla = RemoteDocker(LocalNode("scylla", cluster), image_name=docker_version,
                           command_line=f"--smp 1 {alternator_flags}",
                           extra_docker_opts=extra_docker_opts, docker_network=docker_network)
+    cluster.nodes = [scylla]
     DummyRemoter = collections.namedtuple('DummyRemoter', ['run', 'sudo'])
     scylla.remoter = DummyRemoter(run=scylla.run, sudo=scylla.run)
 

--- a/unit_tests/dummy_remote.py
+++ b/unit_tests/dummy_remote.py
@@ -95,3 +95,7 @@ class LocalScyllaClusterDummy(BaseScyllaCluster):
     @staticmethod
     def get_db_auth():
         return None
+
+    def get_ip_to_node_map(self):
+        """returns {ip: node} map for all nodes in cluster to get node by ip"""
+        return {node.ip_address: node for node in self.nodes}

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -535,6 +535,9 @@ class TestNodetoolStatus(unittest.TestCase):
         datacenter_name_per_region = db_cluster.get_rack_names_per_datacenter_and_rack_idx(db_nodes=[node1])
         assert datacenter_name_per_region == {('east-us', '1'): '1a'}
 
+        nodes_per_region = db_cluster.get_nodes_per_datacenter_and_rack_idx()
+        assert nodes_per_region == {('east-us', '1'): [node1, node2], ('west-us', '2'): [node3, ]}
+
     def test_can_get_nodetool_status_ipv6(self):  # pylint: disable=no-self-use
         resp = "\n".join(["Datacenter: eu-north",
                           "====================",


### PR DESCRIPTION
`RackAwareRoundRobinPolicy` was introduced in scylladb/java-driver#227 and now we'll support passing it to c-s automatically every time we use multiple racks setup, the loader would be spread on multiple AZs, and we should pass each loader the corresponding rack, similar to how we are doing it for DCs

Ref: https://github.com/scylladb/scylla-tools-java/pull/335
Ref: https://github.com/scylladb/java-driver/pull/227

### Testing:
- [x] - simulated Racks - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-cdc-100gb-4h-test/7/
- [x] - base case for comparing (2023.1) - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-cdc-100gb-4h-test/8/
- [x]  - run of case with the fix - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-cdc-100gb-4h-test/14/
- [x] - Multi-DC real AZ - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-multi-dc-rack-aware-test/12/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
