### PR TITLE
fix(longevity-alternator-3h): set different default AZ

### DIFF
--- a/jenkins-pipelines/longevity-alternator-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-alternator-3h.jenkinsfile
@@ -6,6 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
+    availability_zone: 'c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-alternator-3h.yaml',
 


### PR DESCRIPTION
since this test is running on `i4i.4xlarge` by default, and the availability for these instances on AZ `a` is minimal, as the following error shows:
```
(InsufficientInstanceCapacity) when calling the RunInstances
operation (reached max retries: 4): We currently do not have
sufficient i4i.4xlarge capacity in the Availability Zone you
requested (us-east-1a). Our system will be working on
provisioning additional capacity. You can currently get
i4i.4xlarge capacity by not specifying an Availability Zone
in your request or choosing us-east-1b, us-east-1c,
us-east-1d, us-east-1f.
```

moving the default to `c` did make the 5.4 job at least start, so sending this PR to change the default, to increase the chance of success.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
