### PR TITLE
test(multi-az): set multi-az in several tests

### DIFF
--- a/jenkins-pipelines/longevity-cdc-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/longevity-cdc-100gb-4h.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
-    availability_zone: 'a',
+    availability_zone: 'a,b,c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-cdc-100gb-4h.yaml'
 

--- a/jenkins-pipelines/longevity-counters-multidc.jenkinsfile
+++ b/jenkins-pipelines/longevity-counters-multidc.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    availability_zone: 'a',
+    availability_zone: 'a,b,c',
     region: '''["eu-west-1", "us-west-2", "us-east-1"]''',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-counters-multidc.yaml'

--- a/jenkins-pipelines/longevity-multidc-schema-topology-changes-12h.jenkinsfile
+++ b/jenkins-pipelines/longevity-multidc-schema-topology-changes-12h.jenkinsfile
@@ -5,6 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
+    availability_zone: 'a,b,c',
     region: '''["eu-west-1", "eu-west-2"]''',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml"]''',

--- a/test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml
@@ -7,6 +7,7 @@ stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=4320m -schema 'replicati
 stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=4320m -mode cql3 native  -rate threads=50 -pop seq=1..100000000 -log interval=5"]
 
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 60}']
+availability_zone: 'a,b,c'
 n_db_nodes: 6
 n_loaders: 3
 n_monitor_nodes: 1
@@ -18,6 +19,7 @@ instance_type_loader: 'c5.2xlarge'
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '027'
 nemesis_interval: 5
+nemesis_add_node_cnt: 3
 
 user_prefix: 'longevity-tls-50gb-3d'
 

--- a/test-cases/longevity/longevity-cdc-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-4h.yaml
@@ -7,13 +7,12 @@ stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile.yaml ops
               "cassandra-stress user no-warmup profile=/tmp/cdc_profile_preimage_postimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=200m -mode cql3 native -rate threads=100"
              ]
 
-availability_zone: 'a'
+availability_zone: 'a,b,c'
 n_db_nodes: 6
 n_loaders: 2
 n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
-simulated_racks: 3
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '009'

--- a/test-cases/longevity/longevity-counters-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-multidc.yaml
@@ -4,12 +4,11 @@ pre_create_keyspace: "CREATE KEYSPACE scylla_bench WITH replication = {'class': 
 stress_cmd:      "scylla-bench -workload=uniform -mode=counter_update -replication-factor=3 -partition-count=1000 -clustering-row-count=10 -concurrency 1024 -duration 360m -validate-data"
 stress_read_cmd: "scylla-bench -workload=uniform -mode=counter_read   -replication-factor=3 -partition-count=1000 -clustering-row-count=10 -concurrency 512 -duration 360m -validate-data"
 
-availability_zone: 'a'
+availability_zone: 'a,b,c'
 n_db_nodes: '3 3 3'
 n_loaders:  '1 1 1'
 n_monitor_nodes: 1
 
-simulated_racks: 3
 instance_type_db: 'i4i.2xlarge'
 
 user_prefix: longevity-counters-multidc

--- a/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
@@ -9,7 +9,8 @@ stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'repl
              "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(insert=1,read=1,si_read1=1,si_read2=1)' cl=LOCAL_QUORUM duration=700m -mode cql3 native -rate threads=40 -log interval=5",
              ]
 
-n_db_nodes: '5 5'
+availability_zone: 'a,b,c'
+n_db_nodes: '6 6'
 n_loaders: '2 1'
 region_aware_loader: true
 n_monitor_nodes: 1
@@ -21,6 +22,7 @@ nemesis_selector: [["topology_changes"],["!disruptive","schema_changes"]]
 nemesis_interval: 10
 nemesis_filter_seeds: false
 nemesis_during_prepare: false
+nemesis_add_node_cnt: 3
 
 seeds_num: 3
 round_robin: true


### PR DESCRIPTION
Because there are bugs found in multidc, multi-az scenarios we want to test some on regular basis.

Enabled multi-az for 2 tier1 tests and reenabled 2 another that was previously switched to simulated racks.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
