### PR TITLE
fix(syslog): set millisecond resolution

### DIFF
--- a/sdcm/utils/syslogng.py
+++ b/sdcm/utils/syslogng.py
@@ -88,6 +88,7 @@ options {{
   create_dirs(yes);
   perm(0640);
   dir_perm(0750);
+  frac-digits(3);
 }};
 
 source s_network_tcp {{


### PR DESCRIPTION
set millisecond resolution
in syslog-ng configuration

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
