### PR TITLE
fix(k8s-local): install helm

### DIFF
--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -55,6 +55,7 @@ DST_APISERVER_AUDIT_LOG = "/var/log/kubernetes/kube-apiserver-audit.log"
 
 CNI_CALICO_CONFIG = sct_abs_path("sdcm/k8s_configs/cni-calico.yaml")
 CNI_CALICO_VERSION = "v3.24.5"
+HELM_VERSION = "v3.12.1"
 LOGGER = logging.getLogger(__name__)
 POOL_LABEL_NAME = 'minimal-k8s-nodepool'
 
@@ -128,6 +129,11 @@ class MinimalK8SOps:
             sysctl --system
             """)
         node.remoter.sudo(f'bash -cxe "{script}"')
+        node.remoter.sudo(
+            'bash -cxe \"helm version'
+            f' || curl --silent --location "https://get.helm.sh/helm-{HELM_VERSION}-linux-amd64.tar.gz"'
+            '  | tar xz -C /tmp && mv /tmp/linux-amd64/helm /usr/local/bin'
+            '\"')
 
         # NOTE: if running in Hydra then it must have '/dev' mount from host as 'rw'
         for i in range(7, 41):


### PR DESCRIPTION
Recently the helm commands started using local helm installations. 
So, install `helm` package on local K8S to be able to use it with python directly and not only via the `hydra`.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
