### PR TITLE
fix(BoostrapStreamError): Run bootstrap in thread

### DIFF
--- a/jenkins-pipelines/nemesis/longevity-5gb-1h-BootstrapStreamingErrMonkey-aws.jenkinsfile
+++ b/jenkins-pipelines/nemesis/longevity-5gb-1h-BootstrapStreamingErrMonkey-aws.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/nemesis/longevity-5gb-1h-BootstrapStreamingErrMonkey.yaml'
+
+)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -276,6 +276,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self._alert_manager: Optional[PrometheusAlertManagerListener] = None
 
         self.termination_event = threading.Event()
+        self._wait_for_stop_event = threading.Event()
         self.lock = threading.Lock()
 
         self._running_nemesis = None
@@ -508,6 +509,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
         with self.lock:
             self._running_nemesis = nemesis
+
+    @property
+    def wait_for_stop_event(self):
+        return self._wait_for_stop_event
 
     @cached_property
     def distro(self):
@@ -1333,7 +1338,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         text = None
         if verbose:
             text = '%s: Waiting for DB services to be up' % self
-        wait.wait_for(func=self.db_up, step=60, text=text, timeout=timeout, throw_exc=True)
+
+        wait.wait_for(func=self.db_up, step=60, text=text, timeout=timeout,
+                      throw_exc=True, stop_event=self._wait_for_stop_event)
         self.db_init_finished = True
         try:
             self._report_housekeeping_uuid(verbose=True)
@@ -4529,7 +4536,6 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 result = node.remoter.run("cat /proc/sys/crypto/fips_enabled", ignore_status=True)
                 assert int(result.stdout) == 1, "Even though Ubuntu pro is enabled, FIPS is not enabled"
                 # https://ubuntu.com/tutorials/using-the-ua-client-to-enable-fips#4-enabling-fips-crypto-modules
-
         node.update_repo_cache()
         node.install_package('lsof net-tools', wait_for_package_manager=True)
         install_scylla = True
@@ -4561,7 +4567,6 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             node.config_setup(append_scylla_args=self.get_scylla_args())
 
             self._scylla_post_install(node, install_scylla, nic_devname)
-
             # prepare and start saslauthd service
             if self.params.get('prepare_saslauthd'):
                 prepare_and_start_saslauthd_service(node)
@@ -4618,7 +4623,6 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 self.install_scylla_manager(node)
         else:
             self._reuse_cluster_setup(node)
-
         node.wait_db_up(verbose=verbose, timeout=timeout)
         nodes_status = node.get_nodes_status()
         check_nodes_status(nodes_status=nodes_status, current_node=node)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -37,7 +37,6 @@ from collections import defaultdict, Counter, namedtuple
 from concurrent.futures import ThreadPoolExecutor
 from threading import Lock
 from types import MethodType  # pylint: disable=no-name-in-module
-from multiprocessing import Process
 
 from cassandra import ConsistencyLevel, InvalidRequest
 from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
@@ -121,6 +120,7 @@ from sdcm.utils.sstable.sstable_utils import SstableUtils
 from sdcm.utils.toppartition_util import NewApiTopPartitionCmd, OldApiTopPartitionCmd
 from sdcm.utils.version_utils import MethodVersionNotFound, scylla_versions
 from sdcm.utils.raft import Group0MembersNotConsistentWithTokenRingMembersException, TopologyOperations
+from sdcm.utils.raft.common import NodeBootStrapAbortHandler
 from sdcm.wait import wait_for, wait_for_log_lines
 from sdcm.exceptions import (
     KillNemesis,
@@ -4834,119 +4834,70 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         If node was not added anyway, clean it from cluster
         and return the cluster to initial state(by num of nodes)
         """
+        instance_start_timeout = 300
         new_node: BaseNode = self.cluster.add_nodes(
             count=1, dc_idx=self.target_node.dc_idx, enable_auto_bootstrap=True, rack=self.target_node.rack)[0]
         self.monitoring_set.reconfigure_scylla_monitoring()
         self.set_current_running_nemesis(node=new_node)  # prevent to run nemesis on new node when running in parallel
 
-        def start_bootstrap(new_node: BaseNode, timeout=3600):
-            bootstrap_process = Process(target=self.cluster.node_setup,
-                                        name=f"Bootstraping_{new_node.name}",
-                                        kwargs={"node": new_node, "verbose": True, "timeout": int(timeout)},
-                                        daemon=True)
-            try:
-                self.log.info("Start node %s setup and bootstrapp", new_node.name)
-                bootstrap_log_follower = new_node.follow_system_log(patterns=['init - Startup failed',
-                                                                              'init - Startup interrupted',
-                                                                              'initialization completed'])
-                bootstrap_process.start()
-                log_messages = wait_for(func=lambda: list(bootstrap_log_follower),
-                                        text='Waiting for bootstap aborting or finishing', step=5, timeout=timeout)
-
-                if log_messages and ('init - Startup failed' in log_messages[0] or 'init - Startup interrupted' in log_messages[0]):
-                    self.log.debug("Bootstrap node %s was aborted", new_node.name)
-                    raise NodeSetupFailed(node=new_node, error_msg=log_messages[0])
-
-                if new_node.db_up() and new_node.jmx_up():
-                    self.log.info("Node %s bootstrapped succesfull", new_node.name)
-            except Exception as exc:  # pylint: disable=broad-except
-                self.log.warning("Node bootstrap was aborted with error: %s", exc)
-            finally:
-                self.log.debug("Stop node bootstrap process")
-                bootstrap_process.join(60)
-                bootstrap_process.terminate()
-                self.log.debug("Node bootstrap process stopped")
-
-        trigger = partial(
-            start_bootstrap, new_node=new_node)
-
         terminate_pattern = self.target_node.raft.get_random_log_message(operation=TopologyOperations.BOOTSTRAP,
                                                                          seed=self.tester.params.get("nemesis_seed"))
 
-        self.log.info("Stop bootsrap process after log message: '%s'", terminate_pattern.log_message)
+        bootstrapabortmanager = NodeBootStrapAbortHandler(node=new_node, verification_node=self.target_node)
 
-        log_follower = new_node.follow_system_log(patterns=[terminate_pattern.log_message])
+        trigger = partial(
+            bootstrapabortmanager.start_bootstrap)
 
-        watcher = partial(
-            self._call_disrupt_func_after_expression_logged,
-            log_follower=log_follower,
-            disrupt_func=new_node.stop_scylla,
-            disrupt_func_kwargs={},
-            delay=0
-        )
+        watcher = partial(bootstrapabortmanager.abort_bootstrap,
+                          log_message=terminate_pattern.log_message,
+                          timeout=terminate_pattern.timeout + instance_start_timeout)
 
-        with EventsSeverityChangerFilter(new_severity=Severity.WARNING,
-                                         event_class=DatabaseLogEvent,
-                                         regex=".*init - Startup failed.*",
-                                         extra_time_to_expiration=30), \
-                adaptive_timeout(operation=Operations.NEW_NODE, node=self.target_node, timeout=3600) as bootstrap_timeout:
-            ParallelObject(objects=[trigger, watcher], timeout=bootstrap_timeout).call_objects(ignore_exceptions=True)
+        with ignore_stream_mutation_fragments_errors(), contextlib.ExitStack() as stack:
+            for expected_start_failed_context in self.target_node.raft.get_severity_change_filters_scylla_start_failed(
+                    terminate_pattern.timeout):
+                stack.enter_context(expected_start_failed_context)
+            try:
+                ParallelObject(objects=[trigger, watcher],
+                               timeout=terminate_pattern.timeout + instance_start_timeout).call_objects(ignore_exceptions=True)
+            finally:
+                bootstrapabortmanager.set_wait_stop_event()
 
-        host_id_searcher = new_node.follow_system_log(patterns=['Setting local host id to'])
-
-        def clean_unbootstrapped_node():
-            new_node_host_ids = []
-            if found_stings := list(host_id_searcher):
-                for line in found_stings:
-                    new_node_host_id = line.split(" ")[-1].strip()
-                    self.log.info("Node %s has host id: %s in log", new_node.name, new_node_host_id)
-                    new_node_host_ids.append(new_node_host_id)
-            self.log.debug("New host was not properly bootstrapped. Terminate it")
-            self._terminate_cluster_node(new_node)
-            self.log.info("Sleep for gossiper updater")
-            time.sleep(60)
-            self.target_node.raft.clean_group0_garbage(raise_exception=True)
-            if new_node_host_ids:
-                for host_id in new_node_host_ids:
-                    self.target_node.run_nodetool(
-                        f"removenode {host_id}", ignore_status=True, retry=3, warning_event_on_exception=True)
-
-            assert self.target_node.raft.is_cluster_topology_consistent(), \
-                "Group0, Token Ring and number of node in cluster are differs. Check logs"
-            self.cluster.check_nodes_up_and_normal()
-            self.log.info("Failed bootstrapped node removed. Cluster is in initial state")
+        self.log.debug("Clear stop event for wait_for on node %s", new_node.name)
+        new_node.wait_for_stop_event.clear()
 
         if not new_node.db_up():
+            # stop scylla if it was started by scylla-manager-client during setup
+            new_node.stop_scylla_server(ignore_status=True, timeout=600)
+            # Clean garbage from group 0 and scylla data and restart setup
             try:
                 if self.target_node.raft.get_diff_group0_token_ring_members():
                     self.target_node.raft.clean_group0_garbage(raise_exception=True)
                     self.log.debug("Clean old scylla data and restart scylla service")
                     new_node.clean_scylla_data()
                 with adaptive_timeout(operation=Operations.NEW_NODE, node=self.target_node, timeout=3600) as bootstrap_timeout:
-                    new_node.start_scylla_server(verify_up_timeout=bootstrap_timeout)
+                    new_node.start_scylla_server(verify_up_timeout=bootstrap_timeout, verify_down=True)
                     new_node.start_scylla_jmx()
-
                 self.cluster.check_nodes_up_and_normal(nodes=[new_node], verification_node=self.target_node)
             except Exception as exc:  # pylint: disable=broad-except
                 err_message = f"Node {new_node.name} was not bootstrapped upon abort after log line {terminate_pattern}"
                 self.log.error("Scylla service restart failed: %s", exc)
                 self.log.error(err_message)
 
-                clean_unbootstrapped_node()
+                bootstrapabortmanager.clean_unbootstrapped_node()
                 raise BootstrapStreamErrorFailure(err_message) from exc
 
         if new_node.db_up() and not self.target_node.raft.is_cluster_topology_consistent():
-            LOGGER.error("New host was not properly bootstrapped. Terminate it")
-            clean_unbootstrapped_node()
-            self.log.info("Failed bootstrapped node removed. Cluster is in initial state")
-            return
+            LOGGER.error("New host %s was not properly bootstrapped. Terminate it", new_node.name)
+            bootstrapabortmanager.clean_unbootstrapped_node()
+            self.log.info("Failed bootstrapped node %s removed. Cluster is in initial state", new_node.name)
+            raise BootstrapStreamErrorFailure(f"Node {new_node.name} failed to bootstrap")
 
         if new_node.db_up() and self.target_node.raft.is_cluster_topology_consistent():
             self.log.info("Wait 5 minutes with new topology")
             time.sleep(300)
 
             self.log.info("Decommission added new node")
-            self.cluster.decommission(new_node)
+            self.cluster.decommission(new_node, timeout=7200)
 
     def disrupt_disable_binary_gossip_execute_major_compaction(self):
         def are_gate_closed_messages_raised(log_reader):

--- a/sdcm/utils/raft/__init__.py
+++ b/sdcm/utils/raft/__init__.py
@@ -240,7 +240,14 @@ class Raft(RaftFeatureOperations):
             EventsSeverityChangerFilter(new_severity=Severity.WARNING,
                                         event_class=DatabaseLogEvent.RUNTIME_ERROR,
                                         regex=r".*init - Startup failed: std::runtime_error.*repair_reason=bootstrap.*aborted_by_user=true",
-                                        extra_time_to_expiration=timeout)
+                                        extra_time_to_expiration=timeout),
+            EventsSeverityChangerFilter(new_severity=Severity.WARNING,
+                                        event_class=DatabaseLogEvent,
+                                        regex=".*init - Startup failed.*"),
+            EventsSeverityChangerFilter(new_severity=Severity.WARNING,
+                                        event_class=DatabaseLogEvent.DATABASE_ERROR,
+                                        regex=r".*node_ops - bootstrap.*Operation failed.*seastar::abort_requested_exception",
+                                        extra_time_to_expiration=timeout),
 
 
 

--- a/sdcm/utils/raft/common.py
+++ b/sdcm/utils/raft/common.py
@@ -1,5 +1,9 @@
 import logging
+from typing import Iterable
 
+from sdcm.cluster import BaseNode
+from sdcm.wait import wait_for
+from sdcm.sct_events.group_common_events import decorate_with_context, ignore_ycsb_connection_refused
 
 LOGGER = logging.getLogger(__name__)
 
@@ -29,3 +33,70 @@ def validate_raft_on_nodes(nodes: list["BaseNode"]) -> None:
         raise RaftException("Raft is not ready")
 
     LOGGER.debug("Raft is ready!")
+
+
+class NodeBootStrapAbortHandler:
+
+    def __init__(self, node: BaseNode, verification_node: BaseNode):
+        self.node = node
+        self.verification_node: BaseNode = verification_node
+
+    @property
+    def host_id_searcher(self) -> Iterable[str]:
+        return self.node.follow_system_log(patterns=['Setting local host id to'])
+
+    def set_wait_stop_event(self):
+        if not self.node.wait_for_stop_event.is_set():
+            self.node.wait_for_stop_event.set()
+        LOGGER.debug("Stop event was set for node %s", self.node.name)
+
+    def start_bootstrap(self, timeout=3600):
+        try:
+            LOGGER.debug("Starting bootstrap process %s", self.node.name)
+            self.node.parent_cluster.node_setup(self.node, verbose=True, timeout=timeout)
+        except Exception as exc:  # pylint: disable=broad-except
+            LOGGER.error("Setup failed for node %s with err %s", self.node.name, exc)
+        finally:
+            self.set_wait_stop_event()
+        LOGGER.debug("Node %s was bootstrapped", self.node.name)
+
+    def abort_bootstrap(self, log_message: str, timeout: int = 600):
+        LOGGER.debug("Stop bootsrap process after log message: '%s'", log_message)
+        log_follower = self.node.follow_system_log(patterns=[log_message])
+        try:
+            wait_for(func=lambda: list(log_follower), step=5,
+                     text="Waiting log message to stop scylla...",
+                     timeout=timeout,
+                     throw_exc=True,
+                     stop_event=self.node.wait_for_stop_event)
+            self.node.stop_scylla()
+            LOGGER.info("Scylla was stopped succesfully on node %s", self.node.name)
+        except Exception as exc:  # pylint: disable=broad-except
+            LOGGER.warning("Abort was failed on node %s with errof %s", self.node.name, exc)
+        finally:
+            self.set_wait_stop_event()
+
+    def clean_unbootstrapped_node(self):
+        node_host_ids = []
+        if found_stings := list(self.host_id_searcher):
+            for line in found_stings:
+                new_node_host_id = line.split(" ")[-1].strip()
+                LOGGER.debug("Node %s has host id: %s in log", self.node.name, new_node_host_id)
+                node_host_ids.append(new_node_host_id)
+        self.node.log.debug("New host was not properly bootstrapped. Terminate it")
+        self._terminate_node()
+        self.verification_node.raft.clean_group0_garbage(raise_exception=True)
+        if node_host_ids:
+            for host_id in node_host_ids:
+                self.verification_node.run_nodetool(
+                    f"removenode {host_id}", ignore_status=True, retry=3, warning_event_on_exception=True)
+
+        assert self.verification_node.raft.is_cluster_topology_consistent(), \
+            "Group0, Token Ring and number of node in cluster are differs. Check logs"
+        self.node.parent_cluster.check_nodes_up_and_normal()
+        LOGGER.info("Failed bootstrapped node %s removed. Cluster is in initial state", self.node.name)
+
+    @decorate_with_context(ignore_ycsb_connection_refused)
+    def _terminate_node(self):
+        self.node.parent_cluster.terminate_node(self)
+        self.node.test_config.tester_obj.monitors.reconfigure_scylla_monitoring()

--- a/test-cases/nemesis/longevity-5gb-1h-BootstrapStreamingErrMonkey.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-BootstrapStreamingErrMonkey.yaml
@@ -1,0 +1,37 @@
+test_duration: 90
+
+prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
+                     ]
+
+post_prepare_cql_cmds: ['CREATE MATERIALIZED VIEW keyspace1.sort_by_C1 AS SELECT key, "C1" FROM keyspace1.standard1 WHERE "C1" IS NOT NULL and key IS NOT NULL PRIMARY KEY ("C1", key)'
+                        ]
+
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"
+             ]
+
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1
+seeds_num: 3
+
+instance_type_db: 'i4i.large'
+gce_instance_type_db: 'n1-highmem-2'
+gce_instance_type_loader: 'e2-standard-2'
+azure_instance_type_db: 'Standard_L8s_v3'
+instance_type_loader: 'c5.large'
+azure_instance_type_loader: 'Standard_F2s_v2'
+
+nemesis_class_name: 'BootstrapStreamingErrorNemesis'
+nemesis_interval: 3
+nemesis_filter_seeds: false
+nemesis_during_prepare: true
+
+gce_n_local_ssd_disk_db: 1
+
+user_prefix: 'longevity-5gb-1h-BootstrapStreamingErrorNemesis'
+
+server_encrypt: true
+client_encrypt: true


### PR DESCRIPTION
BootstrapStreamError use new multiprocess.Process to start node_setup process and bootstrap the node.
On latest runs sct issue #6668 failed the most of
the nemesis execution.
this patch refactor the nemesis code and move
bootstrap/abort logic to new class, and using
threads to start and stop bootstrap. to avoid long wait timeout, wait_for is use threading.Event
to stop the db_up method

fix: #6668

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
