### PR TITLE
fix(nemesis publisher): add Scylla commit date to ES

### DIFF
--- a/sdcm/nemesis_publisher.py
+++ b/sdcm/nemesis_publisher.py
@@ -49,21 +49,30 @@ class NemesisElasticSearchPublisher:
         test_data = self.stats
         assert test_data, "without self.stats data we can't publish nemesis ES"
         if 'scylla-server' in test_data['versions']:
-            version = test_data['versions']['scylla-server']['version']
-            commit_id = test_data['versions']['scylla-server']['commit_id']
-        elif 'version' in test_data['versions'] and 'commit_id' in test_data['versions']:
-            version = test_data['versions']['version']
-            commit_id = test_data['versions']['commit_id']
+            version = test_data['versions']['scylla-server'].get('version', '')
+            commit_id = test_data['versions']['scylla-server'].get('commit_id', '')
+            commit_date = test_data['versions']['scylla-server'].get('date', '')
+            build_id = test_data['versions']['scylla-server'].get('build_id', '')
+        elif 'version' in test_data['versions']:
+            version = test_data['versions'].get('version', '')
+            commit_id = test_data['versions'].get('commit_id', '')
+            commit_date = test_data['versions'].get('date', '')
+            build_id = test_data['versions'].get('build_id', '')
         else:
             version = ''
             commit_id = ''
-
+            commit_date = ''
+            build_id = ''
+        scylla_version = '.'.join([version, commit_date, commit_id])
         new_nemesis_data = dict(
             test_id=test_data['test_details']['test_id'],
             job_name=test_data['test_details']['job_name'],
             test_name=test_data['test_details']['test_name'],
             scylla_version=version,
             scylla_git_sha=commit_id,
+            scylla_commit_date=commit_date,
+            full_scylla_version=scylla_version,
+            build_id=build_id,
         )
         if status:
             new_nemesis_data.update(


### PR DESCRIPTION
up until now, we were saving only Scylla version
and the git sha of the commit, making chart creation less clear or logical, since we didn't have the
commit dates to order the latest entries.

From now, the entries will have commit date,
allowing us to order the chart by commit date,
and showing the last entries, being more
meaningful for chart presentation.

Refs: scylladb/qa-tasks#1489

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
