### PR TITLE
fix(user_id): fix tag name when BUILD_USER_ID contains braces

### DIFF
--- a/sdcm/utils/get_username.py
+++ b/sdcm/utils/get_username.py
@@ -32,6 +32,7 @@ def get_username() -> str:  # pylint: disable=too-many-return-statements
 
     user_id = os.environ.get('BUILD_USER_ID')
     if user_id:
+        user_id = user_id.replace("[", "").replace("]", "")
         return user_id
 
     current_linux_user = getpass.getuser()


### PR DESCRIPTION
When `BUILD_USER_ID` contains `[]` (e.g. for dependabot user which is `dependabot[bot]` then creation of EKS cluster fails due to forbidden characters in tags.

Fix by removing `[` and `]` from `user_id` returned by `get_username()` function.

fixes: #6661

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
