### PR TITLE
improvement(create_test_release_jobs_enterprise): create folder for FIPS

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1456,7 +1456,8 @@ def create_test_release_jobs_enterprise(branch, username, password, sct_branch, 
         ('ICS', '*ics*', 'ICS'),
         ('Workload_Prioritization', 'features-sla-*', 'Workload Prioritization'),
         ('LDAP', '*ldap*', 'LDAP authorization and authentication tests'),
-        ('LDAP', '*saslauthd*', 'LDAP authorization and authentication tests')
+        ('LDAP', '*saslauthd*', 'LDAP authorization and authentication tests'),
+        ('FIPS', '*fips*', 'FIPS Encryption tests'),
     ]:
         current_dir = f'SCT_Enterprise_Features/{group_name}'
         server.create_directory(name=current_dir, display_name=group_desc)


### PR DESCRIPTION
Since FIPS support is an enterprise feature, its jenkins jobs should only be created under an enterprise release. So I added a new directory and filter in create_test_release_jobs_enterprise, so the FIPS jobs will be created under its own directory under SCT_Enterprise_Features in jenkins.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
