### PR TITLE
fix(FullPartitionScanOperation): Do not print full diff output

### DIFF
--- a/sdcm/scan_operation_thread.py
+++ b/sdcm/scan_operation_thread.py
@@ -383,7 +383,9 @@ class FullPartitionScanOperation(FullscanOperationBase):
                 self.log.debug("Compared output of normal and reversed queries is identical!")
                 result = True
             else:
-                self.log.warning("Normal and reversed queries output differs: \n%s", result.stdout.strip())
+                output = result.stdout.strip()
+                self.log.warning("Normal and reversed queries output differs (diff-size is %s): \n%s",
+                                 len(output.splitlines()), output[200])
                 ls_cmd = f"ls -alh {file_names}"
                 head_cmd = f"head {file_names}"
                 for cmd in [ls_cmd, head_cmd]:


### PR DESCRIPTION
	When full partition scan data is validated, there might
	be a large diff. It cannot be fully printed to log.
	So it will now print the diff size and few first lines only.
	Fixes: #6573 , #6065
Fixes: #6573
Fixes: #6056

This PR is a partial quick fix.
There is an additional fix planned to address the reverse-queries partition validation.
It is in the scope of task: https://github.com/scylladb/qa-tasks/issues/1199
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
