### PR TITLE
fix(disrupt_create_index): ignore apply view update errors

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -82,7 +82,8 @@ from sdcm.sct_events.group_common_events import (ignore_alternator_client_errors
                                                  ignore_scrub_invalid_errors, ignore_view_error_gate_closed_exception,
                                                  ignore_stream_mutation_fragments_errors,
                                                  ignore_ycsb_connection_refused, decorate_with_context,
-                                                 ignore_reactor_stall_errors)
+                                                 ignore_reactor_stall_errors,
+                                                 ignore_error_apply_view_update)
 from sdcm.sct_events.health import DataValidatorEvent
 from sdcm.sct_events.loaders import CassandraStressLogEvent, ScyllaBenchEvent
 from sdcm.sct_events.nemesis import DisruptionEvent
@@ -4629,7 +4630,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         Create index on a random column (regular or static) of a table with the most number of partitions and wait until it gets build.
         Then verify it can be used in a query. Finally, drop the index.
         """
-        with self.cluster.cql_connection_patient(self.target_node, connect_timeout=300) as session:
+        with ignore_error_apply_view_update(), \
+                self.cluster.cql_connection_patient(self.target_node, connect_timeout=300) as session:
+
             ks_cf_list = self.cluster.get_non_system_ks_cf_list(self.target_node, filter_out_mv=True)
             if not ks_cf_list:
                 raise UnsupportedNemesis("No table found to create index on")

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -207,6 +207,18 @@ def ignore_view_error_gate_closed_exception():
 
 
 @contextmanager
+def ignore_error_apply_view_update():
+    with ExitStack() as stack:
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*view - Error applying view update.*data_dictionary::no_such_column_family",
+            extra_time_to_expiration=30
+        ))
+        yield
+
+
+@contextmanager
 def ignore_stream_mutation_fragments_errors():
     with ExitStack() as stack:
         stack.enter_context(EventsSeverityChangerFilter(
@@ -230,7 +242,7 @@ def ignore_stream_mutation_fragments_errors():
         stack.enter_context(EventsSeverityChangerFilter(
             new_severity=Severity.WARNING,
             event_class=DatabaseLogEvent,
-            regex=r".*node_ops - decommission.*Operation failed.*std::runtime_error.*aborted_by_user=true, failed_because=N\/A",
+            regex=r".*node_ops \- decommission.*Operation failed.*std::runtime_error.*aborted_by_user=true, failed_because=N\/A",
             extra_time_to_expiration=30
         ))
         stack.enter_context(EventsSeverityChangerFilter(


### PR DESCRIPTION
During drop SI in CreateIndexNemesis, next errors could happend on nodes:
```
 [shard 11] view - Error applying view update to 10.12.10.61
(view: keyspace1.standard1_c0_nemesis_index, base token: -1446481564018001834,
 view token: -1014392873274778199): data_dictionary::no_such_column_family
 (Can't find a column family with UUID 4f2d7a10-d151-11ed-b247-2390a99b8089)
```

These errors could be expected as discussed in issue: scylladb/scylladb#12977

Change severity for such issues from Error to Warning.

fix scylladb/scylladb#12977

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
