### PR TITLE
improvement(perf during ops): change operations order

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3874,13 +3874,17 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.disrupt_mgmt_repair_cli()
         InfoEvent(message='FinishEvent - Manager repair has finished').publish()
         time.sleep(sleep_time_between_ops)
+        InfoEvent(message='Starting grow disruption').publish()
+        self._grow_cluster(rack=None)
+        InfoEvent(message='Finished grow disruption').publish()
+        time.sleep(sleep_time_between_ops)
         InfoEvent(message='Starting terminate_and_replace disruption').publish()
         self.disrupt_terminate_and_replace_node()
         InfoEvent(message='Finished terminate_and_replace disruption').publish()
         time.sleep(sleep_time_between_ops)
-        InfoEvent(message='Starting grow_shrink disruption').publish()
-        self.disrupt_grow_shrink_cluster()
-        InfoEvent(message="Finished grow_shrink disruption").publish()
+        InfoEvent(message='Starting shrink disruption').publish()
+        self._shrink_cluster(rack=None)
+        InfoEvent(message='Starting shrink disruption').publish()
 
     def _k8s_disrupt_memory_stress(self):
         """Uses chaos-mesh experiment based on https://github.com/chaos-mesh/memStress"""


### PR DESCRIPTION
as we are suffering in mixed workload from really
bad replace node results, we decided that we will
run this operation when the cluster will be larger, reducing the overhead it causes on a 3 nodes cluster, but now doing it on a 6 nodes cluster (between operations `add_node` and `decommission`, so we should get better results for replace node, and not affect any other operations we have currently.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
