### PR TITLE
test(artifact): add a t3.micro artifact test

### DIFF
--- a/configurations/t3_micro_data_volumes.yaml
+++ b/configurations/t3_micro_data_volumes.yaml
@@ -1,0 +1,3 @@
+instance_type_db: 't3.micro'
+data_volume_disk_num: 1  # t3.micro doesn't include any local volumes (outside of root), so an additional disk is required for scylla
+data_volume_disk_size: 50

--- a/jenkins-pipelines/artifacts-ami-t3_micro.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ami-t3_micro.jenkinsfile
@@ -1,0 +1,14 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: '''["test-cases/artifacts/ami.yaml", "configurations/t3_micro_data_volumes.yaml"]''',
+    backend: 'aws',
+    provision_type: 'spot_low_price',
+
+    timeout: [time: 45, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    builds_to_keep: '100'
+)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -384,7 +384,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     @property
     def db_node_instance_type(self) -> Optional[str]:
-        backend = self.parent_cluster.cluster_backend()
+        backend = self.parent_cluster.cluster_backend
         if backend in ("aws", "aws-siren"):
             return self.parent_cluster.params.get("instance_type_db")
         elif backend == "azure":

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1693,6 +1693,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             )
         if self.parent_cluster.params.get('db_nodes_shards_selection') == 'random':
             append_scylla_args += f" --smp {self.scylla_random_shards()}"
+        if self.db_node_instance_type == "t3.micro":
+            append_scylla_args += ' --developer-mode 1 '
 
         if append_scylla_args:
             self.log.debug("Append following args to scylla: `%s'", append_scylla_args)
@@ -2234,7 +2236,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             extra_setup_args += ' --swap-directory / '
         if self.parent_cluster.params.get('unified_package'):
             extra_setup_args += ' --no-verify-package '
-
         self.remoter.run('sudo /usr/lib/scylla/scylla_setup --nic {} --disks {} --setup-nic-and-disks {}'
                          .format(devname, ','.join(disks), extra_setup_args))
 


### PR DESCRIPTION
Since scylla can't start on t3.micro without developer mode activated, I added a check in scylla_setup to activate developer mode when the instance type is t3.micro

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
