### PR TITLE
fix(sct_runner): don't call ssh_run_cmd during cleanup if there is no public IP

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -647,7 +647,7 @@ class AwsSctRunner(SctRunner):
                     instance=instance,
                     test_id=tags.get("TestId"),
                     instance_name=instance_name,
-                    public_ips=[instance.get("PublicIpAddress"), ],
+                    public_ips=[public_ip, ] if (public_ip := instance.get("PublicIpAddress")) else [],
                     launch_time=instance["LaunchTime"],
                     keep=tags.get("keep"),
                     keep_action=tags.get("keep_action"),
@@ -1204,7 +1204,7 @@ def clean_sct_runners(test_status: str,
 
         # ssh_run_cmd currently only works on AWS, no point of wasting time
         # trying to lookup on AWS instance from GCP/Azure
-        if sct_runner_info.cloud_provider == "aws":
+        if sct_runner_info.public_ips and sct_runner_info.cloud_provider == "aws":
             ssh_run_cmd_result = ssh_run_cmd(command=cmd, test_id=sct_runner_info.test_id,
                                              node_name=sct_runner_name, force_use_public_ip=True)
 


### PR DESCRIPTION
In Scylla Cloud staging environment, for security's sake, we have an allocated pool of public IPs for the runners.  If we fail to get an IP due to an empty pool then the cleanup script used to fail since it tried to execute a command via SSH using a public IP.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
