### PR TITLE
fix(k8s-gke): set AZ explicitly as non-`a` for the `us-east1` region

### DIFF
--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -1,5 +1,6 @@
 instance_provision: 'on_demand'
 gce_datacenter: 'us-east1'
+availability_zone: 'c'
 gce_network: 'qa-vpc'
 gce_image_username: 'scylla-test'
 

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-add-remove-rack.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-add-remove-rack.jenkinsfile
@@ -4,6 +4,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-gke',
+    region: 'us-east1',
+    availability_zone: 'c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-add-remove-rack.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-backup.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-backup.jenkinsfile
@@ -4,6 +4,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-gke',
+    region: 'us-east1',
+    availability_zone: 'c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-backup.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-cluster-rolling.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-cluster-rolling.jenkinsfile
@@ -4,6 +4,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-gke',
+    region: 'us-east1',
+    availability_zone: 'c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-cluster-rolling.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-grow-shrink.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-grow-shrink.jenkinsfile
@@ -4,6 +4,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-gke',
+    region: 'us-east1',
+    availability_zone: 'c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-grow-shrink.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-nodetool-flush-and-reshard.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-nodetool-flush-and-reshard.jenkinsfile
@@ -4,6 +4,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-gke',
+    region: 'us-east1',
+    availability_zone: 'c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-nodetool-flush-and-reshard.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-repair.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-repair.jenkinsfile
@@ -4,6 +4,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-gke',
+    region: 'us-east1',
+    availability_zone: 'c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-repair.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-replace.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-replace.jenkinsfile
@@ -4,6 +4,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-gke',
+    region: 'us-east1',
+    availability_zone: 'c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-replace.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-scylla-enterprise.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-scylla-enterprise.jenkinsfile
@@ -4,6 +4,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-gke',
+    region: 'us-east1',
+    availability_zone: 'c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-stop-start.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-stop-start.jenkinsfile
@@ -4,6 +4,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-gke',
+    region: 'us-east1',
+    availability_zone: 'c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-stop-start.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-terminate-decommission-add.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-terminate-decommission-add.jenkinsfile
@@ -4,6 +4,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-gke',
+    region: 'us-east1',
+    availability_zone: 'c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-terminate-decommission-add.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-terminate-replace.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-terminate-replace.jenkinsfile
@@ -4,6 +4,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-gke',
+    region: 'us-east1',
+    availability_zone: 'c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-terminate-replace.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke.jenkinsfile
@@ -4,6 +4,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-gke',
+    region: 'us-east1',
+    availability_zone: 'c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/scylla-operator/longevity-scylla-operator-3h.yaml", "configurations/operator/loader-run-type-dynamic.yaml"]''',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-basic-12h-gke-scylla-enterprise.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-basic-12h-gke-scylla-enterprise.jenkinsfile
@@ -4,6 +4,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-gke',
+    region: 'us-east1',
+    availability_zone: 'c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-basic-12h.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-basic-12h-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-basic-12h-gke.jenkinsfile
@@ -4,6 +4,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-gke',
+    region: 'us-east1',
+    availability_zone: 'c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-basic-12h.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-k8s-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-k8s-gke.jenkinsfile
@@ -5,6 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingOperatorUpgradePipeline(
     backend: 'k8s-gke',
     region: 'us-east1',
+    availability_zone: 'c',
     base_versions: '["2022.1.6"]',
     new_version: '2022.2.7',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',

--- a/jenkins-pipelines/operator/upgrade/upgrade-operator-k8s-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-operator-k8s-gke.jenkinsfile
@@ -5,6 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingOperatorUpgradePipeline(
     backend: 'k8s-gke',
     region: 'us-east1',
+    availability_zone: 'c',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_operator_upgrade',
     test_config: 'test-cases/scylla-operator/kubernetes-operator-upgrade.yaml',
 )

--- a/jenkins-pipelines/operator/upgrade/upgrade-platform-k8s-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-platform-k8s-gke.jenkinsfile
@@ -5,6 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingOperatorUpgradePipeline(
     backend: 'k8s-gke',
     region: 'us-east1',
+    availability_zone: 'c',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_platform_upgrade',
     test_config: '''["test-cases/scylla-operator/kubernetes-platform-upgrade.yaml", "configurations/operator/k8s-upgrade-gke.yaml"]''',
 )

--- a/jenkins-pipelines/operator/upgrade/upgrade-scylla-k8s-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-scylla-k8s-gke.jenkinsfile
@@ -5,6 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingOperatorUpgradePipeline(
     backend: 'k8s-gke',
     region: 'us-east1',
+    availability_zone: 'c',
     base_versions: '["2022.1.6"]',
     new_version: '2022.2.7',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -19,7 +19,7 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('region', '')}",
                description: 'Supported: us-east-1 | eu-west-1 | eu-west-2 | eu-north-1 | eu-central-1 | us-west-2 | random (randomly select region)',
                name: 'region')
-            string(defaultValue: "${pipelineParams.get('availability_zone', 'a')}",
+            string(defaultValue: "${pipelineParams.get('availability_zone', 'b')}",
                description: 'Availability zone',
                name: 'availability_zone')
             string(defaultValue: "${pipelineParams.get('base_versions', '')}",


### PR DESCRIPTION
After merge of the `MultiDC support for GKE backend` PR (https://github.com/scylladb/scylla-cluster-tests/pull/6853) the SCT started respecting the `availability_zone` config option.
It led to the situation that we started getting following error:

```
  ERROR: (gcloud.container.clusters.create) ResponseError: \
    code=400, \
    message=Specified location "us-east1-a" is not a valid zone in the cluster's region "us-east1".
```

It is caused by the fact that the default AZ was `a` and it is absent in the `us-east1` region.

So, fix this situation by explicitly setting the AZ for the GKE jobs.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
