### PR TITLE
fix(install packages): retry install packages when fail

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2065,7 +2065,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.remoter.sudo('apt-get install -y openjdk-11-jre')
             self.remoter.sudo(f'apt-get install -y openjdk-11-jre-headless {additional_pkgs}')
         else:
-            self.remoter.run(f'sudo apt-get install -y openjdk-11-jre-headless {additional_pkgs}')
+            self.install_package(package_name=f'openjdk-11-jre-headless {additional_pkgs}')
             self.remoter.run('sudo update-java-alternatives --jre-headless '
                              '-s java-1.11.0-openjdk-${dpkg-architecture -q DEB_BUILD_ARCH}')
 


### PR DESCRIPTION
Packages installation fail from time to time during node setup. Decided to add retrying for that.

Refs: https://github.com/scylladb/scylla-cluster-tests/issues/6317

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
