### PR TITLE
fix(upgrades): replace `sstabledump` with `scylla sstable dump-data`

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -697,7 +697,9 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         InfoEvent(message='Starting sstabledump to verify correctness of sstables').publish()
         self.db_cluster.nodes[0].remoter.run(
             'for i in `sudo find /var/lib/scylla/data/keyspace_complex/ -type f |grep -v manifest.json |'
-            'grep -v snapshots |head -n 1`; do echo $i; sudo sstabledump $i 1>/tmp/sstabledump.output || '
+            'grep -v snapshots |head -n 1`; do echo $i; '
+            f'sudo {self.db_cluster.nodes[0].add_install_prefix("/usr/bin/scylla")} sstable dump-data '
+            f'--sstables $i 1>/tmp/sstabledump.output || '
             'exit 1; done', verbose=True)
 
         InfoEvent(message='Step8 - Run stress and verify after upgrading entire cluster').publish()


### PR DESCRIPTION
cause of new sstable uuid identifer feature the old `sstabledump` can't currently work with those sstables

Ref: https://github.com/scylladb/scylla-tools-java/issues/333

### Testing

- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/rolling-upgrade-azure-image-test/2/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
