### PR TITLE
fix(k8s): make quasi-multidc func test be more stable

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -140,7 +140,7 @@ def test_deploy_quasi_multidc_db_cluster(db_cluster: ScyllaPodCluster):  # pylin
     def get_pod_names_and_ips(cluster_name: str, namespace: str):
         pod_names_and_ips = kubectl(
             "get pods --no-headers -o=custom-columns=':.metadata.name,:.status.podIP'"
-            f" -l scylla/cluster={cluster_name}",
+            f" -l scylla/cluster={cluster_name},app.kubernetes.io/name=scylla",
             namespace=namespace).stdout.split("\n")
         pod_names_and_ips = [row.strip() for row in pod_names_and_ips if row.strip()]
         assert pod_names_and_ips


### PR DESCRIPTION
There is race condition which may cause following error:

```
    assert pod_names_and_ips
    >   assert len(pod_names_and_ips) == 3
    E   AssertionError: assert 4 == 3
    E    +  where 4 = len([\
      'cleanup-t-podip-quasi-multidc-quasi-dc-2-rack-1-1-vd6kn   10.16.218.203', \
      't-podip-quasi-multidc-quasi-dc-2-rack-1-0                 10.16.218.71', \
      't-podip-quasi-multidc-quasi-dc-2-rack-1-1                 10.16.218.73', \
      't-podip-quasi-multidc-quasi-dc-2-rack-1-2                 10.16.0.77'])
    functional_tests/scylla_operator/test_functional.py:147: AssertionError
```

It is caused by the fact that `Scylla cleanup pods` also have the `scylla/cluster={cluster_name}` label.
So, fix it by adding one more label that is unique to Scylla pods.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
