### PR TITLE
improvement(runner): associate a public IP from a pool

### DIFF
--- a/docker/env/version
+++ b/docker/env/version
@@ -1,1 +1,1 @@
-1.46-move_to_python_3.10.12
+1.47-update-google-libs

--- a/requirements.in
+++ b/requirements.in
@@ -36,9 +36,9 @@ autopep8==1.5.7  # Needed for pre-commit hooks
 kubernetes==24.2.0
 packaging==21.3
 ldap3==2.9.1
-google-api-python-client==2.24.0
-google-cloud-storage==2.4.0
-google-cloud-compute==1.5.2
+google-api-python-client==2.93.0
+google-cloud-storage==2.10.0
+google-cloud-compute==1.13.0
 pip-tools==6.13.0
 azure-identity==1.6.1
 azure-mgmt-compute==23.0.0
@@ -49,6 +49,6 @@ azure-mgmt-resourcegraph==8.0.0
 pydantic==1.10.8
 azure-storage-blob==12.16.0
 questionary==1.10.0
-pbr==1.4
+pbr==5.11.1
 hdrhistogram==0.9.2
 deepdiff==6.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -394,13 +394,13 @@ google-api-core[grpc]==2.11.1 \
     #   google-cloud-compute
     #   google-cloud-core
     #   google-cloud-storage
-google-api-python-client==2.24.0 \
-    --hash=sha256:1c6267c7f018d86afc62dd8ec844a3e7189022a35ee239ed704cbda010888998 \
-    --hash=sha256:75edc13a5c6dd9ff6f47721162a845edc343b4987ee059842e9a7905ad62e917
+google-api-python-client==2.93.0 \
+    --hash=sha256:62ee28e96031a10a1c341f226a75ac6a4f16bdb1d888dc8222b2cdca133d0031 \
+    --hash=sha256:f34abb671afd488bd19d30721ea20fb30d3796ddd825d6f91f26d8c718a9f07d
     # via -r ../../requirements.in
-google-auth==2.21.0 \
-    --hash=sha256:b28e8048e57727e7cf0e5bd8e7276b212aef476654a09511354aa82753b45c66 \
-    --hash=sha256:da3f18d074fa0f5a7061d99b9af8cee3aa6189c987af7c1b07d94566b6b11268
+google-auth==2.22.0 \
+    --hash=sha256:164cba9af4e6e4e40c3a4f90a1a6c12ee56f14c0b4868d1ca91b32826ab334ce \
+    --hash=sha256:d61d1b40897407b574da67da1a833bdc10d5a11642566e506565d1b1a46ba873
     # via
     #   google-api-core
     #   google-api-python-client
@@ -412,17 +412,17 @@ google-auth-httplib2==0.1.0 \
     --hash=sha256:31e49c36c6b5643b57e82617cb3e021e3e1d2df9da63af67252c02fa9c1f4a10 \
     --hash=sha256:a07c39fd632becacd3f07718dfd6021bf396978f03ad3ce4321d060015cc30ac
     # via google-api-python-client
-google-cloud-compute==1.5.2 \
-    --hash=sha256:08c4249b3027f7f2079eaf8196cffc094c7adde335bddc04ea324d6d3107491b \
-    --hash=sha256:0f4a48475bd012dffb688c4ca34b83971bedf9fc12d83c42bab53f971307023a
+google-cloud-compute==1.13.0 \
+    --hash=sha256:0f75d6c09cc504e43f4eceb2a466de9e9eb6fca819ca8ffdcf098ca5b21c7dc1 \
+    --hash=sha256:93b72129c6443c898da5a060d2021bc2d11c2a57ef2fbb9306afbb5126a376b9
     # via -r ../../requirements.in
 google-cloud-core==2.3.3 \
     --hash=sha256:37b80273c8d7eee1ae816b3a20ae43585ea50506cb0e60f3cf5be5f87f1373cb \
     --hash=sha256:fbd11cad3e98a7e5b0343dc07cb1039a5ffd7a5bb96e1f1e27cee4bda4a90863
     # via google-cloud-storage
-google-cloud-storage==2.4.0 \
-    --hash=sha256:5fe26f1381b30e3cc328f46e13531ca8525458f870c1e303c616bdeb7b7f5c66 \
-    --hash=sha256:973e7f7d9afcd4805769b6ea9ac15ab9df7037530850374f1494b5a2c8f65b6b
+google-cloud-storage==2.10.0 \
+    --hash=sha256:934b31ead5f3994e5360f9ff5750982c5b6b11604dc072bc452c25965e076dc7 \
+    --hash=sha256:9433cf28801671de1c80434238fb1e7e4a1ba3087470e90f70c928ea77c2b9d7
     # via -r ../../requirements.in
 google-crc32c==1.5.0 \
     --hash=sha256:024894d9d3cfbc5943f8f230e23950cd4906b2fe004c72e29b209420a1e6b05a \
@@ -881,9 +881,9 @@ pathvalidate==3.0.0 \
     --hash=sha256:cfca1886f3cd8862b10bce18a87f4dc02d6418399e539ede2b010dc8588991ce \
     --hash=sha256:dcdb89f0bde6fd5eba6f2202a7863f657afbc810ef32f60e9258d58ede8155ac
     # via simplesqlite
-pbr==1.4.0 \
-    --hash=sha256:01e05c9397732fa27e4feabd77756c1da6070bc69b5c9584b02d07ecb8f6fde4 \
-    --hash=sha256:f080232fb6b208615b4c1854bf4277bb097d19c9ef89f94f203c1436fe600e92
+pbr==5.11.1 \
+    --hash=sha256:567f09558bae2b3ab53cb3c1e2e33e726ff3338e7bae3db5dc954b3a44eef12b \
+    --hash=sha256:aefc51675b0b533d56bb5fd1c8c6c0522fe31896679882e1c4c63d5e4a0fccb3
     # via
     #   -r ../../requirements.in
     #   hdrhistogram
@@ -1391,9 +1391,9 @@ typing-extensions==4.7.1 \
     #   azure-storage-blob
     #   boto3-stubs
     #   pydantic
-uritemplate==3.0.1 \
-    --hash=sha256:07620c3f3f8eed1f12600845892b0e036a2420acf513c53f7de0abd911a5894f \
-    --hash=sha256:5af8ad10cec94f215e3f48112de2022e1d5a37ed427fbd88652fa908f2ab7cae
+uritemplate==4.1.1 \
+    --hash=sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0 \
+    --hash=sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e
     # via google-api-python-client
 urllib3==1.26.16 \
     --hash=sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f \

--- a/sct.py
+++ b/sct.py
@@ -1533,8 +1533,9 @@ def create_runner_image(cloud_provider, region, availability_zone):
               help="Is the runner for restore monitor purpose or not")
 @click.option("-rt", "--restored-test-id", required=False, type=str,
               help="Test ID of the test that the runner is created for restore monitor")
+@click.option("-p", "--address-pool", required=False, type=str, help="ElasticIP pool to use")
 def create_runner_instance(cloud_provider, region, availability_zone, instance_type, root_disk_size_gb,
-                           test_id, test_name, duration, restore_monitor=False, restored_test_id=""):
+                           test_id, test_name, duration, restore_monitor=False, restored_test_id="", address_pool=None):
     # pylint: disable=too-many-locals
 
     if cloud_provider == "aws":
@@ -1558,6 +1559,7 @@ def create_runner_instance(cloud_provider, region, availability_zone, instance_t
         test_duration=duration,
         restore_monitor=restore_monitor,
         restored_test_id=restored_test_id,
+        address_pool=address_pool,
     )
     if not instance:
         sys.exit(1)

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import string
+import random
 import tempfile
 import datetime
 from contextlib import suppress
@@ -47,6 +48,7 @@ from sdcm.utils.aws_utils import ec2_instance_wait_public_ip, ec2_ami_get_root_d
 from sdcm.utils.aws_region import AwsRegion
 from sdcm.utils.gce_utils import (
     SUPPORTED_PROJECTS,
+    get_gce_compute_addresses_client,
     get_gce_compute_images_client,
     get_gce_compute_instances_client,
     create_instance,
@@ -284,7 +286,8 @@ class SctRunner(ABC):
                          instance_name: str,
                          root_disk_size_gb: int = 0,
                          region_az: str = "",
-                         test_duration: Optional[int] = None) -> Any:
+                         test_duration: int | None = None,
+                         address_pool: str | None = None) -> Any:
         ...
 
     @staticmethod
@@ -377,9 +380,15 @@ class SctRunner(ABC):
     def _get_base_image(self, image: Optional[Any] = None) -> Any:
         ...
 
-    def create_instance(self, test_id: str, test_name: str, test_duration: int,  # pylint: disable=too-many-arguments
-                        instance_type: str = "",  root_disk_size_gb: int = 0,
-                        restore_monitor: bool = False, restored_test_id: str = "") -> Any:
+    def create_instance(self,  # pylint: disable=too-many-arguments
+                        test_id: str,
+                        test_name: str,
+                        test_duration: int,
+                        instance_type: str = "",
+                        root_disk_size_gb: int = 0,
+                        restore_monitor: bool = False,
+                        restored_test_id: str = "",
+                        address_pool: str | None = None) -> Any:
         LOGGER.info("Creating SCT Runner instance...")
         image = self.image
         if not image:
@@ -412,6 +421,7 @@ class SctRunner(ABC):
                 availability_zone=self.availability_zone,
             ),
             test_duration=test_duration,
+            address_pool=address_pool,
         )
 
     @classmethod
@@ -496,7 +506,8 @@ class AwsSctRunner(SctRunner):
                          instance_name: str,
                          root_disk_size_gb: int = 0,
                          region_az: str = "",
-                         test_duration: Optional[int] = None) -> Any:
+                         test_duration: int | None = None,
+                         address_pool: str | None = None) -> Any:
         if region_az.startswith(self.SOURCE_IMAGE_REGION):
             aws_region: AwsRegion = self.aws_region_source
         else:
@@ -515,7 +526,7 @@ class AwsSctRunner(SctRunner):
             KeyName=aws_region.SCT_KEY_PAIR_NAME,
             NetworkInterfaces=[{
                 "DeviceIndex": 0,
-                "AssociatePublicIpAddress": True,
+                "AssociatePublicIpAddress": not address_pool,
                 "SubnetId": subnet.subnet_id,
                 "Groups": [aws_region.sct_security_group.group_id,
                            aws_region.sct_ssh_security_group.group_id],
@@ -538,6 +549,22 @@ class AwsSctRunner(SctRunner):
 
         LOGGER.info("Instance created. Waiting until it becomes running... ")
         instance.wait_until_running()
+
+        if address_pool:
+            LOGGER.info("Associating an EIP from `%s' pool...", address_pool)
+            unassigned_addresses = [
+                addr for addr in aws_region.resource.vpc_addresses.filter(
+                    Filters=[{"Name": "tag:sct-runner-pool", "Values": [address_pool]}]
+                ) if not addr.instance_id
+            ]
+            if not unassigned_addresses:
+                raise Exception(f"There are no unassigned EIPs in `{address_pool}' pool")
+            aws_region.client.associate_address(
+                AllocationId=random.choice(unassigned_addresses).allocation_id,
+                InstanceId=instance.instance_id,
+                AllowReassociation=False,
+            )
+            instance = aws_region.resource.Instance(id=instance.instance_id)
 
         LOGGER.info("Instance `%s' is running. Waiting for public IP...", instance.instance_id)
         ec2_instance_wait_public_ip(instance=instance)
@@ -733,7 +760,8 @@ class GceSctRunner(SctRunner):  # pylint: disable=too-many-instance-attributes
                          instance_name: str,
                          root_disk_size_gb: int = 0,
                          region_az: str = "",
-                         test_duration: Optional[int] = None) -> Any:
+                         test_duration: int | None = None,
+                         address_pool: str | None = None) -> Any:
         LOGGER.info("Creating instance...")
         disks = [disk_from_image(disk_type=f"projects/{self.project_name}/zones/{region_az}/diskTypes/pd-ssd",
                                  disk_size_gb=root_disk_size_gb or self.instance_root_disk_size(test_duration),
@@ -741,12 +769,29 @@ class GceSctRunner(SctRunner):  # pylint: disable=too-many-instance-attributes
                                  source_image=base_image,
                                  auto_delete=True)]
 
+        if address_pool:
+            LOGGER.info("Use External IP address from `%s' pool...", address_pool)
+            addresses_client, info = get_gce_compute_addresses_client()
+            unassigned_addresses = list(
+                addresses_client.list(request=compute_v1.ListAddressesRequest(
+                    project=info["project_id"],
+                    region=region_az.rsplit("-", maxsplit=1)[0],
+                    filter=f"labels.sct-runner-pool={address_pool} AND status=RESERVED",
+                ))
+            )
+            if not unassigned_addresses:
+                raise Exception(f"There are no unassigned External IP addresses in `{address_pool}' pool")
+            external_ipv4 = random.choice(unassigned_addresses).address
+        else:
+            external_ipv4 = None
+
         instance = create_instance(project_id=self.project_name, zone=region_az,
                                    machine_type=self.instance_type(test_duration),
                                    instance_name=instance_name,
                                    network_name=self.SCT_NETWORK,
                                    disks=disks,
                                    external_access=True,
+                                   external_ipv4=external_ipv4,
                                    metadata=tags | {
                                        "launch_time": get_current_datetime_formatted(),
                                        "block-project-ssh-keys": "true",
@@ -909,7 +954,11 @@ class AzureSctRunner(SctRunner):
                          instance_name: str,
                          root_disk_size_gb: int = 0,
                          region_az: str = "",
-                         test_duration: Optional[int] = None) -> Any:
+                         test_duration: int | None = None,
+                         address_pool: str | None = None) -> Any:
+        if address_pool:
+            raise NotImplementedError("--address-pool is not implement for Azure yet")
+
         if base_image is self.BASE_IMAGE:
             azure_region = self.azure_region_source
             additional_kwargs = {

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -40,6 +40,7 @@ SUPPORTED_REGIONS = {
     # us-east1 zones: b, c, and d. Details: https://cloud.google.com/compute/docs/regions-zones#locations
     # Currently choose only zones c and d as zone b frequently fails allocating resources.
     'us-east1': 'cd',
+    'us-east4': 'abc',
     'us-west1': 'abc'}
 
 


### PR DESCRIPTION
The IP pool is a list of pre-allocated IP address tagged with 'sct-runner-pool' tag.
The use of SCT can provide a name of a pool to use (the value of such tag.)

This PR implements such functionality for AWS and GCP. Azure implementation is missed (and not required now.)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
