### PR TITLE
fix(k8s): make `replace` op after disruption not raise false errors

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1398,8 +1398,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         node.wait_for_svc()
         with DbEventsFilter(
                 db_event=DatabaseLogEvent.DATABASE_ERROR,
-                line="init - Startup failed: seastar::sleep_aborted (Sleep is aborted)"):
-            # NOTE: we ignore the 'init - Startup failed' error because we 'replace' pod during the 'init' phase
+                # NOTE: ignore following expected error messages:
+                #       'init - Startup failed: seastar::sleep_aborted (Sleep is aborted)'
+                #       'init - Startup failed: seastar::gate_closed_exception (gate closed)'
+                line="init - Startup failed: seastar"):
             node.mark_to_be_replaced()
             self._kubernetes_wait_till_node_up_after_been_recreated(node, old_uid=old_uid)
 


### PR DESCRIPTION
Running `disrupt_drain_kubernetes_node_then_replace_scylla_node` nemesis we get following false error event:

```
  2023-10-08 05:09:55.731: (DatabaseLogEvent Severity.ERROR) \
    period_type=one-time event_id=<foo-id>: type=DATABASE_ERROR \
    regex=(^ERROR|!\s*?ERR).*\[shard.*\] line_number=3869 \
    node=sct-cluster-2-us-east1-b-us-east1-1
  ERROR 2023-10-08 05:09:54,352 [shard 0:main] \
    init - Startup failed: seastar::gate_closed_exception (gate closed)
```

It is expected because we `replace` a Scylla pod which is in the `init` phase after disruption.

So, just filter this error event out in this nemesis.

It is complementary to the following PR: https://github.com/scylladb/scylla-cluster-tests/pull/6533

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
