### PR TITLE
fix(nemesis): init new node when they are seeds

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1188,11 +1188,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         else:
             new_node.replacement_node_ip = old_node_ip
         try:
-            self.cluster.set_seeds()
-            self.cluster.update_seed_provider()
             with adaptive_timeout(Operations.NEW_NODE, node=self.cluster.nodes[0], timeout=timeout):
                 self.cluster.wait_for_init(node_list=[new_node], timeout=timeout, check_node_health=False)
             self.cluster.clean_replacement_node_options(new_node)
+            self.cluster.set_seeds()
+            self.cluster.update_seed_provider()
         except (NodeSetupFailed, NodeSetupTimeout):
             self.log.warning("TestConfig of the '%s' failed, removing it from list of nodes" % new_node)
             self.cluster.nodes.remove(new_node)


### PR DESCRIPTION
following change proposed on #6581, we missed
another longevity, that does replace node,
as the node cannot be a seed, when it is
replacing a node (see error below):
```
[shard 0:main] init - Bad configuration:
 replace-node-first-boot is not allowed for seed nodes
```
moving the `update_seed_provider()` after
we run `clean_replacement_node_options()`,
so it won't conflict.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
