### PR TITLE
improvement(kallsyms decoder): add script that decodes kallsyms

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     hooks:
     -   id: autopep8
         name: autopep8
-        entry: autopep8 -i -j 2 --max-line-length=120 --ignore=E226,E24,W50,W690,E402
+        entry: autopep8 -i -j 2 --max-line-length=120 --ignore=E226,E24,W50,W690,E402,E731
         language: system
         types: [python]
         exclude: '\.sh$'

--- a/utils/decode_kallsyms.py
+++ b/utils/decode_kallsyms.py
@@ -1,0 +1,53 @@
+import bisect
+import re
+
+
+def kallsyms_search(kallsyms_lines: list[str], address: int):
+    # kallsyms lines looks like this
+    #
+    # ffffffffaa88e2f0 T kfree
+    # ffffffffaa88e400 T __ksize
+    # ffffffffaa88e530 T ksize
+    key = lambda line: int(line.split()[0], 16) - 1
+    return bisect.bisect_right(kallsyms_lines, address, key=key) - 1
+
+
+def cut_addresses_from_log_line_kernel_callstack(line):
+    my_regex = re.compile('0x([0-9a-fA-F]{16})')
+    return my_regex.findall(line)
+
+
+def get_lines_from_log(file_path):
+    file_content = {}
+    with open(file_path, 'r') as file:  # pylint: disable=unspecified-encoding
+        for line in file:
+            if ('kernel callstack' in line and '0x' in line) or 'Reactor stalled for' in line:
+                file_content[line] = cut_addresses_from_log_line_kernel_callstack(line)
+    return file_content
+
+
+def get_kallsyms(path_to_kallsyms):
+    with open(path_to_kallsyms, 'r') as file:  # pylint: disable=unspecified-encoding
+        file_content = file.readlines()
+    return file_content
+
+
+def append_content_to_file(file_stream, content):
+    file_stream.write(content + '\n')
+
+
+def decode_kernel_callstacks(results_file='results.log', input_file='system.log', kallsyms_file='kallsyms',
+                             clear_output_file=True):
+    file_content = get_kallsyms(kallsyms_file)
+    if clear_output_file:
+        with open(results_file, 'w'):  # pylint: disable=unspecified-encoding
+            print(f'clearing file {results_file}')
+
+    with open(results_file, 'a') as file:  # pylint: disable=unspecified-encoding
+        for full_line, stall in get_lines_from_log(input_file).items():
+            append_content_to_file(file, '#' * 76)
+            append_content_to_file(file, full_line)
+            if 'Reactor stalled for' not in full_line:
+                for frame in stall:
+                    append_content_to_file(file, file_content[kallsyms_search(file_content, int(frame, 16))])
+            append_content_to_file(file, '#' * 76)


### PR DESCRIPTION
since we collect kallsyms, and they are sometimes
needed to add valuable informatino to existing issues, i have created this tool to decode kernel callstacks from tests. it is not yet ready to be integrated
with some automatic decoded, but the content is ready to be used, as a standalone script for the now.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
