### PR TITLE
fix(k8s): make `use_mgmt=false` work again for K8S

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2476,7 +2476,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         self.k8s_scylla_manager_auth_token = None
         kwargs = {}
         for k8s_cluster in k8s_clusters:
-            if not kwargs:
+            if not kwargs and params.get('use_mgmt'):
                 kwargs["s3_provider_endpoint"] = k8s_cluster.s3_provider_endpoint
             k8s_cluster.deploy_scylla_cluster(
                 node_pool_name=node_pool_name,


### PR DESCRIPTION
After merge of the `support of mgmt for K8S MultiDC setups` (https://github.com/scylladb/scylla-cluster-tests/pull/6844) The non-mgmt K8S setups started failing with following error:

```
  File "sdcm/tester.py", line 1666, in get_cluster_k8s_eks
    self.db_clusters_multitenant.append(eks.EksScyllaPodCluster(
  File "sdcm/cluster_k8s/__init__.py", line 2501, in __init__
    kwargs["s3_provider_endpoint"] = k8s_cluster.s3_provider_endpoint
  File "sdcm/cluster_k8s/__init__.py", line 1494, in s3_provider_endpoint
    return f"http://{self.minio_ip_address}:9000"
  File "sdcm/cluster_k8s/__init__.py", line 1490, in minio_ip_address
    return self.minio_pod.status.pod_ip
  File "sdcm/cluster_k8s/__init__.py", line 1486, in minio_pod
    raise RuntimeError("Can't find minio pod")
```

So, fix it by checking the `use_mgmt` option to not be `False` processing the mgmt code parts.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
