### PR TITLE
improvement(event): add AuthenticationError c-s subevent

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -86,6 +86,7 @@ CassandraStressLogEvent.OperationOnKey: CRITICAL
 CassandraStressLogEvent.TooManyHintsInFlight: ERROR
 CassandraStressLogEvent.ShardAwareDriver: NORMAL
 CassandraStressLogEvent.SchemaDisagreement: WARNING
+CassandraStressLogEvent.AuthenticationError: WARNING
 SchemaDisagreementErrorEvent: ERROR
 ScyllaBenchLogEvent.ConsistencyError: ERROR
 GeminiStressLogEvent.GeminiEvent: CRITICAL

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -166,6 +166,7 @@ class CassandraStressLogEvent(LogEvent, abstract=True):
     TooManyHintsInFlight: Type[LogEventProtocol]
     ShardAwareDriver: Type[LogEventProtocol]
     SchemaDisagreement: Type[LogEventProtocol]
+    AuthenticationError: Type[LogEventProtocol]
 
 
 class SchemaDisagreementErrorEvent(SctEvent):
@@ -215,15 +216,18 @@ CassandraStressLogEvent.add_subevent_type("ShardAwareDriver", severity=Severity.
                                           regex="Using optimized driver")
 CassandraStressLogEvent.add_subevent_type("SchemaDisagreement", severity=Severity.WARNING,
                                           regex="No schema agreement")
-
+CassandraStressLogEvent.add_subevent_type("AuthenticationError", severity=Severity.WARNING,
+                                          regex="Authentication error on host")
 
 CS_ERROR_EVENTS = (
     CassandraStressLogEvent.TooManyHintsInFlight(),
     CassandraStressLogEvent.OperationOnKey(),
     CassandraStressLogEvent.IOException(),
+    CassandraStressLogEvent.AuthenticationError(),
     CassandraStressLogEvent.ConsistencyError(),
     CassandraStressLogEvent.SchemaDisagreement(),
 )
+
 CS_NORMAL_EVENTS = (CassandraStressLogEvent.ShardAwareDriver(), )
 
 CS_ERROR_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \

--- a/unit_tests/test_sct_events_loaders.py
+++ b/unit_tests/test_sct_events_loaders.py
@@ -399,6 +399,7 @@ class TestCassandraStressLogEvent(unittest.TestCase):
         self.assertTrue(issubclass(CassandraStressLogEvent.OperationOnKey, CassandraStressLogEvent))
         self.assertTrue(issubclass(CassandraStressLogEvent.TooManyHintsInFlight, CassandraStressLogEvent))
         self.assertTrue(issubclass(CassandraStressLogEvent.SchemaDisagreement, CassandraStressLogEvent))
+        self.assertTrue(issubclass(CassandraStressLogEvent.AuthenticationError, CassandraStressLogEvent))
 
     def test_known_cs_normal(self):
         self.assertTrue(issubclass(CassandraStressLogEvent.ShardAwareDriver, CassandraStressLogEvent))
@@ -436,6 +437,11 @@ class TestCassandraStressLogEvent(unittest.TestCase):
                        'Requires 2, alive 1',
                        expected_type='ConsistencyError',
                        expected_severity=Severity.ERROR)
+
+        self.get_event(line='ERROR 13:04:18,965 Authentication error on host rolling-upgrade-sla--centos-8-db-node-373473f1-0-3.c.'
+                            'sct-project-1.internal/10.142.1.41:9042: Cannot achieve consistency level for cl ONE. Requires 1, alive 0',
+                       expected_type='AuthenticationError',
+                       expected_severity=Severity.WARNING)
 
     def test_cs_normal_shared_awarnes_event(self):
         self.get_event(line='com.datastax.driver.core.Cluster - ===== Using optimized driver!!! =====',


### PR DESCRIPTION
Add CassandraStressLogEvent.add_subevent_type WARNING for cassandra-stress error:

ERROR 13:04:18,965 Authentication error on host: Cannot achieve consistency level for cl ONE. Requires 1, alive 0

This error caused by audit enabled. By default audit is disabled in 20223.1 by https://github.com/scylladb/scylla-enterprise/pull/3094. But it won't be enabled in 2022.1 and 2022.2.
This message generates too much noise for us. We do not need it will fail the test.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
