### PR TITLE
feature(loaders): add cql-stress C-S stress tool

### DIFF
--- a/configurations/rust/cql-stress-100gb-4h.yaml
+++ b/configurations/rust/cql-stress-100gb-4h.yaml
@@ -1,0 +1,9 @@
+prepare_write_cmd:  "cql-stress-cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)'"
+
+stress_cmd: ["cql-stress-cassandra-stress write cl=QUORUM duration=240m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -rate threads=30 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)'",
+             "cql-stress-cassandra-stress read  cl=QUORUM duration=240m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -rate threads=30 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)'"
+             ]
+
+# Encryption is not yet supported by cql-stress.
+server_encrypt: false
+client_encrypt: false

--- a/data_dir/scylla-dash-per-server-nemesis.master.json
+++ b/data_dir/scylla-dash-per-server-nemesis.master.json
@@ -824,6 +824,99 @@
         "fieldConfig": {
           "defaults": {
             "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 33
+        },
+        "links": [],
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "B"
+          },
+          {
+            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "D"
+          }
+        ],
+        "title": "cql-stress C-S write latency 95%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
               "mode": "thresholds"
             },
             "custom": {
@@ -887,6 +980,77 @@
           }
         ],
         "title": "C-S stress tools write latency 95% histogram",
+        "type": "histogram"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 33
+        },
+        "links": [],
+        "options": {
+          "bucketOffset": 0,
+          "bucketSize": 2,
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "B"
+          },
+          {
+            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "D"
+          }
+        ],
+        "title": "cql-stress C-S write latency 95% histogram",
         "type": "histogram"
       },
       {
@@ -988,6 +1152,99 @@
         "fieldConfig": {
           "defaults": {
             "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 40
+        },
+        "links": [],
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "sct_cql_stress_cassandra_stress_read_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "C"
+          },
+          {
+            "expr": "sct_cql_stress_cassandra_stress_counter_read_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "E"
+          }
+        ],
+        "title": "cql-stress C-S read latency 95%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
               "mode": "thresholds"
             },
             "custom": {
@@ -1051,6 +1308,77 @@
           }
         ],
         "title": "C-S stress tool read latency 95% histogram",
+        "type": "histogram"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 40
+        },
+        "links": [],
+        "options": {
+          "bucketOffset": 0,
+          "bucketSize": 2,
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "sct_cql_stress_cassandra_stress_read_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "C"
+          },
+          {
+            "expr": "sct_cql_stress_cassandra_stress_counter_read_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "E"
+          }
+        ],
+        "title": "cql-stress C-S read latency 95% histogram",
         "type": "histogram"
       },
       {
@@ -1478,6 +1806,99 @@
         "fieldConfig": {
           "defaults": {
             "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 64
+        },
+        "links": [],
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "B"
+          },
+          {
+            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "D"
+          }
+        ],
+        "title": "cql-stress C-S write latency 99%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
               "mode": "thresholds"
             },
             "custom": {
@@ -1541,6 +1962,77 @@
           }
         ],
         "title": "C-S stress tools write latency 99% histogram",
+        "type": "histogram"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 64
+        },
+        "links": [],
+        "options": {
+          "bucketOffset": 0,
+          "bucketSize": 2,
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "B"
+          },
+          {
+            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "D"
+          }
+        ],
+        "title": "cql-stress C-S write latency 99% histogram",
         "type": "histogram"
       },
       {
@@ -1642,6 +2134,99 @@
         "fieldConfig": {
           "defaults": {
             "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 71
+        },
+        "links": [],
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "sct_cql_stress_cassandra_stress_read_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "C"
+          },
+          {
+            "expr": "sct_cql_stress_cassandra_stress_counter_read_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "E"
+          }
+        ],
+        "title": "cql-stress C-S read latency 99%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
               "mode": "thresholds"
             },
             "custom": {
@@ -1705,6 +2290,77 @@
           }
         ],
         "title": "C-S stress tool read latency 99% histogram",
+        "type": "histogram"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 71
+        },
+        "links": [],
+        "options": {
+          "bucketOffset": 0,
+          "bucketSize": 2,
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "sct_cql_stress_cassandra_stress_read_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "C"
+          },
+          {
+            "expr": "sct_cql_stress_cassandra_stress_counter_read_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "E"
+          }
+        ],
+        "title": "cql-stress C-S read latency 99% histogram",
         "type": "histogram"
       },
       {
@@ -7514,6 +8170,98 @@
         "thresholds": [],
         "timeRegions": [],
         "title": "cassandra-stress ops",
+        "tooltip": {
+          "msResolution": false,
+          "shared": true,
+          "sort": 0,
+          "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "logBase": 1,
+            "min": 0,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "class": "graph_panel",
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "description": "",
+        "editable": true,
+        "error": false,
+        "fill": 0,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 280
+        },
+        "hiddenSeries": false,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.5.2",
+        "pointradius": 1,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+              "expr": "sct_cql_stress_cassandra_stress_read_gauge{type=\"ops\"}",
+              "format": "time_series",
+              "interval": "15s",
+              "intervalFactor": 1,
+              "refId": "C"
+            },
+            {
+              "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"ops\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "cql-stress-cassandra-stress ops",
         "tooltip": {
           "msResolution": false,
           "shared": true,

--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -87,6 +87,7 @@ CassandraStressLogEvent.OperationOnKey: CRITICAL
 CassandraStressLogEvent.TooManyHintsInFlight: ERROR
 CassandraStressLogEvent.ShardAwareDriver: NORMAL
 CassandraStressLogEvent.SchemaDisagreement: WARNING
+CqlStressCassandraStressLogEvent.ReadValidationError: CRITICAL
 SchemaDisagreementErrorEvent: ERROR
 ScyllaBenchLogEvent.ConsistencyError: ERROR
 ScyllaBenchLogEvent.DataValidationError: CRITICAL
@@ -117,6 +118,7 @@ EventsSeverityChangerFilter: NORMAL
 NodetoolEvent: ERROR
 ScyllaBenchEvent: CRITICAL
 CassandraStressEvent: CRITICAL
+CqlStressCassandraStressEvent: CRITICAL
 LatteStressEvent: CRITICAL
 GeminiStressEvent: CRITICAL
 ScyllaServerStatusEvent: NORMAL

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -216,6 +216,7 @@ stress_image:
   kcl: 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC'
   harry: 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816'
   latte: 'scylladb/hydra-loaders:latte-rust1_73-20231025'
+  cql-stress-cassandra-stress: 'scylladb/hydra-loaders:cql-stress-cassandra-stress-20240119'
 
 service_level_shares: [1000]
 

--- a/docker/cql-stress-cassandra-stress/Dockerfile
+++ b/docker/cql-stress-cassandra-stress/Dockerfile
@@ -1,0 +1,16 @@
+FROM rust:1.73 as builder
+
+ARG BRANCH
+ARG REPO
+
+ENV BRANCH=${BRANCH:-master}
+ENV REPO=${REPO:-https://github.com/scylladb/cql-stress.git}
+
+RUN git clone ${REPO} -b ${BRANCH}
+
+RUN cd cql-stress && cargo build --release --bin cql-stress-cassandra-stress
+
+
+FROM rust:1.73-slim as app
+
+COPY --from=builder /cql-stress/target/release/cql-stress-cassandra-stress /usr/local/bin/

--- a/docker/cql-stress-cassandra-stress/README.md
+++ b/docker/cql-stress-cassandra-stress/README.md
@@ -1,0 +1,7 @@
+### build from scylla repo
+```
+export CQL_STRESS_CS_DOCKER_IMAGE=scylladb/hydra-loaders:cql-stress-cassandra-stress-$(date +'%Y%m%d')
+docker build . -t ${CQL_STRESS_CS_DOCKER_IMAGE}
+docker push ${CQL_STRESS_CS_DOCKER_IMAGE}
+echo "${CQL_STRESS_CS_DOCKER_IMAGE}" > image
+```

--- a/docker/cql-stress-cassandra-stress/image
+++ b/docker/cql-stress-cassandra-stress/image
@@ -1,0 +1,1 @@
+scylladb/hydra-loaders:cql-stress-cassandra-stress-20240119

--- a/jenkins-pipelines/rust/longevity-100gb-4h-cql-stress.jenkinsfile
+++ b/jenkins-pipelines/rust/longevity-100gb-4h-cql-stress.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    availability_zone: 'c',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/rust/cql-stress-100gb-4h.yaml"]''',
+    instance_provision_fallback_on_demand: true
+)

--- a/sdcm/cql_stress_cassandra_stress_thread.py
+++ b/sdcm/cql_stress_cassandra_stress_thread.py
@@ -1,0 +1,164 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2023 ScyllaDB
+
+import logging
+import re
+import os
+import time
+import contextlib
+from typing import Any
+from sdcm.loader import CqlStressCassandraStressExporter
+from sdcm.prometheus import nemesis_metrics_obj
+from sdcm.sct_events.loaders import CQL_STRESS_CS_ERROR_EVENTS_PATTERNS, CqlStressCassandraStressEvent
+from sdcm.stress_thread import CassandraStressThread
+from sdcm.utils.common import FileFollowerThread, SoftTimeoutContext
+from sdcm.utils.docker_remote import RemoteDocker
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CqlStressCassandraStressEventsPublisher(FileFollowerThread):
+    def __init__(self, node: Any, log_filename: str, event_id: str = None):
+        super().__init__()
+
+        self.node = str(node)
+        self.log_filename = log_filename
+        self.event_id = event_id
+
+    def run(self) -> None:
+        while not self.stopped():
+            if not os.path.isfile(self.log_filename):
+                time.sleep(0.5)
+                continue
+
+            for line_number, line in enumerate(self.follow_file(self.log_filename)):
+                if self.stopped():
+                    break
+
+                for pattern, event in CQL_STRESS_CS_ERROR_EVENTS_PATTERNS:
+                    if self.event_id:
+                        event.event_id = self.event_id
+
+                    if pattern.search(line):
+                        event.add_info(node=self.node, line=line, line_number=line_number).publish()
+
+
+class CqlStressCassandraStressThread(CassandraStressThread):
+    DOCKER_IMAGE_PARAM_NAME = 'stress_image.cql-stress-cassandra-stress'
+
+    def __init__(self, loader_set, stress_cmd, timeout, stress_num=1, keyspace_num=1, keyspace_name='', compaction_strategy='',  # pylint: disable=too-many-arguments
+                 profile=None, node_list=None, round_robin=False, client_encrypt=False, stop_test_on_failure=True,
+                 params=None):
+        super().__init__(loader_set=loader_set, stress_cmd=stress_cmd, timeout=timeout,
+                         stress_num=stress_num, node_list=node_list,  # pylint: disable=too-many-arguments
+                         round_robin=round_robin, stop_test_on_failure=stop_test_on_failure, params=params,
+                         keyspace_num=keyspace_num, keyspace_name=keyspace_name, profile=profile,
+                         client_encrypt=client_encrypt, compaction_strategy=compaction_strategy)
+
+    def create_stress_cmd(self, cmd_runner, keyspace_idx, loader):  # pylint: disable=too-many-branches
+        stress_cmd = self.stress_cmd
+
+        stress_cmd = self.append_no_warmup_to_cmd(stress_cmd)
+        stress_cmd = self.adjust_cmd_keyspace_name(stress_cmd, keyspace_idx)
+        stress_cmd = self.adjust_cmd_compaction_strategy(stress_cmd)
+
+        if '-col' in stress_cmd:
+            # In cassandra-stress, '-col n=' parameter defines number of columns called (C0, C1, ..., Cn) respectively.
+            # It accepts a distribution as value, however, only 'FIXED' distribution is accepted for the cql mode.
+            # In cql-stress, we decided to accept a number instead.
+            # To support the c-s syntax in test-cases files, we replace occurrences
+            # of n=FIXED(k) to n=k.
+            stress_cmd = re.sub(r' (\'?)n=[\s]*fixed\(([0-9]+)\)(\'?)', r' \1n=\2\3',
+                                stress_cmd, flags=re.IGNORECASE)
+
+        if '-rate' in stress_cmd:
+            # In cassandra-stress either '-rate throttle=' or '-rate fixed=' parameter is accepted.
+            # In cql-stress we decided to change it so 'fixed' is a boolean flag
+            # specifying whether the tool should display coordination-omission fixed latencies.
+            stress_cmd = re.sub(r' fixed=[\s]*([0-9]+/s)',
+                                r' throttle=\1 fixed', stress_cmd)
+
+        if '-pop' in stress_cmd and "seq=" in stress_cmd:
+            # '-pop seq=x..y' syntax is not YET supported by cql-stress.
+            # TODO remove when seq=x..y syntax is supported.
+            LOGGER.warning(
+                "-pop seq=x..y syntax is not YET supported by cql-stress-cassandra-stress. Replacing seq=x..y with dist=SEQ(x..y).")
+            stress_cmd = re.sub(r' seq=[\s]*([\d]+\.\.[\d]+)',
+                                r" 'dist=SEQ(\1)'", stress_cmd)
+
+        stress_cmd = self.adjust_cmd_node_option(stress_cmd, loader, cmd_runner)
+        return stress_cmd
+
+    def _run_cs_stress(self, loader, loader_idx, cpu_idx, keyspace_idx):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+        # TODO:
+        # - Add support for profile yaml once cql-stress supports 'user' command.
+        # - Adjust metrics collection once cql-stress displays the metrics grouped by operation (mixed workload).
+
+        cleanup_context = contextlib.nullcontext()
+        os.makedirs(loader.logdir, exist_ok=True)
+
+        stress_cmd_opt = self.stress_cmd.split(
+            "cql-stress-cassandra-stress", 1)[1].split(None, 1)[0]
+
+        log_id = self._build_log_file_id(loader_idx, cpu_idx, keyspace_idx)
+        log_file_name = os.path.join(
+            loader.logdir, f'cql-stress-cassandra-stress-{stress_cmd_opt}-{log_id}.log')
+
+        LOGGER.debug('cassandra-stress local log: %s', log_file_name)
+
+        cmd_runner_name = loader.ip_address
+
+        cpu_options = ""
+        if self.stress_num > 1:
+            cpu_options = f'--cpuset-cpus="{cpu_idx}"'
+
+        cmd_runner = cleanup_context = RemoteDocker(loader, self.docker_image_name,
+                                                    command_line="-c 'tail -f /dev/null'",
+                                                    extra_docker_opts=f'{cpu_options} '
+                                                    '--network=host '
+                                                    f'--label shell_marker={self.shell_marker}'
+                                                    f' --entrypoint /bin/bash')
+        stress_cmd = self.create_stress_cmd(cmd_runner, keyspace_idx, loader)
+        LOGGER.info('Stress command:\n%s', stress_cmd)
+
+        tag = f'TAG: loader_idx:{loader_idx}-cpu_idx:{cpu_idx}-keyspace_idx:{keyspace_idx}'
+
+        if self.stress_num > 1:
+            node_cmd = f'STRESS_TEST_MARKER={self.shell_marker}; taskset -c {cpu_idx} {stress_cmd}'
+        else:
+            node_cmd = f'STRESS_TEST_MARKER={self.shell_marker}; {stress_cmd}'
+        node_cmd = f'echo {tag}; {node_cmd}'
+
+        result = None
+        with cleanup_context, \
+                CqlStressCassandraStressExporter(instance_name=cmd_runner_name,
+                                                 metrics=nemesis_metrics_obj(),
+                                                 stress_operation=stress_cmd_opt,
+                                                 stress_log_filename=log_file_name,
+                                                 loader_idx=loader_idx, cpu_idx=cpu_idx), \
+                CqlStressCassandraStressEventsPublisher(node=loader, log_filename=log_file_name) as publisher, \
+                CqlStressCassandraStressEvent(node=loader, stress_cmd=self.stress_cmd,
+                                              log_file_name=log_file_name) as cs_stress_event:
+            publisher.event_id = cs_stress_event.event_id
+            try:
+                # prolong timeout by 5% to avoid killing cassandra-stress process
+                hard_timeout = self.timeout + int(self.timeout * 0.05)
+                with SoftTimeoutContext(timeout=self.timeout, operation="cql-stress-cassandra-stress"):
+                    result = cmd_runner.run(
+                        cmd=node_cmd, timeout=hard_timeout, log_file=log_file_name, retry=0)
+            except Exception as exc:  # pylint: disable=broad-except
+                self.configure_event_on_failure(
+                    stress_event=cs_stress_event, exc=exc)
+
+        return loader, result, cs_stress_event

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -78,6 +78,10 @@ class LatteStressEvent(StressEvent):
     ...
 
 
+class CqlStressCassandraStressEvent(StressEvent):
+    ...
+
+
 class CassandraHarryEvent(StressEvent, abstract=True):
     failure: Type[StressEventProtocol]
     error: Type[SctEventProtocol]
@@ -235,6 +239,21 @@ CS_ERROR_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
 
 CS_NORMAL_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
     [(re.compile(event.regex), event) for event in CS_NORMAL_EVENTS]
+
+
+class CqlStressCassandraStressLogEvent(LogEvent, abstract=True):
+    ReadValidationError: Type[LogEventProtocol]
+
+
+CqlStressCassandraStressLogEvent.add_subevent_type(
+    "ReadValidationError", severity=Severity.CRITICAL, regex=r"read validation error")
+
+
+CQL_STRESS_CS_ERROR_EVENTS = (
+    CqlStressCassandraStressLogEvent.ReadValidationError(),
+)
+CQL_STRESS_CS_ERROR_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
+    [(re.compile(event.regex), event) for event in CQL_STRESS_CS_ERROR_EVENTS]
 
 
 class ScyllaBenchLogEvent(LogEvent, abstract=True):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -55,6 +55,7 @@ from sdcm.cluster_aws import LoaderSetAWS
 from sdcm.cluster_aws import MonitorSetAWS
 from sdcm.cluster_k8s import mini_k8s, gke, eks
 from sdcm.cluster_k8s.eks import MonitorSetEKS
+from sdcm.cql_stress_cassandra_stress_thread import CqlStressCassandraStressThread
 from sdcm.provision.azure.provisioner import AzureProvisioner
 from sdcm.provision.network_configuration import ssh_connection_ip_type
 from sdcm.provision.provisioner import provisioner_factory
@@ -1825,7 +1826,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                       keyspace_name=keyspace_name, profile=profile, prefix=prefix, round_robin=round_robin,
                       stats_aggregate_cmds=stats_aggregate_cmds, use_single_loader=use_single_loader)
 
-        if 'cassandra-stress' in stress_cmd:  # cs cmdline might started with JVM_OPTION
+        if 'cql-stress-cassandra-stress' in stress_cmd:
+            params['stop_test_on_failure'] = stop_test_on_failure
+            params['compaction_strategy'] = compaction_strategy
+            return self.run_cql_stress_cassandra_thread(**params)
+        elif 'cassandra-stress' in stress_cmd:  # cs cmdline might started with JVM_OPTION
             params['stop_test_on_failure'] = stop_test_on_failure
             params['compaction_strategy'] = compaction_strategy
             return self.run_stress_cassandra_thread(**params)
@@ -1884,7 +1889,39 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                           stop_test_on_failure=stop_test_on_failure,
                                           params=params or self.params).run()
         self.alter_test_tables_encryption(stress_command=stress_cmd)
+        return cs_thread
 
+    # pylint: disable=too-many-arguments
+    def run_cql_stress_cassandra_thread(
+            self, stress_cmd, duration=None, stress_num=1, keyspace_num=1, profile=None, prefix='', round_robin=False,
+            stats_aggregate_cmds=True, keyspace_name=None, compaction_strategy='', stop_test_on_failure=True, params=None, **_):
+        # pylint: disable=too-many-locals
+        if duration:
+            timeout = self.get_duration(duration)
+        elif self._stress_duration and ' duration=' in stress_cmd:
+            timeout = self.get_duration(self._stress_duration)
+            stress_cmd = re.sub(r'\sduration=\d+[mhd]\s', f' duration={self._stress_duration}m ', stress_cmd)
+        else:
+            timeout = get_timeout_from_stress_cmd(stress_cmd) or self.get_duration(duration)
+
+        if self.create_stats:
+            self.update_stress_cmd_details(stress_cmd, prefix, stresser="cassandra-stress",
+                                           aggregate=stats_aggregate_cmds)
+        stop_test_on_failure = False if not self.params.get("stop_test_on_stress_failure") else stop_test_on_failure
+        cs_thread = CqlStressCassandraStressThread(loader_set=self.loaders,
+                                                   stress_cmd=stress_cmd,
+                                                   timeout=timeout,
+                                                   stress_num=stress_num,
+                                                   keyspace_num=keyspace_num,
+                                                   compaction_strategy=compaction_strategy,
+                                                   profile=profile,
+                                                   node_list=self.db_cluster.nodes,
+                                                   round_robin=round_robin,
+                                                   client_encrypt=self.params.get('client_encrypt'),
+                                                   keyspace_name=keyspace_name,
+                                                   stop_test_on_failure=stop_test_on_failure,
+                                                   params=params or self.params).run()
+        self.alter_test_tables_encryption(stress_command=stress_cmd)
         return cs_thread
 
     # pylint: disable=too-many-arguments,unused-argument

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -662,7 +662,8 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                           'ycsb': 'scylladb/something_else',
                           'kcl': 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC',
                           'harry': 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816',
-                          'latte': 'scylladb/hydra-loaders:latte-rust1_73-20231025'})
+                          'latte': 'scylladb/hydra-loaders:latte-rust1_73-20231025',
+                          'cql-stress-cassandra-stress': 'scylladb/hydra-loaders:cql-stress-cassandra-stress-20240119'})
 
         self.assertEqual(conf.get('stress_image.gemini'), 'scylladb/hydra-loaders:gemini-v1.8.6')
         self.assertEqual(conf.get('stress_image.non-exist'), None)

--- a/unit_tests/test_cql_stress_cassandra_stress_thread.py
+++ b/unit_tests/test_cql_stress_cassandra_stress_thread.py
@@ -1,0 +1,98 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2023 ScyllaDB
+
+import re
+import pytest
+import requests
+
+from sdcm.cql_stress_cassandra_stress_thread import CqlStressCassandraStressThread
+from sdcm.utils.decorators import timeout
+from unit_tests.dummy_remote import LocalLoaderSetDummy
+
+
+pytestmark = [
+    pytest.mark.usefixtures("events"),
+    pytest.mark.integration,
+]
+
+
+def test_01_cql_stress_cassandra_stress(request, docker_scylla, prom_address, params):
+    loader_set = LocalLoaderSetDummy()
+
+    cmd = (
+        """cql-stress-cassandra-stress write cl=ONE duration=1m """
+        """-schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) """
+        """compaction(strategy=SizeTieredCompactionStrategy)' """
+        """-rate threads=10 -pop seq=1..10000000"""
+    )
+
+    cs_thread = CqlStressCassandraStressThread(
+        loader_set, cmd, node_list=[docker_scylla], timeout=120, params=params
+    )
+
+    def cleanup_thread():
+        cs_thread.kill()
+
+    request.addfinalizer(cleanup_thread)
+
+    cs_thread.run()
+
+    @timeout(timeout=60)
+    def check_metrics():
+        output = requests.get("http://{}/metrics".format(prom_address)).text
+        regex = re.compile(
+            r"^sct_cql_stress_cassandra_stress_write_gauge.*?([0-9\.]*?)$", re.MULTILINE)
+        assert "sct_cql_stress_cassandra_stress_write_gauge" in output
+
+        matches = regex.findall(output)
+        assert all(float(i) > 0 for i in matches), output
+
+    check_metrics()
+
+    output = cs_thread.get_results()
+    assert "latency mean" in output[0]
+    assert float(output[0]["latency mean"]) > 0
+
+    assert "latency 99th percentile" in output[0]
+    assert float(output[0]["latency 99th percentile"]) > 0
+
+
+def test_02_cql_stress_cassandra_stress_multi_region(request, docker_scylla, params):
+    loader_set = LocalLoaderSetDummy()
+    loader_set.test_config.set_multi_region(True)
+    request.addfinalizer(
+        lambda: loader_set.test_config.set_multi_region(False))
+    cmd = (
+        """cql-stress-cassandra-stress write cl=ONE duration=1m """
+        """-schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) """
+        """compaction(strategy=SizeTieredCompactionStrategy)' """
+        """-rate threads=10 -pop seq=1..10000000"""
+    )
+
+    cs_thread = CqlStressCassandraStressThread(
+        loader_set, cmd, node_list=[docker_scylla], timeout=120, params=params
+    )
+
+    def cleanup_thread():
+        cs_thread.kill()
+
+    request.addfinalizer(cleanup_thread)
+
+    cs_thread.run()
+
+    output = cs_thread.get_results()
+    assert "latency mean" in output[0]
+    assert float(output[0]["latency mean"]) > 0
+
+    assert "latency 99th percentile" in output[0]
+    assert float(output[0]["latency 99th percentile"]) > 0


### PR DESCRIPTION
Ref: https://github.com/scylladb/cql-stress

cql-stress is a stress tool implemented in Rust. It supports two CLI frontends: scylla-bench and cassandra-stress.

In this commit we introduce a cql-stress-cassandra-stress stress tool to SCT. Currently, the C-S frontend supports 4 basic commands:
- read
- write
- counter_read
- counter_write

## Changes
- docker
  - created docker image definition containing `cql-stress-cassandra-stress` executable
  - pushed docker image to registry
  - updated `defaults/test_default.yaml` accordingly
- loader
  - introduced `CqlStressCassandraStressThread` class deriving from `CassandraStressThread`
    - overridden `create_stress_cmd` and `_run_cs_stress` methods
  - introduced `CqlStressCassandraStressEvent` with critical default severity
  - introduced `CqlStressCassandraStressExporter` which collects the stats on the fly and record them to prometheus
  - added unit tests
- data_dir
  - updated `data_dir/scylla-dash-per-server-nemesis.master.json`. The generated diff looks strange, but the idea was to just copy-paste the existing `cassandra-stress` config for `write` and `read` workloads.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
