### PR TITLE
fix(k8s): fix decommission DB event filter for K8S

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2746,7 +2746,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         timeout = timeout or (node.pod_terminate_timeout * 60)
         with adaptive_timeout(operation=Operations.DECOMMISSION, node=node), DbEventsFilter(
                 db_event=DatabaseLogEvent.RUNTIME_ERROR,
-                line="std::runtime_error.*decommission"):
+                line="std::runtime_error (Operation decommission is in progress, try again)"):
             self.replace_scylla_cluster_value(f"/spec/datacenter/racks/{rack}/members", current_members - 1)
             self.k8s_cluster.kubectl(f"wait --timeout={timeout}s --for=delete pod {node.name}",
                                      namespace=self.namespace,


### PR DESCRIPTION
It doesn't support regex, so, use required substring directly.
Without this fix there are following false negative error SCT events:
```
  2023-09-17 01:19:09.355: (DatabaseLogEvent Severity.ERROR) \
    period_type=one-time event_id=2babd5ad-8d7a-4477-81d5-df5f95c91cb1: \
    type=RUNTIME_ERROR regex=std::runtime_error line_number=9572 \
    node=sct-cluster-dc-1-kind-3
  E0917 01:19:06.376388  1 sidecar/controller.go:143] \
    syncing key 'scylla/sct-cluster-dc-1-kind-3' failed: \
    [can't sync the HostID annotation: \
    local host ID "65530c5c-58a7-4766-8dbb-e8de64dfea04" not found in \
    IP to hostID mapping: map[10.96.118.89:7c4f28f7-3636-4ca1-9178-a3761d11fae6 \
    10.96.222.2:8ed17a3d-5626-4708-9ea8-410570d358a2 \
    10.96.240.199:95e2dd13-d87a-4403-858b-c4074c797c85], \
    can't decommision a node: can't decommission the node: \
    agent [HTTP 500] std::runtime_error (Operation decommission is in progress, try again)]
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
