### PR TITLE
fix(k8s): collect all the logs keeping the directories structure

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1199,12 +1199,12 @@ class KubernetesAPIServerLogCollector(BaseSCTLogCollector):
 class KubernetesLogCollector(BaseSCTLogCollector):
     """Gather K8S logs."""
     log_entities = [
-        FileLog(name='cert_manager.log', search_locally=True),
-        FileLog(name='scylla_manager.log', search_locally=True),
-        FileLog(name='scylla_operator.log', search_locally=True),
-        FileLog(name='haproxy_ingress.log', search_locally=True),
-        FileLog(name='*_cluster_events.log', search_locally=True),
-        FileLog(name='kubectl.version', search_locally=True),
+        DirLog(name='cert_manager.log', search_locally=True),
+        DirLog(name='scylla_manager.log', search_locally=True),
+        DirLog(name='scylla_operator.log', search_locally=True),
+        DirLog(name='haproxy_ingress.log', search_locally=True),
+        DirLog(name='*_cluster_events.log', search_locally=True),
+        DirLog(name='kubectl.version', search_locally=True),
         DirLog(name='cluster-scoped-resources/*', search_locally=True),
         DirLog(name='namespaces/*', search_locally=True),
     ]


### PR DESCRIPTION
For now, we put `cert_manager.log` file and other similar into the single destination dir even if we use multiple K8S. 
So, to avoid the harmful file rewriting, use only `DirLog` classes for log entities.

It becomes useful in multiDC (multi K8S clusters) setups.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
