### PR TITLE
fix(k8s-eks): use latest haproxy ingress controller version

### DIFF
--- a/sdcm/k8s_configs/ingress-controller/10_haproxy-kubernetes-ingress.deploy.yaml
+++ b/sdcm/k8s_configs/ingress-controller/10_haproxy-kubernetes-ingress.deploy.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: haproxy-kubernetes-ingress
       containers:
       - name: haproxy-ingress
-        image: haproxytech/kubernetes-ingress:1.9.0
+        image: haproxytech/kubernetes-ingress:1.10.6
         args:
         - --configmap=haproxy-controller/haproxy-kubernetes-ingress
         - --default-backend-service=haproxy-controller/haproxy-kubernetes-ingress-default-backend


### PR DESCRIPTION
With the scylla-operator-1.10 we started getting HA problems [1] with the `haproxy` service.
So, fix it by using the latest available ingress controller version for haproxy.

[1] https://github.com/scylladb/scylla-operator/issues/1341

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
