### PR TITLE
fix(k8s): make K8S throughput perf test work correctly

### DIFF
--- a/configurations/operator/perf-regression-throughput.yaml
+++ b/configurations/operator/perf-regression-throughput.yaml
@@ -2,3 +2,7 @@
 #       which gets set by the scylla-operator itself. So, redefine this config option
 #       by removing the duplication of the scylla arg which will make Scylla fail.
 append_scylla_args: ''
+
+# NOTE: remove following when the following SCT bug gets fixed:
+#       https://github.com/scylladb/scylla-cluster-tests/issues/6289
+use_hdr_cs_histogram: false


### PR DESCRIPTION
Workaround the SCT bug [1] for the K8S throughput single-tenant test by disabling the HDR feature on loader side.

[1] https://github.com/scylladb/scylla-cluster-tests/issues/6289

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
