### PR TITLE
fix(k8s): fix fstrim scylla disks on k8s

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2162,7 +2162,7 @@ class BaseScyllaPodContainer(BasePodContainer):  # pylint: disable=abstract-meth
             f"Failed to find pods using '{pods_selector}' selector on '{self.node_name}' node "
             f"in '{namespace}' namespace. Didn't run the 'fstrim' command")
         self.parent_cluster.k8s_cluster.kubectl(
-            f"exec -ti {podnames[0]} -- sh -c 'fstrim -v {scylla_disk_path}'",
+            f"exec {podnames[0]} -- sh -c 'fstrim -v {scylla_disk_path}'",
             namespace=namespace)
 
 


### PR DESCRIPTION
When running `fstrim_scylla_disks` on K8s it fails with error: `Unable to use a TTY - input is not a terminal or the right kind of file`. This is possibly caused by `-ti` flag.

Remove `-ti` flag from running trim command.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
