### PR TITLE
fix(Nemesis.add_node): support using `use_preinstalled_scylla: false`

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1183,7 +1183,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             count=1, dc_idx=self.target_node.dc_idx, enable_auto_bootstrap=True, rack=rack)[0]
         self.monitoring_set.reconfigure_scylla_monitoring()
         self.set_current_running_nemesis(node=new_node)  # prevent to run nemesis on new node when running in parallel
-        if new_node.is_replacement_by_host_id_supported:
+
+        # since we need this logic before starting a node, and in `use_preinstalled_scylla: false` case
+        # scylla is not yet installed, we should check the target node for version,
+        # it should be up and with scylla executable available
+        if self.target_node.is_replacement_by_host_id_supported:
             new_node.replacement_host_id = host_id
         else:
             new_node.replacement_node_ip = old_node_ip


### PR DESCRIPTION
since is_replacement_by_host_id_supported is called  before starting a node, 
and in `use_preinstalled_scylla: false` case scylla is not yet installed, 
we should check other running nodes for version

if we don't, we'll fail with a `None` version:

```
ValueError: Cannot parse provided 'None' scylla_version for the comparison.
Transformed scylla_version:
```

Fix: #6591

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
