### PR TITLE
improvement(k8s): use region_name as label in loggers

### DIFF
--- a/unit_tests/test_chaos_mesh.py
+++ b/unit_tests/test_chaos_mesh.py
@@ -28,6 +28,7 @@ from sdcm.utils.k8s.chaos_mesh import PodFailureExperiment, ExperimentStatus, Ch
 @dataclass
 class DummyK8sCluster:
     _commands: Dict[str, Result] = field(default_factory=dict)
+    region_name: str = 'fake-region-1'
 
     def apply_file(self, config_path: str):
         """Parses file content to yaml and prints it."""

--- a/unit_tests/test_utils_k8s.py
+++ b/unit_tests/test_utils_k8s.py
@@ -112,6 +112,7 @@ def test_helm_values_try_set_by_list_index():
 class FakeK8SKluster:  # pylint: disable=too-few-public-methods
     def __init__(self):
         self.get_api_client = mock.MagicMock()
+        self.region_name = 'fake-region-1'
 
 
 def get_k8s_endpoint_update(namespace, pod_name, ip, required_labels_in_place=True,


### PR DESCRIPTION
We have lots of log messages which assume we have just one K8S cluster.
It becomes a problem if we run multiple K8S clusters setup.
So, add `region_name` prefix to bunch of K8S-related loaders to ease debugging.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
