### PR TITLE
Fixed Improper Method Call: Replaced `mktemp`

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2646,7 +2646,9 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         if bundle_cmd_output.failed:
             return None
 
-        bundle_file = Path(tempfile.mktemp(suffix='.yaml'))
+        fd, file_name = tempfile.mkstemp(suffix='.yaml')
+        os.close(fd)
+        bundle_file = Path(file_name)
         bundle_file.write_bytes(base64.decodebytes(bytes(bundle_cmd_output.stdout.strip(), encoding='utf-8')))
 
         lb_external_hostname = k8s_cluster.kubectl(

--- a/sdcm/microbenchmarking.py
+++ b/sdcm/microbenchmarking.py
@@ -313,7 +313,8 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
         if html_report_path:
             html_file_path = html_report_path
         else:
-            html_file_path = tempfile.mkstemp(suffix=".html", prefix="microbenchmarking-")[1]
+            html_fd, html_file_path = tempfile.mkstemp(suffix=".html", prefix="microbenchmarking-")
+            os.close(html_fd)
         self.render_to_html(for_render, html_file_path=html_file_path)
         for_render["full_report"] = False
         summary_html = self.render_to_html(for_render)

--- a/sdcm/remote/remote_base.py
+++ b/sdcm/remote/remote_base.py
@@ -59,7 +59,8 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
             self.extra_ssh_options = extra_ssh_options
         if auth_sleep_time is not None:
             self.auth_sleep_time = auth_sleep_time
-        self.known_hosts_file = tempfile.mkstemp()[1]
+        fd, self.known_hosts_file = tempfile.mkstemp()
+        os.close(fd)
         self._context_generation = 0
         super().__init__(hostname=hostname, user=user, password=password)
 


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->

<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)


## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [`__init__.py`](https://github.com/scylladb/scylla-cluster-tests/blob/master/sdcm/cluster_k8s/__init__.py#L2649), there is a method that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the [Python documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp). iCR suggested that a temporary file should be created using `mkstemp` which is a [safe API](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp). iCR replaced the usage of mktemp with `mkstemp`.


#### Resources Related to `mktemp`
- [POC - Improper Method Call - python - mktemp.mp4](https://drive.google.com/file/d/16YKuKgv7iItWcac2biRyi2Cm8upJ3HP_/view?usp=share_link)
- [MISC - Python - Taking a peek under the tempfile library.mp4](https://drive.google.com/file/d/1ns2_x_ZDvzFwj0eNNxyay-HUMclLasNT/view?usp=share_link)


## Changes
- Replaced `mktemp()` method with `mkstemp()`
- Closed file-descriptors related to `mkstemp()`


## Previously Found & Fixed
- https://www.github.com/spcl/dace/pull/1428
- https://www.github.com/invesalius/invesalius3/pull/679
- https://www.github.com/Azure/azure-linux-extensions/pull/1816
- https://www.github.com/celery/billiard/pull/394


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
