### PR TITLE
fix(artifacts-gce-image): set the number of local SSDs to 16

### DIFF
--- a/test-cases/artifacts/gce-image.yaml
+++ b/test-cases/artifacts/gce-image.yaml
@@ -4,7 +4,7 @@ backtrace_decoding: false
 gce_instance_type_db: 'n1-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
-gce_n_local_ssd_disk_db: 1
+gce_n_local_ssd_disk_db: 16
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
 logs_transport: 'ssh'


### PR DESCRIPTION
In a recent change in the artifact trigger (https://github.com/scylladb/scylla-pkg/pull/3500/files) a new set of large instance types were added. Some of those instance types require at least 16 local SSDs in order to start at all (described here: https://cloud.google.com/compute/docs/disks/local-ssd#choose_number_local_ssds) As such, I set the number of local SSDs in the GCE artifact job to 16

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
