### PR TITLE
test(custom profile): Add support for upgrade and longevity tests + hybrid-RAID

### DIFF
--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -24,6 +24,7 @@ gce_n_local_ssd_disk_db: 3
 
 gce_pd_standard_disk_size_db: 0
 gce_pd_ssd_disk_size_db: 0
+gce_setup_hybrid_raid: false
 gce_pd_ssd_disk_size_loader: 0
 gce_pd_ssd_disk_size_monitor: 0
 

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -124,6 +124,7 @@ stress_multiplier_r: 1
 stress_multiplier_m: 1
 keyspace_num: 1
 cs_user_profiles: []
+prepare_cs_user_profiles: []
 cs_duration: '50m'
 batch_size: 1
 pre_create_schema: false

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -159,6 +159,7 @@
 | **<a href="#user-content-gce_n_local_ssd_disk_db" name="gce_n_local_ssd_disk_db">gce_n_local_ssd_disk_db</a>**  |  | N/A | SCT_GCE_N_LOCAL_SSD_DISK_DB
 | **<a href="#user-content-gce_pd_standard_disk_size_db" name="gce_pd_standard_disk_size_db">gce_pd_standard_disk_size_db</a>**  |  | N/A | SCT_GCE_PD_STANDARD_DISK_SIZE_DB
 | **<a href="#user-content-gce_pd_ssd_disk_size_db" name="gce_pd_ssd_disk_size_db">gce_pd_ssd_disk_size_db</a>**  |  | N/A | SCT_GCE_PD_SSD_DISK_SIZE_DB
+| **<a href="#user-content-gce_setup_hybrid_raid" name="gce_setup_hybrid_raid">gce_setup_hybrid_raid</a>**  |  | N/A | SCT_GCE_SETUP_HYBRID_RAID
 | **<a href="#user-content-gce_pd_ssd_disk_size_loader" name="gce_pd_ssd_disk_size_loader">gce_pd_ssd_disk_size_loader</a>**  |  | N/A | SCT_GCE_PD_SSD_DISK_SIZE_LOADER
 | **<a href="#user-content-gce_pd_ssd_disk_size_monitor" name="gce_pd_ssd_disk_size_monitor">gce_pd_ssd_disk_size_monitor</a>**  |  | N/A | SCT_GCE_SSD_DISK_SIZE_MONITOR
 | **<a href="#user-content-azure_region_name" name="azure_region_name">azure_region_name</a>**  | Supported: eastus | N/A | SCT_AZURE_REGION_NAME

--- a/jenkins-pipelines/longevity-gce-custom-d1-posts-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/longevity-gce-custom-d1-posts-with-nemesis.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'gce',
+    region: 'us-east1',
+    test_name: 'gemini_test.GeminiTest.test_load_random_with_nemesis',
+    test_config: 'test-cases/custom/longevity-gce-custom-d1-posts.yaml'
+)

--- a/jenkins-pipelines/longevity-gce-custom-d1-posts.jenkinsfile
+++ b/jenkins-pipelines/longevity-gce-custom-d1-posts.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'gce',
+    region: 'us-east1',
+    test_name: 'gemini_test.GeminiTest.test_random_load',
+    test_config: 'test-cases/custom/longevity-gce-custom-d1-posts.yaml'
+)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4561,6 +4561,29 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                     if result.ok:
                         self.log.info("Scylla_io_setup result: %s", result.stdout)
 
+                if self.params.get('gce_setup_hybrid_raid'):
+                    gce_n_local_ssd_disk_db = self.params.get('gce_n_local_ssd_disk_db')
+                    gce_pd_ssd_disk_size_db = self.params.get('gce_pd_ssd_disk_size_db')
+                    if not (gce_n_local_ssd_disk_db > 0 and gce_pd_ssd_disk_size_db > 0):
+                        msg = f"Hybrid RAID cannot be configured without NVMe ({gce_n_local_ssd_disk_db}) " \
+                              f"and PD-SSD ({gce_pd_ssd_disk_size_db})"
+                        raise ValueError(msg)
+                    # pylint: disable=anomalous-backslash-in-string
+                    hybrid_raid_setup_cmd = dedent("""
+                        mdadm --create --verbose --force --run /dev/md10 --level=1 --bitmap=none --raid-devices=2 /dev/sdb /dev/md0
+                        md10_uuid=$(sudo blkid /dev/md10 | grep -o 'UUID="[^"]*' | cut -d'"' -f2)
+                        echo "UUID=$md10_uuid /var/lib/scylla xfs defaults,noatime,nofail 0 0" | sudo tee -a /etc/fstab > /dev/null
+                        echo "UUID=$md10_uuid /var/lib/systemd/coredump xfs defaults,noatime,nofail 0 0" | sudo tee -a /etc/fstab > /dev/null
+                        sed -i "s/What=\/dev\/disk\/by-uuid\/[^ ]*/What=\/dev\/disk\/by-uuid\/$md10_uuid/" /etc/systemd/system/var-lib-scylla.mount
+                        mkfs.xfs -f -m crc=1 -d su=2048k,sw=512 -l version=2 -L HybridRAID /dev/md10
+                        systemctl daemon-reload
+                        systemctl restart var-lib-scylla.mount
+                        systemctl restart var-lib-systemd-coredump.mount
+                    """)
+                    result = node.remoter.run('sudo bash -cxe "%s"' % hybrid_raid_setup_cmd)
+                    if result.ok:
+                        self.log.info("Hybrid RAID setup result: %s", result.stdout)
+
                 node.start_scylla_server(verify_up=False)
 
             # code to increase java heap memory to scylla-jmx (because of #7609)

--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -13,6 +13,8 @@
 
 import logging
 import os
+import re
+import tempfile
 import uuid
 import random
 import json
@@ -23,7 +25,7 @@ from sdcm.utils.common import FileFollowerThread
 from sdcm.sct_events.loaders import GeminiStressEvent, GeminiStressLogEvent
 from sdcm.stress_thread import DockerBasedStressThread
 from sdcm.utils.docker_remote import RemoteDocker
-
+from sdcm.utils.user_profile import get_json_file_content
 
 LOGGER = logging.getLogger(__name__)
 
@@ -61,6 +63,7 @@ class GeminiEventsPublisher(FileFollowerThread):
 class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes
 
     DOCKER_IMAGE_PARAM_NAME = "stress_image.gemini"
+    SCHEMA_REGEX = r'--schema (.*\.json)'
 
     def __init__(self, test_cluster, oracle_cluster, loaders, stress_cmd, timeout=None, params=None):  # pylint: disable=too-many-arguments
         super().__init__(loader_set=loaders, stress_cmd=stress_cmd, timeout=timeout, params=params)
@@ -70,12 +73,32 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
         self.gemini_commands = []
         self.gemini_request_timeout = 180
         self.gemini_connect_timeout = 120
+        self.docker = None
 
     @property
     def gemini_result_file(self):
         if not self._gemini_result_file:
             self._gemini_result_file = os.path.join("/", "gemini_result_{}.log".format(uuid.uuid4()))
         return self._gemini_result_file
+
+    def _update_schema_file_path_and_stress_cmd(self) -> str:
+        """
+        If Gemini command uses '--schema' parameter:
+          1. copy the schema file from runner to loader /tmp directory.
+          2. Update this new path in the gemini cmd string.
+        """
+        stress_cmd = self.stress_cmd.strip()
+        if gemini_schema := re.search(self.SCHEMA_REGEX, stress_cmd):
+            gemini_schema_file_path = gemini_schema.group(1)
+            schema_content = get_json_file_content(json_file_path=gemini_schema_file_path)
+            gemini_schema_file_name = os.path.basename(gemini_schema_file_path)
+            dest_path = os.path.join('/tmp', gemini_schema_file_name)
+            with tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8') as tmp_file:
+                json.dump(schema_content, tmp_file)
+                tmp_file.flush()
+                self.docker.send_files(tmp_file.name, dest_path)
+            stress_cmd = re.sub(self.SCHEMA_REGEX, f"--schema {dest_path}", stress_cmd)
+        return stress_cmd
 
     def _generate_gemini_command(self):
         seed = self.params.get('gemini_seed')
@@ -84,9 +107,9 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
             seed = random.randint(1, 100)
         test_nodes = ",".join(self.test_cluster.get_node_cql_ips())
         oracle_nodes = ",".join(self.oracle_cluster.get_node_cql_ips()) if self.oracle_cluster else None
-
+        stress_cmd = self._update_schema_file_path_and_stress_cmd()
         cmd = "./{} --test-cluster={} --outfile {} --seed {} --request-timeout {}s --connect-timeout {}s ".format(
-            self.stress_cmd.strip(),
+            stress_cmd,
             test_nodes,
             self.gemini_result_file,
             seed,
@@ -105,9 +128,9 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
         if self.stress_num > 1:
             cpu_options = f'--cpuset-cpus="{cpu_idx}"'
 
-        docker = cleanup_context = RemoteDocker(loader, self.docker_image_name,
-                                                extra_docker_opts=f'{cpu_options} --label shell_marker={self.shell_marker}'
-                                                                  f' --network=host --entrypoint=""')
+        self.docker = cleanup_context = RemoteDocker(loader, self.docker_image_name,
+                                                     extra_docker_opts=f'{cpu_options} --label shell_marker={self.shell_marker}'
+                                                                       f' --network=host --entrypoint=""')
 
         if not os.path.exists(loader.logdir):
             os.makedirs(loader.logdir, exist_ok=True)
@@ -122,12 +145,12 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
             try:
                 publisher.event_id = gemini_stress_event.event_id
                 gemini_stress_event.log_file_name = log_file_name
-                result = docker.run(cmd=gemini_cmd,
-                                    timeout=self.timeout,
-                                    ignore_status=False,
-                                    log_file=log_file_name,
-                                    retry=0,
-                                    )
+                result = self.docker.run(cmd=gemini_cmd,
+                                         timeout=self.timeout,
+                                         ignore_status=False,
+                                         log_file=log_file_name,
+                                         retry=0,
+                                         )
                 # sleep to gather all latest log messages
                 time.sleep(5)
             except Exception as details:  # pylint: disable=broad-except
@@ -142,11 +165,11 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
                     gemini_stress_event.add_result(result=result)
                     gemini_stress_event.severity = Severity.WARNING
 
-            local_gemini_result_file = os.path.join(docker.node.logdir, os.path.basename(self.gemini_result_file))
-            results_copied = docker.receive_files(src=self.gemini_result_file, dst=local_gemini_result_file)
+            local_gemini_result_file = os.path.join(self.docker.node.logdir, os.path.basename(self.gemini_result_file))
+            results_copied = self.docker.receive_files(src=self.gemini_result_file, dst=local_gemini_result_file)
             assert results_copied, "gemini results aren't available, did gemini even run ?"
 
-        return docker, result, local_gemini_result_file
+        return self.docker, result, local_gemini_result_file
 
     def get_gemini_results(self):
         parsed_results = []

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -753,6 +753,9 @@ class SCTConfiguration(dict):
         dict(name="gce_pd_ssd_disk_size_db", env="SCT_GCE_PD_SSD_DISK_SIZE_DB", type=int,
              help=""),
 
+        dict(name="gce_setup_hybrid_raid", env="SCT_GCE_SETUP_HYBRID_RAID", type=boolean,
+             help="If True, SCT configures a hybrid RAID of NVMEs and an SSD for scylla's data"),
+
         dict(name="gce_pd_ssd_disk_size_loader", env="SCT_GCE_PD_SSD_DISK_SIZE_LOADER", type=int,
              help=""),
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1103,7 +1103,9 @@ class SCTConfiguration(dict):
 
         # PerformanceRegressionUserProfilesTest
         dict(name="cs_user_profiles", env="SCT_CS_USER_PROFILES", type=str_or_list,
-             help=""),
+             help="cassandra-stress user-profiles list. Executed in test step"),
+        dict(name="prepare_cs_user_profiles", env="SCT_PREPARE_CS_USER_PROFILES", type=str_or_list,
+             help="cassandra-stress user-profiles list. Executed in prepare step"),
         dict(name="cs_duration", env="SCT_CS_DURATION", type=str,
              help=""),
         dict(name="cs_debug", env="SCT_CS_DEBUG", type=boolean,

--- a/sdcm/utils/user_profile.py
+++ b/sdcm/utils/user_profile.py
@@ -14,6 +14,7 @@
 """ This module keeps utilities that help to extract schema definition and stress commands from user profile """
 from __future__ import absolute_import, annotations
 
+import json
 import os
 import re
 
@@ -137,3 +138,15 @@ def replace_scylla_qa_internal_path(stress_cmd: str, loader_path: str):
     stress_cmd = re.sub(r"profile=scylla-qa-internal\/\S*",
                         f" profile={loader_path} ", stress_cmd)
     return stress_cmd
+
+
+def get_json_file_content(json_file_path: str) -> dict:
+    """
+    Getting a content of a json file
+    :return: a dict with json data
+    """
+    if not os.path.exists(json_file_path):
+        raise FileNotFoundError('json file {} not found'.format(json_file_path))
+    with open(json_file_path, encoding="utf-8") as json_stream:
+        json_content = json.load(json_stream)
+    return json_content

--- a/test-cases/custom/longevity-gce-custom-d1-posts.yaml
+++ b/test-cases/custom/longevity-gce-custom-d1-posts.yaml
@@ -1,0 +1,28 @@
+test_duration: 900
+n_db_nodes: 3
+n_test_oracle_db_nodes: 1
+n_loaders: 1
+n_monitor_nodes: 1
+
+gemini_cmd: "gemini -d --duration 4h --warmup 5m --schema scylla-qa-internal/custom_d1/posts.json \
+-c 50 -m mixed -f --non-interactive --cql-features normal \
+--max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
+--async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \
+--replication-strategy \"{'class': 'NetworkTopologyStrategy', 'replication_factor': '3'}\" \
+--oracle-replication-strategy \"{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}\""
+
+gce_instance_type_db: 'n1-highmem-4'
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_seed: '111'
+nemesis_interval: 5
+
+user_prefix: 'longevity-3h-custom-d1'
+
+gce_n_local_ssd_disk_db: 2
+gce_pd_ssd_disk_size_db: 200
+gce_setup_hybrid_raid: true
+
+stress_image:
+  gemini: 'scylladb/hydra-loaders:gemini-v1.8.7'
+
+use_preinstalled_scylla: true

--- a/test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml
+++ b/test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml
@@ -1,0 +1,36 @@
+test_duration: 360
+
+# workloads
+# Customer profiles directory path is: scylla-qa-internal/customer-profile/cust_d
+
+# To be used in keyspace_entire_test:
+cs_duration: '300m'  # TODO: measure new upgrade test duration and adjust this one.
+cs_user_profiles:
+    - scylla-qa-internal/custom_d1/write_stress_during_entire_test.yaml
+# write_stress_during_entire_test: cassandra-stress user no-warmup profile=/tmp/write_stress_during_entire_test.yaml  ops'(insert=1,read=2)' cl=ALL n=5000000 -mode cql3 native -rate threads=1000 -pop seq=1..5000000
+
+# To be used in keyspace_custom_preload:
+prepare_cs_user_profiles:
+    - scylla-qa-internal/custom_d1/stress_before_upgrade.yaml
+#stress_before_upgrade: cassandra-stress user no-warmup profile=/tmp/stress_before_upgrade.yaml  ops'(insert=1)' cl=ALL n=5000000 -mode cql3 native -rate threads=1000 -pop seq=1..5000000
+
+n_db_nodes: 4
+n_loaders: 1
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.2xlarge'
+
+user_prefix: 'rolling-upgrade-custom-d1'
+
+server_encrypt: true
+authenticator: 'PasswordAuthenticator'
+authenticator_user: 'cassandra'
+authenticator_password: 'cassandra'
+
+recover_system_tables: true
+
+append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1'
+
+use_mgmt: false
+
+use_prepared_loaders: true


### PR DESCRIPTION
	Supports custom-profile specific disk configuration and CQL schema.
	A new longevity test configures a hybrid-RAID and runs a Gemini load of custom schema.
        A new upgrade test pre-loads custom dataset by initial load.
	The test runs additional custom profile load during the upgrade/rollback.
	It verifies the basic dataset after all nodes are upgraded.
Task: https://github.com/scylladb/qa-tasks/issues/21
[Test plan](https://docs.google.com/document/d/1omGkONrwtm165_8fWf8r8-_gMl9753TW9uII8P4tjDI/edit?usp=sharing)
(not ready for review)
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
