### PR TITLE
feature(KMS): add KMS key rotation on test level

### DIFF
--- a/configurations/kms-ear.yaml
+++ b/configurations/kms-ear.yaml
@@ -1,11 +1,2 @@
-
-scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'KmsKeyProviderFactory', 'kms_host': 'kms_test'}"
-
-# config kms_hosts for AWS KMS service account
-append_scylla_yaml: |
-  kms_hosts:
-      kms_test:
-          master_key: 'alias/kms_encryption_test'
-          aws_region: 'us-east-1'
-
+scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'KmsKeyProviderFactory', 'kms_host': 'auto'}"
 append_scylla_args: '--logger-log-level kms=trace'

--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -35,3 +35,5 @@ data_volume_disk_num: 0
 data_volume_disk_type: 'gp2'
 data_volume_disk_size: 500
 data_volume_disk_iops: 10000 # depend on type iops could be 100-16000 for io2|io3 and 3000-16000 for gp3
+
+kms_key_rotation_interval: 60

--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -101,6 +101,7 @@ TestFrameworkEvent: CRITICAL
 SoftTimeoutEvent: ERROR
 ElasticsearchEvent: ERROR
 SpotTerminationEvent: CRITICAL
+AwsKmsEvent: ERROR
 ScyllaRepoEvent: WARNING
 InfoEvent: ERROR
 ThreadFailedEvent: ERROR

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1229,6 +1229,10 @@ class SCTConfiguration(dict):
         dict(name="scylla_encryption_options", env="SCT_SCYLLA_ENCRYPTION_OPTIONS", type=str_or_list,
              help="options will be used for enable encryption at-rest for tables"),
 
+        dict(name="kms_key_rotation_interval", env="SCT_KMS_KEY_ROTATION_INTERVAL", type=int,
+             help="The time interval in minutes which gets waited before the KMS key rotation happens."
+                  " Applied when the AWS KMS service is configured to be used."),
+
         dict(name="logs_transport", env="SCT_LOGS_TRANSPORT", type=str,
              help="How to transport logs: rsyslog, ssh or docker", choices=("rsyslog", "ssh", "docker", "syslog-ng")),
 

--- a/sdcm/sct_events/system.py
+++ b/sdcm/sct_events/system.py
@@ -195,6 +195,10 @@ class ThreadFailedEvent(InformationalEvent):
         return super().msgfmt + ": message={0.message}\n{0.traceback}"
 
 
+class AwsKmsEvent(ThreadFailedEvent):
+    ...
+
+
 class CoreDumpEvent(InformationalEvent):
     # pylint: disable=too-many-arguments
     def __init__(self,


### PR DESCRIPTION
With this change it becomes possible to enable KMS key rotation and dynamic alias creation for a test.
To do it just use `auto` as a value for the `kms_host` key in the value of the `scylla_encryption_options` config option. 
Example:

```
  scylla_encryption_options: "{ \
    'cipher_algorithm': 'AES/ECB/PKCS5Padding', \
    'secret_key_strength' : 128, \
    'key_provider': 'KmsKeyProviderFactory', \
    'kms_host': 'auto'}"
```

Also, there is no need to specify the `kms_hosts` info in the `append_scylla_yaml` config option as it was before. 
It is allowed and will work if some specific KMS key must be used, but rotation will not be done in this case.
The rotation is done only for the dynamically/automatically created KMS key alias.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
