### PR TITLE
fix(MV-errors): skip all view update error globaly

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -76,12 +76,16 @@ from sdcm.sct_events import Severity
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.decorators import raise_event_on_failure
 from sdcm.sct_events.filters import DbEventsFilter, EventsSeverityChangerFilter, EventsFilter
-from sdcm.sct_events.group_common_events import (ignore_alternator_client_errors, ignore_no_space_errors,
-                                                 ignore_scrub_invalid_errors, ignore_view_error_gate_closed_exception,
-                                                 ignore_stream_mutation_fragments_errors,
-                                                 ignore_ycsb_connection_refused, decorate_with_context,
-                                                 ignore_reactor_stall_errors, ignore_disk_quota_exceeded_errors,
-                                                 ignore_error_apply_view_update)
+from sdcm.sct_events.group_common_events import (
+    ignore_alternator_client_errors,
+    ignore_no_space_errors,
+    ignore_scrub_invalid_errors,
+    ignore_stream_mutation_fragments_errors,
+    ignore_ycsb_connection_refused,
+    decorate_with_context,
+    ignore_reactor_stall_errors,
+    ignore_disk_quota_exceeded_errors,
+)
 from sdcm.sct_events.health import DataValidatorEvent
 from sdcm.sct_events.loaders import CassandraStressLogEvent, ScyllaBenchEvent
 from sdcm.sct_events.nemesis import DisruptionEvent
@@ -3694,7 +3698,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     @decorate_with_context([
         ignore_ycsb_connection_refused,
-        ignore_view_error_gate_closed_exception
     ])
     def reboot_node(self, target_node, hard=True, verify_ssh=True):
         target_node.reboot(hard=hard, verify_ssh=verify_ssh)
@@ -4696,8 +4699,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         Create index on a random column (regular or static) of a table with the most number of partitions and wait until it gets build.
         Then verify it can be used in a query. Finally, drop the index.
         """
-        with ignore_error_apply_view_update(), \
-                self.cluster.cql_connection_patient(self.target_node, connect_timeout=300) as session:
+        with self.cluster.cql_connection_patient(self.target_node, connect_timeout=300) as session:
 
             ks_cf_list = self.cluster.get_non_system_ks_cf_list(self.target_node, filter_out_mv=True)
             if not ks_cf_list:

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -227,12 +227,6 @@ def ignore_compaction_stopped_exceptions():
 
 
 @contextmanager
-def ignore_view_error_gate_closed_exception():
-    with EventsFilter(event_class=DatabaseLogEvent, regex='.*view - Error applying view update.*gate_closed_exception'):
-        yield
-
-
-@contextmanager
 def ignore_large_collection_warning():
     with ExitStack() as stack:
         stack.enter_context(DbEventsFilter(
@@ -248,18 +242,6 @@ def ignore_max_memory_for_unlimited_query_soft_limit():
         stack.enter_context(DbEventsFilter(
             db_event=DatabaseLogEvent.WARNING,
             line="mutation_partition - Memory usage of unpaged query exceeds soft limit"
-        ))
-        yield
-
-
-@contextmanager
-def ignore_error_apply_view_update():
-    with ExitStack() as stack:
-        stack.enter_context(EventsSeverityChangerFilter(
-            new_severity=Severity.WARNING,
-            event_class=DatabaseLogEvent,
-            regex=r".*view - Error applying view update.*data_dictionary::no_such_column_family",
-            extra_time_to_expiration=30
         ))
         yield
 

--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -80,6 +80,14 @@ def start_events_device(log_dir: Optional[Union[str, Path]] = None,
                                 regex=r'.*sidecar/controller.go.*std::runtime_error '
                                       r'\(Operation decommission is in progress, try again\)').publish()
 
+    # TODO: remove when those issues are solved:
+    # https://github.com/scylladb/scylladb/issues/16206
+    # https://github.com/scylladb/scylladb/issues/16259
+    # https://github.com/scylladb/scylladb/issues/15598
+    EventsSeverityChangerFilter(new_severity=Severity.WARNING,
+                                event_class=DatabaseLogEvent,
+                                regex=r".*view - Error applying view update.*").publish()
+
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: supressed').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: suppressed').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.WARNING, line='abort_requested_exception').publish()


### PR DESCRIPTION
we had multiple places where we tried to apply a filtering/demoating of view update errors, and they keep popping up in all kind of cases

* cases of parallel nemesis
* cases our log reading slow down, and those pop out of context, since filter is gone

so cause of those issue, and the fact those aren't gonna be fixed any time soon, we'll apply this filter globaly until all of the view update issues would be addressed

Ref: https://github.com/scylladb/scylladb/issues/16206
Ref: https://github.com/scylladb/scylladb/issues/16259
Ref: https://github.com/scylladb/scylladb/issues/15598

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
