### PR TITLE
fix(k8s-functional): update `pytest.ini` to contain all the markers we use

### DIFF
--- a/functional_tests/scylla_operator/pytest.ini
+++ b/functional_tests/scylla_operator/pytest.ini
@@ -3,5 +3,8 @@ markers =
     requires_node_termination_support: test gets skipped if backend doesn't support specified K8S node termination method
     requires_mgmt: test requires scylla manager to exist, set "use_mgmt: true" to enable it
     requires_backend: used for the specification of supported backends and making a test be skipped if there is not match
+    requires_scylla_versions: test will be skipped if the installed Scylla version doesn't match values of this marker
+    requires_tls: test will be skipped if the TLS+SNI feature is not enabled, set "k8s_enable_tls: true" to enable it
+    required_operator: test will be skipped if the installed Scylla-Operator version doesn't match values of this marker
     readonly: test that does not make any changes to cluster, only reads. Useful for running fast subset of tests
     restart_is_used: used for skipping tests which suffer from https://github.com/scylladb/scylla/issues/9543


### PR DESCRIPTION
Some of the pytest markers we use are absent in the `pytest.ini` config file.
So, update the config with the missing ones to avoid following warnings:

```
  PytestUnknownMarkWarning: Unknown pytest.mark.required_operator - is \
    this a typo?  You can register custom marks to avoid this warning - for \
    details, see https://docs.pytest.org/en/stable/how-to/mark.html
  @pytest.mark.required_operator("v1.10.0")
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
