### PR TITLE
fix(k8s): make the LWT-24h job have correct configuration of disks

### DIFF
--- a/configurations/operator/lwt-basic-24h.yaml
+++ b/configurations/operator/lwt-basic-24h.yaml
@@ -3,3 +3,6 @@ nemesis_selector: ['kubernetes']
 
 n_db_nodes: 5
 k8s_n_scylla_pods_per_cluster: 4
+
+k8s_scylla_disk_gi: 1730
+k8s_minio_storage_size: '1900Gi'


### PR DESCRIPTION
The 'longevity-scylla-operator-lwt-24h' CI job was not run since we switched to the 'dynamic local volume provisioner'. And the latter one depends on the real size of the provided storage. So, fix the Scylla 'pv' requested size by setting really available storage on the currently used 'i4i.2xlarge' instance type. Also, increase the minio storage to be able to run 'mgmt' nemesis during the 24h.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
