### PR TITLE
fix(gce): Use spot instead preemptible in GCE

### DIFF
--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -381,7 +381,7 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                 "block-project-ssh-keys": "true",
                 "ssh-keys": f"{username}:{key_type} {public_key}",
             },
-            preemptible=spot,
+            spot=spot,
             service_accounts=self._service_accounts,
         )
         instance = self._create_node_with_retries(name=name,
@@ -389,7 +389,7 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                                                   create_node_params=create_node_params,
                                                   spot=spot)
 
-        self.log.info('Created %s instance %s', 'spot' if spot else 'on-demand', instance)
+        self.log.debug('Created %s instance %s', 'spot' if spot else 'on-demand', instance)
         try:
             set_tags_as_labels(instance)
         except google.api_core.exceptions.InvalidArgument as exc:
@@ -421,7 +421,7 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                     LOGGER.warning("Attempted to destroy node: {name: %s, idx:%s}, but could not find it. "
                                    "Possibly the node was destroyed already.", name, dc_idx)
 
-            create_node_params['preemptible'] = spot = False
+            create_node_params['spot'] = spot = False
 
             raise gbe
 

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -378,7 +378,6 @@ def create_instance(  # pylint: disable=too-many-arguments,too-many-locals,too-m
     external_access: bool = False,
     external_ipv4: str = None,
     accelerators: List[compute_v1.AcceleratorConfig] = None,
-    preemptible: bool = False,
     spot: bool = False,
     instance_termination_action: str = "STOP",
     custom_hostname: str = None,
@@ -415,8 +414,6 @@ def create_instance(  # pylint: disable=too-many-arguments,too-many-locals,too-m
             This setting requires `external_access` to be set to True to work.
         accelerators: a list of AcceleratorConfig objects describing the accelerators that will
             be attached to the new instance.
-        preemptible: boolean value indicating if the new instance should be preemptible
-            or not. Preemptible VMs have been deprecated and you should now use Spot VMs.
         spot: boolean value indicating if the new instance should be a Spot VM or not.
         instance_termination_action: What action should be taken once a Spot VM is terminated.
             Possible values: "STOP", "DELETE"
@@ -462,11 +459,6 @@ def create_instance(  # pylint: disable=too-many-arguments,too-many-locals,too-m
 
     if accelerators:
         instance.guest_accelerators = accelerators
-
-    if preemptible:
-        # Set the preemptible setting
-        instance.scheduling = compute_v1.Scheduling()
-        instance.scheduling.preemptible = True
 
     if spot:
         # Set the Spot VM setting

--- a/unit_tests/test_nemesis_sisyphus.py
+++ b/unit_tests/test_nemesis_sisyphus.py
@@ -71,7 +71,7 @@ def test_list_all_available_nemesis(generate_file=True):
     disruption_list, disruptions_dict, disruption_classes = sisyphus.get_list_of_disrupt_methods(
         subclasses_list=subclasses, export_properties=True)
 
-    assert len(disruption_list) == 83
+    assert len(disruption_list) == 84
 
     if generate_file:
         with open('data_dir/nemesis.yml', 'w', encoding="utf-8") as outfile1:


### PR DESCRIPTION
Preemptible is deprecated in GCE.

Switch to use SPOT instead.

fixes: https://github.com/scylladb/qa-tasks/issues/306

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
