### PR TITLE
fix(scylla_d_overrides_files): truncate file first

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4588,6 +4588,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                     with remote_file(remoter=node.remoter,
                                      remote_path=f'/etc/scylla.d/{config_file.name}',
                                      sudo=True) as fobj:
+                        fobj.truncate(0)  # first clear the file
                         fobj.write(config_file.read_text())
 
                 node.start_scylla_server(verify_up=False)


### PR DESCRIPTION
in some case we already have data in those files
we want to override, and current code append the content we gave it, and not overidded the file completly

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
