### PR TITLE
fix(nemesis): fix time skew in reading audit logs

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4693,7 +4693,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             audit.configure(audit_config)
             keyspace_name = keyspaces_for_audit[0]
             errors = []
-            audit_start = datetime.datetime.now()
+            audit_start = datetime.datetime.now() - datetime.timedelta(seconds=5)
             InfoEvent(message='Writing/Reading data from audited keyspace').publish()
             write_cmd = f"cassandra-stress write no-warmup cl=ALL n=1000 -schema" \
                         f" 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)" \
@@ -4733,7 +4733,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         audit_config.categories = ["DCL", "DDL", "AUTH", "ADMIN"]
         audit.configure(audit_config)
         table_name = "audit_cf"
-        audit_start = datetime.datetime.now()
+        audit_start = datetime.datetime.now() - datetime.timedelta(seconds=5)
         with self.cluster.cql_connection_patient(node=self.target_node) as session:
             query = f"CREATE TABLE IF NOT EXISTS {keyspace_name}.{table_name} (id int PRIMARY KEY, value timestamp)"
             session.execute(query)
@@ -4742,7 +4742,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             if not audit_rows:
                 errors.append("Audit log is empty while should contain executed DDL (create table) operation")
 
-            audit_start = datetime.datetime.now()
+            audit_start = datetime.datetime.now() - datetime.timedelta(seconds=5)
             query = f"ALTER TABLE {keyspace_name}.{table_name} WITH read_repair_chance = 0.0"
             session.execute(query)
             self.cluster.wait_for_schema_agreement()
@@ -4750,7 +4750,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             if not audit_rows:
                 errors.append("Audit log is empty while should contain executed DDL (alter table) operation")
 
-            audit_start = datetime.datetime.now()
+            audit_start = datetime.datetime.now() - datetime.timedelta(seconds=5)
             query = f"DROP TABLE {keyspace_name}.{table_name}"
             session.execute(query, timeout=300)
             self.cluster.wait_for_schema_agreement()


### PR DESCRIPTION
When there's very little time (<500ms) from cql to audit message in logs it happens that audit line can be missed.

Added 5 seconds margin to time we start to observe audit messages.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/6619

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
