### PR TITLE
feature(k8s): add MultiDC support to GKE backend

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1882,6 +1882,20 @@ class SCTConfiguration(dict):
         return output
 
     @property
+    def gce_datacenters(self) -> List[str]:
+        gce_datacenters = self.environment.get('gce_datacenter')
+        if gce_datacenters is None:
+            gce_datacenters = self.get('gce_datacenter')
+        if gce_datacenters is None:
+            gce_datacenters = ''
+        if isinstance(gce_datacenters, str):
+            gce_datacenters = gce_datacenters.split()
+        output = []
+        for gce_datacenter in gce_datacenters:
+            output.extend(gce_datacenter.split())
+        return output
+
+    @property
     def environment(self) -> dict:
         return self._load_environment_variables()
 


### PR DESCRIPTION
Changes:
- Create `deploy_k8s_gke_cluster` function in the `gke.py` module that will be able to provision GKE clusters.
- Update the `gcloud` attr of the `GkeCluster` class to use `gce_zone` in the gcloud docker container name to be able to use multiple K8S clusters.
- Create `gce_datacenters` attr for the `params` object which will solve the same needs as `region_names` for AWS/EKS backends.
- Start respecting the `availability_zone` SCT config option. If not set then the `b` will be used as before. If set then apply.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
