### PR TITLE
test(AddDropTableMonkey): new nemesis

### DIFF
--- a/jenkins-pipelines/nemesis/longevity-5gb-3h-AddDropTableMonkey-aws.jenkinsfile
+++ b/jenkins-pipelines/nemesis/longevity-5gb-3h-AddDropTableMonkey-aws.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/nemesis/longevity-5gb-3h-AddDropTableMonkey.yaml'
+
+)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -30,6 +30,7 @@ import traceback
 import json
 from distutils.version import LooseVersion
 from contextlib import ExitStack
+from uuid import uuid4
 from typing import Any, List, Optional, Type, Tuple, Callable, Dict, Set, Union, Iterable
 from functools import wraps, partial
 from collections import defaultdict, Counter, namedtuple
@@ -2414,6 +2415,69 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             raise UnsupportedNemesis("AddDropColumnMonkey: can't find table to run on")
         InfoEvent(f'AddDropColumnMonkey table {".".join(self._add_drop_column_target_table)}').publish()
         self._add_drop_column_run_in_cycle()
+
+    def disrupt_add_drop_table(self):
+        """
+        It spawns several threads to create/delete tables into separate keyspaces
+        """
+        self.log.debug("CreateDeleteTableMonkey: Started")
+        self.use_nemesis_seed()
+        nemesis_run_id = uuid4().hex[:8]
+        InfoEvent(f'CreateDeleteTableMonkey with ID {nemesis_run_id} started ').publish()
+        max_execute_concurrency = 10
+        number_of_tables = 1000  # random.randint(1100,1500)
+        nodes_to_execute = self.cluster.nodes * 2
+        number_of_tables_per_thread = math.ceil(number_of_tables/len(nodes_to_execute))
+        max_execute_concurrency_per_thread = math.ceil(max_execute_concurrency/len(nodes_to_execute))
+
+        threads = []
+        with ThreadPoolExecutor(max_workers=len(nodes_to_execute), thread_name_prefix='CreateDeleteTableMonkeyThread') as thread_pool:
+            start_time = time.time()
+            for thread_number in range(len(nodes_to_execute)):  # pylint: disable=consider-using-enumerate
+                threads.append(thread_pool.submit(partial(
+                    self._add_drop_table_in_thread,
+                    nemesis_run_id=nemesis_run_id,
+                    thread_number=thread_number,
+                    number_of_tables=number_of_tables_per_thread,
+                    node=nodes_to_execute[thread_number],
+                    concurrency=max_execute_concurrency_per_thread)))
+            for thread in threads:
+                thread.result()
+            elapsed_time = time.time() - start_time
+
+        InfoEvent(f'CreateDeleteTableMonkey with ID {nemesis_run_id} finised, {number_of_tables} tables '
+                  f'was create/deleted with Execution time: {time.strftime("%H:%M:%S", time.gmtime(elapsed_time))} ').publish()
+
+    def _add_drop_table_in_thread(self, nemesis_run_id, thread_number: int, number_of_tables: int, node: BaseNode, concurrency: int):
+        with self.cluster.cql_connection_patient(node, connect_timeout=1000) as session:
+            keyspace_name = f"CreateDeleteTableMonkey{nemesis_run_id}{thread_number}"
+            create_keyspase = (f"create keyspace {keyspace_name} with replication = "
+                               f"{{'class': 'NetworkTopologyStrategy', 'replication_factor': {len(self.cluster.nodes)}}}")
+            session.execute(create_keyspase, timeout=900)
+
+            tables_index = 0
+            while tables_index < number_of_tables:
+                execute_futures = []
+                for _ in range(concurrency):
+                    create_table = (f"create table {keyspace_name}.CreateDeleteTableMonkey{nemesis_run_id}{tables_index} "
+                                    f"(k int, v1 int, v2 int, primary key ((k)))")
+                    execute_futures.append(
+                        session.execute_async(create_table, timeout=900))
+                    tables_index += 1
+
+                for future in execute_futures:
+                    future.result()
+
+            while tables_index >= number_of_tables:
+                execute_futures = []
+                for _ in range(concurrency):
+                    tables_index -= 1
+                    execute_futures.append(
+                        session.execute_async(
+                            f"drop table {keyspace_name}.CreateDeleteTableMonkey{nemesis_run_id}{tables_index}", timeout=900))
+
+                for future in execute_futures:
+                    future.result()
 
     def modify_table_comment(self):
         # default: comment = ''
@@ -5751,6 +5815,19 @@ class AddDropColumnMonkey(Nemesis):
 
     def disrupt(self):
         self.disrupt_add_drop_column()
+
+
+class AddDropTableMonkey(Nemesis):
+    disruptive = False
+    run_with_gemini = False
+    networking = False
+    kubernetes = True
+    limited = True
+    schema_changes = True
+    free_tier_set = True
+
+    def disrupt(self):
+        self.disrupt_add_drop_table()
 
 
 class ToggleTableIcsMonkey(Nemesis):

--- a/test-cases/nemesis/longevity-5gb-3h-AddDropTableMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-3h-AddDropTableMonkey.yaml
@@ -1,0 +1,37 @@
+test_duration: 360
+
+prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
+                     ]
+
+post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
+                        ]
+
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=180m -validate-data"
+             ]
+
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1
+seeds_num: 3
+
+instance_type_db: 'i4i.large'
+gce_instance_type_db: 'n1-highmem-2'
+gce_instance_type_loader: 'e2-standard-2'
+azure_instance_type_db: 'Standard_L8s_v3'
+instance_type_loader: 'c5.large'
+azure_instance_type_loader: 'Standard_F2s_v2'
+
+nemesis_class_name: 'AddDropTableMonkey'
+nemesis_interval: 3
+nemesis_filter_seeds: false
+nemesis_during_prepare: true
+
+gce_n_local_ssd_disk_db: 1
+
+user_prefix: 'longevity-5gb-3h-AddDropTableMonkey'
+
+server_encrypt: true
+client_encrypt: true


### PR DESCRIPTION
Created new experimental nemesis AddDropTableMonkey for doing add/drop table in parallel and very fast scylla issue:  scylladb/scylladb#7620

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
