### PR TITLE
fix(multitenant): fix missing validate_large_collections attr

### DIFF
--- a/sdcm/utils/operator/multitenant_common.py
+++ b/sdcm/utils/operator/multitenant_common.py
@@ -50,6 +50,7 @@ class TenantMixin:  # pylint: disable=too-many-instance-attributes
         self.start_time = self.get_test_start_time() or time.time()
         self.timeout_thread = self._init_test_timeout_thread()
         self.test_config.reuse_cluster(False)
+        self.validate_large_collections = self.params.get('validate_large_collections')
 
     def get_str_index(self):
         return f"{self.get_str_index_prefix}-{self.db_cluster.k8s_clusters[0].tenants_number}-tenants"


### PR DESCRIPTION
When creating multitenant cluster, `LongevityTest` init is not executed. This causes missing `validate_large_collections` class attribute for multitenant tester classes.

Fix by adding this param to proper init method.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
