### PR TITLE
fix(rolling-upgrade): Change rollling upgrades loader to c7i

### DIFF
--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -19,7 +19,7 @@ n_loaders: 1
 n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
-instance_type_loader: 'c6.2xlarge'
+instance_type_loader: 'c7i.2xlarge'
 
 user_prefix: 'rolling-upgrade'
 


### PR DESCRIPTION
c6 is a typo it should be c6i, but c7i is more available in terms of spot, newer and has better performance for the same price.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
