### PR TITLE
fix(sla-rolling-upgrade): move to run on ubuntu 22.04

### DIFF
--- a/jenkins-pipelines/rolling-upgrade-with-sla-no-shares.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-with-sla-no-shares.jenkinsfile
@@ -6,9 +6,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingUpgradePipeline(
     backend: 'gce',
     base_versions: '',  // auto mode
-    linux_distro: 'centos-8',
-    gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-8',
-
+    linux_distro: 'ubuntu-jammy',
+    gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts',
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
     test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-with-sla-no-shares.yaml"]'''
 )

--- a/jenkins-pipelines/rolling-upgrade-with-sla.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-with-sla.jenkinsfile
@@ -6,9 +6,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingUpgradePipeline(
     backend: 'gce',
     base_versions: '',  // auto mode
-    linux_distro: 'centos-8',
-    gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-8',
-
+    linux_distro: 'ubuntu-jammy',
+    gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts',
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
     test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-with-sla.yaml"]'''
 )


### PR DESCRIPTION
Since we are having issue with coredump creation on centos8,
and that we want the test to be focused on something closer to
scylla formal images.
we are switching those cases off centos8

Closes: #6582

### Testing
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/la_rolling_upgrade_move_to_ubuntu/4/
- [ ] - move triggers to correct place in scylla-pkg

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
