### PR TITLE
fix(gke-upgrade): configure the correct k8s base version

### DIFF
--- a/test-cases/scylla-operator/kubernetes-platform-upgrade.yaml
+++ b/test-cases/scylla-operator/kubernetes-platform-upgrade.yaml
@@ -37,3 +37,4 @@ user_prefix: 'kubernetes-platform-upgrade'
 
 # NOTE: it must be 1 version lower than available in cloud platforms
 eks_cluster_version: '1.26'
+gke_cluster_version: '1.26'


### PR DESCRIPTION
for gke platfrom upgrade we should start with a lower version then available (currectly 1.26)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
