### PR TITLE
fix(rolling upgrade): disable audit

### DIFF
--- a/test-cases/upgrades/generic-rolling-upgrade.yaml
+++ b/test-cases/upgrades/generic-rolling-upgrade.yaml
@@ -19,6 +19,9 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: 'cassandra'
 authenticator_password: 'cassandra'
 
+append_scylla_yaml: |
+  audit: "none"
+
 use_legacy_cluster_init: false
 internode_compression: 'all'
 

--- a/test-cases/upgrades/multi-dc-rolling-upgrade.yaml
+++ b/test-cases/upgrades/multi-dc-rolling-upgrade.yaml
@@ -20,6 +20,9 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: 'cassandra'
 authenticator_password: 'cassandra'
 
+append_scylla_yaml: |
+  audit: "none"
+
 internode_compression: 'all'
 
 use_mgmt: false

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -27,6 +27,9 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: 'cassandra'
 authenticator_password: 'cassandra'
 
+append_scylla_yaml: |
+  audit: "none"
+
 use_mgmt: false
 
 gemini_cmd: "gemini -d --duration 2h \


### PR DESCRIPTION
Audit was disabled by default in 2023.1 by
https://github.com/scylladb/scylla-enterprise/pull/3094. But it was not backported to 2022.1 and 2022.2. It cause to error in cassandra-stress:

ERROR 13:04:18,965 Authentication error on host: Cannot achieve consistency level for cl ONE. Requires 1, alive 0

Disable audit in rolling upgrade tests to prevent this failure

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
