### PR TITLE
fix(k8s): ignore decomission errors from operator agent logs

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2871,9 +2871,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         scylla_shards = node.scylla_shards
 
         timeout = timeout or (node.pod_terminate_timeout * 60)
-        with adaptive_timeout(operation=Operations.DECOMMISSION, node=node), DbEventsFilter(
-                db_event=DatabaseLogEvent.RUNTIME_ERROR,
-                line="std::runtime_error (Operation decommission is in progress, try again)"):
+        with adaptive_timeout(operation=Operations.DECOMMISSION, node=node):
             self.replace_scylla_cluster_value(
                 f"/spec/datacenter/racks/{rack}/members", current_members - 1, dc_idx=dc_idx)
             self.k8s_clusters[node.dc_idx].kubectl(

--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -73,6 +73,13 @@ def start_events_device(log_dir: Optional[Union[str, Path]] = None,
     EventsSeverityChangerFilter(new_severity=Severity.WARNING,
                                 event_class=DatabaseLogEvent.RUNTIME_ERROR,
                                 regex='.*view update generator not plugged to push updates').publish()
+
+    # cause of issue https://github.com/scylladb/scylla-cluster-tests/issues/6119
+    EventsSeverityChangerFilter(new_severity=Severity.WARNING,
+                                event_class=DatabaseLogEvent.RUNTIME_ERROR,
+                                regex=r'.*sidecar/controller.go.*std::runtime_error '
+                                      r'\(Operation decommission is in progress, try again\)').publish()
+
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: supressed').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: suppressed').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.WARNING, line='abort_requested_exception').publish()

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -421,6 +421,19 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
                                "10.12.0.219: std::runtime_error (view update generator not plugged to push updates)") \
                 .publish()
 
+            DatabaseLogEvent.RUNTIME_ERROR() \
+                .add_info(node="A",
+                          line_number=22,
+                          line="E1126 06:51:09.025977       1 sidecar/controller.go:143] syncing key "
+                               "'scylla/sct-cluster-eu-north-1-rack-1-1-0' failed: [can't sync the HostID "
+                               "annotation: local host ID \"877e1a6f-1a41-41d0-9331-88223cae86e8\" not found in IP "
+                               "to hostID mapping: map[172.20.14.11:c1895157-9b21-458d-b135-2f94ca1a5c9f "
+                               "172.20.169.200:fe04409c-7077-4faf-a9bc-3fada4deea1d "
+                               "172.20.171.188:ee21eb2f-8ffe-4017-9c84-ee88de98b5ac], "
+                               "can't decommision a node: can't decommission the node: "
+                               "agent [HTTP 500] std::runtime_error (Operation decommission is in progress, try again)]") \
+                .publish()
+
         log_content = self.get_event_log_file("events.log")
 
         self.assertIn("other back trace", log_content)


### PR DESCRIPTION
Since we have issues with doing this correctly on the specific place it might be happening, we'll ignore this one globaly

Ref: scylladb/scylla-cluster-tests#6119

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
