### PR TITLE
fix(k8s): make k8s log collectors not overlap in log dir names

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1208,7 +1208,7 @@ class KubernetesLogCollector(BaseSCTLogCollector):
         DirLog(name='*_cluster_events.log', search_locally=True),
         DirLog(name='kubectl.version', search_locally=True),
         DirLog(name='cluster-scoped-resources/*', search_locally=True),
-        DirLog(name='namespaces/*', search_locally=True),
+        DirLog(name='namespace-scoped-resources/*', search_locally=True),
     ]
     cluster_log_type = "kubernetes"
     cluster_dir_prefix = "k8s-"

--- a/sdcm/utils/k8s/__init__.py
+++ b/sdcm/utils/k8s/__init__.py
@@ -599,11 +599,12 @@ class KubernetesOps:  # pylint: disable=too-many-public-methods
         # Gather namespace-scoped resources info
         LOGGER.info("K8S-LOGS: gathering namespace scoped resources. list of namespaces: %s",
                     ', '.join(namespaces))
-        os.makedirs(logdir / "namespaces", exist_ok=True)
+        namespace_scope_dir = "namespace-scoped-resources"
+        os.makedirs(logdir / namespace_scope_dir, exist_ok=True)
         for resource_type in kubectl(
                 "api-resources --namespaced=true --verbs=get,list -o name").stdout.split():
             LOGGER.info("K8S-LOGS: gathering '%s' resources", resource_type)
-            logfile = logdir / "namespaces" / f"{resource_type}.{output_format}"
+            logfile = logdir / namespace_scope_dir / f"{resource_type}.{output_format}"
             resources_wide = kubectl(
                 f"get {resource_type} -A -o wide 2>&1 | tee {logfile}", ignore_status=True).stdout
             if resource_type.startswith("events"):
@@ -616,7 +617,7 @@ class KubernetesOps:  # pylint: disable=too-many-public-methods
                 LOGGER.info(
                     "K8S-LOGS: gathering '%s' resources in the '%s' namespace",
                     resource_type, namespace)
-                resource_dir = logdir / "namespaces" / namespace / resource_type
+                resource_dir = logdir / namespace_scope_dir / namespace / resource_type
                 os.makedirs(resource_dir, exist_ok=True)
                 for res in resources_wide.split("\n"):
                     if not re.match(f"{namespace} ", res):


### PR DESCRIPTION
After adding of the scylla-operator's `must-gather logs` support (https://github.com/scylladb/scylla-cluster-tests/pull/6855) we started having partial duplication of it's logs in our own collected K8S logs due to the dir names (those which are used for filtering in `logcollector`) overlapping.

So, fix it by renaming the `namespaces` dir to the `namespace-scoped-resources` following the template used for the `cluster scoped` ones.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
