### PR TITLE
fix(azure): fix reboot delay

### DIFF
--- a/sdcm/cluster_azure.py
+++ b/sdcm/cluster_azure.py
@@ -113,10 +113,10 @@ class AzureNode(cluster.BaseNode):
     def restart(self):
         # When using NVMe disks in Azure, there is no option to Stop and Start an instance.
         # So, for now we will keep restart the same as hard reboot.
-        self._instance.reboot(wait=True)
+        self._instance.reboot(wait=True, hard=False)
 
     def hard_reboot(self):
-        self._instance.reboot(wait=True)
+        self._instance.reboot(wait=True, hard=True)
 
     def destroy(self):
         self.stop_task_threads()

--- a/sdcm/provision/azure/provisioner.py
+++ b/sdcm/provision/azure/provisioner.py
@@ -18,6 +18,7 @@ from typing import Dict, List
 
 from azure.mgmt.compute.models import VirtualMachine, VirtualMachinePriorityTypes
 from azure.mgmt.resource.resources.models import ResourceGroup
+from invoke import Result
 
 from sdcm.provision.azure.ip_provider import IpAddressProvider
 from sdcm.provision.azure.network_interface_provider import NetworkInterfaceProvider
@@ -152,8 +153,8 @@ class AzureProvisioner(Provisioner):  # pylint: disable=too-many-instance-attrib
         self._nic_provider.delete(self._nic_provider.get(name))
         self._ip_provider.delete(self._ip_provider.get(name))
 
-    def reboot_instance(self, name: str, wait=True) -> None:
-        self._vm_provider.reboot(name, wait)
+    def reboot_instance(self, name: str, wait: bool, hard: bool = False) -> None:
+        self._vm_provider.reboot(name, wait, hard)
 
     def list_instances(self) -> List[VmInstance]:
         """List virtual machines for given provisioner."""
@@ -181,6 +182,10 @@ class AzureProvisioner(Provisioner):  # pylint: disable=too-many-instance-attrib
         instance = self._vm_to_instance(self._vm_provider.add_tags(name, tags))
         self._cache[name] = instance
         LOGGER.info("Added tags '%s' to intance '%s'", tags, name)
+
+    def run_command(self, name: str, command: str) -> Result:
+        """Runs command on instance."""
+        return self._vm_provider.run_command(name, command)
 
     @property
     def _resource_group_name(self):

--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -11,6 +11,7 @@
 #
 # Copyright (c) 2022 ScyllaDB
 import base64
+import time
 from datetime import datetime
 import logging
 import os
@@ -20,7 +21,8 @@ from typing import Dict, Optional, Any, List
 
 import binascii
 from azure.core.exceptions import ResourceNotFoundError, AzureError
-from azure.mgmt.compute.models import VirtualMachine
+from azure.mgmt.compute.models import VirtualMachine, RunCommandInput
+from invoke import Result
 
 from sdcm.provision.provisioner import InstanceDefinition, PricingModel, ProvisionError
 from sdcm.provision.user_data import UserDataBuilder
@@ -142,13 +144,17 @@ class VirtualMachineProvider:
             LOGGER.info("Instance %s has been terminated.", name)
         del self._cache[name]
 
-    def reboot(self, name: str, wait: bool = True) -> None:
+    def reboot(self, name: str, wait: bool = True, hard: bool = False) -> None:
         LOGGER.info("Triggering reboot of instance: %s", name)
-        task = self._azure_service.compute.virtual_machines.begin_restart(self._resource_group_name, vm_name=name)
-        if wait is True:
-            LOGGER.info("Waiting for reboot of instance: %s...", name)
-            task.wait()
-            LOGGER.info("Instance %s has been rebooted.", name)
+        flags = "-ff" if hard else "-f"
+        self.run_command(name, f"reboot {flags}")
+        start_time = time.time()
+        while wait and time.time() - start_time < 600:  # 10 minutes
+            time.sleep(10)
+            instance_view = self._azure_service.compute.virtual_machines.instance_view(
+                self._resource_group_name, vm_name=name)
+            if instance_view and instance_view.statuses[-1].display_status == 'VM running':
+                break
 
     def add_tags(self, name: str, tags: Dict[str, str]) -> VirtualMachine:
         """Adds tags to instance (with waiting for completion)"""
@@ -221,6 +227,27 @@ class VirtualMachineProvider:
                 }
             })
         return storage_profile
+
+    def run_command(self, name: str, command: str) -> Result:
+        if name not in self._cache:
+            raise AttributeError(f"Instance '{name}' does not exist in resource group '{self._resource_group_name}'")
+        LOGGER.debug("Running command '%s' on instance: %s", command, name)
+        command_object = RunCommandInput(command_id="RunShellScript", script=[command])
+        result = self._azure_service.compute.virtual_machines.begin_run_command(
+            self._resource_group_name, name, command_object).result()
+        LOGGER.debug("Finished running command '%s' on instance: %s: %s", command, name, result.value[0])
+        try:
+            stdout, stderr = result.value[0].message.split('[stdout]\n')[1].split('\n[stderr]\n')[0:2]
+            exited = 0  # doesn't mean it passed, Azure does not provide rc
+        except IndexError:
+            stdout, stderr = result.value[0].message, ""
+            exited = 1
+        return Result(
+            stdout=stdout,
+            stderr=stderr,
+            exited=exited,
+            encoding="utf-8"
+        )
 
     @staticmethod
     def _get_pricing_params(pricing_model: PricingModel):

--- a/sdcm/provision/provisioner.py
+++ b/sdcm/provision/provisioner.py
@@ -17,6 +17,8 @@ from datetime import datetime
 from enum import Enum
 from typing import List, Dict
 
+from invoke import Result
+
 from sdcm.keystore import SSHKey
 from sdcm.provision.user_data import UserDataObject
 
@@ -86,10 +88,10 @@ class VmInstance:  # pylint: disable=too-many-instance-attributes
         was triggered."""
         self._provisioner.terminate_instance(self.name, wait=wait)
 
-    def reboot(self, wait: bool = True) -> None:
+    def reboot(self, wait: bool = True, hard: bool = False) -> None:
         """Reboots the instance.
         If wait is set to True, waits until machine is up, otherwise, returns when reboot was triggered."""
-        self._provisioner.reboot_instance(self.name, wait)
+        self._provisioner.reboot_instance(self.name, wait, hard)
 
     def add_tags(self, tags: Dict[str, str]) -> None:
         """Adds tags to the instance."""
@@ -99,6 +101,10 @@ class VmInstance:  # pylint: disable=too-many-instance-attributes
     @property
     def availability_zone(self) -> str:
         return self._provisioner.availability_zone
+
+    def run_command(self, command: str) -> Result:
+        """Runs command on instance."""
+        return self._provisioner.run_command(self.name, command)
 
 
 class Provisioner(ABC):
@@ -147,7 +153,7 @@ class Provisioner(ABC):
         """Terminate instance by name"""
         raise NotImplementedError()
 
-    def reboot_instance(self, name: str, wait: bool) -> None:
+    def reboot_instance(self, name: str, wait: bool, hard: bool = False) -> None:
         """Reboot instance by name. """
         raise NotImplementedError()
 
@@ -161,6 +167,10 @@ class Provisioner(ABC):
 
     def add_instance_tags(self, name: str, tags: Dict[str, str]) -> None:
         """Adds tags to instance."""
+        raise NotImplementedError()
+
+    def run_command(self, name: str, command: str) -> Result:
+        """Runs command on instance."""
         raise NotImplementedError()
 
 

--- a/unit_tests/lib/fake_provisioner.py
+++ b/unit_tests/lib/fake_provisioner.py
@@ -11,7 +11,10 @@
 #
 # Copyright (c) 2022 ScyllaDB
 import datetime
+import subprocess
 from typing import List, Dict
+
+from invoke import Result
 
 from sdcm.provision.provisioner import Provisioner, VmInstance, InstanceDefinition, PricingModel
 
@@ -68,8 +71,12 @@ class FakeProvisioner(Provisioner):
     def cleanup(self, wait: bool = False) -> None:
         self._instances = {}
 
-    def reboot_instance(self, name: str, wait: bool) -> None:
+    def reboot_instance(self, name: str, wait: bool, hard: bool = False) -> None:
         pass
+
+    def run_command(self, name: str, command: str) -> Result:
+        """Runs command on instance."""
+        return subprocess.run(command, shell=True, capture_output=True, text=True)  # pylint: disable=subprocess-run-check
 
     @classmethod
     def discover_regions(cls, test_id: str, **kwargs) -> List[Provisioner]:  # pylint: disable=unused-argument

--- a/unit_tests/provisioner/test_provisioner.py
+++ b/unit_tests/provisioner/test_provisioner.py
@@ -132,6 +132,15 @@ def test_can_add_tags(provisioner, definition, backend, provisioner_params):
     assert provisioner.get_or_create_instance(definition).tags.get("tag_key") == "tag_value"
 
 
+def test_can_run_command(provisioner, definition, backend, provisioner_params):
+    assert provisioner.get_or_create_instance(definition).run_command(
+        'echo "hello instance"').stdout == "hello instance\n"
+
+    # validate real tags change
+    provisioner = provisioner_factory.create_provisioner(backend=backend, **provisioner_params)
+    assert provisioner.get_or_create_instance(definition).tags.get("tag_key") == "tag_value"
+
+
 def test_null_tag_value_is_replaced_with_empty_string(provisioner, definition, backend, provisioner_params):
     if backend != "azure":
         pytest.skip("Only Azure does not support null tags")


### PR DESCRIPTION
When triggerring reboot using Azure `begin_restart` SDK it is not rebooted immediately, but rather sheduled for reboot in future. This future for us is too far causing timeouts and broken nemesis logic.

Fix is about running `reboot -f` command instead of `begin_restart` method. This is done by Azure `run_command` API.

Enchanced also provisioner API with running commands possibility as this was required anyway for above change.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
