### PR TITLE
fix(upgrade): Make Scylla upgrade checks work when using 'rc' versions

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -1140,7 +1140,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         def _is_cluster_upgraded() -> bool:
             for node in self.db_cluster.nodes:
                 node.forget_scylla_version()
-                if node.scylla_version != target_version or not node.db_up:
+                if node.scylla_version.replace("~", "-") != target_version.replace("~", "-") or not node.db_up:
                     return False
             return True
         wait.wait_for(


### PR DESCRIPTION
When we use `rc` version like `2023.1.0-rc8` then the Scylla upgrade test fails to match the new Scylla version with the target one. The diff is that the version taken from the Scylla binary has `~` symbol when the target one uses `-`.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
