### PR TITLE
Rework cloud manager instance discovery

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -54,7 +54,7 @@ post_behavior_loader_nodes: "destroy"
 post_behavior_monitor_nodes: "keep-on-failure"
 post_behavior_k8s_cluster: "keep-on-failure"
 
-cloud_credentials_path: '~/.ssh/support'
+cloud_credentials_path: ''
 use_cloud_manager: false
 cloud_prom_bearer_token: ''
 

--- a/get-qa-ssh-keys.sh
+++ b/get-qa-ssh-keys.sh
@@ -9,7 +9,6 @@ umask 077
 aws s3 sync s3://${SSH_KEYS_BUCKET} ${SSH_KEYS_DIR} --exact-timestamps --exclude '*' \
   --include scylla-qa-ec2 \
   --include scylla-test \
-  --include support \
   --include scylla_test_id_ed25519 \
 || (echo "Please refer to https://github.com/scylladb/scylla-cluster-tests#setting-up-sct-environment to configure your aws-cli" && exit 1)
 echo "QA SSH keys obtained."


### PR DESCRIPTION
- Use correct IP address for SSH connection
- Don't use support user credentials (the SSH key will be provided by siren-tests)
- Small refactoring of `find_and_append_cloud_manager_instance_to_collecting_nodes()`

Need to backport https://github.com/scylladb/scylla-cluster-tests/pull/6381/commits/e1e85b4508b227a6076920152b8d066ce382d4cb to SCT release branches to stop sync support key.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
