### PR TITLE
fix(nemesis): raise UnsupportedNemesis if no partitions

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2218,8 +2218,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         partitions_for_delete = self.choose_partitions_for_delete(10, ks_cf, with_clustering_key_data=True)
         if not partitions_for_delete:
-            self.log.error('Not found partitions for delete')
-            return partitions_for_delete
+            raise UnsupportedNemesis('Not found partitions for delete. Nemesis can not be run')
 
         queries = []
         for pkey, ckey in partitions_for_delete.items():
@@ -2258,8 +2257,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         partitions_for_delete = self.choose_partitions_for_delete(10, ks_cf, with_clustering_key_data=True,
                                                                   exclude_partitions=partitions_for_exclude)
         if not partitions_for_delete:
-            self.log.error('Not found partitions for delete')
-            return []
+            raise UnsupportedNemesis('Not found partitions for delete. Nemesis can not be run')
 
         # Choose same "ck" values that exists for all partitions
         # min_clustering_key - the biggest from min(ck) value for all selected partitions
@@ -2293,8 +2291,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         partitions_for_delete = self.choose_partitions_for_delete(10, ks_cf)
 
         if not partitions_for_delete:
-            self.log.error('Not found partitions for delete')
-            return
+            raise UnsupportedNemesis('Not found partitions for delete. Nemesis can not be run')
 
         queries = []
         for partition_key in partitions_for_delete.keys():


### PR DESCRIPTION
In case no partitions found, delete partition/range of partition nemeses can not be run because they need to delete part or full partition. 
Now error log is printed and nemesis finished like 'successfull'. 
Raise UnsupportedNemesis to mark that nemesis was not run

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
