### PR TITLE
fix(quota): skip quota nemesis on not aws backends

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1704,6 +1704,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if self._is_it_on_kubernetes():
             raise UnsupportedNemesis("Skipping nemesis for kubernetes")
 
+        # Need to check on a live cluster with GCP and Azure how the quota configuration works / fails
+        # SCT Issue REF: https://github.com/scylladb/scylla-cluster-tests/issues/6915
+        if self.cluster.params.get('cluster_backend') != 'aws':
+            raise UnsupportedNemesis("The end of quota test only supports AWS at the moment")
+
         result = node.remoter.run('cat /proc/mounts')
         if '/var/lib/scylla' not in result.stdout:
             raise UnsupportedNemesis("Scylla doesn't use an individual storage, skip end of quota test")


### PR DESCRIPTION
The nemesis currently fails on non aws backends
Added a skip check
SCT issue ref: https://github.com/scylladb/scylla-cluster-tests/issues/6915

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
