### PR TITLE
improvement(k8s): use bigger K8S pod readiness timeout

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1762,7 +1762,7 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
     parent_cluster: PodCluster
 
     pod_readiness_delay = 30  # seconds
-    pod_readiness_timeout = 5  # minutes
+    pod_readiness_timeout = 10  # minutes
     pod_terminate_timeout = 5  # minutes
 
     def __init__(self, name: str, parent_cluster: PodCluster, node_prefix: str = "node", node_index: int = 1,


### PR DESCRIPTION
Mainly we run K8S CI job with really small load.
Small load allows us to get Scylla pods up and running much faster than when we have big load.

So, increase the K8S pod readiness timeout from '5' to '10' to cover upcoming new CI jobs with bigger load.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
