### PR TITLE
fix(sct.py): add jepsen test to release jobs

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1409,6 +1409,7 @@ def create_test_release_jobs(branch, username, password, sct_branch, sct_repo):
         ('features-', 'SCT Feature Tests'),
         ('artifacts', 'SCT Artifacts Tests'),
         ('load-test', 'SCT Load Tests'),
+        ('jepsen', 'SCT Jepsen Tests'),
         ('repair-based-operation', "SCT RBO Tests"),
         ('scale', 'SCT Scale Tests'),
         ('operator', 'SCT Operator Tests'),


### PR DESCRIPTION
jepsen job was not create, apart from the
`jepsen-with-raft`, that resides inside `raft`
folder, but is not relevant for newer releases,
since RAFT is already the default configuration.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
