### PR TITLE
fix(test_sct_events_file_logger): Increase thread timeout to 3 seconds

### DIFF
--- a/unit_tests/test_sct_events_file_logger.py
+++ b/unit_tests/test_sct_events_file_logger.py
@@ -38,7 +38,7 @@ class TestFileLogger(unittest.TestCase, EventsUtilsMixin):
         self.assertEqual(self.file_logger._registry, self.events_processes_registry)
 
     def tearDown(self) -> None:
-        self.file_logger.stop(timeout=1)
+        self.file_logger.stop(timeout=3)
         self.teardown_events_processes()
 
     def test_file_logger(self) -> None:


### PR DESCRIPTION
This change fixes an issue where a PR pipeline would randomly fail due
to a low teardown timeout.

Fixes #6747

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
