### PR TITLE
feature(cluster): add `instance_type` to `add_nodes()` call

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3372,11 +3372,12 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
     def wait_for_init(self):
         raise NotImplementedError("Derived class must implement 'wait_for_init' method!")
 
-    def add_nodes(self, count, ec2_user_data='', dc_idx=0, rack=0, enable_auto_bootstrap=False):
+    def add_nodes(self, count, ec2_user_data='', dc_idx=0, rack=0, enable_auto_bootstrap=False, instance_type=None):
         """
         :param count: number of nodes to add
         :param ec2_user_data:
         :param dc_idx: datacenter index, used as an index for self.datacenter list
+        :param instance_type: type of instance to use, can override what's defined in configuration
         :return: list of Nodes
         """
         raise NotImplementedError("Derived class must implement 'add_nodes' method!")

--- a/sdcm/cluster_baremetal.py
+++ b/sdcm/cluster_baremetal.py
@@ -122,7 +122,8 @@ class PhysicalMachineCluster(cluster.BaseCluster):  # pylint: disable=abstract-m
         return node
 
     # pylint: disable=unused-argument,too-many-arguments
-    def add_nodes(self, count, ec2_user_data='', dc_idx=0, rack=0, enable_auto_bootstrap=False):
+    def add_nodes(self, count, ec2_user_data='', dc_idx=0, rack=0, enable_auto_bootstrap=False, instance_type=None):
+        assert instance_type is None, "baremetal can provision diffrent types"
         for node_index in range(count):
             node_name = '%s-%s' % (self.node_prefix, node_index)
             self.nodes.append(self._create_node(node_name,

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -258,7 +258,8 @@ class DockerCluster(cluster.BaseCluster):  # pylint: disable=abstract-method
             self.nodes.append(node)
         return self.nodes
 
-    def add_nodes(self, count, ec2_user_data="", dc_idx=0, rack=0, enable_auto_bootstrap=False):
+    def add_nodes(self, count, ec2_user_data="", dc_idx=0, rack=0, enable_auto_bootstrap=False, instance_type=None):
+        assert instance_type is None, "docker can't provision different instance types"
         return self._get_nodes() if self.test_config.REUSE_CLUSTER else self._create_nodes(count, enable_auto_bootstrap)
 
 
@@ -444,7 +445,8 @@ class MonitorSetDocker(cluster.BaseMonitorSet, DockerCluster):  # pylint: disabl
         node.init()
         return node
 
-    def add_nodes(self, count, ec2_user_data="", dc_idx=0, rack=0, enable_auto_bootstrap=False):
+    def add_nodes(self, count, ec2_user_data="", dc_idx=0, rack=0, enable_auto_bootstrap=False, instance_type=None):
+        assert instance_type is None, "docker can provision different instance types"
         return self._create_nodes(count, enable_auto_bootstrap)
 
     @staticmethod

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2339,7 +2339,9 @@ class PodCluster(cluster.BaseCluster):
                   ec2_user_data: str = "",
                   dc_idx: int = 0,
                   rack: int = 0,
-                  enable_auto_bootstrap: bool = False) -> List[BasePodContainer]:
+                  enable_auto_bootstrap: bool = False,
+                  instance_type=None,
+                  ) -> List[BasePodContainer]:
 
         # TODO: make it work when we have decommissioned (by nodetool) nodes.
         #       Now it will fail because pod which hosts decommissioned Scylla member is reported
@@ -2732,7 +2734,8 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
                   # NOTE: 'dc_idx=None' means 'create %count% nodes on each K8S cluster'
                   dc_idx: int = None,
                   rack: int = 0,
-                  enable_auto_bootstrap: bool = False) -> List[BasePodContainer]:
+                  enable_auto_bootstrap: bool = False,
+                  instance_type=None) -> List[BasePodContainer]:
         if dc_idx is None:
             dc_idx = list(range(len(self.k8s_clusters)))
         elif isinstance(dc_idx, int):
@@ -2742,6 +2745,9 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         else:
             count = [count]
         assert len(count) in (1, len(dc_idx))
+
+        assert instance_type is None, "k8s can't provision different instance types"
+
         new_nodes = []
         self.log.debug(
             "'%s' configuration was taken for the 'dc_idx': %s",
@@ -3001,7 +3007,9 @@ class LoaderPodCluster(cluster.BaseLoaderSet, PodCluster):
                   # NOTE: 'dc_idx=None' means 'create %count% nodes on each K8S cluster'
                   dc_idx: int = None,
                   rack: int = 0,
-                  enable_auto_bootstrap: bool = False) -> List[BasePodContainer]:
+                  enable_auto_bootstrap: bool = False,
+                  instance_type=None
+                  ) -> List[BasePodContainer]:
         if self.loader_cluster_created:
             raise NotImplementedError(
                 "Changing number of nodes in LoaderPodCluster is not supported.")
@@ -3014,6 +3022,8 @@ class LoaderPodCluster(cluster.BaseLoaderSet, PodCluster):
         else:
             count = [count]
         assert len(count) in (1, len(dc_idx))
+        assert instance_type is None, "k8s can't provision different instance types"
+
         new_nodes = []
         for current_dc_idx in dc_idx:
             self.k8s_clusters[current_dc_idx].deploy_loaders_cluster(

--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -660,12 +660,15 @@ class EksScyllaPodCluster(ScyllaPodCluster):
                   ec2_user_data: str = "",
                   dc_idx: int = None,
                   rack: int = 0,
-                  enable_auto_bootstrap: bool = False) -> List[EksScyllaPodContainer]:
+                  enable_auto_bootstrap: bool = False,
+                  instance_type=None
+                  ) -> List[EksScyllaPodContainer]:
         new_nodes = super().add_nodes(count=count,
                                       ec2_user_data=ec2_user_data,
                                       dc_idx=dc_idx,
                                       rack=rack,
-                                      enable_auto_bootstrap=enable_auto_bootstrap)
+                                      enable_auto_bootstrap=enable_auto_bootstrap,
+                                      instance_type=instance_type)
         for node in new_nodes:
             ec2_instance_id = node.ec2_instance_id
             node.k8s_cluster.set_security_groups(ec2_instance_id)
@@ -707,8 +710,9 @@ class MonitorSetEKS(MonitorSetAWS):
         instances = sorted(instances, key=sort_by_index)
         return [ec2.get_instance(instance['InstanceId']) for instance in instances]
 
-    def _create_instances(self, count, ec2_user_data='', dc_idx=0, az_idx=0):
-        instances = super()._create_instances(count=count, ec2_user_data=ec2_user_data, dc_idx=dc_idx, az_idx=az_idx)
+    def _create_instances(self, count, ec2_user_data='', dc_idx=0, az_idx=0, instance_type=None):  # pylint: disable=too-many-arguments
+        instances = super()._create_instances(count=count, ec2_user_data=ec2_user_data, dc_idx=dc_idx,
+                                              az_idx=az_idx, instance_type=instance_type)
         for instance in instances:
             self._ec2_services[dc_idx].create_tags(
                 Resources=[instance.id],

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -505,12 +505,14 @@ class GkeScyllaPodCluster(ScyllaPodCluster):
                   ec2_user_data: str = "",
                   dc_idx: int = None,
                   rack: int = 0,
-                  enable_auto_bootstrap: bool = False) -> List[GkeScyllaPodContainer]:
+                  enable_auto_bootstrap: bool = False,
+                  instance_type=None) -> List[GkeScyllaPodContainer]:
         new_nodes = super().add_nodes(count=count,
                                       ec2_user_data=ec2_user_data,
                                       dc_idx=dc_idx,
                                       rack=rack,
-                                      enable_auto_bootstrap=enable_auto_bootstrap)
+                                      enable_auto_bootstrap=enable_auto_bootstrap,
+                                      instance_type=instance_type)
         return new_nodes
 
 

--- a/sdcm/sct_provision/region_definition_builder.py
+++ b/sdcm/sct_provision/region_definition_builder.py
@@ -67,7 +67,7 @@ class DefinitionBuilder(abc.ABC):
     def regions(self) -> List[str]:
         return self.params.get(self.REGION_MAP)
 
-    def build_instance_definition(self, region: str, node_type: NodeTypeType, index: int) -> InstanceDefinition:
+    def build_instance_definition(self, region: str, node_type: NodeTypeType, index: int, instance_type: str = None) -> InstanceDefinition:
         """Builds one instance definition of given type and index for given region"""
         user_prefix = self.params.get('user_prefix')
         common_tags = TestConfig.common_tags()
@@ -81,7 +81,7 @@ class DefinitionBuilder(abc.ABC):
         mapper = self.SCT_PARAM_MAPPER[node_type]
         return InstanceDefinition(name=name,
                                   image_id=self.params.get(mapper.image_id),
-                                  type=self.params.get(mapper.type),
+                                  type=instance_type or self.params.get(mapper.type),
                                   user_name=self.params.get(mapper.user_name),
                                   root_disk_size=self.params.get(mapper.root_disk_size),
                                   tags=tags,

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -415,7 +415,7 @@ class DummyCluster(BaseScyllaCluster, BaseCluster):  # pylint: disable=too-few-p
             node.config_setup(append_scylla_args=self.get_scylla_args())
 
     # pylint: disable=too-many-arguments
-    def add_nodes(self, count, ec2_user_data='', dc_idx=0, rack=0, enable_auto_bootstrap=False):
+    def add_nodes(self, count, ec2_user_data='', dc_idx=0, rack=0, enable_auto_bootstrap=False, instance_type=None):
         pass
 
 


### PR DESCRIPTION
So now whom ever is calling the `.add_nodes()` can define a diffrent instance type

note: this change doesn't add any configuration option for holding those types, and doesn't do any check that they would fit the backend being used, that on the caller to select the correct types

Closes: #6796

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
