### PR TITLE
Fixes for CloudReplaceNonResponsiveNode: improve SSH-based loggers and .terminate_node() method

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -536,7 +536,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         return None
 
     @property
-    def scylla_shards(self):
+    def scylla_shards(self) -> int:
         """
         Priority of selecting number of shards for Scylla is defined in
         <dist.common.scripts.scylla_util.scylla_cpuinfo.nr_shards> and has following order:
@@ -3402,18 +3402,20 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         for node in self.nodes:
             node.destroy()
 
-    def terminate_node(self, node):
+    def terminate_node(self, node: BaseNode, scylla_shards: int = 0) -> None:
+        # NOTE: BaseNode.scylla_shards uses SSH commands to get actual numbers which is not possible on a dead node.
+        #       In such cases, a caller needs to get the number of shards before the node dies and provide it.
         if node.ip_address not in self.dead_nodes_ip_address_list:
             self.dead_nodes_list.append(DeadNode(
                 name=node.name,
                 public_ip=node.public_ip_address,
                 private_ip=node.private_ip_address,
-                ipv6_ip=node.ipv6_ip_address if self.test_config.IP_SSH_CONNECTIONS == "ipv6" else '',
+                ipv6_ip=node.ipv6_ip_address if self.test_config.IP_SSH_CONNECTIONS == "ipv6" else "",
                 ip_address=node.ip_address,
-                shards=node.scylla_shards,
+                shards=scylla_shards or node.scylla_shards,
                 termination_time=datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
-                terminated_by_nemesis=node.running_nemesis))
-
+                terminated_by_nemesis=node.running_nemesis,
+            ))
         if node in self.nodes:
             self.nodes.remove(node)
         node.destroy()


### PR DESCRIPTION
Main driver for this rework are false failures of some nemeses in ScyllaDB Cloud longevities which shutdown nodes. 

Like:

```
Traceback (most recent call last):
File "/home/ubuntu/scylla-cluster-tests/sdcm/wait.py", line 69, in wait_for
res = retry(func, **kwargs)
File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 404, in __call__
do = self.iter(retry_state=retry_state)
File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 360, in iter
raise retry_exc.reraise()
File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 194, in reraise
raise self
tenacity.RetryError: RetryError[<Future at 0x7f55642bcfa0 state=finished returned bool>]
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
File "/home/ubuntu/scylla-cluster-tests/sdcm/sct_events/decorators.py", line 26, in wrapper
return func(*args, **kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/remote_logger.py", line 120, in _journal_thread
self._wait_ssh_up(verbose=False)
File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/remote_logger.py", line 145, in _wait_ssh_up
super()._wait_ssh_up(*args, **kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/remote_logger.py", line 128, in _wait_ssh_up
wait.wait_for(func=self._remoter.is_up, step=10, text=text, timeout=timeout, throw_exc=True)
File "/home/ubuntu/scylla-cluster-tests/sdcm/wait.py", line 80, in wait_for
raise WaitForTimeoutError(err) from ex
sdcm.wait.WaitForTimeoutError: Wait for: is_up: timeout - 500 seconds - expired
```

To fix this problem:

- Use termination event in `._journal_thread()`
- Introduce checks for readiness for retrieve logs: `._is_ready_for_retrieve()` methods
- Don't use wait_for() for additional implicit waiting loops inside `._journal_thread()`

Also improve the code quality:

- Add type annotations
- Use ellipsis instead of pass for abstract methods
- Add _remoter property
- Remove redundant .node attribute (use ._node instead)
- Use kwargs as much as possible
- Use uppercase for constants
- Use cached_property for properties which return static values
- Remove redundant abstract class `NodeLoggerBase`
- Make `SSHScyllaFileLogger` a child of `SSHGeneralFileLogger`
- Remove code duplication and use correct parameter names in `CSHDRFileLogger`

In addition, added change to eliminate significant delay after node removing caused by trying to get Scylla shards from dead nodes.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
