### PR TITLE
fix(perfRegression pipeline): don't call supportedUpgradeFromVersions

### DIFF
--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -3,7 +3,6 @@ import groovy.json.JsonSlurper
 
 def (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout) = [0,0,0,0,0]
 def base_versions_list = []
-def supportedVersions = []
 
 def call(Map pipelineParams) {
     def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter)
@@ -131,14 +130,21 @@ def call(Map pipelineParams) {
                                         checkout scm
                                         (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout) = getJobTimeouts(params, builder.region)
                                         base_versions_list = params.base_versions.contains('.') ? params.base_versions.split('\\,') : []
-                                        // NOTE: master and enterprise will have 1 single version, but for releases,
-                                        // we will choose automatically only the last one
-                                        supportedVersions = supportedUpgradeFromVersions(
-                                            base_versions_list,
-                                            'ubuntu-focal',
-                                            params.new_scylla_repo,
-                                            params.backend
-                                        )
+                                        def new_repo = params.new_scylla_repo
+                                        supportedVersions = ''
+                                        new_params = params.collectEntries { param -> [param.key, param.value] }
+                                        if (new_repo) {
+                                            // NOTE: master and enterprise will have 1 single version, but for releases,
+                                            // we will choose automatically only the last one
+                                            supportedVersions = supportedUpgradeFromVersions(
+                                                base_versions_list,
+                                                'ubuntu-focal',
+                                                new_repo,
+                                                params.backend
+                                            ).last()
+                                            new_params["scylla_version"] = supportedVersions
+                                        }
+                                        println("the supported version is $supportedVersions")
                                     }
                                 }
                             }
@@ -200,7 +206,7 @@ def call(Map pipelineParams) {
                                                             dir('scylla-cluster-tests') {
                                                                 timeout(time: 30, unit: 'MINUTES') {
                                                                     if (params.backend == 'aws' || params.backend == 'azure') {
-                                                                        provisionResources(params, builder.region)
+                                                                        provisionResources(new_params, builder.region)
                                                                     } else {
                                                                         sh """
                                                                             echo 'Skipping because non-AWS/Azure backends are not supported'
@@ -248,7 +254,7 @@ def call(Map pipelineParams) {
                                                         if [[ ! -z "${params.scylla_ami_id}" ]] ; then
                                                             export SCT_AMI_ID_DB_SCYLLA=${params.scylla_ami_id}
                                                         elif [[ ! -z "${supportedVersions}" ]]; then
-                                                            export SCT_SCYLLA_VERSION=${supportedVersions.last()}
+                                                            export SCT_SCYLLA_VERSION=${supportedVersions}
                                                         elif [[ ! -z "${params.scylla_version}" ]] ; then
                                                             export SCT_SCYLLA_VERSION=${params.scylla_version}
                                                         elif [[ ! -z "${params.scylla_repo}" ]] ; then


### PR DESCRIPTION
when it is not needed.
for now, we are calling it for every test, but when we don't have the `new_scylla_repo` param, we are not passing anything to that function, making it fail
to fulfill its signature.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
