### PR TITLE
feature(k8s-eks): support multi K8S clusters creation (multiDC) in EKS

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1538,10 +1538,12 @@ def clean_clusters_eks(tags_dict: dict, regions: list = None, dry_run: bool = Fa
 
     def delete_cluster(cluster):
         if not dry_run:
-            LOGGER.info("Going to delete: %s", cluster.name)
+            LOGGER.info("Going to delete '%s' EKS cluster in the '%s' region.",
+                        cluster.name, cluster.region_name)
             try:
                 res = cluster.destroy()
-                LOGGER.info("%s deleted=%s", cluster.name, res)
+                LOGGER.info("'%s' EKS cluster in the '%s' region has been deleted. Response=%s",
+                            cluster.name, cluster.region_name, res)
             except Exception as exc:  # pylint: disable=broad-except
                 LOGGER.error(exc)
 


### PR DESCRIPTION
List of changes:
- Add new function to the `eks.py` module which should be used for the creation of any new EKS cluster.
- Utilize that new function in the `tester.py` module creating K8S/EKS clusters.
- Use the `params.region_names` attribute of the Tester class instance to define the number of K8S clusters we want to create. It will be equal to the number of configured AWS regions in the `region_name` SCT config option.
- Update the `clean_clusters_eks` function in the `sdcm/utils/common.py` module with the region info.
  Do it for ease of debugging.

What this change doesn't:
- CI job configuration. It is planeed to be added separately.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
