### PR TITLE
fix(k8s): make nemesis handling logic be stable in multitenant setups

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4967,7 +4967,9 @@ def disrupt_method_wrapper(method, is_exclusive=False):  # pylint: disable=too-m
                     time.sleep(args[0].interval)
                 NEMESIS_LOCK.release()
             else:
-                NEMESIS_RUN_INFO.pop(nemesis_run_info_key)
+                # NOTE: the key may be absent if a nemesis which waits for a lock release
+                #       gets killed/aborted. So, use safe 'pop' call with the default 'None' value.
+                NEMESIS_RUN_INFO.pop(nemesis_run_info_key, None)
 
         return result
 


### PR DESCRIPTION
Closes: #6490

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
