### PR TITLE
fix(cluster): use external_address in cql_ip_address

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -841,7 +841,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     @cached_property
     def cql_ip_address(self):
         if self.test_config.IP_SSH_CONNECTIONS == 'public':
-            return self.ip_address
+            return self.external_address
         with self.remote_scylla_yaml() as scylla_yaml:
             return scylla_yaml.broadcast_rpc_address if scylla_yaml.broadcast_rpc_address else self.ip_address
 


### PR DESCRIPTION
Fixing the changes introduced in https://github.com/scylladb/scylla-cluster-tests/pull/6062 for the case if INTRA_NODE_COMM_PUBLIC is False.

Note, that it's not required to replace second occurrence of  `ip_address` with `external_address`. 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
