### PR TITLE
fix(cluster): install_scylla failing on debian based OS

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2011,6 +2011,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                     apt-get install apt-transport-https -y
                     apt-get install gnupg1-curl dirmngr -y
                     apt-get install software-properties-common -y
+                    apt-get install openjdk-11-jre -y
                 """)
                 self.remoter.run('sudo bash -cxe "%s"' % install_debian_10_prereqs)
 
@@ -2022,9 +2023,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.remoter.run('sudo apt-get install -y rsync')
             self.download_scylla_repo(scylla_repo)
             self.remoter.run('sudo apt-get update')
-            self.remoter.run(
-                'sudo apt-get install -y '
-                ' {} '.format(self.scylla_pkg()))
+            self.install_package(self.scylla_pkg())
 
     def offline_install_scylla(self, unified_package, nonroot):
         """


### PR DESCRIPTION
it is happening on master, and most likely because of the package manager is busy, and since, failing.

we futurely need to hardening it, and change
all calls that install packages to use
the wrap function `node.install_package()`,
as it has built-in a mode to wait for the package
manager, other than lucky.

Refs: https://github.com/scylladb/scylla-cluster-tests/pull/6740#issuecomment-1787088522

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
