### PR TITLE
fix(nemesis): remove SimpleStatement from delete_by_range_using_timestamp

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2264,7 +2264,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.log.debug("Using USING TIMESTAMP clause in the deletion for this partition: %s", pkey)
             timestamp, clustering_key = self.get_random_timestamp_from_partition(
                 ks_cf=ks_cf, pkey=pkey, partition_percentage=partition_percentage)
-            queries.append(SimpleStatement(f"delete from {ks_cf} using timestamp {timestamp} where pk = {pkey}"))
+            queries.append(f"delete from {ks_cf} using timestamp {timestamp} where pk = {pkey}")
             verification_queries.append([pkey, clustering_key, timestamp])
 
         self.run_deletions(queries=queries, ks_cf=ks_cf)


### PR DESCRIPTION
Commit https://github.com/scylladb/scylla-cluster-tests/pull/6450/commits/ bd9acd9ecb600c72ead5a9e181238ccf1aed7f6c presented common solution for all delete_by_range nemeses - run delete query with CL=QUORUM by using 'SimpleStatement'. 
I missed that 'SimpleStatement' is already used in 'delete_by_range_using_timestamp'. So now it causes to query failure:
```
Executing CQL '<SimpleStatement query=<SimpleStatement query=delete from scylla_bench.test using timestamp 1691403471151446 where pk = 122, 
consistency=Not Set>, consistency=QUORUM>' ...
Error querying host 10.0.3.12:9042 
TypeError: object of type 'SimpleStatement' has no len()
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
