### PR TITLE
fix(k8s-gke): define missing `region_name` attr

### DIFF
--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -195,11 +195,6 @@ class GkeCluster(KubernetesCluster):
                  cluster_uuid=None,
                  n_nodes=2,
                  ):
-        super().__init__(
-            params=params,
-            cluster_uuid=cluster_uuid,
-            user_prefix=user_prefix
-        )
         self.gke_cluster_version = gke_cluster_version
         self.gke_k8s_release_channel = gke_k8s_release_channel.strip()
         self.gce_disk_type = gce_disk_type
@@ -210,12 +205,16 @@ class GkeCluster(KubernetesCluster):
         self.n_nodes = n_nodes
         self.gce_project = info['project_id']
         self.gce_user = info['client_email']
-
         dc_parts = gce_datacenter[0].split("-")[:3]
         self.gce_region = "-".join(dc_parts[:2])
         self.gce_zone = f"{self.gce_region}-"
         self.gce_zone += dc_parts[2] if len(dc_parts) == 3 else 'b'
-
+        super().__init__(
+            params=params,
+            cluster_uuid=cluster_uuid,
+            user_prefix=user_prefix,
+            region_name=self.gce_region,
+        )
         self.gke_cluster_created = False
         self._authenticate_in_gcloud()
         self.api_call_rate_limiter = ApiCallRateLimiter(


### PR DESCRIPTION
One of the recent PRs (https://github.com/scylladb/scylla-cluster-tests/pull/6731) made the K8S python logic use the `region_name` attribute of the K8S python class.
But it is not set in case of the GKE setups.
As a result, Scylla pods fail to be provisioned due to it.

So, fix it by setting the `region_name` also in the GKE case.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
