### PR TITLE
fix(oel artifacts): OEL doesn't support i4i instances

### DIFF
--- a/test-cases/artifacts/oel76.yaml
+++ b/test-cases/artifacts/oel76.yaml
@@ -3,7 +3,7 @@ ami_id_db_scylla: 'ami-0d6a24fe35fdf5dc4'
 root_disk_size_db: 50
 backtrace_decoding: false
 cluster_backend: 'aws'
-instance_type_db: 'i4i.large'
+instance_type_db: 'i3.large'
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
 logs_transport: 'ssh'

--- a/test-cases/artifacts/oel81.yaml
+++ b/test-cases/artifacts/oel81.yaml
@@ -3,7 +3,7 @@ ami_id_db_scylla: 'ami-0e883e67243efea62'
 root_disk_size_db: 50
 backtrace_decoding: false
 cluster_backend: 'aws'
-instance_type_db: 'i4i.large'
+instance_type_db: 'i3.large'
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
 logs_transport: 'ssh'


### PR DESCRIPTION
since #6354, all `i3` instances were deprecated
and `i4i` were put in use instead.
It started generating a problem, as OEL apparently doesn't yet support it, so reverting the change
for both OEL versions we currently support,
and we shall revert this PR, once OEL will add
support to `i4i` instances.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
