### PR TITLE
fix(get_scylla_ami_versions): filter debug versions

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1665,18 +1665,12 @@ class SCTConfiguration(dict):
                 self._replace_docker_image_latest_tag()
             elif not self.get('ami_id_db_scylla') and self.get('cluster_backend') == 'aws':
                 aws_arch = get_arch_from_instance_type(self.get('instance_type_db'))
-                # ami.name format examples: ScyllaDB 4.4.0 or ScyllaDB Enterprise 2019.1.1
-                scylla_version_substr = f" {scylla_version}"
                 ami_list = []
                 for region in region_names:
                     if ':' in scylla_version:
                         ami = get_branched_ami(scylla_version=scylla_version, region_name=region, arch=aws_arch)[0]
                     else:
-                        for ami in get_scylla_ami_versions(region_name=region, arch=aws_arch):
-                            if scylla_version_substr in ami.name:
-                                break
-                        else:
-                            raise ValueError(f"AMIs for {scylla_version=} not found in {region}")
+                        ami = get_scylla_ami_versions(version=scylla_version, region_name=region, arch=aws_arch)[0]
                     self.log.debug("Found AMI %s(%s) for scylla_version='%s' in %s",
                                    ami.name, ami.image_id, scylla_version, region)
                     ami_list.append(ami)
@@ -1727,7 +1721,6 @@ class SCTConfiguration(dict):
         # 6.1) handle oracle_scylla_version if exists
         if (oracle_scylla_version := self.get('oracle_scylla_version')) \
            and self.get("db_type") == "mixed_scylla":  # pylint: disable=too-many-nested-blocks
-            suffix = f" {oracle_scylla_version}"  # ami.name format example: ScyllaDB 4.4.0
             if not self.get('ami_id_db_oracle') and self.get('cluster_backend') == 'aws':
                 aws_arch = get_arch_from_instance_type(self.get('instance_type_db'))
                 ami_list = []
@@ -1736,11 +1729,8 @@ class SCTConfiguration(dict):
                         ami = get_branched_ami(
                             scylla_version=oracle_scylla_version, region_name=region, arch=aws_arch)[0]
                     else:
-                        for ami in get_scylla_ami_versions(region_name=region, arch=aws_arch):
-                            if ami.name.endswith(suffix):
-                                break
-                        else:
-                            raise ValueError(f"AMIs for {oracle_scylla_version=} not found in {region}")
+                        ami = get_scylla_ami_versions(version=oracle_scylla_version,
+                                                      region_name=region, arch=aws_arch)[0]
                     self.log.debug("Found AMI %s for oracle_scylla_version='%s' in %s",
                                    ami.image_id, oracle_scylla_version, region)
                     ami_list.append(ami)

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1527,13 +1527,12 @@ def get_scylla_ami_versions(region_name: str, arch: AwsArchType = 'x86_64', vers
                 {'Name': 'architecture', 'Values': [arch]},
             ],
         )
+    images = sorted(images, key=lambda x: x.creation_date, reverse=True)
+    images = [image for image in images if image.tags and 'debug' not in {
+        i['Key']: i['Value'] for i in image.tags}.get('Name', '')]
 
-    _SCYLLA_AMI_CACHE[region_name] = sorted(
-        images,
-        key=lambda x: x.creation_date,
-        reverse=True,
-    )
-    return _SCYLLA_AMI_CACHE[region_name]
+    _SCYLLA_AMI_CACHE[region_name] = images
+    return images
 
 
 @lru_cache


### PR DESCRIPTION
In PR #5502 filter was introduced to `get_branched_ami` but now seems like we case of release like versions which are debug versions (and doesn't get shared
with our account), and we need to ignroe them as well.

Fixes: #6362

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
