### PR TITLE
fix(version_utils): support more version options

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -55,7 +55,7 @@ SEMVER_REGEX = re.compile(
         (?P<minor>0|[1-9]\d*)
         \.
         (?P<patch>0|[1-9]\d*)
-        (?:-(?P<prerelease>
+        (?:[-.](?P<prerelease>
             (?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)
             (?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*
         ))?

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -608,6 +608,7 @@ def test_comparable_scylla_operator_versions_compare(version_string_left, versio
     ("1.9.0-alpha.1-nightly", "1.9.0-alpha.1"),
     ("1.9.0-alpha.1-2-g3321624", "1.9.0-alpha.1-2-g3321624"),
     ("1.9.0-alpha.1-2-g3321624-nightly", "1.9.0-alpha.1-2-g3321624"),
+    ("2024.2.0.dev.0.20231219.c7cdb16538f2.1", "2024.2.0-dev.0.20231219.c7cdb16538f2.1"),
 ))
 def test_comparable_scylla_operator_versions_to_str(version_string_input, version_string_output):
     assert str(ComparableScyllaOperatorVersion(version_string_input)) == version_string_output


### PR DESCRIPTION
now that we get version from more sources (from images tags) we have cases the version looks like:

`2024.2.0.dev.0.20231219.c7cdb16538f2.1`

i.e. dash was replace by a dot, by some part of the SMI code (cause of GCP tag limitations)

so `ComparableScyllaOperatorVersion` was extended to support it

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
