### PR TITLE
fix(cli.py): make wait_for_status be verbose

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -24,13 +24,14 @@ from distutils.version import LooseVersion
 
 import requests
 from invoke.exceptions import Failure as InvokeFailure
+from tenacity import RetryError
+
 from sdcm.remote.libssh2_client.exceptions import Failure as Libssh2Failure
 
 from sdcm import wait
 from sdcm.mgmt.common import \
     TaskStatus, ScyllaManagerError, HostStatus, HostSsl, HostRestStatus, duration_to_timedelta, DEFAULT_TASK_TIMEOUT
 from sdcm.utils.distro import Distro
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -395,10 +396,14 @@ class ManagerTask:
 
     def wait_for_status(self, list_status, check_task_progress=True, timeout=3600, step=120):
         text = "Waiting until task: {} reaches status of: {}".format(self.id, list_status)
-        is_status_reached = wait.wait_for(func=self.is_status_in_list, step=step, throw_exc=True,
-                                          text=text, list_status=list_status, check_task_progress=check_task_progress,
-                                          timeout=timeout)
-        return is_status_reached
+        try:
+            return wait.wait_for(func=self.is_status_in_list, step=step, throw_exc=True,
+                                 text=text, list_status=list_status, check_task_progress=check_task_progress,
+                                 timeout=timeout)
+        except RetryError as ex:
+            raise RetryError(
+                "Failed on waiting until task: {} reaches status of {}: current task status {}: {}".format(
+                    self.id, list_status, self.status, str(ex))) from ex
 
     def wait_for_percentage(self, minimum_percentage, timeout=3600, step=10):
         text = f"Waiting until task: {self.id} reaches at least {minimum_percentage}% progress"


### PR DESCRIPTION
wait_for_status does not return task status on failure, which makes it hard to investigate where task is stuck

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
