### PR TITLE
fix(azure base version): add new supported version

### DIFF
--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -49,10 +49,7 @@ class TestBaseVersion(unittest.TestCase):
         linux_distro = 'ubuntu-jammy'
         cloud_provider = 'azure'
         version_list = general_test(scylla_repo, linux_distro, cloud_provider)
-        # TODO: add 2023.1 to the list below:
-        # once 2023.1 will be released, it will appear in the list below, but as it is not only on an RC,
-        # it was filtered out during `self.filter_rc_only_version(ent_base_version)`
-        self.assertEqual(version_list, ['5.2'])
+        self.assertEqual(version_list, ['5.2', '2023.1'])
 
     def test_4_5_with_centos8(self):
         scylla_repo = self.url_base + '/branch-4.5/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'


### PR DESCRIPTION
since 2023.1 was recently released, and Azure
initial support is 5.2 AND 2023.1, unit tests
started to fail, as we received as a valid base
version also 2023.1.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
