### PR TITLE
fix(syslog-ng): remove log to local file

### DIFF
--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -70,8 +70,6 @@ def configure_syslogng_target_script(host: str, port: int, throttle_per_second: 
             );
         }};
 
-        destination d_system {{ file("/var/log/system.log"); }};
-        log {{ source($source_name); destination(d_system); }};
         EOF
         fi
 


### PR DESCRIPTION
since we are sending the log directly to the sct-runner we don't need to have them duplicated into `/var/log/system.log` later SCT can take them from `journalctl` as needed.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
