### PR TITLE
feature(node): collect lsof and netstat on scylla stop freeze

### DIFF
--- a/sdcm/remote/libssh2_client/__init__.py
+++ b/sdcm/remote/libssh2_client/__init__.py
@@ -635,7 +635,8 @@ class Client:  # pylint: disable=too-many-instance-attributes
         result.stderr = stderr.getvalue()
         if channel is not None:
             try:
-                self.session.eagain(channel.close, timeout=self.timings.channel_close_timeout)
+                with self.session.lock:
+                    channel.close()
             except Exception as exc:  # pylint: disable=broad-except
                 print(f'Failed to close channel due to the following error: {exc}')
             try:


### PR DESCRIPTION
When Scylla freezes on stop, SIGABRT is sent by systemd automatically
creating coredump. It would be informative if `lsof` and `netstat`
output was attached to issue along with core dumps.

In case timeout occures during stopping scylla, collect `lsof` and
`netstat` output. After collection send SIGABRT to Scylla process.

To make this possible, needed to fix our sshlib2 based remoter:

    fix(ssh): Fix close session on timeout
    
    When command times out and does not print anything to stdout/stderr,
    then timeout error does not appear and command hangs until it quits.
    This causes error e.g. when we run `systemctl stop scylla` and there's a
    freeze in stopping Scylla's process.
    
    Fix is about ignoring `channel.close()` return code, which in that case
    returns `LIBSSH2_ERROR_EAGAIN`. This code in case of closing
    channel means that it would block (it is not an error per se:
    https://www.libssh2.org/libssh2_channel_close.html).
    Later we anyway wait for channel to be closed with
    `channel.wait_closed()`.

Fixes https://github.com/scylladb/scylla-cluster-tests/issues/6353
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
