### PR TITLE
fix(nemesis): mgmt restore timeout

### DIFF
--- a/defaults/manager_persistent_snapshots.yaml
+++ b/defaults/manager_persistent_snapshots.yaml
@@ -4,7 +4,7 @@ aws:
   snapshots_sizes:
     5:
       number_of_rows: 5242880
-      expected_timeout: 900  # 15 minutes
+      expected_timeout: 1800  # 30 minutes
       snapshots:
         'sm_20230702185929UTC':
           keyspace_name: "5gb_sizetiered_2022_2"
@@ -23,7 +23,7 @@ aws:
           number_of_nodes: 5
     10:
       number_of_rows: 10485760
-      expected_timeout: 1800  # 30 minutes
+      expected_timeout: 3600  # 60 minutes
       snapshots:
         'sm_20230223105105UTC':
           keyspace_name: "10gb_sizetiered"
@@ -47,7 +47,7 @@ aws:
           number_of_nodes: 4
     100:
       number_of_rows: 104857600
-      expected_timeout: 9000  # 150 minutes
+      expected_timeout: 18000  # 300 minutes
       snapshots:
         'sm_20230223130733UTC':
           keyspace_name: "100gb_sizetiered"
@@ -71,7 +71,7 @@ aws:
           number_of_nodes: 4
     2048:
       number_of_rows: 2147483648
-      expected_timeout: 66000  # 1100 minutes
+      expected_timeout: 132000  # 2200 minutes
       snapshots:
         'sm_20230226074656UTC':
           keyspace_name: "2tb_sizetiered"

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2815,10 +2815,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.log.info("Restoring the schema of the keyspace '%s'", chosen_snapshot_info["keyspace_name"])
             restore_task = mgr_cluster.create_restore_task(restore_schema=True, location_list=location_list,
                                                            snapshot_tag=chosen_snapshot_tag)
-            step = 10
-            extra_time = 300
-            restore_task.wait_and_get_final_status(step=step,
-                                                   timeout=chosen_snapshot_info['expected_timeout'] / step + extra_time)
+
+            restore_task.wait_and_get_final_status(step=10,
+                                                   timeout=6*60)  # giving 6 minutes to restore the schema
             assert restore_task.status == TaskStatus.DONE, f'Schema restoration of {chosen_snapshot_tag} has failed!'
             self.cluster.restart_scylla()  # After schema restoration, you should restart the nodes
 


### PR DESCRIPTION
fix(nemesis): mgmt restore timeout

since #6733 we made changes to this nemesis
(because of OSS vs enterprise system under test
and snapshot versions), but the timeout is still
broken, and from the staging jobs, they did
not fully pass.
this last fix is to align the use of the
`wait_for` calls, where step and timeout
should work now.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
