### PR TITLE
fix(pipelines): fix manager_version description

### DIFF
--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -31,7 +31,7 @@ def call(Map pipelineParams) {
                    description: 'manager agent repo',
                    name: 'scylla_mgmt_agent_address')
             string(defaultValue: "${pipelineParams.get('manager_version', '')}",
-                   description: 'master_latest|3.0|2.6',
+                   description: 'master_latest|3.1|3.0',
                    name: 'manager_version')
             string(defaultValue: '',
                    description: 'a Scylla AMI to run against (for AMI test, should be blank otherwise)',

--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -70,7 +70,7 @@ def call() {
                    name: 'scylla_mgmt_address')
 
             string(defaultValue: '',
-                   description: 'master_latest|3.0|2.6',
+                   description: 'master_latest|3.1|3.0',
                    name: 'manager_version')
 
             string(defaultValue: "spot",

--- a/vars/cdcReplicationPipeline.groovy
+++ b/vars/cdcReplicationPipeline.groovy
@@ -126,7 +126,7 @@ def call(Map pipelineParams) {
                    name: 'scylla_mgmt_address')
 
             string(defaultValue: '',
-                   description: 'master_latest|3.0|2.6',
+                   description: 'master_latest|3.1|3.0',
                    name: 'manager_version')
 
             string(defaultValue: "${pipelineParams.get('email_recipients', 'qa@scylladb.com')}",

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -85,7 +85,7 @@ def call(Map pipelineParams) {
                    name: 'ip_ssh_connections')
 
             string(defaultValue: "${pipelineParams.get('manager_version', '')}",
-                   description: 'master_latest|3.0|2.6',
+                   description: 'master_latest|3.1|3.0',
                    name: 'manager_version')
 
             string(defaultValue: '',

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -107,11 +107,11 @@ def call(Map pipelineParams) {
                    name: 'scylla_mgmt_address')
 
             string(defaultValue: "${pipelineParams.get('manager_version', 'master_latest')}",
-                   description: 'master_latest|3.0|2.6',
+                   description: 'master_latest|3.1|3.0',
                    name: 'manager_version')
 
             string(defaultValue: "${pipelineParams.get('target_manager_version', '')}",
-                   description: 'master_latest|3.0|2.6',
+                   description: 'master_latest|3.1|3.0',
                    name: 'target_manager_version')
 
             string(defaultValue: "${pipelineParams.get('scylla_mgmt_agent_address', '')}",


### PR DESCRIPTION
The current available manager versions are 3.1 and 3.0, so I fixed the parameter's description

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
