### PR TITLE
fix(k8s): fix scylla-operator upgrade test

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1890,7 +1890,7 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
     def k8s_pod_name(self) -> str:
         return str(self._pod.metadata.name)
 
-    def wait_till_k8s_pod_get_uid(self, timeout: int = None, ignore_uid=None) -> str:
+    def wait_till_k8s_pod_get_uid(self, timeout: int = None, ignore_uid=None, throw_exc=False) -> str:
         """
         Wait till pod get any valid uid.
         If ignore_uid is provided it wait till any valid uid different from ignore_uid
@@ -1898,7 +1898,7 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
         if timeout is None:
             timeout = self.pod_replace_timeout
         wait_for(lambda: self.k8s_pod_uid and self.k8s_pod_uid != ignore_uid, timeout=timeout,
-                 text=f"Wait till host {self} get uid", throw_exc=False)
+                 text=f"Wait till host {self} get uid", throw_exc=throw_exc)
         return self.k8s_pod_uid
 
     def wait_for_k8s_node_readiness(self):


### PR DESCRIPTION
Current `scylla-operator upgrade` logic doesn't check that
- The `ScyllaCluster` object gets upgraded right after the `scylla-operator`.
- The `status.conditions` doesn't have errors
- The `init` container of the Scylla pods are of the new version.

It was sleeping for 1 minute and waiting for the rollout to finish.
But if, for any reason, rollout doesn't start, the code picks up the old `rollout` state and moves on with the old `ScyllaCluster` K8S object state.

So, add proper checks to cover problems with the `ScyllaCluster` upgrades:
- Check that scylla pods get new `UID` values meaning they were recreated
- Read ScyllaCluster's `status.conditions` and look for Error's
- Check all the `scylla-operator` images to be of the new version.

Closes: #6943

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
