### PR TITLE
fix(k8s): fix mgmt setup for the multitenant K8S deployments

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2811,12 +2811,12 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
                 self.k8s_scylla_manager_auth_token = base64.b64decode(kubectl(
                     f"get secrets/{self.scylla_cluster_name}-auth-token"
                     " --template='{{ index .data \"auth-token.yaml\" }}'",
-                    namespace=SCYLLA_NAMESPACE).stdout.strip()).decode('utf-8').strip()
+                    namespace=self.namespace).stdout.strip()).decode('utf-8').strip()
             elif current_dc_idx > 0 and self.k8s_scylla_manager_auth_token:
                 existing_k8s_scylla_manager_auth_token = base64.b64decode(kubectl(
                     f"get secrets/{self.scylla_cluster_name}-auth-token"
                     " --template='{{ index .data \"auth-token.yaml\" }}'",
-                    namespace=SCYLLA_NAMESPACE).stdout.strip()).decode('utf-8').strip()
+                    namespace=self.namespace).stdout.strip()).decode('utf-8').strip()
                 if existing_k8s_scylla_manager_auth_token != self.k8s_scylla_manager_auth_token:
                     auth_token_base64 = base64.b64encode(
                         self.k8s_scylla_manager_auth_token.encode('utf-8')).decode('utf-8')
@@ -2825,7 +2825,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
                         ' {"op": "replace", "path": "/data/auth-token.yaml",'
                         f' "value": "{auth_token_base64}"'
                         ' }]\'')
-                    kubectl(patch_cmd, namespace=SCYLLA_NAMESPACE)
+                    kubectl(patch_cmd, namespace=self.namespace)
             # NOTE: remove the 'externalSeeds' values because pod IPs are ephemeral and
             #       we are not going to keep it up-to-date making Scylla pods not try to connect to
             #       some other test run's Scylla pods which may pick up those ephemeral IPs.


### PR DESCRIPTION
Addition of the MultiDC support to K8S setups [1] used hardcoded namespace value for Scylla which is not compatible with the multitenant setups.
So, use proper value for namespace setting up the scylla-manager running in multitenant K8S setups.

[1] https://github.com/scylladb/scylla-cluster-tests/pull/6844

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
