### PR TITLE
feature(sct): add support for using dns names in cluster

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -228,4 +228,6 @@ run_fullscan: []
 stress_step_duration: '15m'
 simulated_racks: 0
 
+use_dns_names: false
+
 use_placement_group: false

--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -819,8 +819,8 @@ def test_operator_managed_tls(db_cluster: ScyllaPodCluster, tmp_path: path.Path)
     db_cluster.nodes[0].refresh_ip_address()
 
     execution_profile = ExecutionProfile(load_balancing_policy=WhiteListRoundRobinPolicy([
-                                         db_cluster.nodes[0].cql_ip_address]))
-    cluster = Cluster(contact_points=[db_cluster.nodes[0].cql_ip_address], port=db_cluster.nodes[0].CQL_SSL_PORT,
+                                         db_cluster.nodes[0].cql_address]))
+    cluster = Cluster(contact_points=[db_cluster.nodes[0].cql_address], port=db_cluster.nodes[0].CQL_SSL_PORT,
                       execution_profiles={EXEC_PROFILE_DEFAULT: execution_profile})
     ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_SSLv23)
     ssl_context.verify_mode = ssl.VerifyMode.CERT_REQUIRED  # pylint: disable=no-member

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -311,7 +311,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
 
     @property
     def all_node_ips_for_stress_command(self):
-        return f' -node {",".join([n.cql_ip_address for n in self.db_cluster.nodes])}'
+        return f' -node {",".join([n.cql_address for n in self.db_cluster.nodes])}'
 
     @staticmethod
     def _get_columns_num_of_single_stress(single_stress_cmd):

--- a/sdcm/cassandra_harry_thread.py
+++ b/sdcm/cassandra_harry_thread.py
@@ -66,7 +66,7 @@ class CassandraHarryThread(DockerBasedStressThread):
 
     def _run_stress(self, loader, loader_idx, cpu_idx):
         # Select first seed node to send the scylla-harry cmds
-        ip = self.node_list[0].cql_ip_address
+        ip = self.node_list[0].cql_address
 
         if not os.path.exists(loader.logdir):
             os.makedirs(loader.logdir, exist_ok=True)

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -513,6 +513,18 @@ class AWSNode(cluster.BaseNode):
         else:
             return self._instance.private_ip_address
 
+    @cached_property
+    def public_dns_name(self) -> str:
+        result = self.remoter.run(
+            'curl http://169.254.169.254/latest/meta-data/public-hostname', verbose=False)
+        return result.stdout.strip()
+
+    @cached_property
+    def private_dns_name(self) -> str:
+        result = self.remoter.run(
+            'curl http://169.254.169.254/latest/meta-data/local-hostname', verbose=False)
+        return result.stdout.strip()
+
     def _get_public_ip_address(self) -> Optional[str]:
         return self._instance.public_ip_address
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1818,7 +1818,7 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
         return None
 
     @property
-    def cql_ip_address(self):
+    def cql_address(self):
         return self.ip_address
 
     @property
@@ -2576,7 +2576,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         pass
 
     @property
-    def seed_nodes_ips(self):
+    def seed_nodes_addresses(self):
         return []
 
     @property

--- a/sdcm/ndbench_thread.py
+++ b/sdcm/ndbench_thread.py
@@ -121,7 +121,7 @@ class NdBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-many-
         self.stress_cmd = ' '.join([f'-Dndbench.config.{param.strip()}' for param in stress_cmd.split(';')])
         timeout = '' if 'cli.timeoutMillis' in self.stress_cmd else f'-Dndbench.config.cli.timeoutMillis={self.timeout * 1000}'
         self.stress_cmd = f'./gradlew {timeout}' \
-                          f' -Dndbench.config.cass.host={self.node_list[0].cql_ip_address} {self.stress_cmd} run'
+                          f' -Dndbench.config.cass.host={self.node_list[0].cql_address} {self.stress_cmd} run'
 
     def _run_stress(self, loader, loader_idx, cpu_idx):
         if not os.path.exists(loader.logdir):

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4273,7 +4273,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         with new_node.remote_scylla_yaml() as scylla_yml:
             scylla_yml.rpc_address = new_node.ip_address
             scylla_yml.seed_provider = [SeedProvider(class_name='org.apache.cassandra.locator.SimpleSeedProvider',
-                                                     parameters=[{"seeds": self.tester.db_cluster.seed_nodes_ips}])]
+                                                     parameters=[{"seeds": self.tester.db_cluster.seed_nodes_addresses}])]
             endpoint_snitch = self.cluster.params.get("endpoint_snitch") or ""
             if endpoint_snitch.endswith("GossipingPropertyFileSnitch"):
                 rackdc_value = {"dc": "add_remove_nemesis_dc"}

--- a/sdcm/nosql_thread.py
+++ b/sdcm/nosql_thread.py
@@ -64,9 +64,9 @@ class NoSQLBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-ma
 
     def build_stress_cmd(self, loader_idx: int):
         if hasattr(self.node_list[0], 'parent_cluster'):
-            target_address = self.node_list[0].parent_cluster.get_node().cql_ip_address
+            target_address = self.node_list[0].parent_cluster.get_node().cql_address
         else:
-            target_address = self.node_list[0].cql_ip_address
+            target_address = self.node_list[0].cql_address
         with self._per_loader_count_lock:
             threads_on_loader = self._per_loader_count.get(loader_idx, 0)
             threads_on_loader += 1

--- a/sdcm/provision/scylla_yaml/node_builder.py
+++ b/sdcm/provision/scylla_yaml/node_builder.py
@@ -56,6 +56,8 @@ class ScyllaYamlNodeAttrBuilder(ScyllaYamlAttrBuilderBase):
 
     @property
     def listen_address(self) -> Optional[str]:
+        if self.params.get('use_dns_names'):
+            return self.node.private_dns_name
         if self._is_ip_ssh_connections_ipv6:
             return self._ipv6_ip_address
         if self.params.get('extra_network_interface'):
@@ -65,6 +67,8 @@ class ScyllaYamlNodeAttrBuilder(ScyllaYamlAttrBuilderBase):
 
     @property
     def rpc_address(self) -> Optional[str]:
+        if self.params.get('use_dns_names'):
+            return self.node.private_dns_name
         if self._is_ip_ssh_connections_ipv6:
             return self._ipv6_ip_address
         if self.params.get('extra_network_interface'):
@@ -74,6 +78,8 @@ class ScyllaYamlNodeAttrBuilder(ScyllaYamlAttrBuilderBase):
 
     @property
     def broadcast_rpc_address(self) -> Optional[str]:
+        if self.params.get('use_dns_names'):
+            return self.node.private_dns_name
         if self._is_ip_ssh_connections_ipv6:
             return self._ipv6_ip_address
         if self.params.get('extra_network_interface'):

--- a/sdcm/provision/scylla_yaml/node_builder.py
+++ b/sdcm/provision/scylla_yaml/node_builder.py
@@ -29,7 +29,7 @@ class ScyllaYamlNodeAttrBuilder(ScyllaYamlAttrBuilderBase):
 
     @property
     def _seed_address(self) -> str:
-        return ','.join(self.node.parent_cluster.seed_nodes_ips)
+        return ','.join(self.node.parent_cluster.seed_nodes_addresses)
 
     @property
     def _private_ip_address(self) -> str:

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1481,6 +1481,9 @@ class SCTConfiguration(dict):
              help="""Forces GossipingPropertyFileSnitch (regardless `endpoint_snitch`) to simulate racks.
              Provide number of racks to simulate."""),
 
+        dict(name="use_dns_names", env="SCT_USE_DNS_NAMES", type=boolean,
+             help="""Use dns names instead of ip addresses for nodes in cluster"""),
+
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1836,6 +1836,11 @@ class SCTConfiguration(dict):
                     f"Simulating racks requires endpoint_snitch to be GossipingPropertyFileSnitch while it set to {self['endpoint_snitch']}"
             self["endpoint_snitch"] = "org.apache.cassandra.locator.GossipingPropertyFileSnitch"
 
+        # 16 Validate use_dns_names
+        if self.get("use_dns_names"):
+            if cluster_backend not in ("aws",):
+                raise ValueError(f"use_dns_names is not supported for {cluster_backend} backend")
+
     def log_config(self):
         self.log.info(self.dump_config())
 

--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -150,7 +150,7 @@ class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-in
             stress_cmd = f'{stress_cmd.strip()} -cloud-config-path={self.target_connection_bundle_file}'
         else:
             # Select first seed node to send the scylla-bench cmds
-            ips = ",".join([n.cql_ip_address for n in self.node_list])
+            ips = ",".join([n.cql_address for n in self.node_list])
             stress_cmd = f'{stress_cmd.strip()} -nodes {ips}'
 
         return stress_cmd

--- a/sdcm/stress/base.py
+++ b/sdcm/stress/base.py
@@ -119,8 +119,8 @@ class DockerBasedStressThread:  # pylint: disable=too-many-instance-attributes
             assert db_nodes, "No node to query, nemesis runs on all DB nodes!"
             node_to_query = random.choice(db_nodes)
             LOGGER.debug("Selected '%s' to query for local nodes", node_to_query)
-            return node_to_query.cql_ip_address
-        return self.node_list[0].cql_ip_address
+            return node_to_query.cql_address
+        return self.node_list[0].cql_address
 
     @property
     def connection_bundle_file(self) -> Path:

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -150,7 +150,7 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
                     LOGGER.error("Not found datacenter for loader region '%s'. Datacenter per loader dict: %s",
                                  loader.region, datacenter_name_per_region)
 
-            node_ip_list = [n.cql_ip_address for n in self.node_list]
+            node_ip_list = [n.cql_address for n in self.node_list]
             stress_cmd += ",".join(node_ip_list)
         if 'skip-unsupported-columns' in self._get_available_suboptions(cmd_runner, '-errors'):
             stress_cmd = self._add_errors_option(stress_cmd, ['skip-unsupported-columns'])

--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -41,8 +41,16 @@ class RemoteDocker(BaseNode):
         return self.internal_ip_address
 
     @property
-    def cql_ip_address(self):
+    def cql_address(self):
         return self.internal_ip_address
+
+    @property
+    def private_dns_name(self):
+        raise NotImplementedError()
+
+    @property
+    def public_dns_name(self) -> str:
+        raise NotImplementedError()
 
     @cached_property
     def running_in_docker(self):

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -121,9 +121,9 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
             target_address = 'alternator'
         else:
             if hasattr(self.node_list[0], 'parent_cluster'):
-                target_address = self.node_list[0].parent_cluster.get_node().cql_ip_address
+                target_address = self.node_list[0].parent_cluster.get_node().cql_address
             else:
-                target_address = self.node_list[0].cql_ip_address
+                target_address = self.node_list[0].cql_address
 
         if 'dynamodb' in self.stress_cmd:
             dynamodb_teample = dedent('''
@@ -168,7 +168,7 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
                 docker.send_files(tmp_file.name, os.path.join('/tmp', 'aws_empty_file'))
 
     def build_stress_cmd(self):
-        hosts = ",".join([i.cql_ip_address for i in self.node_list])
+        hosts = ",".join([i.cql_address for i in self.node_list])
 
         stress_cmd = f'{self.stress_cmd} -s '
         if 'dynamodb' in self.stress_cmd:

--- a/test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml
@@ -32,3 +32,5 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
+
+use_dns_names: true

--- a/test-cases/longevity/longevity-mini-test-1h.yaml
+++ b/test-cases/longevity/longevity-mini-test-1h.yaml
@@ -1,5 +1,5 @@
-test_duration: 1000
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=900m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=2 -pop seq=1..10000000 -log interval=5"]
+test_duration: 180
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=90m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=50 -pop seq=1..10000000 -log interval=5"]
 
 n_db_nodes: 4
 n_loaders: 1
@@ -9,11 +9,8 @@ instance_type_db: 'i4i.large'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_interval: 1
-nemesis_multiply_factor: 1
-use_dns_names: true
-
 
 user_prefix: 'longevity-mini-test'
 space_node_threshold: 6442
 
-append_scylla_args: ' --blocked-reactor-notify-ms 25 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'
+append_scylla_args: '--memory 4G --blocked-reactor-notify-ms 25 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'

--- a/test-cases/longevity/longevity-mini-test-1h.yaml
+++ b/test-cases/longevity/longevity-mini-test-1h.yaml
@@ -1,5 +1,5 @@
-test_duration: 180
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=90m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=50 -pop seq=1..10000000 -log interval=5"]
+test_duration: 1000
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=900m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=2 -pop seq=1..10000000 -log interval=5"]
 
 n_db_nodes: 4
 n_loaders: 1
@@ -9,8 +9,11 @@ instance_type_db: 'i4i.large'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_interval: 1
+nemesis_multiply_factor: 1
+use_dns_names: true
+
 
 user_prefix: 'longevity-mini-test'
 space_node_threshold: 6442
 
-append_scylla_args: '--memory 4G --blocked-reactor-notify-ms 25 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'
+append_scylla_args: ' --blocked-reactor-notify-ms 25 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'

--- a/unit_tests/test_gemini_thread.py
+++ b/unit_tests/test_gemini_thread.py
@@ -27,7 +27,7 @@ class DBCluster:  # pylint: disable=too-few-public-methods
         self.nodes = nodes
 
     def get_node_cql_ips(self):
-        return [node.cql_ip_address for node in self.nodes]
+        return [node.cql_address for node in self.nodes]
 
 
 def test_01_gemini_thread(request, docker_scylla, params):

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -39,7 +39,7 @@ def is_builtin(inst):
 
 # pylint: disable=too-few-public-methods
 class FakeCluster:
-    seed_nodes_ips = ['1.1.1.1']
+    seed_nodes_addresses = ['1.1.1.1']
 
 
 # pylint: disable=too-few-public-methods
@@ -407,7 +407,7 @@ class DummyCluster(BaseScyllaCluster, BaseCluster):  # pylint: disable=too-few-p
         self.name = 'dummy_cluster'
 
     @property
-    def seed_nodes_ips(self):
+    def seed_nodes_addresses(self):
         return [node.ip_address for node in self.nodes]
 
     def init_nodes(self):
@@ -585,7 +585,7 @@ class IntegrationTests(unittest.TestCase):
                     cluster.nodes.append(node)
                 cluster.nodes[0].is_seed = True
                 cluster.init_nodes()
-                seed_node_ips = ','.join(cluster.seed_nodes_ips)
+                seed_node_ips = ','.join(cluster.seed_nodes_addresses)
                 for node in cluster.nodes:
                     node.validate_scylla_yaml(expected_node_config=expected_node_config, seed_node_ips=seed_node_ips)
         finally:

--- a/unit_tests/test_seed_selector.py
+++ b/unit_tests/test_seed_selector.py
@@ -73,8 +73,8 @@ class TestSeedSelector(unittest.TestCase):
         self.cluster.set_seeds()
         self.assertTrue(self.cluster.seed_nodes == [self.cluster.nodes[0], self.cluster.nodes[1]])
         self.assertTrue(self.cluster.non_seed_nodes == [self.cluster.nodes[2]])
-        self.assertTrue(self.cluster.seed_nodes_ips == [self.cluster.nodes[0].ip_address,
-                                                        self.cluster.nodes[1].ip_address])
+        self.assertTrue(self.cluster.seed_nodes_addresses == [self.cluster.nodes[0].ip_address,
+                                                              self.cluster.nodes[1].ip_address])
 
     def test_reuse_cluster_seed(self):
         self.setup_cluster(nodes_number=3)
@@ -84,7 +84,7 @@ class TestSeedSelector(unittest.TestCase):
         self.cluster.set_seeds()
         self.assertTrue(self.cluster.seed_nodes == [self.cluster.nodes[1]])
         self.assertTrue(self.cluster.non_seed_nodes == [self.cluster.nodes[0], self.cluster.nodes[2]])
-        self.assertTrue(self.cluster.seed_nodes_ips == [self.cluster.nodes[1].ip_address])
+        self.assertTrue(self.cluster.seed_nodes_addresses == [self.cluster.nodes[1].ip_address])
 
     def test_random_2_seeds(self):
         self.setup_cluster(nodes_number=3)
@@ -92,7 +92,7 @@ class TestSeedSelector(unittest.TestCase):
         self.cluster.set_seeds()
         self.assertTrue(len(self.cluster.seed_nodes) == 2)
         self.assertTrue(len(self.cluster.non_seed_nodes) == 1)
-        self.assertTrue(len(self.cluster.seed_nodes_ips) == 2)
+        self.assertTrue(len(self.cluster.seed_nodes_addresses) == 2)
 
     def test_first_1_seed(self):
         self.setup_cluster(nodes_number=1)
@@ -100,4 +100,4 @@ class TestSeedSelector(unittest.TestCase):
         self.cluster.set_seeds()
         self.assertTrue(self.cluster.seed_nodes == [self.cluster.nodes[0]])
         self.assertTrue(self.cluster.non_seed_nodes == [])
-        self.assertTrue(self.cluster.seed_nodes_ips == [self.cluster.nodes[0].ip_address])
+        self.assertTrue(self.cluster.seed_nodes_addresses == [self.cluster.nodes[0].ip_address])


### PR DESCRIPTION
We want to test if Scylla works with dns names instead of IP addresses.

Adding proper methods and conditions in various places according to test configuration.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
