### PR TITLE
fix(is_port_used): Added retry to remote command execution

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1192,7 +1192,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     def is_port_used(self, port: int, service_name: str) -> bool:
         # Check that "ss" is present and install if absent
-        ss_version_result = self.remoter.run("ss --version || echo ss_not_found")
+        ss_version_result = self.remoter.run("ss --version || echo ss_not_found", retry=5)
         if "ss_not_found" in ss_version_result.stdout:
             self.log.debug(
                 f"Failed to get 'ss' binary version\n"


### PR DESCRIPTION
In one of our daily runs, the method failed due to a timeout, which caused the entire run to fail. To prevent it from happening in the future, I added a retry.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
