### PR TITLE
improvement(artifact test): add check node exporter liveness

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -23,6 +23,7 @@ import requests
 from sdcm.sct_events import Severity
 from sdcm.sct_events.database import ScyllaHousekeepingServiceEvent
 from sdcm.tester import ClusterTester
+from sdcm.utils.adaptive_timeouts import NodeLoadInfoServices
 from sdcm.utils.housekeeping import HousekeepingDB
 from sdcm.utils.common import get_latest_scylla_release, ScyllaProduct
 
@@ -338,6 +339,11 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
 
         with self.subTest("check cqlsh installation"):
             self.check_cqlsh()
+
+        with self.subTest("check node_exporter liveness"):
+            node_info_service = NodeLoadInfoServices().get(self.node)
+            assert node_info_service.cpu_load_5
+            assert node_info_service.get_memory_available()
 
         # We don't install any time sync service in docker, so the test is unnecessary:
         # https://github.com/scylladb/scylla/tree/master/dist/docker/etc/supervisord.conf.d

--- a/sdcm/utils/adaptive_timeouts/load_info_store.py
+++ b/sdcm/utils/adaptive_timeouts/load_info_store.py
@@ -87,6 +87,11 @@ class NodeLoadInfoService:
             load_1, load_5, load_15 = self.remoter.run('uptime').stdout.split("load average: ")[1].split(",")
             return float(load_1), float(load_5), float(load_15)
 
+    def get_memory_available(self) -> float:
+        metrics = self._get_node_exporter_metrics()
+        mem_available = float(metrics['node_memory_MemAvailable_bytes'])
+        return mem_available
+
     @retrying(n=5, sleep_time=1, allowed_exceptions=(ValueError,))
     def _get_metrics(self, port):
         metrics = self.remoter.run(f'curl -s localhost:{port}/metrics', verbose=False).stdout


### PR DESCRIPTION
From time to time we upgrade Node exporter, which is in charge of OS metrics from Scylla nodes.
Check that it's not dead on arrival.

#### Test:
- [x] - AMI, passed. https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/artifacts-ami-t3_micro-test/7/
- [x] - offline, passed. https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/artifacts-ubuntu2204-offline-test/2/
- [x] - gce image, passed. https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/yulia-artifacts-gce-image/3/
- [x] - deb, passed. https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/artifacts-ubuntu2204-test/2/ 
- [x]  - rpm, passed. https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/artifacts-rocky9-test/2/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
