### PR TITLE
improvement(k8s): make `scylla_operator_chart_version` attr be public

### DIFF
--- a/functional_tests/scylla_operator/conftest.py
+++ b/functional_tests/scylla_operator/conftest.py
@@ -224,9 +224,8 @@ def skip_if_not_supported_scylla_version(request: pytest.FixtureRequest,
 
 @pytest.fixture(autouse=True)
 def skip_based_on_operator_version(request: pytest.FixtureRequest, tester: ScyllaOperatorFunctionalClusterTester):
-    # pylint: disable=protected-access
     if required_operator := request.node.get_closest_marker('required_operator'):
-        current_version = tester.k8s_clusters[0]._scylla_operator_chart_version.split("-")[0]
+        current_version = tester.k8s_clusters[0].scylla_operator_chart_version.split("-")[0]
         required_version = required_operator.args[0]
         if version_utils.ComparableScyllaOperatorVersion(current_version) < required_version:
             pytest.skip(f"require operator version: {required_version}, current version: {current_version}")

--- a/functional_tests/scylla_operator/libs/helpers.py
+++ b/functional_tests/scylla_operator/libs/helpers.py
@@ -158,7 +158,7 @@ def reinstall_scylla_manager(db_cluster: ScyllaPodCluster, manager_version: str)
         log.debug(db_cluster.k8s_cluster.helm_install(
             target_chart_name="scylla-manager",
             source_chart_name="scylla-operator/scylla-manager",
-            version=db_cluster.k8s_cluster._scylla_operator_chart_version,  # pylint: disable=protected-access
+            version=db_cluster.k8s_cluster.scylla_operator_chart_version,
             use_devel=True,
             values=values,
             namespace=SCYLLA_MANAGER_NAMESPACE,

--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -105,7 +105,7 @@ def test_deploy_quasi_multidc_db_cluster(db_cluster: ScyllaPodCluster):  # pylin
     target_chart_name2, namespace2 = (f"{cluster_name}-2", ) * 2
     dc_name, dc_name2 = (f"quasi-dc-{i}" for i in range(1, 3))
     k8s_cluster, kubectl = db_cluster.k8s_cluster, db_cluster.k8s_cluster.kubectl
-    operator_version = k8s_cluster._scylla_operator_chart_version  # pylint: disable=protected-access
+    operator_version = k8s_cluster.scylla_operator_chart_version
     need_to_collect_logs = True
     logdir = f"{os.path.join(k8s_cluster.logdir, 'test_deploy_quasi_multidc_db_cluster')}"
     values = HelmValues({
@@ -537,7 +537,7 @@ def test_check_operator_operability_when_scylla_crd_is_incorrect(db_cluster):
     db_cluster.k8s_cluster.helm_install(
         target_chart_name=target_chart_name,
         source_chart_name="scylla-operator/scylla",
-        version=db_cluster.k8s_cluster._scylla_operator_chart_version,  # pylint: disable=protected-access
+        version=db_cluster.k8s_cluster.scylla_operator_chart_version,
         use_devel=True,
         values=values,
         namespace=namespace)
@@ -766,7 +766,7 @@ def test_deploy_helm_with_default_values(db_cluster: ScyllaPodCluster):
     log.debug(db_cluster.k8s_cluster.helm_install(
         target_chart_name=target_chart_name,
         source_chart_name="scylla-operator/scylla",
-        version=db_cluster.k8s_cluster._scylla_operator_chart_version,  # pylint: disable=protected-access
+        version=db_cluster.k8s_cluster.scylla_operator_chart_version,
         use_devel=True,
         namespace=namespace,
     ))

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -484,7 +484,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def generate_operator_packages(self) -> list[Package]:
         operator_packages = []
         if self.k8s_clusters:
-            operator_helm_chart_version = self.k8s_clusters[0]._scylla_operator_chart_version  # pylint: disable=protected-access
+            operator_helm_chart_version = self.k8s_clusters[0].scylla_operator_chart_version
             operator_packages.append(Package(name="operator-chart", date="",
                                              version=operator_helm_chart_version,
                                              revision_id="", build_id=""))


### PR DESCRIPTION
We use the `scylla_operator_chart_version` attr in lots of places, not only the K8S class instance itself.
So, make it be of the `public` type removing the need to disable the `protected-access` pylint rule.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
