### PR TITLE
feature(k8s): add general support for multiple K8S clusters

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -63,6 +63,8 @@ from functional_tests.scylla_operator.libs.helpers import (
 
 log = logging.getLogger()
 
+# TODO: add support for multiDC setups
+
 
 @pytest.mark.readonly
 def test_single_operator_image_tag_is_everywhere(db_cluster):

--- a/longevity_operator_multi_tenant_test.py
+++ b/longevity_operator_multi_tenant_test.py
@@ -28,10 +28,11 @@ class LongevityOperatorMultiTenantTest(MultiTenantTestMixin, LongevityTest):
 
         self.log.info("Starting tests worker threads")
 
-        self.log.info("Clusters count: %s", self.k8s_cluster.tenants_number)
+        tenants_number = self.k8s_clusters[0].tenants_number
+        self.log.info("Clusters count: %s", tenants_number)
         object_set = ParallelObject(
             timeout=int(self.test_duration) * 60,
             objects=[[tenant] for tenant in self.tenants],
-            num_workers=self.k8s_cluster.tenants_number
+            num_workers=tenants_number,
         )
         object_set.run(func=_run_test_on_one_tenant, unpack_objects=True, ignore_exceptions=False)

--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -651,7 +651,6 @@ class EksScyllaPodContainer(BaseScyllaPodContainer):
 
 
 class EksScyllaPodCluster(ScyllaPodCluster):
-    k8s_cluster: 'EksCluster'
     PodContainerClass = EksScyllaPodContainer
     nodes: List[EksScyllaPodContainer]
 
@@ -659,7 +658,7 @@ class EksScyllaPodCluster(ScyllaPodCluster):
     def add_nodes(self,
                   count: int,
                   ec2_user_data: str = "",
-                  dc_idx: int = 0,
+                  dc_idx: int = None,
                   rack: int = 0,
                   enable_auto_bootstrap: bool = False) -> List[EksScyllaPodContainer]:
         new_nodes = super().add_nodes(count=count,

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -496,7 +496,6 @@ class GkeScyllaPodContainer(BaseScyllaPodContainer):
 
 
 class GkeScyllaPodCluster(ScyllaPodCluster):
-    k8s_cluster: 'GkeCluster'
     node_pool: 'GkeNodePool'
     PodContainerClass = GkeScyllaPodContainer
 
@@ -504,7 +503,7 @@ class GkeScyllaPodCluster(ScyllaPodCluster):
     def add_nodes(self,
                   count: int,
                   ec2_user_data: str = "",
-                  dc_idx: int = 0,
+                  dc_idx: int = None,
                   rack: int = 0,
                   enable_auto_bootstrap: bool = False) -> List[GkeScyllaPodContainer]:
         new_nodes = super().add_nodes(count=count,

--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -728,7 +728,6 @@ class LocalMinimalScyllaPodContainer(BaseScyllaPodContainer):
 # pylint: disable=too-many-ancestors
 class LocalMinimalScyllaPodCluster(ScyllaPodCluster):
     """Represents scylla cluster hosted on locally running minimal k8s clusters such as k3d, minikube or kind"""
-    k8s_cluster: MinimalClusterBase
     PodContainerClass = LocalMinimalScyllaPodContainer
 
     def wait_for_nodes_up_and_normal(self, nodes=None, verification_node=None, iterations=20, sleep_time=60, timeout=0):  # pylint: disable=too-many-arguments
@@ -746,7 +745,7 @@ class LocalMinimalScyllaPodCluster(ScyllaPodCluster):
         self.wait_for_nodes_up_and_normal(nodes=node_list)
 
     def upgrade_scylla_cluster(self, new_version: str) -> None:
-        self.k8s_cluster.docker_pull(f"{self.params.get('docker_image')}:{new_version}")
+        self.k8s_clusters[0].docker_pull(f"{self.params.get('docker_image')}:{new_version}")
         return super().upgrade_scylla_cluster(new_version)
 
     @staticmethod

--- a/sdcm/utils/operator/multitenant_common.py
+++ b/sdcm/utils/operator/multitenant_common.py
@@ -52,7 +52,7 @@ class TenantMixin:  # pylint: disable=too-many-instance-attributes
         self.test_config.reuse_cluster(False)
 
     def get_str_index(self):
-        return f"{self.get_str_index_prefix}-{self.db_cluster.k8s_cluster.tenants_number}-tenants"
+        return f"{self.get_str_index_prefix}-{self.db_cluster.k8s_clusters[0].tenants_number}-tenants"
 
     def id(self):  # pylint: disable=invalid-name
         if "Longevity" in self.__class__.__name__:

--- a/unit_tests/test_utils__operator__multitenant_common.py
+++ b/unit_tests/test_utils__operator__multitenant_common.py
@@ -50,7 +50,7 @@ class FakePerformanceTest(FakeTestBase):
 class FakeDbCluster:  # pylint: disable=too-few-public-methods
     def __init__(self, fake_index):
         self.fake_index = fake_index
-        self.k8s_cluster = type("FakeK8SCluster", (), {"tenants_number": 2})
+        self.k8s_clusters = [type("FakeK8SCluster", (), {"tenants_number": 2})]
         self.params = {}
 
 


### PR DESCRIPTION
Do following changes to SCT to support multiple K8S clusters:
- Add new `k8s_clusters` attr to Tester python class.
- Start using that attr in the K8S provisioning methods.
- Add `k8s_clusters` attr to the Scylla cluster python classes.
- Update all the `add_nodes` methods with the possibility to use different `dc_idx` values.
- The `dc_idx` parameter becomes senseful.
- Update the `disrupt_nodetool_flush_and_reshard_on_kubernetes` nemesis to work correctly using the new approach.
- Update various K8S python methods to use new `k8s_clusters` attr.

What it doesn't do and what will be done in further changes:
- Specific K8S backends updates to be able to create 2+ K8S clusters.
- Scylla-manager update.
- Separation of all the K8S logs. For now `scylla-operator`, `scylla-manager`, `cert-manager` and `scylla-events` streamed logs will get written into the same files from each of K8S clusters.
- Proper SNI support for multiple K8S clusters.
- Support of unique values for the wide range of the SCT config options such as `n_db_nodes`, `k8s_n_scylla_pods_per_cluster` and lots of others.
- Monitoring logic update to post the DC info.
- New CI jobs configurations.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
