### PR TITLE
fix(nemesis): fix verify_initial_inputs_for_delete_nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2112,7 +2112,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if 'scylla_bench' not in test_keyspaces:
             raise UnsupportedNemesis("This nemesis can run on scylla_bench test only")
 
-        if not self.tester.partitions_attrs.max_partitions_in_test_table:
+        if not (self.tester.partitions_attrs and self.tester.partitions_attrs.max_partitions_in_test_table):
             raise UnsupportedNemesis(
                 'This nemesis expects "max_partitions_in_test_table" sub-parameter of data_validation to be set')
 


### PR DESCRIPTION
`verify_initial_inputs_for_delete_nemesis` wrongly assumes `partitions_attrs` isn't None.

as part of #6576 `partitions_attrs` was introduced, and seems to be test only with cases that have the correct configurations, and not with ones using s-b, and without the configuration realted to range deletes

Ref: #6576

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
