### PR TITLE
feature(EaR-kms): enable user encryption by default

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -142,8 +142,11 @@ from sdcm.paths import (
     SCYLLA_MANAGER_TLS_KEY_FILE,
 )
 from sdcm.sct_provision.aws.user_data import ScyllaUserDataBuilder
-from sdcm.exceptions import KillNemesis, NodeNotReady
-
+from sdcm.exceptions import (
+    KillNemesis,
+    NodeNotReady,
+    SstablesNotFound,
+)
 
 # Test duration (min). Parameter used to keep instances produced by tests that
 # are supposed to run longer than 24 hours from being killed
@@ -4329,6 +4332,10 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                     encryption_results = sstable_util.is_sstable_encrypted()
                     assert encryption_results
                     assert all(encryption_result is True for encryption_result in encryption_results)
+
+                except SstablesNotFound as exc:
+                    self.log.warning(f"Couldn't check the fact of encryption (KMS) for sstables: {exc}")
+
                 except Exception:  # pylint: disable=broad-except
                     AwsKmsEvent(
                         message="Failed to check the fact of encryption (KMS) for sstables",

--- a/sdcm/exceptions.py
+++ b/sdcm/exceptions.py
@@ -71,3 +71,7 @@ class WaitForTimeoutError(Exception):
 
 class ExitByEventError(Exception):
     """Exception that would be raised if wait.wait_for stopped by event"""
+
+
+class SstablesNotFound(Exception):
+    pass

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -330,6 +330,7 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods,too-many-
 
     system_key_directory: str = None  # None
     system_info_encryption: dict = None  # None
+    user_info_encryption: dict = None  # None
     kmip_hosts: dict = None  # None
     kms_hosts: dict = None  # None
 

--- a/sdcm/remote/libssh2_client/__init__.py
+++ b/sdcm/remote/libssh2_client/__init__.py
@@ -443,7 +443,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
             if stdout_stream is not None:
                 try:
                     stdout = reader.stdout.get(timeout=timeout_read_data_chunk)
-                    data = stdout.decode(encoding) + '\n'
+                    data = stdout.decode(encoding, errors='ignore') + '\n'
                     stdout_stream.write(data)
                     for watcher in watchers:
                         watcher.submit_line(data)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -796,6 +796,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         )
 
     def prepare_kms_host(self) -> None:
+        if self.params.is_enterprise and self.params.get('cluster_backend') == 'aws' and not self.params.get('scylla_encryption_options'):
+            self.params['scylla_encryption_options'] = "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'KmsKeyProviderFactory', 'kms_host': 'auto'}"  # pylint: disable=line-too-long
         if not (scylla_encryption_options := self.params.get("scylla_encryption_options") or ''):
             return None
         kms_host = (yaml.safe_load(scylla_encryption_options) or {}).get("kms_host") or ''

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -816,6 +816,17 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             # NOTE: the 'aws_region' will be changed per each node separately depending on it's region
             'aws_region': 'auto'
         }
+        append_scylla_yaml['user_info_encryption'] = {
+            'enabled': True,
+            'key_provider': 'KmsKeyProviderFactory',
+            'kms_host': kms_host,
+        }
+        append_scylla_yaml['system_info_encryption'] = {
+            'enabled': True,
+            'key_provider': 'KmsKeyProviderFactory',
+            'kms_host': kms_host,
+        }
+        self.log.warning("`user_info_encryption` and `system_info_encryption` are configured to use KMS by default")
         self.params["append_scylla_yaml"] = yaml.safe_dump(append_scylla_yaml)
         return None
 

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -391,6 +391,7 @@ class ScyllaYamlTest(unittest.TestCase):
                 'user_defined_function_allocation_limit_bytes': None,
                 'user_defined_function_contiguous_allocation_limit_bytes': None,
                 'user_defined_function_time_limit_ms': None,
+                'user_info_encryption': None,
                 'view_building': None,
                 'view_hints_directory': None,
                 'virtual_dirty_soft_limit': None,


### PR DESCRIPTION
using the feature from scylladb/scylla-enterprise#3389 when we have `scylla_encryption_options` configured with KMS we would enable the `user_info_encryption` and the `system_info_encryption` similar to who it would be working on scylla-cloud

Ref: scylladb/scylla-enterprise#3389

#### Testing
- [x] - 2023.1: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/EaR-longevity-kms-200gb-6h-test/21/
- [x] - enterprise: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/EaR-longevity-kms-200gb-6h-test/31/
- [x] regular case -  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/27/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
