### PR TITLE
feature(decode_kallsyms): add commandline options

### DIFF
--- a/utils/decode_kallsyms.py
+++ b/utils/decode_kallsyms.py
@@ -1,5 +1,9 @@
+#!/usr/bin/env python
+
 import bisect
 import re
+
+import click
 
 
 def kallsyms_search(kallsyms_lines: list[str], address: int):
@@ -51,3 +55,15 @@ def decode_kernel_callstacks(results_file='results.log', input_file='system.log'
                 for frame in stall:
                     append_content_to_file(file, file_content[kallsyms_search(file_content, int(frame, 16))])
             append_content_to_file(file, '#' * 76)
+
+
+@click.command(help="Decode kernel callstack")
+@click.option('-i', '--input-file', default='system.log', type=click.Path(exists=True))
+@click.option('-k', '--kallsyms-file', default='kallsyms', type=click.Path(exists=True))
+@click.option('-r', '--results-file', default='results.log', type=click.Path(exists=False))
+def decode(input_file, kallsyms_file, results_file):
+    decode_kernel_callstacks(input_file=input_file, kallsyms_file=kallsyms_file, results_file=results_file)
+
+
+if __name__ == "__main__":
+    decode()  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
new it can be called from commnadline as follow:

```
./utils/decode_kallsyms.py  -i ~/Desktop/system.log -k ~/Desktop/kallsyms_20231114_000857
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
