### PR TITLE
fix(event_process): fix stop events process under stream of events

### DIFF
--- a/sdcm/sct_events/events_device.py
+++ b/sdcm/sct_events/events_device.py
@@ -137,7 +137,7 @@ class EventsDevice(multiprocessing.Process):
     def inbound_events(self, stop_event: StopEvent) -> Generator[Any, None, None]:
         with zmq.Context() as ctx, self._sub_socket(ctx) as sub:
             while not stop_event.is_set():
-                while sub.poll(timeout=self.sub_polling_timeout):
+                if sub.poll(timeout=self.sub_polling_timeout):
                     yield sub.recv_pyobj(flags=zmq.NOBLOCK)
 
     # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
When there's a lot of events coming to events process (e.g. `events_analyzer`) it doesn't verify state of `stop_event`. This makes it to last longer than stop timeout and failing the test usually.

Fix is about verifying state of `stop_event` after each event in `inbound_events` generator - not only when it's silent for 1 second.

fixes: #6232

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
