### PR TITLE
fix(scan_operation_thread): aggregation scan verify

### DIFF
--- a/sdcm/scan_operation_thread.py
+++ b/sdcm/scan_operation_thread.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import random
-import re
 import tempfile
 import threading
 import time
@@ -21,6 +20,9 @@ from sdcm.sct_events import Severity
 from sdcm.sct_events.database import FullScanEvent, FullPartitionScanReversedOrderEvent, FullPartitionScanEvent, \
     FullScanAggregateEvent
 from sdcm.utils.common import get_table_clustering_order, get_partition_keys
+from sdcm.db_stats import PrometheusDBStats
+from sdcm.test_config import TestConfig
+from sdcm.utils.decorators import retrying, Retry
 
 if TYPE_CHECKING:
     from sdcm.cluster import BaseScyllaCluster, BaseCluster, BaseNode
@@ -591,9 +593,10 @@ class FullScanAggregatesOperation(FullscanOperationBase):
                       event: Type[FullScanEvent | FullPartitionScanEvent
                                   | FullPartitionScanReversedOrderEvent]) -> None:
         self.log.debug('Will run command %s', cmd)
+        validate_forward_service_requests_start_time = time.time()
         try:
             cmd_result = session.execute(
-                query=cmd, trace=True, timeout=self._session_execution_timeout)
+                query=cmd, trace=False, timeout=self._session_execution_timeout)
         except OperationTimedOut as exc:
             self.log.error(traceback.format_exc())
             self.current_operation_stat.exceptions.append(repr(exc))
@@ -613,16 +616,15 @@ class FullScanAggregatesOperation(FullscanOperationBase):
             event.severity = Severity.ERROR
             return
 
-        message, severity = self._validate_fullscan_result(cmd_result)
+        message, severity = self._validate_fullscan_result(cmd_result, validate_forward_service_requests_start_time)
         if not severity:
             event.message = f"{type(self).__name__} operation ended successfully: {message}"
         else:
             event.severity = severity
             event.message = f"{type(self).__name__} operation failed: {message}"
+
     def _validate_fullscan_result(
-            self, cmd_result: ResultSet):
-        regex_found = False
-        dispatch_forward_statement_regex_pattern = re.compile(r"Dispatching forward_request to \d* endpoints")
+            self, cmd_result: ResultSet, validate_forward_service_requests_start_time):
         result = cmd_result.all()
 
         if not result:
@@ -632,20 +634,39 @@ class FullScanAggregatesOperation(FullscanOperationBase):
         output = "\n".join([str(i) for i in result])
         if int(result[0].count) <= 0:
             return f"Fullscan failed - count is not bigger than 0: {output}", Severity.ERROR
-        get_query_trace = cmd_result.get_query_trace().events
-        for trace_event in get_query_trace:
-            if dispatch_forward_statement_regex_pattern.search(str(trace_event)):
-                regex_found = True
-                break
         self.log.debug("Fullscan aggregation result: %s", output)
 
-        if not regex_found:
-            self.log.debug("\n".join([str(i) for i in get_query_trace]))
+        try:
+            self.validate_forward_service_requests_dispatched_to_other_nodes(
+                validate_forward_service_requests_start_time)
+        except Retry as retry_exception:
+            self.log.debug("prometheus_forward_service_requests metrics:\n %s",
+                           str(retry_exception))
             self.log.debug("Fullscan aggregation result: %s", output)
-            return "Fullscan failed - 'Dispatching forward_request' message was not found in query trace events", \
-                Severity.WARNING
+            return "Fullscan failed - 'forward_service_requests_dispatched_to_other_nodes' was not triggered", \
+                Severity.ERROR
 
         return f'result {result[0]}', None
+
+    @retrying(n=6, sleep_time=10, allowed_exceptions=(Retry, ))
+    def validate_forward_service_requests_dispatched_to_other_nodes(self, start_time):
+        prometheus = PrometheusDBStats(
+            TestConfig().tester_obj().monitors.nodes[0].external_address)
+        prometheus_forward_service_requests = prometheus.query(
+            'scylla_forward_service_requests_dispatched_to_other_nodes',
+            start_time, time.time())
+
+        # expected format is :
+        # [{'metric': {'__name__': 'scylla_forward_service_requests_dispatched_to_other_nodes',
+        # 'instance': '10.4.0.181', 'job': 'scylla', 'shard': '0'}, 'values': [[1690287334.763, '0']]}, ...]
+        for metric in prometheus_forward_service_requests:
+            forward_service_requests_dispatched_before_query = int(metric["values"][0][1])
+            forward_service_requests_dispatched_after_query = int(metric["values"][-1][1])
+            if forward_service_requests_dispatched_before_query < forward_service_requests_dispatched_after_query:
+                self.log.info('forward_service_requests_dispatched_to_other_nodes was triggered')
+                return
+
+        raise Retry(prometheus_forward_service_requests)
 
 
 class PagedResultHandler:

--- a/unit_tests/test_scan_operation_thread.py
+++ b/unit_tests/test_scan_operation_thread.py
@@ -9,12 +9,23 @@ test_scan_negative_exception - getting operation_timed_out in scan execution (wi
 from pathlib import Path
 import os
 from threading import Event
+from importlib import reload
 from unittest.mock import MagicMock, patch
 import pytest
 from cassandra import OperationTimedOut, ReadTimeout
 from unit_tests.test_cluster import DummyDbCluster, DummyNode
-from sdcm.scan_operation_thread import ScanOperationThread, FullScanParams
+from sdcm.utils.decorators import retrying, Retry
+import sdcm.scan_operation_thread
+from sdcm.scan_operation_thread import ScanOperationThread, FullScanParams, PrometheusDBStats
 
+
+def mock_retrying_decorator(*args, **kwargs):  # pylint: disable=unused-argument
+    """Decorate by doing nothing."""
+    return retrying(1, 1, allowed_exceptions=(Retry, ))
+
+
+with patch('sdcm.utils.decorators.retrying', mock_retrying_decorator):
+    reload(sdcm.scan_operation_thread)
 
 DEFAULT_PARAMS = {
     'termination_event': Event(),
@@ -85,10 +96,24 @@ class MockCqlConnectionPatient(MagicMock):
     events = ["Dispatching forward_request to 1 endpoints"]
 
 
-@pytest.fixture(scope='module')
-def cluster(node):  # pylint: disable=redefined-outer-name
+@pytest.fixture(scope='module', name="cluster")
+def new_cluster(node):  # pylint: disable=redefined-outer-name
     db_cluster = DBCluster(MockCqlConnectionPatient(), [node], {})
     node.parent_cluster = db_cluster
+
+    def tester_obj():
+        class Monitors:
+            def __getattribute__(self, item):
+                if item not in "external_address":
+                    return self
+                else:
+                    return "test"
+
+            def __getitem__(self, item):
+                return self
+        return Monitors()
+
+    db_cluster.test_config.tester_obj = tester_obj
     return db_cluster
 
 
@@ -100,13 +125,32 @@ def test_scan_positive(mode, events, cluster):  # pylint: disable=redefined-oute
         mode=mode,
         **DEFAULT_PARAMS
     )
-    with events.wait_for_n_events(events.get_events_logger(), count=2, timeout=10):
-        ScanOperationThread(default_params)._run_next_scan_operation()  # pylint: disable=protected-access
-    all_events = get_event_log_file(events)
-    assert "Severity.NORMAL" in all_events[0] and "period_type=begin" in all_events[0]
-    assert "Severity.NORMAL" in all_events[1] and "period_type=end" in all_events[1]
-    if mode == "aggregate":
-        assert "MockCqlConnectionPatient" in all_events[1]
+    with patch.object(PrometheusDBStats, '__init__', return_value=None):
+        with patch.object(PrometheusDBStats, 'query', return_value=[{'values': [[0, '1'], [1, '2']]}]):
+            with events.wait_for_n_events(events.get_events_logger(), count=2, timeout=10):
+                ScanOperationThread(default_params)._run_next_scan_operation()  # pylint: disable=protected-access
+            all_events = get_event_log_file(events)
+            assert "Severity.NORMAL" in all_events[0] and "period_type=begin" in all_events[0]
+            assert "Severity.NORMAL" in all_events[1] and "period_type=end" in all_events[1]
+            if mode == "aggregate":
+                assert "MockCqlConnectionPatient" in all_events[1]
+
+
+def test_negative_prometheus_validation_error(events, cluster):
+    default_params = FullScanParams(
+        db_cluster=cluster,
+        ks_cf='a.b',
+        mode="aggregate",
+        **DEFAULT_PARAMS
+    )
+    with patch.object(PrometheusDBStats, '__init__', return_value=None):
+        with patch.object(PrometheusDBStats, 'query', return_value=[{'values': [[0, '1'], [1, '1']]}]):
+            with events.wait_for_n_events(events.get_events_logger(), count=2, timeout=2):
+                ScanOperationThread(default_params)._run_next_scan_operation()  # pylint: disable=protected-access
+            all_events = get_event_log_file(events)
+            assert "Severity.NORMAL" in all_events[0] and "period_type=begin" in all_events[0]
+            assert "Severity.ERROR" in all_events[1] and "period_type=end" in all_events[
+                1] and "Fullscan failed - 'forward_service_requests_dispatched_to_other_nodes' was not triggered" in all_events[1]
 
 
 class ExecuteOperationTimedOutMockCqlConnectionPatient(MockCqlConnectionPatient):


### PR DESCRIPTION
PR: https://github.com/scylladb/scylla-cluster-tests/pull/6423 
Implement full aggregation scan verification via prometheus metric: scylla_forward_service_requests_dispatched_to_other_nodes

PR: https://github.com/scylladb/scylla-cluster-tests/pull/6461 
fix test_scan_positive test according to new validation logic in validate_forward_service_requests_dispatched_to_other_nodesi aad new negative test test_negative_prometheus_validation_error

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
