### PR TITLE
fix(k8s): skip 'nodetool_enospc' nemesis as broken

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1596,7 +1596,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def _k8s_fake_enospc_error(self, node):
         """Fakes ENOSPC error for scylla container (for /var/lib/scylla dir) using chaos-mesh without filling up disk."""
-        if not self._is_chaos_mesh_initialized():
+        raise UnsupportedNemesis("https://github.com/scylladb/scylla-cluster-tests/issues/6327")
+        if not self._is_chaos_mesh_initialized():  # pylint: disable=unreachable
             raise UnsupportedNemesis(
                 "Chaos Mesh is not installed. Set 'k8s_use_chaos_mesh' config option to 'true'")
         no_space_errors_in_log = node.follow_system_log(patterns=['No space left on device'])


### PR DESCRIPTION
The 'nodetool_enospc' nemesis fails all the time on K8S [1]. So, skip it until the the bug gets fixed.

[1] https://github.com/scylladb/scylla-cluster-tests/issues/6327

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
