### PR TITLE
Rolling upgrade fixes

### DIFF
--- a/test-cases/upgrades/multi-dc-rolling-upgrade.yaml
+++ b/test-cases/upgrades/multi-dc-rolling-upgrade.yaml
@@ -2,7 +2,7 @@ test_duration: 360
 # Workloads
 stress_before_upgrade: cassandra-stress write no-warmup cl=ALL n=10100200 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compression=LZ4Compressor compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native compression=lz4 -rate threads=1000 -pop seq=1..10100200 -log interval=5
 stress_during_entire_upgrade: cassandra-stress write no-warmup cl=QUORUM n=20100200 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compression=LZ4Compressor compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native compression=lz4 -rate threads=60 -pop seq=10100201..30200400 -log interval=5
-stress_after_cluster_upgrade: cassandra-stress read no-warmup cl=ONE n=30200400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compression=LZ4Compressor' -mode cql3 native compression=lz4 -rate threads=1000 -pop seq=1..30200400 -log interval=5
+stress_after_cluster_upgrade: cassandra-stress read no-warmup cl=QUORUM n=30200400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compression=LZ4Compressor' -mode cql3 native compression=lz4 -rate threads=1000 -pop seq=1..30200400 -log interval=5
 
 instance_type_db: 'i4i.2xlarge'
 n_db_nodes: '3 3'

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -19,6 +19,7 @@ n_loaders: 1
 n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
+instance_type_loader: 'c6.2xlarge'
 
 user_prefix: 'rolling-upgrade'
 


### PR DESCRIPTION
The rolling upgrades test now runs many stress commands including c-s,s-b and gemini.
It seems that the memory is stressed on the loaders and we need to increase it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
