### PR TITLE
fix(k8s): make mgmt work in K8S multiDC setup

### DIFF
--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -134,7 +134,9 @@ def deploy_k8s_eks_cluster(region_name: str, availability_zone: str,
         k8s_cluster.chaos_mesh.initialize()
     k8s_cluster.prepare_k8s_scylla_nodes(node_pools=scylla_pool)
     if params.get('use_mgmt'):
-        k8s_cluster.deploy_scylla_manager(pool_name=k8s_cluster.AUXILIARY_POOL_NAME)
+        # NOTE: deploy scylla-manager only in the first region. It will then be used by each of the regions
+        if params.region_names.index(region_name) == 0:
+            k8s_cluster.deploy_scylla_manager(pool_name=k8s_cluster.AUXILIARY_POOL_NAME)
     return k8s_cluster
 
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-multidc-12h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-multidc-12h.yaml
@@ -24,12 +24,12 @@ nemesis_interval: 5
 user_prefix: 'long-eks-multidc-12h'
 space_node_threshold: 64424
 
+use_mgmt: true
+k8s_minio_storage_size: '500Gi'
+
 k8s_db_node_service_type: Headless
 k8s_db_node_to_node_broadcast_ip_type: PodIP
 k8s_db_node_to_client_broadcast_ip_type: PodIP
-
-# TODO: enable the scylla-manager installation when it's multi-K8S-cluster support gets added
-use_mgmt: false
 
 # EKS
 region_name: 'eu-north-1 eu-west-1'

--- a/test-cases/scylla-operator/longevity-scylla-operator-multidc-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-multidc-3h.yaml
@@ -1,12 +1,12 @@
 test_duration: 300
 
 prepare_write_cmd: [
-  "cassandra-stress write cl=QUORUM n=10240000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1500 -col 'n=FIXED(2) size=FIXED(512)' -pop seq=1..10240000 -log interval=5",
-  "cassandra-stress write cl=QUORUM n=10240000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1500 -col 'n=FIXED(2) size=FIXED(512)' -pop seq=10240001..20480000 -log interval=5",
+  "cassandra-stress write cl=QUORUM n=5120000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1500 -col 'n=FIXED(2) size=FIXED(512)' -pop seq=1..5120000 -log interval=5",
+  "cassandra-stress write cl=QUORUM n=5120000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1500 -col 'n=FIXED(2) size=FIXED(512)' -pop seq=5120001..10240000 -log interval=5",
 ]
 stress_cmd: [
-  "cassandra-stress mixed cl=LOCAL_QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=25 -pop 'dist=uniform(1..15360000)' -col 'n=FIXED(2) size=FIXED(512)' -log interval=5",
-  "cassandra-stress mixed cl=LOCAL_QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=25 -pop 'dist=uniform(5120001..20480000)' -col 'n=FIXED(2) size=FIXED(512)' -log interval=5",
+  "cassandra-stress mixed cl=LOCAL_QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=25 -pop 'dist=uniform(1..7680000)' -col 'n=FIXED(2) size=FIXED(512)' -log interval=5",
+  "cassandra-stress mixed cl=LOCAL_QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=25 -pop 'dist=uniform(2560001..10240000)' -col 'n=FIXED(2) size=FIXED(512)' -log interval=5",
 ]
 round_robin: true
 
@@ -24,12 +24,12 @@ nemesis_interval: 5
 user_prefix: 'long-eks-multidc-3h'
 space_node_threshold: 64424
 
+use_mgmt: true
+k8s_minio_storage_size: '200Gi'
+
 k8s_db_node_service_type: Headless
 k8s_db_node_to_node_broadcast_ip_type: PodIP
 k8s_db_node_to_client_broadcast_ip_type: PodIP
-
-# TODO: enable the scylla-manager installation when it's multi-K8S-cluster support gets added
-use_mgmt: false
 
 # EKS
 region_name: 'eu-north-1 eu-west-1'


### PR DESCRIPTION
To make Scylla-Manager work in MultiDC K8S setups we should do following [1]:
- Install it only in one region
- Make Scylla pods use auth token from that the only scylla-manager.

So, do above changes and update the multiDC config files. Make 3h config write twice less data so the 'mgmt backup' could fit the 3h time range in case one wants to test it using that job.

[1] https://github.com/scylladb/scylla-operator/blob/master/docs/source/multidc/multidc.md#scylla-manager

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
