### PR TITLE
improvement(MonitorLogCollector): Added scylla-manager.yaml

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -31,7 +31,8 @@ from functools import cached_property
 import requests
 
 import sdcm.monitorstack.ui as monitoring_ui
-from sdcm.paths import SCYLLA_YAML_PATH, SCYLLA_PROPERTIES_PATH, SCYLLA_MANAGER_AGENT_YAML_PATH
+from sdcm.paths import SCYLLA_YAML_PATH, SCYLLA_PROPERTIES_PATH, SCYLLA_MANAGER_AGENT_YAML_PATH, \
+    SCYLLA_MANAGER_YAML_PATH
 from sdcm.provision import provisioner_factory
 from sdcm.provision.provisioner import ProvisionerError
 from sdcm.remote import RemoteCmdRunnerBase, LocalCmdRunner
@@ -896,6 +897,8 @@ class MonitorLogCollector(LogCollector):
                    command='docker logs --details -t agraf'),
         CommandLog(name='aalert.log',
                    command='docker logs --details -t aalert'),
+        CommandLog(name='scylla-manager.yaml',
+                   command=f'cat {SCYLLA_MANAGER_YAML_PATH}'),
         FileLog(name='scylla_manager.log',
                 command='sudo journalctl -u scylla-manager.service --no-tail',
                 search_locally=True),


### PR DESCRIPTION
Since the yaml is sometimes required for manager related investigations, I added it to the collected log entities of the monitor log collector

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
