### PR TITLE
fix(offline-install): don't expect `scylla_repo`

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2183,7 +2183,9 @@ class SCTConfiguration(dict):
     def _check_version_supplied(self, backend: str):
         options_must_exist = []
 
-        if not self.get('use_preinstalled_scylla') and not backend == 'baremetal':
+        if (not self.get('use_preinstalled_scylla') and
+                not backend == 'baremetal' and
+                not self.get('unified_package')):
             options_must_exist += ['scylla_repo']
 
         if self.get('db_type') == 'cloud_scylla':


### PR DESCRIPTION
recent change a13612a1a7344d1f93eeb3a40a180f96dfd4bd4e made a few configuration mandatory, but it didn't handle the offline installer case, i.e. when `unified_package` is defined insted of `scylla_repo`

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
