### PR TITLE
improvement(k8s): add `create_namespace` method to KubernetesCluster

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -390,7 +390,7 @@ def test_check_operator_operability_when_scylla_crd_is_incorrect(db_cluster):
             },
         }]
     })
-    db_cluster.k8s_cluster.kubectl(f"create namespace {namespace}", ignore_status=True)
+    db_cluster.k8s_cluster.create_namespace(namespace=namespace)
     db_cluster.k8s_cluster.helm_install(
         target_chart_name=target_chart_name,
         source_chart_name="scylla-operator/scylla",
@@ -616,13 +616,7 @@ def test_deploy_helm_with_default_values(db_cluster: ScyllaPodCluster):
     target_chart_name, namespace = ("t-default-values",) * 2
     expected_capacity = '10Gi'
 
-    log.info("Create %s namespace", namespace)
-
-    namespaces = yaml.safe_load(db_cluster.k8s_cluster.kubectl("get namespaces -o yaml").stdout)
-
-    if not [ns["metadata"]["name"] for ns in namespaces["items"] if ns["metadata"]["name"] == namespace]:
-        db_cluster.k8s_cluster.kubectl(f"create namespace {namespace}")
-
+    db_cluster.k8s_cluster.create_namespace(namespace=namespace)
     db_cluster.k8s_cluster.create_scylla_manager_agent_config(namespace=namespace)
 
     log.debug('Deploy cluster with default storage capacity (expected "%s")', expected_capacity)

--- a/sdcm/utils/k8s/chaos_mesh.py
+++ b/sdcm/utils/k8s/chaos_mesh.py
@@ -72,7 +72,7 @@ class ChaosMesh:  # pylint: disable=too-few-public-methods
         LOGGER.info("Installing chaos-mesh on %s k8s cluster...", self._k8s_cluster.k8s_scylla_cluster_name)
         self._k8s_cluster.helm("repo add chaos-mesh https://charts.chaos-mesh.org")
         self._k8s_cluster.helm('repo update')
-        self._k8s_cluster.kubectl(f"create namespace {self.NAMESPACE}")
+        self._k8s_cluster.create_namespace(self.NAMESPACE)
         aux_node_pool_affinity = get_helm_pool_affinity_values(
             self._k8s_cluster.POOL_LABEL_NAME, self._k8s_cluster.AUXILIARY_POOL_NAME)
         scylla_node_pool_affinity = get_helm_pool_affinity_values(


### PR DESCRIPTION
We have bunch of places where we create K8S namespaces. 
So, make a common method that will do it in a safe way and reuse it. 
It will also reduce the code in place of usage where we should check a namespace for existence.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
