### PR TITLE
fix(nodetool_cleanup): remove retries from cleanup

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1276,7 +1276,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 for node in self.cluster.nodes:
                     with adaptive_timeout(Operations.CLEANUP, node=node, timeout=HOUR_IN_SEC * 48):
                         for keyspace in test_keyspaces:
-                            node.run_nodetool(sub_cmd='cleanup', args=keyspace)
+                            node.run_nodetool(sub_cmd='cleanup', args=keyspace, retry=0)
             finally:
                 self.unset_current_running_nemesis(new_node)
         return new_node
@@ -1866,7 +1866,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         def _nodetool_cleanup(node):
             InfoEvent('NodetoolCleanupMonkey %s' % node).publish()
             with adaptive_timeout(Operations.CLEANUP, node, timeout=HOUR_IN_SEC * 48):
-                node.run_nodetool(sub_cmd="cleanup")
+                node.run_nodetool(sub_cmd="cleanup", retry=0)
 
         parallel_objects = ParallelObject(self.cluster.nodes, num_workers=min(
             32, len(self.cluster.nodes)), timeout=HOUR_IN_SEC * 48)
@@ -3397,7 +3397,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 for node in self.cluster.nodes:
                     with adaptive_timeout(Operations.CLEANUP, node, timeout=HOUR_IN_SEC * 48):
                         for keyspace in test_keyspaces:
-                            node.run_nodetool(sub_cmd='cleanup', args=keyspace)
+                            node.run_nodetool(sub_cmd='cleanup', args=keyspace, retry=0)
             finally:
                 self.unset_current_running_nemesis(new_node)
 


### PR DESCRIPTION
There is no point of retries on this command, since once it started the reties would fail with the following:

```
failed: std::runtime_error (cleanup request failed:
  there is an ongoing cleanup on keyspace1.standard1)
```

Ref: https://github.com/scylladb/scylladb/issues/14004

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
