### PR TITLE
improvement(k8s): use dynamic loader run type for thrpt perf jobs

### DIFF
--- a/configurations/operator/perf-regression-throughput.yaml
+++ b/configurations/operator/perf-regression-throughput.yaml
@@ -1,3 +1,8 @@
+k8s_scylla_disk_gi: 1760
+k8s_loader_run_type: 'dynamic'
+# NOTE: HDR feature is not compatible with the way how dynamic loaders work
+use_hdr_cs_histogram: false
+
 # NOTE: main configuration adds '--blocked-reactor-notify-ms' arg
 #       which gets set by the scylla-operator itself. So, redefine this config option
 #       by removing the duplication of the scylla arg which will make Scylla fail.

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -8,10 +8,6 @@ stress_multiplier_w: 2
 stress_multiplier_r: 2
 stress_multiplier_m: 2
 
-# NOTE: following is needed for the K8S case
-k8s_loader_run_type: 'static'
-k8s_scylla_disk_gi: 1760
-
 n_db_nodes: 3
 n_loaders: 4
 n_monitor_nodes: 1


### PR DESCRIPTION
The static loader connections tend to hang making the perf jobs not provide results.
So, workaround loader stream hangings by using the dynamic loader run type where such problem doesn't exist.
Also, disable the `HDR` feature because it is not compatible with the way how dynamic loaders work.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
