### PR TITLE
fix(DBOraclePlanBuilder): use valid config parameter

### DIFF
--- a/sdcm/sct_provision/aws/instance_parameters_builder.py
+++ b/sdcm/sct_provision/aws/instance_parameters_builder.py
@@ -171,7 +171,7 @@ class ScyllaInstanceParamsBuilder(AWSInstanceParamsBuilder):
 
 
 class OracleScyllaInstanceParamsBuilder(ScyllaInstanceParamsBuilder):
-    _INSTANCE_TYPE_PARAM_NAME = 'instance_type_db'
+    _INSTANCE_TYPE_PARAM_NAME = 'instance_type_db_oracle'
     _IMAGE_ID_PARAM_NAME = 'ami_id_db_oracle'
     _ROOT_DISK_SIZE_PARAM_NAME = 'root_disk_size_db'
 


### PR DESCRIPTION
OracleScyllaInstanceParamsBuilder use wrong name of parameter instance type:
_INSTANCE_TYPE_PARAM_NAME = 'instance_type_db' instead of _INSTANCE_TYPE_PARAM_NAME = 'instance_type_db_oracle'

These is was also a reason why gemini could failed on different tests, because oracle node has too slow instance

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
