### PR TITLE
fix(cassandra-stress): remove nodes with running nemesis as coordinators

### DIFF
--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -146,7 +146,7 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
                     LOGGER.error("Not found datacenter for loader region '%s'. Datacenter per loader dict: %s",
                                  loader.region, datacenter_name_per_region)
 
-            node_ip_list = [n.cql_ip_address for n in self.node_list]
+            node_ip_list = [n.cql_ip_address for n in self.node_list if not n.running_nemesis]
             stress_cmd += ",".join(node_ip_list)
         if 'skip-unsupported-columns' in self._get_available_suboptions(cmd_runner, '-errors'):
             stress_cmd = self._add_errors_option(stress_cmd, ['skip-unsupported-columns'])


### PR DESCRIPTION
In the case where nemesis_during_prepare is enabled, or in multi-nemesis scenarios, some nodes can be down when we start a stress thread, which will cuase the stress to be DOA. To avoid that, I filtered out any node that has an active nemesis running

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
