### PR TITLE
improvement(k8s): reuse operator's `NodeConfig` for static vol provisioner

### DIFF
--- a/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
+++ b/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
@@ -79,7 +79,7 @@ spec:
       serviceAccountName: node-setup-daemonset
       containers:
       - name: cpu-policy
-        image: bitnami/kubectl:1.21.4
+        image: bitnami/kubectl:1.26.11
         imagePullPolicy: Always
         env:
           - name: NODE
@@ -174,8 +174,9 @@ spec:
         app: node-pkg-installer
     spec:
       containers:
-      # NOTE: image is built on Feb 1, 2023 -> scylla-operator:1.9.0-alpha.1
-      - image: "scylladb/scylla-operator@sha256:10e3e7dddc2de1bbd473710223a4be5e8c5ef5dc9bb1a61d81fdc398d9dcd74c"
+      # TODO: set the following image to some static tag that supports also ARM arch (when appears)
+      #       As of Dec 15, 2023 only the 'latest' tag does support ARM.
+      - image: "scylladb/scylla-operator:latest"
         imagePullPolicy: "Always"
         name: node-pkg-installer
         command:
@@ -217,41 +218,9 @@ spec:
       hostIPC: true
       serviceAccountName: node-setup-daemonset
       containers:
-      - name: node-setup
-        image: scylladb/scylla-machine-image:k8s-aws-666.development-20201023.0c4dfa1
-        imagePullPolicy: Always
-        env:
-          - name: ROOT_DISK
-            value: /mnt/hostfs/mnt/raid-disks/disk0
-          - name: SCYLLAD_CONF_MOUNT
-            value: /mnt/scylla.d/
-        command:
-          - "/bin/bash"
-          - "-c"
-          - "--"
-        args:
-          - |
-            # NOTE: following is needed to avoid package installation failures caused
-            #       by the absent scylla package repositories.
-            yum-config-manager --disable scylla --disable scylla-generic --disable scylladb-scylla-3rdparty
-            # NOTE: 'args' will be updated in the code
-            #        when perf tuning is disabled it is ['--all']
-            #        when perf tuning is enabled it is ['--setup-disks']
-            /opt/scylladb/scylla-machine-image/scylla_k8s_node_setup ${SCYLLA_MACHINE_IMAGE_ARGS}
-        securityContext:
-          privileged: true
-        volumeMounts:
-          - name: hostfs
-            mountPath: /mnt/hostfs
-            mountPropagation: Bidirectional
-          - name: hostetcscyllad
-            mountPath: /mnt/scylla.d
-            mountPropagation: Bidirectional
-          - name: hostirqbalanceconfig
-            mountPath: /etc/conf.d/irqbalance
-            mountPropagation: Bidirectional
+      # NOTE: the 'pv-setup' is needed only for the 'static' local volume provisioner
       - name: pv-setup
-        image: bitnami/kubectl:1.21.4
+        image: bitnami/kubectl:1.26.11
         imagePullPolicy: Always
         env:
           - name: HOSTFS

--- a/sdcm/k8s_configs/gke/scylla-node-prepare.yaml
+++ b/sdcm/k8s_configs/gke/scylla-node-prepare.yaml
@@ -55,55 +55,8 @@ spec:
         value: scylla-clusters
         effect: NoSchedule
       containers:
-      # NOTE: the 'node-setup' container's script was taken from the following place:
-      #       https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/local-ssd#run-local-volume-static-provisioner
-      #       https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/blob/be7c6372/examples/gke-daemonset-raid-disks.yaml
-      - name: node-setup
-        image: gcr.io/google-containers/startup-script:v1
-        securityContext:
-          privileged: true
-        env:
-          - name: STARTUP_SCRIPT
-            value: |
-              set -o errexit
-              set -o nounset
-              set -o pipefail
-
-              devices=()
-              for ssd in /dev/disk/by-id/google-local-ssd-block*; do
-                if [ -e "${ssd}" ]; then
-                  devices+=("${ssd}")
-                fi
-              done
-              if [ "${#devices[@]}" -eq 0 ]; then
-                echo "No Local NVMe SSD disks found."
-                exit 0
-              fi
-
-              seen_arrays=(/dev/md/*)
-              device=${seen_arrays[0]}
-              echo "Setting RAID array with Local SSDs on device ${device}"
-              if [ ! -e "$device" ]; then
-                device="/dev/md/0"
-                echo "y" | mdadm --create "${device}" --level=0 --force --raid-devices=${#devices[@]} "${devices[@]}"
-              fi
-
-              if ! tune2fs -l "${device}" ; then
-                echo "Formatting '${device}'"
-                mkfs.xfs "${device}"
-              fi
-
-              mountpoint=/mnt/raid-disks/disk0
-              mkdir -p "${mountpoint}"
-              echo "Mounting '${device}' at '${mountpoint}'"
-              mount -o discard,defaults "${device}" "${mountpoint}"
-              chmod a+w "${mountpoint}"
-        volumeMounts:
-          - name: hostfs
-            mountPath: /mnt/hostfs
-            mountPropagation: Bidirectional
       - name: pv-setup
-        image: bitnami/kubectl:1.21.4
+        image: bitnami/kubectl:1.26.11
         imagePullPolicy: Always
         env:
           - name: HOSTFS
@@ -139,7 +92,7 @@ spec:
 
             # Create directories for each Scylla cluster on each K8S node which will host PVs
             while true; do
-              if [[ -z $(mount | grep  "/dev/md0") ]]; then
+              if [[ -z $(mount | grep  "raid-disks/disk0") ]]; then
                 sleep 5;
                 continue
               fi

--- a/sdcm/k8s_configs/static-local-volume-provisioner.yaml
+++ b/sdcm/k8s_configs/static-local-volume-provisioner.yaml
@@ -55,7 +55,7 @@ data:
     local-raid-disks:
        volumeMode: Filesystem
        fsType: xfs
-       namePattern: pv-
+       namePattern: "pv-*"
        hostDir: "/mnt/raid-disks/disk0/"
        mountDir: "/mnt/raid-disks/disk0/"
 ---
@@ -92,7 +92,7 @@ spec:
         value: scylla-clusters
         effect: NoSchedule
       containers:
-        - image: "quay.io/external_storage/local-volume-provisioner:v2.3.4"
+        - image: "k8s.gcr.io/sig-storage/local-volume-provisioner:v2.5.0"
           imagePullPolicy: IfNotPresent
           name: provisioner
           securityContext:


### PR DESCRIPTION
The Custom Resource Definition (CRD) called `NodeConfig` developed by the scylla-operator dev team is used to configure K8S nodes which are going to host Scylla pods.
It is able to configure SSD disks into RAID arrays. We were using it only running the dynamic local volume provisioner, but not the static one.

So, start using it for each of the volume provisioners we have. It will allow us to:
- Simplify existing code
- Stop using redundant pods - `scylla-machine-image` in EKS and `gcr.io/google-containers/startup-script` in GKE.

Also:
- Update the `bitnami/kubectl` image to be `1.26.11` that is the most recent one which supports `x86` and `ARM` architectures.
- Use much newer docker image for the `static local volume provisioner`. It also supports `x86` and `ARM` architectures.
- Update a bit the `static local volume provisioner` config to be aligned with the new image we switched to.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
