### PR TITLE
fix(oracle version): use latest 2021.1 version

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -113,7 +113,7 @@ authenticator_password: ''
 gemini_version: '0.9.2'
 n_test_oracle_db_nodes: 1
 gemini_seed: 0
-oracle_scylla_version: '4.6.9'
+oracle_scylla_version: '2021.1.15'
 append_scylla_args_oracle: '--enable-cache false'
 
 # cassandra-stress defaults

--- a/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
@@ -31,5 +31,5 @@ stress_cdclog_reader_cmd: "cdc-stressor -duration 215m -stream-query-round-durat
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i3.8xlarge'
-oracle_scylla_version: "2020.1.7"
+oracle_scylla_version: '2021.1.15'
 append_scylla_args_oracle: '--enable-cache false'

--- a/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
@@ -23,5 +23,5 @@ gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i3.8xlarge'
-oracle_scylla_version: "2020.1.7"
+oracle_scylla_version: '2021.1.15'
 append_scylla_args_oracle: '--enable-cache false'

--- a/test-cases/gemini/gemini-basic-3h-ics.yaml
+++ b/test-cases/gemini/gemini-basic-3h-ics.yaml
@@ -21,5 +21,5 @@ gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i3.8xlarge'
-oracle_scylla_version: "2020.1.7"
+oracle_scylla_version: '2021.1.15'
 append_scylla_args_oracle: '--enable-cache false'

--- a/test-cases/gemini/gemini-basic-3h.yaml
+++ b/test-cases/gemini/gemini-basic-3h.yaml
@@ -22,5 +22,5 @@ gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i3.8xlarge'
-oracle_scylla_version: '4.3.3'
+oracle_scylla_version: '2021.1.15'
 append_scylla_args_oracle: '--enable-cache false'

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -500,7 +500,7 @@ class IntegrationTests(unittest.TestCase):
         'State': 'available', 'BlockDeviceMappings': [
             {'DeviceName': '/dev/sda1',
              'Ebs': {'DeleteOnTermination': True,
-                     'SnapshotId': 'snap-0a2df75621efaf18c',
+                     'SnapshotId': 'snap-0717a2bee0a38bc84',
                      'VolumeSize': 30,
                      'VolumeType': 'gp2',
                      'Encrypted': False}},
@@ -520,19 +520,19 @@ class IntegrationTests(unittest.TestCase):
              'VirtualName': 'ephemeral6'},
             {'DeviceName': '/dev/sdi',
              'VirtualName': 'ephemeral7'}],
-        'Description': 'ScyllaDB 4.6.9', 'EnaSupport': True, 'Hypervisor': 'xen',
-        'Name': 'ScyllaDB 4.6.9', 'RootDeviceName': '/dev/sda1', 'RootDeviceType': 'ebs',
+        'Description': 'ScyllaDB Enterprise 2021.1.15', 'EnaSupport': True, 'Hypervisor': 'xen',
+        'Name': 'ScyllaDB Enterprise 2021.1.15', 'RootDeviceName': '/dev/sda1', 'RootDeviceType': 'ebs',
         'Tags': [
-            {'Key': 'ScyllaMachineImageVersion', 'Value': '4.6.9-20221009.a36534e106b-1'},
-            {'Key': 'ScyllaPython3Version', 'Value': '4.6.9-0.20221009.18e7a4603-1'},
+            {'Key': 'ScyllaMachineImageVersion', 'Value': '2021.1.15-20221011.82741b636ba-1'},
+            {'Key': 'ScyllaPython3Version', 'Value': '2021.1.15-20221011.82741b636ba-1'},
             {'Key': 'user_data_format_version', 'Value': '2'},
-            {'Key': 'ScyllaToolsVersion', 'Value': '4.6.9-0.20221009.18e7a4603-1'},
-            {'Key': 'ScyllaJMXVersion', 'Value': '4.6.9-0.20221009.18e7a4603-1'},
-            {'Key': 'branch', 'Value': 'branch-4.6'},
-            {'Key': 'scylla-git-commit', 'Value': '18e7a46038379e566619197eb11c1f650bfec2be'},
-            {'Key': 'build-tag', 'Value': 'jenkins-scylla-4.6-ami-63'},
-            {'Key': 'ScyllaVersion', 'Value': '4.6.9-0.20221009.18e7a4603-1'},
-            {'Key': 'build-id', 'Value': '94'}
+            {'Key': 'ScyllaToolsVersion', 'Value': '2021.1.15-20221011.82741b636ba-1'},
+            {'Key': 'ScyllaJMXVersion', 'Value': '2021.1.15-20221011.82741b636ba-1'},
+            {'Key': 'branch', 'Value': 'branch-2021.1'},
+            {'Key': 'scylla-git-commit', 'Value': '3d8c23d0b20af12302608c6286ace0c3dc070828'},
+            {'Key': 'build-tag', 'Value': 'jenkins-enterprise-2021.1-promote-release-213'},
+            {'Key': 'ScyllaVersion', 'Value': '2021.1.15-20221011.82741b636ba-1'},
+            {'Key': 'build-id', 'Value': '213'}
         ], 'VirtualizationType': 'hvm'})
 
     @property


### PR DESCRIPTION
since the AMI for 4.6.9 no longer exists
backport of https://github.com/scylladb/scylla-cluster-tests/pull/6030

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
