### PR TITLE
fix(get_branched_repo): handle OSS/enterprise releases

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -68,7 +68,6 @@ from sdcm.utils.common import (
     get_gce_images_versioned,
     gce_meta_to_dict,
     get_builder_by_test_id,
-    get_s3_scylla_repos_mapping,
     get_testrun_dir,
     list_clusters_eks,
     list_clusters_gke,
@@ -106,11 +105,11 @@ from sdcm.utils.gce_utils import SUPPORTED_PROJECTS, gce_public_addresses
 from sdcm.utils.context_managers import environment
 from sdcm.cluster_k8s import mini_k8s
 from sdcm.utils.es_index import create_index, get_mapping
+from sdcm.utils.version_utils import get_s3_scylla_repos_mapping
 import sdcm.provision.azure.utils as azure_utils
 from utils.build_system.create_test_release_jobs import JenkinsPipelines  # pylint: disable=no-name-in-module,import-error
 from utils.get_supported_scylla_base_versions import UpgradeBaseVersion  # pylint: disable=no-name-in-module,import-error
 from utils.mocks.aws_mock import AwsMock  # pylint: disable=no-name-in-module,import-error
-
 
 SUPPORTED_CLOUDS = ("aws", "gce", "azure",)
 DEFAULT_CLOUD = SUPPORTED_CLOUDS[0]

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -33,7 +33,6 @@ from sdcm.utils import alternator
 from sdcm.utils.aws_utils import get_arch_from_instance_type
 from sdcm.utils.common import (
     ami_built_by_scylla,
-    find_scylla_repo,
     get_ami_tags,
     get_branched_ami,
     get_branched_gce_images,
@@ -49,6 +48,7 @@ from sdcm.utils.version_utils import (
     get_scylla_docker_repo_from_version,
     resolve_latest_repo_symlink,
     get_specific_tag_of_docker_image,
+    find_scylla_repo,
 )
 from sdcm.sct_events.base import add_severity_limit_rules, print_critical_events
 from sdcm.utils.gce_utils import get_gce_image_tags

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -457,8 +457,10 @@ def get_systemd_version(output: str) -> int:
 
 
 def get_scylla_docker_repo_from_version(scylla_version: str):
-    if scylla_version == 'latest':
+    if scylla_version in ('latest', 'master:latest'):
         return 'scylladb/scylla-nightly'
+    if scylla_version in ('enterprise', 'enterprise:latest'):
+        return 'scylladb/scylla-enterprise-nightly'
     if is_enterprise(scylla_version):
         return 'scylladb/scylla-enterprise'
     return 'scylladb/scylla'

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -16,8 +16,8 @@ import os
 import logging
 from enum import Enum, auto
 from string import Template
-from typing import List, Optional
-from collections import namedtuple
+from typing import List, Optional, Literal
+from collections import namedtuple, defaultdict
 from urllib.parse import urlparse
 from functools import lru_cache, wraps
 from itertools import count
@@ -743,3 +743,123 @@ def get_relocatable_pkg_url(scylla_version: str) -> str:
         except Exception as exc:  # pylint: disable=broad-except
             LOGGER.warning("Couldn't get relocatable_pkg link due to: %s", exc)
     return relocatable_pkg
+
+
+_S3_SCYLLA_REPOS_CACHE = defaultdict(dict)
+
+
+def get_s3_scylla_repos_mapping(dist_type='centos', dist_version=None):
+    """
+    get the mapping from version prefixes to rpm .repo or deb .list files locations
+
+    :param dist_type: which distro to look up centos/ubuntu/debian
+    :param dist_version: family name of the distro version
+
+    :return: a mapping of versions prefixes to repos
+    :rtype: dict
+    """
+    if (dist_type, dist_version) in _S3_SCYLLA_REPOS_CACHE:
+        return _S3_SCYLLA_REPOS_CACHE[(dist_type, dist_version)]
+
+    s3_client: S3Client = boto3.client('s3', region_name=DEFAULT_AWS_REGION)
+    bucket = 'downloads.scylladb.com'
+
+    if dist_type == 'centos':
+        response = s3_client.list_objects(Bucket=bucket, Prefix='rpm/centos/', Delimiter='/')
+
+        for repo_file in response['Contents']:
+            filename = os.path.basename(repo_file['Key'])
+            # only if path look like 'rpm/centos/scylla-1.3.repo', we deem it formal one
+            if filename.startswith('scylla-') and filename.endswith('.repo'):
+                version_prefix = filename.replace('.repo', '').split('-')[-1]
+                _S3_SCYLLA_REPOS_CACHE[(
+                    dist_type, dist_version)][version_prefix] = "https://s3.amazonaws.com/{bucket}/{path}".format(
+                    bucket=bucket,
+                    path=repo_file['Key'])
+
+    elif dist_type in ('ubuntu', 'debian'):
+        response = s3_client.list_objects(Bucket=bucket, Prefix='deb/{}/'.format(dist_type), Delimiter='/')
+        for repo_file in response['Contents']:
+            filename = os.path.basename(repo_file['Key'])
+
+            # only if path look like 'deb/debian/scylla-3.0-jessie.list', we deem it formal one
+            repo_regex = re.compile(r'\d+\.\d\.list')
+            if filename.startswith('scylla-') and (
+                    filename.endswith('-{}.list'.format(dist_version)) or
+                    repo_regex.search(filename)):
+                version_prefix = \
+                    filename.replace('-{}.list'.format(dist_version), '').replace('.list', '').split('-')[-1]
+                _S3_SCYLLA_REPOS_CACHE[(
+                    dist_type, dist_version)][version_prefix] = "https://s3.amazonaws.com/{bucket}/{path}".format(
+                    bucket=bucket,
+                    path=repo_file['Key'])
+
+    else:
+        raise NotImplementedError("[{}] is not yet supported".format(dist_type))
+    return _S3_SCYLLA_REPOS_CACHE[(dist_type, dist_version)]
+
+
+def find_scylla_repo(scylla_version, dist_type='centos', dist_version=None):
+    """
+    Get a repo/list of scylla, based on scylla version match
+
+    :param scylla_version: branch version to look for, ex. 'branch-2019.1:latest', 'branch-3.1:l'
+    :param dist_type: one of ['centos', 'ubuntu', 'debian']
+    :param dist_version: family name of the distro version
+    :raises: ValueError if not found
+
+    :return: str url repo/list
+    """
+    if ':' in scylla_version:
+        branch_repo = get_branched_repo(scylla_version, dist_type)
+        if branch_repo:
+            return branch_repo
+
+    repo_map = get_s3_scylla_repos_mapping(dist_type, dist_version)
+
+    # pylint: disable=useless-else-on-loop
+    for key in repo_map:
+        if scylla_version.startswith(key):
+            return repo_map[key]
+    else:
+        raise ValueError(f"repo for scylla version {scylla_version} wasn't found")
+
+
+def get_branched_repo(scylla_version: str,
+                      dist_type: Literal["centos", "ubuntu", "debian"] = "centos",
+                      bucket: str = "downloads.scylladb.com") -> Optional[str]:
+    """
+    Get a repo/list of scylla, based on scylla version match
+
+    :param scylla_version: branch version to look for, ex. 'branch-2019.1:latest', 'branch-3.1:l'
+    :param dist_type: one of ['centos', 'ubuntu', 'debian']
+    :param bucket: which bucket to download from
+    :return: str url repo/list, or None if not found
+    """
+    try:
+        branch, branch_version = scylla_version.split(':', maxsplit=1)
+    except ValueError:
+        raise ValueError(f"{scylla_version=} should be in `branch-x.y:<date>' or `branch-x.y:latest' format") from None
+
+    if dist_type == "centos":
+        prefix = f"unstable/scylla/{branch}/rpm/centos/{branch_version}/"
+        filename = "scylla.repo"
+    elif dist_type in ("ubuntu", "debian",):
+        branch_id = branch.replace('branch-', '').replace('enterprise-', '')
+        product = 'scylla-enterprise' if branch == 'enterprise' or is_enterprise(branch_id) else 'scylla'
+        prefix = f"unstable/{product}/{branch}/deb/unified/{branch_version}/scylladb-{branch_id}/"
+        filename = "scylla.list"
+    else:
+        raise ValueError(f"Unsupported {dist_type=}")
+
+    s3_client: S3Client = boto3.client("s3", region_name=DEFAULT_AWS_REGION)
+    response = s3_client.list_objects(Bucket=bucket, Prefix=prefix, Delimiter='/')
+
+    for repo_file in response.get("Contents", ()):
+        if os.path.basename(repo_file['Key']) == filename:
+            return f"https://s3.amazonaws.com/{bucket}/{repo_file['Key']}"
+
+    if branch_version.isdigit():
+        LOGGER.warning("Repo path doesn't include `build-id' anymore, try to use a date.")
+
+    return None

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -5,8 +5,7 @@ import re
 import os
 
 from sdcm.utils.version_utils import is_enterprise, get_all_versions
-from sdcm.utils.common import get_s3_scylla_repos_mapping
-from sdcm.utils.version_utils import ComparableScyllaVersion
+from sdcm.utils.version_utils import ComparableScyllaVersion, get_s3_scylla_repos_mapping
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 


### PR DESCRIPTION
##### fix(get_branched_repo): handle OSS/enterprise releases

code was hard coded incorrectly, and was working only for master
and not for enterprise, nor releases

all the function related to this function where moved
to `sdcm.utils.version_utils` to avoid cyclic dependency.

##### feature(docker_repo): select correctly for master/enterprise branch

we use this function to determinte where to look for docker
images in dockerhub, and now it's works for more options
like:
- master:latest
- enterprise
- enterprise:latest

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
