### PR TITLE
fix(sct_config): remove `bench_run` and `fullscan`

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -78,8 +78,6 @@
 | **<a href="#user-content-email_subject_postfix" name="email_subject_postfix">email_subject_postfix</a>**  | Email subject postfix | N/A | SCT_EMAIL_SUBJECT_POSTFIX
 | **<a href="#user-content-enable_test_profiling" name="enable_test_profiling">enable_test_profiling</a>**  | Turn on sct profiling | N/A | SCT_ENABLE_TEST_PROFILING
 | **<a href="#user-content-ssh_transport" name="ssh_transport">ssh_transport</a>**  | Set type of ssh library to use. Could be 'fabric' (default) or 'libssh2' | libssh2 | SSH_TRANSPORT
-| **<a href="#user-content-bench_run" name="bench_run">bench_run</a>**  | If true would kill the scylla-bench thread in the test teardown | N/A | SCT_BENCH_RUN
-| **<a href="#user-content-fullscan" name="fullscan">fullscan</a>**  | If true would kill the fullscan thread in the test teardown | N/A | SCT_FULLSCAN
 | **<a href="#user-content-experimental" name="experimental">experimental</a>**  | when enabled scylla will use it's experimental features | True | SCT_EXPERIMENTAL
 | **<a href="#user-content-server_encrypt" name="server_encrypt">server_encrypt</a>**  | when enable scylla will use encryption on the server side | N/A | SCT_SERVER_ENCRYPT
 | **<a href="#user-content-client_encrypt" name="client_encrypt">client_encrypt</a>**  | when enable scylla will use encryption on the client side | N/A | SCT_CLIENT_ENCRYPT

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -465,13 +465,6 @@ class SCTConfiguration(dict):
              help="""Turn on sct profiling"""),
         dict(name="ssh_transport", env="SSH_TRANSPORT", type=str,
              help="""Set type of ssh library to use. Could be 'fabric' (default) or 'libssh2'"""),
-        # should be removed once stress commands would be refactored
-        dict(name="bench_run", env="SCT_BENCH_RUN", type=boolean,
-             help="""If true would kill the scylla-bench thread in the test teardown"""),
-
-        # should be removed once stress commands would be refactored
-        dict(name="fullscan", env="SCT_FULLSCAN", type=boolean,
-             help="""If true would kill the fullscan thread in the test teardown"""),
 
         # Scylla command line arguments options
         dict(name="experimental", env="SCT_EXPERIMENTAL", type=boolean,

--- a/test-cases/longevity/longevity-large-partition-200k_pks-2days-i4i.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-2days-i4i.yaml
@@ -1,6 +1,5 @@
 test_duration: 3240
 
-bench_run: true
 max_partitions_in_test_table: 1000
 partition_range_with_data_validation: 0-250
 prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=250 -clustering-row-count=100000 -clustering-row-size=uniform:3072..5120 -concurrency=10 -connection-count=10 -rows-per-request=10 -consistency-level=quorum -timeout=90s -validate-data" ,

--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -1,6 +1,5 @@
 test_duration: 6480
 
-bench_run: true
 max_partitions_in_test_table: 1000
 partition_range_with_data_validation: 0-250
 prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=250 -clustering-row-count=100000 -clustering-row-size=uniform:3072..5120 -concurrency=10 -connection-count=10 -rows-per-request=10 -consistency-level=quorum -timeout=90s -validate-data" ,

--- a/test-cases/longevity/longevity-large-partition-2days.yaml
+++ b/test-cases/longevity/longevity-large-partition-2days.yaml
@@ -1,6 +1,5 @@
 test_duration: 3000
 
-bench_run: true
 
 prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=100 -clustering-row-count=50000 -clustering-row-size=uniform:100..5120 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150",
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=100 -clustering-row-count=50000 -partition-offset=101 -clustering-row-size=uniform:100..5120 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150",

--- a/test-cases/longevity/longevity-large-partition-3h.yaml
+++ b/test-cases/longevity/longevity-large-partition-3h.yaml
@@ -1,6 +1,5 @@
 test_duration: 210
 
-bench_run: true
 max_partitions_in_test_table: 400
 partition_range_with_data_validation: 0-100
 prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=100 -clustering-row-count=5555                       -clustering-row-size=uniform:1024..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data" ,

--- a/test-cases/longevity/longevity-large-partition-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-4days.yaml
@@ -1,6 +1,5 @@
 test_duration: 6480
 
-bench_run: true
 
 prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=6 -clustering-row-count=10000000 -clustering-row-size=2048 -concurrency=8 -rows-per-request=2000 -timeout=180s -connection-count 8 -retry-number=3 -retry-interval=40s -consistency-level=all",
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=6 -clustering-row-count=10000000 -partition-offset=6 -clustering-row-size=2048 -concurrency=8 -rows-per-request=2000 -timeout=180s -connection-count 8 -retry-number=3 -retry-interval=40s -consistency-level=all",

--- a/test-cases/longevity/longevity-large-partition-8h.yaml
+++ b/test-cases/longevity/longevity-large-partition-8h.yaml
@@ -1,6 +1,5 @@
 test_duration: 600
 
-bench_run: true
 max_partitions_in_test_table: 400
 partition_range_with_data_validation: 0-100
 prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=100 -clustering-row-count=5555                       -clustering-row-size=uniform:1024..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data" ,

--- a/test-cases/longevity/longevity-twcs-3h.yaml
+++ b/test-cases/longevity/longevity-twcs-3h.yaml
@@ -1,5 +1,4 @@
 test_duration: 210
-bench_run: true
 
 stress_cmd: ["scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=4000 -clustering-row-count=10000 -clustering-row-size=200 -concurrency=100 -rows-per-request=1 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 30000 --timeout 120s -retry-number=30 -retry-interval=80ms,1s -duration=170m"]
 # write-rate with timeseries workload for read mode

--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -1,5 +1,4 @@
 test_duration: 3000
-bench_run: true
 
 stress_cmd: ["scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=4000 -clustering-row-count=10000 -clustering-row-size=200 -concurrency=150 -rows-per-request=1 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 30000 -timeout=120s -retry-number=30 -retry-interval=80ms,1s -duration=2880m"]
 # write-rate with timeseries workload for read mode


### PR DESCRIPTION
those configuration options are not in use anymore by any code, and should be removed

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
