### PR TITLE
fix(kms_user): drop kms_hack.conf and place credential to ~scylla

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1616,10 +1616,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 fobj.write(KeyStore().get_file_contents('kms_user_credentials').decode())
 
             self.remoter.sudo(shell_script_cmd("""
-                mkdir -p /home/scylla/.aws
-                mv /home/scyllaadm/.aws/credentials /home/scylla/.aws/credentials
-                chown -R scylla /home/scylla/.aws
-                echo 'HOME=/home/scylla' > /etc/scylla.d/kms_hack.conf
+                mkdir -p /var/lib/scylla/.aws
+                mv /home/scyllaadm/.aws/credentials /var/lib/scylla/.aws/credentials
+                chown -R scylla /var/lib/scylla/.aws
                 """), verbose=True, ignore_status=False)
 
         self.process_scylla_args(append_scylla_args)


### PR DESCRIPTION
Modifying HOME environment breaks "dist: make p11-kit-trust.so able to work in relocatable package" PR on scylla-enterprise. It should use correct homedir of scylla user(/var/lib/scylla).

related scylladb/scylla-enterprise#3023
