### PR TITLE
fix(Artifact): skip verify_xfs_online_discard_enabled if using t3.micro

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -322,7 +322,8 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
         with self.subTest("verify write cache for NVMe devices"):
             self.verify_nvme_write_cache()
 
-        if backend != "docker" and not self.params.get("nonroot_offline_install"):
+        if (backend != "docker" and not self.params.get("nonroot_offline_install")
+                and self.node.db_node_instance_type != "t3.micro"):
             with self.subTest("verify XFS online discard enabled"):
                 self.verify_xfs_online_discard_enabled()
 


### PR DESCRIPTION
Since t3.micro instances don't have any local volume outside of root, t3.micro runs have an additional ebs volume. In such cases, online-discard is not enabled for the mount point, which causes verify_xfs_online_discard_enabled to fail. As such, I skipped the check when using t3.micro

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
