### PR TITLE
feature(cluster): Add support refactored setup scripts and config files

### DIFF
--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -856,8 +856,11 @@ class TestStatsMixin(Stats):
             }
             if scylla_conf and "scylla_args" not in setup_details:
                 scylla_server_conf = f"/etc/{'sysconfig' if node.distro.is_rhel_like else 'default'}/scylla-server"
-                setup_details.update({"scylla_args": output(f"grep ^SCYLLA_ARGS {scylla_server_conf}"),
-                                      "io_conf": output("grep -v ^# /etc/scylla.d/io.conf"),
+                setup_details.update({"scylla_args": output(f"grep ^SCYLLA_ARGS {scylla_server_conf}"), })
+                if node.has_seastar_conf:
+                    setup_details.update({"seastar.conf": output("cat /etc/scylla.d/seastar.conf"), })
+                else:
+                    setup_details.update({"io_conf": output("grep -v ^# /etc/scylla.d/io.conf"),
                                       "cpuset_conf": output("grep -v ^# /etc/scylla.d/cpuset.conf"), })
             sysctl_excludes = (
                 'net.bridge', 'net.ipv', 'net.netfilter', 'kernel.sched_', 'sunrpc',


### PR DESCRIPTION
On https://github.com/scylladb/scylladb/pull/14674, we are trying to refactor setup scripts and config files.

Since it big change, it will  break compatibility with existing scripts. To avoid Jenkins test failure when we merge the PR, we need to modify following SCT code:
 - /etc/scylla.d/cpuset.conf and /etc/scylla.d/io.conf are replaced by /etc/scylla.d/seastar.conf
 - scylla_sysconfig_setup renamed to scylla_perftune_setup

Also, to support both older version of Scylla and new version of Scylla with same SCT code, we need to detect which version of Scylla is running.
To detect that, this patch adds BaseNode.has_seastar_conf property, detects Scylla version and access different setup scripts / config files.
