### PR TITLE
fix(gemini-ics): Increase loader and db instance types

### DIFF
--- a/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
@@ -3,7 +3,8 @@ n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 n_monitor_nodes: 1
-instance_type_db: 'i3.large'
+instance_type_db: 'i3.2xlarge'
+instance_type_loader: 'c5.4xlarge'
 
 user_prefix: 'ics-cdc-gemini-basic-3h'
 ami_db_scylla_user: 'centos'
@@ -14,10 +15,10 @@ nemesis_interval: 5
 # gemini
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -m mixed -f
 # the below cmd runs about 3 hours
-gemini_cmd: "gemini -d --duration 3h --warmup 30m -c 50 -m mixed -f --non-interactive \
+gemini_cmd: "gemini -d --duration 3h --warmup 30m -c 20 -m mixed -f --non-interactive \
 --cql-features normal --table-options \"compaction={'class': 'IncrementalCompactionStrategy'}\" \
---max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
---async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \
+--max-mutation-retries 25 --max-mutation-retries-backoff 10s \
+--async-objects-stabilization-attempts 25 --async-objects-stabilization-backoff 10s \
 --replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" \
 --oracle-replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '1'}\" "
 
@@ -30,5 +31,5 @@ gemini_table_options:
 stress_cdclog_reader_cmd: "cdc-stressor -duration 215m -stream-query-round-duration 30s"
 
 db_type: mixed_scylla
-instance_type_db_oracle: 'i3.8xlarge'
+instance_type_db_oracle: 'i3.16xlarge'
 oracle_scylla_version: "2021.1.15"

--- a/test-cases/gemini/gemini-basic-3h-ics.yaml
+++ b/test-cases/gemini/gemini-basic-3h-ics.yaml
@@ -3,7 +3,8 @@ n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 n_monitor_nodes: 1
-instance_type_db: 'i3.large'
+instance_type_db: 'i3.4xlarge'
+instance_type_loader: 'c5.2xlarge'
 
 user_prefix: 'ics-gemini-basic-3h'
 ami_db_scylla_user: 'centos'
@@ -11,14 +12,17 @@ ami_db_scylla_user: 'centos'
 # gemini
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -m mixed -f
 # the below cmd runs about 3 hours
-gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 50 -m mixed -f --non-interactive \
+gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 25 -m mixed -f --non-interactive \
 --cql-features normal --table-options \"compaction={'class': 'IncrementalCompactionStrategy'}\" \
---max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
---async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms "
+--max-mutation-retries 25 --max-mutation-retries-backoff 10s \
+--async-objects-stabilization-attempts 25 --async-objects-stabilization-backoff 5s \
+--replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" \
+--oracle-replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '1'}\""
+
 
 
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
 db_type: mixed_scylla
-instance_type_db_oracle: 'i3.8xlarge'
+instance_type_db_oracle: 'i3.16xlarge'
 oracle_scylla_version: "2021.1.15"


### PR DESCRIPTION
Gemini could generate very complex schemas and this could lead that OOM on loader and not enough resouces on db nodes.

Increase instance types to avoid unpredictable failures

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
