### PR TITLE
fix(raft_operation): Timeout for log message depend on appearence in log

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -227,6 +227,24 @@ def ignore_stream_mutation_fragments_errors():
             regex=r".*storage_service \- .*Operation failed",
             extra_time_to_expiration=30
         ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*node_ops - decommission.*Operation failed.*std::runtime_error.*aborted_by_user=true, failed_because=N\/A",
+            extra_time_to_expiration=30
+        ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*node_ops - decommission.*Operation failed.*std::runtime_error.*failed_because=seastar::rpc::closed_error",
+            extra_time_to_expiration=30
+        ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*node_ops - decommission.*Operation failed.*std::runtime_error.*seastar::abort_requested_exception",
+            extra_time_to_expiration=30
+        ))
         yield
 
 


### PR DESCRIPTION
Decommission could take different time depend on instance, size of dataset
number of nodes. Decommission streaming error randomly choose log line after
which decommission process should be aborted. Default timeout to wait
log message could be not enough to wait for messages from the end of
decommission.

Split messages for start and end process and return with method
the expected timeout.

Issue #6627
Issue #6181

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [x] All new and existing unit tests passed (CI)
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
