### PR TITLE
fix(mgmt_cli_test): address test_client_encryption flakiness

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -458,6 +458,10 @@ class HealthcheckTask(ManagerTask):
     def __init__(self, task_id, cluster_id, manager_node):
         ManagerTask.__init__(self, task_id=task_id, cluster_id=cluster_id, manager_node=manager_node)
 
+    def progress_string(self, **kwargs):
+        # progress command does not support healthcheck tasks
+        return ""
+
 
 class BackupTask(ManagerTask):
     def __init__(self, task_id, cluster_id, manager_node):


### PR DESCRIPTION
Closes #6436 

Test creates a repair task, does something then enables client ssl, restart scylla nodes and assert repair status is an ERROR.
Since there is a gap between creating a repair task and restarting scylla, it is possible that task is finished before scylla is restarted.
As result test can falsely fail.

Solution - to move repair task creating after scylla is being reconfigured

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
