### PR TITLE
fix(longevity-4h-raft): use consistent-topology-changes

### DIFF
--- a/configurations/raft/enable_raft_experimental.yaml
+++ b/configurations/raft/enable_raft_experimental.yaml
@@ -1,3 +1,3 @@
 append_scylla_yaml: |
   experimental_features:
-    - raft
+    - consistent-topology-changes

--- a/data_dir/cdc_profile_multidc.yaml
+++ b/data_dir/cdc_profile_multidc.yaml
@@ -1,8 +1,7 @@
 keyspace: cdc_test
 
 keyspace_definition: |
-
-  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 3, 'us-eastscylla_node_east': 2}  AND durable_writes = true;
+  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}  AND durable_writes = true;
 
 table: test_table
 

--- a/data_dir/cdc_profile_multidc_postimage.yaml
+++ b/data_dir/cdc_profile_multidc_postimage.yaml
@@ -1,8 +1,7 @@
 keyspace: cdc_test
 
 keyspace_definition: |
-
-  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 2, 'us-eastscylla_node_east': 3}  AND durable_writes = true;
+  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}  AND durable_writes = true;
 
 table: test_table_postimage
 

--- a/data_dir/cdc_profile_multidc_preimage.yaml
+++ b/data_dir/cdc_profile_multidc_preimage.yaml
@@ -1,8 +1,7 @@
 keyspace: cdc_test
 
 keyspace_definition: |
-
-  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 2, 'us-eastscylla_node_east': 3}  AND durable_writes = true;
+  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}  AND durable_writes = true;
 
 table: test_table_preimage
 

--- a/data_dir/cdc_profile_multidc_preimage_postimage.yaml
+++ b/data_dir/cdc_profile_multidc_preimage_postimage.yaml
@@ -1,8 +1,7 @@
 keyspace: cdc_test
 
 keyspace_definition: |
-
-  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 3, 'us-eastscylla_node_east': 2}  AND durable_writes = true;
+  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}  AND durable_writes = true;
 
 table: test_table_preimage_postimage
 

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -127,10 +127,10 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
         prepare_write_cmd = self.params.get('prepare_write_cmd')
         keyspace_num = self.params.get('keyspace_num')
 
-        self.pre_create_alternator_tables()
+        # self.pre_create_alternator_tables()
 
-        self.run_pre_create_keyspace()
-        self.run_pre_create_schema()
+        # self.run_pre_create_keyspace()
+        # self.run_pre_create_schema()
 
         if scan_operation_params := self._get_scan_operation_params():
             for scan_param in scan_operation_params:

--- a/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml
@@ -1,4 +1,4 @@
-test_duration: 500
+test_duration: 600
 
 stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=480m -mode cql3 native -rate threads=75",
               "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc_preimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=480m -mode cql3 native -rate threads=75",


### PR DESCRIPTION
experimenta-feature flag RAFT was renamed to consistent-topology-changes

rename and enable experimental consistent-topology-changes feature

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
