### PR TITLE
refactor(hinted_handoff): Disable hinted_handoff for all tests

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -72,7 +72,7 @@ email_subject_postfix: ''
 
 collect_logs: false
 
-hinted_handoff: 'enabled'
+hinted_handoff: 'disabled'
 
 server_encrypt: false
 client_encrypt: false

--- a/test-cases/longevity/longevity-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-100gb-4h.yaml
@@ -26,3 +26,5 @@ client_encrypt: true
 
 pre_create_schema: True
 sstable_size: 100
+
+hinted_handoff: 'enabled'

--- a/test-cases/longevity/longevity-large-collections-12h.yaml
+++ b/test-cases/longevity/longevity-large-collections-12h.yaml
@@ -15,7 +15,3 @@ nemesis_interval: 15
 
 user_prefix: 'longevity-large-collections-12h'
 space_node_threshold: 64424
-
-# Disable hinted handoff to avoid a known issue:
-# https://github.com/scylladb/scylla/issues/4935
-hinted_handoff: 'disabled'

--- a/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.result.json
@@ -18,5 +18,5 @@
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,
   "enable_ipv6_dns_lookup": false,
-  "hinted_handoff_enabled": true
+  "hinted_handoff_enabled": false
 }

--- a/unit_tests/test_data/test_scylla_yaml_builders/artifact_amazon2.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/artifact_amazon2.result.json
@@ -18,5 +18,5 @@
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,
   "enable_ipv6_dns_lookup": false,
-  "hinted_handoff_enabled": true
+  "hinted_handoff_enabled": false
 }

--- a/unit_tests/test_data/test_scylla_yaml_builders/cdc-replication-longevity.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/cdc-replication-longevity.result.json
@@ -20,5 +20,5 @@
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,
   "enable_ipv6_dns_lookup": false,
-  "hinted_handoff_enabled": true
+  "hinted_handoff_enabled": false
 }

--- a/unit_tests/test_data/test_scylla_yaml_builders/functional.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/functional.result.json
@@ -18,5 +18,5 @@
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,
   "enable_ipv6_dns_lookup": false,
-  "hinted_handoff_enabled": true
+  "hinted_handoff_enabled": false
 }

--- a/unit_tests/test_data/test_scylla_yaml_builders/jepsen.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/jepsen.result.json
@@ -18,5 +18,5 @@
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,
   "enable_ipv6_dns_lookup": false,
-  "hinted_handoff_enabled": true
+  "hinted_handoff_enabled": false
 }

--- a/unit_tests/test_data/test_scylla_yaml_builders/longevity-10gb-3h.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/longevity-10gb-3h.result.json
@@ -20,5 +20,5 @@
   "enable_ipv6_dns_lookup": true,
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,
-  "hinted_handoff_enabled": true
+  "hinted_handoff_enabled": false
 }

--- a/unit_tests/test_data/test_scylla_yaml_builders/manager-backup-1TB-gce.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/manager-backup-1TB-gce.result.json
@@ -18,5 +18,5 @@
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,
   "enable_ipv6_dns_lookup": false,
-  "hinted_handoff_enabled": true
+  "hinted_handoff_enabled": false
 }

--- a/unit_tests/test_data/test_scylla_yaml_builders/perf-regression.100threads.30M-keys.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/perf-regression.100threads.30M-keys.result.json
@@ -18,5 +18,5 @@
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,
   "enable_ipv6_dns_lookup": false,
-  "hinted_handoff_enabled": true
+  "hinted_handoff_enabled": false
 }

--- a/unit_tests/test_data/test_scylla_yaml_builders/rolling-upgrade.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/rolling-upgrade.result.json
@@ -26,5 +26,5 @@
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,
   "enable_ipv6_dns_lookup": false,
-  "hinted_handoff_enabled": true
+  "hinted_handoff_enabled": false
 }

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -192,7 +192,7 @@ class ScyllaYamlClusterAttrBuilderTest(ScyllaYamlClusterAttrBuilderBase):
                     'ldap_server_type': 'ms_ad',
                     'internode_encryption': True,
                     'client_encrypt': True,
-                    'hinted_handoff': True,
+                    'hinted_handoff': False,
                     'prepare_saslauthd': True,
                 }
             },
@@ -204,7 +204,7 @@ class ScyllaYamlClusterAttrBuilderTest(ScyllaYamlClusterAttrBuilderBase):
                 'authorizer': 'CassandraAuthorizer',
                 'enable_ipv6_dns_lookup': False,
                 'endpoint_snitch': 'org.apache.cassandra.locator.GossipingPropertyFileSnitch',
-                'hinted_handoff_enabled': True,
+                'hinted_handoff_enabled': False,
                 'ldap_attr_role': 'cn', 'ldap_bind_dn': 'SOMEDN', 'ldap_bind_passwd': 'PASSWORD',
                 'ldap_url_template': 'ldap://3.3.3.3:389/dc=scylla-qa,dc=com?cn?sub?(member=CN={USER},dc=scylla-qa,dc=com)',
                 'role_manager': 'com.scylladb.auth.LDAPRoleManager',


### PR DESCRIPTION
The feature is disabled in all cloud clusters and probably in the field. leaving one sanity test to make sure it still works, but disabling for all other scenarios for now.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
