### PR TITLE
fix(debian installation): GPG key for openjdk remove

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1992,9 +1992,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                     apt-get update
                     apt-get install apt-transport-https -y
                     apt-get install gnupg1-curl dirmngr -y
-                    curl https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
                     apt-get install software-properties-common -y
-                    add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
                 """)
                 self.remoter.run('sudo bash -cxe "%s"' % install_debian_10_prereqs)
 


### PR DESCRIPTION
we had a recent issue with `gpg: no valid OpenPGP data found.`.
while investigating this issue, we started thinkin why
it was added at the first place, and since now, we deliver
the jdk we need within our builds, this "workaround"
is not necessary anymore.



ran [here](https://jenkins.scylladb.com/job/scylla-staging/job/fabio/job/debian_no_gpg_key/job/upgrade-debian11/2/) to confirm it works
example of failures are [this manager job](https://jenkins.scylladb.com/job/manager-3.2/job/debian10-sanity-test/1/) and [this 2023.1 job](https://jenkins.scylladb.com/job/enterprise-2023.1/job/upgrade-with-raft/job/rolling-upgrade-debian11-with-raft-test/7/) among others

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
