### PR TITLE
fix(azure): do not run `disable_daily_triggered_services` on loaders

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4776,7 +4776,8 @@ class BaseLoaderSet():
 
         # update repo cache and system after system is up
         node.update_repo_cache()
-        node.disable_daily_triggered_services()
+        if self.params.get("cluster_backend") != "azure":
+            node.disable_daily_triggered_services()
 
         if TestConfig().REUSE_CLUSTER:
             self.kill_stress_thread()


### PR DESCRIPTION
After backport of the https://github.com/scylladb/scylla-cluster-tests/pull/6759 PR to the `branch-5.2`
we started getting following error running Azure CI jobs and using the 'branch-5.2' branch:

```
      Command: 'sudo docker pull scylladb/scylla:latest'
      Exit code: 1
      Stdout:
      Stderr: sudo: docker: command not found
```

So, fix it by not running the `disable_daily_triggered_services` method when the Azure backend is used.

Fixes: #6859

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
