### PR TITLE
fix(nemesis): init new nodes must set them as seeds

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1188,6 +1188,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         else:
             new_node.replacement_node_ip = old_node_ip
         try:
+            self.cluster.set_seeds()
+            self.cluster.update_seed_provider()
             with adaptive_timeout(Operations.NEW_NODE, node=self.cluster.nodes[0], timeout=timeout):
                 self.cluster.wait_for_init(node_list=[new_node], timeout=timeout, check_node_health=False)
             self.cluster.clean_replacement_node_options(new_node)


### PR DESCRIPTION
since #6136 we have been testing our clusters
like all nodes are seeds (since Scylla is now
"seedless" for quite some time), but when running
`disrupt_grow_shrink_cluster` for the 5th time,
we start failing with error:
```
AssertionError: We should have at least one selected seed by now
```

this fix will also be fixing all other nemeses
that do add new nodes to the cluster, when running for quite some time, probability of hitting it on
regular replace node operations is smaller, since
this nemesis runs 3 times add new node in each loop iteration.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
