### PR TITLE
fix(run_cqlsh): handle both quotes escaping and multiline commands

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2710,7 +2710,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                       connect_timeout=connect_timeout, ssl_params=ssl_params)
 
         # escape double quotes, that might be on keyspace/tables names
-        command = json.dumps(command.strip())
+        command = '"{}"'.format(command.strip().replace('"', '\\"'))
 
         cqlsh_cmd = self.add_install_prefix('/usr/bin/cqlsh')
         if self.is_cqlsh_support_cloud_bundle:

--- a/unit_tests/test_run_cqlsh.py
+++ b/unit_tests/test_run_cqlsh.py
@@ -32,3 +32,12 @@ def test_01_cqlsh_check_escaping(docker_scylla, use_redundant_symbols):
     cql_cmd = 'describe keyspace "10gb_keyspace"'
     res = docker_scylla.run_cqlsh(cql_cmd)
     assert 'CREATE KEYSPACE "10gb_keyspace"' in res.stdout
+
+
+def test_02_cqlsh_check_multiline(docker_scylla):
+    cql_cmd = """
+        create keyspace if not exists "10gb_keyspace" with replication =
+        {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}
+    """
+    res = docker_scylla.run_cqlsh(cql_cmd)
+    assert res.ok


### PR DESCRIPTION
merge of #6897 has cause multiline cql command to fail `run_cqlsh`
the usage of `json.dumps` was nice for the escaping, but since
we don't want to start policing all the calls to run_cqlsh,
and CQL command tend to be multiline (create table for example)
we are reverting it, and gonna use more specific code, that would
just escape the double quotes.

Fixes: #6921

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
