### PR TITLE
fix(offline-installer): bring back the install of python2

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1904,6 +1904,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
         if not nonroot:
             self.install_package(package_name='xfsprogs mdadm')
+
+        if not self.distro.is_rocky9:  # centos/rocky 9 and above don't have python2 anymore
+            self.install_package(package_name='python2')
         # Offline install does't provide openjdk-11, it has to be installed in advance
         # https://github.com/scylladb/scylla-jmx/issues/127
         if self.distro.is_amazon2:


### PR DESCRIPTION
for older release which depends on python2, we still need to install it, and we keep on installing until it's not available anymore. (centos/rocky 9 and ubutnu 23.04 and above)

#### Testing
- [x] https://jenkins.scylladb.com/view/enterprise-2023.1/job/enterprise-2023.1/job/branch_2023.1_future/job/artifacts-centos8-offline-test/3/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
