### PR TITLE
fix(upgrade): not fail on truncated entries timeouts

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -21,6 +21,7 @@ import logging
 import random
 import time
 import re
+import traceback
 
 from collections import OrderedDict
 from uuid import UUID
@@ -30,7 +31,10 @@ from cassandra.util import sortedset, SortedSet  # pylint: disable=no-name-in-mo
 from cassandra import ConsistencyLevel
 from cassandra.protocol import ProtocolException  # pylint: disable=no-name-in-module
 
+from sdcm.sct_events import Severity
+from sdcm.sct_events.system import InfoEvent
 from sdcm.tester import ClusterTester
+from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations
 from sdcm.utils.decorators import retrying
 from sdcm.utils.cdc.options import CDC_LOGTABLE_SUFFIX
 from sdcm.utils.version_utils import ComparableScyllaVersion
@@ -3042,19 +3046,26 @@ class FillDatabaseData(ClusterTester):
             # Added sleep after each created table
             time.sleep(15)
 
-    @staticmethod
-    def cql_insert_data_to_simple_tables(session, rows):  # pylint: disable=invalid-name
+    def cql_insert_data_to_simple_tables(self, session, rows):  # pylint: disable=invalid-name
         def insert_query():
-            return f'INSERT INTO truncate_table{i} (my_id, col1, value) VALUES ( {k}, {k}, {k})'
-        for i in range(rows):  # pylint: disable=unused-variable
-            for k in range(100):  # pylint: disable=unused-variable
-                session.execute(insert_query())
+            with adaptive_timeout(Operations.QUERY, node=self.db_cluster.nodes[0], timeout=60, query="INSERT"):
+                session.execute(
+                    f'INSERT INTO truncate_table{i} (my_id, col1, value) VALUES ( {k}, {k}, {k})', timeout=120)
 
-    @staticmethod
-    def cql_truncate_simple_tables(session, rows):
+        for i in range(rows):
+            for k in range(100):
+                # Catch the exception as we do not want to stop the test on this failure
+                try:
+                    insert_query()
+                except Exception as details:  # pylint: disable=broad-except
+                    InfoEvent(message=f"Failed insert data to simple tables. Error: {str(details)}. Traceback: {traceback.format_exc()}",
+                              severity=Severity.ERROR).publish()
+
+    def cql_truncate_simple_tables(self, session, rows):
         truncate_query = 'TRUNCATE TABLE truncate_table%d'
         for i in range(rows):
-            session.execute(truncate_query % i)
+            with adaptive_timeout(Operations.QUERY, node=self.db_cluster.nodes[0], timeout=60, query="TRUNCATE"):
+                session.execute(truncate_query % i, timeout=300)
 
     def fill_db_data_for_truncate_test(self, insert_rows):
         # Prepare connection and keyspace

--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -32,6 +32,13 @@ def _get_soft_timeout(node_info_service: NodeLoadInfoService, timeout: int | flo
         return timeout, {}
 
 
+def _get_query_timeout(node_info_service: NodeLoadInfoService, timeout: int | float = None, query: str = None) -> \
+        tuple[int | float, dict[str, Any]]:
+    timeout, stats = _get_soft_timeout(node_info_service=node_info_service, timeout=timeout)
+    stats["query"] = query
+    return timeout, stats
+
+
 class Operations(Enum):
     """Available operations for adaptive timeouts. Each operation maps to a function to calculate timeout based on node load info.
 
@@ -48,6 +55,7 @@ class Operations(Enum):
     SCRUB = ("scrub", _get_soft_timeout, ("timeout",))
     SOFT_TIMEOUT = ("soft_timeout", _get_soft_timeout, ("timeout",))
     FLUSH = ("flush", _get_soft_timeout, ("timeout",))
+    QUERY = ("query", _get_query_timeout, ("timeout", "query"))
 
 
 @contextmanager

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -25,12 +25,14 @@ from functools import wraps, cache
 from typing import List
 
 from argus.client.sct.types import Package
+from cassandra import ConsistencyLevel
 
 from sdcm import wait
 from sdcm.cluster import BaseNode
 from sdcm.fill_db_data import FillDatabaseData
 from sdcm.sct_events import Severity
 from sdcm.stress_thread import CassandraStressThread
+from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations
 from sdcm.utils.version_utils import get_node_supported_sstable_versions
 from sdcm.sct_events.system import InfoEvent
 from sdcm.sct_events.database import IndexSpecialColumnErrorEvent
@@ -48,6 +50,7 @@ def truncate_entries(func):
     def inner(self, *args, **kwargs):
         node = args[0]
         with self.db_cluster.cql_connection_patient(node, keyspace='truncate_ks') as session:
+            session.default_consistency_level = ConsistencyLevel.QUORUM
             InfoEvent(message="Start truncate simple tables").publish()
             try:
                 self.cql_truncate_simple_tables(session=session, rows=NUMBER_OF_ROWS_FOR_TRUNCATE_TEST)
@@ -61,6 +64,7 @@ def truncate_entries(func):
 
         # re-new connection
         with self.db_cluster.cql_connection_patient(node, keyspace='truncate_ks') as session:
+            session.default_consistency_level = ConsistencyLevel.QUORUM
             self.validate_truncated_entries_for_table(session=session, system_truncated=True)
             self.read_data_from_truncated_tables(session=session)
             self.cql_insert_data_to_simple_tables(session=session, rows=NUMBER_OF_ROWS_FOR_TRUNCATE_TEST)
@@ -127,7 +131,8 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         for table_name in tables_name:
             InfoEvent(message="Start read data from truncated tables").publish()
             try:
-                count = self.rows_to_list(session.execute(truncate_query.format(table_name)))
+                with adaptive_timeout(Operations.QUERY, node=self.db_cluster.nodes[0], timeout=60, query="SELECT"):
+                    count = self.rows_to_list(session.execute(truncate_query.format(table_name), timeout=120))
                 self.assertEqual(str(count[0][0]), '0',
                                  msg='Expected that there is no data in the table truncate_ks.{}, but found {} rows'
                                  .format(table_name, count[0][0]))


### PR DESCRIPTION
Read from truncated table fails with timeout (60sec) from time to time in case of mixed cluster (one node upgraded from OSS to 2023.1).
Add 'adaptive_timeout' to insert into and  read from truncated tables to be able to check how long time the query runs.
Also add try .. catch for insert into truncate tables to prevent test stop on timeout.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
