### PR TITLE
refactor(manager upgrade): set base version to 3.1

### DIFF
--- a/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.0',
+    manager_version: '3.1',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: 'test-cases/upgrades/manager-upgrade.yaml',

--- a/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.0',
+    manager_version: '3.1',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/debian10.yaml"]''',

--- a/jenkins-pipelines/manager/debian11-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian11-manager-upgrade.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.0',
+    manager_version: '3.1',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/debian11.yaml"]''',

--- a/jenkins-pipelines/manager/older-enterprise-ami-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/older-enterprise-ami-manager-upgrade.jenkinsfile
@@ -11,7 +11,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.0',
+    manager_version: '3.1',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: 'test-cases/upgrades/manager-upgrade.yaml',

--- a/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.0',
+    manager_version: '3.1',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu20.yaml"]''',

--- a/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.0',
+    manager_version: '3.1',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu22.yaml"]''',


### PR DESCRIPTION
Since manager 3.1 is now the latest released manager version, the manager upgrade test should start from it

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
