### PR TITLE
improvement(k8s): handle better the target node change in K8S nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1392,7 +1392,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def _disrupt_kubernetes_then_replace_scylla_node(self, disruption_method):
         if not self._is_it_on_kubernetes():
             raise UnsupportedNemesis('Supported only on kubernetes')
-        self.set_target_node()
         node = self.target_node
         InfoEvent(f'Running {disruption_method} on K8S node that hosts {node} scylla pod').publish()
         old_uid = node.k8s_pod_uid
@@ -1439,6 +1438,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if not self._is_it_on_kubernetes():
             raise UnsupportedNemesis('Supported only on kubernetes')
         self.set_target_node(
+            # NOTE: pick up a new target node only in the same region to reduce possible confusion
+            #       during the debug process in case of a failure.
+            dc_idx=self.target_node.dc_idx,
             rack=random.choice(list(self.cluster.racks)), allow_only_last_node_in_rack=True)
         node = self.target_node
 


### PR DESCRIPTION
Make the `_disrupt_kubernetes_then_decommission_and_add_scylla_node` nemesis method
pick the latest Scylla pod in a rack only in the same region as the current target node.
It will allow us to avoid possible confusion in case of the debugging a failure in the multiDC setup.

Also, remove redefinition of the target node
in the `_disrupt_kubernetes_then_replace_scylla_node` nemesis method.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
