### PR TITLE
feature(commitlog): Checking commitlog in sct

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -135,3 +135,4 @@ ScyllaSysconfigSetupEvent: NORMAL
 TestStepEvent: ERROR
 CpuNotHighEnoughEvent: ERROR
 HWPerforanceEvent: CRITICAL
+CommitLogCheckErrorEvent: ERROR

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -238,3 +238,5 @@ use_placement_group: false
 validate_large_collections: false
 
 scylla_d_overrides_files: []
+
+run_commit_log_check_thread: true

--- a/sdcm/commit_log_check_thread.py
+++ b/sdcm/commit_log_check_thread.py
@@ -1,0 +1,187 @@
+import traceback
+import logging
+import time
+import re
+import threading
+from dataclasses import dataclass
+from distutils.util import strtobool
+from sdcm.sct_events.database import CommitLogCheckErrorEvent
+from sdcm.rest.remote_curl_client import RemoteCurlClient
+
+
+@dataclass
+class CommitlogConfigParams:
+    def __init__(self, db_cluster, ):
+        logger = logging.getLogger(self.__class__.__name__)
+        with db_cluster.cql_connection_patient(
+                node=db_cluster.nodes[0],
+                connect_timeout=300,) as session:
+            self.use_hard_size_limit = bool(strtobool(session.execute(
+                "SELECT value FROM system.config WHERE name='commitlog_use_hard_size_limit'").one().value))
+            self.segment_size_in_mb = int(session.execute(
+                "SELECT value FROM system.config WHERE name='commitlog_segment_size_in_mb'").one().value)
+            self.max_disk_size = int(RemoteCurlClient(
+                host="localhost:10000", endpoint="commitlog", node=db_cluster.nodes[0]).run_remoter_curl(
+                method="GET", path="metrics/max_disk_size", params=None).stdout)
+            self.smp = len(re.findall(
+                "shard",
+                db_cluster.nodes[0].remoter.run('seastar-cpu-map.sh -n scylla').stdout))
+            self.total_space = int(self.max_disk_size / self.smp)
+
+            logger.debug("CommitlogConfigParams")
+            logger.debug("smp: %s", self.smp)
+            logger.debug("max_disk_size: %s", self.max_disk_size)
+            logger.debug("total_space: %s", self.total_space)
+            logger.debug("use_hard_size_limit: %s", self.use_hard_size_limit)
+            logger.debug("segment_size_in_mb: %s", self.segment_size_in_mb)
+
+    smp: int
+    total_space: int
+    max_disk_size: int
+    use_hard_size_limit: bool
+    segment_size_in_mb: int
+
+
+@dataclass
+class PrometheusQueries:
+    def __init__(self, commitlog_params: CommitlogConfigParams):
+        self.overflow_commit_log_directory = self.overflow_commit_log_directory.format(
+            commitlog_total_space=commitlog_params.total_space,
+            commitlog_segment_size_in_mb=commitlog_params.segment_size_in_mb
+        )
+
+        self.zero_free_segments = self.zero_free_segments.format(
+            commitlog_total_space=commitlog_params.total_space,
+            commitlog_segment_size_in_mb=commitlog_params.segment_size_in_mb
+        )
+    # Prometheus queries with detailed description below
+    overflow_commit_log_directory = ("scylla_commitlog_disk_total_bytes>=({commitlog_total_space}"
+                                     "%2B({commitlog_segment_size_in_mb}%2A1048576))")
+    """
+        returns commitlog total size on disk if commit log directory exceed the limit
+
+        commit_log_directory_query description:
+        %2A is *
+        %2B is +
+
+        {commitlog_total_space} :
+        set to max_disk_size(value from API) divided  to number for shards
+        see CommitLogCheckThread.init_commitlog_params_from_db()
+
+        + {commitlog_segment_size_in_mb}*1048576) :
+        add size of 1 segment,  Scylla actually stops creating new segments not when the next segment
+        would cause us to exceed the value,
+        but instead it checks if we've already reached or exceeded the limit.
+
+        scylla_commitlog_disk_total_bytes > :
+        filter all good values when scylla_commitlog_disk_total_bytes<= commitlog_total_space + 1 segment
+        and return from Prometheus only bad
+    """
+
+    zero_free_segments = \
+        ("scylla_commitlog_disk_active_bytes>((scylla_commitlog_disk_total_bytes>={commitlog_total_space})"
+         "%2D({commitlog_segment_size_in_mb}%2A1048576))")
+    """
+        returns commitlog active size on disk if number of free segments drop to zero
+
+        free_segments_query description:
+        %2A is *
+        %2D is -
+
+        {commitlog_total_space} :
+        set to max_disk_size(value from API) divided  to number for shards
+        see CommitLogCheckThread.init_commitlog_params_from_db()
+
+        scylla_commitlog_disk_total_bytes >= {commitlog_total_space}:
+        Scylla has 0 free segments and allocates new segments until exceed limit {commitlog_total_space}
+        this condition will ignore result when Scylla does not exceed  segments limit
+
+        - {commitlog_segment_size_in_mb}*1048576) :
+        minus size of 1 segment,  to ensure that Scylla has at least 1 free segment number of active_bytes should be
+        less then "scylla_commitlog_disk_total_bytes"-"1 segment"
+
+        scylla_commitlog_disk_active_bytes > :
+        filter all good values when scylla_commitlog_disk_active_bytes<= scylla_commitlog_disk_total_bytes - 1 segment
+        and return from Prometheus only bad
+    """
+
+
+# pylint: disable=too-many-instance-attributes
+class CommitLogCheckThread:
+    """
+        if commitlog-use-hard-size-limit is enabled,
+        this thread will check the following metrics during the test:
+
+        1) commit log directory does not exceed the limit at any stage of the test.
+           if it exceeded - send an error event that fails the test.
+
+        2) free segments don't drop to zero at any stage of the test,
+        otherwise, send an error event that fails the test.
+    """
+
+    # Prometheus API limit: check_interval/discreteness must be less then 11000
+    check_interval = 10 * 60
+    discreteness = 1
+
+    def __init__(self, custer_tester, test_duration, termination_event=None, thread_name: str = ""):
+        self.log = logging.getLogger(self.__class__.__name__)
+        self.prometheus = custer_tester.prometheus_db
+        self.test_duration = test_duration
+
+        self.commitlog_params = CommitlogConfigParams(custer_tester.db_cluster)
+        self.prometheus_queries = PrometheusQueries(self.commitlog_params)
+        self.start_time = None
+
+        self._thread = threading.Thread(daemon=True, name=f"{self.__class__.__name__}_{thread_name}", target=self.run)
+        self.termination_event = termination_event
+        if not self.termination_event:
+            self.termination_event = custer_tester.db_cluster.nemesis_termination_event
+
+    def start(self):
+        if self.commitlog_params.use_hard_size_limit:
+            self.log.debug("starting CommitLogCheckThread")
+            self._thread.start()
+        else:
+            self.log.debug(
+                "CommitLogCheckThread was not started due to commitlog_use_hard_size_limit is %s",
+                self.commitlog_params.use_hard_size_limit)
+
+    def join(self, timeout=None):
+        return self._thread.join(timeout)
+
+    def run(self):
+        self.log.debug("CommitLogCheckThread Started")
+        try:
+            thread_end_time = time.time() + self.test_duration
+
+            self.start_time = time.time()
+
+            while time.time() < thread_end_time and not self.termination_event.is_set():
+                interval_end_time = self.start_time + self.check_interval
+                self.termination_event.wait(self.check_interval)
+                self.overflow_commit_log_directory_checker(self.start_time, interval_end_time)
+                self.zero_free_segments_checker(self.start_time, interval_end_time)
+
+                self.start_time = interval_end_time
+        except Exception as exc:  # pylint: disable=broad-except
+            trace = traceback.format_exc()
+            CommitLogCheckErrorEvent(
+                message=f"CommitLogCheckThread failed: {exc.__repr__()} with traceback {trace}").publish()
+            raise
+        self.log.debug("CommitLogCheckThread finished")
+
+    def overflow_commit_log_directory_checker(self, start_time, end_time):
+        response = self.prometheus.query(
+            self.prometheus_queries.overflow_commit_log_directory, start_time, end_time, self.discreteness)
+        self.log.debug("overflow_commit_log_directory: %s", response)
+        if response:
+            CommitLogCheckErrorEvent(
+                message=f"commit log directory exceed the limit. Prometheus response: {response}").publish()
+
+    def zero_free_segments_checker(self, start_time, end_time):
+        response = self.prometheus.query(
+            self.prometheus_queries.zero_free_segments, start_time, end_time, self.discreteness)
+        self.log.debug("zero_free_segments: %s", response)
+        if response:
+            CommitLogCheckErrorEvent(
+                message=f"free segments drop to zero. Prometheus response:: {response}").publish()

--- a/sdcm/rest/remote_curl_client.py
+++ b/sdcm/rest/remote_curl_client.py
@@ -29,7 +29,7 @@ class RemoteCurlClient(RestClient):
 
     def run_remoter_curl(self, method: Literal["GET", "POST"],  # pylint: disable=too-many-arguments
                          path: str,
-                         params: dict[str, str],
+                         params: dict[str, str] | None,
                          timeout: int = 120,
                          retry: int = 0):
         prepared_request = self._prepare_request(method=method, path=path, params=params)

--- a/sdcm/rest/rest_client.py
+++ b/sdcm/rest/rest_client.py
@@ -46,7 +46,7 @@ class RestClient:
         LOGGER.info("Sending a POST request for: %s", url)
         return requests.post(url=url, params=params)
 
-    def _prepare_request(self, method: Literal["GET", "POST"], path: str, params: dict[str, str]):
+    def _prepare_request(self, method: Literal["GET", "POST"], path: str, params: dict[str, str] | None):
         full_url = f"{self._base_url}/{path}"
         prepared_request = requests.Request(method=method, url=full_url, params=params).prepare()
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1516,6 +1516,10 @@ class SCTConfiguration(dict):
 
         dict(name="validate_large_collections", env="SCT_VALIDATE_LARGE_COLLECTIONS", type=boolean,
              help="Enable validation for large cells in system table and logs"),
+
+        dict(name="run_commit_log_check_thread", env="SCT_RUN_COMMIT_LOG_CHECK_THREAD", type=boolean,
+             help="""Run commit log check thread if commitlog_use_hard_size_limit is True"""),
+
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -248,6 +248,17 @@ class IndexSpecialColumnErrorEvent(InformationalEvent):
         return super().msgfmt + ": message={0.message}"
 
 
+class CommitLogCheckErrorEvent(InformationalEvent):
+    def __init__(self, message: str, severity: Severity = Severity.ERROR):
+        super().__init__(severity=severity)
+
+        self.message = message
+
+    @property
+    def msgfmt(self) -> str:
+        return super().msgfmt + ": message={0.message}"
+
+
 class ScyllaServerEventPattern(NamedTuple):
     pattern: Pattern
     period_func: Callable

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -129,6 +129,7 @@ from sdcm.utils.latency import calculate_latency, analyze_hdr_percentiles
 from sdcm.utils.csrangehistogram import CSHistogramTagTypes, CSWorkloadTypes, make_cs_range_histogram_summary, \
     make_cs_range_histogram_summary_by_interval
 from sdcm.utils.raft.common import validate_raft_on_nodes
+from sdcm.commit_log_check_thread import CommitLogCheckThread
 from test_lib.compaction import CompactionStrategy
 
 CLUSTER_CLOUD_IMPORT_ERROR = ""
@@ -957,6 +958,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 db_cluster.validate_seeds_on_all_nodes()
                 validate_raft_on_nodes(nodes=db_cluster.nodes)
                 db_cluster.start_kms_key_rotation_thread()
+
+        if self.params.get('run_commit_log_check_thread'):
+            self.run_commit_log_check_thread(self.get_duration(None))
 
     def set_system_auth_rf(self, db_cluster=None):
 
@@ -2167,6 +2171,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             the ScanOperationThread
         """
         ScanOperationThread(thread_params=fullscan_params, thread_name=thread_name).start()
+
+    def run_commit_log_check_thread(self, duration):
+        if self.monitors:
+            CommitLogCheckThread(self, duration).start()
 
     def run_tombstone_gc_verification_thread(self, duration=None, interval=600, propagation_delay_in_seconds=3600, **kwargs):
         """Run a thread of tombstones gc verification.


### PR DESCRIPTION
Checking "free segments" and "commitlog directory" metrics in SCT task: https://github.com/scylladb/qa-tasks/issues/1523

introdus new SCT background thread CommitLogCheckThread

if commitlog-use-hard-size-limit is enabled,
this thread will check the following metrics during the test:

1) commit log directory does not exceed the limit at any stage of the test. if it exceeded - send an error event that fails the test.

2) free segments don't drop to zero at any stage of the test, otherwise, send an error event that fails the test.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
