### PR TITLE
fix(db node): return scylla_shard as int always

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -541,7 +541,12 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         2) CPUSET
         3) Number of cores on the machine
         """
-        return self.smp or self.cpuset or self.cpu_cores
+        shards = self.smp or self.cpuset or self.cpu_cores
+        try:
+            return int(shards)
+        except Exception:  # pylint: disable=broad-except
+            self.log.error("Failed to convert to integer shards value: %s", shards)
+            return 0
 
     @property
     def cpuset(self):


### PR DESCRIPTION
`scylla_shards` may return string instead of integer value. It cause to failure with error like:
```
TypeError: '>' not supported between instances of 'str' and 'int'
```

This property may receive the shards value from 3 different properties: `cpu_cores`, `smp` or `cpuset`. Every this property is used by different functions. So to decrease the impact of this fix, the shards value will be converted inside `scylla_shards` property, not in every property.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/6562

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
