### PR TITLE
fix(install_syslogng_service): clear all syslog-ng packages

### DIFF
--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -173,7 +173,7 @@ def install_syslogng_service():
         elif apt-get --help 2>/dev/null 1>&2 ; then
             if dpkg-query --show syslog-ng ; then
                 rm /etc/syslog-ng/syslog-ng.conf  # Make sure we have default syslog-ng.conf
-                apt-get purge --autoremove -y syslog-ng
+                apt-get purge -y syslog-ng*
                 DPKG_FORCE=confmiss apt-get --reinstall -y install syslog-ng
                 SYSLOG_NG_INSTALLED=1
             else


### PR DESCRIPTION
when syslong-ng need to be reinstalled, sometimes it doen't created the syslog-ng.conf as expected
so we need to purge all syslog-ng packages out of system first, not just the main one.

Fixes: #6703

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
