### PR TITLE
fix(Argus reporting): fix ussue #6370

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1701,7 +1701,7 @@ def create_argus_test_run():
             job_url=get_job_url(),
             started_by=get_username(),
             commit_id=get_git_commit_id(),
-            sct_config=params,
+            sct_config=None,
         )
         LOGGER.info("Initialized Argus TestRun with test id %s", get_test_config().argus_client().run_id)
     except ArgusClientError:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -389,26 +389,14 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def init_argus_run(self):
         try:
             self.test_config.init_argus_client(self.params)
-            try:
-                status = self.test_config.argus_client().get_status()
-                is_argus_run_exists = True
-                message = f"test_id {self.test_config.test_id()} already exists in Argus with status: {status}"
-            except ArgusClientError as exc:
-                if exc.args[1] == 'DoesNotExist':
-                    message = f"test_id {self.test_config.test_id()} does not exist in Argus"
-                    is_argus_run_exists = False
-                else:
-                    raise
-            self.log.info(message)
-            if not is_argus_run_exists:
-                self.test_config.argus_client().submit_sct_run(
-                    job_name=get_job_name(),
-                    job_url=get_job_url(),
-                    started_by=get_username(),
-                    commit_id=get_git_commit_id(),
-                    sct_config=self.params,
-                )
-                self.log.info("Initialized Argus TestRun with test id %s", self.test_config.argus_client().run_id)
+            self.test_config.argus_client().submit_sct_run(
+                job_name=get_job_name(),
+                job_url=get_job_url(),
+                started_by=get_username(),
+                commit_id=get_git_commit_id(),
+                sct_config=self.params,
+            )
+            self.log.info("Submitted Argus TestRun with test id %s", self.test_config.argus_client().run_id)
             self.test_config.argus_client().set_sct_runner(
                 public_ip=get_sct_runner_ip(),
                 private_ip=get_my_ip(),


### PR DESCRIPTION
now create-argus-test-run creates
a test stub with only Jenkins DATA
test DATA will be populated by SCTtest itself

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
