### PR TITLE
improvement(test-cases): Add bare metal performance test

### DIFF
--- a/jenkins-pipelines/perf-regression-throughput-baremetal-example.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-baremetal-example.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "baremetal",
+    region: "eu-west-1",
+    test_name: "performance_regression_test.PerformanceRegressionTest.test_write",
+    test_config: """["test-cases/performance/perf-regression-throughput-baremetal-5gb.yaml"]""",
+
+    timeout: [time: 120, unit: "MINUTES"]
+)

--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -101,6 +101,9 @@ class KeyStore:  # pylint: disable=too-many-public-methods
     def get_argus_rest_credentials(self):
         return self.get_json("argus_rest_credentials.json")
 
+    def get_baremetal_config(self, config_name: str):
+        return self.get_json(f"{config_name}.json")
+
 
 def pub_key_from_private_key_file(key_file):
     try:

--- a/sdcm/node_exporter_setup.py
+++ b/sdcm/node_exporter_setup.py
@@ -9,10 +9,16 @@ class NodeExporterSetup:  # pylint: disable=too-few-public-methods
     def install(node):
         node.install_package('wget')
         node.remoter.sudo(shell_script_cmd(f"""
-            useradd -rs /bin/false node_exporter
+            if ! id node_exporter > /dev/null 2>&1; then
+                useradd -rs /bin/false node_exporter
+            fi
             wget https://github.com/prometheus/node_exporter/releases/download/v{NODE_EXPORTER_VERSION}/node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
             tar -xzvf node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
             mv node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64/node_exporter /usr/local/bin
+
+            if [ -e /etc/systemd/system/node_exporter.service ]; then
+                rm /etc/systemd/system/node_exporter.service
+            fi
 
             cat <<EOM >> /etc/systemd/system/node_exporter.service
             [Unit]

--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -152,6 +152,8 @@ def install_syslogng_service():
         SYSLOG_NG_INSTALLED=""
         if yum --help 2>/dev/null 1>&2 ; then
             if rpm -q syslog-ng ; then
+                rm /etc/syslog-ng/syslog-ng.conf  # Make sure we have default syslog-ng.conf
+                yum reinstall -y syslog-ng
                 SYSLOG_NG_INSTALLED=1
             else
                 for n in 1 2 3 4 5 6 7 8 9; do # cloud-init is running it with set +o braceexpand
@@ -170,6 +172,9 @@ def install_syslogng_service():
             fi
         elif apt-get --help 2>/dev/null 1>&2 ; then
             if dpkg-query --show syslog-ng ; then
+                rm /etc/syslog-ng/syslog-ng.conf  # Make sure we have default syslog-ng.conf
+                apt-get purge --autoremove -y syslog-ng
+                DPKG_FORCE=confmiss apt-get --reinstall -y install syslog-ng
                 SYSLOG_NG_INSTALLED=1
             else
                 cat /etc/apt/sources.list

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -935,6 +935,9 @@ class SCTConfiguration(dict):
 
         # baremetal config options
 
+        dict(name="s3_baremetal_config", env="SCT_S3_BAREMETAL_CONFIG", type=str,
+             help=""),
+
         dict(name="db_nodes_private_ip", env="SCT_DB_NODES_PRIVATE_IP", type=str_or_list_or_eval,
              help=""),
 
@@ -1502,7 +1505,7 @@ class SCTConfiguration(dict):
 
         'docker': ['user_credentials_path', 'scylla_version'],
 
-        'baremetal': ['db_nodes_private_ip', 'db_nodes_public_ip', 'user_credentials_path'],
+        'baremetal': ['s3_baremetal_config', 'db_nodes_private_ip', 'db_nodes_public_ip', 'user_credentials_path'],
 
         'aws-siren': ["user_prefix", "instance_type_loader", "region_name", "cloud_credentials_path",
                       "nemesis_filter_seeds"],

--- a/test-cases/performance/perf-regression-throughput-baremetal-5gb.yaml
+++ b/test-cases/performance/perf-regression-throughput-baremetal-5gb.yaml
@@ -1,0 +1,56 @@
+test_duration: 90
+
+prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=312500 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=10 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..312500",
+                    "cassandra-stress write no-warmup cl=ALL n=312500 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=10 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=312501..625000",
+                    "cassandra-stress write no-warmup cl=ALL n=312500 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=10 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=625001..937500",
+                    "cassandra-stress write no-warmup cl=ALL n=312500 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=10 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=937501..1250000"]
+
+
+stress_cmd_w: "cassandra-stress write no-warmup cl=ALL n=1250000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=4 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..1250000"
+stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=30m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=4 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..1250000,625001,1250000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=30m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=4 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..1250000,625001,1250000)' "
+stress_multiplier: 1
+instance_type_db: 'i3.2xlarge'
+
+cluster_backend: baremetal
+user_credentials_path: '~/.ssh/scylla-qa-ec2'
+
+use_preinstalled_scylla: false
+run_db_node_benchmarks: false
+ssh_transport: fabric
+ip_ssh_connections: public
+
+use_mgmt: false
+s3_baremetal_config: baremetal_config_example
+
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1
+
+db_nodes_public_ip: []
+db_nodes_private_ip: []
+
+monitor_nodes_public_ip: []
+monitor_nodes_private_ip: []
+
+loaders_public_ip: []
+loaders_private_ip: []
+
+user_prefix: 'perf-throughput-disk-and-cache'
+space_node_threshold: 644245094
+ami_id_db_scylla_desc: 'VERSION_DESC'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5'
+backtrace_decoding: false
+print_kernel_callstack: true
+
+
+store_perf_results: true
+send_email: true
+email_recipients: ['scylla-perf-results@scylladb.com']
+
+email_subject_postfix: 'disk and cache'
+custom_es_index: 'performancestatsv2'
+
+use_hdr_cs_histogram: true

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -132,6 +132,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_DB_NODES_PRIVATE_IP'] = '["1.2.3.4", "1.2.3.5"]'
         os.environ['SCT_DB_NODES_PUBLIC_IP'] = '["1.2.3.4", "1.2.3.5"]'
         os.environ['SCT_USE_PREINSTALLED_SCYLLA'] = 'true'
+        os.environ['SCT_S3_BAREMETAL_CONFIG'] = "some_config"
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 

--- a/vars/getCloudProviderFromBackend.groovy
+++ b/vars/getCloudProviderFromBackend.groovy
@@ -8,7 +8,8 @@ def call(String backend) {
         'aws-siren': 'aws',
         'gce-siren': 'gce',
         'azure': 'azure',
-        'docker': 'aws'
+        'docker': 'aws',
+        'baremetal': 'aws'
         ]
     if (!backend) {
         return backend


### PR DESCRIPTION
This commit fixes some issues regarding bare metal instances -
specifically it fixes setup for loader and monitor nodes, adds a new
keystore method to retrive bare metal cluster information instead of
storing it in the test case and fixes syslong-ng setup script to make
sure it reinstalls if it's present - to make repeated runs possible as
previously it would just do nothing and syslog-ng would transfer logs to
an old sct runner instead. Some similar fixes for prometheus and
scylla_setup scripts to make sure we can run them multiple times on the
same instance.

Task: scylladb/qa-tasks#1233

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
