### PR TITLE
improvement(user profile): change sdcm.utils.get_profile_content

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -184,6 +184,24 @@ def get_sct_root_path():
     return os.path.abspath(sct_root_dir)
 
 
+def find_file_under_sct_dir(filename: str, sub_folder: str = None):
+    """
+    Find file under scylla_cluster_test where sub_folder is part of the file path (optional)
+    """
+    sct_path = Path(get_sct_root_path())
+    profile_file_full_path = sct_path.rglob(filename)
+    for profile_file_path in profile_file_full_path:
+        # sub_folder == "/tmp" - cover user profile path inside cassandra-stress command, like:
+        # "cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)'
+        if sub_folder == "/tmp" or sub_folder is None:
+            # return first found file with the name
+            return str(profile_file_path)
+        elif sub_folder in str(profile_file_path.parent):
+            return str(profile_file_path)
+
+    raise FileNotFoundError(f"User profile file {filename} not found under {str(sct_path)}")
+
+
 def verify_scylla_repo_file(content, is_rhel_like=True):
     LOGGER.info('Verifying Scylla repo file')
     if is_rhel_like:


### PR DESCRIPTION
Search for user profile full path under SCT folder on a runner. It supports to search for SCT local user profiles and scyll-qa-internal profiles

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
