### PR TITLE
fix(nemesis): Add new nemesis for topology changes feature

### DIFF
--- a/data_dir/nemesis.yml
+++ b/data_dir/nemesis.yml
@@ -234,6 +234,14 @@
   - topology_changes = True
 - disrupt_rebuild_streaming_err:
   - disruptive = True
+- disrupt_refuse_connection_with_block_scylla_ports_on_banned_node:
+  - disruptive = True
+  - topology_changes = True
+  - kubernetes = False
+- disrupt_refuse_connection_with_send_sigstop_signal_to_scylla_on_banned_node:
+  - disruptive = True
+  - topology_changes = True
+  - kubernetes = False
 - disrupt_remove_node_then_add_node:
   - disruptive = True
   - kubernetes = False

--- a/data_dir/nemesis_classes.yml
+++ b/data_dir/nemesis_classes.yml
@@ -29,6 +29,8 @@
 - EnospcMonkey
 - GrowShrinkClusterNemesis
 - HardRebootNodeMonkey
+- IsolateNodeWithIptableRuleNemesis
+- IsolateNodeWithProcessSignalNemesis
 - LoadAndStreamMonkey
 - MajorCompactionMonkey
 - MemoryStressMonkey

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-IsolateNodeWithIptableRuleNemesis-aws.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-IsolateNodeWithIptableRuleNemesis-aws.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: """['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/IsolateNodeWithIptableRuleNemesis.yaml']"""
+
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-IsolateNodeWithIptableRuleNemesis-azure.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-IsolateNodeWithIptableRuleNemesis-azure.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'azure',
+    region: 'eastus',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: """['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/IsolateNodeWithIptableRuleNemesis.yaml']"""
+
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-IsolateNodeWithIptableRuleNemesis-docker.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-IsolateNodeWithIptableRuleNemesis-docker.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'docker',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: """['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/IsolateNodeWithIptableRuleNemesis.yaml', 'configurations/nemesis/additional_configs/docker_backend_local.yaml']"""
+
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-IsolateNodeWithIptableRuleNemesis-gce.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-IsolateNodeWithIptableRuleNemesis-gce.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'gce',
+    region: 'us-east1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: """['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/IsolateNodeWithIptableRuleNemesis.yaml']"""
+
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-IsolateNodeWithProcessSignalNemesis-aws.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-IsolateNodeWithProcessSignalNemesis-aws.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: """['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/IsolateNodeWithProcessSignalNemesis.yaml']"""
+
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-IsolateNodeWithProcessSignalNemesis-azure.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-IsolateNodeWithProcessSignalNemesis-azure.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'azure',
+    region: 'eastus',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: """['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/IsolateNodeWithProcessSignalNemesis.yaml']"""
+
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-IsolateNodeWithProcessSignalNemesis-docker.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-IsolateNodeWithProcessSignalNemesis-docker.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'docker',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: """['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/IsolateNodeWithProcessSignalNemesis.yaml', 'configurations/nemesis/additional_configs/docker_backend_local.yaml']"""
+
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-IsolateNodeWithProcessSignalNemesis-gce.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-IsolateNodeWithProcessSignalNemesis-gce.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'gce',
+    region: 'us-east1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: """['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/IsolateNodeWithProcessSignalNemesis.yaml']"""
+
+)

--- a/sdcm/exceptions.py
+++ b/sdcm/exceptions.py
@@ -91,3 +91,7 @@ class RaftTopologyCoordinatorNotFound(Exception):
 
 class NemesisStressFailure(Exception):
     """Exception to be raised to stop Nemesis flow, if stress command failed"""
+
+
+class BannedQueryExecUnexpectedSuccess(Exception):
+    """Exception when query executed successfully on banned node"""

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -38,8 +38,9 @@ from concurrent.futures import ThreadPoolExecutor
 from threading import Lock
 from types import MethodType  # pylint: disable=no-name-in-module
 
-from cassandra import ConsistencyLevel, InvalidRequest
+from cassandra import ConsistencyLevel, InvalidRequest, Unavailable
 from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
+from cassandra.cluster import NoHostAvailable, OperationTimedOut  # pylint: disable=no-name-in-module
 from invoke import UnexpectedExit
 from elasticsearch.exceptions import ConnectionTimeout as ElasticSearchConnectionTimeout
 from argus.common.enums import NemesisStatus
@@ -127,6 +128,7 @@ from sdcm.utils.loader_utils import DEFAULT_USER, DEFAULT_USER_PASSWORD, SERVICE
 from sdcm.utils.nemesis_utils.indexes import get_random_column_name, create_index, \
     wait_for_index_to_be_built, verify_query_by_index_works, drop_index, get_column_names, \
     wait_for_view_to_be_built, drop_materialized_view, is_cf_a_view
+from sdcm.utils.nemesis_utils import node_operations
 from sdcm.utils.node import build_node_api_command
 from sdcm.utils.replication_strategy_utils import temporary_replication_strategy_setter, \
     NetworkTopologyReplicationStrategy, ReplicationStrategy, SimpleReplicationStrategy
@@ -157,12 +159,14 @@ from sdcm.exceptions import (
     BootstrapStreamErrorFailure,
     QuotaConfigurationFailure,
     NemesisStressFailure,
+    BannedQueryExecUnexpectedSuccess,
 )
 from test_lib.compaction import CompactionStrategy, get_compaction_strategy, get_compaction_random_additional_params, \
     get_gc_mode, GcMode, calculate_allowed_twcs_ttl, get_table_compaction_info
 from test_lib.cql_types import CQLTypeBuilder
 from test_lib.sla import ServiceLevel, MAX_ALLOWED_SERVICE_LEVELS
 from sdcm.utils.topology_ops import FailedDecommissionOperationMonitoring
+
 
 LOGGER = logging.getLogger(__name__)
 # NOTE: following lock is needed in the K8S multitenant case
@@ -3720,9 +3724,12 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         node_to_remove = self.target_node
         up_normal_nodes = self.cluster.get_nodes_up_and_normal(verification_node=node_to_remove)
-        # node_to_remove must be different than node
-        verification_node = random.choice([n for n in self.cluster.nodes if n is not node_to_remove])
 
+        with Nemesis.run_nemesis(node_list=up_normal_nodes, nemesis_label="RemoveNodeAddNode") as verification_node:
+            self._remove_node_add_node(verification_node=verification_node, node_to_remove=node_to_remove)
+
+    def _remove_node_add_node(self, verification_node, node_to_remove, remove_node_host_id=None):
+        # node_to_remove must be different than node
         # node_to_remove is single/last seed in cluster, before
         # it will be terminated, choose new seed node
         num_of_seed_nodes = len(self.cluster.seed_nodes)
@@ -3732,14 +3739,17 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.cluster.update_seed_provider()
 
         # get node's host_id
-        removed_node_status = self.cluster.get_node_status_dictionary(
-            ip_address=node_to_remove.ip_address, verification_node=verification_node)
-        assert removed_node_status is not None, "failed to get host_id using nodetool status"
-        host_id = removed_node_status["host_id"]
+        if not remove_node_host_id:
+            removed_node_status = self.cluster.get_node_status_dictionary(
+                ip_address=node_to_remove.ip_address, verification_node=verification_node)
+            assert removed_node_status is not None, "failed to get host_id using nodetool status"
+            host_id = removed_node_status["host_id"]
+        else:
+            host_id = remove_node_host_id
 
         with ignore_ycsb_connection_refused():
             # node stop and make sure its "DN"
-            node_to_remove.stop_scylla_server(verify_up=True, verify_down=True)
+            node_to_remove.stop_scylla_server(verify_up=False, verify_down=True)
 
             # terminate node
             self._terminate_cluster_node(node_to_remove)
@@ -3747,20 +3757,19 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         @retrying(n=3, sleep_time=5, message="Removing node from cluster...")
         def remove_node():
             removenode_reject_msg = r"Rejected removenode operation.*the node being removed is alive"
-            # nodetool removenode 'host_id'
-            rnd_node = random.choice([n for n in self.cluster.nodes if n is not self.target_node])
-            self.log.info("Running removenode command on {}, Removing node with the following host_id: {}"
-                          .format(rnd_node.ip_address, host_id))
-            with adaptive_timeout(Operations.REMOVE_NODE, rnd_node, timeout=HOUR_IN_SEC * 48):
-                res = rnd_node.run_nodetool("removenode {}".format(
-                    host_id), ignore_status=True, verbose=True, long_running=True, retry=0)
-            if res.failed and re.match(removenode_reject_msg, res.stdout + res.stderr):
-                raise Exception(f"Removenode was rejected {res.stdout}\n{res.stderr}")
+            with Nemesis.run_nemesis(node_list=self.cluster.nodes, nemesis_label="RemoveNodeAddNode") as rnd_node:
+                self.log.info("Running removenode command on {}, Removing node with the following host_id: {}"
+                              .format(rnd_node.ip_address, host_id))
+                with adaptive_timeout(Operations.REMOVE_NODE, rnd_node, timeout=HOUR_IN_SEC * 48):
+                    res = rnd_node.run_nodetool("removenode {}".format(
+                        host_id), ignore_status=True, verbose=True, long_running=True, retry=0)
+                if res.failed and re.match(removenode_reject_msg, res.stdout + res.stderr):
+                    raise Exception(f"Removenode was rejected {res.stdout}\n{res.stderr}")
 
             return res.exit_status
 
         # full cluster repair
-        up_normal_nodes.remove(node_to_remove)
+        up_normal_nodes = self.cluster.get_nodes_up_and_normal(verification_node)
         # Repairing will result in a best effort repair due to the terminated node,
         # and as a result requires ignoring repair errors
         with DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR,
@@ -3772,56 +3781,52 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     self.log.error(f"failed to execute repair command "
                                    f"on node {node} due to the following error: {str(details)}")
 
-            # WORKAROUND: adding here the continuation of the nemesis to avoid the late filter messages above failing
-            # the entire nemesis.
-
-            exit_status = remove_node()
-
-            # if remove node command failed by any reason,
-            # we will remove the terminated node from
-            # dead_nodes_list, so the health validator terminate the job
-            if exit_status != 0:
-                self.log.error(f"nodetool removenode command exited with status {exit_status}")
-                # check difference between group0 and token ring,
-                garbage_host_ids = verification_node.raft.get_diff_group0_token_ring_members()
-                self.log.debug("Difference between token ring and group0 is %s", garbage_host_ids)
-                if garbage_host_ids:
-                    # if difference found, clean garbage and continue
-                    verification_node.raft.clean_group0_garbage()
+        exit_status = remove_node()
+        # if remove node command failed by any reason,
+        # we will remove the terminated node from
+        # dead_nodes_list, so the health validator terminate the job
+        if exit_status != 0:
+            self.log.error(f"nodetool removenode command exited with status {exit_status}")
+            # check difference between group0 and token ring,
+            garbage_host_ids = verification_node.raft.get_diff_group0_token_ring_members()
+            self.log.debug("Difference between token ring and group0 is %s", garbage_host_ids)
+            if garbage_host_ids:
+                # if difference found, clean garbage and continue
+                verification_node.raft.clean_group0_garbage()
+            else:
+                # group0 and token ring are consistent. Removenode failed by meanigfull reason.
+                # remove node from dead_nodes list to raise critical issue by HealthValidator
+                self.log.debug(
+                    f"Remove failed node {node_to_remove} from dead node list {self.cluster.dead_nodes_list}")
+                node = next((n for n in self.cluster.dead_nodes_list if n.ip_address ==
+                            node_to_remove.ip_address), None)
+                if node:
+                    self.cluster.dead_nodes_list.remove(node)
                 else:
-                    # group0 and token ring are consistent. Removenode failed by meanigfull reason.
-                    # remove node from dead_nodes list to raise critical issue by HealthValidator
-                    self.log.debug(
-                        f"Remove failed node {node_to_remove} from dead node list {self.cluster.dead_nodes_list}")
-                    node = next((n for n in self.cluster.dead_nodes_list if n.ip_address ==
-                                node_to_remove.ip_address), None)
-                    if node:
-                        self.cluster.dead_nodes_list.remove(node)
-                    else:
-                        self.log.debug(f"Node {node.name} with ip {node.ip_address} was not found in dead_nodes_list")
+                    self.log.debug(f"Node {node.name} with ip {node.ip_address} was not found in dead_nodes_list")
 
-            # verify node is removed by nodetool status
-            removed_node_status = self.cluster.get_node_status_dictionary(
-                ip_address=node_to_remove.ip_address, verification_node=verification_node)
-            assert removed_node_status is None, \
-                "Node was not removed properly (Node status:{})".format(removed_node_status)
+        # verify node is removed by nodetool status
+        removed_node_status = self.cluster.get_node_status_dictionary(
+            ip_address=node_to_remove.ip_address, verification_node=verification_node)
+        assert removed_node_status is None, \
+            "Node was not removed properly (Node status:{})".format(removed_node_status)
 
-            # add new node with same type (data node / zero token node)
-            new_node_args = {"count": 1, "rack": self.target_node.rack}
-            if self.target_node._is_zero_token_node:
-                new_node_args.update({"is_zero_node": True})
-            new_node = self._add_and_init_new_cluster_nodes(**new_node_args)[0]
-            # in case the removed node was not last seed.
-            if node_to_remove.is_seed and num_of_seed_nodes > 1:
-                new_node.set_seed_flag(True)
-                self.cluster.update_seed_provider()
-            # after add_node, the left nodes have data that isn't part of their tokens anymore.
-            # In order to eliminate cases that we miss a "data loss" bug because of it, we cleanup this data.
-            # This fix important when just user profile is run in the test and "keyspace1" doesn't exist.
-            try:
-                self.nodetool_cleanup_on_all_nodes_parallel()
-            finally:
-                self.unset_current_running_nemesis(new_node)
+        # add new node with same type (data node / zero token node)
+        new_node_args = {"count": 1, "rack": self.target_node.rack}
+        if self.target_node._is_zero_token_node:
+            new_node_args.update({"is_zero_node": True})
+        new_node = self._add_and_init_new_cluster_nodes(**new_node_args)[0]
+        # in case the removed node was not last seed.
+        if node_to_remove.is_seed and num_of_seed_nodes > 1:
+            new_node.set_seed_flag(True)
+            self.cluster.update_seed_provider()
+        # after add_node, the left nodes have data that isn't part of their tokens anymore.
+        # In order to eliminate cases that we miss a "data loss" bug because of it, we cleanup this data.
+        # This fix important when just user profile is run in the test and "keyspace1" doesn't exist.
+        try:
+            self.nodetool_cleanup_on_all_nodes_parallel()
+        finally:
+            self.unset_current_running_nemesis(new_node)
 
     @target_all_nodes
     def disrupt_network_reject_inter_node_communication(self):
@@ -5435,6 +5440,88 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.target_node.start_scylla()
             assert self.target_node != new_coordinator_node, \
                 f"New coordinator node was not elected while old one {coordinator_node.name} was stopped"
+
+    @target_all_nodes
+    def disrupt_refuse_connection_with_block_scylla_ports_on_banned_node(self):
+        self._refuse_connection_from_banned_node(use_iptables=True)
+
+    @target_all_nodes
+    def disrupt_refuse_connection_with_send_sigstop_signal_to_scylla_on_banned_node(self):
+        self._refuse_connection_from_banned_node(use_iptables=False)
+
+    def _refuse_connection_from_banned_node(self, use_iptables=False):
+        """Banned node could not connect with rest nodes in cluster
+
+        If node was removed from cluster for any reason, even if removed node
+        become alive and try to communicate with rest node in cluster, all connections
+        from it should be refused by other nodes in cluster
+        1. on target node block any scylladb process
+        1.1 Pause process
+        1.2 Block with iptables port 9100/10000
+        2. Wait and remove target node from cluster
+        3. start scylla on target node
+        4. Create exclusive connection to target node
+        5. Execute cql command on target node and validate that no operation
+        from target node passed to cluster
+        """
+        if not self.target_node.raft.is_consistent_topology_changes_enabled:
+            raise UnsupportedNemesis("Raft feature: consistent-topology-changes is not enabled")
+        if self._is_it_on_kubernetes():
+            raise UnsupportedNemesis("Skip test for K8S because no supported yet")
+        keyspace_name = "banned_keyspace"
+        table_name = "table1"
+
+        def drop_keyspace(node):
+            with self.cluster.cql_connection_patient(node=node) as session:
+                LOGGER.debug("Drop keyspace %s", keyspace_name)
+                session.execute(f"DROP KEYSPACE IF EXISTS {keyspace_name}", timeout=300)
+
+        simulate_node_unavailability = node_operations.block_scylla_ports if use_iptables else node_operations.pause_scylla_with_sigstop
+        with self.run_nemesis(node_list=self.cluster.nodes,
+                              nemesis_label=f"Running {simulate_node_unavailability.__name__}") as working_node, ExitStack() as stack:
+            target_host_id = self.target_node.host_id
+            stack.callback(self._remove_node_add_node, verification_node=working_node, node_to_remove=self.target_node,
+                           remove_node_host_id=target_host_id)
+
+            self.tester.create_keyspace(keyspace_name, replication_factor=3)
+            self.tester.create_table(name=table_name, keyspace_name=keyspace_name, key_type="bigint",
+                                     columns={"name": "text"})
+            stack.callback(drop_keyspace, node=working_node)
+
+            with simulate_node_unavailability(self.target_node):
+                # target node stopped by Contextmanger. Wait while its status will be updated
+                wait_for(node_operations.is_node_seen_as_down, timeout=600, throw_exc=True,
+                         down_node=self.target_node, verification_node=working_node, text=f"Wait other nodes see {self.target_node.name} as DOWN...")
+                self.log.debug("Remove node %s : hostid: %s with blocked scylla from cluster",
+                               self.target_node.name, target_host_id)
+                working_node.run_nodetool(f"removenode {target_host_id}", retry=0, long_running=True)
+                assert node_operations.is_node_removed_from_cluster(removed_node=self.target_node, verification_node=working_node), \
+                    f"Node {self.target_node.name} with host id {target_host_id} was not removed. See log errors"
+
+                # Context manager at exit  start scylla on target node.
+                # But node already removed from cluster. So any operations from it
+                # should be banned. If query executed succesfull, raise an error
+            assert self.target_node.db_up(), f"Scylla was not up on node {self.target_node.name}"
+
+            with self.cluster.cql_connection_exclusive(node=self.target_node) as session:
+                for key in random.sample(range(1, 100001), 1000):
+                    try:
+                        stmt = SimpleStatement(f"INSERT INTO {keyspace_name}.{table_name} (key, name) VALUES ({key}, 'name{key}');",
+                                               consistency_level=ConsistencyLevel.QUORUM)
+                        session.execute(stmt)
+                        self.log.error("Banned query passed to cluster from banned node")
+                        raise BannedQueryExecUnexpectedSuccess(
+                            "Query from banned node was executed succesful with Consistency.QUORUM")
+                    except (NoHostAvailable, OperationTimedOut, Unavailable) as exc:
+                        self.log.debug("Query failed with error: %s as expected", exc)
+
+            with self.cluster.cql_connection_patient(working_node) as session:
+                LOGGER.debug("Check keyspace %s.%s is empty", keyspace_name, table_name)
+                result = list(session.execute(f"SELECT * from {keyspace_name}.{table_name}"))
+                LOGGER.debug("Query result %s", result)
+                assert not result, f"New rows were added from banned node, {result}"
+
+            drop_keyspace(working_node)
 
 
 def disrupt_method_wrapper(method, is_exclusive=False):  # pylint: disable=too-many-statements  # noqa: PLR0915
@@ -7058,3 +7145,21 @@ class SerialRestartOfElectedTopologyCoordinatorNemesis(Nemesis):
 
     def disrupt(self):
         self.disrupt_serial_restart_elected_topology_coordinator()
+
+
+class IsolateNodeWithProcessSignalNemesis(Nemesis):
+    disruptive = True
+    topology_changes = True
+    kubernetes = False
+
+    def disrupt(self):
+        self.disrupt_refuse_connection_with_send_sigstop_signal_to_scylla_on_banned_node()
+
+
+class IsolateNodeWithIptableRuleNemesis(Nemesis):
+    disruptive = True
+    topology_changes = True
+    kubernetes = False
+
+    def disrupt(self):
+        self.disrupt_refuse_connection_with_block_scylla_ports_on_banned_node()

--- a/sdcm/rest/raft_api.py
+++ b/sdcm/rest/raft_api.py
@@ -1,0 +1,29 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2024 ScyllaDB
+from typing import TypeVar
+from sdcm.rest.remote_curl_client import RemoteCurlClient
+
+BaseNode = TypeVar("BaseNode")
+
+
+class RaftApi(RemoteCurlClient):
+    """Raft api commands"""
+
+    def __init__(self, node: BaseNode):
+        super().__init__(host="localhost:10000", endpoint="raft", node=node)
+
+    def read_barrier(self, group_id: str) -> str:
+        path = f"read_barrier?group_id={group_id}"
+        return self.run_remoter_curl(method="POST",
+                                     path=path,
+                                     params={}, timeout=30).stdout.strip()

--- a/sdcm/utils/nemesis_utils/node_operations.py
+++ b/sdcm/utils/nemesis_utils/node_operations.py
@@ -1,0 +1,51 @@
+import contextlib
+import logging
+
+from typing import Optional
+
+from sdcm.cluster import BaseNode
+
+LOGGER = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def block_scylla_ports(target_node: "BaseNode", ports: list[int] | None = None):
+    ports = ports or [7001, 7000, 9042, 9142, 19042, 19142]
+    target_node.install_package("iptables")
+    target_node.start_service("iptables", ignore_status=True)
+    target_node.log.debug("Block connections %s", target_node.name)
+    for port in ports:
+        target_node.remoter.sudo(f"iptables -A INPUT -p tcp --dport {port} -j DROP")
+        target_node.remoter.sudo(f"iptables -A OUTPUT -p tcp --dport {port} -j DROP")
+    yield
+    target_node.log.debug("Remove all iptable rules %s", target_node.name)
+    for port in ports:
+        target_node.remoter.sudo(f"iptables -D INPUT -p tcp --dport {port} -j DROP")
+        target_node.remoter.sudo(f"iptables -D OUTPUT -p tcp --dport {port} -j DROP")
+    target_node.stop_service("iptables", ignore_status=True)
+
+
+@contextlib.contextmanager
+def pause_scylla_with_sigstop(target_node: "BaseNode"):
+    target_node.log.debug("Send signal SIGSTOP to scylla process on node %s", target_node.name)
+    target_node.remoter.sudo("pkill --signal SIGSTOP -e scylla", timeout=60)
+    yield
+    target_node.log.debug("Send signal SIGCONT to scylla process on node %s", target_node.name)
+    target_node.remoter.sudo(cmd="pkill --signal SIGCONT -e scylla", timeout=60)
+
+
+def is_node_removed_from_cluster(removed_node: BaseNode, verification_node: BaseNode) -> bool:
+    LOGGER.debug("Verification node %s", verification_node.name)
+    cluster_status: Optional[dict] = removed_node.parent_cluster.get_nodetool_status(
+        verification_node=verification_node)
+    if not cluster_status:
+        return False
+    result = []
+    for dc in cluster_status:
+        result.append(removed_node.ip_address not in cluster_status[dc].keys())
+    return all(result)
+
+
+def is_node_seen_as_down(down_node: BaseNode, verification_node: BaseNode) -> bool:
+    LOGGER.debug("Verification node %s", verification_node.name)
+    return down_node not in verification_node.parent_cluster.get_nodes_up_and_normal(verification_node)

--- a/sdcm/utils/raft/__init__.py
+++ b/sdcm/utils/raft/__init__.py
@@ -13,6 +13,7 @@ from sdcm.sct_events import Severity
 from sdcm.utils.features import is_consistent_topology_changes_feature_enabled, is_consistent_cluster_management_feature_enabled
 from sdcm.utils.health_checker import HealthEventsGenerator
 from sdcm.wait import wait_for
+from sdcm.rest.raft_api import RaftApi
 
 
 LOGGER = logging.getLogger(__name__)
@@ -137,6 +138,9 @@ class RaftFeatureOperations(ABC):
         log_patterns = self.TOPOLOGY_OPERATION_LOG_PATTERNS.get(operation)
         return list(map(self.get_message_waiting_timeout, log_patterns))
 
+    def call_read_barrier(self):
+        ...
+
 
 class RaftFeature(RaftFeatureOperations):
     TOPOLOGY_OPERATION_LOG_PATTERNS: dict[TopologyOperations, Iterable[MessagePosition]] = {
@@ -172,19 +176,24 @@ class RaftFeature(RaftFeatureOperations):
         state = self.get_status()
         return state == "use_post_raft_procedures"
 
+    def get_group0_id(self, session) -> str:
+        try:
+            row = session.execute("select value from system.scylla_local where key = 'raft_group0_id'").one()
+            return row.value
+        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            err_msg = f"Get group0 members failed with error: {exc}"
+            LOGGER.error(err_msg)
+            return ""
+
     def get_group0_members(self) -> list[dict[str, str]]:
         LOGGER.debug("Get group0 members")
         group0_members = []
         try:
             with self._node.parent_cluster.cql_connection_patient_exclusive(node=self._node) as session:
-                row = session.execute("select value from system.scylla_local where key = 'raft_group0_id'").one()
-                if not row:
-                    return []
-                raft_group0_id = row.value
-
+                raft_group0_id = self.get_group0_id(session)
+                assert raft_group0_id, "Group0 id was not found"
                 rows = session.execute(f"select server_id, can_vote from system.raft_state  \
                                         where group_id = {raft_group0_id} and disposition = 'CURRENT'").all()
-
                 for row in rows:
                     group0_members.append({"host_id": str(row.server_id),
                                            "voter": row.can_vote})
@@ -347,6 +356,28 @@ class RaftFeature(RaftFeatureOperations):
         LOGGER.debug("Group0 and token-ring are consistent on node %s (host_id=%s)...",
                      self._node.name, self._node.host_id)
 
+    def call_read_barrier(self):
+        """ Wait until the node applies all previously committed Raft entries
+
+        Any schema/topology changes are committed with Raft group0 on node. Before
+        change is written to node, raft group0 checks that all previous schema/
+        topology changes were applied. Raft triggers read_barrier on node, and
+        node applies all previous changes(commits) before new schema/operation
+        write will be applied. After read barrier finished, it guarantees that
+        node has all schema/topology changes, which was done in cluster before
+        read_barrier started on node.
+
+        """
+        with self._node.parent_cluster.cql_connection_patient_exclusive(node=self._node) as session:
+            raft_group0_id = self.get_group0_id(session)
+            assert raft_group0_id, "Group0 id was not found"
+        try:
+            api = RaftApi(self._node)
+            result = api.read_barrier(group_id=raft_group0_id)
+            LOGGER.debug("Api response %s", result)
+        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            LOGGER.error("Trigger read-barrier via rest api failed %s", exc)
+
 
 class NoRaft(RaftFeatureOperations):
     TOPOLOGY_OPERATION_LOG_PATTERNS = {
@@ -405,6 +436,9 @@ class NoRaft(RaftFeatureOperations):
         LOGGER.debug("Raft feature is disabled on node %s (host_id=%s)", self._node.name, self._node.host_id)
 
         yield None
+
+    def call_read_barrier(self):
+        ...
 
 
 def get_raft_mode(node) -> RaftFeature | NoRaft:

--- a/unit_tests/test_nemesis.py
+++ b/unit_tests/test_nemesis.py
@@ -240,7 +240,11 @@ class TestSisyphusMonkeyNemesisFilter:
             "disrupt_decommission_streaming_err",
             "disrupt_remove_node_then_add_node",
             "disrupt_bootstrap_streaming_error",
-            "disrupt_serial_restart_elected_topology_coordinator"]
+            "disrupt_serial_restart_elected_topology_coordinator",
+            "disrupt_refuse_connection_with_block_scylla_ports_on_banned_node",
+            "disrupt_refuse_connection_with_send_sigstop_signal_to_scylla_on_banned_node"
+
+        ]
 
     @pytest.fixture(autouse=True)
     def expected_schema_changes_methods(self):

--- a/unit_tests/test_nemesis_sisyphus.py
+++ b/unit_tests/test_nemesis_sisyphus.py
@@ -80,7 +80,7 @@ def test_list_all_available_nemesis(generate_file=True):
     disruption_list, disruptions_dict, disruption_classes = sisyphus.get_list_of_disrupt_methods(
         subclasses_list=subclasses, export_properties=True)
 
-    assert len(disruption_list) == 90
+    assert len(disruption_list) == 92
 
     if generate_file:
         with open(sct_abs_path('data_dir/nemesis.yml'), 'w', encoding="utf-8") as outfile1:


### PR DESCRIPTION
New nemesis for raft feature consistent-topology-changes:
ban removed node if it try back to cluster
The new nemesis send signal to scylla process and set it PAUSED
After the node with paused scylla marked as DN, the node is removed
After that signal SIGCONT is send and scylla is backed. but any connection
from that node should be ignored.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
