### PR TITLE
fix(microbenchmark): switch ES index

### DIFF
--- a/sdcm/microbenchmarking.py
+++ b/sdcm/microbenchmarking.py
@@ -43,7 +43,7 @@ setup_stdout_logger()
 LOGGER = logging.getLogger("microbenchmarking")
 LOGGER.setLevel(logging.DEBUG)
 
-MICROBENCHMARK_INDEX_NAME = 'microbenchmarkingv2'
+MICROBENCHMARK_INDEX_NAME = 'microbenchmarkingv3'
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Recently cpu settings were changed for microbenchmark tests: https://github.com/scylladb/scylla-pkg/pull/3618
Because of that, historical perf results are not relevant.

Switch ES index so we make comparisons to results with the same CPU settings.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
