### PR TITLE
fix(decommission): move system.log when decommission

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -21,6 +21,7 @@ import re
 import abc
 import json
 import math
+import shutil
 import tempfile
 import time
 import base64
@@ -2821,6 +2822,8 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
                 namespace=self.namespace,
                 timeout=timeout + 10)
         self.terminate_node(node, scylla_shards=scylla_shards)
+        shutil.move(node.system_log, os.path.join(
+            node.logdir, f"system_{datetime.now().strftime('%y_%m_%d_%H_%M_%S')}.log"))
         if current_members == 1:
             self._delete_k8s_rack(rack, dc_idx=dc_idx)
 

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -790,6 +790,8 @@ class ScyllaLogCollector(LogCollector):
                                     "-u scylla-image-setup.service -u scylla-io-setup.service -u scylla-server.service "
                                     "-u scylla-jmx.service -u scylla-housekeeping-restart.service "
                                     "-u scylla-housekeeping-daily.service -o short-precise", search_locally=True),
+                    FileLog(name='system_*',
+                            search_locally=True),
                     FileLog(name='kallsyms_*',
                             search_locally=True),
                     FileLog(name='lsof_*',


### PR DESCRIPTION
When scylla node is added after decommission on K8s it may get the same name. This leads to system.log being reused and reread by `DbLogReader` which in result duplicates log lines to sct.log and also generates events according to log lines from the past.

Fix is about renaming system.log after decommission so it is not reread. Also need to make log collector to find these decommissioned nodes logs.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/6806

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
