### PR TITLE
Revert "fix(monitor-setup): stop using `mikefarah/yq` docker"

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5562,6 +5562,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
               message="Waiting for reconfiguring scylla monitoring")
     def reconfigure_scylla_monitoring(self):
         for node in self.nodes:
+            cluster_backend = self.params.get("cluster_backend")
             monitoring_targets = []
             for db_node in self.targets["db_cluster"].nodes:
                 monitoring_targets.append(f"[{getattr(db_node, self.DB_NODES_IP_ADDRESS)}]:9180")
@@ -5575,9 +5576,10 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
                 python3 genconfig.py -s -n -d {self.monitoring_conf_dir} {monitoring_targets}
             """), verbose=True)
 
-            with node._remote_yaml(f'{self.monitoring_conf_dir}/node_exporter_servers.yml') as exporter_yaml:  # pylint: disable=protected-access
-                exporter_yaml[0]['targets'] += [f'[{node.private_ip_address}]:9100']
-                exporter_yaml[0]['targets'] = list(set(exporter_yaml[0]['targets']))  # remove duplicates
+            if cluster_backend != "docker":
+                node.remoter.sudo(f"docker run --rm -v {self.monitoring_conf_dir}:/workdir"
+                                  f" mikefarah/yq:3 yq w -i node_exporter_servers.yml"
+                                  f" '[0].targets[+]' ''[{node.private_ip_address}]:9100''", verbose=True)
 
             if self.params.get("cloud_prom_bearer_token"):
                 node.remoter.sudo(shell_script_cmd(f"""\


### PR DESCRIPTION
Reverts scylladb/scylla-cluster-tests#6746

this fix is not yet stable, and causing monitoring stack be wrongly configured
for now until figured out, we'll revert this change

#6757