### PR TITLE
improvement(K8S): use smaller instance type on EKS running func-l tests

### DIFF
--- a/configurations/operator/functional-eks.yaml
+++ b/configurations/operator/functional-eks.yaml
@@ -1,0 +1,2 @@
+instance_type_db: 'i4i.xlarge'
+k8s_scylla_disk_gi: 800

--- a/jenkins-pipelines/operator/functional/functional-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/functional/functional-eks.jenkinsfile
@@ -7,7 +7,7 @@ longevityPipeline(
     functional_test: true,
     region: 'eu-north-1',
     test_name: 'functional_tests/scylla_operator',
-    test_config: 'test-cases/scylla-operator/functional.yaml',
+    test_config: '''["test-cases/scylla-operator/functional.yaml", "configurations/operator/functional-eks.yaml"]''',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
     availability_zone: 'a,b',
     post_behavior_db_nodes: 'destroy',


### PR DESCRIPTION
We use default value as `i4i.4xlarge`.
It is not needed in case of the functional tests.
So, use much smaller instance type `i4i.xlarge` in this case.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
