### PR TITLE
fix(docs): document how to clear monitoring docker instances

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -125,3 +125,10 @@ hydra attach-test-sg --user `whoami`
 ssh -i ~/.ssh/scylla-qa-ec2 ubuntu@44.192.58.53
 # keep in mind the user name and key, can be different between backend or between tests
 ```
+
+## How can I clear monitoring stack create by `hydra investigate show-monitor`
+
+```bash
+# this would clear all of the dockers used by monitoring stack that are currently running
+docker rm -f -v $(docker ps --filter name=agraf\|aprom\|aalert -a -q)
+```


### PR DESCRIPTION
show how monitor stack create with `hydra investigate show-monitor` can be cleaned (with killing all other running docker instances)

Fixes: #3074

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
