### PR TITLE
fix(artifact-arm-centos8): update the base image

### DIFF
--- a/configurations/arm/centos8.yaml
+++ b/configurations/arm/centos8.yaml
@@ -1,5 +1,5 @@
 ami_db_scylla_user: 'centos'
-ami_id_db_scylla: 'ami-08396399fcc3968ff' # CentOS Stream 8 aarch64 20230530
+ami_id_db_scylla: 'ami-05b7b54d9a348ef3e' # CentOS Stream 8 aarch64 20231127
 region_name: 'eu-west-1'
 instance_type_db: 'im4gn.xlarge'
 use_preinstalled_scylla: false


### PR DESCRIPTION
Since the image we used seems to be deleted from AWS, and we were getting the following error:

```
   File ".../sdcm/utils/aws_utils.py", line 359, in ec2_ami_get_root_device_name
     if image.root_device_name:
   File ".../boto3/resources/factory.py", line 386, in property_loader
     return self.meta.data.get(name)
 AttributeError: 'NoneType' object has no attribute 'get'
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
