### PR TITLE
fix(scan_operation_thread): Disable tracing

### DIFF
--- a/sdcm/scan_operation_thread.py
+++ b/sdcm/scan_operation_thread.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import random
-import re
 import tempfile
 import threading
 import time
@@ -451,7 +450,7 @@ class FullScanAggregatesOperation(FullscanOperationBase):
         self.log.debug('Will run command %s', cmd)
         try:
             cmd_result = session.execute(
-                query=cmd, trace=True, timeout=self._session_execution_timeout)
+                query=cmd, trace=False, timeout=self._session_execution_timeout)
         except OperationTimedOut as exc:
             self.log.error(traceback.format_exc())
             self.current_operation_stat.exceptions.append(repr(exc))
@@ -479,8 +478,9 @@ class FullScanAggregatesOperation(FullscanOperationBase):
             event.message = f"{type(self).__name__} operation failed: {message}"
     def _validate_fullscan_result(
             self, cmd_result: ResultSet):
-        regex_found = False
-        dispatch_forward_statement_regex_pattern = re.compile(r"Dispatching forward_request to \d* endpoints")
+        # TODO: https://github.com/scylladb/scylla-cluster-tests/issues/6368
+        # regex_found = False
+        # dispatch_forward_statement_regex_pattern = re.compile(r"Dispatching forward_request to \d* endpoints")
         result = cmd_result.all()
 
         if not result:
@@ -490,18 +490,19 @@ class FullScanAggregatesOperation(FullscanOperationBase):
         output = "\n".join([str(i) for i in result])
         if int(result[0].count) <= 0:
             return f"Fullscan failed - count is not bigger than 0: {output}", Severity.ERROR
-        get_query_trace = cmd_result.get_query_trace().events
-        for trace_event in get_query_trace:
-            if dispatch_forward_statement_regex_pattern.search(str(trace_event)):
-                regex_found = True
-                break
         self.log.debug("Fullscan aggregation result: %s", output)
 
-        if not regex_found:
-            self.log.debug("\n".join([str(i) for i in get_query_trace]))
-            self.log.debug("Fullscan aggregation result: %s", output)
-            return "Fullscan failed - 'Dispatching forward_request' message was not found in query trace events", \
-                Severity.WARNING
+        # TODO: https://github.com/scylladb/scylla-cluster-tests/issues/6368
+        # get_query_trace = cmd_result.get_query_trace().events
+        # for trace_event in get_query_trace:
+        #     if dispatch_forward_statement_regex_pattern.search(str(trace_event)):
+        #         regex_found = True
+        #         break
+        # if not regex_found:
+        #     self.log.debug("\n".join([str(i) for i in get_query_trace]))
+        #     self.log.debug("Fullscan aggregation result: %s", output)
+        #     return "Fullscan failed - 'Dispatching forward_request' message was not found in query trace events", \
+        #         Severity.WARNING
 
         return f'result {result[0]}', None
 

--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -1,5 +1,5 @@
 test_duration: 255
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=10m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5"
              ]
 
 n_db_nodes: 6
@@ -10,8 +10,8 @@ instance_type_db: 'i4i.2xlarge'
 gce_instance_type_db: 'n2-highmem-16'
 gce_instance_type_loader: 'e2-standard-4'
 azure_instance_type_db: 'Standard_L8s_v3'
-run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 10}']
-nemesis_class_name: 'SisyphusMonkey'
+run_fullscan: ['{"mode": "aggregate", "ks_cf": "keyspace1.standard1", "interval": 10}']
+nemesis_class_name: 'NoOpMonkey'
 nemesis_seed: '111'
 nemesis_interval: 2
 ssh_transport: 'libssh2'


### PR DESCRIPTION
Disable 'implicit' tracing at FullScanAggregatesOperation issue: https://github.com/scylladb/scylla-cluster-tests/issues/6368

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
