### PR TITLE
fix(nemesis): make MgmtCorruptThenRepair nemesis be out of limited group

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5780,7 +5780,6 @@ class MgmtCorruptThenRepair(Nemesis):
     manager_operation = True
     disruptive = True
     kubernetes = True
-    limited = True
 
     def disrupt(self):
         self.disrupt_mgmt_corrupt_then_repair()


### PR DESCRIPTION
The newly added `MgmtCorruptThenRepair` nemesis
should not have been marked with the `limited = True` flag.
It must have had it as `False` like the `CorruptThenRepair` one does.

Fixes: #6599

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
