### PR TITLE
fix(k8s-multitenant): remove `k8s_enable_tls` from cases

### DIFF
--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-multitenant.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-multitenant.yaml
@@ -35,5 +35,3 @@ nemesis_during_prepare: false
 space_node_threshold: [64424, 64423]
 
 user_prefix: 'longevity-scylla-operator-3h-multitenant'
-
-k8s_enable_tls: true

--- a/test-cases/scylla-operator/longevity-scylla-operator-many-clients-4h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-many-clients-4h.yaml
@@ -27,7 +27,6 @@ use_mgmt: false
 k8s_deploy_monitoring: false
 k8s_enable_performance_tuning: true
 k8s_loader_run_type: 'static'
-k8s_enable_tls: true
 
 user_prefix: 'operator-many-clients-4h'
 space_node_threshold: 64424


### PR DESCRIPTION
two cases still had `k8s_enable_tls: true`, even that we don't want to use it until all of it's issues gonna be address

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
