### PR TITLE
improvement(installation): enable select version in repo

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -240,7 +240,8 @@ class SCTConfiguration(dict):
              ),
 
         dict(name="scylla_repo", env="SCT_SCYLLA_REPO", type=str,
-             help="Url to the repo of scylla version to install scylla"),
+             help="Url to the repo of scylla version to install scylla. Can provide specific version after a colon "
+                  "e.g: `https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-2021.1.list:2021.1.18`"),
 
         dict(name="scylla_apt_keys", env="SCT_SCYLLA_APT_KEYS", type=str_or_list,
              help="APT keys for ScyllaDB repos"),
@@ -1333,7 +1334,7 @@ class SCTConfiguration(dict):
         dict(name="append_scylla_setup_args", env="SCT_APPEND_SCYLLA_SETUP_ARGS", type=str,
              help="More arguments to append to scylla_setup command line"),
 
-        dict(name="use_preinstalled_scylla", env="SCT_USE_PREINSTALLED_SCYLLA", type=bool,
+        dict(name="use_preinstalled_scylla", env="SCT_USE_PREINSTALLED_SCYLLA", type=boolean,
              help="Don't install/update ScyllaDB on DB nodes"),
         dict(name="stress_cdclog_reader_cmd", env="SCT_STRESS_CDCLOG_READER_CMD",
              type=str,


### PR DESCRIPTION
We need to select specific version when using repo url as by default it is using always latest.

Added possibility to specify scylla version after a colon in `scylla_repo` param.

closes: https://github.com/scylladb/scylla-cluster-tests/issues/6722

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
