### PR TITLE
fix(gemini-3h-with-nemesis): Setting fixed gemini seed

### DIFF
--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -22,6 +22,7 @@ gemini_cmd: "gemini -d --duration 3h --warmup 30m \
 --async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \
 --replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" \
 --oracle-replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '1'}\""
+gemini_seed: 69
 
 gemini_version: '1.7.8'
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used


### PR DESCRIPTION
In order to keep on the same regression test for patch releases, instead of bumping into old known issues or new issues that aren't going to be handled in this old release, the gemini_seed is set to a seed number that is proved to passed already.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
