### PR TITLE
fix(artifact test): remove 'developer-mode' arg for t3.micro

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1704,8 +1704,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             )
         if self.parent_cluster.params.get('db_nodes_shards_selection') == 'random':
             append_scylla_args += f" --smp {self.scylla_random_shards()}"
-        if self.db_node_instance_type == "t3.micro":
-            append_scylla_args += ' --developer-mode 1 '
 
         if append_scylla_args:
             self.log.debug("Append following args to scylla: `%s'", append_scylla_args)


### PR DESCRIPTION
The change is presented in https://github.com/scylladb/scylla-cluster-tests/pull/6566/commits/ e49c4f4bc1c524a348fa888eed84faebd4aeb63a added '--developer-mode' scylla argument for t3.micro artifact test.

But later '--developer-mode' agrument was added to be default by https://github.com/scylladb/scylla-machine-image/pull/482.

As result
https://jenkins.scylladb.com/job/enterprise-2023.1/job/artifacts/job/artifacts-ami-t3_micro-test/ fails with error:
```
scylla[4265]: FATAL: Exception during startup, aborting: boost::wrapexcept<boost::program_options:: multiple_occurrences> (option '--developer-mode' cannot be specified more than once)
```

Remove '--developer-mode' arg.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
