### PR TITLE
fix(event): ignore Azure audit messages

### DIFF
--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -151,7 +151,7 @@ DatabaseLogEvent.add_subevent_type("RPC_CONNECTION", severity=Severity.WARNING,
 DatabaseLogEvent.add_subevent_type("DATABASE_ERROR", severity=Severity.ERROR,
                                    regex=r"(^ERROR|!\s*?ERR).*\[shard.*\]")
 DatabaseLogEvent.add_subevent_type("BACKTRACE", severity=Severity.ERROR,
-                                   regex="backtrace")
+                                   regex="^(?!.*audit:).*backtrace")
 SYSTEM_ERROR_EVENTS = (
     DatabaseLogEvent.WARNING(),
     DatabaseLogEvent.NO_SPACE_ERROR(),


### PR DESCRIPTION
Azure audit messages include a word 'backtrace' that causes to creating error DatabaseLogEvent and test failure.
This commit present regex change for DatabaseLogEvent.BACKTRACE event that allow to ignore the audit messages that include 'backtrace'.

```
2023-09-10T07:35:58+00:00    !NOTICE | audit: PATH item=3 name='/usr/share/man/man3/
backtrace_symbols_fd.3.gz' inode=41608 dev=08:01 mode=0120777 ouid=0 ogid=0 
rdev=00:00 nametype=CREATE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
