### PR TITLE
fix(docker): handle correctly older sshd versions

### DIFF
--- a/docker/scylla-sct/ubuntu/Dockerfile
+++ b/docker/scylla-sct/ubuntu/Dockerfile
@@ -38,6 +38,4 @@ COPY ./etc/sshd-service.sh /sshd-service.sh
 
 RUN export SSH_VERSION=$(ssh -V 2>&1 | cut -f 1  --delimiter=' ' | cut -f 2 --delimiter='_') && \
     dpkg --compare-versions "$SSH_VERSION" ">=" "8.8p1" && \
-    echo $'PubkeyAcceptedAlgorithms +ssh-rsa\nHostKeyAlgorithms +ssh-rsa' >> /etc/ssh/sshd_config
-
-# ENTRYPOINT service ssh start && /docker-entrypoint.py
+    echo $'PubkeyAcceptedAlgorithms +ssh-rsa\nHostKeyAlgorithms +ssh-rsa' >> /etc/ssh/sshd_config  || true


### PR DESCRIPTION
in PR #6888 we introduced the sshd configuration, but remove a part of the code the was ignoring the outcome of the sshd version check, hence when the condition failed, the docker build phase failed

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
