### PR TITLE
fix(perf-latency): use `email_subject_postfix` for subject

### DIFF
--- a/configurations/disable_cluster_health_check.yaml
+++ b/configurations/disable_cluster_health_check.yaml
@@ -1,2 +1,0 @@
-cluster_health_check: false
-nemesis_interval: 2

--- a/configurations/perf-regresssion-upgrade.yaml
+++ b/configurations/perf-regresssion-upgrade.yaml
@@ -1,0 +1,5 @@
+cluster_health_check: false
+nemesis_interval: 2
+
+user_prefix: 'perf-latency-upgrade'
+email_subject_postfix: 'latency during upgrades'

--- a/jenkins-pipelines/perf-regression-latency-650gb-during-rolling-upgrade.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-650gb-during-rolling-upgrade.jenkinsfile
@@ -7,6 +7,6 @@ perfRegressionParallelPipeline(
     base_versions: '',  // auto mode
     backend: "aws",
     test_name: "performance_regression_test.PerformanceRegressionUpgradeTest",
-    test_config: """["test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml", "configurations/disable_cluster_health_check.yaml"]""",
+    test_config: """["test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml", "configurations/perf-regression-upgrade.yaml"]""",
     sub_tests: ["test_latency_write_with_upgrade", "test_latency_read_with_upgrade", "test_latency_mixed_with_upgrade"]
 )

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -870,7 +870,7 @@ class PerformanceRegressionUpgradeTest(PerformanceRegressionTest, UpgradeTest): 
         self.display_results(results, test_name='test_latency_with_upgrade')
         self.update_test_details(scrap_metrics_step=60)
         self.display_results(results, test_name='test_latency_during_upgrade')
-        self.check_latency_during_ops(op_is_upgrade=True)
+        self.check_latency_during_ops()
 
     def _prepare_latency_with_upgrade(self):
         self.run_fstrim_on_all_db_nodes()

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -226,7 +226,6 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
         super().__init__(es_index=es_index, es_doc_type=es_doc_type, email_recipients=email_recipients,
                          email_template_fp="results_latency_during_ops_short.html", logger=logger, events=events)
         self.percentiles = ['percentile_90', 'percentile_99']
-        self.test_name_for_email_subject = 'latency during operations'
 
     def get_debug_events(self):
         return self.get_events(event_severity=[Severity.DEBUG.name])
@@ -407,7 +406,7 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
         except Exception as exc:  # pylint: disable=broad-except
             LOGGER.error("Compare results failed: %s", exc)
 
-    def check_regression(self, test_id, data, is_gce=False, node_benchmarks=None):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
+    def check_regression(self, test_id, data, is_gce=False, node_benchmarks=None, email_subject_postfix=None):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements, too-many-arguments
         doc = self.get_test_by_id(test_id)
         full_test_name = doc["_source"]["test_details"]["test_name"]
         test_name = full_test_name.split('.')[-1]  # Example: longevity_test.LongevityTest.test_custom_time
@@ -448,7 +447,7 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
         dataset_size = re.search(r'(\d{3}gb)', config_files).group() or 'unknown size'
 
         subject = (f'{self._get_email_tags(doc, is_gce)} Performance Regression Compare Results '
-                   f'({self.test_name_for_email_subject} {dataset_size}) -'
+                   f'({email_subject_postfix} {dataset_size}) -'
                    f' {test_name} - {test_version} - {str(test_start_time)}')
         best_results_per_nemesis = self._get_best_per_nemesis_for_each_version(doc, is_gce)
         self._compare_current_best_results_average(data, best_results_per_nemesis)
@@ -493,15 +492,6 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
         self.save_email_data_file(subject, email_data, file_path='email_data.json')
 
         return True
-
-
-class LatencyDuringUpgradesPerformanceAnalyzer(LatencyDuringOperationsPerformanceAnalyzer):
-    def __init__(self, es_index, es_doc_type, email_recipients=(), logger=None,  # pylint: disable=too-many-arguments
-                 events=None):
-        super().__init__(es_index=es_index, es_doc_type=es_doc_type, email_recipients=email_recipients,
-                         logger=logger, events=events)
-        self.percentiles = ['percentile_90', 'percentile_99']
-        self.test_name_for_email_subject = 'latency during upgrades'
 
 
 class SpecifiedStatsPerformanceAnalyzer(BaseResultsAnalyzer):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -81,7 +81,7 @@ from sdcm.utils.ldap import LDAP_USERS, LDAP_PASSWORD, LDAP_ROLE, LDAP_BASE_OBJE
 from sdcm.utils.log import configure_logging, handle_exception
 from sdcm.db_stats import PrometheusDBStats
 from sdcm.results_analyze import PerformanceResultsAnalyzer, SpecifiedStatsPerformanceAnalyzer, \
-    LatencyDuringOperationsPerformanceAnalyzer, LatencyDuringUpgradesPerformanceAnalyzer
+    LatencyDuringOperationsPerformanceAnalyzer
 from sdcm.sct_config import init_and_verify_sct_config
 from sdcm.sct_events import Severity
 from sdcm.sct_events.setup import start_events_device, stop_events_device
@@ -3052,13 +3052,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         assert used >= size, f"Waiting for Scylla data dir to reach '{size}', " \
                              f"current size is: '{used}'"
 
-    def check_latency_during_ops(self, op_is_upgrade=False):
+    def check_latency_during_ops(self):
         start_time = self.start_time if not self.create_stats else self._stats["test_details"]["start_time"]
         end_time = time.time()
-        if op_is_upgrade:
-            analyzer = LatencyDuringUpgradesPerformanceAnalyzer
-        else:
-            analyzer = LatencyDuringOperationsPerformanceAnalyzer
+        analyzer = LatencyDuringOperationsPerformanceAnalyzer
         results_analyzer = analyzer(es_index=self._test_index,
                                     es_doc_type=self._es_doc_type,
                                     email_recipients=self.params.get(
@@ -3088,7 +3085,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.update({"latency_during_ops": latency_results})
             self.update_test_details()
             results_analyzer.check_regression(test_id=self._test_id, data=latency_results,
-                                              node_benchmarks=benchmarks_results)
+                                              node_benchmarks=benchmarks_results,
+                                              email_subject_postfix=self.params.get('email_subject_postfix'))
 
     def check_regression(self):
         results_analyzer = PerformanceResultsAnalyzer(es_index=self._test_index,

--- a/test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml
@@ -35,3 +35,4 @@ send_email: true
 email_recipients: ["scylla-perf-results@scylladb.com"]
 use_prepared_loaders: true
 use_hdr_cs_histogram: true
+email_subject_postfix: 'latency during grow-shrink'

--- a/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
@@ -36,3 +36,4 @@ email_recipients: ["scylla-perf-results@scylladb.com"]
 use_prepared_loaders: true
 use_hdr_cs_histogram: true
 use_placement_group: true
+email_subject_postfix: 'latency during operations'


### PR DESCRIPTION
as other perf test cases, we want some degree of control on the email report subjects, so we can tell between the test cases we have.

now each case can define how the test would be shown in emails

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
