### PR TITLE
fix(syslogng): increase buffer sizes

### DIFF
--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -45,8 +45,8 @@ def configure_syslogng_target_script(host: str, port: int, throttle_per_second: 
         disk_buffer_option=""
         if syslog-ng -V | grep disk; then
             disk_buffer_option="disk-buffer(
-                    mem-buf-size(100000)
-                    disk-buf-size(2000000)
+                    mem-buf-size(1048576)
+                    disk-buf-size(104857600)
                     reliable(yes)
                     dir(\\\"/tmp\\\")
                 )"


### PR DESCRIPTION
We have problems with missing log lines when there's a flood from scylla log.

Increase buffer sizes so we syslogng survives log bursts.

fixes: #6689

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
