### PR TITLE
fix(healthcheck): fix silent flag in curl

### DIFF
--- a/sdcm/utils/node.py
+++ b/sdcm/utils/node.py
@@ -26,5 +26,5 @@ def build_node_api_command(path_url, request_method: RequestMethods = RequestMet
         path_url = '/' + path_url
     silent_flag = '-s ' if silent else ''
 
-    return f'curl -X {silent_flag}{request_method.value} --header "Content-Type: application/json" --header ' \
+    return f'curl {silent_flag}-X {request_method.value} --header "Content-Type: application/json" --header ' \
            f'"Accept: application/json" "http://127.0.0.1:{api_port}{path_url}"'


### PR DESCRIPTION
When silent is set for `build_node_api_command` then `-s` flag is placed in wrong place making curl command to fail.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
