### PR TITLE
improvement(k8s-eks): use `k8s_log_api_calls` option to enable API logs

### DIFF
--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -309,7 +309,7 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):  # pylint: disable=
                             'controllerManager',
                             'scheduler'
                         ],
-                        'enabled': True
+                        'enabled': self.params.get("k8s_log_api_calls"),
                     },
                 ]
             },


### PR DESCRIPTION
API K8S EKS logs are billable.
So, enable it only when configured to be so using the `k8s_log_api_calls` config option.
When enabled, the logs can be viewed on the AWS website like following:

https://eu-north-1.console.aws.amazon.com/cloudwatch/home?region=eu-north-1#logsV2:log-groups

It is stored endlessly by default, the retention is not set. 
So, no need to gather it ourselves. Just use web console when logging gets enabled.

Closes: #3859

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
