### PR TITLE
fix(logcollector): don't fail if no builders found

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2409,9 +2409,11 @@ def get_builder_by_test_id(test_id):
             LOGGER.info("Nothing found")
             return None
 
-    search_obj = ParallelObject(builders, timeout=30, num_workers=len(builders))
-    results = search_obj.run(search_test_id_on_builder, ignore_exceptions=True, unpack_objects=True)
-    found_builders = [builder.result for builder in results if not builder.exc and builder.result]
+    if builders:
+        search_obj = ParallelObject(builders, timeout=30, num_workers=len(builders))
+        results = search_obj.run(search_test_id_on_builder, ignore_exceptions=True, unpack_objects=True)
+        found_builders = [builder.result for builder in results if not builder.exc and builder.result]
+
     if not found_builders:
         LOGGER.info("Nothing found for %s", test_id)
 


### PR DESCRIPTION
logcollector failed to run for AWS accounts w/o SCT builders deployed in. This PR fixes the problem with `get_builder_by_test_id()` function: `ParallelObject` requeries a non-empty list of arguments.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~ I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
