### PR TITLE
feature(argus): Gemini integration

### DIFF
--- a/docker/env/version
+++ b/docker/env/version
@@ -1,1 +1,1 @@
-1.49-update-urllib3
+1.50-gemini-argus

--- a/requirements.in
+++ b/requirements.in
@@ -29,7 +29,7 @@ mysql-connector-python==8.0.26
 docker==4.4.4  # can't use >=5 because of tcconfig==0.26.0
 python-jenkins==1.7.0
 ssh2-python==1.0.0
-argus-alm==0.11.4
+argus-alm==0.11.6
 parameterized==0.8.1
 pylint==2.11.1  # Needed for pre-commit hooks
 autopep8==1.5.7  # Needed for pre-commit hooks

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -548,6 +548,50 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         except Exception:  # pylint: disable=broad-except
             self.log.error("Error saving logs to Argus", exc_info=True)
 
+    def argus_collect_gemini_results(self):
+        try:
+            # pylint: disable=no-member
+            if not getattr(self, "gemini_results"):
+                return
+
+            if self.loaders:
+                gemini_version = self.loaders.gemini_version
+            else:
+                self.log.warning("Failed to get gemini version as loader instance is not created")
+                gemini_version = ""
+
+            seed = self.params.get("gemini_seed")
+            gemini_command, *_ = self.gemini_results["cmd"]
+            if not seed:
+                seed_match = re.search(r"--seed (?P<seed>\d+) ", gemini_command)
+                if seed_match:
+                    seed = seed_match.groupdict().get("seed", -1)
+                else:
+                    seed = -1
+
+            results = self.gemini_results["results"]
+            results = results[0] if len(results) > 0 else None
+            if not results or not isinstance(results, dict):
+                self.log.warning("Results object is not a dictionary: %s\nReplacing with empty dict.", results)
+                results = {}
+
+            self.test_config.argus_client().submit_gemini_results({
+                "gemini_command": "\n".join(self.gemini_results["cmd"]),
+                "gemini_read_errors": results.get("read_errors", -1),
+                "gemini_read_ops": results.get("read_ops", -1),
+                "gemini_seed": seed,
+                "gemini_status": self.gemini_results["status"],
+                "gemini_version": gemini_version,
+                "gemini_write_errors": results.get("write_errors", -1),
+                "gemini_write_ops": results.get("write_ops", -1),
+                "oracle_node_ami_id": self.params.get("ami_id_db_oracle"),
+                "oracle_node_instance_type": self.params.get("instance_type_db_oracle"),
+                "oracle_node_scylla_version": self.cs_db_cluster.nodes[0].scylla_version if self.cs_db_cluster else "N/A",
+                "oracle_nodes_count": self.params.get("n_test_oracle_db_nodes"),
+            })
+        except Exception:  # pylint: disable=broad-except
+            self.log.warning("Error submitting gemini results to argus", exc_info=True)
+
     def _init_data_validation(self):
         if data_validation := self.params.get('data_validation'):
             data_validation_params = yaml.safe_load(data_validation)
@@ -2810,6 +2854,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.update_test_with_errors()
         time.sleep(1)  # Sleep is needed to let final event being saved into files
         self.save_email_data()
+        self.argus_collect_gemini_results()
         self.destroy_localhost()
         self.send_email()
         self.stop_event_device()


### PR DESCRIPTION
This commit adds a way for SCT to submit gemini results to argus.
The results are collected during email data phase, with information
mirroring that of the email and additionally submitting the gemini seed
used.

Task: scylladb/qa-tasks#1481

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
