### PR TITLE
ci(k8s-eks): add ARM CI jobs configurations

### DIFF
--- a/configurations/arm/eks.yaml
+++ b/configurations/arm/eks.yaml
@@ -1,0 +1,5 @@
+k8s_instance_type_auxiliary: 't4g.large'
+k8s_instance_type_monitor: 't4g.large'
+instance_type_loader: 'c6gn.xlarge'
+instance_type_db: 'im4gn.4xlarge'
+k8s_scylla_disk_gi: 6900

--- a/configurations/operator/functional-eks-arm.yaml
+++ b/configurations/operator/functional-eks-arm.yaml
@@ -1,0 +1,6 @@
+user_prefix: 'functional-arm'
+k8s_instance_type_auxiliary: 't4g.large'
+k8s_instance_type_monitor: 't4g.large'
+instance_type_loader: 'c6gn.xlarge'
+instance_type_db: 'im4gn.xlarge'
+k8s_scylla_disk_gi: 1600

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-arm.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-arm.jenkinsfile
@@ -1,0 +1,17 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'k8s-eks',
+    region: 'eu-west-2',
+    availability_zone: 'c',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/scylla-operator/longevity-scylla-operator-3h.yaml", "configurations/arm/eks.yaml"]''',
+    email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+    post_behavior_k8s_cluster: 'destroy',
+    k8s_log_api_calls: false,
+)

--- a/jenkins-pipelines/operator/functional/functional-eks-arm.jenkinsfile
+++ b/jenkins-pipelines/operator/functional/functional-eks-arm.jenkinsfile
@@ -1,0 +1,18 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'k8s-eks',
+    region: 'eu-west-2',
+    availability_zone: 'c',
+    functional_test: true,
+    test_name: 'functional_tests/scylla_operator',
+    test_config: '''["test-cases/scylla-operator/functional.yaml", "configurations/operator/functional-eks-arm.yaml"]''',
+    email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+    post_behavior_k8s_cluster: 'destroy',
+    k8s_log_api_calls: false,
+)


### PR DESCRIPTION
Add following CI jobs configurations:
- Longevity K8S EKS 3h, full ARM
- Functional K8S EKS tests, full ARM

Also, update the EKS module by adding detection of the ARM instance types and selecting proper image for VM.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
