### PR TITLE
fix(k8s): make the `cleanup` test be more stable

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -172,10 +172,15 @@ def test_add_new_node_and_check_old_nodes_are_cleaned_up(db_cluster):
             cql_create_ks_cmd = (
                 f"CREATE KEYSPACE IF NOT EXISTS {current_ks_name}"
                 f" WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : {db_rf}}}")
-            db_cluster.nodes[0].run_cqlsh(cmd=cql_create_ks_cmd, timeout=10)
-            time.sleep(4)
-            db_cluster.nodes[0].run_cqlsh(cmd=f"DROP KEYSPACE IF EXISTS {current_ks_name}", timeout=10)
-            time.sleep(4)
+            try:
+                db_cluster.nodes[0].run_cqlsh(cmd=cql_create_ks_cmd, timeout=60)
+                time.sleep(4)
+                db_cluster.nodes[0].run_cqlsh(cmd=f"DROP KEYSPACE IF EXISTS {current_ks_name}", timeout=60)
+                time.sleep(4)
+            except Exception as exc:  # pylint: disable=broad-except
+                # NOTE: we don't care if some of the queries fail.
+                #       At first, there are redundant ones and, at second, they are utilitary.
+                log.warning("Utilitary CQL query has failed: %s", exc)
         log.info("%s: log search succeeded", log_follower_name)
 
     new_nodes_count = 1


### PR DESCRIPTION
In the `test_add_new_node_and_check_old_nodes_are_cleaned_up` K8S functional test we use utilitary CQL queries which just create noise in DB logs to make our log reader move on fast enough. And those queries may timeout from time to time.
We don't really care whether they timeout or not while some of them pass.
So, ignore those queries errors.
Also, increase the client timeout from `10` to `60` seconds to reduce number of failed queries.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
