### PR TITLE
feature(sct_config): add validation for `scylla_d_overrides_files`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,6 +120,8 @@ pipeline {
             steps {
                 script {
                     try {
+                        checkoutQaInternal(params)
+
                         sh ''' ./docker/env/hydra.sh bash ./utils/lint_test_cases.sh '''
                         pullRequestSetResult('success', 'jenkins/lint_test_cases', 'All test cases are passed')
                     } catch(Exception ex) {

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -40,6 +40,7 @@ from sdcm.utils.common import (
     get_scylla_ami_versions,
     get_scylla_gce_images_versions,
     convert_name_to_ami_if_needed,
+    get_sct_root_path,
 )
 from sdcm.utils.operations_thread import ConfigParams
 from sdcm.utils.version_utils import (
@@ -2038,6 +2039,7 @@ class SCTConfiguration(dict):
                                 break  # We are ok here and skipping whole command if file is there
                             raise ValueError(f"Stress command parameter '{param_name}' contains profile "
                                              f"'{profile_path}' that does not exists under data_dir/")
+        self._validate_scylla_d_overrides_files_exists()
 
     def verify_configuration(self):
         """
@@ -2159,6 +2161,12 @@ class SCTConfiguration(dict):
             assert az_count == 1 and regions_count == 1, \
                 (f"Number of Regions({regions_count}) and AZ({az_count}) should be 1 "
                  f"when param use_placement_group is used")
+
+    def _validate_scylla_d_overrides_files_exists(self):
+        if scylla_d_overrides_files := self.get("scylla_d_overrides_files"):
+            for config_file_path in scylla_d_overrides_files:
+                config_file = pathlib.Path(get_sct_root_path()) / config_file_path
+                assert config_file.exists(), f"{config_file} doesn't exists, please check your configuration"
 
     def _check_per_backend_required_values(self, backend: str):
         if backend in self.available_backends:

--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -121,11 +121,7 @@ def call() {
                             credentialsId:'b8a774da-0e46-4c91-9f74-09caebaea261',
                             branch: params.sct_branch)
 
-                      dir("scylla-qa-internal") {
-                        git(url: 'git@github.com:scylladb/scylla-qa-internal.git',
-                            credentialsId:'b8a774da-0e46-4c91-9f74-09caebaea261',
-                            branch: 'master')
-                      }
+                      checkoutQaInternal(params)
                   }
                }
             }

--- a/vars/cdcReplicationPipeline.groovy
+++ b/vars/cdcReplicationPipeline.groovy
@@ -155,12 +155,7 @@ def call(Map pipelineParams) {
                     }
                     dir('scylla-cluster-tests') {
                         checkout scm
-
-                        dir("scylla-qa-internal") {
-                            git(url: 'git@github.com:scylladb/scylla-qa-internal.git',
-                                credentialsId:'b8a774da-0e46-4c91-9f74-09caebaea261',
-                                branch: 'master')
-                        }
+                        checkoutQaInternal(params)
                     }
                 }
             }

--- a/vars/checkoutQaInternal.groovy
+++ b/vars/checkoutQaInternal.groovy
@@ -1,0 +1,9 @@
+#!groovy
+
+def call(Map params = [:]) {
+    dir("scylla-qa-internal") {
+        git(url: 'git@github.com:scylladb/scylla-qa-internal.git',
+            credentialsId:'b8a774da-0e46-4c91-9f74-09caebaea261',
+            branch: 'master')
+    }
+}

--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -83,12 +83,7 @@ def call(Map pipelineParams) {
                     dir('scylla-cluster-tests') {
                         timeout(time: 5, unit: 'MINUTES') {
                             checkout scm
-
-                            dir("scylla-qa-internal") {
-                                git(url: 'git@github.com:scylladb/scylla-qa-internal.git',
-                                    credentialsId:'b8a774da-0e46-4c91-9f74-09caebaea261',
-                                    branch: 'master')
-                            }
+                            checkoutQaInternal(params)
                         }
                     }
                 }

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -170,12 +170,7 @@ def call(Map pipelineParams) {
                     dir('scylla-cluster-tests') {
                         timeout(time: 5, unit: 'MINUTES') {
                             checkout scm
-
-                            dir("scylla-qa-internal") {
-                                git(url: 'git@github.com:scylladb/scylla-qa-internal.git',
-                                    credentialsId:'b8a774da-0e46-4c91-9f74-09caebaea261',
-                                    branch: 'master')
-                            }
+                            checkoutQaInternal(params)
                         }
                     }
                 }

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -162,12 +162,7 @@ def call(Map pipelineParams) {
                     }
                     dir('scylla-cluster-tests') {
                         checkout scm
-
-                        dir("scylla-qa-internal") {
-                            git(url: 'git@github.com:scylladb/scylla-qa-internal.git',
-                                credentialsId:'b8a774da-0e46-4c91-9f74-09caebaea261',
-                                branch: 'master')
-                        }
+                        checkoutQaInternal(params)
                     }
                }
             }


### PR DESCRIPTION
since it gonna be quite easy to have mistakes with this configuration since files it's gonna use span across multiple repos we are adding a validation a the very read of configuration to fail as fast as we can if those are missing.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
