### PR TITLE
fix(test_default): stop keeping db nodes

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -48,10 +48,10 @@ seeds_num: 1
 instance_provision: "spot"
 
 execute_post_behavior: false
-post_behavior_db_nodes: "keep-on-failure"
+post_behavior_db_nodes: "destroy"
 post_behavior_loader_nodes: "destroy"
 post_behavior_monitor_nodes: "keep-on-failure"
-post_behavior_k8s_cluster: "keep-on-failure"
+post_behavior_k8s_cluster: "destroy"
 
 cloud_credentials_path: ''
 use_cloud_manager: false

--- a/unit_tests/provisioner/test_azure_region_definition_builder.py
+++ b/unit_tests/provisioner/test_azure_region_definition_builder.py
@@ -52,7 +52,8 @@ def test_can_create_basic_scylla_instance_definition_from_sct_config():
 
     instance_definition = InstanceDefinition(name=f"{prefix}-db-node-eastus-1", image_id=env_config.SCT_AZURE_IMAGE_DB,
                                              type="Standard_L8s_v3", user_name="scyllaadm", root_disk_size=30,
-                                             tags=tags | {"NodeType": "scylla-db", "keep_action": "", 'NodeIndex': '1'},
+                                             tags=tags | {"NodeType": "scylla-db", "keep_action": "terminate",
+                                                          'NodeIndex': '1'},
                                              ssh_key=ssh_key)
     assert len(region_definitions) == 2
     actual_region_definition = region_definitions[0]

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -67,7 +67,7 @@ def call(Map pipelineParams) {
                    description: 'true|false',
                    name: 'instance_provision_fallback_on_demand')
 
-            string(defaultValue: "${pipelineParams.get('post_behavior_db_nodes', 'keep-on-failure')}",
+            string(defaultValue: "${pipelineParams.get('post_behavior_db_nodes', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_db_nodes')
             string(defaultValue: "${pipelineParams.get('post_behavior_loader_nodes', 'destroy')}",
@@ -76,7 +76,7 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('post_behavior_monitor_nodes', 'keep-on-failure')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_monitor_nodes')
-            string(defaultValue: "${pipelineParams.get('post_behavior_k8s_cluster', 'keep-on-failure')}",
+            string(defaultValue: "${pipelineParams.get('post_behavior_k8s_cluster', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_k8s_cluster')
 


### PR DESCRIPTION
since most of the time, we don't have
enough people investigating failures,
and in many cases, we have issues being
reproduced, and instances are being left
alive for long time.
in any case, when we want to reproduce an
issue, we manually set the test to `keep`
so changing it to `destroy` won't impact
us too much..

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
