### PR TITLE
fix(k8s): make perf thrpt job be working

### DIFF
--- a/configurations/operator/perf-regression-throughput.yaml
+++ b/configurations/operator/perf-regression-throughput.yaml
@@ -1,0 +1,4 @@
+# NOTE: main configuration adds '--blocked-reactor-notify-ms' arg
+#       which gets set by the scylla-operator itself. So, redefine this config option
+#       by removing the duplication of the scylla arg which will make Scylla fail.
+append_scylla_args: ''

--- a/jenkins-pipelines/operator/performance/perf-regression-throughput-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/performance/perf-regression-throughput-eks.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "k8s-eks",
     region: 'us-east-1',
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: "test-cases/performance/perf-regression.100threads.30M-keys.yaml",
+    test_config: '''["test-cases/performance/perf-regression.100threads.30M-keys.yaml","configurations/operator/perf-regression-throughput.yaml"]''',
     sub_tests: ["test_write", "test_read", "test_mixed"],
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
     k8s_enable_performance_tuning: true,


### PR DESCRIPTION
Some time ago the `append_scylla_args` option was added to the general config we use for testing throughput on K8S:

```
  test-cases/performance/perf-regression.100threads.30M-keys.yaml
```

And it's values are not compatible with the scylla-operator. 
So, redefine that config option to make Scylla work with this config.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
