### PR TITLE
fix(artifact-test): fallback to next az in arm tests

### DIFF
--- a/test-cases/artifacts/centos8.yaml
+++ b/test-cases/artifacts/centos8.yaml
@@ -16,3 +16,4 @@ scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-centos8'
 use_preinstalled_scylla: false
+aws_fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/debian10.yaml
+++ b/test-cases/artifacts/debian10.yaml
@@ -20,3 +20,4 @@ scylla_apt_keys:
 test_duration: 60
 user_prefix: 'artifacts-debian10'
 use_preinstalled_scylla: false
+aws_fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/ubuntu2004.yaml
+++ b/test-cases/artifacts/ubuntu2004.yaml
@@ -20,3 +20,4 @@ scylla_apt_keys:
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2004'
 use_preinstalled_scylla: false
+aws_fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/ubuntu2204.yaml
+++ b/test-cases/artifacts/ubuntu2204.yaml
@@ -16,3 +16,4 @@ scylla_linux_distro: 'ubuntu-jammy'
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2204'
 use_preinstalled_scylla: false
+aws_fallback_to_next_availability_zone: true


### PR DESCRIPTION
It happens we don't have capacity in default AZ for arm artifact tests.

Add `aws_fallback_to_next_availability_zone: true` to test configurations.

fixes: #6684

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
