### PR TITLE
fix(events-setup): fix regex for ignoring scylladb/scylladb#15672

### DIFF
--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -72,7 +72,7 @@ def start_events_device(log_dir: Optional[Union[str, Path]] = None,
                                 '(error system:104, read: Connection reset by peer)').publish()
     EventsSeverityChangerFilter(new_severity=Severity.WARNING,
                                 event_class=DatabaseLogEvent.RUNTIME_ERROR,
-                                regex='view update generator not plugged to push updates').publish()
+                                regex='.*view update generator not plugged to push updates').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: supressed').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: suppressed').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.WARNING, line='abort_requested_exception').publish()

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -404,7 +404,7 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
         self.assertNotIn("this is filtered", log_content)
 
     def test_default_filters(self):
-        with self.wait_for_n_events(self.get_events_logger(), count=2):
+        with self.wait_for_n_events(self.get_events_logger(), count=3):
             DatabaseLogEvent.BACKTRACE() \
                 .add_info(node="A",
                           line_number=22,
@@ -414,11 +414,22 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
             DatabaseLogEvent.BACKTRACE() \
                 .add_info(node="A", line_number=22, line="other back trace that shouldn't be filtered") \
                 .publish()
+            DatabaseLogEvent.RUNTIME_ERROR() \
+                .add_info(node="A",
+                          line_number=22,
+                          line="!ERR | scylla[5969]: [shard 1:stat] storage_proxy - exception during mutation write to "
+                               "10.12.0.219: std::runtime_error (view update generator not plugged to push updates)") \
+                .publish()
 
         log_content = self.get_event_log_file("events.log")
 
         self.assertIn("other back trace", log_content)
         self.assertNotIn("supressed", log_content)
+
+        warnings_log_content = self.get_event_log_file("warning.log")
+        assert 'std::runtime_error' in warnings_log_content
+        error_log_content = self.get_event_log_file("error.log")
+        assert 'RUNTIME_ERROR' not in error_log_content
 
     def test_failed_stall_during_filter(self):
         with self.wait_for_n_events(self.get_events_logger(), count=5, timeout=3):


### PR DESCRIPTION
PR #6793 introduce an ignore for print like:
```
[shard 3:stat] storage_proxy - exception during mutation write
to 10.12.0.219: std::runtime_error (view update generator not plugged to
push updates)
```

the regex wasn't really catching the print, the change fixes that and intoduce it into the unittest to verify it.

Ref: #6793
Ref: scylladb/scylladb#15672

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
