### PR TITLE
fix(node utils): health check started failing

### DIFF
--- a/sdcm/utils/node.py
+++ b/sdcm/utils/node.py
@@ -21,9 +21,10 @@ class RequestMethods(Enum):
     POST = 'POST'
 
 
-def build_node_api_command(path_url, request_method: RequestMethods = RequestMethods.GET, api_port=10000):
+def build_node_api_command(path_url, request_method: RequestMethods = RequestMethods.GET, api_port=10000, silent=True):
     if not path_url.startswith('/'):
         path_url = '/' + path_url
+    silent_flag = '-s ' if silent else ''
 
-    return f'curl -X {request_method} --header "Content-Type: application/json" --header ' \
+    return f'curl -X {silent_flag}{request_method.value} --header "Content-Type: application/json" --header ' \
            f'"Accept: application/json" "http://127.0.0.1:{api_port}{path_url}"'

--- a/sdcm/utils/sstable/load_utils.py
+++ b/sdcm/utils/sstable/load_utils.py
@@ -123,7 +123,7 @@ class SstableLoadUtils:
             # `load_and_stream` parameter is not supported by nodetool yet. This is workaround
             # https://github.com/scylladb/scylla-tools-java/issues/253
             path = f'/storage_service/sstables/{keyspace_name}?cf={table_name}&load_and_stream=true'
-            load_api_cmd = build_node_api_command(path_url=path, request_method=RequestMethods.POST)
+            load_api_cmd = build_node_api_command(path_url=path, request_method=RequestMethods.POST, silent=False)
             node.remoter.run(load_api_cmd)
 
     @staticmethod


### PR DESCRIPTION
since #6601 was introduced, because a function
that checks for token rings started failing
on the `curl` command builder.
this commit aims to fix it.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
