### PR TITLE
test(artifact): disable writeback cache setting verification

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -226,13 +226,6 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
                                 f"matches: {snitch_matches_scylla_yaml}"
                             )
 
-    def verify_write_back_cache_param(self) -> None:
-        if self.params.get("cluster_backend") in ("gce", "azure") and self.params.get("use_preinstalled_scylla"):
-            expected_write_back_cache_param = 0
-        else:
-            expected_write_back_cache_param = None
-        self.assertEqual(self.write_back_cache, expected_write_back_cache_param)
-
     def verify_docker_latest_match_release(self) -> None:
         for product in typing.get_args(ScyllaProduct):
             latest_version = get_latest_scylla_release(product=product)
@@ -315,9 +308,6 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
         if backend == "aws":
             with self.subTest("check ENA support"):
                 assert self.node.ena_support, "ENA support is not enabled"
-
-        with self.subTest("verify write_back_cache perftune parameter"):
-            self.verify_write_back_cache_param()
 
         with self.subTest("verify write cache for NVMe devices"):
             self.verify_nvme_write_cache()


### PR DESCRIPTION
It was decided to not to set writeback cache setting in perftune, while we specifically verify this setting. This causes artifact test fail.

Idea is to disable this verification temporarily so it does not break artifact tests and enable it back when [the
change](https://github.com/scylladb/scylla-machine-image/pull/394) is merged.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
