### PR TITLE
fix(sct_config): remove unused parameter gce_image

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -146,7 +146,6 @@
 | **<a href="#user-content-gce_project" name="gce_project">gce_project</a>**  | gcp project name to use | N/A | SCT_GCE_PROJECT
 | **<a href="#user-content-gce_datacenter" name="gce_datacenter">gce_datacenter</a>**  | Supported: us-east1 - means that the zone will be selected automatically or you can mention the zone explicitly, for example: us-east1-b | N/A | SCT_GCE_DATACENTER
 | **<a href="#user-content-gce_network" name="gce_network">gce_network</a>**  |  | N/A | SCT_GCE_NETWORK
-| **<a href="#user-content-gce_image" name="gce_image">gce_image</a>**  | GCE image to use for all node types: db, loader and monitor | N/A | SCT_GCE_IMAGE
 | **<a href="#user-content-gce_image_db" name="gce_image_db">gce_image_db</a>**  |  | N/A | SCT_GCE_IMAGE_DB
 | **<a href="#user-content-gce_image_monitor" name="gce_image_monitor">gce_image_monitor</a>**  |  | N/A | SCT_GCE_IMAGE_MONITOR
 | **<a href="#user-content-gce_image_loader" name="gce_image_loader">gce_image_loader</a>**  |  | N/A | SCT_GCE_IMAGE_LOADER

--- a/internal_test_data/complex_test_case_with_version.yaml
+++ b/internal_test_data/complex_test_case_with_version.yaml
@@ -25,7 +25,7 @@ instance_provision: 'on_demand'
 
 user_credentials_path: '~/.ssh/scylla-test'
 gce_network: 'qa-vpc'
-gce_image: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
 gce_datacenter: 'us-east1-b'
 gce_image_username: 'scylla-test'
 gce_instance_type_db: 'n1-highmem-16'

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -711,9 +711,6 @@ class SCTConfiguration(dict):
         dict(name="gce_network", env="SCT_GCE_NETWORK", type=str,
              help=""),
 
-        dict(name="gce_image", env="SCT_GCE_IMAGE", type=str,
-             help="GCE image to use for all node types: db, loader and monitor"),
-
         dict(name="gce_image_db", env="SCT_GCE_IMAGE_DB", type=str,
              help=""),
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1037,12 +1037,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         user_credentials = self.params.get('user_credentials_path')
         self.credentials.append(UserRemoteCredentials(key_file=user_credentials))
 
-        gce_image_db = self.params.get('gce_image_db').strip()
-        if not gce_image_db:
-            gce_image_db = self.params.get('gce_image').strip()
-        gce_image_monitor = self.params.get('gce_image_monitor').strip()
-        if not gce_image_monitor:
-            gce_image_monitor = self.params.get('gce_image').strip()
         cluster_additional_disks = {'pd-ssd': self.params.get('gce_pd_ssd_disk_size_db'),
                                     'pd-standard': self.params.get('gce_pd_standard_disk_size_db')}
 
@@ -1069,7 +1063,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 raise ImportError(f"cluster_cloud isn't installed. {CLUSTER_CLOUD_IMPORT_ERROR}")
             self.db_cluster = cluster_cloud.ScyllaCloudCluster(**params)
         else:
-            self.db_cluster = ScyllaGCECluster(gce_image=gce_image_db,
+            self.db_cluster = ScyllaGCECluster(gce_image=self.params.get('gce_image_db').strip(),
                                                gce_image_type=db_info['disk_type'],
                                                gce_image_size=db_info['disk_size'],
                                                gce_n_local_ssd=db_info['n_local_ssd'],
@@ -1093,7 +1087,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         if monitor_info['n_nodes'] > 0:
             monitor_additional_disks = {'pd-ssd': self.params.get('gce_pd_ssd_disk_size_monitor')}
-            self.monitors = MonitorSetGCE(gce_image=gce_image_monitor,
+            self.monitors = MonitorSetGCE(gce_image=self.params.get('gce_image_monitor').strip(),
                                           gce_image_type=monitor_info['disk_type'],
                                           gce_image_size=monitor_info['disk_size'],
                                           gce_n_local_ssd=monitor_info['n_local_ssd'],


### PR DESCRIPTION
The SCT parameter `gce_image` was used in ancient times before we got GCE Scylla machine images to define GCE images once for all types of nodes. But nowadays, it's not used anywhere and doesn't have a default value, causing failures of Scylla Cloud longevities.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
