### PR TITLE
fix(set_auth_rf): remove parallelism

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -905,9 +905,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     def set_system_auth_rf(self, db_cluster=None):
 
-        def _nodetool_repair(node):
-            node.run_nodetool(sub_cmd="repair -pr system_auth", timeout=MINUTE_IN_SEC * 20)
-
         if not db_cluster:
             db_cluster = self.db_cluster
         # No need to change system tables when running via scylla-cloud
@@ -935,9 +932,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                              num_retry_on_failure=3)
         self.log.debug("system_auth description: %s", res.stdout)
         self.log.info('repair system_auth keyspace ...')
-        parallel_objects = ParallelObject(self.db_cluster.nodes, num_workers=min(
-            32, len(self.db_cluster.nodes)), timeout=MINUTE_IN_SEC * 25)
-        parallel_objects.run(_nodetool_repair)
+        for node in self.db_cluster.nodes:
+            node.run_nodetool(sub_cmd="repair -pr system_auth", timeout=MINUTE_IN_SEC * 20)
         self.log.info('repair system_auth keyspace done')
 
     @cache


### PR DESCRIPTION
There are timeouts errors during repair of system_auth when setting system_auth during node setup. Looks like repair freezes (db log hang for 20m on repair roles table).

Because it was never recommended to run this repair in parallel (but should not affect either). Removing parallelism so we can exclude this as a root cause of freezing repair of system_auth table.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
