### PR TITLE
improvement(k8s): assign and use `k8s_cluster` attr for node/pod objects

### DIFF
--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -600,7 +600,7 @@ class EksScyllaPodContainer(BaseScyllaPodContainer):
 
     @property
     def ec2_host(self):
-        return self.parent_cluster.k8s_cluster.get_ec2_instance_by_id(self.ec2_instance_id)
+        return self.k8s_cluster.get_ec2_instance_by_id(self.ec2_instance_id)
 
     @property
     def ec2_instance_id(self):
@@ -616,8 +616,8 @@ class EksScyllaPodContainer(BaseScyllaPodContainer):
             '''))
         self._instance_wait_safe(self.ec2_instance_destroy)
         self.wait_for_k8s_node_readiness()
-        self.parent_cluster.k8s_cluster.set_security_groups_on_all_instances()
-        self.parent_cluster.k8s_cluster.set_tags_on_all_instances()
+        self.k8s_cluster.set_security_groups_on_all_instances()
+        self.k8s_cluster.set_tags_on_all_instances()
 
     def ec2_instance_destroy(self, ec2_host=None):
         ec2_host = ec2_host or self.ec2_host
@@ -668,8 +668,9 @@ class EksScyllaPodCluster(ScyllaPodCluster):
                                       rack=rack,
                                       enable_auto_bootstrap=enable_auto_bootstrap)
         for node in new_nodes:
-            self.k8s_cluster.set_security_groups(node.ec2_instance_id)
-            self.k8s_cluster.set_tags(node.ec2_instance_id)
+            ec2_instance_id = node.ec2_instance_id
+            node.k8s_cluster.set_security_groups(ec2_instance_id)
+            node.k8s_cluster.set_tags(ec2_instance_id)
         return new_nodes
 
 

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -436,7 +436,7 @@ class GkeScyllaPodContainer(BaseScyllaPodContainer):
 
     @property
     def k8s_node(self):
-        k8s_cluster = self.parent_cluster.k8s_cluster
+        k8s_cluster = self.k8s_cluster
         return k8s_cluster.gce_service.get(project=k8s_cluster.gce_project,
                                            zone=k8s_cluster.gce_zone,
                                            instance=self.node_name)
@@ -456,8 +456,8 @@ class GkeScyllaPodContainer(BaseScyllaPodContainer):
         if self.k8s_node:
             instances_client, _ = get_gce_compute_instances_client()
             operation = instances_client.delete(instance=self.k8s_node.name,
-                                                project=self.parent_cluster.k8s_cluster.gce_project,
-                                                zone=self.parent_cluster.k8s_cluster.gce_zone)
+                                                project=self.k8s_cluster.gce_project,
+                                                zone=self.k8s_cluster.gce_zone)
             wait_for_extended_operation(operation, "wait for k8s_node deletion")
 
     def _instance_wait_safe(self, instance_method: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
@@ -489,7 +489,7 @@ class GkeScyllaPodContainer(BaseScyllaPodContainer):
         # Removing GKE instance and adding one node back to the cluster
         # TBD: Remove below lines when https://issuetracker.google.com/issues/178302655 is fixed
         self.parent_cluster.node_pool.remove_instance(instance_name=node_name)
-        self.parent_cluster.k8s_cluster.resize_node_pool(
+        self.k8s_cluster.resize_node_pool(
             self.parent_cluster.node_pool.name,
             self.parent_cluster.node_pool.num_nodes,
         )

--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -707,7 +707,7 @@ class LocalMinimalScyllaPodContainer(BaseScyllaPodContainer):
 
     @cached_property
     def host_remoter(self):
-        return self.parent_cluster.k8s_cluster.remoter
+        return self.k8s_cluster.remoter
 
     @property
     def docker_id(self):

--- a/sdcm/utils/k8s/chaos_mesh.py
+++ b/sdcm/utils/k8s/chaos_mesh.py
@@ -121,7 +121,7 @@ class ChaosMeshExperiment:
     CHAOS_KIND = ""  # need to override it in child classes
 
     def __init__(self, pod: "sdcm.cluster_k8s.BasePodContainer", name: str, timeout: int = 0):
-        self._k8s_cluster = pod.parent_cluster.k8s_cluster
+        self._k8s_cluster = pod.k8s_cluster
         self._name = name
         self._namespace = pod.parent_cluster.namespace
         self._experiment = {

--- a/unit_tests/test_chaos_mesh.py
+++ b/unit_tests/test_chaos_mesh.py
@@ -46,19 +46,19 @@ class DummyK8sCluster:
 
 @dataclass
 class DummyPodCluster:
-    k8s_cluster: DummyK8sCluster
     namespace: str = "scylla"
 
 
 @dataclass
 class DummyPod:
     parent_cluster: DummyPodCluster
+    k8s_cluster: DummyK8sCluster
     name: str
 
 
 def test_podchaos_experiment_configuration_is_valid(capsys):
     k8s_cluster = DummyK8sCluster()
-    pod = DummyPod(DummyPodCluster(k8s_cluster), name="dummy-pod-1")
+    pod = DummyPod(DummyPodCluster(), k8s_cluster, name="dummy-pod-1")
     experiment = PodFailureExperiment(pod=pod, duration="10s")
     experiment.start()
     captured = capsys.readouterr()
@@ -82,7 +82,7 @@ def test_podchaos_experiment_configuration_is_valid(capsys):
 
 def test_memorystress_experiment_configuration_is_valid(capsys):
     k8s_cluster = DummyK8sCluster()
-    pod = DummyPod(DummyPodCluster(k8s_cluster), name="dummy-pod-1")
+    pod = DummyPod(DummyPodCluster(), k8s_cluster, name="dummy-pod-1")
     experiment = MemoryStressExperiment(pod=pod, duration="10s", workers=4, size="512MB", time_to_reach="10s")
     experiment.start()
     captured = capsys.readouterr()
@@ -146,7 +146,7 @@ unknown_conditions = ''
 def test_experiment_statuses_for_podchaos_condidtions(conditions, status):
     k8s_cluster = DummyK8sCluster()
     k8s_cluster.register_kubectl_result("get PodChaos", Result(stdout=conditions))
-    pod = DummyPod(DummyPodCluster(k8s_cluster), name="dummy-pod-1")
+    pod = DummyPod(DummyPodCluster(), k8s_cluster, name="dummy-pod-1")
 
     experiment = PodFailureExperiment(pod=pod, duration="10s")
     assert experiment.get_status() == status
@@ -155,7 +155,7 @@ def test_experiment_statuses_for_podchaos_condidtions(conditions, status):
 def test_wait_for_finished_returns_when_status_is_finished():
     k8s_cluster = DummyK8sCluster()
     k8s_cluster.register_kubectl_result("get PodChaos", Result(stdout=finished_conditions))
-    pod = DummyPod(DummyPodCluster(k8s_cluster), name="dummy-pod-1")
+    pod = DummyPod(DummyPodCluster(), k8s_cluster, name="dummy-pod-1")
 
     experiment = PodFailureExperiment(pod=pod, duration="1s")
     experiment.start()
@@ -167,7 +167,7 @@ def test_wait_for_finished_raises_exception_when_status_is_error():
     k8s_cluster = DummyK8sCluster()
     k8s_cluster.register_kubectl_result("get PodChaos", Result(error_conditions))
     k8s_cluster.register_kubectl_result("describe PodChaos ", Result(stdout="pod description got from k8s"))
-    pod = DummyPod(DummyPodCluster(k8s_cluster), name="dummy-pod-1")
+    pod = DummyPod(DummyPodCluster(), k8s_cluster, name="dummy-pod-1")
 
     experiment = PodFailureExperiment(pod=pod, duration="1s")
     experiment.start()
@@ -180,7 +180,7 @@ def test_wait_for_finished_raises_exception_when_timeout_occurs():
     k8s_cluster = DummyK8sCluster()
     k8s_cluster.register_kubectl_result("get PodChaos", Result(running_conditions))
     k8s_cluster.register_kubectl_result("describe PodChaos ", Result(stdout="pod description got from k8s"))
-    pod = DummyPod(DummyPodCluster(k8s_cluster), name="dummy-pod-1")
+    pod = DummyPod(DummyPodCluster(), k8s_cluster, name="dummy-pod-1")
 
     experiment = PodFailureExperiment(pod=pod, duration="1s")
     experiment._timeout = 0


### PR DESCRIPTION
Each pod always has `1:1` mapping with a K8S cluster.
Running in a multiDC environment we need to switch between K8S clusters easily.
So, add `k8s_cluster` attribute to all pod python classes and use it where possible
to minimize further changes adding support for multiDC setups.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
