### PR TITLE
fix(sla tests): missed closing apostrophe

### DIFF
--- a/test-cases/nemesis/longevity-5gb-1h-SlaDecreaseSharesDuringLoad.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-SlaDecreaseSharesDuringLoad.yaml
@@ -1,10 +1,10 @@
 test_duration: 140
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) -mode cql3 native -rate threads=800 -pop seq=1..5048570 -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=800 -pop seq=1..5048570 -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=90m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) -mode cql3 native -rate threads=400 -pop seq=1..5048570 -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=90m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) -mode cql3 native -rate threads=400 -pop seq=1..5048570 -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=90m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) -mode cql3 native -rate threads=400 -pop seq=1..5048570 -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=90m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=400 -pop seq=1..5048570 -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=90m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=400 -pop seq=1..5048570 -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=90m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=400 -pop seq=1..5048570 -log interval=5"
              ]
 
 n_db_nodes: 3

--- a/test-cases/nemesis/longevity-5gb-1h-SlaReplaceUsingDropDuringLoad.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-SlaReplaceUsingDropDuringLoad.yaml
@@ -1,10 +1,10 @@
 test_duration: 140
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) -mode cql3 native -rate threads=800 -pop seq=1..5048570 -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=800 -pop seq=1..5048570 -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=90m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) -mode cql3 native -rate threads=400 -pop seq=1..5048570 -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=90m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) -mode cql3 native -rate threads=400 -pop seq=1..5048570 -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=90m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) -mode cql3 native -rate threads=400 -pop seq=1..5048570 -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=90m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=400 -pop seq=1..5048570 -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=90m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=400 -pop seq=1..5048570 -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=90m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=400 -pop seq=1..5048570 -log interval=5"
              ]
 
 n_db_nodes: 3


### PR DESCRIPTION
SLA nemesis tests: missed closing apostrophe.
It was added by https://github.com/scylladb/scylla-cluster-tests/pull/6361

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
