### PR TITLE
revert(instance type): use i3 type for SLA longevity

### DIFF
--- a/test-cases/enterprise-features/workload-prioritization/longevity/longevity-sla-system-24h.yaml
+++ b/test-cases/enterprise-features/workload-prioritization/longevity/longevity-sla-system-24h.yaml
@@ -14,7 +14,7 @@ round_robin: true
 
 sla: true
 
-instance_type_db: 'i4i.2xlarge'
+instance_type_db: 'i3.2xlarge'
 instance_type_loader: 'c5.2xlarge'
 
 run_fullscan: ['{"mode": "random", "ks_cf": "keyspace1.standard1", "interval": 5}'] # 'ks.cf|random, interval(min)'

--- a/test-cases/longevity/longevity-sla-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-sla-100gb-4h.yaml
@@ -19,7 +19,7 @@ round_robin: true
 
 sla: true
 
-instance_type_db: 'i4i.2xlarge'
+instance_type_db: 'i3.2xlarge'
 instance_type_loader: 'c5.2xlarge'
 
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 5}']


### PR DESCRIPTION
DB instance type has been changed from i3 to i4i by https://github.com/scylladb/scylla-cluster-tests/pull/6354. 
It's because i3 family was depricated in scylla-cloud. 
It caused to load decreasing in SLA longevities. And it is a critical problem for those longevities as we need almost 100% load during the tests.
I revert this change for SLA longevities and open the task [#1455](https://github.com/scylladb/qa-tasks/issues/1455) to adjust the load for i4i DB instance type

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
