### PR TITLE
fix(longevity 200k-pk): Increase loader type to e2-standard-4

### DIFF
--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -61,6 +61,7 @@ round_robin: true
 
 instance_type_db: 'i3en.3xlarge'
 gce_instance_type_db: 'n2-highmem-16'
+gce_instance_type_loader: 'e2-standard-4'
 gce_n_local_ssd_disk_db: 24
 
 nemesis_class_name: 'SisyphusMonkey'


### PR DESCRIPTION
	The 200k-pk run with loader e2-standard-2 experienced an OOM.
	It might be resolved using a stronger instance.
	Refs: https://github.com/scylladb/scylla-bench/issues/127

Refs: https://github.com/scylladb/scylla-bench/issues/127
[argus](https://argus.scylladb.com/test/917e825f-11f9-4493-acdb-ec5266a3af78/runs?additionalRuns[]=5cd89f45-07f3-4865-8f4a-34c4071e2bdd)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
