### PR TITLE
fix(monitor-setup): stop using `mikefarah/yq` docker

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5559,7 +5559,6 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
               message="Waiting for reconfiguring scylla monitoring")
     def reconfigure_scylla_monitoring(self):
         for node in self.nodes:
-            cluster_backend = self.params.get("cluster_backend")
             monitoring_targets = []
             for db_node in self.targets["db_cluster"].nodes:
                 monitoring_targets.append(f"[{getattr(db_node, self.DB_NODES_IP_ADDRESS)}]:9180")
@@ -5573,10 +5572,9 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
                 python3 genconfig.py -s -n -d {self.monitoring_conf_dir} {monitoring_targets}
             """), verbose=True)
 
-            if cluster_backend != "docker":
-                node.remoter.sudo(f"docker run --rm -v {self.monitoring_conf_dir}:/workdir"
-                                  f" mikefarah/yq:3 yq w -i node_exporter_servers.yml"
-                                  f" '[0].targets[+]' ''[{node.private_ip_address}]:9100''", verbose=True)
+            with node._remote_yaml(f'{self.monitoring_conf_dir}/node_exporter_servers.yml') as exporter_yaml:  # pylint: disable=protected-access
+                exporter_yaml[0]['targets'] += [f'[{node.private_ip_address}]:9100']
+                exporter_yaml[0]['targets'] = list(set(exporter_yaml[0]['targets']))  # remove duplicates
 
             if self.params.get("cloud_prom_bearer_token"):
                 node.remoter.sudo(shell_script_cmd(f"""\


### PR DESCRIPTION
we need to edit a remote file, an we used a docker image of yq for that.

changing it to use SCT `remote_file` context manager

Fixes: #6743

### Testing
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-5gb-1h-GrowShrinkClusterNemesis-aws-test/2/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
