### PR TITLE
improvement(sla tests): wait for a service level is propagated to nodes

### DIFF
--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -39,6 +39,15 @@ def _get_query_timeout(node_info_service: NodeLoadInfoService, timeout: int | fl
     return timeout, stats
 
 
+def _get_service_level_propagation_timeout(node_info_service: NodeLoadInfoService, timeout: int | float = None,
+                                           service_level_for_test_step: str = None) -> \
+        tuple[int | float, dict[str, Any]]:
+    """service_level_for_test_step will report in ES on which step of test the timeout happened"""
+    timeout, stats = _get_soft_timeout(node_info_service=node_info_service, timeout=timeout)
+    stats["service_level_for_test_step"] = service_level_for_test_step
+    return timeout, stats
+
+
 class Operations(Enum):
     """Available operations for adaptive timeouts. Each operation maps to a function to calculate timeout based on node load info.
 
@@ -56,6 +65,8 @@ class Operations(Enum):
     SOFT_TIMEOUT = ("soft_timeout", _get_soft_timeout, ("timeout",))
     FLUSH = ("flush", _get_soft_timeout, ("timeout",))
     QUERY = ("query", _get_query_timeout, ("timeout", "query"))
+    SERVICE_LEVEL_PROPAGATION = ("service_level_propagation", _get_service_level_propagation_timeout,
+                                 ("timeout", "service_level_for_test_step"))
 
 
 @contextmanager

--- a/sdcm/utils/adaptive_timeouts/load_info_store.py
+++ b/sdcm/utils/adaptive_timeouts/load_info_store.py
@@ -13,6 +13,7 @@
 import logging
 import time
 import uuid
+from collections import defaultdict
 from datetime import datetime
 from functools import cached_property
 import re
@@ -121,6 +122,26 @@ class NodeLoadInfoService:
     @cached_property
     def shards_count(self) -> int:
         return len([key for key in self._get_scylla_metrics() if key.startswith('scylla_lsa_free_space')])
+
+    def scylla_scheduler_shares(self) -> dict:
+        """
+        output example: {"sl:sl200": [200, 200], "sl:default": [1000, 1000]}
+        """
+        scheduler_regex = re.compile(r".*group=\"(?P<group>.*)\",shard=\"(?P<shard>\d+)")
+        scheduler_group_shares = defaultdict(list)
+        all_metrix = self._get_metrics(port=9180)
+        for key, value in all_metrix.items():
+            if key.startswith('scylla_scheduler_shares'):
+                try:
+                    match = scheduler_regex.match(key)
+                    try:
+                        scheduler_group_shares[match.groups()[0]].append(int(value.split(".")[0]))
+                    except ValueError as details:
+                        LOGGER.error("Failed to to convert value %s to integer. Error: %s", value, details)
+                except AttributeError as error:
+                    LOGGER.error("Failed to match metric: %s. Error: %s", key, error)
+
+        return scheduler_group_shares
 
     @cached_property
     def read_bandwidth_mb(self) -> float:

--- a/sdcm/utils/adaptive_timeouts/load_info_store.py
+++ b/sdcm/utils/adaptive_timeouts/load_info_store.py
@@ -123,17 +123,20 @@ class NodeLoadInfoService:
     def shards_count(self) -> int:
         return len([key for key in self._get_scylla_metrics() if key.startswith('scylla_lsa_free_space')])
 
+    @cached_property
+    def scheduler_regex(self) -> re.compile:
+        return re.compile(r".*group=\"(?P<group>.*)\",shard=\"(?P<shard>\d+)")
+
     def scylla_scheduler_shares(self) -> dict:
         """
         output example: {"sl:sl200": [200, 200], "sl:default": [1000, 1000]}
         """
-        scheduler_regex = re.compile(r".*group=\"(?P<group>.*)\",shard=\"(?P<shard>\d+)")
         scheduler_group_shares = defaultdict(list)
-        all_metrix = self._get_metrics(port=9180)
-        for key, value in all_metrix.items():
+        all_metrics = self._get_metrics(port=9180)
+        for key, value in all_metrics.items():
             if key.startswith('scylla_scheduler_shares'):
                 try:
-                    match = scheduler_regex.match(key)
+                    match = self.scheduler_regex.match(key)
                     try:
                         scheduler_group_shares[match.groups()[0]].append(int(value.split(".")[0]))
                     except ValueError as details:


### PR DESCRIPTION
Wait for scheduler group is created for a new service level on every node before start the load. Use 'scylla_scheduler_group_shares' prometheus metric for that. Now we wait about 15-30 sec. But if scheduler group was not created, the service level does not receive the resources and the nemesis is failed with 'no recources' error. But it wrong. Correct error - scheduler group  was not created on the node(s)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
