### PR TITLE
improvement(kms): add one more variation of the KMS nemesis

### DIFF
--- a/data_dir/nemesis.yml
+++ b/data_dir/nemesis.yml
@@ -56,7 +56,10 @@
 - disrupt_drain_kubernetes_node_then_replace_scylla_node:
   - disruptive = True
   - kubernetes = True
-- disrupt_enable_disable_table_encryption_aws_kms_provider:
+- disrupt_enable_disable_table_encryption_aws_kms_provider_with_rotation:
+  - disruptive = True
+  - kubernetes = False
+- disrupt_enable_disable_table_encryption_aws_kms_provider_without_rotation:
   - disruptive = True
   - kubernetes = False
 - disrupt_grow_shrink_cluster:

--- a/data_dir/nemesis_classes.yml
+++ b/data_dir/nemesis_classes.yml
@@ -20,7 +20,8 @@
 - DrainKubernetesNodeThenDecommissionAndAddScyllaNode
 - DrainKubernetesNodeThenReplaceScyllaNode
 - DrainerMonkey
-- EnableDisableTableEncryptionAwsKmsProviderMonkey
+- EnableDisableTableEncryptionAwsKmsProviderWithRotationMonkey
+- EnableDisableTableEncryptionAwsKmsProviderWithoutRotationMonkey
 - EnospcAllNodesMonkey
 - EnospcMonkey
 - GrowShrinkClusterNemesis

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3856,20 +3856,24 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     # TODO: add support for the 'LocalFileSystemKeyProviderFactory' and 'KmipKeyProviderFactory' key providers
     # TODO: add encryption for a table with large partitions?
 
-    def disrupt_enable_disable_table_encryption_aws_kms_provider(self):
-        if self.cluster.params.get("cluster_backend") != "aws":
-            raise UnsupportedNemesis("This nemesis is supported only on the AWS cluster backend")
-        if not self.cluster.nodes[0].is_enterprise:
-            raise UnsupportedNemesis("KMS+EaR feature is only supported by Scylla Enterprise")
-        self._enable_disable_table_encryption(additional_scylla_encryption_options={
-            'key_provider': 'KmsKeyProviderFactory'})
+    def disrupt_enable_disable_table_encryption_aws_kms_provider_without_rotation(self):
+        self._enable_disable_table_encryption(
+            enable_kms_key_rotation=False,
+            additional_scylla_encryption_options={'key_provider': 'KmsKeyProviderFactory'})
+
+    def disrupt_enable_disable_table_encryption_aws_kms_provider_with_rotation(self):
+        self._enable_disable_table_encryption(
+            enable_kms_key_rotation=True,
+            additional_scylla_encryption_options={'key_provider': 'KmsKeyProviderFactory'})
 
     @scylla_versions(("2023.2.0-dev", None))
-    def _enable_disable_table_encryption(self, additional_scylla_encryption_options=None):
+    def _enable_disable_table_encryption(self, enable_kms_key_rotation, additional_scylla_encryption_options=None):
+        if self.cluster.params.get("cluster_backend") != "aws":
+            raise UnsupportedNemesis("This nemesis is supported only on the AWS cluster backend")
+
         scylla_encryption_options = {'cipher_algorithm': 'AES/ECB/PKCS5Padding', 'secret_key_strength': 128}
         scylla_encryption_options |= additional_scylla_encryption_options or {}
         aws_kms, kms_key_alias_name = None, None
-        enable_kms_key_rotation = False
 
         # Handle AWS KMS specific parts
         if additional_scylla_encryption_options and additional_scylla_encryption_options.get(
@@ -5053,12 +5057,35 @@ class StopStartMonkey(Nemesis):
         self.disrupt_stop_start_scylla_server()
 
 
-class EnableDisableTableEncryptionAwsKmsProviderMonkey(Nemesis):
+class EnableDisableTableEncryptionAwsKmsProviderWithRotationMonkey(Nemesis):
     disruptive = True
     kubernetes = False  # Enable it when EKS SCT code starts supporting the KMS service
 
     def disrupt(self):
-        self.disrupt_enable_disable_table_encryption_aws_kms_provider()
+        self.disrupt_enable_disable_table_encryption_aws_kms_provider_with_rotation()
+
+
+class EnableDisableTableEncryptionAwsKmsProviderWithoutRotationMonkey(Nemesis):
+    disruptive = True
+    kubernetes = False  # Enable it when EKS SCT code starts supporting the KMS service
+
+    def disrupt(self):
+        self.disrupt_enable_disable_table_encryption_aws_kms_provider_without_rotation()
+
+
+class EnableDisableTableEncryptionAwsKmsProviderMonkey(Nemesis):
+    disruptive = True
+    kubernetes = False  # Enable it when EKS SCT code starts supporting the KMS service
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.disrupt_methods_list = [
+            'disrupt_enable_disable_table_encryption_aws_kms_provider_without_rotation',
+            'disrupt_enable_disable_table_encryption_aws_kms_provider_with_rotation',
+        ]
+
+    def disrupt(self):
+        self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list, predefined_sequence=True)
 
 
 # Disabling this nemesis due to mulitple known issues like (https://github.com/scylladb/scylla/issues/5080).

--- a/unit_tests/test_nemesis_sisyphus.py
+++ b/unit_tests/test_nemesis_sisyphus.py
@@ -71,7 +71,7 @@ def test_list_all_available_nemesis(generate_file=True):
     disruption_list, disruptions_dict, disruption_classes = sisyphus.get_list_of_disrupt_methods(
         subclasses_list=subclasses, export_properties=True)
 
-    assert len(disruption_list) == 81
+    assert len(disruption_list) == 82
 
     if generate_file:
         with open('data_dir/nemesis.yml', 'w', encoding="utf-8") as outfile1:


### PR DESCRIPTION
Before we had only one variation - without KMS key rotation.
So, add one more - with KMS key rotation.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
