### PR TITLE
feature(eks-arm): add new test configuration to run ARM based EKS test

### DIFF
--- a/configurations/arm/eks.yaml
+++ b/configurations/arm/eks.yaml
@@ -1,0 +1,1 @@
+instance_type_db: 'im4gn.4xlarge'

--- a/jenkins-pipelines/operator/functional/functional-eks-arm.jenkinsfile
+++ b/jenkins-pipelines/operator/functional/functional-eks-arm.jenkinsfile
@@ -1,0 +1,18 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'k8s-eks',
+    functional_test: true,
+    region: 'eu-west-1',
+    test_name: 'functional_tests/scylla_operator',
+    test_config: '''["test-cases/scylla-operator/functional.yaml", "configurations/arm/eks.yaml"]''',
+    email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'a,b',
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+    post_behavior_k8s_cluster: 'destroy',
+    k8s_log_api_calls: false,
+)

--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -44,6 +44,7 @@ from sdcm.utils.aws_utils import (
     get_ec2_network_configuration,
     tags_as_ec2_tags,
     EksClusterCleanupMixin,
+    get_arch_from_instance_type,
 )
 
 
@@ -54,6 +55,8 @@ R = TypeVar("R")  # pylint: disable=invalid-name
 SUPPORTED_EBS_STORAGE_CLASSES = ['gp3', ]
 
 EC2_INSTANCE_UPDATE_LOCK = Lock()
+
+ARCH_TO_IMAGE_TYPE_MAPPING = {'arm64': 'AL2_ARM_64', 'x86_64': 'AL2_x86_64'}
 
 
 def deploy_k8s_eks_cluster(region_name: str, availability_zone: str,
@@ -164,6 +167,8 @@ class EksNodePool(CloudK8sNodePool):
             is_deployed: bool = False,
             user_data: str = None,
     ):
+        arch = get_arch_from_instance_type(instance_type)
+        image_type = ARCH_TO_IMAGE_TYPE_MAPPING.get(arch)
         super().__init__(
             k8s_cluster=k8s_cluster,
             name=name,


### PR DESCRIPTION
feature(eks): support arm image type

add code to identify base on the instance type,
what is the `amiType` needs to be passes to EKS
CreateNodegroup call


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
