### PR TITLE
fix(monitor): install node_exporter instead of using docker

### DIFF
--- a/sdcm/node_exporter_setup.py
+++ b/sdcm/node_exporter_setup.py
@@ -1,7 +1,7 @@
 from sdcm.remote import shell_script_cmd
 
 
-NODE_EXPORTER_VERSION = '1.5.0'
+NODE_EXPORTER_VERSION = '1.7.0'
 
 
 class NodeExporterSetup:  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
at some point we started using docker for running the node_exporter
on the monitoring machine, but since then we have implemented
installation of node_exporter for loader nodes.

we are switching to that, since the docker based options
seems to be unstable (since 2020 it was failing, and wasn't tracked)

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/6861

#### Testing
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/31/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
