### PR TITLE
fix(get_version_based_on_conf): handle `unified_package` correctly

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2332,11 +2332,7 @@ class SCTConfiguration(dict):
         scylla_version = None
         _is_enterprise = False
 
-        if not self.get('use_preinstalled_scylla'):
-            scylla_repo = self.get('scylla_repo')
-            scylla_version = get_branch_version(scylla_repo)
-            _is_enterprise = is_enterprise(scylla_version)
-        elif unified_package := self.get('unified_package'):
+        if unified_package := self.get('unified_package'):
             with tempfile.TemporaryDirectory() as tmpdirname:
                 LOCALRUNNER.run(shell_script_cmd(f"""
                     cd {tmpdirname}
@@ -2347,7 +2343,10 @@ class SCTConfiguration(dict):
                 scylla_version = next(pathlib.Path(tmpdirname).glob('**/SCYLLA-VERSION-FILE')).read_text()
                 scylla_product = next(pathlib.Path(tmpdirname).glob('**/SCYLLA-PRODUCT-FILE')).read_text()
                 _is_enterprise = scylla_product == 'scylla-enterprise'
-
+        elif not self.get('use_preinstalled_scylla'):
+            scylla_repo = self.get('scylla_repo')
+            scylla_version = get_branch_version(scylla_repo)
+            _is_enterprise = is_enterprise(scylla_version)
         elif self.get('db_type') == 'cloud_scylla':
             _is_enterpise = True
         elif backend == 'aws':

--- a/unit_tests/test_config_get_version_based_on_conf.py
+++ b/unit_tests/test_config_get_version_based_on_conf.py
@@ -154,6 +154,7 @@ def test_unified_package():
     os.environ[
         'SCT_GCE_IMAGE_DB'] = 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
 
+    os.environ['SCT_USE_PREINSTALLED_SCYLLA'] = 'false'
     conf = sct_config.SCTConfiguration()
     conf.verify_configuration()
 


### PR DESCRIPTION
since we were attending to `use_preinstalled_scylla` first, we were missing the fact we need to check the `unified_package` and were testing an empty `scylla_repo`

checking `unified_packgae` first fixes this issue.

Fixes: #6868

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
