### PR TITLE
feature(hydra-ssh): support gce on ssh/tunnel command

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1758,6 +1758,7 @@ cli.add_command(sct_ssh.tunnel)
 cli.add_command(sct_ssh.copy_cmd)
 cli.add_command(sct_ssh.attach_test_sg_cmd)
 cli.add_command(sct_ssh.ssh_cmd)
+cli.add_command(sct_ssh.gcp_allow_public)
 
 if __name__ == '__main__':
     cli.main(prog_name="hydra")

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -381,7 +381,7 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                 "startup-script": startup_script,
                 "user-data": self.prepare_user_data(enable_auto_bootstrap),
                 "block-project-ssh-keys": "true",
-                "ssh-keys": f"{username}:{key_type} {public_key}",
+                "ssh-keys": f"{username}:{key_type} {public_key} {username}",
             },
             spot=spot,
             service_accounts=self._service_accounts,

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1201,13 +1201,15 @@ def _(metadata: dict):
 
 def filter_gce_by_tags(tags_dict, instances: list[GceInstance]) -> list[GceInstance]:
     filtered_instances = []
+
     for instance in instances:
         tags = gce_meta_to_dict(instance.metadata)
-        for tag_k, tag_v in tags_dict.items():
-            if tag_k not in tags or (tags[tag_k] not in tag_v if isinstance(tag_v, list) else tags[tag_k] != tag_v):
-                break
-        else:
+        found_keys = set(k for k in tags_dict if k in tags and tags_dict[k] == tags[k])
+        if 'Name' in tags_dict.keys() and tags_dict['Name'] == instance.name:
+            found_keys |= {"Name"}
+        if found_keys == set(tags_dict.keys()):
             filtered_instances.append(instance)
+
     return filtered_instances
 
 

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -540,3 +540,37 @@ def gce_set_labels(instances_client: compute_v1.InstancesClient,
                                             instances_set_labels_request_resource=request)
 
     return wait_for_extended_operation(operation, f"setting labels on {instance.name}")
+
+
+def gce_set_tags(instances_client: compute_v1.InstancesClient,
+                 instance: compute_v1.Instance,
+                 new_tags: list,
+                 project: str,
+                 zone: str):
+    """
+    Helper to do the set_tags operation correctly, without
+    removing existing tags and applying the fingerprinting correctly
+
+    Args:
+        instances_client: client to execute the operation on.
+        instance: the instance to label
+        new_tags: list of the tags to apply
+        project: the project id to use
+        zone: the zone instance is in
+
+    Returns:
+        Whatever the operation.result() returns.
+    """
+
+    request = compute_v1.SetTagsInstanceRequest()
+
+    request.tags_resource = instance.tags
+    request.tags_resource.items.extend(new_tags)
+    request.tags_resource.items = list(set(request.tags_resource.items))
+    request.zone = zone
+    request.project = project
+    request.instance = instance.name
+
+    operation = instances_client.set_tags(request=request)
+
+    return wait_for_extended_operation(operation, f"setting tags on {instance.name}")


### PR DESCRIPTION
with this change we can now the following commands:

```
hydra ssh --user `whoami`
hydra ssh-cmd rolling-upgrade--ubuntu-focal-db-node-6e9857ea-0-3 ls /
hydra tunnel --test-id 1234-1234-1234-1234
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
