### PR TITLE
fix(integration-tests): fix LoaderSetDummy class

### DIFF
--- a/unit_tests/dummy_remote.py
+++ b/unit_tests/dummy_remote.py
@@ -74,8 +74,8 @@ class LocalLoaderSetDummy(BaseCluster):
     # pylint: disable=super-init-not-called,abstract-method
     def __init__(self, nodes=None):
         self.name = "LocalLoaderSetDummy"
-        self.nodes = nodes if nodes is not None else [LocalNode("loader_node", parent_cluster=self)]
         self.params = {}
+        self.nodes = nodes if nodes is not None else [LocalNode("loader_node", parent_cluster=self)]
 
     @staticmethod
     def get_db_auth():

--- a/unit_tests/test_manual.py
+++ b/unit_tests/test_manual.py
@@ -57,6 +57,7 @@ class DbNode:  # pylint: disable=no-init,too-few-public-methods
 class LoaderSetDummy:  # pylint: disable=no-init,too-few-public-methods
     def __init__(self):
         self.nodes = [Node()]
+        self.params = {}
 
     @staticmethod
     def get_db_auth():


### PR DESCRIPTION
`params` class attribute for `LoaderSetDummy` started to be required (due introduction of dns_names). Missing it is causing some integration tests to fail.

This commit adds `params` attribute to `LoaderSetDummy` class with empty content (as it's not required)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
