### PR TITLE
fix(kms): allow to run KMS nemesis starting with 2023.1.1 Scylla version

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3941,7 +3941,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             enable_kms_key_rotation=True,
             additional_scylla_encryption_options={'key_provider': 'KmsKeyProviderFactory'})
 
-    @scylla_versions(("2023.2.0-dev", None))
+    @scylla_versions(("2023.1.1-dev", None))
     def _enable_disable_table_encryption(self, enable_kms_key_rotation, additional_scylla_encryption_options=None):
         if self.cluster.params.get("cluster_backend") != "aws":
             raise UnsupportedNemesis("This nemesis is supported only on the AWS cluster backend")


### PR DESCRIPTION
The support for the `KMS+EaR` feature in the enterprise Scylla is going to be added in the `2023.1.1` version.
So, update the decorator for the appropriate nemesis with the proper version.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
