### PR TITLE
fix(get_arch_from_instance_type): get the actual architecture from aws

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1708,9 +1708,9 @@ class SCTConfiguration(dict):
                 self.log.info("Assume that Scylla Docker image has repo file pre-installed.")
                 self._replace_docker_image_latest_tag()
             elif not self.get('ami_id_db_scylla') and self.get('cluster_backend') == 'aws':
-                aws_arch = get_arch_from_instance_type(self.get('instance_type_db'))
                 ami_list = []
                 for region in region_names:
+                    aws_arch = get_arch_from_instance_type(self.get('instance_type_db'), region_name=region)
                     try:
                         if ':' in scylla_version:
                             ami = get_branched_ami(scylla_version=scylla_version, region_name=region, arch=aws_arch)[0]
@@ -1778,9 +1778,9 @@ class SCTConfiguration(dict):
         if (oracle_scylla_version := self.get('oracle_scylla_version')) \
            and self.get("db_type") == "mixed_scylla":  # pylint: disable=too-many-nested-blocks
             if not self.get('ami_id_db_oracle') and self.get('cluster_backend') == 'aws':
-                aws_arch = get_arch_from_instance_type(self.get('instance_type_db'))
                 ami_list = []
                 for region in region_names:
+                    aws_arch = get_arch_from_instance_type(self.get('instance_type_db'), region_name=region)
                     try:
                         if ':' in oracle_scylla_version:
                             ami = get_branched_ami(


### PR DESCRIPTION
replace the hardcoded list we have with actuall calls to ec2 to get the architecture of that instance type we are gonna use.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
