### PR TITLE
fix(artifacts-amazon2-test): install java 11

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2002,7 +2002,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
         # Offline install does't provide openjdk-11, it has to be installed in advance
         # https://github.com/scylladb/scylla-jmx/issues/127
-        if self.is_rhel_like():
+        if self.distro.is_amazon2:
+            self.remoter.sudo(f'yum install -y {additional_pkgs}')
+            self.remoter.sudo('amazon-linux-extras install java-openjdk11')
+        elif self.distro.is_rhel_like:
             self.remoter.run(f'sudo yum install -y java-11-openjdk-headless {additional_pkgs}')
         elif self.distro.is_sles:
             raise Exception("Offline install on SLES isn't supported")


### PR DESCRIPTION
this offline installer test wasn't triggered on master so we missed that it doesn't install java correctly and now scylla is failing to install since java 11 or 8 isn't available

Fix: #6336

### Testing
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-amazon2-test/4/
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-amazon2-arm-test/4/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
