### PR TITLE
fix(disrupt_add_remove_dc): put back c-s thread into context

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4453,9 +4453,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.tester.create_keyspace("keyspace_new_dc", replication_factor={
                                     datacenters[0]: min(3, len(self.cluster.nodes))})
         node_added = False
-
-        with ExitStack() as context_manager, \
-                temporary_replication_strategy_setter(node) as replication_strategy_setter:
+        with ExitStack() as context_manager:
             def finalizer(exc_type, *_):
                 # in case of test end/killed, leave the cleanup alone
                 if exc_type is not KillNemesis:
@@ -4465,32 +4463,36 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                         self.cluster.decommission(new_node)
             context_manager.push(finalizer)
 
-            new_node = self._add_new_node_in_new_dc()
-            node_added = True
-            status = self.tester.db_cluster.get_nodetool_status()
-            new_dc_list = [dc for dc in list(status.keys()) if dc.endswith("_nemesis_dc")]
-            assert new_dc_list, "new datacenter was not registered"
-            new_dc_name = new_dc_list[0]
-            for keyspace in system_keyspaces + ["keyspace_new_dc"]:
-                strategy = ReplicationStrategy.get(node, keyspace)
-                assert isinstance(strategy, NetworkTopologyReplicationStrategy), \
-                    "Should have been already switched to NetworkStrategy"
-                strategy.replication_factors.update({new_dc_name: 1})
-                replication_strategy_setter(**{keyspace: strategy})
-            InfoEvent(message='execute rebuild on new datacenter').publish()
-            with wait_for_log_lines(node=new_node, start_line_patterns=["rebuild.*started with keyspaces="],
-                                    end_line_patterns=["rebuild.*finished with keyspaces="],
-                                    start_timeout=60, end_timeout=600):
-                new_node.run_nodetool(sub_cmd=f"rebuild -- {datacenters[0]}", retry=0)
-            InfoEvent(message='Running full cluster repair on each node').publish()
-            for cluster_node in self.cluster.nodes:
-                cluster_node.run_nodetool(sub_cmd="repair -pr", publish_event=True)
-            datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())
-            self._write_read_data_to_multi_dc_keyspace(datacenters)
+            with temporary_replication_strategy_setter(node) as replication_strategy_setter:
+                new_node = self._add_new_node_in_new_dc()
+                node_added = True
+                status = self.tester.db_cluster.get_nodetool_status()
+                new_dc_list = [dc for dc in list(status.keys()) if dc.endswith("_nemesis_dc")]
+                assert new_dc_list, "new datacenter was not registered"
+                new_dc_name = new_dc_list[0]
+                for keyspace in system_keyspaces + ["keyspace_new_dc"]:
+                    strategy = ReplicationStrategy.get(node, keyspace)
+                    assert isinstance(strategy, NetworkTopologyReplicationStrategy), \
+                        "Should have been already switched to NetworkStrategy"
+                    strategy.replication_factors.update({new_dc_name: 1})
+                    replication_strategy_setter(**{keyspace: strategy})
+                InfoEvent(message='execute rebuild on new datacenter').publish()
+                with wait_for_log_lines(node=new_node, start_line_patterns=["rebuild.*started with keyspaces="],
+                                        end_line_patterns=["rebuild.*finished with keyspaces="],
+                                        start_timeout=60, end_timeout=600):
+                    new_node.run_nodetool(sub_cmd=f"rebuild -- {datacenters[0]}", retry=0)
+                InfoEvent(message='Running full cluster repair on each node').publish()
+                for cluster_node in self.cluster.nodes:
+                    cluster_node.run_nodetool(sub_cmd="repair -pr", publish_event=True)
+                datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())
+                self._write_read_data_to_multi_dc_keyspace(datacenters)
 
-        datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())
-        assert not [dc for dc in datacenters if dc.endswith("_nemesis_dc")], "new datacenter was not unregistered"
-        self._verify_multi_dc_keyspace_data(consistency_level="QUORUM")
+            self.cluster.decommission(new_node)
+            node_added = False
+
+            datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())
+            assert not [dc for dc in datacenters if dc.endswith("_nemesis_dc")], "new datacenter was not unregistered"
+            self._verify_multi_dc_keyspace_data(consistency_level="QUORUM")
 
     def get_cassandra_stress_write_cmds(self):
         write_cmds = self.tester.params.get("prepare_write_cmd")


### PR DESCRIPTION
as part of #6873, one verification thread, that was supposed to be after node decommission, we done after keyspace was dropped putting back the decommission part into the sequence, and that validation thread into the context as well.

Ref: #6873

#### Tests
- [x] - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-5gb-1h-AddRemoveDcNemesis-aws-test/10/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
