### PR TITLE
fix(artifacts): use default logs_transport for Docker test

### DIFF
--- a/test-cases/artifacts/docker.yaml
+++ b/test-cases/artifacts/docker.yaml
@@ -1,6 +1,5 @@
 backtrace_decoding: false
 cluster_backend: 'docker'
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0


### PR DESCRIPTION
Found that we don't have node's logs for Docker artifacts test :( It's not really critical, but it's better to have it.

There is a fix.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
