### PR TITLE
fix(k8s): skip empty rack deletion test and nemesis for broken versions

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -394,6 +394,10 @@ def test_orphaned_services_after_shrink_cluster(db_cluster):
     assert not get_orphaned_services(db_cluster), "Orphaned services were found after decommission"
 
 
+# NOTE: version limitation is caused by the following:
+#       - https://github.com/scylladb/scylla-enterprise/issues/3211
+#       - https://github.com/scylladb/scylladb/issues/14184
+@pytest.mark.requires_scylla_versions(("5.2.7", None), ("2023.1.1", None))
 def test_orphaned_services_multi_rack(db_cluster):
     """ Issue https://github.com/scylladb/scylla-operator/issues/514 """
     log.info("Add node to the rack 1")

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3796,6 +3796,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._grow_cluster(rack=None)
         self._shrink_cluster(rack=None)
 
+    # NOTE: version limitation is caused by the following:
+    #       - https://github.com/scylladb/scylla-enterprise/issues/3211
+    #       - https://github.com/scylladb/scylladb/issues/14184
+    @scylla_versions(("5.2.7", None), ("2023.1.1", None))
     def disrupt_grow_shrink_new_rack(self):
         if not self._is_it_on_kubernetes():
             raise UnsupportedNemesis("Adding new rack is not supported for non-k8s Scylla clusters")


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
