### PR TITLE
Fix hydra image build issues

### DIFF
--- a/docker/env/version
+++ b/docker/env/version
@@ -1,1 +1,1 @@
-1.47-update-google-libs
+1.47-pyyaml-awscli-fix-cython-r2

--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,10 @@
-PyYAML==5.4.1
+PyYAML==6.0.1
 paramiko==3.0.0
 fabric==2.6.0
 invoke==1.6.0
-boto3==1.26.49
-boto3-stubs[s3,ec2,dynamodb,pricing]==1.26.49
-awscli==1.27.49
+boto3==1.28.4
+boto3-stubs[s3,ec2,dynamodb,pricing]==1.28.4
+awscli==1.29.4
 aexpect==1.6.2
 scylla-driver==3.25.11
 requests==2.31.0

--- a/unit_tests/provisioner/test_user_data_builder.py
+++ b/unit_tests/provisioner/test_user_data_builder.py
@@ -62,7 +62,7 @@ def test_user_data_builder_generates_valid_yaml_from_single_user_data_object():
 
     builder = UserDataBuilder(user_data_objects=[user_data_object_1])
     user_data_yaml = builder.build_user_data_yaml()
-    loaded_yaml = yaml.load(user_data_yaml)
+    loaded_yaml = yaml.safe_load(user_data_yaml)
 
     assert user_data_yaml.startswith("#cloud-config\n"), "user-data yaml must start with #cloud-config"
     assert loaded_yaml['packages'] == ['some-pkg-to-install']
@@ -83,7 +83,7 @@ def test_user_data_can_merge_user_data_objects_yaml():
 
     builder = UserDataBuilder(user_data_objects=[user_data_object_1, user_data_object_2, user_data_object_3])
     user_data_yaml = builder.build_user_data_yaml()
-    loaded_yaml = yaml.load(user_data_yaml)
+    loaded_yaml = yaml.safe_load(user_data_yaml)
 
     assert sorted(loaded_yaml['packages']) == sorted(
         ['some-pkg-to-install', 'another-pkg-to-install', 'pkg-from-empty'])
@@ -96,7 +96,7 @@ def test_user_data_can_merge_user_data_objects_yaml():
 def test_only_done_runcmd_in_yaml_when_no_user_data_objects():
     builder = UserDataBuilder(user_data_objects=[])
     user_data_yaml = builder.build_user_data_yaml()
-    loaded_yaml = yaml.load(user_data_yaml)
+    loaded_yaml = yaml.safe_load(user_data_yaml)
 
     assert not loaded_yaml["packages"]
     assert not loaded_yaml["write_files"]
@@ -106,7 +106,7 @@ def test_only_done_runcmd_in_yaml_when_no_user_data_objects():
 def test_only_done_runcmd_in_yaml_when_no_applicable_user_data_objects():
     builder = UserDataBuilder(user_data_objects=[NotApplicableUserDataObject()])
     user_data_yaml = builder.build_user_data_yaml()
-    loaded_yaml = yaml.load(user_data_yaml)
+    loaded_yaml = yaml.safe_load(user_data_yaml)
 
     assert not loaded_yaml["packages"]
     assert not loaded_yaml["write_files"]

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -430,8 +430,8 @@ class ScyllaYamlTest(unittest.TestCase):
         yaml1 = ScyllaYaml(cluster_name='cluster1', redis_keyspace_replication_strategy='NetworkTopologyStrategy')
         test_config_file = Path(__file__).parent / 'test_data' / 'scylla_yaml_update.yaml'
         with open(test_config_file, encoding="utf-8") as test_file:
-            test_config_file_yaml = yaml.load(test_file)
-            append_scylla_args_dict = yaml.load(test_config_file_yaml["append_scylla_yaml"])
+            test_config_file_yaml = yaml.safe_load(test_file)
+            append_scylla_args_dict = yaml.safe_load(test_config_file_yaml["append_scylla_yaml"])
         yaml1.update(append_scylla_args_dict)
         assert yaml1.enable_sstables_mc_format == append_scylla_args_dict["enable_sstables_mc_format"]
         assert yaml1.enable_sstables_md_format == append_scylla_args_dict["enable_sstables_md_format"]


### PR DESCRIPTION
This PR fixes hydra image building issues, namely it updates PyYAML 
(and relevant dependencies) to prevent build errors with Cython

- fix(hydra): Update PyYAML and awscli
- improvement(hydra): Update hydra image to contain PyYAML==6.0.1

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
