### PR TITLE
fix(upgrade_test): handle uuid sstable identifier on upgradesstable

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -404,7 +404,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
                     r"find /var/lib/scylla/data/system -type f ! -path '*snapshots*' -printf %f\\n")
                 all_sstable_files = result.stdout.splitlines()
 
-                sstable_version_regex = re.compile(r'(\w+)-\d+-(.+)\.(db|txt|sha1|crc32)')
+                sstable_version_regex = re.compile(r'(\w+)-[^-]+-(.+)\.(db|txt|sha1|crc32)')
 
                 sstable_versions = {sstable_version_regex.search(f).group(
                     1) for f in all_sstable_files if sstable_version_regex.search(f)}


### PR DESCRIPTION
since scylladb/scylladb/pull/13932 sstable identifier are not numbers, and the regex we were using in upgradesstable procudure assumed they are.

failing like the following:
```
AssertionError: Failed to upgrade the sstable format [False, False, False, False]
```

Ref: https://github.com/scylladb/scylladb/pull/13932

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
