### PR TITLE
improvement(k8s-eks): use actual version of the `vpc-cni` plugin

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -14,7 +14,7 @@ eks_role_arn: 'arn:aws:iam::797456418907:role/eksServicePolicy'
 eks_service_ipv4_cidr: '172.20.0.0/16'
 eks_nodegroup_role_arn: 'arn:aws:iam::797456418907:role/helm-test-worker-nodes-NodeInstanceRole-6ACHDYEKNN3I'
 # NOTE: https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
-eks_vpc_cni_version: 'v1.12.6-eksbuild.1'
+eks_vpc_cni_version: 'v1.15.3-eksbuild.1'
 
 scylla_version: '5.2.7'
 scylla_mgmt_agent_version: '3.1.0'


### PR DESCRIPTION
According to the AWS docs [1] the actual version of the 'vpc-cni' addon is 'v1.15.3-eksbuild.1'.
So, start using it.

[1] https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
