### PR TITLE
test(fips): added a 4h 100gb longevity with fips enabled + artifact fixes

### DIFF
--- a/configurations/local-ear.yaml
+++ b/configurations/local-ear.yaml
@@ -1,2 +1,8 @@
-
 scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'LocalFileSystemKeyProviderFactory', 'secret_key_file': '/etc/scylla/encrypt_conf/secret_key'}"
+pre_create_schema: true
+append_scylla_yaml: |
+  system_key_directory: /etc/encrypt_conf/
+  system_info_encryption:
+      enabled: True  # system_info_encryption
+      key_provider: LocalFileSystemKeyProviderFactory  # system_info_encryption
+      secret_key_file: '/etc/scylla/encrypt_conf/system_info_encryption_keyfile'

--- a/configurations/longevity-fips-and-encryptions.yaml
+++ b/configurations/longevity-fips-and-encryptions.yaml
@@ -1,0 +1,9 @@
+ami_id_db_scylla: 'ubuntu-pro-fips-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-fips-server-20221121-7bc828d1-c072-4d33-a989-fbad50380cfb'
+scylla_linux_distro: 'ubuntu-focal'
+use_preinstalled_scylla: false
+ami_db_scylla_user: 'ubuntu'
+client_encrypt: true
+server_encrypt: true
+internode_encryption: 'all'
+user_prefix: 'longevity-fips'
+test_duration: 400

--- a/jenkins-pipelines/longevity-100gb-4h-fips.jenkinsfile
+++ b/jenkins-pipelines/longevity-100gb-4h-fips.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+// This scenario can only be triggered with a scylla repo, not an ami
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/longevity-fips-and-encryptions.yaml", "configurations/local-ear.yaml"]'''
+)

--- a/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
@@ -27,12 +27,3 @@ authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
 
 pre_create_schema: True
-scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'LocalFileSystemKeyProviderFactory', 'secret_key_file': '/etc/scylla/encrypt_conf/secret_key'}"
-
-# enable system_info_encryption, config kmip_hosts
-append_scylla_yaml: |
-  system_key_directory: /etc/encrypt_conf/
-  system_info_encryption:
-      enabled: True  # system_info_encryption
-      key_provider: LocalFileSystemKeyProviderFactory  # system_info_encryption
-      secret_key_file: '/etc/scylla/encrypt_conf/system_info_encryption_keyfile'


### PR DESCRIPTION
FIPS are a set of standards for encryption algorithms (among others). To verify that Scylla complies with all fips completely, I created this scenario which enables every kind of encryption scylla supports, while FIPS is enabled

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
