### PR TITLE
fix(longevity-1tb): Move read stress under stress_cmd

### DIFF
--- a/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
@@ -6,11 +6,8 @@ prepare_write_cmd: ["cassandra-stress write cl=QUORUM n=275050075 -schema 'repli
 
 stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=6800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=100 -pop seq=1..550100150  -log interval=5 -col 'size=FIXED(200) n=FIXED(5)'",
              "cassandra-stress mixed cl=QUORUM duration=6800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=100 -pop seq=550100151..1100200300  -log interval=5 -col 'size=FIXED(200) n=FIXED(5)'",
-             "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=6800m -mode cql3 native -rate threads=10"]
-
-
-stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=6800m -mode cql3 native  -rate threads=10 -pop seq=1..1100200300  -log interval=5 -col 'size=FIXED(200) n=FIXED(5)'" ]
-
+             "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=6800m -mode cql3 native -rate threads=10",
+             "cassandra-stress read cl=QUORUM duration=6800m -mode cql3 native  -rate threads=10 -pop seq=1..1100200300  -log interval=5 -col 'size=FIXED(200) n=FIXED(5)'" ]
 
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "random", "interval": 120}']
 round_robin: true


### PR DESCRIPTION
The read stress was under stress_read_cmd which doesn't work with round_robin and there isn't any reason to use this parameter here.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
