### PR TITLE
fix(longevity): extend root_disk_size_runner to 120 for 1tb-5days

### DIFF
--- a/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
@@ -24,6 +24,7 @@ instance_type_db: 'i4i.4xlarge'
 gce_instance_type_db: 'n2-highmem-16'
 gce_n_local_ssd_disk_db: 16
 azure_instance_type_db: 'Standard_L16s_v3'
+root_disk_size_runner: 120
 
 instance_type_loader: 'c5.4xlarge'
 gce_instance_type_loader: 'c2-standard-16'


### PR DESCRIPTION
This commit changes the default disk size for sct runner to 120 GB in longevity-1TB-5days because we run out of space on the sct runner

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
