### PR TITLE
improvement(log-collector): add ms precision to scylla logs

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -788,7 +788,7 @@ class ScyllaLogCollector(LogCollector):
                             command="sudo journalctl --no-tail --no-pager -u scylla-ami-setup.service "
                                     "-u scylla-image-setup.service -u scylla-io-setup.service -u scylla-server.service "
                                     "-u scylla-jmx.service -u scylla-housekeeping-restart.service "
-                                    "-u scylla-housekeeping-daily.service", search_locally=True),
+                                    "-u scylla-housekeeping-daily.service -o short-precise", search_locally=True),
                     FileLog(name='kallsyms_*',
                             search_locally=True),
                     FileLog(name='lsof_*',


### PR DESCRIPTION
It was requested from dev team to support ms precision in db logs.

Adding `-o short-precise` to collection command that does the job.

fixes: #6682
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
