### PR TITLE
fix(remote): allow use non-RSA private keys

### DIFF
--- a/sdcm/remote/remote_cmd_runner.py
+++ b/sdcm/remote/remote_cmd_runner.py
@@ -16,7 +16,7 @@ import os
 import threading
 
 from fabric import Connection, Config
-from paramiko import SSHException, RSAKey
+from paramiko import SSHException
 from paramiko.ssh_exception import NoValidConnectionsError, AuthenticationException
 from invoke.watchers import StreamWatcher
 from invoke.exceptions import UnexpectedExit, Failure
@@ -121,4 +121,6 @@ class RemoteCmdRunner(RemoteCmdRunnerBase, ssh_transport='fabric', default=True)
             config=self.ssh_config,
             connect_timeout=self.connect_timeout,
             connect_kwargs={
-                'pkey': RSAKey(filename=os.path.expanduser(self.key_file))} if self.key_file else None)
+                "key_filename": os.path.expanduser(self.key_file),
+            } if self.key_file else None,
+        )


### PR DESCRIPTION
Change parameter passed to paramiko Connection from `pkey` to `key_filename`. This allows paramiko to guess the type of a private key.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
