### PR TITLE
fix(get_gce_builders): get public ip correctly

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -78,7 +78,7 @@ from sdcm import wait
 from sdcm.utils.ldap import DEFAULT_PWD_SUFFIX, SASLAUTHD_AUTHENTICATOR, LdapServerType
 from sdcm.keystore import KeyStore
 from sdcm.utils.docker_utils import ContainerManager
-from sdcm.utils.gce_utils import GcloudContainerMixin
+from sdcm.utils.gce_utils import GcloudContainerMixin, gce_public_addresses
 from sdcm.remote import LocalCmdRunner
 from sdcm.remote import RemoteCmdRunnerBase
 from sdcm.utils.gce_utils import (
@@ -2422,7 +2422,7 @@ def get_gce_builders(tags=None, running=False):
 
     for gce_builder in gce_builders:
         builders.append({"builder": {
-            "public_ip": gce_builder.public_ips[0],
+            "public_ip": gce_public_addresses(gce_builder)[0],
             "name": gce_builder.name,
             "user": "scylla-test",
             "key_file": os.path.expanduser(ssh_key_path)


### PR DESCRIPTION
as part of libcloud removal in #6137 this function was really used, and it was missed it need to be adapted.

when using an old gce project when we have builders other than test runners we see this issue.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
