### PR TITLE
fix(k8s): fix installing helm on local k8s

### DIFF
--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -131,8 +131,8 @@ class MinimalK8SOps:
         node.remoter.sudo(f'bash -cxe "{script}"')
         node.remoter.sudo(
             'bash -cxe \"helm version'
-            f' || curl --silent --location "https://get.helm.sh/helm-{HELM_VERSION}-linux-amd64.tar.gz"'
-            '  | tar xz -C /tmp && mv /tmp/linux-amd64/helm /usr/local/bin'
+            f' || (curl --silent --location "https://get.helm.sh/helm-{HELM_VERSION}-linux-amd64.tar.gz"'
+            '  | tar xz -C /tmp && mv /tmp/linux-amd64/helm /usr/local/bin)'
             '\"')
 
         # NOTE: if running in Hydra then it must have '/dev' mount from host as 'rw'


### PR DESCRIPTION
when helm is already installed command still tries some installation parts - which is not necessary and fails.

It looks like braces were missing to skip installing helm when is installed.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
