### PR TITLE
fix(gemini): use newer stable enough gemini version v1.8.6

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -114,7 +114,7 @@ authenticator_password: ''
 # gemini defaults
 n_test_oracle_db_nodes: 1
 gemini_seed: 0
-oracle_scylla_version: '2021.1.15'
+oracle_scylla_version: '2021.1.21'
 append_scylla_args_oracle: '--enable-cache false'
 
 # cassandra-stress defaults
@@ -206,7 +206,7 @@ stress_image:
   nosqlbench: 'scylladb/hydra-loaders:nosqlbench-4.15.49'
   cassandra-stress: '' # default would be same version as scylla under test
   scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.18'
-  gemini: 'scylladb/hydra-loaders:gemini-1.7.8'
+  gemini: 'scylladb/hydra-loaders:gemini-v1.8.6'
   alternator-dns: 'scylladb/hydra-loaders:alternator-dns-0.1'
   cdc-stresser: 'scylladb/hydra-loaders:cdc-stresser-20210630'
   kcl: 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC'

--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -74,7 +74,7 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
     @property
     def gemini_result_file(self):
         if not self._gemini_result_file:
-            self._gemini_result_file = os.path.join("/gemini", "gemini_result_{}.log".format(uuid.uuid4()))
+            self._gemini_result_file = os.path.join("/", "gemini_result_{}.log".format(uuid.uuid4()))
         return self._gemini_result_file
 
     def _generate_gemini_command(self):
@@ -85,7 +85,7 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
         test_nodes = ",".join(self.test_cluster.get_node_cql_ips())
         oracle_nodes = ",".join(self.oracle_cluster.get_node_cql_ips()) if self.oracle_cluster else None
 
-        cmd = "{} --test-cluster={} --outfile {} --seed {} --request-timeout {}s --connect-timeout {}s ".format(
+        cmd = "./{} --test-cluster={} --outfile {} --seed {} --request-timeout {}s --connect-timeout {}s ".format(
             self.stress_cmd.strip(),
             test_nodes,
             self.gemini_result_file,
@@ -106,7 +106,8 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
             cpu_options = f'--cpuset-cpus="{cpu_idx}"'
 
         docker = cleanup_context = RemoteDocker(loader, self.docker_image_name,
-                                                extra_docker_opts=f'{cpu_options} --label shell_marker={self.shell_marker} --network=host')
+                                                extra_docker_opts=f'{cpu_options} --label shell_marker={self.shell_marker}'
+                                                                  f' --network=host --entrypoint=""')
 
         if not os.path.exists(loader.logdir):
             os.makedirs(loader.logdir, exist_ok=True)

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -454,10 +454,10 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertEqual(conf.get('ami_id_db_oracle'), ami_2021_1_15)
 
     def test_16_oracle_scylla_version_us_east_1(self):
-        ami_4_6_3 = "ami-09c658571b2d46d18"
+        ami_2021_1_21 = "ami-07a24cfab7424e96c"
 
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_ORACLE_SCYLLA_VERSION'] = "4.6.3"
+        os.environ['SCT_ORACLE_SCYLLA_VERSION'] = "2021.1.21"
         os.environ['SCT_REGION_NAME'] = 'us-east-1'
         os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-eae4f795'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
@@ -466,7 +466,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 
-        self.assertEqual(conf.get('ami_id_db_oracle'), ami_4_6_3)
+        self.assertEqual(conf.get('ami_id_db_oracle'), ami_2021_1_21)
 
     @pytest.mark.integration
     def test_16_oracle_scylla_version_eu_west_1(self):
@@ -681,7 +681,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                          {'alternator-dns': 'scylladb/hydra-loaders:alternator-dns-0.1',
                           'cassandra-stress': 'scylla-bench',
                           'cdc-stresser': 'scylladb/hydra-loaders:cdc-stresser-A',
-                          'gemini': 'scylladb/hydra-loaders:gemini-1.7.8',
+                          'gemini': 'scylladb/hydra-loaders:gemini-v1.8.6',
                           'ndbench': 'scylladb/hydra-loaders:ndbench-jdk8-A',
                           'nosqlbench': 'scylladb/hydra-loaders:nosqlbench-A',
                           'scylla-bench': 'scylladb/something',
@@ -689,7 +689,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                           'kcl': 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC',
                           'harry': 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816'})
 
-        self.assertEqual(conf.get('stress_image.gemini'), 'scylladb/hydra-loaders:gemini-1.7.8')
+        self.assertEqual(conf.get('stress_image.gemini'), 'scylladb/hydra-loaders:gemini-v1.8.6')
         self.assertEqual(conf.get('stress_image.non-exist'), None)
 
         self.assertEqual(conf.get('stress_read_cmd'), ['cassandra_stress', 'cassandra_stress'])


### PR DESCRIPTION
Currently used gemini `1.7.8` is too old for now and started failing with the most recent docker version on the ubuntu.

So, switch to more recent stable enough gemini version which is used in the current SCT master branch - `v1.8.6`.

Also, update the oracle version to the latest `patch` version.

Fixes: #6457

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] ~~I didn't leave commented-out/debugging code~~
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
