### PR TITLE
fix(unit_test): set --experimental-features explicitly

### DIFF
--- a/configurations/raft/enable_raft_experimental.yaml
+++ b/configurations/raft/enable_raft_experimental.yaml
@@ -1,3 +1,6 @@
 append_scylla_yaml: |
   experimental_features:
+    - alternator-streams
+    - alternator-ttl
+    - keyspace-storage-options
     - raft

--- a/configurations/raft/enable_raft_experimental.yaml
+++ b/configurations/raft/enable_raft_experimental.yaml
@@ -1,6 +1,3 @@
 append_scylla_yaml: |
   experimental_features:
-    - alternator-streams
-    - alternator-ttl
-    - keyspace-storage-options
     - raft

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -14,10 +14,6 @@ manager_scylla_backend_version: '2022'
 
 scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.6.repo'
 
-experimental_features:
-  - alternator-streams
-  - alternator-ttl
-  - keyspace-storage-options
 round_robin: false
 
 append_scylla_args: '--blocked-reactor-notify-ms 25 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -14,7 +14,10 @@ manager_scylla_backend_version: '2022'
 
 scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.6.repo'
 
-experimental: true
+experimental_features:
+  - alternator-streams
+  - alternator-ttl
+  - keyspace-storage-options
 round_robin: false
 
 append_scylla_args: '--blocked-reactor-notify-ms 25 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -78,7 +78,6 @@
 | **<a href="#user-content-email_subject_postfix" name="email_subject_postfix">email_subject_postfix</a>**  | Email subject postfix | N/A | SCT_EMAIL_SUBJECT_POSTFIX
 | **<a href="#user-content-enable_test_profiling" name="enable_test_profiling">enable_test_profiling</a>**  | Turn on sct profiling | N/A | SCT_ENABLE_TEST_PROFILING
 | **<a href="#user-content-ssh_transport" name="ssh_transport">ssh_transport</a>**  | Set type of ssh library to use. Could be 'fabric' (default) or 'libssh2' | libssh2 | SSH_TRANSPORT
-| **<a href="#user-content-experimental" name="experimental">experimental</a>**  | when enabled scylla will use it's experimental features | True | SCT_EXPERIMENTAL
 | **<a href="#user-content-server_encrypt" name="server_encrypt">server_encrypt</a>**  | when enable scylla will use encryption on the server side | N/A | SCT_SERVER_ENCRYPT
 | **<a href="#user-content-client_encrypt" name="client_encrypt">client_encrypt</a>**  | when enable scylla will use encryption on the client side | N/A | SCT_CLIENT_ENCRYPT
 | **<a href="#user-content-hinted_handoff" name="hinted_handoff">hinted_handoff</a>**  | when enable or disable scylla hinted handoff (enabled/disabled) | enabled | SCT_HINTED_HANDOFF

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -78,6 +78,7 @@
 | **<a href="#user-content-email_subject_postfix" name="email_subject_postfix">email_subject_postfix</a>**  | Email subject postfix | N/A | SCT_EMAIL_SUBJECT_POSTFIX
 | **<a href="#user-content-enable_test_profiling" name="enable_test_profiling">enable_test_profiling</a>**  | Turn on sct profiling | N/A | SCT_ENABLE_TEST_PROFILING
 | **<a href="#user-content-ssh_transport" name="ssh_transport">ssh_transport</a>**  | Set type of ssh library to use. Could be 'fabric' (default) or 'libssh2' | libssh2 | SSH_TRANSPORT
+| **<a href="#user-content-experimental-features" name="experimental_features">experimental_features</a>**  | unlock specified experimental features | N/A | SCT_EXPERIMENTAL_FEATURES
 | **<a href="#user-content-server_encrypt" name="server_encrypt">server_encrypt</a>**  | when enable scylla will use encryption on the server side | N/A | SCT_SERVER_ENCRYPT
 | **<a href="#user-content-client_encrypt" name="client_encrypt">client_encrypt</a>**  | when enable scylla will use encryption on the client side | N/A | SCT_CLIENT_ENCRYPT
 | **<a href="#user-content-hinted_handoff" name="hinted_handoff">hinted_handoff</a>**  | when enable or disable scylla hinted handoff (enabled/disabled) | enabled | SCT_HINTED_HANDOFF

--- a/internal_test_data/complex_test_case_with_version.yaml
+++ b/internal_test_data/complex_test_case_with_version.yaml
@@ -19,7 +19,10 @@ nemesis_interval: 5
 user_prefix: 'longevity-50gb-4d-not-jenkins'
 space_node_threshold: 644245094
 ip_ssh_connections: 'private'
-experimental: true
+experimental_features:
+  - alternator-streams
+  - alternator-ttl
+  - keyspace-storage-options
 instance_provision: 'on_demand'
 
 

--- a/internal_test_data/complex_test_case_with_version.yaml
+++ b/internal_test_data/complex_test_case_with_version.yaml
@@ -19,10 +19,6 @@ nemesis_interval: 5
 user_prefix: 'longevity-50gb-4d-not-jenkins'
 space_node_threshold: 644245094
 ip_ssh_connections: 'private'
-experimental_features:
-  - alternator-streams
-  - alternator-ttl
-  - keyspace-storage-options
 instance_provision: 'on_demand'
 
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1689,8 +1689,8 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
         #       So, define some options here by default. It may be extended later if needed.
         with self.remote_scylla_yaml(namespace=namespace) as scylla_yml:
             # Process cluster params
-            if self.params.get("experimental"):
-                scylla_yml["experimental"] = self.params.get("experimental")
+            if self.params.get("experimental_features"):
+                scylla_yml["experimental_features"] = self.params.get("experimental_features")
             if self.params.get("hinted_handoff"):
                 scylla_yml["hinted_handoff_enabled"] = self.params.get(
                     "hinted_handoff").lower() in ("enabled", "true")

--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -436,7 +436,6 @@ class FillDatabaseData(ClusterTester):
                 [[-4]]
             ],
             'min_version': '1.7',
-            'skip_condition': "'experimental_features' in self.params",
             'max_version': '',
             'skip': ''},
         {

--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -436,7 +436,7 @@ class FillDatabaseData(ClusterTester):
                 [[-4]]
             ],
             'min_version': '1.7',
-            'skip_condition': "self.params.get('experimental')",
+            'skip_condition': "'experimental_features' in self.params",
             'max_version': '',
             'skip': ''},
         {

--- a/sdcm/provision/scylla_yaml/cluster_builder.py
+++ b/sdcm/provision/scylla_yaml/cluster_builder.py
@@ -12,7 +12,7 @@
 # Copyright (c) 2021 ScyllaDB
 
 from functools import cached_property
-from typing import Optional, Any
+from typing import Optional, Any, List
 
 from pydantic import Field
 
@@ -38,10 +38,11 @@ class ScyllaYamlClusterAttrBuilder(ScyllaYamlAttrBuilderBase):
         return None
 
     @property
-    def experimental(self) -> Optional[bool]:
-        if self.params.get('experimental') is None:
-            return None
-        return bool(self.params.get('experimental'))
+    def experimental_features(self) -> List[str]:
+        features = self.params.get('experimental_features')
+        if features is None:
+            return []
+        return features
 
     @property
     def enable_ipv6_dns_lookup(self) -> bool:

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -268,7 +268,6 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods,too-many-
     developer_mode: bool = None  # False
     skip_wait_for_gossip_to_settle: int = None  # -1
     force_gossip_generation: int = None  # -1
-    experimental: bool = None  # False
     experimental_features: list[str] = None  # []
     lsa_reclamation_step: int = None  # 1
     prometheus_port: int = None  # 9180

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -467,9 +467,6 @@ class SCTConfiguration(dict):
              help="""Set type of ssh library to use. Could be 'fabric' (default) or 'libssh2'"""),
 
         # Scylla command line arguments options
-        dict(name="experimental", env="SCT_EXPERIMENTAL", type=boolean,
-             help="when enabled scylla will use it's experimental features"),
-
         dict(name="server_encrypt", env="SCT_SERVER_ENCRYPT", type=boolean,
              help="when enable scylla will use encryption on the server side"),
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -467,6 +467,9 @@ class SCTConfiguration(dict):
              help="""Set type of ssh library to use. Could be 'fabric' (default) or 'libssh2'"""),
 
         # Scylla command line arguments options
+        dict(name="experimental_features", env="SCT_EXPERIMENTAL_FEATURES", type=list,
+             help="unlock specified experimental features"),
+
         dict(name="server_encrypt", env="SCT_SERVER_ENCRYPT", type=boolean,
              help="when enable scylla will use encryption on the server side"),
 

--- a/test-cases/features/alternator-ttl/longevity-alternator-1h-scan-12h-ttl-no-lwt-2h-grace-4loaders-sisyphus.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-1h-scan-12h-ttl-no-lwt-2h-grace-4loaders-sisyphus.yaml
@@ -61,10 +61,11 @@ alternator_secret_access_key: 'password'
 # TTL mode is experimental in version 5.1.
 # Enable TTL feature in Scylla.
 # Set 'alternator_ttl_period_in_seconds' to 1 hour for the TTL scan interval.
-experimental: true
+experimental_features:
+  - alternator-streams
+  - alternator-ttl
+  - keyspace-storage-options
 append_scylla_yaml: |
-  experimental_features:
-    - alternator-ttl
   alternator_ttl_period_in_seconds: 3600
 
 # Set 'gc_grace_seconds' for 2 hours

--- a/test-cases/features/alternator-ttl/longevity-alternator-1h-scan-12h-ttl-no-lwt-2h-grace-4loaders-sisyphus.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-1h-scan-12h-ttl-no-lwt-2h-grace-4loaders-sisyphus.yaml
@@ -62,9 +62,7 @@ alternator_secret_access_key: 'password'
 # Enable TTL feature in Scylla.
 # Set 'alternator_ttl_period_in_seconds' to 1 hour for the TTL scan interval.
 experimental_features:
-  - alternator-streams
   - alternator-ttl
-  - keyspace-storage-options
 append_scylla_yaml: |
   alternator_ttl_period_in_seconds: 3600
 

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired-data.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired-data.yaml
@@ -53,10 +53,11 @@ alternator_secret_access_key: 'password'
 # Enable TTL feature in Scylla.
 # Set 'alternator_ttl_period_in_seconds' to 1 hour for the TTL scan interval.
 # Set 'gc_grace_seconds' for 8 minutes.
-experimental: true
+experimental_features:
+  - alternator-streams
+  - alternator-ttl
+  - keyspace-storage-options
 append_scylla_yaml: |
-  experimental_features:
-    - alternator-ttl
   alternator_ttl_period_in_seconds: 240
 
 post_prepare_cql_cmds: "ALTER TABLE alternator_usertable_no_lwt.usertable_no_lwt with gc_grace_seconds = 480;"

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired-data.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired-data.yaml
@@ -54,9 +54,7 @@ alternator_secret_access_key: 'password'
 # Set 'alternator_ttl_period_in_seconds' to 1 hour for the TTL scan interval.
 # Set 'gc_grace_seconds' for 8 minutes.
 experimental_features:
-  - alternator-streams
   - alternator-ttl
-  - keyspace-storage-options
 append_scylla_yaml: |
   alternator_ttl_period_in_seconds: 240
 

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-multiple-ttl-8m-grace.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-multiple-ttl-8m-grace.yaml
@@ -102,9 +102,7 @@ alternator_secret_access_key: 'password'
 # TTL: 16 different ones. The longer is 10 days, the second longer is 2.5 hours
 # GC Grace: 8 minutes
 experimental_features:
-  - alternator-streams
   - alternator-ttl
-  - keyspace-storage-options
 append_scylla_yaml: |
   alternator_ttl_period_in_seconds: 240
 

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-multiple-ttl-8m-grace.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-multiple-ttl-8m-grace.yaml
@@ -101,10 +101,11 @@ alternator_secret_access_key: 'password'
 # Scan: 4 minutes
 # TTL: 16 different ones. The longer is 10 days, the second longer is 2.5 hours
 # GC Grace: 8 minutes
-experimental: true
+experimental_features:
+  - alternator-streams
+  - alternator-ttl
+  - keyspace-storage-options
 append_scylla_yaml: |
-  experimental_features:
-    - alternator-ttl
   alternator_ttl_period_in_seconds: 240
 
 post_prepare_cql_cmds: "ALTER TABLE alternator_usertable_no_lwt.usertable_no_lwt with gc_grace_seconds = 480;"

--- a/test-cases/features/alternator-ttl/longevity-alternator-disable-enable-ttl.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-disable-enable-ttl.yaml
@@ -53,9 +53,7 @@ alternator_secret_access_key: 'password'
 # (YCSB TTL parameter is set to 10 minutes)
 # Set 'gc_grace_seconds' for 8 minutes,
 experimental_features:
-  - alternator-streams
   - alternator-ttl
-  - keyspace-storage-options
 append_scylla_yaml: |
   alternator_ttl_period_in_seconds: 240
 

--- a/test-cases/features/alternator-ttl/longevity-alternator-disable-enable-ttl.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-disable-enable-ttl.yaml
@@ -52,10 +52,11 @@ alternator_secret_access_key: 'password'
 # Set 'alternator_ttl_period_in_seconds' to 4 minutes for the TTL scan interval.
 # (YCSB TTL parameter is set to 10 minutes)
 # Set 'gc_grace_seconds' for 8 minutes,
-experimental: true
+experimental_features:
+  - alternator-streams
+  - alternator-ttl
+  - keyspace-storage-options
 append_scylla_yaml: |
-  experimental_features:
-    - alternator-ttl
   alternator_ttl_period_in_seconds: 240
 
 post_prepare_cql_cmds: "ALTER TABLE alternator_usertable_no_lwt.usertable_no_lwt with gc_grace_seconds = 480;"

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-big-dataset.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-big-dataset.yaml
@@ -58,10 +58,11 @@ alternator_secret_access_key: 'password'
 # Enable TTL feature in Scylla.
 # Set 'alternator_ttl_period_in_seconds' to 1 hour for the TTL scan interval.
 # gc_grace_seconds: 2 hours.
-experimental: true
+experimental_features:
+  - alternator-streams
+  - alternator-ttl
+  - keyspace-storage-options
 append_scylla_yaml: |
-  experimental_features:
-    - alternator-ttl
   alternator_ttl_period_in_seconds: 3600
 
 

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-big-dataset.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-big-dataset.yaml
@@ -59,9 +59,7 @@ alternator_secret_access_key: 'password'
 # Set 'alternator_ttl_period_in_seconds' to 1 hour for the TTL scan interval.
 # gc_grace_seconds: 2 hours.
 experimental_features:
-  - alternator-streams
   - alternator-ttl
-  - keyspace-storage-options
 append_scylla_yaml: |
   alternator_ttl_period_in_seconds: 3600
 

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-large-writes.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-large-writes.yaml
@@ -59,9 +59,7 @@ alternator_secret_access_key: 'password'
 # TTL (YCSB parameter): 8 minutes.
 # gc_grace_seconds: 20 minutes
 experimental_features:
-  - alternator-streams
   - alternator-ttl
-  - keyspace-storage-options
 append_scylla_yaml: |
   alternator_ttl_period_in_seconds: 600
 

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-large-writes.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-large-writes.yaml
@@ -58,10 +58,11 @@ alternator_secret_access_key: 'password'
 # Scan interval: 10 minutes
 # TTL (YCSB parameter): 8 minutes.
 # gc_grace_seconds: 20 minutes
-experimental: true
+experimental_features:
+  - alternator-streams
+  - alternator-ttl
+  - keyspace-storage-options
 append_scylla_yaml: |
-  experimental_features:
-    - alternator-ttl
   alternator_ttl_period_in_seconds: 600
 
 post_prepare_cql_cmds: "ALTER TABLE alternator_usertable_no_lwt.usertable_no_lwt with gc_grace_seconds = 1200;"

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-lwt.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-lwt.yaml
@@ -39,8 +39,9 @@ alternator_secret_access_key: 'password'
 # TTL mode is experimental in version 5.1.
 # Enable TTL feature in Scylla.
 # Set 'alternator_ttl_period_in_seconds' to 7 minutes for the TTL scan interval.
-experimental: true
+experimental_features:
+  - alternator-streams
+  - alternator-ttl
+  - keyspace-storage-options
 append_scylla_yaml: |
-  experimental_features:
-    - alternator-ttl
   alternator_ttl_period_in_seconds: 420

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-lwt.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-lwt.yaml
@@ -40,8 +40,6 @@ alternator_secret_access_key: 'password'
 # Enable TTL feature in Scylla.
 # Set 'alternator_ttl_period_in_seconds' to 7 minutes for the TTL scan interval.
 experimental_features:
-  - alternator-streams
   - alternator-ttl
-  - keyspace-storage-options
 append_scylla_yaml: |
   alternator_ttl_period_in_seconds: 420

--- a/test-cases/longevity/longevity-alternator-streams-100gb-12h.yaml
+++ b/test-cases/longevity/longevity-alternator-streams-100gb-12h.yaml
@@ -48,8 +48,6 @@ user_prefix: 'alternator-streams-4h'
 space_node_threshold: 64424
 experimental_features:
   - alternator-streams
-  - alternator-ttl
-  - keyspace-storage-options
 
 alternator_port: 8080
 dynamodb_primarykey_type: HASH

--- a/test-cases/longevity/longevity-alternator-streams-100gb-12h.yaml
+++ b/test-cases/longevity/longevity-alternator-streams-100gb-12h.yaml
@@ -46,7 +46,10 @@ nemesis_interval: 5
 
 user_prefix: 'alternator-streams-4h'
 space_node_threshold: 64424
-experimental: true
+experimental_features:
+  - alternator-streams
+  - alternator-ttl
+  - keyspace-storage-options
 
 alternator_port: 8080
 dynamodb_primarykey_type: HASH

--- a/test-cases/longevity/longevity-cdc-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-4h.yaml
@@ -24,5 +24,3 @@ user_prefix: 'longevity-cdc-100gb-4h'
 space_node_threshold: 64424
 
 server_encrypt: true
-
-experimental_features: []

--- a/test-cases/longevity/longevity-cdc-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-4h.yaml
@@ -25,4 +25,4 @@ space_node_threshold: 64424
 
 server_encrypt: true
 
-experimental: false
+experimental_features: []

--- a/test-cases/scale/scale-cluster.yaml
+++ b/test-cases/scale/scale-cluster.yaml
@@ -14,7 +14,6 @@ instance_type_db: 'm5d.large'
 
 user_prefix: 'cluster-scale-test'
 ssh_transport: 'libssh2'
-experimental_features: []
 use_legacy_cluster_init: true
 
 nemesis_interval: 5

--- a/test-cases/scale/scale-cluster.yaml
+++ b/test-cases/scale/scale-cluster.yaml
@@ -14,7 +14,7 @@ instance_type_db: 'm5d.large'
 
 user_prefix: 'cluster-scale-test'
 ssh_transport: 'libssh2'
-experimental: false
+experimental_features: []
 use_legacy_cluster_init: true
 
 nemesis_interval: 5

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -77,8 +77,16 @@ def fixture_docker_scylla(request: pytest.FixtureRequest):
             os.chdir(curr_dir)
 
     ssl_dir = (Path(__file__).parent.parent / 'data_dir' / 'ssl_conf').absolute()
+    # experimental features previous enabled by '--experimental' umbrella flag, which
+    # was deprecated and removed, so let's specify them explictly. 'udf' should be
+    # enabled separately along with 'enable_user_defined_functions'
+    experimental_features = ['alternator-streams',
+                             'alternator-ttl',
+                             'keyspace-storage-options']
+    experimental_flags = ' '.join(f'--experimental-features {feature}'
+                                  for feature in experimental_features)
     scylla = RemoteDocker(LocalNode("scylla", cluster), image_name=docker_version,
-                          command_line=f"--smp 1 --experimental 1 {alternator_flags}",
+                          command_line=f"--smp 1 {experimental_flags} {alternator_flags}",
                           extra_docker_opts=(f'-p 8000 -p {BaseNode.CQL_PORT} --cpus="1" -v {entryfile_path}:/entry.sh'
                                              f' -v {ssl_dir}:/etc/scylla/ssl_conf'
                                              ' --entrypoint /entry.sh'))

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -77,16 +77,8 @@ def fixture_docker_scylla(request: pytest.FixtureRequest):
             os.chdir(curr_dir)
 
     ssl_dir = (Path(__file__).parent.parent / 'data_dir' / 'ssl_conf').absolute()
-    # experimental features previous enabled by '--experimental' umbrella flag, which
-    # was deprecated and removed, so let's specify them explictly. 'udf' should be
-    # enabled separately along with 'enable_user_defined_functions'
-    experimental_features = ['alternator-streams',
-                             'alternator-ttl',
-                             'keyspace-storage-options']
-    experimental_flags = ' '.join(f'--experimental-features {feature}'
-                                  for feature in experimental_features)
     scylla = RemoteDocker(LocalNode("scylla", cluster), image_name=docker_version,
-                          command_line=f"--smp 1 {experimental_flags} {alternator_flags}",
+                          command_line=f"--smp 1 {alternator_flags}",
                           extra_docker_opts=(f'-p 8000 -p {BaseNode.CQL_PORT} --cpus="1" -v {entryfile_path}:/entry.sh'
                                              f' -v {ssl_dir}:/etc/scylla/ssl_conf'
                                              ' --entrypoint /entry.sh'))

--- a/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.result.json
@@ -13,7 +13,7 @@
       ]
     }
   ],
-  "experimental_features": ["alternator-streams", "alternator-ttl", "keyspace-storage-options"],
+  "experimental_features": [],
   "prometheus_address": "0.0.0.0",
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,

--- a/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.result.json
@@ -13,7 +13,7 @@
       ]
     }
   ],
-  "experimental": true,
+  "experimental_features": ["alternator-streams", "alternator-ttl", "keyspace-storage-options"],
   "prometheus_address": "0.0.0.0",
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,

--- a/unit_tests/test_data/test_scylla_yaml_builders/artifact_amazon2.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/artifact_amazon2.result.json
@@ -13,7 +13,7 @@
       ]
     }
   ],
-  "experimental_features": ["alternator-streams", "alternator-ttl", "keyspace-storage-options"],
+  "experimental_features": [],
   "prometheus_address": "0.0.0.0",
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,

--- a/unit_tests/test_data/test_scylla_yaml_builders/artifact_amazon2.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/artifact_amazon2.result.json
@@ -13,7 +13,7 @@
       ]
     }
   ],
-  "experimental": true,
+  "experimental_features": ["alternator-streams", "alternator-ttl", "keyspace-storage-options"],
   "prometheus_address": "0.0.0.0",
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,

--- a/unit_tests/test_data/test_scylla_yaml_builders/cdc-replication-longevity.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/cdc-replication-longevity.result.json
@@ -15,7 +15,7 @@
     }
   ],
   "broadcast_rpc_address": "__NODE_PRIVATE_ADDRESS__",
-  "experimental": true,
+  "experimental_features": ["alternator-streams", "alternator-ttl", "keyspace-storage-options"],
   "prometheus_address": "0.0.0.0",
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,

--- a/unit_tests/test_data/test_scylla_yaml_builders/cdc-replication-longevity.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/cdc-replication-longevity.result.json
@@ -15,7 +15,7 @@
     }
   ],
   "broadcast_rpc_address": "__NODE_PRIVATE_ADDRESS__",
-  "experimental_features": ["alternator-streams", "alternator-ttl", "keyspace-storage-options"],
+  "experimental_features": [],
   "prometheus_address": "0.0.0.0",
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,

--- a/unit_tests/test_data/test_scylla_yaml_builders/functional.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/functional.result.json
@@ -13,7 +13,7 @@
       ]
     }
   ],
-  "experimental_features": ["alternator-streams", "alternator-ttl", "keyspace-storage-options"],
+  "experimental_features": [],
   "prometheus_address": "0.0.0.0",
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,

--- a/unit_tests/test_data/test_scylla_yaml_builders/functional.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/functional.result.json
@@ -13,7 +13,7 @@
       ]
     }
   ],
-  "experimental": true,
+  "experimental_features": ["alternator-streams", "alternator-ttl", "keyspace-storage-options"],
   "prometheus_address": "0.0.0.0",
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,

--- a/unit_tests/test_data/test_scylla_yaml_builders/jepsen.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/jepsen.result.json
@@ -13,7 +13,7 @@
       ]
     }
   ],
-  "experimental_features": ["alternator-streams", "alternator-ttl", "keyspace-storage-options"],
+  "experimental_features": [],
   "prometheus_address": "0.0.0.0",
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,

--- a/unit_tests/test_data/test_scylla_yaml_builders/jepsen.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/jepsen.result.json
@@ -13,7 +13,7 @@
       ]
     }
   ],
-  "experimental": true,
+  "experimental_features": ["alternator-streams", "alternator-ttl", "keyspace-storage-options"],
   "prometheus_address": "0.0.0.0",
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,

--- a/unit_tests/test_data/test_scylla_yaml_builders/longevity-10gb-3h.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/longevity-10gb-3h.result.json
@@ -15,7 +15,7 @@
     }
   ],
   "broadcast_rpc_address": "__NODE_IPV6_ADDRESS__",
-  "experimental": true,
+  "experimental_features": ["alternator-streams", "alternator-ttl", "keyspace-storage-options"],
   "prometheus_address": "__NODE_IPV6_ADDRESS__",
   "enable_ipv6_dns_lookup": true,
   "alternator_enforce_authorization": false,

--- a/unit_tests/test_data/test_scylla_yaml_builders/longevity-10gb-3h.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/longevity-10gb-3h.result.json
@@ -15,7 +15,7 @@
     }
   ],
   "broadcast_rpc_address": "__NODE_IPV6_ADDRESS__",
-  "experimental_features": ["alternator-streams", "alternator-ttl", "keyspace-storage-options"],
+  "experimental_features": [],
   "prometheus_address": "__NODE_IPV6_ADDRESS__",
   "enable_ipv6_dns_lookup": true,
   "alternator_enforce_authorization": false,

--- a/unit_tests/test_data/test_scylla_yaml_builders/manager-backup-1TB-gce.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/manager-backup-1TB-gce.result.json
@@ -13,7 +13,7 @@
       ]
     }
   ],
-  "experimental_features": ["alternator-streams", "alternator-ttl", "keyspace-storage-options"],
+  "experimental_features": [],
   "prometheus_address": "0.0.0.0",
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,

--- a/unit_tests/test_data/test_scylla_yaml_builders/manager-backup-1TB-gce.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/manager-backup-1TB-gce.result.json
@@ -13,7 +13,7 @@
       ]
     }
   ],
-  "experimental": true,
+  "experimental_features": ["alternator-streams", "alternator-ttl", "keyspace-storage-options"],
   "prometheus_address": "0.0.0.0",
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,

--- a/unit_tests/test_data/test_scylla_yaml_builders/perf-regression.100threads.30M-keys.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/perf-regression.100threads.30M-keys.result.json
@@ -13,7 +13,7 @@
       ]
     }
   ],
-  "experimental_features": ["alternator-streams", "alternator-ttl", "keyspace-storage-options"],
+  "experimental_features": [],
   "prometheus_address": "0.0.0.0",
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,

--- a/unit_tests/test_data/test_scylla_yaml_builders/perf-regression.100threads.30M-keys.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/perf-regression.100threads.30M-keys.result.json
@@ -13,7 +13,7 @@
       ]
     }
   ],
-  "experimental": true,
+  "experimental_features": ["alternator-streams", "alternator-ttl", "keyspace-storage-options"],
   "prometheus_address": "0.0.0.0",
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,

--- a/unit_tests/test_data/test_scylla_yaml_builders/rolling-upgrade.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/rolling-upgrade.result.json
@@ -20,7 +20,7 @@
     "keyfile": "/etc/scylla/ssl_conf/db.key",
     "truststore": "/etc/scylla/ssl_conf/cadb.pem"
   },
-  "experimental_features": ["alternator-streams", "alternator-ttl", "keyspace-storage-options"],
+  "experimental_features": [],
   "saslauthd_socket_path": "/run/saslauthd/mux",
   "prometheus_address": "0.0.0.0",
   "alternator_enforce_authorization": false,

--- a/unit_tests/test_data/test_scylla_yaml_builders/rolling-upgrade.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/rolling-upgrade.result.json
@@ -20,7 +20,7 @@
     "keyfile": "/etc/scylla/ssl_conf/db.key",
     "truststore": "/etc/scylla/ssl_conf/cadb.pem"
   },
-  "experimental": true,
+  "experimental_features": ["alternator-streams", "alternator-ttl", "keyspace-storage-options"],
   "saslauthd_socket_path": "/run/saslauthd/mux",
   "prometheus_address": "0.0.0.0",
   "alternator_enforce_authorization": false,

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -247,7 +247,6 @@ class ScyllaYamlTest(unittest.TestCase):
                 'enable_sstables_md_format': None,
                 'enable_user_defined_functions': None,
                 'endpoint_snitch': None,
-                'experimental': None,
                 'experimental_features': None,
                 'fd_initial_value_ms': None,
                 'fd_max_interval_ms': None,

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -95,6 +95,7 @@ class ScyllaYamlClusterAttrBuilderTest(ScyllaYamlClusterAttrBuilderBase):
                 'cluster_name': 'test-cluster',
                 'alternator_enforce_authorization': False,
                 'enable_ipv6_dns_lookup': False,
+                'experimental_features': [],
             }
         )
 
@@ -125,6 +126,7 @@ class ScyllaYamlClusterAttrBuilderTest(ScyllaYamlClusterAttrBuilderBase):
                 'authorizer': 'AllowAllAuthorizer',
                 'enable_ipv6_dns_lookup': False,
                 'endpoint_snitch': 'org.apache.cassandra.locator.Ec2Snitch',
+                'experimental_features': [],
                 'ldap_attr_role': 'cn',
                 'ldap_bind_dn': 'cn=admin,dc=scylla-qa,dc=com', 'ldap_bind_passwd': 'scylla-0',
                 'ldap_url_template': 'ldap://1.1.1.1:389/dc=scylla-qa,dc=com?cn?sub?'
@@ -162,7 +164,9 @@ class ScyllaYamlClusterAttrBuilderTest(ScyllaYamlClusterAttrBuilderBase):
                 'authenticator': 'com.scylladb.auth.SaslauthdAuthenticator',
                 'authorizer': 'CassandraAuthorizer',
                 'enable_ipv6_dns_lookup': False,
-                'ldap_attr_role': 'cn', 'ldap_bind_dn': 'cn=admin,dc=scylla-qa,dc=com',
+                'experimental_features': [],
+                'ldap_attr_role': 'cn',
+                'ldap_bind_dn': 'cn=admin,dc=scylla-qa,dc=com',
                 'ldap_bind_passwd': 'scylla-0',
                 'ldap_url_template': 'ldap://1.1.1.1:389/dc=scylla-qa,dc=com?cn?sub?'
                                      '(uniqueMember=uid={USER},ou=Person,dc=scylla-qa,dc=com)',
@@ -204,6 +208,7 @@ class ScyllaYamlClusterAttrBuilderTest(ScyllaYamlClusterAttrBuilderBase):
                 'authorizer': 'CassandraAuthorizer',
                 'enable_ipv6_dns_lookup': False,
                 'endpoint_snitch': 'org.apache.cassandra.locator.GossipingPropertyFileSnitch',
+                'experimental_features': [],
                 'hinted_handoff_enabled': False,
                 'ldap_attr_role': 'cn', 'ldap_bind_dn': 'SOMEDN', 'ldap_bind_passwd': 'PASSWORD',
                 'ldap_url_template': 'ldap://3.3.3.3:389/dc=scylla-qa,dc=com?cn?sub?(member=CN={USER},dc=scylla-qa,dc=com)',


### PR DESCRIPTION
now that we've deprecated and later stopped handling the option "experimental". let's specify the "experimetan_features" explictly. this should address the failures in the upgrade tests which expect that the experimental features are enabled by "--experimental 1" command line option.

Fixes https://github.com/scylladb/scylladb/issues/15214
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
