### PR TITLE
refactor(rollin-upgrades): Increase diversity of instance types

### DIFF
--- a/configurations/gce/n2-highmem-16.yaml
+++ b/configurations/gce/n2-highmem-16.yaml
@@ -1,0 +1,2 @@
+gce_instance_type_db: 'n2-highmem-16'
+gce_n_local_ssd_disk_db: 4

--- a/configurations/gce/n2-highmem-32.yaml
+++ b/configurations/gce/n2-highmem-32.yaml
@@ -1,0 +1,2 @@
+gce_instance_type_db: 'n2-highmem-32'
+gce_n_local_ssd_disk_db: 8

--- a/configurations/gce/n2-highmem-48.yaml
+++ b/configurations/gce/n2-highmem-48.yaml
@@ -1,0 +1,2 @@
+gce_instance_type_db: 'n2-highmem-48'
+gce_n_local_ssd_disk_db: 16

--- a/configurations/gce/n2-highmem-64.yaml
+++ b/configurations/gce/n2-highmem-64.yaml
@@ -1,0 +1,2 @@
+gce_instance_type_db: 'n2-highmem-64'
+gce_n_local_ssd_disk_db: 24

--- a/configurations/gce/n2-higmem-8.yaml
+++ b/configurations/gce/n2-higmem-8.yaml
@@ -1,0 +1,2 @@
+gce_instance_type_db: 'n2-highmem-8'
+gce_n_local_ssd_disk_db: 2

--- a/jenkins-pipelines/rolling-upgrade-centos7.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-centos7.jenkinsfile
@@ -10,6 +10,6 @@ rollingUpgradePipeline(
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7',
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
-    test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
+    test_config: '''["test-cases/upgrades/rolling-upgrade.yaml", "configurations/gce/n2-highmem-8.yaml"]''',
     internode_compression: 'all'
 )

--- a/jenkins-pipelines/rolling-upgrade-centos8.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-centos8.jenkinsfile
@@ -10,6 +10,6 @@ rollingUpgradePipeline(
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-8',
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
-    test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
+    test_config: '''["test-cases/upgrades/rolling-upgrade.yaml", "configurations/gce/n2-highmem-16.yaml"]''',
     internode_compression: 'all'
 )

--- a/jenkins-pipelines/rolling-upgrade-debian10.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-debian10.jenkinsfile
@@ -10,5 +10,5 @@ rollingUpgradePipeline(
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-10',
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
-    test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
+    test_config: '''["test-cases/upgrades/rolling-upgrade.yaml", "configurations/gce/n2-highmem-32.yaml"]'''
 )

--- a/jenkins-pipelines/rolling-upgrade-debian11.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-debian11.jenkinsfile
@@ -10,5 +10,5 @@ rollingUpgradePipeline(
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-11',
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
-    test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
+    test_config: '''["test-cases/upgrades/rolling-upgrade.yaml", "configurations/gce/n2-highmem-48.yaml"]''',
 )

--- a/jenkins-pipelines/rolling-upgrade-ubuntu20.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu20.04.jenkinsfile
@@ -9,6 +9,6 @@ rollingUpgradePipeline(
     linux_distro: 'ubuntu-focal',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2004-lts',
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
-    test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
+    test_config: '''["test-cases/upgrades/rolling-upgrade.yaml", "configurations/gce/n2-highmem-64.yaml"]''',
     internode_compression: 'all',
 )

--- a/jenkins-pipelines/rolling-upgrade-ubuntu22.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu22.04.jenkinsfile
@@ -9,6 +9,6 @@ rollingUpgradePipeline(
     linux_distro: 'ubuntu-focal',
     use_preinstalled_scylla: true,
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
-    test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
+    test_config: '''["test-cases/upgrades/rolling-upgrade.yaml", "configurations/gce/n2-highmem-32.yaml"]''',
     internode_compression: 'all',
 )


### PR DESCRIPTION
In order to catch more issues with installations and upgrades that are related to instance type sizes (e.g. perftune issues related to amount of cores), this commit spread 5 common instances types in gce with higher amount of disks accordingly.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
