### PR TITLE
fix(LongevityOperatorMultiTenantTest): support new generic test_duration

### DIFF
--- a/sdcm/utils/operator/multitenant_common.py
+++ b/sdcm/utils/operator/multitenant_common.py
@@ -38,7 +38,7 @@ class TenantMixin:  # pylint: disable=too-many-instance-attributes
         self._es_doc_type = "test_stats"
         self._stats = self._init_stats()
         self.test_config = test_config
-        self._duration = self.params.get(key='test_duration')
+        self._init_test_duration()
         self.create_stats = self.params.get(key='store_perf_results')
         self.status = "RUNNING"
         self.cluster_index = str(cluster_index)

--- a/unit_tests/test_utils__operator__multitenant_common.py
+++ b/unit_tests/test_utils__operator__multitenant_common.py
@@ -32,6 +32,9 @@ class FakeTestBase:
     def _init_test_timeout_thread(self):
         pass
 
+    def _init_test_duration(self):
+        pass
+
 
 class FakeLongevityTest(FakeTestBase):
     pass


### PR DESCRIPTION
in #5398 new configuration option to set the test duration were introduced, and broke the k8s multi-tanent longevity like this:

```
AttributeError: 'TenantForLongevityTest-2' object has no attribute '_stress_duration'.
  Did you mean: 'test_duration'?
```

this would call the same method to get those parameters initilized

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
