### PR TITLE
fix(azure get_scylla_images): reverse the list order

### DIFF
--- a/sdcm/provision/azure/utils.py
+++ b/sdcm/provision/azure/utils.py
@@ -90,7 +90,7 @@ def get_scylla_images(  # pylint: disable=too-many-branches,too-many-locals
 
     if only_latest:
         return output[-1:]
-    return output
+    return output[::-1]
 
 
 IMAGE_URL_REGEX = re.compile(

--- a/unit_tests/provisioner/test_azure_get_scylla_images.py
+++ b/unit_tests/provisioner/test_azure_get_scylla_images.py
@@ -36,7 +36,7 @@ def test_can_get_scylla_images_based_on_branch(azure_service):
 
 def test_can_get_scylla_images_based_on_scylla_version(azure_service):
     images = get_scylla_images("4.6.4", "eastus", azure_service=azure_service)
-    assert images[0].name == "ScyllaDB-4.6.4-0.20220516.11f008e8f-1-build-27"
+    assert images[0].name == "ScyllaDB-4.6.4-0.20220718.b60f14601-1-build-28"
     assert len(images) == 2
 
 


### PR DESCRIPTION
right now, the images we find for Azure are ordered by their creation time, so, we need to reverse this list's order to be able to use the "1st" image in
the list to have the newest image in use, when the list has more than 1 item.
same thing we have for all other cloud providers.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
