### PR TITLE
Enable azure extension operations back

### DIFF
--- a/sdcm/cluster_azure.py
+++ b/sdcm/cluster_azure.py
@@ -59,6 +59,14 @@ class AzureNode(cluster.BaseNode):
                          node_prefix=node_prefix,
                          dc_idx=dc_idx)
 
+    def init(self) -> None:
+        super().init()
+        # disable auditd service
+        self.remoter.sudo("systemctl stop auditd", ignore_status=True)
+        self.remoter.sudo("systemctl disable auditd", ignore_status=True)
+        self.remoter.sudo("systemctl mask auditd", ignore_status=True)
+        self.remoter.sudo("systemctl daemon-reload", ignore_status=True)
+
     @cached_property
     def tags(self) -> Dict[str, str]:
         return {**super().tags,

--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -174,7 +174,6 @@ class VirtualMachineProvider:
     def _get_os_profile(computer_name: str, admin_username: str,
                         admin_password: str, ssh_public_key: str, custom_data: str) -> Dict[str, Any]:
         os_profile = {"os_profile": {
-            "allow_extension_operations": False,
             "computer_name": computer_name,
             "admin_username": admin_username,
             "admin_password": admin_password,

--- a/unit_tests/provisioner/fake_azure_service.py
+++ b/unit_tests/provisioner/fake_azure_service.py
@@ -520,7 +520,7 @@ class FakeVirtualMachines:
                         }
                     },
                     "secrets": [],
-                    "allowExtensionOperations": False,
+                    "allowExtensionOperations": True,
                     "requireGuestProvisionSignal": True
                 },
                 "networkProfile": {


### PR DESCRIPTION
Recently we disabled Azure Extension Operations which is required for
running efficient reboots (using azure agent).

Enabling it back, and workaround `auditd` issue by disabling and masking
it (so it can't be enabled).

fixes: #6656

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
