### PR TITLE
fix(large-partition-200k-pk): Change default AZ

### DIFF
--- a/jenkins-pipelines/longevity-large-partition-200k-pks-4days.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-200k-pks-4days.jenkinsfile
@@ -6,6 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
+    availability_zone: 'b',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
     test_config: 'test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml'
 


### PR DESCRIPTION
since we are failing to run the test because of
lack of resources, and following the error message from EC2:
```
An error occurred (InsufficientInstanceCapacity) when
calling the RunInstances operation (reached max retries: 4):
We currently do not have sufficient c5n.4xlarge capacity in
the Availability Zone you requested (eu-west-1a). Our
system will be working on provisioning additional capacity.
You can currently get c5n.4xlarge capacity by not specifying
an Availability Zone in your request or choosing eu-west-1b,
eu-west-1c.
```

found this when running 5.4 job, and changing the
default AZ would allow the test to run better, without failing with lack of resources again and again.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
