### PR TITLE
fix(install-hydra.sh): fix help function to a real command

### DIFF
--- a/install-hydra.sh
+++ b/install-hydra.sh
@@ -24,8 +24,8 @@ if ! aws --version; then
 fi
 echo "AWS CLI installed."
 echo "==================================     NOTES      ================================================="
-echo "To check that Hydra is installed, run 'hydra ls' anywhere in bash."
-echo "It will run 'ls' command in the SCT Docker container."
+echo "To check that Hydra is installed, run 'hydra bash' anywhere in bash."
+echo "It will create a SCT Docker container and connect to its bash."
 echo "When running Hydra for the first time it will build the SCT Docker image. Please be patient!"
 echo "==================================================================================================="
 echo "Please run 'aws configure' to configure AWS CLI"


### PR DESCRIPTION
right now, bash script's command describes a command that doesn't exist, leading newcomers to this mistake and making them to give up in using it.

Fixes: #4781

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
