### PR TITLE
improvement(k8s-local): use latest versions for K8S and Scylla

### DIFF
--- a/defaults/k8s_local_kind_config.yaml
+++ b/defaults/k8s_local_kind_config.yaml
@@ -1,12 +1,12 @@
 # Version of the kind to be used
-mini_k8s_version: '0.17.0'
+mini_k8s_version: '0.20.0'
 
 n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
 
-scylla_version: '5.2.7'
-scylla_mgmt_agent_version: '3.1.0'
-mgmt_docker_image: 'scylladb/scylla-manager:3.1.0'
+scylla_version: '5.2.9'
+scylla_mgmt_agent_version: '3.2.2'
+mgmt_docker_image: 'scylladb/scylla-manager:3.2.2'
 
 # NOTE: If 'k8s_scylla_operator_docker_image' not set then the one from helm chart will be used.
 # To test nightly builds define it like this: 'scylladb/scylla-operator:nightly'
@@ -51,4 +51,4 @@ backup_bucket_location: 'minio-bucket'
 #       It will allow to test 'serverless' feature against any stable Scylla release
 #       with old 'cassandra-stress' binary.
 stress_image:
-  cassandra-stress: 'scylladb/scylla:5.2.7'
+  cassandra-stress: 'scylladb/scylla:5.2.9'


### PR DESCRIPTION
The K8S version we use in the `KinD` tool is pretty old - `v1.25`.
Default `Scylla` and `Scylla-manager` versions are also not the most recent ones.
So, update of it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
