### PR TITLE
fix(cleanup-api): enlarge timeout to 10min

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -747,7 +747,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         of the command in (4).
         """
         compaction_args = self._prepare_start_stop_compaction()
-        trigger_func = partial(compaction_args.compaction_ops.trigger_cleanup_compaction)
+        trigger_func = partial(compaction_args.compaction_ops.trigger_cleanup_compaction, timeout=500)
         watch_func = partial(compaction_args.compaction_ops.stop_on_user_compaction_logged,
                              node=compaction_args.target_node,
                              mark=compaction_args.target_node.mark_log(),

--- a/sdcm/rest/storage_service_client.py
+++ b/sdcm/rest/storage_service_client.py
@@ -29,11 +29,11 @@ class StorageServiceClient(RemoteCurlClient):
 
         return self.run_remoter_curl(method="POST", path=path, params=params, timeout=360)
 
-    def cleanup_ks_cf(self, keyspace: str, cf: Optional[str] = None) -> Result:
+    def cleanup_ks_cf(self, keyspace: str, cf: Optional[str] = None, timeout: int = 500) -> Result:
         params = {"cf": cf} if cf else {}
         path = f"keyspace_cleanup/{keyspace}"
 
-        return self.run_remoter_curl(method="POST", path=path, params=params)
+        return self.run_remoter_curl(method="POST", path=path, params=params, timeout=timeout)
 
     def scrub_ks_cf(self, keyspace: str, cf: Optional[str] = None, scrub_mode: Optional[str] = None) -> Result:
         params = {"cf": cf} if cf else {}

--- a/sdcm/utils/compaction_ops.py
+++ b/sdcm/utils/compaction_ops.py
@@ -52,8 +52,8 @@ class CompactionOps:
 
         return self.storage_service_client.scrub_ks_cf(**params)
 
-    def trigger_cleanup_compaction(self, keyspace: str = "keyspace1", cf: str = "standard1") -> Result:
-        return self.storage_service_client.cleanup_ks_cf(keyspace=keyspace, cf=cf)
+    def trigger_cleanup_compaction(self, keyspace: str = "keyspace1", cf: str = "standard1", timeout: int = 500) -> Result:
+        return self.storage_service_client.cleanup_ks_cf(keyspace=keyspace, cf=cf, timeout=timeout)
 
     def trigger_validation_compaction(self, keyspace: str = "keyspace1", cf: str = "standard1") -> Result:
         return self.storage_service_client.scrub_ks_cf(keyspace=keyspace,


### PR DESCRIPTION
the default timeout for `run_remoter_curl` is 2min, and seems like in some cases that's not enough and we might
get into the retry and get the following errors:

```
cleanup request failed: there is an ongoing cleanup on keyspace1.standard1
```

we enlarge it to 10min, and if it would be needed we'll apply AdaptiveTimeout for it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
