### PR TITLE
fix(nemesis): snapshot expected result should include view(s) of table

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -95,7 +95,7 @@ from sdcm.utils.common import (get_db_tables, generate_random_string,
                                update_certificates, reach_enospc_on_node, clean_enospc_on_node,
                                parse_nodetool_listsnapshots,
                                update_authenticator, ParallelObject,
-                               ParallelObjectResult, sleep_for_percent_of_duration)
+                               ParallelObjectResult, sleep_for_percent_of_duration, get_views_of_base_table)
 from sdcm.utils.compaction_ops import CompactionOps, StartStopCompactionArgs
 from sdcm.utils.context_managers import nodetool_context
 from sdcm.utils.decorators import retrying, latency_calculator_decorator
@@ -3012,12 +3012,12 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             The snapshot may be taken for a few options:
             - for all keyspaces (with all their tables) - nodetool snapshot cmd without parameters:
                 nodetool snapshot
-            - for one kespace (with all its tables) - nodetool snapshot cmd with "-ks" parameter:
+            - for one keyspace (with all its tables) - nodetool snapshot cmd with "-ks" parameter:
                 nodetool snapshot -ks system
             - for a few keyspaces (with all their tables) - nodetool snapshot cmd with "-ks" parameter:
                 nodetool snapshot -ks system, system_schema
-            - for one kespace and few tables - nodetool snapshot cmd with "-cf" parameter like:
-                nodetool snapshot test -cf cf1,cf2
+            - for one keyspace and few tables - nodetool snapshot cmd with "-cf" parameter like:
+                nodetool snapshot test -cf cf1,cf2. In this case the snapshot will be taken for table and its MVs
 
             By parsing of nodetool_cmd is recognized with type of snapshot was created.
             This function check if all expected keyspace/tables are in the snapshot
@@ -3027,12 +3027,19 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         keyspace_table = []
         if len(snapshot_params) > 1:
             if snapshot_params[1] == "-kc":
+                # Example: snapshot -kc cqlstress_lwt_example
                 for ks in snapshot_params[2].split(','):
                     keyspace_table.extend([k_c.split('.') for k_c in ks_cf if k_c.startswith(f"{ks}.")])
             else:
+                # Example: snapshot cqlstress_lwt_example -cf blogposts_update_one_column_lwt_indicator_expect,blogposts
                 keyspace = snapshot_params[1]
-                keyspace_table.extend([[keyspace, cf] for cf in snapshot_params[3].split(',')])
+                with self.cluster.cql_connection_patient(self.cluster.nodes[0]) as session:
+                    for cf in snapshot_params[3].split(','):
+                        keyspace_table.extend([[keyspace, cf]])
+                        for view in get_views_of_base_table(keyspace_name=keyspace, base_table_name=cf, session=session):
+                            keyspace_table.extend([[keyspace, view]])
         else:
+            # Example: snapshot
             keyspace_table.extend([k_c.split('.') for k_c in ks_cf])
 
         snapshot_content_list = [[elem.keyspace_name, elem.table_name] for elem in snapshot_content]

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -153,6 +153,18 @@ def get_first_view_with_name_like(view_name_substr: str, session) -> tuple:
     return result.one().keyspace_name, result.one().view_name, result.one().base_table_name
 
 
+def get_views_of_base_table(keyspace_name: str, base_table_name: str, session) -> list:
+    query = f"select view_name from system_schema.views " \
+            f"where keyspace_name = '{keyspace_name}' and base_table_name = '{base_table_name}' ALLOW FILTERING"
+    LOGGER.debug("Run query: %s", query)
+    result = session.execute(query)
+    views = []
+    for row in result:
+        views.append(row.view_name)
+
+    return views
+
+
 def get_entity_columns(keyspace_name: str, entity_name: str, session) -> list:
     query = f"select column_name, kind, type from system_schema.columns where keyspace_name = '{keyspace_name}' " \
             f"and table_name='{entity_name}'"


### PR DESCRIPTION
`disrupt_snapshot_operations` nemesis fails with error: 'Snapshot content not as expected. ' It happens when the snapshot is taken for list of tables with command qith '-cf- parameter, like: 
`snapshot cqlstress_lwt_example -cf blogposts_update_one_column_lwt_indicator_expect,blogposts`

and the table has view(s).

It happens  after the https://github.com/scylladb/scylladb/commit/ad04f200d3b058a0ee27f0d4920ba02d487564d2 was merged but nemesis was not adjusted.

Now the Scylla automatically takes snapshot of views when snapping the base table. 
This fix adds related MVs to the expected result of snapshot

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/6527

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
