### PR TITLE
fix(jepsen): fix jepsen yaml configs

### DIFF
--- a/test-cases/jepsen/jepsen.yaml
+++ b/test-cases/jepsen/jepsen.yaml
@@ -13,6 +13,7 @@ n_loaders: 1
 n_monitor_nodes: 1
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'debian-buster'
+use_preinstalled_scylla: false
 user_prefix: 'jepsen'
 scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylla-4.6-buster.list'
 jepsen_scylla_repo: 'https://github.com/scylladb/jepsen.git'

--- a/test-cases/jepsen/jepsen_with_raft.yaml
+++ b/test-cases/jepsen/jepsen_with_raft.yaml
@@ -13,6 +13,7 @@ n_loaders: 1
 n_monitor_nodes: 1
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'debian-buster'
+use_preinstalled_scylla: false
 user_prefix: 'jepsen'
 jepsen_scylla_repo: 'https://github.com/scylladb/jepsen.git'
 jepsen_test_count: 5


### PR DESCRIPTION
after merging pr: https://github.com/scylladb/scylla-cluster-tests/pull/6411
jepsen tests start failig by error 'Exception: There is no pre-installed ScyllaDB '

this PR exlisitly set use_preinstalled_scylla: false in jepsen config files

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
