### PR TITLE
fix(sct_runner): fix create-runner-image on GCP

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -742,7 +742,7 @@ class GceSctRunner(SctRunner):  # pylint: disable=too-many-instance-attributes
                                  auto_delete=True)]
 
         instance = create_instance(project_id=self.project_name, zone=region_az,
-                                   machine_type=self.instance_type(test_duration),
+                                   machine_type=instance_type,
                                    instance_name=instance_name,
                                    network_name=self.SCT_NETWORK,
                                    disks=disks,


### PR DESCRIPTION
`hydra create-runner-image` failed to run on GCP after #6137

The instance type is selected based on test_duration here: https://github.com/scylladb/scylla-cluster-tests/blob/f77e6b3d0bada938c74c7f495fc14c14d57be761/sdcm/sct_runner.py#L405

and doesn't need to be overwritten in the `_create_instance(...)` method

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
