### PR TITLE
Revert "fix(p11-trust): remove scylla reloc libp11-kit.so"

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1598,11 +1598,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             is_kms = bool(scylla_yml.kms_hosts)
 
         if is_kms:
-            # Hack for overriding issue https://github.com/scylladb/scylla-enterprise/issues/2792
-            # TODO: should be remove once a proper fix is implemented
-            self.remoter.sudo("find /opt/scylladb/ -iname *libp11-kit.so* | sudo xargs rm",
-                              verbose=True, ignore_status=True)
-            self.install_package("p11-kit")
 
             # Hack to get credentials into place, until we can use instance profiles and roles
             # TODO: remove when https://github.com/scylladb/scylla-enterprise/pull/3032 is finalized


### PR DESCRIPTION
269b34ff1561b1e2a9349cbbef0ad873d7c1c39e isn't needed when scylladb/scylla-enterprise#3023 is in place

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
