### PR TITLE
feature(test-cases): Add test cases for low and asymmetric loads

### DIFF
--- a/configurations/rf1-non-disruptive.yaml
+++ b/configurations/rf1-non-disruptive.yaml
@@ -1,0 +1,11 @@
+test_duration: 400
+prepare_write_cmd:
+  - "cassandra-stress write cl=ONE n=200200300  -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1)' -mode cql3 native -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..200200300 -log interval=15"
+
+stress_cmd:
+  - "cassandra-stress write cl=ONE duration=240m  -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1)' -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=400200300..600200300 -log interval=15"
+run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 5}']
+
+nemesis_class_name: 'NonDisruptiveMonkey'
+nemesis_seed: '24325345'
+user_prefix: 'longevity-200gb-48h-rf1'

--- a/jenkins-pipelines/longevity-200gb-48h-asymmetric.jenkinsfile
+++ b/jenkins-pipelines/longevity-200gb-48h-asymmetric.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: """["test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml", "configurations/db-nodes-shards-random.yaml"]""",
+
+)

--- a/jenkins-pipelines/longevity-200gb-48h-rf1.jenkinsfile
+++ b/jenkins-pipelines/longevity-200gb-48h-rf1.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: """["test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml", "configurations/rf1-non-disruptive.yaml"]""",
+    instance_provision_fallback_on_demand: true
+)

--- a/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -1,10 +1,15 @@
 test_duration: 3100
-prepare_write_cmd: "cassandra-stress write cl=ALL n=200200300  -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..200200300 -log interval=15"
+prepare_write_cmd:
+  - "cassandra-stress write cl=ALL n=200200300  -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..200200300 -log interval=15"
+  - "cassandra-stress write cl=ALL n=500 -schema 'keyspace=lowload1 replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=1 -col 'size=FIXED(50) n=FIXED(1)' -pop seq=1..500 -log interval=15"
 # prepare_verify_cmd: "cassandra-stress read cl=ALL n=200200300  -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=2000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..200200300 -log interval=15"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=2860m  -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=400200300..600200300 -log interval=15"]
-stress_read_cmd: ["cassandra-stress read cl=ONE duration=2860m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..200200300 -log interval=5"]
-run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 5}']
+stress_cmd:
+  - "cassandra-stress write cl=QUORUM duration=2860m  -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=400200300..600200300 -log interval=15"
+  - "cassandra-stress read cl=ONE duration=2860m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..200200300 -log interval=5"
+  - "cassandra-stress read cl=ONE duration=2860m -schema 'keyspace=lowload1 replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=1  -col 'size=FIXED(50) n=FIXED(1)' -pop seq=1..500 -log interval=5"
+run_fullscan:
+  - '{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 5}'
 n_db_nodes: 4
 n_loaders: 1
 n_monitor_nodes: 1


### PR DESCRIPTION
This change adds new configurations for 200gb-48 longevities and one
low load 4 hour longevity, intended to simulate a low load happening
during repair processes, to cover potential overhead like in
scylladb/scylladb#14093.

Task: scylladb/qa-tasks#1416

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
