### PR TITLE
fix(install_package): install `lsof` package before using it

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1731,6 +1731,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self.remoter.sudo(f'{pkg_cmd} install -y {package_name}', ignore_status=ignore_status)
 
     def is_apt_lock_free(self) -> bool:
+        # NOTE: dockerized Scylla doesn't have the 'lsof' package by default
+        result = self.remoter.sudo("which lsof || apt-get install -y lsof", ignore_status=True)
         result = self.remoter.sudo("lsof /var/lib/dpkg/lock", ignore_status=True)
         return result.exit_status == 1
 


### PR DESCRIPTION
Recently merged PR (https://github.com/scylladb/scylla-cluster-tests/pull/6810) made the `install_scylla_debuginfo` node method retry in case of failures instead of using the `try-and-go` approach.
It leads to waste of time by having following timeouts:

```
  Wait for: Checking if package manager is free: timeout - 60 seconds - expired
```

Cumulatively it leads to `Functional EKS tests` job timeout because those redundant waits take hours in summary.

The timeouts are caused, on it's turn, by the following error:

```
  Running command "lsof /var/lib/dpkg/lock"...
  /bin/bash: line 1: lsof: command not found
  wait_for: Retrying Checking if package manager is free: attempt 2 ended with: False
```

So, fix it by installing the `lsof` package if absent to avoid redundant retries in case of it's absence.

Fixes: #6929

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
