### PR TITLE
improvement(k8s): use region_name in the loader pods names

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -3019,12 +3019,14 @@ class LoaderPodCluster(cluster.BaseLoaderSet, PodCluster):
             self.k8s_clusters[current_dc_idx].deploy_loaders_cluster(
                 node_pool_name=self.node_pool_name, namespace=self.namespace)
             node_count_in_dc = count[current_dc_idx] if current_dc_idx < len(count) else count[0]
+            k8s_loader_cluster_name = (
+                f"{self.loader_cluster_name}-{self.k8s_clusters[current_dc_idx].region_name}")
             if self.k8s_loader_run_type == "dynamic":
                 # TODO: if it is needed to catch coredumps of loader pods then need to create
                 #       appropriate daemonset with affinity rules for scheduling on the loader K8S nodes
                 for node_index in range(node_count_in_dc):
                     node = self.PodContainerClass(
-                        name=f"{self.loader_cluster_name}-{node_index}",
+                        name=f"{k8s_loader_cluster_name}-{node_index}",
                         parent_cluster=self,
                         base_logdir=self.logdir,
                         node_prefix=self.node_prefix,
@@ -3042,7 +3044,7 @@ class LoaderPodCluster(cluster.BaseLoaderSet, PodCluster):
                 modifiers=self.k8s_clusters[current_dc_idx].calculated_loader_affinity_modifiers,
                 environ={
                     "K8S_NAMESPACE": self.namespace,
-                    "K8S_LOADER_CLUSTER_NAME": self.loader_cluster_name,
+                    "K8S_LOADER_CLUSTER_NAME": k8s_loader_cluster_name,
                     "DOCKER_IMAGE_WITH_TAG": self._get_docker_image(),
                     "N_LOADERS": node_count_in_dc,
                     "POD_CPU_LIMIT": self.k8s_clusters[current_dc_idx].calculated_loader_cpu_limit,


### PR DESCRIPTION
Running a multiDC K8S setups we need to understand which region which loader belongs to as easy as possible.
So, add `region_name` value to the loader pods names.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
