### PR TITLE
fix(azure-vm): disable azure agents

### DIFF
--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -168,6 +168,7 @@ class VirtualMachineProvider:
     def _get_os_profile(computer_name: str, admin_username: str,
                         admin_password: str, ssh_public_key: str, custom_data: str) -> Dict[str, Any]:
         os_profile = {"os_profile": {
+            "allow_extension_operations": False,
             "computer_name": computer_name,
             "admin_username": admin_username,
             "admin_password": admin_password,

--- a/unit_tests/provisioner/fake_azure_service.py
+++ b/unit_tests/provisioner/fake_azure_service.py
@@ -505,7 +505,7 @@ class FakeVirtualMachines:
                         }
                     },
                     "secrets": [],
-                    "allowExtensionOperations": True,
+                    "allowExtensionOperations": False,
                     "requireGuestProvisionSignal": True
                 },
                 "networkProfile": {


### PR DESCRIPTION
since those agents are enabling auditd, which in turn spams our logs with information we don't need

Fixes: https://github.com/scylladb/scylla-enterprise-machine-image/issues/63

### Testing

- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-10gb-3h-azure-test/18/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
