### PR TITLE
fix(gce): fix provision on_demand instances

### DIFF
--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -463,10 +463,10 @@ def create_instance(  # pylint: disable=too-many-arguments,too-many-locals,too-m
         instance.guest_accelerators = accelerators
 
     instance.scheduling = compute_v1.Scheduling()
-    instance.scheduling.on_host_maintenance = "TERMINATE"
 
     if spot:
         # Set the Spot VM setting
+        instance.scheduling.on_host_maintenance = "TERMINATE"
         instance.scheduling.provisioning_model = (
             compute_v1.Scheduling.ProvisioningModel.SPOT.name
         )


### PR DESCRIPTION
Cannot use 'on_demand' instances due:
`e2 instances do not support onHostMaintenance=TERMINATE unless they are preemptible.`
this was recently introduced and caused this regression.

Fix is about moving this setting `TERMINATE` onHostMaintenance only for spot instances.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
