### PR TITLE
fix(k8s): ignore timeout error deleting quasi-milti-dc ns

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -21,6 +21,7 @@ import threading
 import time
 import ssl
 import base64
+import invoke
 import path
 
 import pytest
@@ -218,7 +219,10 @@ def test_deploy_quasi_multidc_db_cluster(db_cluster: ScyllaPodCluster):  # pylin
             KubernetesOps.gather_k8s_logs(
                 logdir_path=logdir, kubectl=kubectl, namespaces=[namespace, namespace2])
         k8s_cluster.helm(f"uninstall {target_chart_name} --timeout 120s", namespace=namespace)
-        kubectl(f"delete namespace {namespace}", ignore_status=True, timeout=120)
+        try:
+            kubectl(f"delete namespace {namespace}", ignore_status=True, timeout=120)
+        except invoke.exceptions.CommandTimedOut as exc:
+            log.warning("Deletion of the '%s' namespace timed out: %s", namespace, exc)
 
 
 @pytest.mark.restart_is_used


### PR DESCRIPTION
To avoid following false `timeout` errors:

```
  Command: 'kubectl delete namespace t-podip-quasi-multidc'

  Stdout:
  namespace "t-podip-quasi-multidc" deleted

  Stderr:
```

Which happen in the `test_deploy_quasi_multidc_db_cluster` K8S func test.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
