### PR TITLE
[backport]feature(aws): placement group create/list/delete

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -226,3 +226,5 @@ custom_es_index: ''
 run_fullscan: []
 
 stress_step_duration: '15m'
+
+use_placement_group: false

--- a/sct.py
+++ b/sct.py
@@ -73,6 +73,7 @@ from sdcm.utils.common import (
     list_load_balancers_aws,
     list_cloudformation_stacks_aws,
     list_instances_aws,
+    list_placement_groups_aws,
     list_instances_gce,
     list_logs_by_test_id,
     list_resources_docker,
@@ -384,6 +385,26 @@ def list_resources(ctx, user, test_id, get_all, get_all_running, verbose):
         click.echo(aws_table.get_string(title="SGs used on AWS"))
     else:
         click.secho("No security groups found for selected filters in AWS!", fg="yellow")
+
+    click.secho("Checking AWS Placement Groups...", fg='green')
+    placement_groups = list_placement_groups_aws(tags_dict=params, available=get_all_running, verbose=verbose)
+    if placement_groups:
+        aws_table = PrettyTable(["Name", "Id", "TestId", "RunByUser"])
+        aws_table.align = "l"
+        aws_table.sortby = 'Id'
+        for group in placement_groups:
+            tags = aws_tags_to_dict(group.get('Tags'))
+            test_id = tags.get("TestId", "N/A")
+            run_by_user = tags.get("RunByUser", "N/A")
+            name = tags.get("Name", "N/A")
+            aws_table.add_row([
+                name,
+                group['GroupId'],
+                test_id,
+                run_by_user])
+        click.echo(aws_table.get_string(title="SGs used on AWS"))
+    else:
+        click.secho("No placement groups found for selected filters in AWS!", fg="yellow")
 
     click.secho("Checking AWS Load Balancers...", fg='green')
     load_balancers = list_load_balancers_aws(tags_dict=params, verbose=verbose)

--- a/sdcm/provision/aws/utils.py
+++ b/sdcm/provision/aws/utils.py
@@ -359,3 +359,15 @@ def configure_eth1_script():
 def configure_set_preserve_hostname_script():
     return 'grep "preserve_hostname: true" /etc/cloud/cloud.cfg 1>/dev/null 2>&1 ' \
            '|| echo "preserve_hostname: true" >> /etc/cloud/cloud.cfg\n'
+
+
+# -----AWS Placement Group section -----
+def create_cluster_placement_groups_aws(name: str, tags: dict, region=None, dry_run=False):
+    ec2: EC2Client = ec2_clients[region]
+    result = ec2.create_placement_group(
+        DryRun=dry_run, GroupName=name, Strategy='cluster',
+        TagSpecifications=[{
+            'ResourceType': 'placement-group',
+            "Tags": [{"Key": key, "Value": value} for key, value in tags.items()] +
+                    [{"Key": "Name", "Value": name}], }],)
+    return result

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -624,6 +624,10 @@ class SCTConfiguration(dict):
         dict(name="security_group_ids", env="SCT_SECURITY_GROUP_IDS", type=str_or_list,
              help="AWS security groups ids to use"),
 
+        dict(name="use_placement_group", env="SCT_USE_PLACEMENT_GROUP", type=str,
+             help="if true, create 'cluster' placement group for test case "
+                  "for low-latency network performance achievement"),
+
         dict(name="subnet_id", env="SCT_SUBNET_ID", type=str_or_list,
              help="AWS subnet ids to use"),
 
@@ -1966,6 +1970,8 @@ class SCTConfiguration(dict):
         self._check_partition_range_with_data_validation_correctness()
         self._verify_scylla_bench_mode_and_workload_parameters()
 
+        self._validate_placement_group_required_values()
+
     def _replace_docker_image_latest_tag(self):
         docker_repo = self.get('docker_image')
         scylla_version = self.get('scylla_version')
@@ -2038,6 +2044,14 @@ class SCTConfiguration(dict):
         num_of_db_nodes = sum([int(i) for i in str(self.get('n_db_nodes')).split(' ')]) + int(self.get('add_node_cnt'))
         assert num_of_db_nodes > seeds_num, \
             "Nemesis cannot run when 'nemesis_filter_seeds' is true and seeds number is equal to nodes number"
+
+    def _validate_placement_group_required_values(self):
+        if self.get("use_placement_group"):
+            az_count = len(self.get('availability_zone').split(',')) if self.get('availability_zone') else 1
+            regions_count = len(self.region_names)
+            assert az_count == 1 and regions_count == 1, \
+                (f"Number of Regions({regions_count}) and AZ({az_count}) should be 1 "
+                 f"when param use_placement_group is used")
 
     def _check_per_backend_required_values(self, backend: str):
         if backend in self.available_backends:

--- a/sdcm/sct_provision/aws/__init__.py
+++ b/sdcm/sct_provision/aws/__init__.py
@@ -1,0 +1,12 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2023 ScyllaDB

--- a/sdcm/sct_provision/aws/cluster.py
+++ b/sdcm/sct_provision/aws/cluster.py
@@ -29,6 +29,7 @@ from sdcm.sct_provision.aws.instance_parameters_builder import ScyllaInstancePar
 from sdcm.sct_provision.aws.user_data import ScyllaUserDataBuilder, AWSInstanceUserDataBuilder
 from sdcm.sct_provision.common.utils import INSTANCE_PROVISION_SPOT, INSTANCE_PROVISION_SPOT_FLEET
 from sdcm.test_config import TestConfig
+from sdcm.provision.aws.utils import create_cluster_placement_groups_aws
 
 
 class ClusterNode(BaseModel):
@@ -56,6 +57,7 @@ class ClusterBase(BaseModel):
     _NODE_NUM_PARAM_NAME = None
     _INSTANCE_PARAMS_BUILDER = None
     _USER_PARAM = None
+    _USE_PLACEMENT_GROUP = True
 
     @property
     def _provisioner(self):
@@ -97,6 +99,14 @@ class ClusterBase(BaseModel):
     @property
     def cluster_name(self):
         return '%s-%s' % (cluster.prepend_user_prefix(self._user_prefix, self._cluster_postfix), self._short_id)
+
+    @property
+    def placement_group_name(self):
+        if self.params.get("use_placement_group") and self._USE_PLACEMENT_GROUP:
+            return '%s-%s' % (
+                cluster.prepend_user_prefix(self._user_prefix, "placement_group"), self._short_id)
+        else:
+            return None
 
     @property
     def _node_prefix(self):
@@ -196,7 +206,8 @@ class ClusterBase(BaseModel):
         params_builder = self._INSTANCE_PARAMS_BUILDER(  # pylint: disable=not-callable
             params=self.params,
             region_id=region_id,
-            user_data_raw=self._user_data
+            user_data_raw=self._user_data,
+            placement_group=self.placement_group_name
         )
         return AWSInstanceParams(**params_builder.dict(exclude_none=True, exclude_unset=True, exclude_defaults=True))
 
@@ -280,6 +291,8 @@ class MonitoringCluster(ClusterBase):
     _NODE_NUM_PARAM_NAME = 'n_monitor_nodes'
     _INSTANCE_PARAMS_BUILDER = MonitorInstanceParamsBuilder
     _USER_PARAM = 'ami_monitor_user'
+    # disable placement group for monitor nodes, because it doesn't need low-latency network performance
+    _USE_PLACEMENT_GROUP = False
 
     @property
     def _user_data(self) -> str:
@@ -287,6 +300,18 @@ class MonitoringCluster(ClusterBase):
             params=self.params,
             syslog_host_port=self._test_config.get_logging_service_host_port(),
         ).to_string()
+
+
+class PlacementGroup(ClusterBase):
+
+    @property
+    def _user_data(self) -> str:
+        return ''
+
+    def provision(self):
+        if self.placement_group_name:
+            create_cluster_placement_groups_aws(
+                name=self.placement_group_name, tags=self.common_tags, region=self._region(0))
 
 
 ClusterNode.update_forward_refs()

--- a/sdcm/sct_provision/aws/instance_parameters_builder.py
+++ b/sdcm/sct_provision/aws/instance_parameters_builder.py
@@ -29,6 +29,7 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
     params: Union[SCTConfiguration, dict] = Field(as_dict=False)
     region_id: int = Field(as_dict=False)
     user_data_raw: Union[str, UserDataBuilderBase] = Field(as_dict=False)
+    placement_group: str = None
 
     _INSTANCE_TYPE_PARAM_NAME: str = None
     _IMAGE_ID_PARAM_NAME: str = None
@@ -86,7 +87,9 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
         """
         if len(self._availability_zones) != 1:
             return None
-        return AWSPlacementInfo(AvailabilityZone=self._region_name + self._availability_zones[0])
+        return AWSPlacementInfo(
+            AvailabilityZone=self._region_name + self._availability_zones[0],
+            GroupName=self.placement_group)
 
     @property
     def UserData(self) -> Optional[str]:  # pylint: disable=invalid-name

--- a/sdcm/sct_provision/aws/layout.py
+++ b/sdcm/sct_provision/aws/layout.py
@@ -13,7 +13,8 @@
 
 from functools import cached_property
 
-from sdcm.sct_provision.aws.cluster import OracleDBCluster, DBCluster, LoaderCluster, MonitoringCluster
+from sdcm.sct_provision.aws.cluster import (
+    OracleDBCluster, DBCluster, LoaderCluster, MonitoringCluster, PlacementGroup)
 from sdcm.sct_provision.common.layout import SCTProvisionLayout
 from sdcm.test_config import TestConfig
 
@@ -25,6 +26,8 @@ class SCTProvisionAWSLayout(SCTProvisionLayout, cluster_backend='aws'):
         return TestConfig()
 
     def provision(self):
+        if self.placement_group:
+            self.placement_group.provision()
         if self.db_cluster:
             self.db_cluster.provision()
         if self.monitoring_cluster:
@@ -63,6 +66,14 @@ class SCTProvisionAWSLayout(SCTProvisionLayout, cluster_backend='aws'):
         if not self._provision_another_scylla_cluster:
             return None
         return OracleDBCluster(
+            params=self._params,
+            common_tags=self._test_config.common_tags(),
+            test_id=self._test_config.test_id(),
+        )
+
+    @cached_property
+    def placement_group(self):
+        return PlacementGroup(
             params=self._params,
             common_tags=self._test_config.common_tags(),
             test_id=self._test_config.test_id(),

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -57,6 +57,7 @@ import boto3
 from mypy_boto3_s3 import S3Client, S3ServiceResource
 from mypy_boto3_ec2 import EC2Client, EC2ServiceResource
 from mypy_boto3_ec2.service_resource import Image as EC2Image
+from botocore.exceptions import ClientError
 import docker  # pylint: disable=wrong-import-order; false warning because of docker import (local file vs. package)
 import libcloud.storage.providers
 import libcloud.storage.types
@@ -3055,9 +3056,11 @@ def list_placement_groups_aws(tags_dict=None, region_name=None, available=False,
     return placement_groups
 
 
+@retrying(n=30, sleep_time=10, allowed_exceptions=(ClientError,))
 def clean_placement_groups_aws(tags_dict: dict, regions=None, dry_run=False):
     """Remove all placement groups with specific tags in AWS."""
     # pylint: disable=too-many-locals,import-outside-toplevel
+    tags_dict = {key: value for key, value in tags_dict.items() if key != "NodeType"}
     assert tags_dict, "tags_dict not provided (can't clean all instances)"
     if regions:
         aws_placement_groups = {}
@@ -3074,12 +3077,12 @@ def clean_placement_groups_aws(tags_dict: dict, regions=None, dry_run=False):
         client: EC2Client = boto3.client('ec2', region_name=region)
         for instance in instance_list:
             name = instance.get("GroupName")
-            LOGGER.info("Going to delete placement group '{name} ".format(name=name))
+            LOGGER.info("Going to delete placement group '{name} in region {region}".format(name=name, region=region))
             if not dry_run:
                 try:
                     response = client.delete_placement_group(GroupName=name)
                     LOGGER.debug("Done. Result: %s\n", response)
                 except Exception as ex:  # pylint: disable=broad-except
-                    LOGGER.debug("Failed with: %s", str(ex))
-
+                    LOGGER.info("Failed with: %s", str(ex))
+                    raise
 # ----------

--- a/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
@@ -48,3 +48,5 @@ custom_es_index: 'performancestatsv2'
 use_hdr_cs_histogram: true
 
 append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
+
+use_placement_group: true

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -176,6 +176,26 @@ def call(Map pipelineParams) {
                                             }
                                         }
 
+                                        stage("Provision Resources for ${sub_test}") {
+                                                catchError() {
+                                                    script {
+                                                        wrap([$class: 'BuildUser']) {
+                                                            dir('scylla-cluster-tests') {
+                                                                timeout(time: 30, unit: 'MINUTES') {
+                                                                    if (params.backend == 'aws' || params.backend == 'azure') {
+                                                                        provisionResources(params, builder.region)
+                                                                    } else {
+                                                                        sh """
+                                                                            echo 'Skipping because non-AWS/Azure backends are not supported'
+                                                                        """
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                        }
+
                                         stage("Run ${sub_test}"){
                                             catchError(stageResult: 'FAILURE') {
                                                 wrap([$class: 'BuildUser']) {


### PR DESCRIPTION
backport into perf-v14  for  https://github.com/scylladb/scylla-cluster-tests/pull/6594 and https://github.com/scylladb/scylla-cluster-tests/pull/6571
 
this commit is:
1) Include provision step into the performance pipeline 2) Add the ability to create load and DB instances within one AWS placement group and config parameter to enable this feature
3) Update i4i Throughput perf test to  use the new feature 4) extend sct.py 'list-resources', 'clean-resourses' to support AWS placement groups

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
