### PR TITLE
fix(cdc-test): prolong test duration

### DIFF
--- a/test-cases/longevity/longevity-cdc-3d-400gb.yaml
+++ b/test-cases/longevity/longevity-cdc-3d-400gb.yaml
@@ -1,4 +1,4 @@
-test_duration: 4550
+test_duration: 4740
 
 prepare_write_cmd: ["cassandra-stress user no-warmup profile=/tmp/cdc_profile_400gb.yaml ops'(insert=1)' cl=QUORUM n=50000000 -mode cql3 native -rate threads=100",
                     "cassandra-stress user no-warmup profile=/tmp/cdc_profile_400gb_preimage.yaml ops'(insert=1)' cl=QUORUM n=50000000 -mode cql3 native -rate threads=200",


### PR DESCRIPTION
Test duration for cdc 3days test is too short causing test to fail due timeout.

Prolong duration to match prepare + stress duration. From previous run, it was 6h from test start to stress_cmd start, so used 6+1h margin as a base for new duration.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
