### PR TITLE
fix(install_client_certificate): use absolute path, and not relative

### DIFF
--- a/sdcm/provision/helpers/certificate.py
+++ b/sdcm/provision/helpers/certificate.py
@@ -14,12 +14,13 @@
 from textwrap import dedent
 
 from sdcm.remote import shell_script_cmd
+from sdcm.utils.common import get_data_dir_path
 
 
 def install_client_certificate(remoter):
     if remoter.run('ls /etc/scylla/ssl_conf', ignore_status=True).ok:
         return
-    remoter.send_files(src='./data_dir/ssl_conf', dst='/tmp/')  # pylint: disable=not-callable
+    remoter.send_files(src=get_data_dir_path('ssl_conf'), dst='/tmp/')  # pylint: disable=not-callable
     setup_script = dedent("""
         mkdir -p ~/.cassandra/
         cp /tmp/ssl_conf/client/cqlshrc ~/.cassandra/
@@ -33,7 +34,7 @@ def install_client_certificate(remoter):
 def install_encryption_at_rest_files(remoter):
     if remoter.sudo('ls /etc/encrypt_conf/system_key_dir', ignore_status=True).ok:
         return
-    remoter.send_files(src="./data_dir/encrypt_conf", dst="/tmp/")
+    remoter.send_files(src=get_data_dir_path('encrypt_conf'), dst="/tmp/")
     remoter.sudo(shell_script_cmd(dedent("""
         rm -rf /etc/encrypt_conf
         mv -f /tmp/encrypt_conf /etc


### PR DESCRIPTION
since we are using relative path, we might run into the following error, cause some code migt change the current direcotry:

```
Exit code: 1
Stdout:
Stderr:
+ '[' -z '' ']'
+ return
+ case $- in
+ return
+ mkdir -p /home/scyllaadm/.cassandra/
+ cp /tmp/ssl_conf/client/cqlshrc /home/scyllaadm/.cassandra/

cp: cannot stat '/tmp/ssl_conf/client/cqlshrc': No such file or directory
```

to be on the safe side, abspath should be used

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
