### PR TITLE
fix(azure utils): get_scylla_images using version flag

### DIFF
--- a/sdcm/provision/azure/utils.py
+++ b/sdcm/provision/azure/utils.py
@@ -39,7 +39,8 @@ def get_scylla_images(  # pylint: disable=too-many-branches,too-many-locals
     if len(version_bucket) == 1:
         if '.' in scylla_version:
             # Plain version, like 4.5.0
-            tags_to_search['scylla_version'] = lambda ver: ver and ver.replace("~", "-").startswith(scylla_version)
+            tags_to_search['scylla_version'] = lambda ver: ver and ver.replace("~", "-").startswith(scylla_version)\
+                and '-dev' not in ver
         else:
             # commit id
             tags_to_search['scylla_version'] = lambda ver: ver and scylla_version[:9] in ver


### PR DESCRIPTION
in the case we use a version, we must ignore master images, as master has a "version" prefix, but it
is marked with `-dev`, and it must be ignored
in this case.

found by @yaronkaikov

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
