### PR TITLE
improvement(k8s): bump the local volume provisioner version

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -126,7 +126,7 @@ MINIO_NAMESPACE = "minio"
 SCYLLA_CONFIG_NAME = "scylla-config"
 SCYLLA_AGENT_CONFIG_NAME = "scylla-agent-config"
 
-K8S_LOCAL_VOLUME_PROVISIONER_VERSION = "0.2.0-rc.0"  # without 'v' prefix
+K8S_LOCAL_VOLUME_PROVISIONER_VERSION = "0.3.0-alpha.1"  # without 'v' prefix
 # NOTE: these values are taken from the default values of the "scylla-manager" helm chart.
 #       Needs to be defined separately to be able to reuse for image caching running on local K8S
 SCYLLA_VERSION_IN_SCYLLA_MANAGER = "5.2.11"


### PR DESCRIPTION
Make it be the latest available version `0.3.0-alpha.1` which also supports ARM processors.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
