### PR TITLE
fix(remote_file): write inplace into the file

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5562,7 +5562,6 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
               message="Waiting for reconfiguring scylla monitoring")
     def reconfigure_scylla_monitoring(self):
         for node in self.nodes:
-            cluster_backend = self.params.get("cluster_backend")
             monitoring_targets = []
             for db_node in self.targets["db_cluster"].nodes:
                 monitoring_targets.append(f"[{getattr(db_node, self.DB_NODES_IP_ADDRESS)}]:9180")
@@ -5576,10 +5575,9 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
                 python3 genconfig.py -s -n -d {self.monitoring_conf_dir} {monitoring_targets}
             """), verbose=True)
 
-            if cluster_backend != "docker":
-                node.remoter.sudo(f"docker run --rm -v {self.monitoring_conf_dir}:/workdir"
-                                  f" mikefarah/yq:3 yq w -i node_exporter_servers.yml"
-                                  f" '[0].targets[+]' ''[{node.private_ip_address}]:9100''", verbose=True)
+            with node._remote_yaml(f'{self.monitoring_conf_dir}/node_exporter_servers.yml') as exporter_yaml:  # pylint: disable=protected-access
+                exporter_yaml[0]['targets'] += [f'[{node.private_ip_address}]:9100']
+                exporter_yaml[0]['targets'] = list(set(exporter_yaml[0]['targets']))  # remove duplicates
 
             if self.params.get("cloud_prom_bearer_token"):
                 node.remoter.sudo(shell_script_cmd(f"""\

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5564,10 +5564,8 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
         for node in self.nodes:
             monitoring_targets = []
             for db_node in self.targets["db_cluster"].nodes:
-                monitoring_targets.append(f"[{getattr(db_node, self.DB_NODES_IP_ADDRESS)}]:9180")
+                monitoring_targets.append(f"{normalize_ipv6_url(getattr(db_node, self.DB_NODES_IP_ADDRESS))}:9180")
             monitoring_targets = " ".join(monitoring_targets)
-            if self.params.get("ip_ssh_connections") != "ipv6":
-                monitoring_targets = monitoring_targets.replace("[", "").replace("]", "")
             node.remoter.sudo(shell_script_cmd(f"""\
                 cd {self.monitor_install_path}
                 mkdir -p {self.monitoring_conf_dir}
@@ -5576,7 +5574,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
             """), verbose=True)
 
             with node._remote_yaml(f'{self.monitoring_conf_dir}/node_exporter_servers.yml') as exporter_yaml:  # pylint: disable=protected-access
-                exporter_yaml[0]['targets'] += [f'[{node.private_ip_address}]:9100']
+                exporter_yaml[0]['targets'] += [f'{normalize_ipv6_url(node.private_ip_address)}:9100']
                 exporter_yaml[0]['targets'] = list(set(exporter_yaml[0]['targets']))  # remove duplicates
 
             if self.params.get("cloud_prom_bearer_token"):

--- a/sdcm/remote/remote_file.py
+++ b/sdcm/remote/remote_file.py
@@ -20,6 +20,7 @@ from io import StringIO
 import yaml
 
 from sdcm import wait
+from sdcm.remote import shell_script_cmd
 
 
 LOGGER = logging.getLogger(__name__)
@@ -64,7 +65,10 @@ def remote_file(remoter, remote_path, serializer=StringIO.getvalue, deserializer
             LOGGER.debug("New content of `%s':\n%s", remote_path, content)
 
         remote_tempfile = remoter.run("mktemp").stdout.strip()
-        remote_tempfile_move_cmd = f"mv '{remote_tempfile}' '{remote_path}'"
+        remote_tempfile_move_cmd = shell_script_cmd(f"""\
+            cat '{remote_tempfile}' > '{remote_path}'
+            rm '{remote_tempfile}'
+            """)
         wait.wait_for(remoter.send_files,
                       step=10,
                       text=f"Waiting for updating of `{remote_path}' on {remoter.hostname}",

--- a/unit_tests/test_remoter.py
+++ b/unit_tests/test_remoter.py
@@ -460,7 +460,7 @@ class TestRemoteFile(unittest.TestCase):
         self.assertEqual(remoter.rf_dst, remoter.sf_src)
         self.assertEqual(remoter.sf_data, "test data")
         self.assertFalse(os.path.exists(remoter.sf_src))
-        self.assertEqual(remoter.command_to_run, f"mv 'temporary' '{some_file}'")
+        self.assertEqual(remoter.command_to_run, f'bash -cxe "cat \'temporary\' > \'{some_file}\'\nrm \'temporary\'\n"')
 
     def test_remote_file_preserve_ownership(self):
         remoter = self.remoter_cls()


### PR DESCRIPTION
since in some cases there's a process listing on changes
to this file, doing so with `mv` fails to continue the watch
on those files

### Testing
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-5gb-1h-GrowShrinkClusterNemesis-aws-test/5/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
