### PR TITLE
ci(k8s-gke): add MultiDC CI jobs

### DIFF
--- a/configurations/operator/multidc-gke-12h.yaml
+++ b/configurations/operator/multidc-gke-12h.yaml
@@ -1,0 +1,4 @@
+user_prefix: 'long-gke-multidc-12h'
+
+root_disk_size_db: 50
+k8s_scylla_disk_gi: 1100

--- a/configurations/operator/multidc-gke-3h.yaml
+++ b/configurations/operator/multidc-gke-3h.yaml
@@ -1,0 +1,4 @@
+user_prefix: 'long-gke-multidc-3h'
+
+root_disk_size_db: 50
+k8s_scylla_disk_gi: 1100

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-multidc-12h-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-multidc-12h-gke.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'k8s-gke',
+    region: '''["us-east1", "us-west1"]''',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/scylla-operator/longevity-scylla-operator-multidc-12h.yaml", "configurations/operator/multidc-gke-12h.yaml"]''',
+    email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'c',
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
+)

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-multidc-3h-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-multidc-3h-gke.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'k8s-gke',
+    region: '''["us-east1", "us-west1"]''',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/scylla-operator/longevity-scylla-operator-multidc-3h.yaml", "configurations/operator/multidc-gke-3h.yaml"]''',
+    email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'b',
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
+)

--- a/test-cases/scylla-operator/longevity-scylla-operator-multidc-12h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-multidc-12h.yaml
@@ -35,3 +35,11 @@ use_mgmt: false
 region_name: 'eu-north-1 eu-west-1'
 instance_type_db: 'i4i.4xlarge'
 k8s_scylla_disk_gi: 3490
+
+# GKE
+gce_datacenter: 'us-east1 us-west1'
+gce_instance_type_db: 'n1-standard-16'
+gce_root_disk_type_db: 'pd-ssd'
+gce_n_local_ssd_disk_db: 3
+
+# NOTE: for GKE job the 'k8s_scylla_disk_gi' and 'user_prefix' options must be redefined

--- a/test-cases/scylla-operator/longevity-scylla-operator-multidc-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-multidc-3h.yaml
@@ -35,3 +35,11 @@ use_mgmt: false
 region_name: 'eu-north-1 eu-west-1'
 instance_type_db: 'i4i.2xlarge'
 k8s_scylla_disk_gi: 1500
+
+# GKE
+gce_datacenter: 'us-east1 us-west1'
+gce_instance_type_db: 'n1-standard-8'
+gce_root_disk_type_db: 'pd-ssd'
+gce_n_local_ssd_disk_db: 3
+
+# NOTE: for GKE job the 'k8s_scylla_disk_gi' and 'user_prefix' options must be redefined


### PR DESCRIPTION
Add `3h` and `12h` - the same way as we have it for EKS backend.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
