### PR TITLE
fix(run_cqlsh): make it work having new line and space symbols in cmd

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2710,7 +2710,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                       connect_timeout=connect_timeout, ssl_params=ssl_params)
 
         # escape double quotes, that might be on keyspace/tables names
-        command = json.dumps(command)
+        command = json.dumps(command.strip())
 
         cqlsh_cmd = self.add_install_prefix('/usr/bin/cqlsh')
         if self.is_cqlsh_support_cloud_bundle:

--- a/unit_tests/test_run_cqlsh.py
+++ b/unit_tests/test_run_cqlsh.py
@@ -18,9 +18,13 @@ pytestmark = [
 ]
 
 
-def test_01_cqlsh_check_escaping(docker_scylla):
-    cql_cmd = ('create keyspace if not exists "10gb_keyspace" with replication = '
-               '{\'class\': \'NetworkTopologyStrategy\', \'replication_factor\': 1}')
+@pytest.mark.parametrize("use_redundant_symbols", [True, False])
+def test_01_cqlsh_check_escaping(docker_scylla, use_redundant_symbols):
+    prefix, suffix = ("\n    ", "    \n") if use_redundant_symbols else ("", "")
+    cql_cmd = (
+        f'{prefix}create keyspace if not exists "10gb_keyspace" with replication = '
+        '{\'class\': \'NetworkTopologyStrategy\', \'replication_factor\': 1}'
+        f'{suffix}')
 
     res = docker_scylla.run_cqlsh(cql_cmd)
     assert res.ok


### PR DESCRIPTION
Recently we merged PR (https://github.com/scylladb/scylla-cluster-tests/pull/6897) which fixed the escape quotes approach.
But it added another problem that if we have new lines of additional spaces
in the beginning or ending of the command then it doesn't filter it out making CQLSH fails with the syntax errors.

So, fix it by removing the redundant symbols calling the `strip()` string method.
Also, cover this change in unit tests.

Fixes: #6916

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
