### PR TITLE
improvement(BaseNode): move wait_node_fully_start

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3110,6 +3110,13 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             token_ring_members.append({"host_id": member.get("value"), "ip_address": member.get("key")})
         return token_ring_members
 
+    def wait_node_fully_start(self, verbose=True, timeout=3600):
+        self.log.info('Waiting scylla services to start after node reboot')
+        self.wait_db_up(verbose=verbose, timeout=timeout)
+        self.log.info('Waiting JMX services to start after node reboot')
+        self.wait_jmx_up(verbose=verbose, timeout=timeout)
+        self.parent_cluster.wait_for_nodes_up_and_normal(nodes=[self])
+
 
 class FlakyRetryPolicy(RetryPolicy):
 


### PR DESCRIPTION
Accroding to task: https://github.com/scylladb/qa-tasks/issues/1146 
Move the wait_node_fully_start method to BaseNode in cluster.py
Fix the refferences for this method in nemesis.py

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
