### PR TITLE
fix(DecommissionStreamingErr): Increase timeout waiting for log patterns

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3706,9 +3706,14 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             disrupt_func_kwargs={"target_node": self.target_node, "hard": True, "verify_ssh": True},
             delay=0
         )
-        timeout = 1200
-        if self.cluster.params.get('cluster_backend') == 'azure':
-            timeout += 1200  # Azure reboot can take up to 20min to initiate
+
+        if terminate_pattern in ["became a group 0 non-voter", "leaving token ring", "left token ring",
+                                 "Finished token ring movement"]:
+            timeout = MAX_TIME_WAIT_FOR_DECOMMISSION
+        else:
+            timeout = 1200
+            if self.cluster.params.get('cluster_backend') == 'azure':
+                timeout += 1200  # Azure reboot can take up to 20min to initiate
 
         with contextlib.ExitStack() as stack:
             for expected_start_failed_context in self.target_node.raft.get_severity_change_filters_scylla_start_failed(timeout):


### PR DESCRIPTION
        Following a nodetool decommission command, SCT waits for a log message like:
        `became a group 0 non-voter` before issuing a reboot.
        This pattern and some other, may only occur after the decommission RBNO finished.
        Thus, the next nemesis step of 'reboot' may take up to decommission-timeout to initialize.
        
        Fixes: scylladb/scylladb#6522 

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/6522
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
