### PR TITLE
fix(large-partition-200k): remove partition validation

### DIFF
--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -83,12 +83,15 @@ stop_test_on_stress_failure: false
 run_fullscan: ['{"mode": "partition", "ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 100000, "validate_data": true}']
 
 use_preinstalled_scylla: true
+
 # To validate rows in partitions: collect data about partitions and their rows amount
 # before and after running nemesis and compare it
-data_validation: |
-  validate_partitions: true
-  table_name: "scylla_bench.test"
-  primary_key_column: "pk"
-  max_partitions_in_test_table: 1000
-  partition_range_with_data_validation: 0-250
-  limit_rows_number: 10000
+
+# TODO: enable it back once https://github.com/scylladb/qa-tasks/issues/1578 is handled
+#data_validation: |
+#  validate_partitions: true
+#  table_name: "scylla_bench.test"
+#  primary_key_column: "pk"
+#  max_partitions_in_test_table: 1000
+#  partition_range_with_data_validation: 0-250
+#  limit_rows_number: 10000


### PR DESCRIPTION
validation is keep timing out on this use case, looks like it's reading too much
```
2023-12-02 14:59:58.509: (TestFrameworkEvent Severity.ERROR)
period_type=one-time event_id=9f0498a0-1588-4b5a-9b4d-7e013ada2705,
source=PartitionsValidationAttributes message=Failed to collect partition info.
Error details: Requested pages were not delivered before timeout.
Requested: 1; retrieved: 0; empty retrieved 0
```

for now we'll disable it for this use case, until further investigated as for the root, maybe this case is overloading already.

#### Testing
- [x] 12h run: https://argus.scylladb.com/test/7539b0e9-7dfd-4ad7-ab9d-a4cde2807077/runs?additionalRuns[]=a9240d39-6069-4a53-9e87-07f068c2afff 
        crashed on a known issue after 9 hours, but didn't see any of the other issue we had with the validation.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
