### PR TITLE
improvement(node setup): Configure a hybrid RAID on GCE

### DIFF
--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -24,6 +24,7 @@ gce_n_local_ssd_disk_db: 3
 
 gce_pd_standard_disk_size_db: 0
 gce_pd_ssd_disk_size_db: 0
+gce_setup_hybrid_raid: false
 gce_pd_ssd_disk_size_loader: 0
 gce_pd_ssd_disk_size_monitor: 0
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -159,6 +159,7 @@
 | **<a href="#user-content-gce_n_local_ssd_disk_db" name="gce_n_local_ssd_disk_db">gce_n_local_ssd_disk_db</a>**  |  | N/A | SCT_GCE_N_LOCAL_SSD_DISK_DB
 | **<a href="#user-content-gce_pd_standard_disk_size_db" name="gce_pd_standard_disk_size_db">gce_pd_standard_disk_size_db</a>**  |  | N/A | SCT_GCE_PD_STANDARD_DISK_SIZE_DB
 | **<a href="#user-content-gce_pd_ssd_disk_size_db" name="gce_pd_ssd_disk_size_db">gce_pd_ssd_disk_size_db</a>**  |  | N/A | SCT_GCE_PD_SSD_DISK_SIZE_DB
+| **<a href="#user-content-gce_setup_hybrid_raid" name="gce_setup_hybrid_raid">gce_setup_hybrid_raid</a>**  |  | N/A | SCT_GCE_SETUP_HYBRID_RAID
 | **<a href="#user-content-gce_pd_ssd_disk_size_loader" name="gce_pd_ssd_disk_size_loader">gce_pd_ssd_disk_size_loader</a>**  |  | N/A | SCT_GCE_PD_SSD_DISK_SIZE_LOADER
 | **<a href="#user-content-gce_pd_ssd_disk_size_monitor" name="gce_pd_ssd_disk_size_monitor">gce_pd_ssd_disk_size_monitor</a>**  |  | N/A | SCT_GCE_SSD_DISK_SIZE_MONITOR
 | **<a href="#user-content-azure_region_name" name="azure_region_name">azure_region_name</a>**  | Supported: eastus | N/A | SCT_AZURE_REGION_NAME

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -753,6 +753,9 @@ class SCTConfiguration(dict):
         dict(name="gce_pd_ssd_disk_size_db", env="SCT_GCE_PD_SSD_DISK_SIZE_DB", type=int,
              help=""),
 
+        dict(name="gce_setup_hybrid_raid", env="SCT_GCE_SETUP_HYBRID_RAID", type=boolean,
+             help="If True, SCT configures a hybrid RAID of NVMEs and an SSD for scylla's data"),
+
         dict(name="gce_pd_ssd_disk_size_loader", env="SCT_GCE_PD_SSD_DISK_SIZE_LOADER", type=int,
              help=""),
 


### PR DESCRIPTION
	Use a custom script to replace Scylla perftune.py,
	That configures a hybrid RAID-1, using mdadm devices.

This PR is dependant on https://github.com/scylladb/scylla-qa-internal/pull/30
Task: https://github.com/scylladb/qa-tasks/issues/21
[Test plan](https://docs.google.com/document/d/1omGkONrwtm165_8fWf8r8-_gMl9753TW9uII8P4tjDI/edit?usp=sharing)

#### Testing
- [x] - https://jenkins.scylladb.com/job/scylla-staging/job/yarongilor/job/gemini-3h-with-nemesis-test-hybrid-raid-n2-highmem-32/7/
- [x] [argus job](https://argus.scylladb.com/test/574507a7-22f2-4df6-a854-3eb3496c832b/runs?additionalRuns%5B%5D=c09b5b84-59ca-463e-8d01-f0412b620fce)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
