### PR TITLE
fix(longevity): remove MV creation in large partition tests

### DIFF
--- a/test-cases/longevity/longevity-large-partition-3h.yaml
+++ b/test-cases/longevity/longevity-large-partition-3h.yaml
@@ -28,9 +28,7 @@ stress_cmd: ["scylla-bench -workload=sequential -mode=write -replication-factor=
              "scylla-bench -workload=sequential -mode=read  -replication-factor=3 -partition-count=25 -clustering-row-count=5555 -partition-offset=76   -clustering-row-size=uniform:1024..2048   -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=170m -validate-data"
             ]
 
-post_prepare_cql_cmds: ["CREATE INDEX si_text ON scylla_bench.test(v)",
-                        "CREATE MATERIALIZED VIEW scylla_bench.view_test AS SELECT * FROM scylla_bench.test where ck IS NOT NULL AND pk is not null PRIMARY KEY (pk, ck) with comment = 'TEST VIEW'"
-                       ]
+post_prepare_cql_cmds: "CREATE MATERIALIZED VIEW scylla_bench.view_test AS SELECT * FROM scylla_bench.test where ck IS NOT NULL AND pk is not null PRIMARY KEY (pk, ck) with comment = 'TEST VIEW'"
 
 n_db_nodes: 5
 n_loaders: 4


### PR DESCRIPTION
Remove MV and SI creation during 'post-prepare-cql' as it may cause to index nemesis failure.

The problem that scylla_bench.test table has few columns for few indexes creation.
So post-prepare-cql or index nemesis (depend how was run first) may fail with error like:
```
cassandra.InvalidRequest: Error from server: code=2200 [Invalid query] message="Index si_text is a duplicate of existing index test_v_nemesis"
```

Meanwhile it was decided do not perform full fix of the issue and just remove MV/SI creation from 'post-prepare-cql' section.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/6565


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
