### PR TITLE
fix(perf-regression): use `stop_test_on_stress_failure: false`

### DIFF
--- a/test-cases/performance/perf-regression-latency-1TB.yaml
+++ b/test-cases/performance/perf-regression-latency-1TB.yaml
@@ -32,3 +32,4 @@ custom_es_index: 'performancestatsv2'
 use_hdr_cs_histogram: true
 
 use_placement_group: true
+stop_test_on_stress_failure: false

--- a/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
@@ -37,3 +37,5 @@ use_prepared_loaders: true
 use_hdr_cs_histogram: true
 use_placement_group: true
 email_subject_postfix: 'latency during operations'
+
+stop_test_on_stress_failure: false

--- a/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
@@ -50,3 +50,4 @@ use_hdr_cs_histogram: true
 append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
 
 use_placement_group: true
+stop_test_on_stress_failure: false


### PR DESCRIPTION
we don't want to stop those test on case of failures like this we still want to finish the test and report the results even if some queries were failing

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
