### PR TITLE
fix(provision): fix fallback to next availability zone

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1210,7 +1210,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         def _get_all_zones_common_params() -> list[dict]:
             all_zones_common_params = []
             aws_region = AwsRegion(region_name=regions[0])
-            availability_zones = [zone[-1] for zone in aws_region.availability_zones]
+            availability_zones = [zone[-1] for zone in
+                                  aws_region.get_availability_zones_for_instance_type(self.params.get('instance_type_db'))]
             for zone in availability_zones:
                 all_zones_common_params.append(
                     get_common_params(params=self.params, regions=regions, credentials=self.credentials,

--- a/sdcm/utils/aws_region.py
+++ b/sdcm/utils/aws_region.py
@@ -13,7 +13,7 @@
 
 import logging
 from ipaddress import ip_network
-from functools import cached_property
+from functools import cached_property, cache
 
 import boto3
 import botocore
@@ -79,6 +79,21 @@ class AwsRegion:
     def availability_zones(self):
         response = self.client.describe_availability_zones()
         return [zone["ZoneName"]for zone in response['AvailabilityZones'] if zone["State"] == "available"]
+
+    @cache
+    def get_availability_zones_for_instance_type(self, instance_type):
+        response = self.client.describe_instance_type_offerings(
+            LocationType='availability-zone',
+            Filters=[
+                {
+                    'Name': 'instance-type',
+                    'Values': [
+                        instance_type,
+                    ]
+                },
+            ]
+        )
+        return [offering['Location'] for offering in response['InstanceTypeOfferings']]
 
     @cached_property
     def vpc_ipv6_cidr(self):


### PR DESCRIPTION
When using instance type that is not available in all availability zones for given region, provision may fail. This is because we try provision in az's starting from first az. When first az does not support given instance type it fails with error `Spot request cannot be fulfilled due to invalid availability zone.`

Fix is by filtering az's that support provided instance type.

fixes: #6495 
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
