### PR TITLE
improvement(k8s): add support of the multiple kubeconfig files

### DIFF
--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -346,8 +346,10 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):  # pylint: disable=
             kubectl_token_path=self.kubectl_token_path
         )
 
-    def create_kubectl_config(self):
-        LOCALRUNNER.run(f'aws eks --region {self.region_name} update-kubeconfig --name {self.short_cluster_name}')
+    def create_kubectl_config(self) -> None:
+        LOCALRUNNER.run(
+            f"aws eks --region {self.region_name} update-kubeconfig"
+            f" --name {self.short_cluster_name} --kubeconfig={self.kube_config_path}")
 
     def deploy(self):
         LOGGER.info("Create EKS cluster `%s'", self.short_cluster_name)

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -54,6 +54,7 @@ from sdcm.utils.common import (
     normalize_ipv6_url, create_remote_storage_dir,
 )
 from sdcm.utils.auto_ssh import AutoSshContainerMixin
+from sdcm.utils.context_managers import environment
 from sdcm.utils.decorators import retrying
 from sdcm.utils.docker_utils import get_docker_bridge_gateway
 from sdcm.utils.get_username import get_username
@@ -1223,26 +1224,35 @@ class KubernetesLogCollector(BaseSCTLogCollector):
                     return os.path.join(base_logdir, sub_dir)
         return ""
 
-    def _find_k8s_subdir(self, test_run_logdir) -> str:
+    def _find_k8s_subdirs(self, test_run_logdir) -> str:
+        k8s_subdirs = []
         for sub_dir in next(os.walk(test_run_logdir))[1]:
-            if not sub_dir.endswith(self.test_id[:8]) or any(
-                    log_type in sub_dir for log_type in ('db-cluster', 'loader-set', 'monitor-set')):
+            if self.test_id[:6] not in sub_dir:
                 continue
             sub_files = next(os.walk(os.path.join(test_run_logdir, sub_dir)))[2]
             if any(file_name in sub_files for file_name in ('cert_manager.log', 'scylla_operator.log')):
-                return os.path.join(test_run_logdir, sub_dir)
-        return ""
+                k8s_subdirs.append(os.path.join(test_run_logdir, sub_dir))
+        return k8s_subdirs
 
     def collect_logs(self, local_search_path: Optional[str] = None) -> list[str]:
         try:
             base_logdir = TestConfig.base_logdir()
             test_run_logdir = self._find_test_run_subdir_by_test_id(base_logdir)
-            if test_run_logdir:
-                k8s_logdir = self._find_k8s_subdir(test_run_logdir)
-                if os.path.isdir(k8s_logdir) and not os.path.isdir(os.path.join(k8s_logdir, "namespaces")):
-                    os.environ["_SCT_TEST_LOGDIR"] = test_run_logdir
-                    os.environ["KUBECONFIG"] = os.path.join(test_run_logdir, ".kube/config")
-                    KubernetesOps.gather_k8s_logs(k8s_logdir)
+            if not test_run_logdir:
+                return super().collect_logs(local_search_path=local_search_path)
+            k8s_logdirs = self._find_k8s_subdirs(test_run_logdir)
+            with environment(_SCT_TEST_LOGDIR=test_run_logdir):
+                for k8s_logdir in k8s_logdirs:
+                    if os.path.isdir(k8s_logdir) and not os.path.isdir(
+                            os.path.join(k8s_logdir, "namespaces")):
+                        for _, _, current_k8s_logdir_sub_file in next(
+                                os.walk(os.path.join(k8s_logdir, '.kube'))):
+                            if not current_k8s_logdir_sub_file.endswith("config"):
+                                continue
+                            with environment(KUBECONFIG=os.path.join(
+                                    k8s_logdir, '.kube', current_k8s_logdir_sub_file)):
+                                KubernetesOps.gather_k8s_logs(k8s_logdir)
+                                break
         except Exception as exc:  # pylint: disable=broad-except
             LOGGER.warning("Got following failure processing the K8S logs: %s", exc)
         return super().collect_logs(local_search_path=local_search_path)

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2485,12 +2485,6 @@ def clean_resources_according_post_behavior(params, config, logdir, dry_run=Fals
     actions_per_type = get_post_behavior_actions(config)
     LOGGER.debug(actions_per_type)
 
-    if (config.get("cluster_backend") or "").startswith("k8s"):
-        # Define 'KUBECONFIG' env var that is needed in some cases on K8S backends
-        testrun_dir = get_testrun_dir(test_id=params.get('TestId'), base_dir=logdir)
-        kubeconfig_dir = Path(testrun_dir) if testrun_dir else Path(logdir)
-        os.environ['KUBECONFIG'] = str(kubeconfig_dir / ".kube/config")
-
     node_types_to_cleanup = []
     for cluster_nodes_type, action_type in actions_per_type.items():
         if action_type["action"] == "keep":


### PR DESCRIPTION
SCT runner must be able to talk to multiple K8S clusters in the multiDC setups.
So, update the kubectl and helm code to be smart enough to work with separate kubeconfig files.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
