### PR TITLE
fix(azure): Creating instances didn't respected `disk_size`

### DIFF
--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -203,28 +203,24 @@ class VirtualMachineProvider:
                            "create_option": "FromImage",
                            "deleteOption": "Delete",  # somehow deletion of VM does not delete os_disk anyway...
                            "managed_disk": {
-                               "storage_account_type": "Premium_LRS",  # SSD
+                               "storage_account_type": "StandardSSD_LRS",  # SSD
                            }
                            } | ({} if disk_size is None else {"disk_size_gb": disk_size}),
         }}
         if image_id.startswith("/subscriptions/"):
-            storage_profile.update({
-                "storage_profile": {
-                    "image_reference": {"id": image_id},
-                    "deleteOption": "Delete"
-                }
+            storage_profile['storage_profile'].update({
+                "image_reference": {"id": image_id},
+                "deleteOption": "Delete"
             })
         else:
             image_reference_values = image_id.split(":")
-            storage_profile.update({
-                "storage_profile": {
-                    "image_reference": {
-                        "publisher": image_reference_values[0],
-                        "offer": image_reference_values[1],
-                        "sku": image_reference_values[2],
-                        "version": image_reference_values[3],
-                    },
-                }
+            storage_profile['storage_profile'].update({
+                "image_reference": {
+                    "publisher": image_reference_values[0],
+                    "offer": image_reference_values[1],
+                    "sku": image_reference_values[2],
+                    "version": image_reference_values[3],
+                },
             })
         return storage_profile
 


### PR DESCRIPTION
the `_get_scylla_storage_profile` function was overriding the `storage_profile` part, and dropping all the `os_disk` configuration.

it's now defaulting to `StandardSSD_LRS`, since we are standard instances for runners.

Ref: https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types

Fixes: #6614

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
