### PR TITLE
feature(edquot): Add quota configuration and EndOfQuotaNemesis

### DIFF
--- a/data_dir/nemesis.yml
+++ b/data_dir/nemesis.yml
@@ -332,3 +332,6 @@
   - disruptive = False
   - kubernetes = True
   - free_tier_set = True
+- disrupt_end_of_quota_nemesis:
+  - disruptive = True
+  - kubernetes = False

--- a/jenkins-pipelines/nemesis/longevity-5gb-1h-EndOfQuotaNemesis-aws.jenkinsfile
+++ b/jenkins-pipelines/nemesis/longevity-5gb-1h-EndOfQuotaNemesis-aws.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/nemesis/longevity-5gb-1h-EndOfQuotaNemesis.yaml'
+
+)

--- a/sdcm/exceptions.py
+++ b/sdcm/exceptions.py
@@ -65,6 +65,10 @@ class KillNemesis(BaseException):
     """Exception that would be raised, when a nemesis thread is killed at teardown of the test"""
 
 
+class QuotaConfigurationFailure(Exception):
+    """Exception that would be raised, if quota configuration failed"""
+
+
 class WaitForTimeoutError(Exception):
     """Exception that would be raised timeout exceeded in wait.wait_for function"""
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -82,7 +82,7 @@ from sdcm.sct_events.group_common_events import (ignore_alternator_client_errors
                                                  ignore_scrub_invalid_errors, ignore_view_error_gate_closed_exception,
                                                  ignore_stream_mutation_fragments_errors,
                                                  ignore_ycsb_connection_refused, decorate_with_context,
-                                                 ignore_reactor_stall_errors,
+                                                 ignore_reactor_stall_errors, ignore_disk_quota_exceeded_errors,
                                                  ignore_error_apply_view_update)
 from sdcm.sct_events.health import DataValidatorEvent
 from sdcm.sct_events.loaders import CassandraStressLogEvent, ScyllaBenchEvent
@@ -97,6 +97,8 @@ from sdcm.utils.common import (get_db_tables, generate_random_string,
                                parse_nodetool_listsnapshots,
                                update_authenticator, ParallelObject,
                                ParallelObjectResult, sleep_for_percent_of_duration, get_views_of_base_table)
+from sdcm.utils.quota import configure_quota_on_node_for_scylla_user_context, is_quota_enabled_on_node, enable_quota_on_node, \
+    write_data_to_reach_end_of_quota
 from sdcm.utils.compaction_ops import CompactionOps, StartStopCompactionArgs
 from sdcm.utils.context_managers import nodetool_context
 from sdcm.utils.decorators import retrying, latency_calculator_decorator
@@ -137,6 +139,7 @@ from sdcm.exceptions import (
     NemesisSubTestFailure,
     AuditLogTestFailure,
     BootstrapStreamErrorFailure,
+    QuotaConfigurationFailure,
 )
 from test_lib.compaction import CompactionStrategy, get_compaction_strategy, get_compaction_random_additional_params, \
     get_gc_mode, GcMode
@@ -1682,6 +1685,42 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                         reach_enospc_on_node(target_node=node)
                     finally:
                         clean_enospc_on_node(target_node=node, sleep_time=sleep_time)
+
+    def disrupt_end_of_quota_nemesis(self, sleep_time=30):
+        """
+        Nemesis flow
+        ---------------------
+        1. Enable quota on the node.
+        2. Check disk usage.
+        3. Define quota size same as disk usage + 3GB.
+        4. Approach end of quota in a loop with fallocate file that takes 90% of quota size each iteration.
+        5. Wait for end of quota message to appear in the log - "Disk quota exceeded" / Except I/O Error if happens.
+        6. Remove the sparse files.
+        7. Remove the quota by setting it to 0.
+        8. Restart scylla server.
+        9. Verify scylla is up.
+        """
+
+        node = self.target_node
+        if self._is_it_on_kubernetes():
+            raise UnsupportedNemesis("Skipping nemesis for kubernetes")
+
+        result = node.remoter.run('cat /proc/mounts')
+        if '/var/lib/scylla' not in result.stdout:
+            raise UnsupportedNemesis("Scylla doesn't use an individual storage, skip end of quota test")
+
+        enable_quota_on_node(node)
+        quota_enabled = is_quota_enabled_on_node(node)
+        if not quota_enabled:
+            raise QuotaConfigurationFailure("Failed to configure quota on the cluster")
+
+        with ignore_disk_quota_exceeded_errors(node):
+            with configure_quota_on_node_for_scylla_user_context(node) as quota_size:
+                write_data_to_reach_end_of_quota(node, quota_size)
+            LOGGER.debug('Sleep 15 seconds before restart scylla-server')
+            time.sleep(15)
+            node.restart_scylla_server()
+            node.wait_db_up()
 
     def disrupt_remove_service_level_while_load(self):
         # Temporary solution. We do not want to run SLA nemeses during not-SLA test until the feature is stable
@@ -6485,3 +6524,11 @@ class DisableBinaryGossipExecuteMajorCompaction(Nemesis):
 
     def disrupt(self):
         self.disrupt_disable_binary_gossip_execute_major_compaction()
+
+
+class EndOfQuotaNemesis(Nemesis):
+    disruptive = True
+    config_changes = True
+
+    def disrupt(self):
+        self.disrupt_end_of_quota_nemesis()

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -134,6 +134,32 @@ def ignore_no_space_errors(node):
 
 
 @contextmanager
+def ignore_disk_quota_exceeded_errors(node):
+    with ExitStack() as stack:
+        stack.enter_context(DbEventsFilter(
+            db_event=DatabaseLogEvent.BACKTRACE,
+            line="Disk quota exceeded",
+            node=node,
+        ))
+        stack.enter_context(DbEventsFilter(
+            db_event=DatabaseLogEvent.FILESYSTEM_ERROR,
+            line="Disk quota exceeded",
+            node=node,
+        ))
+        stack.enter_context(DbEventsFilter(
+            db_event=DatabaseLogEvent.DATABASE_ERROR,
+            line="Disk quota exceeded",
+            node=node,
+        ))
+        stack.enter_context(DbEventsFilter(
+            db_event=DatabaseLogEvent.DISK_ERROR,
+            line="Disk quota exceeded",
+            node=node,
+        ))
+        yield
+
+
+@contextmanager
 def ignore_mutation_write_errors():
     with ExitStack() as stack:
         stack.enter_context(EventsSeverityChangerFilter(

--- a/sdcm/utils/quota.py
+++ b/sdcm/utils/quota.py
@@ -1,0 +1,128 @@
+from __future__ import absolute_import, annotations
+
+import logging
+import time
+from contextlib import contextmanager
+
+from sdcm.exceptions import QuotaConfigurationFailure
+from sdcm.wait import wait_for
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def enable_quota_on_node(node):
+    if not is_quota_enabled_on_node(node):
+        LOGGER.info('Enabling quota on node {}'.format(node.name))
+        change_default_grub_cmd = 'sed -i s\'/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"/' \
+                                  'GRUB_CMDLINE_LINUX_DEFAULT="quiet splash rootflags=uquota,pquota"/\' ' \
+                                  '/etc/default/grub'
+        mk_grub_cmd = 'grub-mkconfig -o /boot/grub/grub.cfg'
+        enable_uquota_on_mount_cmd = 'sed -i s\'/Options=noatime,discard/Options=noatime,discard,uquota/\' ' \
+                                     '/etc/systemd/system/var-lib-scylla.mount'
+
+        node.remoter.sudo(cmd=change_default_grub_cmd)
+        node.remoter.sudo(cmd=mk_grub_cmd)
+        node.remoter.sudo(cmd=enable_uquota_on_mount_cmd)
+        LOGGER.debug('Rebooting node: "{}"'.format(node.name))
+        node.reboot(hard=False)
+        node.wait_node_fully_start()
+
+
+def is_quota_enabled_on_node(node):
+    """ Verify usrquota is enabled on scylla user. """
+    LOGGER.info("Verifying quota is configured on the node {}".format(node.name))
+    verify_usrquot_in_mount_cmd = "mount | grep /var/lib/scylla | awk {'print $6'} | cut -d ',' -f 8"
+    result = node.remoter.run(cmd=verify_usrquot_in_mount_cmd).stdout.rstrip().replace(")", "")
+    if not result == "usrquota":
+        LOGGER.warning("User quota on user scylla at /var/lib/scylla is not enabled")
+        return False
+    return True
+
+
+def get_currently_used_space_by_scylla_user(node) -> int:
+    result = node.remoter.sudo("xfs_quota -x -c 'report' /var/lib/scylla | grep scylla | tail -1")
+    used_space = int(result.stdout.split()[1])
+    return used_space
+
+
+def get_quota_size_to_configure(node):
+    used_space = get_currently_used_space_by_scylla_user(node)
+    LOGGER.debug('Currently used space by scylla user is: {}K'.format(used_space))
+    return used_space + 3000000
+
+
+@contextmanager
+def configure_quota_on_node_for_scylla_user_context(node):
+    """
+    Configure quota with current disk usage size by scylla user + 3GB on /var/lib/scylla mount point
+    Verify quota was configured
+    yield the quota size
+    Remove quota configuration
+    """
+    quota_size = get_quota_size_to_configure(node)
+    LOGGER.info("Configuring quota for scylla user with quota size: {}K on node {}".format(quota_size, node))
+    conf_quota_cmd = f"xfs_quota -x -c 'limit bsoft={quota_size}K bhard={quota_size}K scylla' /var/lib/scylla"
+    node.remoter.sudo(conf_quota_cmd, verbose=True)
+    verify_quota_is_configured_for_scylla_user(node)
+    try:
+        yield quota_size
+    finally:
+        remove_quota_configuration_from_scylla_user_on_node(node)
+
+
+def verify_quota_is_configured_for_scylla_user(node):
+    """Verifies quota ia actually configured for scylla user, but doesn't verify enforcement in ON"""
+    get_scylla_user_quota_value = 'xfs_quota -x -c "report -h" /var/lib/scylla | grep scylla | tail -1 | awk {\'print $4\'}'
+    LOGGER.info("Verifying quota is configured for scylla user")
+    quota_value = node.remoter.sudo(get_scylla_user_quota_value).stdout.rstrip()
+    if quota_value == "0":
+        LOGGER.error("Failed to configure quota on user")
+        raise QuotaConfigurationFailure(
+            "Quota was not configured for scylla user. The value for hard quota is: {}".format(quota_value))
+    LOGGER.info("Quota was configured for scylla user with value: {}".format(quota_value))
+
+
+def remove_quota_configuration_from_scylla_user_on_node(node):
+    LOGGER.info('Remove quota configuration from user \'scylla\' by setting it to 0')
+    quota_remove_cmd = "xfs_quota -x -c 'limit bsoft=0 bhard=0 scylla' /var/lib/scylla"
+    node.remoter.sudo(quota_remove_cmd, verbose=True)
+
+
+def write_data_to_reach_end_of_quota(node, quota_size):
+    LOGGER.debug('Watching the log for the relevant message for quota...')
+    quota_exceeded_appearances = node.follow_system_log(
+        patterns=[r'Shutting down communications due to I\/O errors until operator intervention: Disk error:.*Disk quota exceeded'])
+    node.remoter.sudo('chsh -s /bin/bash scylla')  # Enable login for scylla user
+
+    def approach_end_of_quota():
+        if bool(list(quota_exceeded_appearances)):
+            return True
+        currently_used_space = get_currently_used_space_by_scylla_user(node)
+        occupy_space_size = int((quota_size - currently_used_space) * 90 / 100)
+        occupy_space_cmd = f"su - scylla -c 'fallocate -l {occupy_space_size}K /var/lib/scylla/occupy_90percent.{time.time()}'"
+        try:
+            LOGGER.debug('Cost 90% free space on /var/lib/scylla/ by {}'.format(occupy_space_cmd))
+            node.remoter.sudo(occupy_space_cmd, Verbose=True)
+        except Exception as exc:  # pylint: disable=broad-except
+            LOGGER.warning("We should have reached the expected I/O error and quota has exceeded\n"
+                           "Message: {}".format(str(exc)))
+        return bool(list(quota_exceeded_appearances))
+
+    try:
+        wait_for(func=approach_end_of_quota,
+                 timeout=300,
+                 step=10,
+                 text="Waiting for 'Disk error: std::system_error (error system:122, Disk quota exceeded)' "
+                 "string to appear in the node log",
+                 throw_exc=False
+                 )
+        LOGGER.debug('Sleep 5 minutes before releasing space to scylla')
+        time.sleep(300)
+
+    finally:
+        LOGGER.debug('Delete occupy_90percent file to release space to scylla-server')
+        node.remoter.sudo('rm -rf /var/lib/scylla/occupy_90percent.*')  # Remove the sparse files
+
+        LOGGER.debug('Disable scylla user login')
+        node.remoter.sudo('usermod -s /sbin/nologin scylla')  # Disable login for scylla user

--- a/test-cases/nemesis/longevity-5gb-1h-EndOfQuotaNemesis.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-EndOfQuotaNemesis.yaml
@@ -1,0 +1,31 @@
+test_duration: 90
+
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+             ]
+
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1
+seeds_num: 3
+
+instance_type_db: 'i4i.large'
+gce_instance_type_db: 'n1-highmem-2'
+gce_instance_type_loader: 'e2-standard-2'
+azure_instance_type_db: 'Standard_L8s_v3'
+instance_type_loader: 'c5.large'
+azure_instance_type_loader: 'Standard_F2s_v2'
+
+nemesis_class_name: 'EndOfQuotaNemesis'
+nemesis_interval: 3
+nemesis_filter_seeds: false
+nemesis_during_prepare: true
+
+gce_n_local_ssd_disk_db: 1
+
+user_prefix: 'longevity-5gb-1h-EndOfQuotaNemesis'
+
+server_encrypt: true
+client_encrypt: true

--- a/unit_tests/test_nemesis.py
+++ b/unit_tests/test_nemesis.py
@@ -247,6 +247,7 @@ class TestSisyphusMonkeyNemesisFilter:
             "disrupt_switch_between_password_authenticator_and_saslauthd_authenticator_and_back",
             "disrupt_resetlocalschema",
             "disrupt_toggle_audit_syslog",
+            "disrupt_end_of_quota_nemesis",
         ]
 
     @pytest.fixture(autouse=True)

--- a/unit_tests/test_nemesis_sisyphus.py
+++ b/unit_tests/test_nemesis_sisyphus.py
@@ -71,7 +71,7 @@ def test_list_all_available_nemesis(generate_file=True):
     disruption_list, disruptions_dict, disruption_classes = sisyphus.get_list_of_disrupt_methods(
         subclasses_list=subclasses, export_properties=True)
 
-    assert len(disruption_list) == 84
+    assert len(disruption_list) == 85
 
     if generate_file:
         with open('data_dir/nemesis.yml', 'w', encoding="utf-8") as outfile1:


### PR DESCRIPTION
According to task: https://github.com/scylladb/qa-tasks/issues/1086

This commit adds the possibility to configure quota on a node and adds the EndOfQuotaNemesis
The EndOfQuotaNemesis configures quota with current disk usage + 1GB and waits for `Disk quota exceeded` message in logs. Then the quota is cleared and scylla-server service is restarted.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
