### PR TITLE
fix(k8s): enable GKE token update thread back

### DIFF
--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -304,7 +304,7 @@ class EksTokenUpdateThread(TokenUpdateThread):
         super().__init__(kubectl_token_path=kubectl_token_path)
 
     def get_token(self) -> str:
-        return LOCALRUNNER.run(self._aws_cmd).stdout
+        return LOCALRUNNER.run(self._aws_cmd).stdout.strip()
 
 
 # pylint: disable=too-many-instance-attributes
@@ -428,7 +428,9 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):  # pylint: disable=
 
     def create_token_update_thread(self):
         return EksTokenUpdateThread(
-            aws_cmd=f'aws eks --region {self.region_name} get-token --cluster-name {self.short_cluster_name}',
+            aws_cmd=(
+                f'aws eks --region {self.region_name} get-token'
+                f' --cluster-name {self.short_cluster_name} --output text --query "status.token"'),
             kubectl_token_path=self.kubectl_token_path
         )
 

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -240,7 +240,7 @@ class GcloudTokenUpdateThread(TokenUpdateThread):
         super().__init__(kubectl_token_path=kubectl_token_path)
 
     def get_token(self) -> str:
-        return self._gcloud.run(f'config config-helper --min-expiry={self._token_min_duration * 60} --format=json')
+        return self._gcloud.run('auth print-access-token').strip()
 
 
 class GcloudException(Exception):
@@ -254,7 +254,6 @@ class GkeCluster(KubernetesCluster):
     IS_NODE_TUNING_SUPPORTED = True
     NODE_PREPARE_FILE = sct_abs_path("sdcm/k8s_configs/gke/scylla-node-prepare.yaml")
     NODE_CONFIG_CRD_FILE = sct_abs_path("sdcm/k8s_configs/gke/node-config-crd.yaml")
-    TOKEN_UPDATE_NEEDED = False
     pools: Dict[str, GkeNodePool]
 
     # pylint: disable=too-many-arguments,too-many-locals


### PR DESCRIPTION
Recently added support for the scylla-operator's `must gather K8S logs` (https://github.com/scylladb/scylla-cluster-tests/pull/6855) 
doesn't work on the GKE backend because our kubeconfig, in this case, depends on the `gke-gcloud-auth-plugin` binary.

To make it work we should switch to usage of the `K8S access tokens` in the kubeconfig files.

So, enable the token update thread in the GKE backend back.

Also, change the kubectl auth plugin we use in our kubeconfig.
Start using `tokenFile` instead of the `exec` to avoid following kind of failures:

```
  exec plugin is configured to use API version \
    client.authentication.k8s.io/v1beta1, \
    plugin returned version client.authentication.k8s.io/__internal
```

Fixes: #6899

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
