### PR TITLE
test(nemesis): add AWS KMS + EaR nemesis

### DIFF
--- a/data_dir/nemesis.yml
+++ b/data_dir/nemesis.yml
@@ -56,6 +56,9 @@
 - disrupt_drain_kubernetes_node_then_replace_scylla_node:
   - disruptive = True
   - kubernetes = True
+- disrupt_enable_disable_table_encryption_aws_kms_provider:
+  - disruptive = True
+  - kubernetes = False
 - disrupt_grow_shrink_cluster:
   - disruptive = True
   - kubernetes = True

--- a/data_dir/nemesis_classes.yml
+++ b/data_dir/nemesis_classes.yml
@@ -20,6 +20,7 @@
 - DrainKubernetesNodeThenDecommissionAndAddScyllaNode
 - DrainKubernetesNodeThenReplaceScyllaNode
 - DrainerMonkey
+- EnableDisableTableEncryptionAwsKmsProviderMonkey
 - EnospcAllNodesMonkey
 - EnospcMonkey
 - GrowShrinkClusterNemesis

--- a/sdcm/utils/aws_kms.py
+++ b/sdcm/utils/aws_kms.py
@@ -1,0 +1,145 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2023 ScyllaDB
+
+from itertools import cycle
+import logging
+
+import botocore
+import boto3
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AwsKms:
+    NUM_OF_KMS_KEYS = 3
+    KMS_KEYS_TAGS = {
+        'Purpose': 'Rotation',
+        'UsedBy': 'QA',
+    }
+
+    def __init__(self, region_names):
+        if not region_names:
+            raise ValueError("'region_names' parameter cannot be empty")
+        self.region_names = region_names if isinstance(region_names, list) else [region_names]
+        self.mapping = {
+            region_name: {
+                'client': boto3.client('kms', region_name=region_name),
+                'kms_key_ids': [],
+                'kms_keys_aliases': {},
+            } for region_name in self.region_names
+        }
+        self.num_of_tags_to_match = len(self.KMS_KEYS_TAGS)
+
+    def create_kms_key(self, region_name):
+        LOGGER.info("Creating KMS key in the '%s' region", region_name)
+        kms_key = self.mapping[region_name]['client'].create_key(
+            Description='qa-kms-key-for-rotation',
+            Tags=[{'TagKey': k, 'TagValue': v} for k, v in self.KMS_KEYS_TAGS.items()],
+        )
+        self.mapping[region_name]['kms_key_ids'].append(kms_key['KeyMetadata']['KeyId'])
+
+    def get_kms_key_tags(self, kms_key_id, region_name):
+        try:
+            tags = self.mapping[region_name]['client'].list_resource_tags(KeyId=kms_key_id, Limit=999)['Tags']
+            return {tag['TagKey']: tag['TagValue'] for tag in tags}
+        except botocore.exceptions.ClientError as exc:
+            LOGGER.debug(exc.response)
+            if any(msg in exc.response['Error']['Code'] for msg in ('AccessDeniedException', 'NotFound')):
+                return {}
+            raise
+
+    def get_kms_keys(self, region_name, next_marker=None):
+        client, kwargs = self.mapping[region_name]['client'], {'Limit': 30}
+        if next_marker:
+            kwargs['Marker'] = next_marker
+        kms_keys = client.list_keys(**kwargs)
+        for kms_key in kms_keys['Keys']:
+            current_kms_key_id = kms_key['KeyId']
+            if not client.describe_key(KeyId=current_kms_key_id)['KeyMetadata']['Enabled']:
+                continue
+            yield current_kms_key_id
+        if kms_keys.get("NextMarker"):
+            yield from self.get_kms_keys(region_name=region_name, next_marker=kms_keys["NextMarker"])
+
+    def find_or_create_suitable_kms_keys(self):
+        for region_name in self.region_names:
+            if self.NUM_OF_KMS_KEYS <= len(self.mapping[region_name]['kms_key_ids']):
+                continue
+            for current_kms_key_id in self.get_kms_keys(region_name):
+                current_kms_key_tags = self.get_kms_key_tags(current_kms_key_id, region_name)
+                if not current_kms_key_tags:
+                    continue
+                kms_key_tags_match_counter = 0
+                for expected_k, expected_v in self.KMS_KEYS_TAGS.items():
+                    if current_kms_key_tags.get(expected_k) != expected_v:
+                        break
+                    kms_key_tags_match_counter += 1
+                if kms_key_tags_match_counter >= self.num_of_tags_to_match:
+                    self.mapping[region_name]['kms_key_ids'].append(current_kms_key_id)
+                if self.NUM_OF_KMS_KEYS == len(self.mapping[region_name]['kms_key_ids']):
+                    break
+            while self.NUM_OF_KMS_KEYS > len(self.mapping[region_name]['kms_key_ids']):
+                self.create_kms_key(region_name)
+
+    def get_next_kms_key(self, kms_key_alias_name, region_name):
+        # Create endless KMS keys iterator
+        if kms_key_alias_name not in self.mapping[region_name]['kms_keys_aliases']:
+            self.mapping[region_name]['kms_keys_aliases'][kms_key_alias_name] = cycle(
+                self.mapping[region_name]['kms_key_ids'])
+
+        kms_key_id_candidate = next(self.mapping[region_name]['kms_keys_aliases'][kms_key_alias_name])
+        # Walk through the aliases of the KMS key candidate and check that our alias is not there
+        for alias in self.mapping[region_name]['client'].list_aliases(
+                KeyId=kms_key_id_candidate, Limit=999)['Aliases']:
+            if kms_key_alias_name == alias['AliasName']:
+                # Current KMS Key candidate is already assigned to the alias, so, return another one
+                return next(self.mapping[region_name]['kms_keys_aliases'][kms_key_alias_name])
+        # Current KMS Key candidate is not assigned to the alias, use it
+        return kms_key_id_candidate
+
+    def create_alias(self, kms_key_alias_name, tolerate_already_exists=True):
+        self.find_or_create_suitable_kms_keys()
+        for region_name in self.region_names:
+            kms_key_id = self.get_next_kms_key(kms_key_alias_name, region_name)
+            LOGGER.info(
+                "Creating '%s' alias for the '%s' KMS key in the '%s' region",
+                kms_key_alias_name, kms_key_id, region_name)
+            try:
+                self.mapping[region_name]['client'].create_alias(
+                    AliasName=kms_key_alias_name, TargetKeyId=kms_key_id)
+            except botocore.exceptions.ClientError as exc:
+                LOGGER.debug(exc.response)
+                if not ('AlreadyExistsException' in exc.response['Error']['Code'] and tolerate_already_exists):
+                    raise
+
+    def rotate_kms_key(self, kms_key_alias_name):
+        self.find_or_create_suitable_kms_keys()
+        for region_name in self.region_names:
+            new_kms_key_id = self.get_next_kms_key(kms_key_alias_name, region_name)
+            LOGGER.info(
+                "Assigning the '%s' alias to the '%s' KMS key in the '%s' region",
+                kms_key_alias_name, new_kms_key_id, region_name)
+            self.mapping[region_name]['client'].update_alias(
+                AliasName=kms_key_alias_name, TargetKeyId=new_kms_key_id)
+
+    def delete_alias(self, kms_key_alias_name, tolerate_errors=True):
+        LOGGER.info("Deleting the '%s' alias in the KMS", kms_key_alias_name)
+        for region_name in self.region_names:
+            try:
+                self.mapping[region_name]['client'].delete_alias(AliasName=kms_key_alias_name)
+                if kms_key_alias_name in self.mapping[region_name]['kms_keys_aliases']:
+                    self.mapping[region_name]['kms_keys_aliases'].remove(kms_key_alias_name)
+            except botocore.exceptions.ClientError as exc:
+                LOGGER.debug(exc.response)
+                if not tolerate_errors:
+                    raise

--- a/unit_tests/test_nemesis_sisyphus.py
+++ b/unit_tests/test_nemesis_sisyphus.py
@@ -71,7 +71,7 @@ def test_list_all_available_nemesis(generate_file=True):
     disruption_list, disruptions_dict, disruption_classes = sisyphus.get_list_of_disrupt_methods(
         subclasses_list=subclasses, export_properties=True)
 
-    assert len(disruption_list) == 79
+    assert len(disruption_list) == 80
 
     if generate_file:
         with open('data_dir/nemesis.yml', 'w', encoding="utf-8") as outfile1:


### PR DESCRIPTION
New nemesis works when:
- AWS backend is used
- Test uses Scylla version that supports `KMS`+`EaR`+`InstanceProfiles`
- Instance profile, defined in the `aws_instance_profile_name_db`
  option, utilizes the `kms_user_policy` policy.


The new code utilizes several existing KMS keys for the creation of KMS key aliases and KMS keys rotation under these aliases.
If keys are absent they get created automatically.
Alias is kept per whole test run and gets cleaned up in the `cleanup` stage.
It is done so to avoid redundant Scylla nodes restarts.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
