### PR TITLE
fix(K8sNetworkBlock): wait for recovery from disruption

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3203,6 +3203,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         experiment = NetworkPacketLossExperiment(self.target_node, duration, probability=100)
         experiment.start()
         experiment.wait_until_finished()
+        time.sleep(15)
         self._wait_all_nodes_un()
 
     def disrupt_network_block(self):


### PR DESCRIPTION
After finishing `NetworkPacketLossExperiment` SCT verifies if node returned to cluster straight away. This causes errors like: `nodetool: Failed to connect to '127.0.0.1:7199' - ConnectException: 'Connection refused (Connection refused)'.` for several seconds.

Fix is by giving node several seconds to recover from this disruption and return networking back to normal. This way we should avoid unnecessary nodetool failures.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
