### PR TITLE
fix(stress-ng): install the correct way

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2838,8 +2838,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.target_node.install_epel()
             self.target_node.remoter.sudo('yum install -y stress-ng')
         elif self.target_node.distro.is_ubuntu:
-            # Install stress on Ubuntu: https://snapcraft.io/install/stress-ng/ubuntu
-            self.target_node.remoter.sudo('snap install stress-ng')
+            self.target_node.remoter.sudo('apt-get -y install stress-ng')
         else:
             raise UnsupportedNemesis(f"{self.target_node.distro} OS not supported!")
         self.log.info('Try to allocate 120% available memory, the allocated memory will be swaped out')


### PR DESCRIPTION
this is kind of cherry-pick from same fix
on master #6557.

original commit message is:

fix(nemesis.py): Use apt to install stress-ng on ubuntu

Since stress-ng snap was taken down by Canonical for some reason this commit removes the snapd installation and replaces stress-ng install to main ubuntu repositories.

Closes scylladb#6555

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
