### PR TITLE
Manager 3.2 - no longer initialize a repair after a restore task

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -198,9 +198,6 @@ class BackupFunctionsMixIn(LoaderUtilsMixin):
                           f'Restore run time: {restore_task.duration}.').publish()
         if restore_schema:
             self.db_cluster.restart_scylla()  # After schema restoration, you should restart the nodes
-        if restore_data:
-            for node in self.db_cluster.nodes:
-                node.run_nodetool("repair")  # After data restoration, you should repair every node
 
     def run_verification_read_stress(self):
         stress_queue = []

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -28,6 +28,7 @@ import re
 import time
 import traceback
 import json
+from distutils.version import LooseVersion
 
 from typing import Any, List, Optional, Type, Tuple, Callable, Dict, Set, Union, Iterable
 from functools import wraps, partial
@@ -2728,10 +2729,12 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         restore_task.wait_and_get_final_status(step=30, timeout=chosen_snapshot_info["expected_timeout"])
         assert restore_task.status == TaskStatus.DONE, f'Data restoration of {chosen_snapshot_tag} has failed!'
 
-        mgr_task = mgr_cluster.create_repair_task()
-        task_final_status = mgr_task.wait_and_get_final_status(timeout=chosen_snapshot_info["expected_timeout"])
-        assert task_final_status == TaskStatus.DONE, 'Task: {} final status is: {}.'.format(
-            mgr_task.id, str(mgr_task.status))
+        manager_version = mgr_cluster.sctool.parsed_client_version
+        if manager_version < LooseVersion("3.2"):
+            mgr_task = mgr_cluster.create_repair_task()
+            task_final_status = mgr_task.wait_and_get_final_status(timeout=chosen_snapshot_info["expected_timeout"])
+            assert task_final_status == TaskStatus.DONE, 'Task: {} final status is: {}.'.format(
+                mgr_task.id, str(mgr_task.status))
 
         confirmation_stress_template = persistent_manager_snapshots_dict[cluster_backend]["confirmation_stress_template"]
         stress_queue = execute_data_validation_thread(command_template=confirmation_stress_template,


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
