### PR TITLE
fix(nemesis.py): Use apt to install stress-ng on ubuntu

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4151,9 +4151,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.target_node.install_epel()
             self.target_node.remoter.sudo('yum install -y stress-ng')
         elif self.target_node.distro.is_ubuntu:
-            # Install stress on Ubuntu: https://snapcraft.io/install/stress-ng/ubuntu
-            self.target_node.remoter.sudo('apt -y install snapd')
-            self.target_node.remoter.sudo('snap install stress-ng')
+            self.target_node.remoter.sudo('apt-get -y install stress-ng')
         else:
             raise UnsupportedNemesis(f"{self.target_node.distro} OS not supported!")
 


### PR DESCRIPTION
Since stress-ng snap was taken down by Canonical for some reason this
commit removes the snapd installation and replaces stress-ng install to
main ubuntu repositories.

Closes #6555

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
