### PR TITLE
fix(dashboard): remove scylla_thrift_served metric

### DIFF
--- a/data_dir/scylla-dash-per-server-nemesis.2021.1.json
+++ b/data_dir/scylla-dash-per-server-nemesis.2021.1.json
@@ -329,7 +329,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[60s])) + sum(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[60s])) + (sum(irate(scylla_alternator_operation{cluster=~\"$cluster|$^\"}[60s])) or vector(0))",
+                                "expr": "sum(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[60s])) + (sum(irate(scylla_alternator_operation{cluster=~\"$cluster|$^\"}[60s])) or vector(0))",
                                 "intervalFactor": 1,
                                 "legendFormat": "Total Requests",
                                 "refId": "A",
@@ -528,7 +528,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]]) + sum(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                                "expr": "sum(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
                                 "format": "time_series",
                                 "intervalFactor": 1,
                                 "legendFormat": "",

--- a/data_dir/scylla-dash-per-server-nemesis.master.json
+++ b/data_dir/scylla-dash-per-server-nemesis.master.json
@@ -388,7 +388,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "(sum(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[60s])) or vector(0)) + (sum(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[60s])) or vector(0)) + (sum(irate(scylla_alternator_operation{cluster=~\"$cluster|$^\"}[60s])) or vector(0))",
+            "expr": "(sum(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[60s])) or vector(0)) + (sum(irate(scylla_alternator_operation{cluster=~\"$cluster|$^\"}[60s])) or vector(0))",
             "intervalFactor": 1,
             "legendFormat": "Total Requests",
             "refId": "A",
@@ -602,7 +602,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(rate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]]) + (sum(rate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]]) or max(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by([[by]])*0)",
+            "expr": "sum(rate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "",

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -295,7 +295,7 @@ class PrometheusDBStats:
         if self.alternator:
             query = "sum(irate(scylla_alternator_operation{}[30s]))"
         else:
-            query = "sum(irate(scylla_transport_requests_served{}[30s]))%20%2B%20sum(irate(scylla_thrift_served{}[30s]))"
+            query = "sum(irate(scylla_transport_requests_served{}[30s]))"
         return self._get_query_values(query, start_time, end_time, scrap_metrics_step=scrap_metrics_step)
 
     def get_scylla_reactor_utilization(self, start_time, end_time, scrap_metrics_step=None, instance=None):


### PR DESCRIPTION
After all nodes in cluster are updated from 2021.1 to 2022.1 and got new Scylla version, requests graph stops to report. It happens due to 'scylla_thrift_served' metric was removed beginnig from 2022.1 as it always is empty.
Remove 'scylla_thrift_served' from 2021.1 and master graph as not relevant

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
