### PR TITLE
fix(compaction_params): pass only supported params

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2424,7 +2424,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         """
             Alters a non-system table compaction strategy from ICS to any-other and vise versa.
         """
-        list_additional_params = get_compaction_random_additional_params()
         all_ks_cfs = self.cluster.get_non_system_ks_cf_list(db_node=self.target_node)
 
         if not all_ks_cfs:
@@ -2443,7 +2442,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         new_compaction_strategy_as_dict = {'class': new_compaction_strategy.value}
 
         if new_compaction_strategy in [CompactionStrategy.INCREMENTAL, CompactionStrategy.SIZE_TIERED]:
-            for param in list_additional_params:
+            for param in get_compaction_random_additional_params(new_compaction_strategy):
                 new_compaction_strategy_as_dict.update(param)
         alter_command_prefix = 'ALTER TABLE ' if not is_cf_a_view(
             node=self.target_node, ks=keyspace, cf=table) else 'ALTER MATERIALIZED VIEW '

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -126,6 +126,7 @@ from sdcm.utils.latency import calculate_latency, analyze_hdr_percentiles
 from sdcm.utils.csrangehistogram import CSHistogramTagTypes, CSWorkloadTypes, make_cs_range_histogram_summary, \
     make_cs_range_histogram_summary_by_interval
 from sdcm.utils.raft.common import validate_raft_on_nodes
+from test_lib.compaction import CompactionStrategy
 
 CLUSTER_CLOUD_IMPORT_ERROR = ""
 try:
@@ -2301,7 +2302,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             prefix = ' AND compaction={'
             postfix = '}'
             compaction_clause = " 'class': '%s'" % compaction
-            if sstable_size:
+            if sstable_size and compaction in [CompactionStrategy.LEVELED.value, CompactionStrategy.INCREMENTAL.value]:
                 compaction_clause += ", 'sstable_size_in_mb' : '%s'" % sstable_size
             query += prefix + compaction_clause + postfix
 

--- a/test_lib/compaction.py
+++ b/test_lib/compaction.py
@@ -85,7 +85,7 @@ def get_compaction_strategy(node, keyspace, table):
     return compaction
 
 
-def get_compaction_random_additional_params():
+def get_compaction_random_additional_params(strategy: CompactionStrategy):
     """
 
     :return: list_additional_params
@@ -96,8 +96,17 @@ def get_compaction_random_additional_params():
     min_threshold = random.randint(2, 10)
     max_threshold = random.randint(4, 64)
     sstable_size_in_mb = random.randint(50, 2000)
-    list_additional_params = [{'bucket_high': bucket_high}, {'bucket_low': bucket_low},
-                              {'min_sstable_size': min_sstable_size}, {'min_threshold': min_threshold},
-                              {'max_threshold': max_threshold}, {'sstable_size_in_mb': sstable_size_in_mb}]
 
-    return list_additional_params
+    # doc : https://github.com/scylladb/scylladb/blob/d543b96d1837c73f2ded42d4c5c8de17005c2f36/docs/cql/compaction.rst
+    list_additional_params_options = {
+        CompactionStrategy.LEVELED: [{'sstable_size_in_mb': sstable_size_in_mb}],
+        CompactionStrategy.SIZE_TIERED:
+            [{'bucket_high': bucket_high}, {'bucket_low': bucket_low}, {'min_sstable_size': min_sstable_size},
+             {'min_threshold': min_threshold}, {'max_threshold': max_threshold}],
+        CompactionStrategy.TIME_WINDOW: [{'min_threshold': min_threshold}, {'max_threshold': max_threshold}],
+        CompactionStrategy.INCREMENTAL:
+            [{'bucket_high': bucket_high}, {'bucket_low': bucket_low}, {'min_sstable_size': min_sstable_size},
+             {'min_threshold': min_threshold}, {'max_threshold': max_threshold},
+             {'sstable_size_in_mb': sstable_size_in_mb}]
+    }
+    return list_additional_params_options[strategy]


### PR DESCRIPTION
SCT code was abusing the fact scylla wasn't checking, and is passing some parameters regardless if they how supported

now it is fixed for sstable_size_in_mb parameter and get_compaction_random_additional_params function

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
