### PR TITLE
fix(nemesis.py): restore only OSS snapshots on OSS

### DIFF
--- a/defaults/manager_persistent_snapshots.yaml
+++ b/defaults/manager_persistent_snapshots.yaml
@@ -9,14 +9,17 @@ aws:
         'sm_20230702185929UTC':
           keyspace_name: "5gb_sizetiered_2022_2"
           scylla_version: "2022.2.9"
+          scylla_product: "enterprise"
           number_of_nodes: 5
         'sm_20230702201949UTC':
           keyspace_name: "5gb_sizetiered_2022_1"
           scylla_version: "2022.1.7"
+          scylla_product: "enterprise"
           number_of_nodes: 5
         'sm_20230702190638UTC':
           keyspace_name: "5gb_sizetiered_5_2"
           scylla_version: "5.2.3"
+          scylla_product: "oss"
           number_of_nodes: 5
     10:
       number_of_rows: 10485760
@@ -25,18 +28,22 @@ aws:
         'sm_20230223105105UTC':
           keyspace_name: "10gb_sizetiered"
           scylla_version: "5.1.6"
+          scylla_product: "oss"
           number_of_nodes: 3
         'sm_20230702173347UTC':
           keyspace_name: "10gb_sizetiered_2022_2"
           scylla_version: "2022.2.9"
+          scylla_product: "enterprise"
           number_of_nodes: 4
         'sm_20230702173940UTC':
           keyspace_name: "10gb_sizetiered_2022_1"
           scylla_version: "2022.1.7"
+          scylla_product: "enterprise"
           number_of_nodes: 4
         'sm_20230702173329UTC':
           keyspace_name: "10gb_sizetiered_5_2"
           scylla_version: "5.2.3"
+          scylla_product: "oss"
           number_of_nodes: 4
     100:
       number_of_rows: 104857600
@@ -45,18 +52,22 @@ aws:
         'sm_20230223130733UTC':
           keyspace_name: "100gb_sizetiered"
           scylla_version: "5.1.6"
+          scylla_product: "oss"
           number_of_nodes: 3
         'sm_20230702235739UTC':
           keyspace_name: "100gb_sizetiered_2022_2"
           scylla_version: "2022.2.9"
+          scylla_product: "enterprise"
           number_of_nodes: 4
         'sm_20230703000641UTC':
           keyspace_name: "100gb_sizetiered_2022_1"
           scylla_version: "2022.1.7"
+          scylla_product: "enterprise"
           number_of_nodes: 4
         'sm_20230703000157UTC':
           keyspace_name: "100gb_sizetiered_5_2"
           scylla_version: "5.2.3"
+          scylla_product: "oss"
           number_of_nodes: 4
     2048:
       number_of_rows: 2147483648
@@ -65,4 +76,5 @@ aws:
         'sm_20230226074656UTC':
           keyspace_name: "2tb_sizetiered"
           scylla_version: "5.1.6"
+          scylla_product: "oss"
           number_of_nodes: 3

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2818,7 +2818,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.log.info("Restoring the schema of the keyspace '%s'", chosen_snapshot_info["keyspace_name"])
             restore_task = mgr_cluster.create_restore_task(restore_schema=True, location_list=location_list,
                                                            snapshot_tag=chosen_snapshot_tag)
-            restore_task.wait_and_get_final_status(step=10, timeout=120)
+            step = 10
+            extra_time = 300
+            restore_task.wait_and_get_final_status(step=step,
+                                                   timeout=chosen_snapshot_info['expected_timeout'] / step + extra_time)
             assert restore_task.status == TaskStatus.DONE, f'Schema restoration of {chosen_snapshot_tag} has failed!'
             self.cluster.restart_scylla()  # After schema restoration, you should restart the nodes
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2774,7 +2774,14 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
             self.use_nemesis_seed()
             chosen_snapshot_size = random.choice(fitting_snapshot_sizes)
-            snapshot_tag = random.choice(list(snapshot_groups_by_size[chosen_snapshot_size]["snapshots"].keys()))
+            if self.cluster.nodes[0].is_enterprise:
+                snapshot_tag = random.choice(list(snapshot_groups_by_size[chosen_snapshot_size]["snapshots"].keys()))
+            else:
+                all_snapshots = snapshot_groups_by_size[chosen_snapshot_size]["snapshots"]
+                oss_snapshots = [snapshot_key for snapshot_key, snapshot_value in all_snapshots.items() if
+                                 snapshot_value['scylla_product'] == "oss"]
+
+                snapshot_tag = random.choice(oss_snapshots)
             snapshot_info = snapshot_groups_by_size[chosen_snapshot_size]["snapshots"][snapshot_tag]
             snapshot_info.update({"expected_timeout": snapshot_groups_by_size[chosen_snapshot_size]["expected_timeout"],
                                   "number_of_rows": snapshot_groups_by_size[chosen_snapshot_size]["number_of_rows"]})


### PR DESCRIPTION
since enterprise has an in-memory feature that
is not avaiable on OSS, we got a restore failing
on `malformed_sstable_exception`:
```
Column in_memory missing in current schema
```

Fixes: scylladb/scylladb#15846

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
