### PR TITLE
fix(nemesis jobs): Remove MVs from individual nemesis

### DIFF
--- a/templates/test_config/template-longevity-5gb-1h.yaml.j2
+++ b/templates/test_config/template-longevity-5gb-1h.yaml.j2
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-AbortRepairMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-AbortRepairMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-AddDropColumnMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-AddDropColumnMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-AddRemoveDcNemesis.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-AddRemoveDcNemesis.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-AddRemoveMvNemesis.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-AddRemoveMvNemesis.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-AddRemoveRackNemesis.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-AddRemoveRackNemesis.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-BlockNetworkMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-BlockNetworkMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-CDCStressorMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-CDCStressorMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-ClusterRollingRestart.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ClusterRollingRestart.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-ClusterRollingRestartRandomOrder.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ClusterRollingRestartRandomOrder.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-CorruptThenRebuildMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-CorruptThenRebuildMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-CorruptThenRepairMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-CorruptThenRepairMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-CorruptThenScrubMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-CorruptThenScrubMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-CreateIndexNemesis.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-CreateIndexNemesis.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-DecommissionMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DecommissionMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-DecommissionSeedNode.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DecommissionSeedNode.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-DecommissionStreamingErrMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DecommissionStreamingErrMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-DeleteByPartitionsMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DeleteByPartitionsMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-DeleteByRowsRangeMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DeleteByRowsRangeMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-DeleteOverlappingRowRangesMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DeleteOverlappingRowRangesMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-DisableBinaryGossipExecuteMajorCompaction.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DisableBinaryGossipExecuteMajorCompaction.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-DrainKubernetesNodeThenDecommissionAndAddScyllaNode.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DrainKubernetesNodeThenDecommissionAndAddScyllaNode.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-DrainKubernetesNodeThenReplaceScyllaNode.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DrainKubernetesNodeThenReplaceScyllaNode.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-DrainerMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-DrainerMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-EnableDisableTableEncryptionAwsKmsProviderWithRotationMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-EnableDisableTableEncryptionAwsKmsProviderWithRotationMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-EnableDisableTableEncryptionAwsKmsProviderWithoutRotationMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-EnableDisableTableEncryptionAwsKmsProviderWithoutRotationMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-EnospcAllNodesMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-EnospcAllNodesMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-EnospcMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-EnospcMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-GrowShrinkClusterNemesis.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-GrowShrinkClusterNemesis.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-HardRebootNodeMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-HardRebootNodeMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-LoadAndStreamMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-LoadAndStreamMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-MajorCompactionMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-MajorCompactionMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-MemoryStressMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-MemoryStressMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-MgmtBackup.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-MgmtBackup.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-MgmtBackupSpecificKeyspaces.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-MgmtBackupSpecificKeyspaces.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-MgmtRepair.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-MgmtRepair.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-MgmtRestore.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-MgmtRestore.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-ModifyTableMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ModifyTableMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-MultipleHardRebootNodeMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-MultipleHardRebootNodeMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-NemesisSequence.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-NemesisSequence.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-NoCorruptRepairMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-NoCorruptRepairMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-NodeRestartWithResharding.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-NodeRestartWithResharding.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-NodeTerminateAndReplace.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-NodeTerminateAndReplace.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-NodeToolCleanupMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-NodeToolCleanupMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-OperatorNodeReplace.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-OperatorNodeReplace.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-OperatorNodetoolFlushAndReshard.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-OperatorNodetoolFlushAndReshard.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-PauseLdapNemesis.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-PauseLdapNemesis.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-RandomInterruptionNetworkMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RandomInterruptionNetworkMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-RebuildStreamingErrMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RebuildStreamingErrMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-RefreshBigMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RefreshBigMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-RefreshMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RefreshMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-RejectNodeExporterNetworkMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RejectNodeExporterNetworkMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-RejectThriftNetworkMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RejectThriftNetworkMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-RemoveServiceLevelMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RemoveServiceLevelMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-RepairStreamingErrMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RepairStreamingErrMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-ResetLocalSchemaMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ResetLocalSchemaMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-RollingRestartConfigChangeInternodeCompression.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-RollingRestartConfigChangeInternodeCompression.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-ScyllaKillMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ScyllaKillMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-SnapshotOperations.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-SnapshotOperations.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-SoftRebootNodeMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-SoftRebootNodeMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-SslHotReloadingNemesis.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-SslHotReloadingNemesis.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-StartStopCleanupCompaction.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-StartStopCleanupCompaction.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-StartStopMajorCompaction.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-StartStopMajorCompaction.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-StartStopScrubCompaction.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-StartStopScrubCompaction.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-StartStopValidationCompaction.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-StartStopValidationCompaction.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-StopStartInterfacesNetworkMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-StopStartInterfacesNetworkMonkey.yaml
@@ -4,8 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
 
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",

--- a/test-cases/nemesis/longevity-5gb-1h-StopStartMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-StopStartMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-StopWaitStartMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-StopWaitStartMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-SwitchBetweenPasswordAuthAndSaslauthdAuth.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-SwitchBetweenPasswordAuthAndSaslauthdAuth.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-TerminateAndRemoveNodeMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-TerminateAndRemoveNodeMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-TerminateKubernetesHostThenDecommissionAndAddScyllaNode.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-TerminateKubernetesHostThenDecommissionAndAddScyllaNode.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-TerminateKubernetesHostThenReplaceScyllaNode.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-TerminateKubernetesHostThenReplaceScyllaNode.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-ToggleAuditNemesisSyslog.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ToggleAuditNemesisSyslog.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-ToggleCDCMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ToggleCDCMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-ToggleGcModeMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ToggleGcModeMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-ToggleLdapConfiguration.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ToggleLdapConfiguration.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-ToggleTableIcsMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-ToggleTableIcsMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-TopPartitions.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-TopPartitions.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-TruncateLargeParititionMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-TruncateLargeParititionMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"

--- a/test-cases/nemesis/longevity-5gb-1h-TruncateMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-TruncateMonkey.yaml
@@ -4,9 +4,6 @@ prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replic
                      "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
                      ]
 
-post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
-                        ]
-
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
              "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"


### PR DESCRIPTION
Since those introduced we are hitting again
and again an issue with unbounded view updates.

we are taking it out for now.

Ref: https://github.com/scylladb/scylladb/issues/15717

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
