### PR TITLE
fix(cluster): node setup - install package wait for package manager

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2048,7 +2048,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         elif self.distro.is_sles:
             raise Exception("Offline install on SLES isn't supported")
         elif self.distro.is_debian10 or self.distro.is_debian11:
-            self.remoter.run(f'sudo apt-get install -y openjdk-11-jre-headless {additional_pkgs}')
+            self.remoter.sudo('apt-get install -y openjdk-11-jre')
+            self.remoter.sudo(f'apt-get install -y openjdk-11-jre-headless {additional_pkgs}')
         else:
             self.remoter.run(f'sudo apt-get install -y openjdk-11-jre-headless {additional_pkgs}')
             self.remoter.run('sudo update-java-alternatives --jre-headless '

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4517,7 +4517,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 # https://ubuntu.com/tutorials/using-the-ua-client-to-enable-fips#4-enabling-fips-crypto-modules
 
         node.update_repo_cache()
-        node.install_package('lsof net-tools', wait_for_package_manager=False)
+        node.install_package('lsof net-tools', wait_for_package_manager=True)
         install_scylla = True
 
         if self.params.get("use_preinstalled_scylla") and node.is_scylla_installed(raise_if_not_installed=True):


### PR DESCRIPTION
we saw on few runs of 5.4 that some of the jobs
(offline and regular) artifacts (on debian OSes)
failing while installing dependency packages.

Fixes: scylladb/scylladb#15878

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
