### PR TITLE
fix(perf_GCP): set use_preinstalled_scylla true

### DIFF
--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -23,6 +23,7 @@ instance_type_monitor: 't3.small'
 space_node_threshold: 644245094
 #------
 #GCE
+use_preinstalled_scylla: true
 gce_instance_type_db: 'n2-highmem-8'
 gce_root_disk_type_db: 'pd-ssd'
 gce_n_local_ssd_disk_db: 8

--- a/test-cases/performance/perf-search-best-throughput-config.yaml
+++ b/test-cases/performance/perf-search-best-throughput-config.yaml
@@ -25,6 +25,7 @@ space_node_threshold: 644245094
 ami_id_loader: 'scylla-qa-loader-ami-v19'
 #--------
 #GCE
+use_preinstalled_scylla: true
 gce_instance_type_db: 'n2-highmem-8'
 gce_root_disk_type_db: 'pd-ssd'
 gce_n_local_ssd_disk_db: 8


### PR DESCRIPTION
commit https://github.com/scylladb/scylla-cluster-tests/pull/6363 was reverted
as the result GCE default is "use_preinstalled_scylla: false" for AWS: "use_preinstalled_scylla: true"
so decided to set explicitly "use_preinstalled_scylla: true" in GCE perf configs

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
