### PR TITLE
fix(aws): expose shard-aware ports

### DIFF
--- a/sdcm/utils/aws_region.py
+++ b/sdcm/utils/aws_region.py
@@ -323,11 +323,25 @@ class AwsRegion:
                         "Ipv6Ranges": [{'CidrIpv6': '::/0', 'Description': 'Allow CQL for ALL'}]
                     },
                     {
+                        "FromPort": 19042,
+                        "ToPort": 19042,
+                        "IpProtocol": "tcp",
+                        "IpRanges": [{'CidrIp': '0.0.0.0/0', 'Description': 'Allow shard-aware CQL for ALL'}],
+                        "Ipv6Ranges": [{'CidrIpv6': '::/0', 'Description': 'Allow shard-aware CQL for ALL'}]
+                    },
+                    {
                         "FromPort": 9142,
                         "ToPort": 9142,
                         "IpProtocol": "tcp",
                         "IpRanges": [{'CidrIp': '0.0.0.0/0', 'Description': 'Allow SSL CQL for ALL'}],
                         "Ipv6Ranges": [{'CidrIpv6': '::/0', 'Description': 'Allow SSL CQL for ALL'}]
+                    },
+                    {
+                        "FromPort": 19142,
+                        "ToPort": 19142,
+                        "IpProtocol": "tcp",
+                        "IpRanges": [{'CidrIp': '0.0.0.0/0', 'Description': 'Allow shard-aware SSL CQL for ALL'}],
+                        "Ipv6Ranges": [{'CidrIpv6': '::/0', 'Description': 'Allow shard-aware SSL CQL for ALL'}]
                     },
                     {
                         "FromPort": 9100,


### PR DESCRIPTION
# Motivation
When running local tests with AWS backend, the driver cannot connect to shard-aware CQL port (19042) since it's not exposed during AWS security groups configuration.

The issue can be reproduced simply with https://github.com/scylladb/scylla-cluster-tests#run-test-locally-with-aws-backend.
NOTE: the reason this test fails may seem to be different, since logs tell us that `ALTER KEYSPACE` query is timed out. What happens is that the driver tries to open connections to shard-aware ports (with default SCT's connection timeout being 100s) which blocks the python driver's worker threads. It's clearly a python driver issue which hopefully will be fixed soon.

# Changes
- Exposed shard-aware ports (both non-SSL and SSL) in AWS security group.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
