### PR TITLE
fix(functional-eks): prolong delete namespace timeout

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -210,14 +210,14 @@ def test_deploy_quasi_multidc_db_cluster(db_cluster: ScyllaPodCluster):  # pylin
                     logdir_path=logdir, kubectl=kubectl, namespaces=[namespace, namespace2])
                 need_to_collect_logs = False
             k8s_cluster.helm(f"uninstall {target_chart_name2} --timeout 120s", namespace=namespace2)
-            kubectl(f"delete namespace {namespace2}", ignore_status=True, timeout=30)
+            kubectl(f"delete namespace {namespace2}", ignore_status=True, timeout=120)
 
     finally:
         if need_to_collect_logs:
             KubernetesOps.gather_k8s_logs(
                 logdir_path=logdir, kubectl=kubectl, namespaces=[namespace, namespace2])
         k8s_cluster.helm(f"uninstall {target_chart_name} --timeout 120s", namespace=namespace)
-        kubectl(f"delete namespace {namespace}", ignore_status=True, timeout=30)
+        kubectl(f"delete namespace {namespace}", ignore_status=True, timeout=120)
 
 
 @pytest.mark.restart_is_used


### PR DESCRIPTION
Still there's some timeout issue during deletion of namespace. Looks it takes a bit more than 30 seconds.

Prolong delete namespace timeout to 2 minutes.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
