### PR TITLE
fix(arm): detect the ARM instance types on AWS more correctly

### DIFF
--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -27,7 +27,21 @@ from sdcm.test_config import TestConfig
 from sdcm.keystore import KeyStore
 
 LOGGER = logging.getLogger(__name__)
-ARM_ARCH_PREFIXES = ('im4', 'is4', 'a1.', 'inf', 'm6', 'c6g', 'r6', 'm7', 'c7g', 'r7')
+# NOTE: non storage-optimized instance types may be used for K8S auxiliary/loader nodes
+ARM_ARCH_PREFIXES = (
+    # General purpose
+    'm7g.', 'm6g.', 't4g.',
+    # Compute-optimized
+    'c7g.', 'c7gn.', 'c6g.', 'c6gn.',
+    # Memory-optimized
+    'r8g.', 'r7g.', 'r6g.', 'x2gd.',
+    # Accelerated computing
+    'g5g.',
+    # Storage-optimized
+    'i4g.', 'im4gn.', 'is4gen.',
+    # High performance computing (HPC) optimized
+    'hpc7g.',
+)
 AwsArchType = Literal['x86_64', 'arm64']
 
 


### PR DESCRIPTION
Following problems exist in the current code of the ARM detection on AWS:
- Some of the existing prefixes are ambiguous such as `m6` which match `m6g` (ARM) and `m6i` (Intel) processors.
- Some of the instance types are just absent which can be used in K8S. Example: `t4g.large`

So, fix the `ARM_ARCH_PREFIXES` var in the `sdcm/utils/aws_utils.py` module be less ambiguous and contain more possible ARM prefixes.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
