### PR TITLE
fix(upgrade_test): forget the scylla_version after node upgrade

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -319,6 +319,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             InfoEvent(message='upgrade_node - starting to "update_scylla_yaml"').publish()
             self._update_scylla_yaml_on_node(node_to_update=node, updates=scylla_yaml_updates)
             InfoEvent(message='upgrade_node - ended to "update_scylla_yaml"').publish()
+        node.forget_scylla_version()
         InfoEvent(message='upgrade_node - starting to "start_scylla_server"').publish()
         node.start_scylla_server(verify_up_timeout=500)
         InfoEvent(message='upgrade_node - ended to "start_scylla_server"').publish()


### PR DESCRIPTION
we recently introduced code that does logic based on `node.scylla_version` at the end of the upgrade sequence, and it wasn't working as we expected, returning the base version.

we now in the upgrade sequence clear the cached for scylla_version related functions/attributes

Ref: https://github.com/scylladb/scylladb/issues/16147

### Testing
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-debian11-test/7/
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-ubuntu20.04-test/16/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
