### PR TITLE
fix(cassandra-stress): wait for first stress to create schema

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1865,6 +1865,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                           client_encrypt=self.params.get('client_encrypt'),
                                           keyspace_name=keyspace_name,
                                           stop_test_on_failure=stop_test_on_failure,
+                                          prometheus_db=self.prometheus_db,
                                           params=params or self.params).run()
         scylla_encryption_options = self.params.get('scylla_encryption_options')
         if scylla_encryption_options and 'write' in stress_cmd:

--- a/test-cases/longevity/longevity-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-100gb-4h.yaml
@@ -1,16 +1,21 @@
 test_duration: 330
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=10485760 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(512) n=FIXED(10)' -pop seq=1..10485760",
+                    "cassandra-stress write no-warmup cl=ALL n=10485760 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(512) n=FIXED(10)' -pop seq=10485760..20971520",
+                    "cassandra-stress write no-warmup cl=ALL n=10485760 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(512) n=FIXED(10)' -pop seq=20971520..31457280",
+                    "cassandra-stress write no-warmup cl=ALL n=10485760 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(512) n=FIXED(10)' -pop seq=31457280..41943040"]
 
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=240m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=240m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
              ]
 
-n_db_nodes: 6
+n_db_nodes: 3
 n_loaders: 2
 n_monitor_nodes: 1
 seeds_num: 3
+round_robin: true
 
+instance_type_loader: 'c5.2xlarge'
 instance_type_db: 'i4i.4xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
@@ -24,7 +29,6 @@ space_node_threshold: 64424
 server_encrypt: true
 client_encrypt: true
 
-pre_create_schema: True
 sstable_size: 100
 
 hinted_handoff: 'enabled'

--- a/unit_tests/test_cassandra_stress_thread.py
+++ b/unit_tests/test_cassandra_stress_thread.py
@@ -10,6 +10,9 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2022 ScyllaDB
+
+from unittest.mock import MagicMock
+
 import pytest
 
 from sdcm.stress_thread import CassandraStressThread
@@ -23,7 +26,6 @@ pytestmark = [
 
 def test_01_cassandra_stress(request, docker_scylla, params):
     params['cs_debug'] = True
-
     loader_set = LocalLoaderSetDummy()
 
     cmd = (
@@ -140,3 +142,49 @@ def test_03_cassandra_stress_multi_region(request, docker_scylla, params):
 
     assert "latency 99th percentile" in output[0]
     assert float(output[0]["latency 99th percentile"]) > 0
+
+
+@pytest.mark.parametrize("fail_metric", (
+        pytest.param(True, id="error"),
+        pytest.param(False, id='ok'),
+))
+def test_04_round_robin(request, docker_scylla, params, fail_metric):
+    
+    # for testing we reset the global state, so we can test multiple times
+    CassandraStressThread.should_wait_for_schema = False
+
+    prometheus_db = MagicMock()
+    if fail_metric:
+        prometheus_db.metric_has_data = MagicMock(side_effect = Exception('Test'))
+    params['round_robin'] = True
+
+    # set specific load so we skip loader search to match running version
+    params['stress_image']['cassandra-stress'] = 'docker.io/scylladb/scylla-nightly:5.2.0-dev-0.20220820.516089beb0b8'
+    loader_set = LocalLoaderSetDummy()
+
+    cmds = [
+        "cassandra-stress write no-warmup cl=ALL n=100 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1)' -mode cql3 native -rate threads=1  -pop seq=1..100",
+        "cassandra-stress write no-warmup cl=ALL n=100 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1)' -mode cql3 native -rate threads=1  -pop seq=100..200",
+        "cassandra-stress write no-warmup cl=ALL n=100 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1)' -mode cql3 native -rate threads=1  -pop seq=200..300",
+        "cassandra-stress write no-warmup cl=ALL n=100 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1)' -mode cql3 native -rate threads=1  -pop seq=300..400",
+    ]
+    cs_threads =  [CassandraStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=120, params=params, prometheus_db=prometheus_db).run() for cmd in cmds]
+
+    def cleanup_thread():
+        for cs_thread in cs_threads:
+            cs_thread.kill()
+
+    request.addfinalizer(cleanup_thread)
+
+    for cs_thread in cs_threads:
+        output = cs_thread.get_results()
+        assert "latency mean" in output[0]
+        assert float(output[0]["latency mean"]) > 0
+
+        assert "latency 99th percentile" in output[0]
+        assert float(output[0]["latency 99th percentile"]) > 0
+
+    prometheus_db.metric_has_data.assert_called_once_with('sum(sct_cassandra_stress_write_gauge{type="ops"}) by (instance) '
+                                                          '+ sum(sct_cassandra_stress_read_gauge{type="ops"}) by (instance) '
+                                                          '+ sum(sct_cassandra_stress_mixed_gauge{type="ops"}) by (instance) '
+                                                          '+ sum(sct_cassandra_stress_user_gauge{type="ops"}) by (instance)', n=10)

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -617,7 +617,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         entire_write_cs_thread_pool = self.run_stress_thread(stress_cmd=write_stress_during_entire_test)
 
         # Let to write_stress_during_entire_test complete the schema changes
-        self.metric_has_data(
+        self.prometheus_db.metric_has_data(
             metric_query='sct_cassandra_stress_write_gauge{type="ops", keyspace="keyspace_entire_test"}', n=10)
 
         # Prepare keyspace and tables for truncate test
@@ -649,7 +649,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         prepare_write_stress = self.params.get('prepare_write_stress')
         prepare_write_cs_thread_pool = self.run_stress_thread(stress_cmd=prepare_write_stress)
         InfoEvent(message='Sleeping for 60s to let cassandra-stress start before the upgrade...').publish()
-        self.metric_has_data(
+        self.prometheus_db.metric_has_data(
             metric_query='sct_cassandra_stress_write_gauge{type="ops", keyspace="keyspace1"}', n=5)
 
         # start gemini write workload
@@ -657,7 +657,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             InfoEvent(message="Start gemini during upgrade").publish()
             gemini_thread = self.run_gemini(self.params.get("gemini_cmd"))
             # Let to write_stress_during_entire_test complete the schema changes
-            self.metric_has_data(
+            self.prometheus_db.metric_has_data(
                 metric_query='gemini_cql_requests', n=10)
 
         with ignore_upgrade_schema_errors():
@@ -1349,7 +1349,7 @@ class UpgradeCustomTest(UpgradeTest):
                 continue
 
             try:
-                self.metric_has_data(
+                self.prometheus_db.metric_has_data(
                     metric_query='sct_cassandra_stress_user_gauge{type="ops", keyspace="%s"}' % keyspace_name, n=10)
             except Exception as err:  # pylint: disable=broad-except
                 InfoEvent(


### PR DESCRIPTION
up until now, we had a 30sec sleep after the first stress run in
each stress thread, when round_robin was used with multiple commands
we still get to two stress command racing at the begining
and might fail on schema creation.

there is an ongoing work, as maybe fix the c-s code, but for the
sake of supporting older c-s version (ones we use in perf branches)
we introduce a new way to wait for the first load to start (via
checking metrics), and only then release other loads

#### Testing
- [ ] 200gb round robin: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/33/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
