### PR TITLE
fix(rolling-upgrades): switch to using docker based loaders

### DIFF
--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -39,6 +39,4 @@ gemini_seed: 66
 
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
-use_prepared_loaders: true
-
 use_preinstalled_scylla: false


### PR DESCRIPTION
we are still using the c-s inside the loader image, and that is an older version of c-s and java-drivers, so we try again to update it to work with the docker based ones.

after this, we might fix the c-s to a specific docker image of some release, to make sure it's the same version across the whole upgrade

### Testing
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/rolling-upgrade-ubuntu20.04-test/8/ took 5h
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/rolling-upgrade-ubuntu20.04-test/9/ took 5.5h

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
