### PR TITLE
fix(performance): update AWS loader to c6i.2xlarge

### DIFF
--- a/test-cases/performance/perf-regression-latency-1TB.yaml
+++ b/test-cases/performance/perf-regression-latency-1TB.yaml
@@ -14,7 +14,7 @@ n_loaders: 4
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.4xlarge'
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c6i.2xlarge'
 instance_type_monitor: 't3.large'
 
 user_prefix: 'perf-regression-latency'

--- a/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
@@ -18,7 +18,7 @@ n_monitor_nodes: 1
 
 # AWS
 instance_type_db: 'i4i.2xlarge'
-instance_type_loader: 'c5.2xlarge'
+instance_type_loader: 'c6i.2xlarge'
 instance_type_monitor: 't3.small'
 #------
 


### PR DESCRIPTION
since we are having issues with availability of c4/c5 machines we would be switching to those new types of machines, assuming they would be more available

### Testing
- [x] -  thouroput v14 - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/scylla-master-perf-regression-throughput-non-shard-aware-i4i-test/2/
- [x] -  latency v14 - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/scylla-master-perf-regression-latency-shard-aware-1TB-test/2/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
