### PR TITLE
fix(sstables_utils): do not use multiline string defining cqlsh command

### DIFF
--- a/sdcm/utils/sstable/load_utils.py
+++ b/sdcm/utils/sstable/load_utils.py
@@ -205,10 +205,9 @@ class SstableLoadUtils:
     @classmethod
     def create_keyspace(cls, node, keyspace_name: str = "keyspace1", strategy: str = 'NetworkTopologyStrategy',
                         replication_factor: int = 1):
-        node.run_cqlsh("""
-                CREATE KEYSPACE %s WITH replication = {'class': '%s',
-                'replication_factor': %s}
-                """ % (keyspace_name, strategy, replication_factor))
+        node.run_cqlsh(
+            "CREATE KEYSPACE %s WITH replication = {'class': '%s', 'replication_factor': %s}" % (
+                keyspace_name, strategy, replication_factor))
 
     @classmethod
     def create_table_for_load(cls, node, schema_file_and_path: str, session):


### PR DESCRIPTION
This is follow-up fix for the recently merged PRs (https://github.com/scylladb/scylla-cluster-tests/pull/6897) and (https://github.com/scylladb/scylla-cluster-tests/pull/6918).

We should not use multi-line strings defining cql commands, because any new lines in the middle of the string won't be removed and will cause following syntax errors:

```
  Command: '/usr/bin/cqlsh --no-color   --request-timeout=120 --connect-timeout=60 \
    -e "CREATE KEYSPACE keyspace1 WITH replication = \
    {\'class\': \'NetworkTopologyStrategy\',\\n             \'replication_factor\': 3}"  10.16.254.197 9042'
  Exit code: 2

  Stdout:
  Stderr:

  <stdin>:1:Invalid syntax at char 82
  <stdin>:1:  CREATE KEYSPACE keyspace1 WITH replication = \
    {'class': 'NetworkTopologyStrategy',\n                'replication_factor': 3};
  <stdin>:1:
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
