### PR TITLE
fix(Jenkins): use correct shebang string

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,8 +39,7 @@ def createRunConfiguration(String backend) {
 }
 
 def runSendEmail(){
-    sh """
-    #!/bin/bash
+    sh """#!/bin/bash
 
     set -xe
     env
@@ -53,8 +52,7 @@ def runSendEmail(){
 }
 
 def runRestoreMonitoringStack(){
-    sh """
-    #!/bin/bash
+    sh """#!/bin/bash
 
     set -xe
     env

--- a/vars/getJobTimeouts.groovy
+++ b/vars/getJobTimeouts.groovy
@@ -3,8 +3,7 @@
 List<Integer> call(Map params, String region){
     // handle params which can be a json list
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
-    def cmd = """
-    #!/bin/bash
+    def cmd = """#!/bin/bash
     export SCT_CLUSTER_BACKEND="${params.backend}"
     export SCT_CONFIG_FILES=${test_config}
     if [[ -n "${params.region ? params.region : ''}" ]] ; then


### PR DESCRIPTION
Fix rest (missed) of shebang lines after fixing most of them in https://github.com/scylladb/scylla-cluster-tests/pull/5527

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x]  I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
