### PR TITLE
fix(run_cqlsh): make sure we escape double quotes

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2709,14 +2709,17 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                       auth_params=auth_params, use_keyspace=use_keyspace, timeout=timeout,
                       connect_timeout=connect_timeout, ssl_params=ssl_params)
 
+        # escape double quotes, that might be on keyspace/tables names
+        command = json.dumps(command)
+
         cqlsh_cmd = self.add_install_prefix('/usr/bin/cqlsh')
         if self.is_cqlsh_support_cloud_bundle:
             connection_bundle_file = self.parent_cluster.connection_bundle_file
             target_connection_bundle_file = str(Path('/tmp/') / connection_bundle_file.name)
             self.remoter.send_files(str(connection_bundle_file), target_connection_bundle_file)
 
-            return f'{cqlsh_cmd} {options} -e "{command}" --cloudconf {target_connection_bundle_file}'
-        return f'{cqlsh_cmd} {options} -e "{command}" {host} {port}'
+            return f'{cqlsh_cmd} {options} -e {command} --cloudconf {target_connection_bundle_file}'
+        return f'{cqlsh_cmd} {options} -e {command} {host} {port}'
 
     def run_cqlsh(self, cmd, keyspace=None, port=None, timeout=120, verbose=True, split=False, target_db_node=None,
                   connect_timeout=60, num_retry_on_failure=1):

--- a/unit_tests/test_run_cqlsh.py
+++ b/unit_tests/test_run_cqlsh.py
@@ -1,0 +1,30 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2023 ScyllaDB
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+]
+
+
+def test_01_cqlsh_check_escaping(docker_scylla):
+    cql_cmd = ('create keyspace if not exists "10gb_keyspace" with replication = '
+               '{\'class\': \'NetworkTopologyStrategy\', \'replication_factor\': 1}')
+
+    res = docker_scylla.run_cqlsh(cql_cmd)
+    assert res.ok
+
+    cql_cmd = 'describe keyspace "10gb_keyspace"'
+    res = docker_scylla.run_cqlsh(cql_cmd)
+    assert 'CREATE KEYSPACE "10gb_keyspace"' in res.stdout


### PR DESCRIPTION
since some keyspace or table names might be with quotes we should escape them, before passing it to the cqlsh command line

Ref: scylladb/scylla-cluster-tests#6790
Fixes: #6878

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
