### PR TITLE
feature(aws): placement group creation

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -227,3 +227,5 @@ run_fullscan: []
 
 stress_step_duration: '15m'
 simulated_racks: 0
+
+use_placement_group: false

--- a/sdcm/provision/aws/utils.py
+++ b/sdcm/provision/aws/utils.py
@@ -359,3 +359,15 @@ def configure_eth1_script():
 def configure_set_preserve_hostname_script():
     return 'grep "preserve_hostname: true" /etc/cloud/cloud.cfg 1>/dev/null 2>&1 ' \
            '|| echo "preserve_hostname: true" >> /etc/cloud/cloud.cfg\n'
+
+
+# -----AWS Placement Group section -----
+def create_cluster_placement_groups_aws(name: str, tags: dict, region=None, dry_run=False):
+    ec2: EC2Client = ec2_clients[region]
+    result = ec2.create_placement_group(
+        DryRun=dry_run, GroupName=name, Strategy='cluster',
+        TagSpecifications=[{
+            'ResourceType': 'placement-group',
+            "Tags": [{"Key": key, "Value": value} for key, value in tags.items()] +
+                    [{"Key": "Name", "Value": name}], }],)
+    return result

--- a/sdcm/sct_provision/aws/__init__.py
+++ b/sdcm/sct_provision/aws/__init__.py
@@ -1,0 +1,12 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2023 ScyllaDB

--- a/sdcm/sct_provision/aws/instance_parameters_builder.py
+++ b/sdcm/sct_provision/aws/instance_parameters_builder.py
@@ -30,6 +30,7 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
     region_id: int = Field(as_dict=False)
     user_data_raw: Union[str, UserDataBuilderBase] = Field(as_dict=False)
     availability_zone: int = 0
+    placement_group: str = None
 
     _INSTANCE_TYPE_PARAM_NAME: str = None
     _IMAGE_ID_PARAM_NAME: str = None
@@ -82,7 +83,9 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
 
     @property
     def Placement(self) -> Optional[AWSPlacementInfo]:  # pylint: disable=invalid-name
-        return AWSPlacementInfo(AvailabilityZone=self._region_name + self._availability_zones[self.availability_zone])
+        return AWSPlacementInfo(
+            AvailabilityZone=self._region_name + self._availability_zones[self.availability_zone],
+            GroupName=self.placement_group)
 
     @property
     def UserData(self) -> Optional[str]:  # pylint: disable=invalid-name

--- a/sdcm/sct_provision/aws/layout.py
+++ b/sdcm/sct_provision/aws/layout.py
@@ -13,7 +13,8 @@
 
 from functools import cached_property
 
-from sdcm.sct_provision.aws.cluster import OracleDBCluster, DBCluster, LoaderCluster, MonitoringCluster
+from sdcm.sct_provision.aws.cluster import (
+    OracleDBCluster, DBCluster, LoaderCluster, MonitoringCluster, PlacementGroup)
 from sdcm.sct_provision.common.layout import SCTProvisionLayout
 from sdcm.test_config import TestConfig
 
@@ -25,6 +26,8 @@ class SCTProvisionAWSLayout(SCTProvisionLayout, cluster_backend='aws'):
         return TestConfig()
 
     def provision(self):
+        if self.placement_group:
+            self.placement_group.provision()
         if self.db_cluster:
             self.db_cluster.provision()
         if self.monitoring_cluster:
@@ -63,6 +66,14 @@ class SCTProvisionAWSLayout(SCTProvisionLayout, cluster_backend='aws'):
         if not self._provision_another_scylla_cluster:
             return None
         return OracleDBCluster(
+            params=self._params,
+            common_tags=self._test_config.common_tags(),
+            test_id=self._test_config.test_id(),
+        )
+
+    @cached_property
+    def placement_group(self):
+        return PlacementGroup(
             params=self._params,
             common_tags=self._test_config.common_tags(),
             test_id=self._test_config.test_id(),

--- a/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
@@ -48,3 +48,5 @@ custom_es_index: 'performancestatsv2'
 use_hdr_cs_histogram: true
 
 append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
+
+use_placement_group: true

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -178,6 +178,26 @@ def call(Map pipelineParams) {
                                             }
                                         }
 
+                                        stage("Provision Resources for ${sub_test}") {
+                                                catchError() {
+                                                    script {
+                                                        wrap([$class: 'BuildUser']) {
+                                                            dir('scylla-cluster-tests') {
+                                                                timeout(time: 30, unit: 'MINUTES') {
+                                                                    if (params.backend == 'aws' || params.backend == 'azure') {
+                                                                        provisionResources(params, builder.region)
+                                                                    } else {
+                                                                        sh """
+                                                                            echo 'Skipping because non-AWS/Azure backends are not supported'
+                                                                        """
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                        }
+
                                         stage("Run ${sub_test}"){
                                             catchError(stageResult: 'FAILURE') {
                                                 wrap([$class: 'BuildUser']) {


### PR DESCRIPTION
this commit is:
1) Include provision step into the performance pipeline
2) Add the ability to create load and DB instances within one AWS placement group
and config parameter to enable this feature
3) Update i4i Throughput perf test to  use the new feature
4) Update clean_placement_groups_aws functionality
to support --post-behavior flag in sct.py clean-resources command

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
