### PR TITLE
fix(aws-root-disk): make sure we are using gp3 for disks in AWS

### DIFF
--- a/sdcm/sct_provision/aws/instance_parameters_builder.py
+++ b/sdcm/sct_provision/aws/instance_parameters_builder.py
@@ -48,7 +48,7 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
                     DeviceName=self._root_device_name,
                     Ebs=AWSDiskMappingEbsInfo(
                         VolumeSize=self._root_device_size,
-                        VolumeType='gp2',
+                        VolumeType='gp3',
                     )
                 )
             )

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -541,7 +541,7 @@ class AwsSctRunner(SctRunner):
                 "DeviceName": ec2_ami_get_root_device_name(image_id=base_image, region=aws_region.region_name),
                 "Ebs": {
                     "VolumeSize": root_disk_size_gb or self.instance_root_disk_size(test_duration),
-                    "VolumeType": "gp2"
+                    "VolumeType": "gp3"
                 }
             }]
         )

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1257,7 +1257,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                                                region=regions[0]),
                     "Ebs": {
                         "VolumeSize": loader_info['disk_size'],
-                        "VolumeType": "gp2"
+                        "VolumeType": "gp3"
                     }
                 }]
             else:

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -224,7 +224,7 @@ def init_monitoring_info_from_params(monitor_info: dict, params: dict, regions: 
                                                            region=regions[0]),
                 "Ebs": {
                     "VolumeSize": monitor_info['disk_size'],
-                    "VolumeType": "gp2"
+                    "VolumeType": "gp3"
                 }
             }]
         else:
@@ -254,7 +254,7 @@ def init_db_info_from_params(db_info: dict, params: dict, regions: List, root_de
                 "DeviceName": root_device,
                 "Ebs": {
                     "VolumeSize": db_info['disk_size'],
-                    "VolumeType": "gp2"
+                    "VolumeType": "gp3"
                 }
             }]
         else:

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -514,7 +514,7 @@ class IntegrationTests(unittest.TestCase):
              'Ebs': {'DeleteOnTermination': True,
                      'SnapshotId': 'snap-0717a2bee0a38bc84',
                      'VolumeSize': 30,
-                     'VolumeType': 'gp2',
+                     'VolumeType': 'gp3',
                      'Encrypted': False}},
             {'DeviceName': '/dev/sdb',
              'VirtualName': 'ephemeral0'},


### PR DESCRIPTION
Cause of cost and prerformence, we rather use gp3 disks across the board, in this change we are changing all aws root disks to be using gp3

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
