### PR TITLE
fix(pipelines): handle stress_duration correctly

### DIFF
--- a/vars/getJobTimeouts.groovy
+++ b/vars/getJobTimeouts.groovy
@@ -22,7 +22,7 @@ List<Integer> call(Map params, String region){
     """
     def testData = sh(script: cmd, returnStdout: true).trim()
     println(testData)
-    if (params.stress_duration == "") {
+    if (params.stress_duration == "" || params.stress_duration == null) {
         testData = testData =~ /test_duration: (\d+)/
         testDuration = testData[0][1].toInteger()
     } else {


### PR DESCRIPTION
a76ed862ad99c58012699546822eab08a94b2ea9 introduced a new parameter to the longevity pipeline, but it's was breaking all other pipelines, like:

```
java.lang.NullPointerException: Cannot invoke method toInteger() on null object
```


### Testing

- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/rolling-upgrade-centos8-test/9


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
