### PR TITLE
fix(sct.py): kms resoruces cleanup with all regions

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -621,7 +621,7 @@ def clean_cloud_resources(tags_dict, config=None, dry_run=False):  # pylint: dis
         clean_test_security_groups(tags_dict, regions=aws_regions, dry_run=dry_run)
         clean_placement_groups_aws(tags_dict, regions=aws_regions, dry_run=dry_run)
         if cluster_backend == 'aws':
-            clean_aws_kms_alias(tags_dict, config.region_names)
+            clean_aws_kms_alias(tags_dict, aws_regions or all_aws_regions())
     if cluster_backend in ('gce', 'k8s-gke', ''):
         for project in gce_projects:
             with environment(SCT_GCE_PROJECT=project):


### PR DESCRIPTION
currently if no region is defined, the kms cleanup breaks cause of: `raise ValueError("'region_names' parameter cannot be empty")`

adding the need change, so it would be able to work across all regions when needed

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
