### PR TITLE
fix(k8s): add class providing key based locks and use it for K8S

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -98,6 +98,20 @@ SCYLLA_AMI_OWNER_ID_LIST = ["797456418907", "158855661827"]
 SCYLLA_GCE_IMAGES_PROJECT = "scylla-images"
 
 
+class KeyBasedLock():  # pylint: disable=too-few-public-methods
+    """Class designed for creating locks based on hashable keys."""
+
+    def __init__(self):
+        self.key_lock_mapping = {}
+        self.handler_lock = threading.Lock()
+
+    def get_lock(self, hashable_key):
+        with self.handler_lock:
+            if hashable_key not in self.key_lock_mapping:
+                self.key_lock_mapping[hashable_key] = threading.Lock()
+            return self.key_lock_mapping[hashable_key]
+
+
 def deprecation(message):
     warnings.warn(message, DeprecationWarning, stacklevel=3)
 


### PR DESCRIPTION
The `test_add_new_node_and_check_old_nodes_are_cleaned_up` K8S functional test has race condition where it may fail with the following error:
```
  Command: 'kubectl cp /tmp/tmpj8_823ao.yaml scylla/sct-cluster-dc-1-kind-0:/tmp/tmpj8_823ao.yaml -c scylla'
  Exit code: 2
  Stderr:
  tar: tmpj8_823ao.yaml: Cannot open: File exists
  tar: Exiting with failure status due to previous errors
  command terminated with exit code 2
```

It is caused by the concurrent `cqlsh` cmd calls to the same Scylla pods. In this test there are about 7 concurrent such calls equal to the number of keyspaces in Scylla.

So, fix it by using lock mechanism per each pod.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
