### PR TITLE
test(upgrade): custom_d1 rolling upgrade test

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -124,6 +124,7 @@ stress_multiplier_r: 1
 stress_multiplier_m: 1
 keyspace_num: 1
 cs_user_profiles: []
+prepare_cs_user_profiles: []
 cs_duration: '50m'
 batch_size: 1
 pre_create_schema: false

--- a/internal_test_data/cs_user_profile.yaml
+++ b/internal_test_data/cs_user_profile.yaml
@@ -1,0 +1,16 @@
+test_duration: 5
+
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1
+user_prefix: 'fruch-testing'
+
+cs_user_profiles:
+    - scylla-qa-internal/custom_d1/rolling_upgrade_dataset.yaml,60m
+    - scylla-qa-internal/custom_d1/rolling_upgrade_dataset1.yaml,20m
+prepare_cs_user_profiles:
+    - scylla-qa-internal/custom_d1/rolling_upgrade_dataset.yaml,30m
+    - scylla-qa-internal/custom_d1/rolling_upgrade_dataset1.yaml,20m
+
+db_type: scylla
+instance_type_db: 'i4i.large'

--- a/jenkins-pipelines/upgrade_custom/rolling-sequential-upgrade-custom_d1.jenkinsfile
+++ b/jenkins-pipelines/upgrade_custom/rolling-sequential-upgrade-custom_d1.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+rollingUpgradePipeline(
+    backend: 'gce',
+    linux_distro: 'ubuntu-focal',
+    base_versions: '',
+    test_name: 'upgrade_test.UpgradeCustomTest.test_custom_profile_sequential_rolling_upgrade',
+    test_config: "test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml",
+)

--- a/jenkins-pipelines/upgrade_custom/rolling-upgrade-custom_d1.jenkinsfile
+++ b/jenkins-pipelines/upgrade_custom/rolling-upgrade-custom_d1.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+rollingUpgradePipeline(
+    backend: 'gce',
+    linux_distro: 'ubuntu-focal',
+    base_versions: '',
+    test_name: 'upgrade_test.UpgradeCustomTest.test_custom_profile_rolling_upgrade',
+    test_config: "test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml",
+)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1109,7 +1109,9 @@ class SCTConfiguration(dict):
 
         # PerformanceRegressionUserProfilesTest
         dict(name="cs_user_profiles", env="SCT_CS_USER_PROFILES", type=str_or_list,
-             help=""),
+             help="cassandra-stress user-profiles list. Executed in test step"),
+        dict(name="prepare_cs_user_profiles", env="SCT_PREPARE_CS_USER_PROFILES", type=str_or_list,
+             help="cassandra-stress user-profiles list. Executed in prepare step"),
         dict(name="cs_duration", env="SCT_CS_DURATION", type=str,
              help=""),
         dict(name="cs_debug", env="SCT_CS_DEBUG", type=boolean,

--- a/test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml
+++ b/test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml
@@ -1,0 +1,43 @@
+test_duration: 360
+
+# workloads
+# Customer profiles directory path is: scylla-qa-internal/customer-profile/cust_d
+cs_user_profiles:
+    - scylla-qa-internal/custom_d1/rolling_upgrade_dataset.yaml,60m
+
+
+prepare_cs_user_profiles:
+    - scylla-qa-internal/custom_d1/rolling_upgrade_dataset.yaml,30m
+
+n_db_nodes: 4
+n_loaders: 2
+n_monitor_nodes: 1
+
+gce_instance_type_db: 'n2-highmem-8'
+gce_instance_type_loader: 'n1-highmem-8'
+gce_n_local_ssd_disk_db: 2
+gce_pd_ssd_disk_size_db: 750
+gce_setup_hybrid_raid: true
+
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2004-lts'
+use_preinstalled_scylla: false
+
+scylla_d_overrides_files: [
+  'scylla-qa-internal/custom_d1/workload1/scylla.d/n2-highmem-8/cpuset.conf',
+  'scylla-qa-internal/custom_d1/workload1/scylla.d/memory.conf',
+  'scylla-qa-internal/custom_d1/workload1/scylla.d/io.conf',
+]
+
+user_prefix: 'rolling-upgrade-custom-d1'
+
+authenticator: 'PasswordAuthenticator'
+authenticator_user: 'cassandra'
+authenticator_password: 'cassandra'
+
+recover_system_tables: true
+
+append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1'
+
+use_mgmt: false
+
+use_prepared_loaders: true

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -106,6 +106,8 @@ def call(Map pipelineParams) {
                                 wrap([$class: 'BuildUser']) {
                                     dir('scylla-cluster-tests') {
                                         checkout scm
+                                        checkoutQaInternal(params)
+
                                         ArrayList base_versions_list = params.base_versions.contains('.') ? params.base_versions.split('\\,') : []
                                         supportedVersions = supportedUpgradeFromVersions(
                                             base_versions_list,
@@ -145,6 +147,7 @@ def call(Map pipelineParams) {
                                                         wrap([$class: 'BuildUser']) {
                                                             dir('scylla-cluster-tests') {
                                                                 checkout scm
+                                                                checkoutQaInternal(params)
                                                             }
                                                         }
                                                     }


### PR DESCRIPTION
Rolling upgrade test for custom_d1. The goal is simulate main customers load and run rolling 
upgrade with it.
Two upgrade flows added:
- upgrade/rollback from one version to another
- sequential upgrade/rollback: 2021.1.23 -> 2022.1.23 -> 2023.1.1. It is temporary hardcoded 
solution. 


### Testing
- [x] - Upgrade from 2021.1.23 to 2022.1.11 passed:
https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/rolling_upgrade_custom_d1/33/

- [x] - Upgrade from 2022.1.11 to 2023.1. 
Failed with Scylla issue https://github.com/scylladb/scylla-enterprise/issues/3533

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
