### PR TITLE
feature(cluster_replacement): add cluster replacement tests

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -353,3 +353,4 @@
 | **<a href="#user-content-custom_es_index" name="custom_es_index">custom_es_index</a>**  | Use custom ES index for storing test results | N/A | SCT_CUSTOM_ES_INDEX
 | **<a href="#user-content-simulated_racks" name="simulated_racks">simulated_racks</a>**  | Forces GossipingPropertyFileSnitch (regardless `endpoint_snitch`) to simulate racks.<br>Provide number of racks to simulate. | N/A | SCT_SIMULATED_RACKS
 | **<a href="#user-content-use_dns_names" name="use_dns_names">use_dns_names</a>**  | Use dns names instead of ip addresses for nodes in cluster | N/A | SCT_USE_DNS_NAMES
+| **<a href="#user-content-upscale_instance_type</a>**  |   New instance type to pass to the add_nodes method for upscale/downscale cluster tests | N/A | SCT_NEW_INSTANCE_TYPE

--- a/full_cluster_replacement_test.py
+++ b/full_cluster_replacement_test.py
@@ -1,0 +1,96 @@
+import logging
+from longevity_test import LongevityTest
+from sdcm import prometheus
+from sdcm.sct_events.system import InfoEvent
+from sdcm.utils import loader_utils
+
+LOGGER = logging.getLogger(__name__)
+
+
+class FullClusterReplacement(LongevityTest, loader_utils.LoaderUtilsMixin):
+    """
+    The purpose of these tests is replacement of all nodes in the ScyllaDB.
+    Cluster Replacement QA task: https://github.com/scylladb/qa-tasks/issues/1164
+    Cluster replacement test plan: https://docs.google.com/document/d/1aKCTs6SiH9ORDYvkAQ8upOpVwZqaxsW9VfbJqKG63g0/edit
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.metrics_srv = prometheus.nemesis_metrics_obj()
+        self.stress_queue = []
+
+    def start_load(self):
+        keyspace_num = self.params.get('keyspace_num')
+        stress_cmd = self.params.get('stress_cmd')
+        # Start the load
+        self.run_pre_create_schema()
+        self.run_prepare_write_cmd()
+        # self.run_post_prepare_cql_cmds() Uncomment when MV solved: Ref: https://github.com/scylladb/scylladb/issues/15717
+        self.assemble_and_run_all_stress_cmd(self.stress_queue, stress_cmd, keyspace_num)
+
+    def verify_stress_threads_after_node_replacement(self):
+        for stress in self.stress_queue:
+            self.verify_stress_thread(cs_thread_pool=stress)
+
+    def add_new_node_then_decommission_one_node(self, node_to_be_removed, dc_idx=0, new_instance_type=None):
+        """
+        This method use to replaces a node in a cluster by 'Add a new node to the cluster and then decommission the old node' procedure # pylint: disable=line-too-long
+        It adds a new node to the cluster, waits for initialization, decommissions the specified node,
+        and reconfigures the monitoring system.
+        The procedure from: https://opensource.docs.scylladb.com/stable/operating-scylla/procedures/cluster-management/replace-running-node.html#add-a-new-node-to-the-cluster-and-then-decommission-the-old-node # pylint: disable=line-too-long
+        """
+        self.metrics_srv.event_start('add_node')
+        new_node = \
+            self.db_cluster.add_nodes(count=1, dc_idx=dc_idx, enable_auto_bootstrap=True, instance_type=new_instance_type)[
+                0]
+        self.db_cluster.wait_for_init(node_list=[new_node], timeout=3600, check_node_health=False)
+        self.metrics_srv.event_stop('add_node')
+        self.monitors.reconfigure_scylla_monitoring()
+
+        # Decommission node to be replaced
+        InfoEvent(message='Decommission node: {}'.format(node_to_be_removed)).publish()
+        self.db_cluster.decommission(node_to_be_removed)
+        for node in self.db_cluster.nodes:
+            node.run_nodetool(sub_cmd='cleanup')
+
+    def test_rolling_full_cluster_replacement_add_then_decommission_nodes(self):
+        InfoEvent(message="Starting cluster replacement test by add then decommission nodes...").publish()
+        self.start_load()
+        new_instance_type = self.db_cluster.params.get('new_instance_type')
+        # Run node replacement procedure for all nodes and verify data
+        for node in self.db_cluster.nodes:
+            self.add_new_node_then_decommission_one_node(node_to_be_removed=node, new_instance_type=new_instance_type)
+            self.verify_stress_threads_after_node_replacement()
+
+        InfoEvent(message="Finished cluster replacement test by add then decommission nodes...").publish()
+
+    def test_multidc_rolling_full_cluster_replacement_add_then_decommission_nodes(self):
+        new_instance_type = self.params.get('new_instance_type')
+
+        InfoEvent(message="Starting multi-dc cluster replacement test by add then decommission nodes "
+                          "with repair and major compaction in the end...").publish()
+        self.start_load()
+
+        # Run node replacement procedure for all nodes and verify data
+        number_of_nodes_in_each_dc = int(len(self.db_cluster.nodes)/2)
+        for i, node in enumerate(self.db_cluster.nodes):
+            if i >= number_of_nodes_in_each_dc:
+                dc_idx = 0
+            else:
+                dc_idx = 1
+            self.add_new_node_then_decommission_one_node(
+                node_to_be_removed=node, dc_idx=dc_idx, new_instance_type=new_instance_type)
+            self.verify_stress_threads_after_node_replacement()
+
+        # Full Repair and major compaction
+        # This is not required for the replacement procedure, but can be a part of the test to check repair and
+        # compaction on a replaced cluster.
+        for node in self.db_cluster.nodes:
+            InfoEvent(message=f"Starting a repair on node {node.name}")
+            node.run_nodetool(sub_cmd="repair -pr", publish_event=True)
+            node.run_nodetool(sub_cmd="compact", publish_event=True)
+            InfoEvent(message=f"Waiting for compactions to finish on {node.name}")
+            self.wait_no_compactions_running()
+
+        InfoEvent(message="Finished multi-dc cluster replacement test by add then decommission nodes "
+                          "with repair and major compaction in the end...").publish()

--- a/jenkins-pipelines/features-full-cluster-replacement-add-decommission-upscale.jenkinsfile
+++ b/jenkins-pipelines/features-full-cluster-replacement-add-decommission-upscale.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'full_cluster_replacement_test.FullClusterReplacement.test_rolling_full_cluster_replacement_add_then_decommission_nodes',
+    test_config: 'test-cases/features/full-cluster-replacement-upscale.yaml',
+
+    timeout: [time: 270, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/features-full-cluster-replacement-add-decommission.jenkinsfile
+++ b/jenkins-pipelines/features-full-cluster-replacement-add-decommission.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'full_cluster_replacement_test.FullClusterReplacement.test_rolling_full_cluster_replacement_add_then_decommission_nodes',
+    test_config: 'test-cases/features/full-cluster-replacement.yaml',
+
+    timeout: [time: 270, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/features-full-cluster-replacement-multiAZ-multiDC-1TB.jenkinsfile
+++ b/jenkins-pipelines/features-full-cluster-replacement-multiAZ-multiDC-1TB.jenkinsfile
@@ -1,0 +1,14 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    availability_zone: 'a,b',
+    backend: 'aws',
+    region: '''["eu-west-1", "eu-west-2"]''',
+    test_name: 'full_cluster_replacement_test.FullClusterReplacement.test_multidc_rolling_full_cluster_replacement_add_then_decommission_nodes',
+    test_config: 'test-cases/features/full-cluster-replacement-multiAZ-multiDC-1TB.yaml',
+
+    timeout: [time: 1500, unit: 'MINUTES']
+)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1509,6 +1509,8 @@ class SCTConfiguration(dict):
 
         dict(name="validate_large_collections", env="SCT_VALIDATE_LARGE_COLLECTIONS", type=boolean,
              help="Enable validation for large cells in system table and logs"),
+        dict(name="new_instance_type", env="SCT_NEW_INSTANCE_TYPE", type=str,
+             help="New instance type to upscale or downscale a node"),
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',

--- a/test-cases/features/full-cluster-replacement-multiAZ-multiDC-1TB.yaml
+++ b/test-cases/features/full-cluster-replacement-multiAZ-multiDC-1TB.yaml
@@ -1,0 +1,33 @@
+test_duration: 1440
+
+prepare_write_cmd:  ["cassandra-stress write cl=ALL n=275050075 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=150 -col 'size=FIXED(200) n=FIXED(5)' -pop seq=1..275050075",
+                    "cassandra-stress write cl=ALL n=275050075 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=150 -col 'size=FIXED(200) n=FIXED(5)' -pop seq=275050076..550100150",
+                    "cassandra-stress write cl=ALL n=275050075 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=150 -col 'size=FIXED(200) n=FIXED(5)' -pop seq=550100151..825150225",
+                    "cassandra-stress write cl=ALL n=275050075 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=150 -col 'size=FIXED(200) n=FIXED(5)' -pop seq=825150226..1100200300",
+                    "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
+                    ]
+# post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
+# Add the MV after the bug is resolved. Ref: https://github.com/scylladb/scylladb/issues/15717
+
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"
+             ]
+
+availability_zone: 'a,b'
+region_name: 'us-east-1 eu-west-1'
+n_db_nodes: '4 4'
+n_loaders: 4
+instance_type_loader: 'c5.2xlarge'
+n_monitor_nodes: 1
+seeds_num: 3
+
+instance_type_db: 'i4i.xlarge'
+user_prefix: 'full-cluster-replacement-multiAZ-multiDC'
+nemesis_class_name: 'NoOpMonkey'
+
+server_encrypt: true
+client_encrypt: true
+
+nemesis_during_prepare: false
+use_preinstalled_scylla: true

--- a/test-cases/features/full-cluster-replacement-upscale.yaml
+++ b/test-cases/features/full-cluster-replacement-upscale.yaml
@@ -1,0 +1,24 @@
+test_duration: 200
+
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=120m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5"
+             ]
+# post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
+# Add the MV after the bug is resolved. Ref: https://github.com/scylladb/scylladb/issues/15717
+
+
+region_name: 'eu-west-1'
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1
+seeds_num: 3
+
+instance_type_db: 'i4i.2xlarge'
+new_instance_type: 'i4i.4xlarge'
+user_prefix: 'full-cluster-replacement-upscale'
+nemesis_class_name: 'NoOpMonkey'
+
+server_encrypt: true
+client_encrypt: true
+
+nemesis_during_prepare: false
+use_preinstalled_scylla: true

--- a/test-cases/features/full-cluster-replacement.yaml
+++ b/test-cases/features/full-cluster-replacement.yaml
@@ -1,0 +1,26 @@
+test_duration: 300
+
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+
+# post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
+# Add the MV after the bug is resolved. Ref: https://github.com/scylladb/scylladb/issues/15717
+
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=240m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=240m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+             ]
+
+region_name: 'eu-west-1'
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1
+seeds_num: 3
+
+instance_type_db: 'i4i.4xlarge'
+user_prefix: 'full-cluster-replacement-add-decommission'
+nemesis_class_name: 'NoOpMonkey'
+
+server_encrypt: true
+client_encrypt: true
+
+nemesis_during_prepare: false
+use_preinstalled_scylla: true


### PR DESCRIPTION
feature(cluster_replacement): add cluster replacement feature tests file
    
This PR adds cluster replacement feature tests
According to task: https://github.com/scylladb/qa-tasks/issues/1164
Rolling cluster replacement with Multi-DC and Multi-AZ
Adding a new node and then decommission one node.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
