### PR TITLE
feat(repair): enable single-host-parallelism for repairs

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4571,10 +4571,14 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
     def scylla_manager_cluster_name(self):
         return self.name
 
-    def get_cluster_manager(self, create_cluster_if_not_exists: bool = True) -> AnyManagerCluster:
+    @property
+    def scylla_manager_tool(self):
         if not self.params.get('use_mgmt'):
             raise ScyllaManagerError('Scylla-manager configuration is not defined!')
-        manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.scylla_manager_node, scylla_cluster=self)
+        return mgmt.get_scylla_manager_tool(manager_node=self.scylla_manager_node, scylla_cluster=self)
+
+    def get_cluster_manager(self, create_cluster_if_not_exists: bool = True) -> AnyManagerCluster:
+        manager_tool = self.scylla_manager_tool
         LOGGER.debug("sctool version is : {}".format(manager_tool.sctool.version))
         cluster_name = self.scylla_manager_cluster_name  # pylint: disable=no-member
         mgr_cluster = manager_tool.get_cluster(cluster_name)


### PR DESCRIPTION
https://github.com/scylladb/scylla-manager/pull/3496 brought new repair option --single-host-parallelism we need to test it

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
