### PR TITLE
feature(nemesis): introduce `raise_exception_in_thread`

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -42,6 +42,7 @@ from sdcm.sct_events.system import InfoEvent
 from sdcm.sct_events.group_common_events import ignore_no_space_errors, ignore_stream_mutation_fragments_errors
 from sdcm.utils.gce_utils import get_gce_storage_client
 from sdcm.utils.azure_utils import AzureService
+from sdcm.exceptions import FilesNotCorrupted
 
 
 class BackupFunctionsMixIn(LoaderUtilsMixin):
@@ -264,18 +265,6 @@ class BackupFunctionsMixIn(LoaderUtilsMixin):
         self.log.info('Sleeping for 15s to let cassandra-stress run...')
         time.sleep(15)
         return stress_thread
-
-
-class NoFilesFoundToDestroy(Exception):
-    pass
-
-
-class NoKeyspaceFound(Exception):
-    pass
-
-
-class FilesNotCorrupted(Exception):
-    pass
 
 
 # pylint: disable=too-many-public-methods

--- a/sdcm/cassandra_harry_thread.py
+++ b/sdcm/cassandra_harry_thread.py
@@ -20,7 +20,8 @@ from sdcm.loader import CassandraHarryStressExporter
 from sdcm.prometheus import nemesis_metrics_obj
 from sdcm.sct_events.loaders import CassandraHarryEvent, CASSANDRA_HARRY_ERROR_EVENTS_PATTERNS
 from sdcm.utils.docker_remote import RemoteDocker
-from sdcm.stress_thread import format_stress_cmd_error, DockerBasedStressThread
+from sdcm.stress_thread import DockerBasedStressThread
+from sdcm.stress.base import format_stress_cmd_error
 from sdcm.utils.common import FileFollowerThread
 
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -86,6 +86,7 @@ from sdcm.utils.common import (
     download_dir_from_cloud,
     generate_random_string,
     prepare_and_start_saslauthd_service,
+    raise_exception_in_thread,
 )
 from sdcm.utils.ci_tools import get_test_name
 from sdcm.utils.distro import Distro
@@ -135,6 +136,7 @@ from sdcm.paths import (
     SCYLLA_MANAGER_TLS_KEY_FILE,
 )
 from sdcm.sct_provision.aws.user_data import ScyllaUserDataBuilder
+from sdcm.exceptions import KillNemesis
 
 
 # Test duration (min). Parameter used to keep instances produced by tests that
@@ -4387,6 +4389,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         # pylint: disable=protected-access
         current_thread_frames = sys._current_frames()
         for nemesis_thread in self.nemesis_threads:
+            raise_exception_in_thread(nemesis_thread, KillNemesis)
             nemesis_thread.join(timeout)
             if nemesis_thread.is_alive():
                 stack_trace = traceback.format_stack(current_thread_frames[nemesis_thread.ident])

--- a/sdcm/exceptions.py
+++ b/sdcm/exceptions.py
@@ -55,3 +55,7 @@ class AuditLogTestFailure(Exception):
 class BootstrapStreamErrorFailure(Exception):  # pylint: disable=too-few-public-methods
     """ raised if node was not boostrapped after bootstrap
     streaming was aborted """
+
+
+class KillNemesis(BaseException):
+    """Exception that would be raised, when a nemesis thread is killed at teardown of the test"""

--- a/sdcm/exceptions.py
+++ b/sdcm/exceptions.py
@@ -1,0 +1,57 @@
+class NoFilesFoundToDestroy(Exception):
+    pass
+
+
+class NoKeyspaceFound(Exception):
+    pass
+
+
+class FilesNotCorrupted(Exception):
+    pass
+
+
+class LogContentNotFound(Exception):
+    pass
+
+
+class LdapNotRunning(Exception):
+    pass
+
+
+class TimestampNotFound(Exception):
+    pass
+
+
+class PartitionNotFound(Exception):
+    pass
+
+
+class WatcherCallableException(Exception):
+    """ raised when a watcher function in a trigger - watcher pair fails"""
+
+
+class UnsupportedNemesis(Exception):
+    """ raised from within a nemesis execution to skip this nemesis"""
+
+
+class CdcStreamsWasNotUpdated(Exception):
+    """ raised if messages:
+          - Generation {}: streams description table already updated
+          - CDC description table successfully updated with generation
+        were not found in logs
+    """
+
+
+class NemesisSubTestFailure(Exception):
+    """ raised if nemesis got error from sub test
+    """
+
+
+class AuditLogTestFailure(Exception):
+    """ raised if nemesis got error from audit log validation
+    """
+
+
+class BootstrapStreamErrorFailure(Exception):  # pylint: disable=too-few-public-methods
+    """ raised if node was not boostrapped after bootstrap
+    streaming was aborted """

--- a/sdcm/kcl_thread.py
+++ b/sdcm/kcl_thread.py
@@ -21,7 +21,8 @@ import threading
 from functools import cached_property
 from typing import Dict
 
-from sdcm.stress_thread import format_stress_cmd_error, DockerBasedStressThread
+from sdcm.stress_thread import DockerBasedStressThread
+from sdcm.stress.base import format_stress_cmd_error
 from sdcm.utils.docker_remote import RemoteDocker
 from sdcm.sct_events.system import InfoEvent
 from sdcm.sct_events.loaders import KclStressEvent

--- a/sdcm/ndbench_thread.py
+++ b/sdcm/ndbench_thread.py
@@ -22,8 +22,8 @@ from sdcm.prometheus import nemesis_metrics_obj
 from sdcm.sct_events.loaders import NdBenchStressEvent, NDBENCH_ERROR_EVENTS_PATTERNS
 from sdcm.utils.common import FileFollowerThread
 from sdcm.utils.docker_remote import RemoteDocker
-from sdcm.stress_thread import format_stress_cmd_error, DockerBasedStressThread
-
+from sdcm.stress_thread import DockerBasedStressThread
+from sdcm.stress.base import format_stress_cmd_error
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -118,6 +118,21 @@ from sdcm.utils.toppartition_util import NewApiTopPartitionCmd, OldApiTopPartiti
 from sdcm.utils.version_utils import MethodVersionNotFound, scylla_versions
 from sdcm.utils.raft import Group0MembersNotConsistentWithTokenRingMembersException
 from sdcm.wait import wait_for, wait_for_log_lines
+from sdcm.exceptions import (
+    NoFilesFoundToDestroy,
+    NoKeyspaceFound,
+    FilesNotCorrupted,
+    LogContentNotFound,
+    LdapNotRunning,
+    TimestampNotFound,
+    PartitionNotFound,
+    WatcherCallableException,
+    UnsupportedNemesis,
+    CdcStreamsWasNotUpdated,
+    NemesisSubTestFailure,
+    AuditLogTestFailure,
+    BootstrapStreamErrorFailure,
+)
 from test_lib.compaction import CompactionStrategy, get_compaction_strategy, get_compaction_random_additional_params, \
     get_gc_mode, GcMode
 from test_lib.cql_types import CQLTypeBuilder
@@ -136,78 +151,11 @@ EXCLUSIVE_NEMESIS_NAMES = (
 )
 
 
-class NoFilesFoundToDestroy(Exception):
-    pass
-
-
-class NoKeyspaceFound(Exception):
-    pass
-
-
-class FilesNotCorrupted(Exception):
-    pass
-
-
-class LogContentNotFound(Exception):
-    pass
-
-
-class LdapNotRunning(Exception):
-    pass
-
-
-class TimestampNotFound(Exception):
-    pass
-
-
-class PartitionNotFound(Exception):
-    pass
-
-
-class TriggerCallableException(Exception):
-    """ raised when a trigger function in a trigger - watcher pair fails"""
-
-
-class WatcherCallableException(Exception):
-    """ raised when a watcher function in a trigger - watcher pair fails"""
-
-
-class UnsupportedNemesis(Exception):
-    """ raised from within a nemesis execution to skip this nemesis"""
-
-
-class NoMandatoryParameter(Exception):
-    """ raised from within a nemesis execution to skip this nemesis"""
-
-
 class DefaultValue:  # pylint: disable=too-few-public-methods
     """
     This is class is intended to be used as default value for the cases when None is not applicable
     """
     ...
-
-
-class CdcStreamsWasNotUpdated(Exception):
-    """ raised if messages:
-          - Generation {}: streams description table already updated
-          - CDC description table successfully updated with generation
-        were not found in logs
-    """
-
-
-class NemesisSubTestFailure(Exception):
-    """ raised if nemesis got error from sub test
-    """
-
-
-class AuditLogTestFailure(Exception):
-    """ raised if nemesis got error from audit log validation
-    """
-
-
-class BootstrapStreamErrorFailure(Exception):  # pylint: disable=too-few-public-methods
-    """ raised if node was not boostrapped after bootstrap
-    streaming was aborted """
 
 
 class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-methods

--- a/sdcm/nosql_thread.py
+++ b/sdcm/nosql_thread.py
@@ -18,8 +18,7 @@ import uuid
 import threading
 
 from sdcm.cluster import BaseNode
-from sdcm.sct_events import Severity
-from sdcm.stress.base import format_stress_cmd_error, DockerBasedStressThread
+from sdcm.stress.base import DockerBasedStressThread
 from sdcm.sct_events.loaders import NoSQLBenchStressEvent, NOSQLBENCH_EVENT_PATTERNS
 from sdcm.utils.common import FileFollowerThread
 
@@ -113,6 +112,5 @@ class NoSQLBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-ma
                                               f'{stress_cmd} --report-graphite-to graphite-exporter:9109',
                                           timeout=self.timeout + self.shutdown_timeout, log_file=log_file_name)
             except Exception as exc:  # pylint: disable=broad-except
-                stress_event.severity = Severity.CRITICAL if self.stop_test_on_failure else Severity.ERROR
-                stress_event.add_error(errors=[format_stress_cmd_error(exc)])
+                self.configure_event_on_failure(stress_event=stress_event, exc=exc)
             return None

--- a/sdcm/sct_events/continuous_event.py
+++ b/sdcm/sct_events/continuous_event.py
@@ -120,7 +120,7 @@ class ContinuousEvent(SctEvent, abstract=True):
         return self.begin_event()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_tb is not None:
+        if exc_tb is not None and isinstance(exc_val, Exception):
             if not isinstance(self.errors, list):
                 self.errors = []
 

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -29,7 +29,7 @@ from sdcm.sct_events import Severity
 from sdcm.utils.common import FileFollowerThread, get_data_dir_path, time_period_str_to_seconds, SoftTimeoutContext
 from sdcm.utils.user_profile import get_profile_content
 from sdcm.sct_events.loaders import CassandraStressEvent, CS_ERROR_EVENTS_PATTERNS, CS_NORMAL_EVENTS_PATTERNS
-from sdcm.stress.base import DockerBasedStressThread, format_stress_cmd_error
+from sdcm.stress.base import DockerBasedStressThread
 from sdcm.utils.docker_remote import RemoteDocker
 from sdcm.utils.version_utils import get_docker_image_by_version
 from sdcm.utils.remote_logger import SSHLoggerBase
@@ -319,8 +319,7 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
                 with SoftTimeoutContext(timeout=self.timeout, operation="cassandra-stress"):
                     result = cmd_runner.run(cmd=node_cmd, timeout=hard_timeout, log_file=log_file_name, retry=0)
             except Exception as exc:  # pylint: disable=broad-except
-                cs_stress_event.severity = Severity.CRITICAL if self.stop_test_on_failure else Severity.ERROR
-                cs_stress_event.add_error(errors=[format_stress_cmd_error(exc)])
+                self.configure_event_on_failure(stress_event=cs_stress_event, exc=exc)
 
         return loader, result, cs_stress_event
 

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -38,7 +38,8 @@ import zipfile
 import io
 import tempfile
 import traceback
-from typing import Iterable, List, Callable, Optional, Dict, Union, Literal, Any
+import ctypes
+from typing import Iterable, List, Callable, Optional, Dict, Union, Literal, Any, Type
 from urllib.parse import urlparse
 from unittest.mock import MagicMock, Mock
 from textwrap import dedent
@@ -52,7 +53,6 @@ import hashlib
 from pathlib import Path
 
 import requests
-
 import boto3
 from mypy_boto3_s3 import S3Client, S3ServiceResource
 from mypy_boto3_ec2 import EC2Client, EC2ServiceResource
@@ -3152,3 +3152,8 @@ def SoftTimeoutContext(timeout: int, operation: str):  # pylint: disable=invalid
     if duration > timeout:
         SoftTimeoutEvent(operation=operation, soft_timeout=timeout,
                          duration=duration).publish_or_dump()
+
+
+def raise_exception_in_thread(thread: threading.Thread, exception_type: Type[BaseException]):
+    res = ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_ulong(thread.ident), ctypes.py_object(exception_type))
+    LOGGER.debug("PyThreadState_SetAsyncExc: return [%s]", res)

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -21,7 +21,7 @@ from unittest import mock
 
 from parameterized import parameterized
 
-from sdcm.nemesis import UnsupportedNemesis
+from sdcm.exceptions import UnsupportedNemesis
 from sdcm.prometheus import start_metrics_server
 from sdcm.sct_events.nodetool import NodetoolEvent
 from sdcm.utils.decorators import timeout


### PR DESCRIPTION
`raise_exception_in_thread` is introduced as a way to force kill a nemesis thread for the following reasons:

a) so we don't wait for 30min at the end of every test (can be
   more depend on the nemsis/testcase))
b) so nemesis are depended on the load (ex. SLA), and since we
   kill the load before stopping the nemesis, if we are currently
   during such a nemesis, it would spit false posisitve events
   since it won't find enough load on the cluster as it expects.

Fixes: #6439

### Testing
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/25/
- [x] - https://argus.scylladb.com/test/4f234961-de7a-4d4a-a0bb-0795c66a7212/runs?additionalRuns[]=20d3d721-2bb5-4150-a423-6839d9603c44


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
