### PR TITLE
ci(k8s-eks): add CI job configuration for the EKS multiDC setups

### DIFF
--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-multidc-12h-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-multidc-12h-eks.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'k8s-eks',
+    region: '''["eu-north-1", "eu-west-1"]''',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/scylla-operator/longevity-scylla-operator-multidc-12h.yaml',
+    email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'c',
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
+)

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-multidc-3h-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-multidc-3h-eks.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'k8s-eks',
+    region: '''["eu-north-1", "eu-west-1"]''',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/scylla-operator/longevity-scylla-operator-multidc-3h.yaml',
+    email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'b',
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
+)

--- a/test-cases/scylla-operator/longevity-scylla-operator-multidc-12h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-multidc-12h.yaml
@@ -1,0 +1,37 @@
+test_duration: 900
+
+prepare_write_cmd: [
+  "cassandra-stress write cl=QUORUM n=10240000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=3000 -col 'n=FIXED(2) size=FIXED(512)' -pop seq=1..10240000 -log interval=5",
+  "cassandra-stress write cl=QUORUM n=10240000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=3000 -col 'n=FIXED(2) size=FIXED(512)' -pop seq=10240001..20480000 -log interval=5",
+]
+stress_cmd: [
+  "cassandra-stress mixed cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=50 -pop 'dist=uniform(1..15360000)' -col 'n=FIXED(2) size=FIXED(512)' -log interval=5",
+  "cassandra-stress mixed cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=50 -pop 'dist=uniform(5120001..20480000)' -col 'n=FIXED(2) size=FIXED(512)' -log interval=5",
+]
+round_robin: true
+
+n_db_nodes: 4
+n_loaders: 1
+n_monitor_nodes: 1
+k8s_n_scylla_pods_per_cluster: 3
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_selector: ['kubernetes']
+nemesis_during_prepare: false
+nemesis_seed: '013'
+nemesis_interval: 5
+
+user_prefix: 'long-eks-multidc-12h'
+space_node_threshold: 64424
+
+k8s_db_node_service_type: Headless
+k8s_db_node_to_node_broadcast_ip_type: PodIP
+k8s_db_node_to_client_broadcast_ip_type: PodIP
+
+# TODO: enable the scylla-manager installation when it's multi-K8S-cluster support gets added
+use_mgmt: false
+
+# EKS
+region_name: 'eu-north-1 eu-west-1'
+instance_type_db: 'i4i.4xlarge'
+k8s_scylla_disk_gi: 3490

--- a/test-cases/scylla-operator/longevity-scylla-operator-multidc-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-multidc-3h.yaml
@@ -1,0 +1,37 @@
+test_duration: 300
+
+prepare_write_cmd: [
+  "cassandra-stress write cl=QUORUM n=10240000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1500 -col 'n=FIXED(2) size=FIXED(512)' -pop seq=1..10240000 -log interval=5",
+  "cassandra-stress write cl=QUORUM n=10240000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1500 -col 'n=FIXED(2) size=FIXED(512)' -pop seq=10240001..20480000 -log interval=5",
+]
+stress_cmd: [
+  "cassandra-stress mixed cl=LOCAL_QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=25 -pop 'dist=uniform(1..15360000)' -col 'n=FIXED(2) size=FIXED(512)' -log interval=5",
+  "cassandra-stress mixed cl=LOCAL_QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=25 -pop 'dist=uniform(5120001..20480000)' -col 'n=FIXED(2) size=FIXED(512)' -log interval=5",
+]
+round_robin: true
+
+n_db_nodes: 4
+n_loaders: 1
+n_monitor_nodes: 1
+k8s_n_scylla_pods_per_cluster: 3
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_selector: ['kubernetes']
+nemesis_during_prepare: false
+nemesis_seed: '026'
+nemesis_interval: 5
+
+user_prefix: 'long-eks-multidc-3h'
+space_node_threshold: 64424
+
+k8s_db_node_service_type: Headless
+k8s_db_node_to_node_broadcast_ip_type: PodIP
+k8s_db_node_to_client_broadcast_ip_type: PodIP
+
+# TODO: enable the scylla-manager installation when it's multi-K8S-cluster support gets added
+use_mgmt: false
+
+# EKS
+region_name: 'eu-north-1 eu-west-1'
+instance_type_db: 'i4i.2xlarge'
+k8s_scylla_disk_gi: 1500


### PR DESCRIPTION
Add 2 CI jobs:
- 3h  using the `i4i.2xlarge` instance type for DB-specific pods
- 12h using the `i4i.4xlarge` instance type for DB-specific pods

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
