### PR TITLE
fix(sct_ssh): `attach-test-sg` failed to handle one respone

### DIFF
--- a/sct_ssh.py
+++ b/sct_ssh.py
@@ -62,7 +62,7 @@ def get_name(instance):
 
 @get_name.register(dict)
 def _(instance: dict):
-    get_tags(instance).get('Name')
+    return get_tags(instance).get('Name')
 
 
 @get_name.register(compute_v1.Instance)
@@ -220,7 +220,7 @@ def select_instance_group(region: str = None, backends: list | None = None, **ta
         gce_vms = list_instances_gce(tags, running=True)
 
     if len(aws_vms + gce_vms) == 1:
-        return (aws_vms + gce_vms)[0]
+        return aws_vms + gce_vms
 
     if not aws_vms and not gce_vms:
         click.echo(click.style("Found no matching instances", fg='red'))
@@ -394,7 +394,7 @@ def attach_test_sg_cmd(user, test_id, region, group_id):
     instances = select_instance_group(region=region, backends=['aws'], test_id=test_id, user=user)
 
     for i in instances:
-        aws_region: AwsRegion = AwsRegion(get_region(i))
+        aws_region: AwsRegion = AwsRegion(region or get_region(i))
         instance = aws_region.resource.Instance(i['InstanceId'])
         click.echo(click.style(f"attaching test SG to {get_name(i)}", fg='green'))
         if group_id:


### PR DESCRIPTION
casue of copy-patse error in #6734, `select_instance_group` was returning one item, and not a list as intend.

and failing to get the instance region, since it was giving a key of a dict, and not the whole dict.

Fixes: #6764

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
