### PR TITLE
fix(group_common_events): Expand regexp to filter more messages

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -242,7 +242,7 @@ def ignore_stream_mutation_fragments_errors():
         stack.enter_context(EventsSeverityChangerFilter(
             new_severity=Severity.WARNING,
             event_class=DatabaseLogEvent,
-            regex=r".*node_ops - decommission.*Operation failed.*std::runtime_error.*seastar::abort_requested_exception",
+            regex=r".*node_ops - decommission.*Operation failed.*seastar::abort_requested_exception",
             extra_time_to_expiration=30
         ))
         yield


### PR DESCRIPTION
During decommission_streaming_err next message could appear if decommission was aborted:
```
Nov 04 22:54:27.378538 longevity-twcs-48h-master-db-node-1e08af7e-3 scylla[39839]:
[shard 0:strm] node_ops - decommission[384e4830-3d66-4c17-853e-8406cd102a31]:
Operation failed, sync_nodes={10.4.11.231, 10.4.8.165, 10.4.8.201, 10.4.9.29}:
seastar::abort_requested_exception (abort requested)
```

Such message is not caught by ignore_stream_mutation_fragments_errors function.
Regexp was widened to catch similar messages.

Latest issue was found in JOB: longevity-twcs-48h-test
TestID: 1e08af7e-a630-460e-8fdd-c71ca75ad92b
Argus: scylla-master/longevity/longevity-twcs-48h-test#93

Issue https://github.com/scylladb/scylladb/issues/15630

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
