### PR TITLE
fix(k8s): update scylla manager for k8s tests

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -125,8 +125,8 @@ SCYLLA_AGENT_CONFIG_NAME = "scylla-agent-config"
 K8S_LOCAL_VOLUME_PROVISIONER_VERSION = "0.1.0-rc.0"  # without 'v' prefix
 # NOTE: these values are taken from the default values of the "scylla-manager" helm chart.
 #       Needs to be defined separately to be able to reuse for image caching running on local K8S
-SCYLLA_VERSION_IN_SCYLLA_MANAGER = "4.3.0"
-SCYLLA_MANAGER_AGENT_VERSION_IN_SCYLLA_MANAGER = "2.2.1"
+SCYLLA_VERSION_IN_SCYLLA_MANAGER = "5.2.6"
+SCYLLA_MANAGER_AGENT_VERSION_IN_SCYLLA_MANAGER = "3.1.1"
 
 # NOTE: add custom annotations to a ServiceAccount used by a ScyllaCluster
 #       It is needed to make sure that annotations survive operator upgrades


### PR DESCRIPTION
Recently we bumped to issue with startup failure of scylla-manager due housekeeping service hang. We found we use `4.6.0` for it.

Let's bump Manager's Scylla version along with Manager to test latest versions.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
