### PR TITLE
fix(rolling-upgrade): use correctly versions to cover rc versions

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -771,9 +771,9 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         InfoEvent(message='Starting sstabledump to verify correctness of sstables').publish()
         first_node = self.db_cluster.nodes[0]
         if first_node.is_enterprise:
-            should_use_sstabledump = ComparableScyllaVersion(first_node.scylla_version) < "2023.2"
+            should_use_sstabledump = ComparableScyllaVersion(first_node.scylla_version) < "2023.2.0~rc0"
         else:
-            should_use_sstabledump = ComparableScyllaVersion(first_node.scylla_version) < "5.4"
+            should_use_sstabledump = ComparableScyllaVersion(first_node.scylla_version) < "5.4.0~rc0"
         if should_use_sstabledump:
             dump_cmd = 'sstabledump'
         else:


### PR DESCRIPTION
the logic to pick the correct sstable tool was branch version and cause of that wasn't covering correctly the release canidate versions

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
