### PR TITLE
Revert "improvement(gce): change `instance_type_db_oracle:` for gemini tests"

### DIFF
--- a/test-cases/cdc/cdc-15m-replication-gemini.yaml
+++ b/test-cases/cdc/cdc-15m-replication-gemini.yaml
@@ -7,7 +7,7 @@ n_db_nodes: 3
 instance_type_db: 'i4i.large'
 
 n_test_oracle_db_nodes: 1
-instance_type_db_oracle: 'i4i.large'
+instance_type_db_oracle: 'i3.large'
 
 n_loaders: 1
 instance_type_loader: 'c5.large'

--- a/test-cases/cdc/cdc-15m-replication-postimage.yaml
+++ b/test-cases/cdc/cdc-15m-replication-postimage.yaml
@@ -7,7 +7,7 @@ n_db_nodes: 3
 instance_type_db: 'i4i.large'
 
 n_test_oracle_db_nodes: 1
-instance_type_db_oracle: 'i4i.large'
+instance_type_db_oracle: 'i3.large'
 
 n_loaders: 1
 instance_type_loader: 'c5.large'

--- a/test-cases/cdc/cdc-15m-replication-preimage.yaml
+++ b/test-cases/cdc/cdc-15m-replication-preimage.yaml
@@ -7,7 +7,7 @@ n_db_nodes: 3
 instance_type_db: 'i4i.large'
 
 n_test_oracle_db_nodes: 1
-instance_type_db_oracle: 'i4i.large'
+instance_type_db_oracle: 'i3.large'
 
 n_loaders: 1
 instance_type_loader: 'c5.large'

--- a/test-cases/cdc/cdc-15m-replication.yaml
+++ b/test-cases/cdc/cdc-15m-replication.yaml
@@ -7,7 +7,7 @@ n_db_nodes: 3
 instance_type_db: 'i4i.large'
 
 n_test_oracle_db_nodes: 1
-instance_type_db_oracle: 'i4i.large'
+instance_type_db_oracle: 'i3.large'
 
 n_loaders: 1
 instance_type_loader: 'c5.large'

--- a/test-cases/cdc/cdc-replication-longevity.yaml
+++ b/test-cases/cdc/cdc-replication-longevity.yaml
@@ -7,7 +7,7 @@ n_db_nodes: 3
 instance_type_db: 'i4i.large'
 
 n_test_oracle_db_nodes: 1
-instance_type_db_oracle: 'i4i.large'
+instance_type_db_oracle: 'i3.large'
 
 n_loaders: 1
 instance_type_loader: 'c5.large'

--- a/test-cases/features/dns-cluster-5min.yaml
+++ b/test-cases/features/dns-cluster-5min.yaml
@@ -8,7 +8,7 @@ n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
 
-instance_type_db: 'i4i.xlarge'
+instance_type_db: 'i4i.2xlarge'
 instance_type_loader: 'c5.4xlarge'
 instance_type_monitor: 't2.small'
 

--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -24,4 +24,4 @@ gemini_cmd: "gemini -d --duration 8h --warmup 2h -c 50 \
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
 db_type: mixed_scylla
-instance_type_db_oracle: 'i4i.16xlarge'
+instance_type_db_oracle: 'i3.16xlarge'

--- a/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
@@ -30,5 +30,5 @@ gemini_table_options:
 stress_cdclog_reader_cmd: "cdc-stressor -duration 215m -stream-query-round-duration 30s"
 
 db_type: mixed_scylla
-instance_type_db_oracle: 'i4i.8xlarge'
+instance_type_db_oracle: 'i3.8xlarge'
 oracle_scylla_version: "2021.1.15"

--- a/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
@@ -22,5 +22,5 @@ gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 50 -m mixed -f --non-
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
 db_type: mixed_scylla
-instance_type_db_oracle: 'i4i.8xlarge'
+instance_type_db_oracle: 'i3.8xlarge'
 oracle_scylla_version: "2021.1.15"

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -27,4 +27,4 @@ gemini_cmd: "gemini -d --duration 3h --warmup 30m \
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
 db_type: mixed_scylla
-instance_type_db_oracle: 'i4i.8xlarge'
+instance_type_db_oracle: 'i3.8xlarge'

--- a/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
@@ -24,4 +24,4 @@ gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 50 \
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
 db_type: mixed_scylla
-instance_type_db_oracle: 'i4i.8xlarge'
+instance_type_db_oracle: 'i3.8xlarge'

--- a/test-cases/gemini/gemini-basic-3h-ics.yaml
+++ b/test-cases/gemini/gemini-basic-3h-ics.yaml
@@ -20,5 +20,5 @@ gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 50 -m mixed -f --non-
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
 db_type: mixed_scylla
-instance_type_db_oracle: 'i4i.8xlarge'
+instance_type_db_oracle: 'i3.8xlarge'
 oracle_scylla_version: "2021.1.15"

--- a/test-cases/gemini/gemini-basic-3h.yaml
+++ b/test-cases/gemini/gemini-basic-3h.yaml
@@ -21,4 +21,4 @@ gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 50 \
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
 db_type: mixed_scylla
-instance_type_db_oracle: 'i4i.8xlarge'
+instance_type_db_oracle: 'i3.8xlarge'

--- a/test-cases/performance/ycsb/perf-base.yaml
+++ b/test-cases/performance/ycsb/perf-base.yaml
@@ -48,7 +48,7 @@ n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
 
-instance_type_db: 'i3.4xlarge'
+instance_type_db: 'i4i.4xlarge'
 instance_type_loader: 'c5.9xlarge'
 
 authenticator: 'PasswordAuthenticator'

--- a/unit_tests/test_data/test_scylla_yaml_builders/cdc-replication-longevity.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/cdc-replication-longevity.yaml
@@ -7,7 +7,7 @@ n_db_nodes: 3
 instance_type_db: 'i4i.large'
 
 n_test_oracle_db_nodes: 1
-instance_type_db_oracle: 'i4i.large'
+instance_type_db_oracle: 'i3.large'
 
 n_loaders: 1
 instance_type_loader: 'c5.large'


### PR DESCRIPTION
This reverts commit 6e3d34cd1b9fc6533a4e5a3874fd36ad401b9a81.

The reverted commit in question breaks gemini jobs, as the currently used AMI 
for oracle nodes does not support the instance types in question, failing at 
node_setup stage with

```
2023-10-23T11:47:59.434+00:00 gemini-with-nemesis-3h-normal-argus-oracle-db-node-4709e913-1      !ERR | scylla[12015]:  [shard 0] init - Startup failed: std::runtime_error (Bad I/O Scheduler configuration)
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
