### PR TITLE
improvement(k8s): use actual value for the `fs.aio-max-nr` option

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -899,10 +899,10 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
                 "disabled": False,
                 "ingressClassName": "haproxy",
             }}}
-        # NOTE: '5578536' value is defined in the scylla repo here:
+        # NOTE: fs.aio-max-nr's value is defined in the scylla repo here:
         #       dist/common/sysctl.d/99-scylla-aio.conf
-        #       It is the same for the 4.3.x , 4.4.x and 4.5.x versions
-        sysctls = ["fs.aio-max-nr=5578536", ]
+        #       Scylla 5.0+ has it as '30000000'
+        sysctls = ["fs.aio-max-nr=300000000", ]
         if self.params.get('print_kernel_callstack'):
             sysctls += ["kernel.perf_event_paranoid=0", ]
 


### PR DESCRIPTION
Scylla `5.0+` define the `fs.aio-max-nr` option to be `30000000`.
So, update our K8S code to align with it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
