### PR TITLE
fix(cluster.py): remove 'experimental' config option from scylla.yaml

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1656,6 +1656,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 self.proposed_scylla_yaml
             )
 
+        # TODO: remove when https://github.com/scylladb/scylla-machine-image/issues/484 gets fixed
+        with self.remote_scylla_yaml() as scylla_yml:
+            scylla_yml.experimental = None
+
         self.process_scylla_args(append_scylla_args)
 
         if debug_install:

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -499,7 +499,8 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method
             expected_node_yaml = expected_node_yaml.replace(
                 '__SEED_NODE_IPS__', seed_node_ips)
             expected_node_yaml = expected_node_yaml.replace('__NODE_IPV6_ADDRESS__', self.ipv6_ip_address)
-            assert json.loads(expected_node_yaml) == node_yaml.dict(exclude_unset=True, exclude_defaults=True)
+            assert json.loads(expected_node_yaml) == node_yaml.dict(
+                exclude_unset=True, exclude_defaults=True, exclude_none=True)
 
 
 class IntegrationTests(unittest.TestCase):


### PR DESCRIPTION
In Scylla the support of the `experimental` option was dropped.
But the `scylla-machine-image` project has bug [1] where it always defines that config option.
So, workaround it by explicitly removing that option from the `scylla.yaml`.

[1] https://github.com/scylladb/scylla-machine-image/issues/484

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
