### PR TITLE
improvement(kms): remove workaround for the 'p11-kit' package

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1631,13 +1631,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 'ldap_bind_dn': ldap_bind_dn,
                 'ldap_bind_pw': ldap_bind_pw}
 
-    def configure_kms(self):
-        # Hack for overriding issue https://github.com/scylladb/scylla-enterprise/issues/2792
-        # TODO: should be removed once a proper fix is implemented
-        self.remoter.sudo("find /opt/scylladb/ -iname *libp11-kit.so* | sudo xargs rm",
-                          verbose=True, ignore_status=True)
-        self.install_package("p11-kit")
-
     # pylint: disable=invalid-name,too-many-arguments,too-many-locals,too-many-statements,unused-argument,too-many-branches
     def config_setup(self,
                      append_scylla_args='',
@@ -1649,10 +1642,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 self.parent_cluster.proposed_scylla_yaml,
                 self.proposed_scylla_yaml
             )
-            is_kms = bool(scylla_yml.kms_hosts)
-
-        if is_kms:
-            self.configure_kms()
 
         self.process_scylla_args(append_scylla_args)
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3973,7 +3973,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                         }
                         is_restart_needed = True
                 if is_restart_needed:
-                    node.configure_kms()
                     node.restart_scylla()
 
         # Create table with encryption


### PR DESCRIPTION
The Scylla enterprise PR [1] was merged which fixed the [2] bug. So, remove the workaround for the `p11-kit` package as unneeded.

[1] scylla-enterprise/pull/3023
[2] scylla-enterprise/issues/2792

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
