### PR TITLE
fix(nemesis): change chunk size to 128KB

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2442,7 +2442,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         algo = random.choice(algos)
         prop_val = {"sstable_compression": algo}
         if algo:
-            prop_val["chunk_length_kb"] = random.choice(["4K", "64KB", "1M"])
+            prop_val["chunk_length_kb"] = random.choice(["4K", "64KB", "128KB"])
             prop_val["crc_check_chance"] = random.random()
         self._modify_table_property(name="compression", val=str(prop_val))
 


### PR DESCRIPTION
According to task: https://github.com/scylladb/qa-tasks/issues/1400 
This commit changes the "chunk_length_kb" random choice to 128KB instead of 1MB as it is capped to 128KB according to 
https://github.com/scylladb/scylladb/commit/8a9de08510a5e9161daad0292c41d9aabbfe995d

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
