### PR TITLE
fix(gce_setup_hybrid_raid): default to use duplex

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4577,7 +4577,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                         src=f"{get_sct_root_path()}/scylla-qa-internal/custom_d1/{hybrid_raid_script}", dst=target_path)
 
                     # /dev/sdb is the additional SSD that is used for creting RAID-1 along with the other NVMEs (RAID-0)
-                    hybrid_raid_setup_cmd = f"sudo python3 {target_path} --nvme-raid-level 0 --write-mostly-device /dev/sdb"
+                    hybrid_raid_setup_cmd = f"sudo python3 {target_path} --nvme-raid-level 0 --write-mostly-device /dev/sdb --duplex"
                     # The timeout value is dependent on the SSD size and might have to be adjusted if a fixed "standard"
                     # disk size is agreed to be used (should be around 370GB).
                     # So this make sure the "mdadm --create" command will get enough time to finish.


### PR DESCRIPTION
hybrid disk setup should always go along with the duplex feature otherwise we'll have request timeout, cause the quoue is shared between read and write

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
