### PR TITLE
feature(k8s): add support for the `must-gather` operator command

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1472,6 +1472,10 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
     def gather_k8s_logs(self) -> None:
         return KubernetesOps.gather_k8s_logs(logdir_path=self.logdir, kubectl=self.kubectl)
 
+    @log_run_info
+    def gather_k8s_logs_by_operator(self) -> None:
+        return KubernetesOps.gather_k8s_logs_by_operator(kluster=self)
+
     @property
     def minio_pod(self) -> Resource:
         for pod in KubernetesOps.list_pods(self, namespace=MINIO_NAMESPACE):

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1260,6 +1260,19 @@ class KubernetesLogCollector(BaseSCTLogCollector):
         return super().collect_logs(local_search_path=local_search_path)
 
 
+class KubernetesMustGatherLogCollector(BaseSCTLogCollector):
+    """Gather K8S logs using the 'must-gather' scylla-operator command."""
+    log_entities = [
+        DirLog(name='must-gather/*', search_locally=True),
+    ]
+    cluster_log_type = "kubernetes-must-gather"
+    cluster_dir_prefix = "k8s-"
+    collect_timeout = 600
+
+    def collect_logs(self, local_search_path: Optional[str] = None) -> list[str]:
+        return super().collect_logs(local_search_path=local_search_path)
+
+
 class JepsenLogCollector(LogCollector):
     cluster_log_type = "jepsen-data"
     cluster_dir_prefix = "jepsen-data"
@@ -1390,6 +1403,7 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
         if self.backend.startswith("k8s"):
             self.cluster_log_collectors |= {
                 KubernetesLogCollector: self.kubernetes_set,
+                KubernetesMustGatherLogCollector: self.kubernetes_set,
                 KubernetesAPIServerLogCollector: self.kubernetes_set,
             }
         self.cluster_log_collectors |= {

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -105,6 +105,7 @@ from sdcm.cdclog_reader_thread import CDCLogReaderThread
 from sdcm.logcollector import (
     KubernetesAPIServerLogCollector,
     KubernetesLogCollector,
+    KubernetesMustGatherLogCollector,
     LoaderLogCollector,
     MonitorLogCollector,
     BaseSCTLogCollector,
@@ -2759,6 +2760,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         # debugging info is lost
         if self.k8s_clusters:
             for k8s_cluster in self.k8s_clusters:
+                k8s_cluster.gather_k8s_logs_by_operator()
                 k8s_cluster.gather_k8s_logs()
 
         if self.params.get('collect_logs'):
@@ -3215,6 +3217,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                     {"name": "k8s_cluster",
                      "nodes": [],
                      "collector": KubernetesLogCollector,
+                     "logname": "k8s_log", },
+                    {"name": "k8s_cluster_must_gather",
+                     "nodes": [],
+                     "collector": KubernetesMustGatherLogCollector,
                      "logname": "k8s_log", },
                     )
 


### PR DESCRIPTION
In scylla-operator-v1.11.0 was added possibility to gather K8S logs by using it's binary.
It is required for support requests and bug reports.
So, add it's support here in addition to our main K8S gathering logic and save as a separate archive.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
