### PR TITLE
fix(wait_for_view_to_be_built): ignore some errors in parallel nemesis

### DIFF
--- a/sdcm/utils/nemesis_utils/indexes.py
+++ b/sdcm/utils/nemesis_utils/indexes.py
@@ -14,6 +14,7 @@
 import logging
 import random
 import time
+from contextlib import nullcontext
 
 from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
 
@@ -76,15 +77,20 @@ def wait_for_index_to_be_built(node: BaseNode, ks, index_name, timeout=300) -> N
 def wait_for_view_to_be_built(node: BaseNode, ks, view_name, timeout=300) -> None:
     LOGGER.info('waiting for view/index %s to be built', view_name)
     start_time = time.time()
-    while time.time() - start_time < timeout:
-        result = node.run_nodetool(f"viewbuildstatus {ks}.{view_name}",
-                                   ignore_status=True, verbose=False, publish_event=False)
-        if f"{ks}.{view_name}_index has finished building" in result.stdout:
-            InfoEvent(message=f"Index {ks}.{view_name} was built").publish()
-        if f"{ks}.{view_name} has finished building" in result.stdout:
-            InfoEvent(message=f"View/index {ks}.{view_name} was built").publish()
-            return
-        time.sleep(30)
+    with (EventsFilter(  # ignore apply view errors when multiple nemesis are running scylladb/scylla-cluster-tests#6469
+            event_class=DatabaseLogEvent.DATABASE_ERROR,
+            regex=".*view - Error applying view update to.*",
+            extra_time_to_expiration=180,
+    ) if node.parent_cluster.nemesis_count > 1 else nullcontext()):
+        while time.time() - start_time < timeout:
+            result = node.run_nodetool(f"viewbuildstatus {ks}.{view_name}",
+                                       ignore_status=True, verbose=False, publish_event=False)
+            if f"{ks}.{view_name}_index has finished building" in result.stdout:
+                InfoEvent(message=f"Index {ks}.{view_name} was built").publish()
+            if f"{ks}.{view_name} has finished building" in result.stdout:
+                InfoEvent(message=f"View/index {ks}.{view_name} was built").publish()
+                return
+            time.sleep(30)
     raise TimeoutError(f"Timeout error while creating view/index {view_name}. "
                        f"stdout\n: {result.stdout}\n"
                        f"stderr\n: {result.stderr}")


### PR DESCRIPTION
In case test uses parallel nemesis, in case one node is down during create index/view, db throws errors like `Error applying view update`. We want to ignore such errors.

Added EventsFilter during wait for index/view to be built in situations we use parallel nemesis.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/6469

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
