### PR TITLE
fix(mv si 4d): increase monitor instance type

### DIFF
--- a/test-cases/longevity/longevity-mv-si-4days.yaml
+++ b/test-cases/longevity/longevity-mv-si-4days.yaml
@@ -18,6 +18,8 @@ instance_type_db: 'i4i.4xlarge'
 gce_instance_type_db: 'n2-highmem-32'
 gce_n_local_ssd_disk_db: 16
 
+instance_type_monitor: 't3.xlarge'
+
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '023'
 nemesis_interval: 30


### PR DESCRIPTION
during master tier1 runs, we seen monitor having
some dificulties to show dashboards, for more
than one run, so we here increase the instance
type for the monitor, expecting it to work
better for future runs.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
