### PR TITLE
fix(upgrade-test): clear the cached scylla version upon upgrade

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -329,6 +329,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         new_ver = result.stdout.strip()
         assert self.orig_ver != new_ver, "scylla-server version isn't changed"
         self.new_ver = new_ver
+        node.forget_scylla_version()
         InfoEvent(message='upgrade_node - starting to "_update_argus_upgraded_version"').publish()
         self._update_argus_upgraded_version(node, new_ver)
         InfoEvent(message='upgrade_node - ended to "_update_argus_upgraded_version"').publish()


### PR DESCRIPTION
the scylla_version is a cached property of BaseNode. once the property is set, the property stays with the owner instance unless it is cleared with `forget_scylla_version()` method. this method is called in the test of `test_kubernetes_scylla_upgrade()` after all nodes are upgraded. but we also do rolling uprade in `test_rolling_upgrade`, which uses sstabledump or
`scylla sstable dump-data` to verify the correctness of sstabels after upgrading some nodes in the cluster on first node which has upgrade to the version being tested. but if we upgrade from an older version which do not support uuid-identifier sstable and to a version which support this feature. we are still using the cached version, which implies that it does not support this feature, and we can use the java-based sstabledump for reading the sstables. but unfortunately, the sstables have been upgraded to the newer supported version and their identifiers (filenames) are also the uuid-based ones. this is why the upgrade test from pre-5.4 to 5.4 fails with this very test.

in this change, we clear the cached version number when a certain node is upgraded.

Fixes https://github.com/scylladb/scylladb/issues/16147
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
