### PR TITLE
fix(k8s): allow to schedule scylla and scylla cleanup pods on same nodes

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -866,9 +866,10 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
         placement = add_pool_node_affinity({}, self.POOL_LABEL_NAME, pool_name) if pool_name else {}
         placement["podAntiAffinity"] = {"requiredDuringSchedulingIgnoredDuringExecution": [{
             "topologyKey": "kubernetes.io/hostname",
-            "labelSelector": {"matchExpressions": [{
-                "key": "scylla/cluster", "operator": "In", "values": [cluster_name],
-            }]}
+            "labelSelector": {"matchExpressions": [
+                {"key": "scylla/cluster", "operator": "In", "values": [cluster_name]},
+                {"key": "app.kubernetes.io/name", "operator": "In", "values": ["scylla"]},
+            ]}
         }]}
         placement["tolerations"] = [{
             "key": "role",


### PR DESCRIPTION
scylla-operator `1.10.0-rc.0` runs `cleanup` pods after cluster scale up operation.
And this kind of pods have the same label as scylla pods have -> `scylla/cluster=<scylla-cluster-name>`.
Our pod anti-affinity rules catch it thinking it is Scylla pods and block Scylla pods scheduling.
It is wrong.
So, fix it by updating the `pod anti-affinity` rules to detect exactly Scylla pods.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
