### PR TITLE
improvement(scylla-bench): add CRITICAL error on data vaidation failure

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -89,6 +89,8 @@ CassandraStressLogEvent.ShardAwareDriver: NORMAL
 CassandraStressLogEvent.SchemaDisagreement: WARNING
 SchemaDisagreementErrorEvent: ERROR
 ScyllaBenchLogEvent.ConsistencyError: ERROR
+ScyllaBenchLogEvent.DataValidationError: CRITICAL
+ScyllaBenchLogEvent.ParseDistributionError: CRITICAL
 GeminiStressLogEvent.GeminiEvent: CRITICAL
 PrometheusAlertManagerEvent: CRITICAL
 ScyllaOperatorLogEvent: ERROR

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -239,13 +239,23 @@ CS_NORMAL_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
 
 class ScyllaBenchLogEvent(LogEvent, abstract=True):
     ConsistencyError: Type[LogEventProtocol]
+    DataValidationError: Type[LogEventProtocol]
+    ParseDistributionError: Type[LogEventProtocol]
 
 
 ScyllaBenchLogEvent.add_subevent_type("ConsistencyError", severity=Severity.ERROR, regex=r"received only")
+# Scylla-bench data validation was added by https://github.com/scylladb/scylla-bench/commit/3eb53d8ce11e5ad26062bcc662edb31dda521ccf
+ScyllaBenchLogEvent.add_subevent_type("DataValidationError", severity=Severity.CRITICAL,
+                                      regex=r"doesn't match |failed to validate data|failed to verify checksum|corrupt checksum or data|"
+                                            r"data corruption")
+ScyllaBenchLogEvent.add_subevent_type("ParseDistributionError", severity=Severity.CRITICAL,
+                                      regex=r"missing parameter|unexpected parameter|unsupported|invalid")
 
 
 SCYLLA_BENCH_ERROR_EVENTS = (
     ScyllaBenchLogEvent.ConsistencyError(),
+    ScyllaBenchLogEvent.DataValidationError(),
+    ScyllaBenchLogEvent.ParseDistributionError(),
 )
 SCYLLA_BENCH_ERROR_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
     [(re.compile(event.regex), event) for event in SCYLLA_BENCH_ERROR_EVENTS]

--- a/unit_tests/test_sct_events_loaders.py
+++ b/unit_tests/test_sct_events_loaders.py
@@ -446,6 +446,8 @@ class TestCassandraStressLogEvent(unittest.TestCase):
 class TestScyllaBenchLogEvent(unittest.TestCase):
     def test_known_scylla_bench_errors(self):
         self.assertTrue(issubclass(ScyllaBenchLogEvent.ConsistencyError, ScyllaBenchLogEvent))
+        self.assertTrue(issubclass(ScyllaBenchLogEvent.DataValidationError, ScyllaBenchLogEvent))
+        self.assertTrue(issubclass(ScyllaBenchLogEvent.ParseDistributionError, ScyllaBenchLogEvent))
 
     def test_scylla_bench_error_events_list(self):
         self.assertSetEqual(set(dir(ScyllaBenchLogEvent)) - set(dir(LogEvent)),


### PR DESCRIPTION
Task: https://github.com/scylladb/qa-tasks/issues/1492

Scylla-bench data validation was fixed by
https://github.com/scylladb/scylla-bench/commit/3eb53d8ce11e5ad26062bcc662edb31dda521ccf. We need to create scylla-bench CRITICAL event if data validation failed.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
