### PR TITLE
fix(test_config): stop referencing real AMIs

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -17,5 +17,10 @@ module.exports = {
         'body-min-length': [2, 'always', 30],
         'body-max-line-length': [2, 'always', 100],
         'body-leading-blank': [2, 'always'],
+    },
+    parserPreset: {
+      parserOpts: {
+        noteKeywords: ['\\[\\d+\\]']
+      }
     }
 };

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -383,3 +383,18 @@ def get_scylla_images_ec2_resource(region_name: str) -> EC2ServiceResource:
                                 aws_session_token=response['Credentials']['SessionToken'])
 
     return new_session.resource("ec2", region_name=region_name)
+
+
+def get_ssm_ami(parameter: str, region_name) -> str:
+    """
+    get AMIs from SSM parameters
+
+    examples:
+    - '/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id'
+    - '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
+
+    Ref: https://discourse.ubuntu.com/t/finding-ubuntu-images-with-the-aws-ssm-parameter-store/15507
+    """
+    client = boto3.client('ssm', region_name=region_name)
+    value = client.get_parameter(Name=parameter)
+    return value['Parameter']['Value']

--- a/unit_tests/test_ndbench_thread.py
+++ b/unit_tests/test_ndbench_thread.py
@@ -86,8 +86,8 @@ def test_03_dynamodb_api(request, docker_scylla, events, params):
     assert len(cat["ERROR"]) >= 1
     assert any("Encountered an exception when driving load" in err for err in cat["ERROR"])
 
-    assert len(cat["CRITICAL"]) >= 3
-    assert "BUILD FAILED" in cat["CRITICAL"][-1]
+    assert len(cat["CRITICAL"]) >= 2
+    assert any("BUILD FAILED" in critical for critical in cat["CRITICAL"])
 
 
 def test_04_verify_data(request, docker_scylla, events, params):


### PR DESCRIPTION
since we have some tests that was counting on specific AMIs to exist and from time to time those are being depracated.

so we should be pointing to any specific one, we are now gonna query get latest scylla, or latest specific AMIs base on SSM paramters

[1]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/finding-an-ami.html#systems-manager-permissions
[2]: https://discourse.ubuntu.com/t/finding-ubuntu-images-with-the-aws-ssm-parameter-store/15507

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
