### PR TITLE
improvement(report_templates): Sort performance results by version

### DIFF
--- a/sdcm/report_templates/results_performance.html
+++ b/sdcm/report_templates/results_performance.html
@@ -85,7 +85,7 @@
             <th>Diff last</th>
             <th>Commit, Date</th>
         </tr>
-        {% for cmp_res in res_list %}
+        {% for cmp_res in res_list | sort(attribute="best.version_dst") %}
         {% set best_stat=cmp_res.best.res.get(stat_name) %}
         {% set last_stat=cmp_res.last.res.get(stat_name) %}
         <tr>


### PR DESCRIPTION
This change adjusts the order in which the performance results table is
built, ordering each row by scylla version it was compared to.

Task: scylladb/qa-tasks#1144

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
