### PR TITLE
fix(perf_simple_query): fix email reporting

### DIFF
--- a/sdcm/report_templates/results_perf_simple_query.html
+++ b/sdcm/report_templates/results_perf_simple_query.html
@@ -78,7 +78,7 @@
                 {% endfor %}
             {% elif "is_"+key+"_within_limits" in line %}
                 {% if line["is_"+key+"_within_limits"] %}
-                    {% if line[key+"_diff"] > 5 %}
+                    {% if line[key+"_diff"] > 5 or ( ("_per_op" in key) and (line[key+"_diff"] < -5) ) %}
                         <td>{{ result }}(<span class="green fbold">{{ line[key+"_diff"] }}%</span>)</td>
                     {% else %}
                         <td>{{ result }}({{ line[key+"_diff"] }}%)</td>

--- a/sdcm/utils/microbenchmarking/perf_simple_query_reporter.py
+++ b/sdcm/utils/microbenchmarking/perf_simple_query_reporter.py
@@ -114,8 +114,12 @@ class PerfSimpleQueryAnalyzer(BaseResultsAnalyzer):
                 if value > 0 and key != "mad tps":
                     diff = test_stats['stats'][key] / value
                     table_line["is_" + key + "_within_limits"] = False
-                    if diff > 1 - regression_limit:
-                        table_line["is_" + key + "_within_limits"] = True
+                    if "_per_op" in key:
+                        if diff < 1 + regression_limit:
+                            table_line["is_" + key + "_within_limits"] = True
+                    else:
+                        if diff > 1 - regression_limit:
+                            table_line["is_" + key + "_within_limits"] = True
                     table_line[key + "_diff"] = round((diff - 1) * 100, 2)
                     table_line[key] = round(table_line[key], 2)
             table_line["mad tps"] = round(table_line["mad tps"], 2)


### PR DESCRIPTION
fix email regression reporting X per op -> lower is better.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
