### PR TITLE
fix(prepare_kms_host): enable kms only for supported versions

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -96,7 +96,10 @@ from sdcm.utils.operations_thread import ThreadParams
 from sdcm.utils.replication_strategy_utils import LocalReplicationStrategy, NetworkTopologyReplicationStrategy
 from sdcm.utils.threads_and_processes_alive import gather_live_processes_and_dump_to_file, \
     gather_live_threads_and_dump_to_file
-from sdcm.utils.version_utils import get_relocatable_pkg_url
+from sdcm.utils.version_utils import (
+    get_relocatable_pkg_url,
+    ComparableScyllaVersion,
+)
 from sdcm.ycsb_thread import YcsbStressThread
 from sdcm.ndbench_thread import NdBenchStressThread
 from sdcm.kcl_thread import KclStressThread, CompareTablesSizesThread
@@ -800,7 +803,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         )
 
     def prepare_kms_host(self) -> None:
-        if self.params.is_enterprise and self.params.get('cluster_backend') == 'aws' and not self.params.get('scylla_encryption_options'):
+        if (self.params.is_enterprise and ComparableScyllaVersion(self.params.scylla_version) >= '2023.2.0~rc0'
+                and self.params.get('cluster_backend') == 'aws'
+                and not self.params.get('scylla_encryption_options')):
             self.params['scylla_encryption_options'] = "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'KmsKeyProviderFactory', 'kms_host': 'auto'}"  # pylint: disable=line-too-long
         if not (scylla_encryption_options := self.params.get("scylla_encryption_options") or ''):
             return None


### PR DESCRIPTION
when we introduced enabling EaR KMS for all AWS enterpise runs, it broke running older enterpise versions, since they don't support KMS

scylla would fail like this:
```
[shard 0] init - Startup failed: std::invalid_argument (Unknown provider: KmsKeyProviderFactory)
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
