### PR TITLE
fix(k8s): wait for pods readiness in `add_nodes` method

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2347,7 +2347,11 @@ class PodCluster(cluster.BaseCluster):
 
         # Wait while whole cluster (on all racks) including new nodes are up and running
         current_dc_nodes = [node for node in self.nodes if node.dc_idx == dc_idx]
-        self.wait_for_pods_running(pods_to_wait=count, total_pods=len(current_dc_nodes) + count, dc_idx=dc_idx)
+        expected_dc_nodes_count = len(current_dc_nodes) + count
+        self.wait_for_pods_running(
+            pods_to_wait=count, total_pods=expected_dc_nodes_count, dc_idx=dc_idx)
+        self.wait_for_pods_readiness(
+            pods_to_wait=count, total_pods=expected_dc_nodes_count, dc_idx=dc_idx)
 
         # Register new nodes and return whatever was registered
         k8s_pods = KubernetesOps.list_pods(self.k8s_clusters[dc_idx], namespace=self.namespace)


### PR DESCRIPTION
Creating Scylla pods in the `add_nodes` method we wait only for the `Running` state of pods.
In this state Scylla pods are running and Scylla is only starting.
It is ok to do so in case of the single region,
because while a last Scylla pod is being bootstrapped we do other stuff
such as package installation and monitoring configuration.

But running the multiDC setup, it is not acceptable, 
because we create next DB members right after the last one is created in the first region.
As of now, we get following error in the multiDC setup:

```
  ERROR 2023-11-02 09:56:21,418 [shard 0] init - Startup failed: \
    std::runtime_error (Node 10.0.9.215 has gossip status=UNKNOWN. \
    Try fixing it before adding new node to the cluster.)
```

So, fix it by waiting for the pod `readiness` in the `add_nodes` method.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
