### PR TITLE
fix(k8s): use latest 5.2 version -> 5.2.7

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -16,7 +16,7 @@ eks_nodegroup_role_arn: 'arn:aws:iam::797456418907:role/helm-test-worker-nodes-N
 # NOTE: https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
 eks_vpc_cni_version: 'v1.12.6-eksbuild.1'
 
-scylla_version: '5.2.1'
+scylla_version: '5.2.7'
 scylla_mgmt_agent_version: '3.1.0'
 k8s_cert_manager_version: '1.8.0'
 
@@ -67,4 +67,4 @@ backup_bucket_location: 'minio-bucket'
 #       It will allow to test 'serverless' feature against any stable Scylla release
 #       with old 'cassandra-stress' binary.
 stress_image:
-  cassandra-stress: 'scylladb/scylla:5.2.1'
+  cassandra-stress: 'scylladb/scylla:5.2.7'

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -18,7 +18,7 @@ k8s_n_auxiliary_nodes: 2
 
 k8s_instance_type_auxiliary: 'n1-standard-2'
 
-scylla_version: '5.2.1'
+scylla_version: '5.2.7'
 scylla_mgmt_agent_version: '3.1.0'
 mgmt_docker_image: 'scylladb/scylla-manager:3.1.0'
 
@@ -77,4 +77,4 @@ backup_bucket_location: 'minio-bucket'
 #       It will allow to test 'serverless' feature against any stable Scylla release
 #       with old 'cassandra-stress' binary.
 stress_image:
-  cassandra-stress: 'scylladb/scylla:5.2.1'
+  cassandra-stress: 'scylladb/scylla:5.2.7'

--- a/defaults/k8s_local_kind_config.yaml
+++ b/defaults/k8s_local_kind_config.yaml
@@ -4,7 +4,7 @@ mini_k8s_version: '0.17.0'
 n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
 
-scylla_version: '5.2.1'
+scylla_version: '5.2.7'
 scylla_mgmt_agent_version: '3.1.0'
 mgmt_docker_image: 'scylladb/scylla-manager:3.1.0'
 
@@ -51,4 +51,4 @@ backup_bucket_location: 'minio-bucket'
 #       It will allow to test 'serverless' feature against any stable Scylla release
 #       with old 'cassandra-stress' binary.
 stress_image:
-  cassandra-stress: 'scylladb/scylla:5.2.1'
+  cassandra-stress: 'scylladb/scylla:5.2.7'


### PR DESCRIPTION
Use scylla-5.2.7 as default Scylla version and for cassandra-stress load.
It includes the fix [1] for the empty rack removal from the ScyllaCluster K8S objects.

[1] https://github.com/scylladb/scylladb/pull/14893

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
