### PR TITLE
improvement(logs): collect db logs upon VM termination

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -53,7 +53,6 @@ from cassandra.policies import WhiteListRoundRobinPolicy, HostFilterPolicy, Roun
 from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
 
 from argus.backend.util.enums import ResourceState
-from argus.client.sct.types import LogLink
 from sdcm.node_exporter_setup import NodeExporterSetup
 from sdcm.db_log_reader import DbLogReader
 from sdcm.mgmt import AnyManagerCluster, ScyllaManagerError
@@ -122,7 +121,7 @@ from sdcm.sct_events.filters import EventsSeverityChangerFilter
 from sdcm.utils.auto_ssh import AutoSshContainerMixin
 from sdcm.monitorstack.ui import AlternatorDashboard
 from sdcm.logcollector import GrafanaSnapshot, GrafanaScreenShot, PrometheusSnapshots, upload_archive_to_s3, \
-    save_kallsyms_map, collect_diagnostic_data, ScyllaLogCollector
+    save_kallsyms_map, collect_diagnostic_data, EvictedScyllaLogCollector
 from sdcm.utils.ldap import LDAP_SSH_TUNNEL_LOCAL_PORT, LDAP_BASE_OBJECT, LDAP_PASSWORD, LDAP_USERS, \
     LDAP_PORT, DEFAULT_PWD_SUFFIX
 from sdcm.utils.remote_logger import get_system_logging_thread
@@ -3422,12 +3421,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
             ))
         if node in self.nodes:
             self.nodes.remove(node)
-        ScyllaLogCollector.cluster_log_type = node.name
-        log_links = ScyllaLogCollector([node],
-                                       test_id=self.test_config.test_id(),
-                                       storage_dir=os.path.join(self.logdir, "collected_logs"),
-                                       params=self.params).collect_logs()
-        self.test_config.argus_client().submit_sct_logs([LogLink(log_name=node.name, log_link=log_links[0])])
+        EvictedScyllaLogCollector(node, params=self.params).collect_logs()
         node.destroy()
 
     def get_db_auth(self):


### PR DESCRIPTION
We need `system.log` to be collected for decommissioned/removed nodes for bugs investigation - this log contain proper timestamps. Also other collected usually files might be useful.

Collect logs like we collect them after tests for terminated VM's.

fixes: #6688

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
