### PR TITLE
fix(longevity 4h): move default to new AZ

### DIFF
--- a/jenkins-pipelines/longevity-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/longevity-100gb-4h.jenkinsfile
@@ -6,6 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
+    availability_zone: 'c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-100gb-4h.yaml',
     instance_provision_fallback_on_demand: true


### PR DESCRIPTION
last ~10 builds are failing to acquire resources
in the current AZ:
```
An error occurred (InsufficientInstanceCapacity) when calling the
RunInstances operation (reached max retries: 4): We currently do
not have sufficient i4i.4xlarge capacity in the Availability Zone
you requested (us-east-1a)
```

this is a try to have it working using the current trigger mechanism, but changing the AZ to be able to get this test working.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
