### PR TITLE
test(perf_simple_query): x86_64 job

### DIFF
--- a/jenkins-pipelines/perf-simple-query-x86.jenkinsfile
+++ b/jenkins-pipelines/perf-simple-query-x86.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'microbenchmarking_test.PerfSimpleQueryTest.test_perf_simple_query',
-    test_config: 'test-cases/microbenchmarking/amazon_perf_simple_query_ARM.yaml',
+    test_config: """[ 'test-cases/microbenchmarking/amazon_perf_simple_query_ARM.yaml', 'test-cases/microbenchmarking/amazon_perf_simple_query_x86.yaml' ]""",
     email_recipients: "scylla-perf-results@scylladb.com"
 )

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2018,8 +2018,8 @@ class SCTConfiguration(dict):
 
         self._verify_data_volume_configuration(backend)
 
-        self._validate_seeds_number()
         if self.get('n_db_nodes'):
+            self._validate_seeds_number()
             self._validate_nemesis_can_run_on_non_seed()
             self._validate_number_of_db_nodes_divides_by_az_number()
 

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -27,7 +27,7 @@ from sdcm.test_config import TestConfig
 from sdcm.keystore import KeyStore
 
 LOGGER = logging.getLogger(__name__)
-ARM_ARCH_PREFIXES = ('im4', 'is4', 'a1.', 'inf', 'm6', 'c6', 'r6', 'm7', 'c7', 'r7')
+ARM_ARCH_PREFIXES = ('im4', 'is4', 'a1.', 'inf', 'm6', 'c6g', 'r6', 'm7', 'c7g', 'r7')
 AwsArchType = Literal['x86_64', 'arm64']
 
 

--- a/test-cases/microbenchmarking/amazon_perf_simple_query_ARM.yaml
+++ b/test-cases/microbenchmarking/amazon_perf_simple_query_ARM.yaml
@@ -9,7 +9,7 @@ use_mgmt: false
 
 instance_type_db: 'c7g.large'
 data_volume_disk_num: 1
-user_prefix: 'perf-microbenchmarking-amazon'
+user_prefix: 'perf-microbenchmarking-amazon-ARM'
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
 

--- a/test-cases/microbenchmarking/amazon_perf_simple_query_x86.yaml
+++ b/test-cases/microbenchmarking/amazon_perf_simple_query_x86.yaml
@@ -1,0 +1,2 @@
+instance_type_db: 'c6i.large'
+user_prefix: 'perf-microbenchmarking-amazon-x86'


### PR DESCRIPTION
Run perf_simple_query on  x86_64

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
