### PR TITLE
fix(k8s): make scylla-manager pod waiter work correctly

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2970,8 +2970,9 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
 
 
 class ManagerPodCluser(PodCluster):  # pylint: disable=abstract-method
-    def wait_for_pods_running(self, pods_to_wait: int, total_pods: int | callable, dc_idx: int = 0):
-        super().wait_for_pods_running(pods_to_wait=pods_to_wait, total_pods=(lambda x: x > 1), dc_idx=dc_idx)
+    @property
+    def pod_selector(self):
+        return 'app.kubernetes.io/name=scylla-manager'
 
 
 class LoaderPodCluster(cluster.BaseLoaderSet, PodCluster):


### PR DESCRIPTION
Stop wrapping the `wait_for_pods_running` method and just start using proper `scylla-manager` pod selector to filter out all other pods.

It started being required after merge of https://github.com/scylladb/scylla-cluster-tests/pull/6785 where we added usage of the one more method - `wait_for_pods_readiness`.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
