### PR TITLE
fix(events): ignore error with MV related error in shutdown

### DIFF
--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -70,6 +70,9 @@ def start_events_device(log_dir: Optional[Union[str, Path]] = None,
                                 event_class=DatabaseLogEvent.DATABASE_ERROR,
                                 regex='ldap_connection - Seastar read failed: std::system_error '
                                 '(error system:104, read: Connection reset by peer)').publish()
+    EventsSeverityChangerFilter(new_severity=Severity.WARNING,
+                                event_class=DatabaseLogEvent.RUNTIME_ERROR,
+                                regex='view update generator not plugged to push updates').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: supressed').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: suppressed').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.WARNING, line='abort_requested_exception').publish()


### PR DESCRIPTION
It was agree that those are not high severity, and we can ignore them for now, decided to global ignore those, and not try to apply the filter only the shutdowns.

Ref: scylladb/scylladb#15672

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
