### PR TITLE
fix(test_repair_multiple_keyspace_types): removed system_traces

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -847,7 +847,7 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         self.log.info('Task: {} is done.'.format(repair_task.id))
         self.log.debug("sctool version is : {}".format(manager_tool.sctool.version))
 
-        expected_keyspaces_to_be_repaired = ["system_auth", "system_distributed", "system_traces",  # pylint: disable=invalid-name
+        expected_keyspaces_to_be_repaired = ["system_auth", "system_distributed",  # pylint: disable=invalid-name
                                              self.NETWORKSTRATEGY_KEYSPACE_NAME]
         per_keyspace_progress = repair_task.per_keyspace_progress
         self.log.info("Looking in the repair output for all of the required keyspaces")


### PR DESCRIPTION
as of 3.2, system_traces is no longer included in the default manager repair (i.e., unless it's specifically specified)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
