### PR TITLE
fix(rolling-upgrade): don't upgrade from 5.3 versions

### DIFF
--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -20,6 +20,9 @@ supported_src_oss = {'2021.1': '4.3', '2022.1': '5.0', '2022.2': '5.1', '2023.1'
 start_support_versions = {'centos-8': {'scylla': '4.1', 'enterprise': '2021.1'}}
 start_support_backend = {'azure': {'scylla': '5.2', 'enterprise': '2023.1'}}
 
+# list of version that are available, but aren't supported, and we should test upgrades from
+unsupported_versions = ['5.3', ]
+
 
 class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
 
@@ -173,6 +176,8 @@ class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
             # Enterprise: the major version is smaller than the start support version
             if self.ent_start_support_version and is_enterprise(version_prefix) and \
                     ComparableScyllaVersion(version_prefix) < self.ent_start_support_version:
+                continue
+            if version_prefix in unsupported_versions:
                 continue
             supported_versions.append(version_prefix)
         version_list = self.get_supported_scylla_base_versions(supported_versions)

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -115,11 +115,12 @@ class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
                         ent_base_version += ent_release_list[idx - 2:][:2]
                     else:
                         LOGGER.warning('enterprise version format not the default - %s', version)
-            elif version == 'enterprise' or ComparableScyllaVersion(version) > ent_release_list[0]:
+            elif version == 'enterprise':
                 ent_base_version.append(ent_release_list[-1])
-            elif re.match(r'\d+.\d+', version) and ComparableScyllaVersion(version) >= ent_release_list[0]:
-                oss_base_version.append(oss_release_list[-1])
-                ent_base_version += ent_release_list[-2:]
+            elif re.match(r'\d+.\d+', version):
+                relevant_versions = [v for v in ent_release_list if ComparableScyllaVersion(v) < version]
+                # oss_base_version.append(oss_release_list[-1])
+                ent_base_version += relevant_versions[-2:]
         elif product == 'scylla':
             if version in supported_versions:
                 # The dest version is a released opensource version
@@ -130,12 +131,13 @@ class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
                 else:
                     # Choose the last two releases as upgrade base
                     oss_base_version += oss_release_list[idx-1:][:2]
-            elif version == 'master' or ComparableScyllaVersion(version) > oss_release_list[0]:
+            elif version == 'master':
                 oss_base_version.append(oss_release_list[-1])
-            elif re.match(r'\d+.\d+', version) and ComparableScyllaVersion(version) < oss_release_list[0]:
+            elif re.match(r'\d+.\d+', version):
+                relevant_versions = [v for v in oss_release_list if ComparableScyllaVersion(v) < version]
                 # If dest version is smaller than the first supported opensource release,
                 # it might be an invalid dest version
-                oss_base_version.append(oss_release_list[-1])
+                oss_base_version.append(relevant_versions[-1])
         else:
             raise ValueError("Unsupported product %s" % product)
 


### PR DESCRIPTION
since version 5.3 was skipped, and won't be suppported we shouldn't ever upgrade from it in rolling upgrades

(for some time we we doing upgardes from 5.3-rc1, when we shouldn't have)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
