### PR TITLE
fix(rolling upgrade): disable audit

### DIFF
--- a/test-cases/upgrades/generic-rolling-upgrade.yaml
+++ b/test-cases/upgrades/generic-rolling-upgrade.yaml
@@ -14,6 +14,9 @@ scylla_linux_distro: 'centos'
 
 user_prefix: 'rolling-upgrade'
 
+append_scylla_yaml: |
+  audit: "none"
+
 server_encrypt: true
 authenticator: 'PasswordAuthenticator'
 authenticator_user: 'cassandra'

--- a/test-cases/upgrades/multi-dc-rolling-upgrade.yaml
+++ b/test-cases/upgrades/multi-dc-rolling-upgrade.yaml
@@ -15,6 +15,9 @@ region_name: 'eu-west-1 eu-west-2'
 
 user_prefix: 'multi-dc-rolling-upgrade'
 
+append_scylla_yaml: |
+  audit: "none"
+
 server_encrypt: true
 authenticator: 'PasswordAuthenticator'
 authenticator_user: 'cassandra'

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -22,6 +22,9 @@ instance_type_db: 'i3.2xlarge'
 
 user_prefix: 'rolling-upgrade'
 
+append_scylla_yaml: |
+  audit: "none"
+
 server_encrypt: true
 authenticator: 'PasswordAuthenticator'
 authenticator_user: 'cassandra'


### PR DESCRIPTION
Audit was disabled by default in 2023.1 by
https://github.com/scylladb/scylla-enterprise/pull/3094. But it is still enabled in 2022.1 and 2022.2.
It cause to error in cassandra-stress:
```
ERROR 13:04:18,965 Authentication error on host: Cannot achieve consistency level for cl ONE. Requires 1, alive 0
```

Disable audit in rolling upgrade tests to prevent this failure

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
