### PR TITLE
improvement(perf latency): email subject to have nemesis name

### DIFF
--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -222,11 +222,12 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
     Get latency during operations performance analyzer
     """
 
-    def __init__(self, es_index, es_doc_type, email_recipients=(), logger=None, events=None):   # pylint: disable=too-many-arguments
+    def __init__(self, es_index, es_doc_type, email_recipients=(), logger=None, events=None,  # pylint: disable=too-many-arguments
+                 nemesis_class_name=None):
         super().__init__(es_index=es_index, es_doc_type=es_doc_type, email_recipients=email_recipients,
                          email_template_fp="results_latency_during_ops_short.html", logger=logger, events=events)
         self.percentiles = ['percentile_90', 'percentile_99']
-        self.test_name_for_email_subject = 'latency during operations'
+        self.test_name_for_email_subject = f'latency during {nemesis_class_name}'
 
     def get_debug_events(self):
         return self.get_events(event_severity=[Severity.DEBUG.name])
@@ -497,10 +498,11 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
 
 class LatencyDuringUpgradesPerformanceAnalyzer(LatencyDuringOperationsPerformanceAnalyzer):
     def __init__(self, es_index, es_doc_type, email_recipients=(), logger=None,  # pylint: disable=too-many-arguments
-                 events=None):
+                 events=None, nemesis_class_name='upgrades'):
         super().__init__(es_index=es_index, es_doc_type=es_doc_type, email_recipients=email_recipients,
                          logger=logger, events=events)
         self.percentiles = ['percentile_90', 'percentile_99']
+        self.log.debug('we set %s for compatibility reason, but not used in this test', nemesis_class_name)
         self.test_name_for_email_subject = 'latency during upgrades'
 
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3115,6 +3115,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def check_latency_during_ops(self, op_is_upgrade=False):
         start_time = self.start_time if not self.create_stats else self._stats["test_details"]["start_time"]
         end_time = time.time()
+        nemesis_class_name = self.params.get('nemesis_class_name') or 'upgrades'
         if op_is_upgrade:
             analyzer = LatencyDuringUpgradesPerformanceAnalyzer
         else:
@@ -3124,7 +3125,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                     email_recipients=self.params.get(
                                         'email_recipients'),
                                     events=get_events_grouped_by_category(
-                                        _registry=self.events_processes_registry))
+                                        _registry=self.events_processes_registry),
+                                    nemesis_class_name=nemesis_class_name,
+                                    )
         with open(self.latency_results_file, encoding="utf-8") as file:
             latency_results = json.load(file)
         self.log.debug('latency_results were loaded from file %s and its result is %s',


### PR DESCRIPTION
since we have a new test, that does run a different nemesis class, we want to have different email subjects to each one, since "operations" is already not enough.

email subject will change "operations" to "`nemesis_class_name`", but everything else should stay the same.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
