### PR TITLE
fix(cli.py): fix wait_for_status

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -24,13 +24,14 @@ from distutils.version import LooseVersion
 
 import requests
 from invoke.exceptions import Failure as InvokeFailure
+from tenacity import RetryError
+
 from sdcm.remote.libssh2_client.exceptions import Failure as Libssh2Failure
 
 from sdcm import wait
 from sdcm.mgmt.common import \
     TaskStatus, ScyllaManagerError, HostStatus, HostSsl, HostRestStatus, duration_to_timedelta, DEFAULT_TASK_TIMEOUT
 from sdcm.utils.distro import Distro
-from sdcm.wait import WaitForTimeoutError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -399,8 +400,8 @@ class ManagerTask:
             return wait.wait_for(func=self.is_status_in_list, step=step, throw_exc=True,
                                  text=text, list_status=list_status, check_task_progress=check_task_progress,
                                  timeout=timeout)
-        except WaitForTimeoutError as ex:
-            raise WaitForTimeoutError(
+        except RetryError as ex:
+            raise RetryError(
                 "Failed on waiting until task: {} reaches status of {}: current task status {}: {}".format(
                     self.id, list_status, self.status, str(ex))) from ex
 


### PR DESCRIPTION
wait_for_status does not return task status on failure, which makes it hard to investigate where task is stuck

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
