### PR TITLE
improvement(version_utils): support more version options

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -140,6 +140,10 @@ class ComparableScyllaVersion:
         _scylla_version = _scylla_version.replace('-aarch64', '')
         _scylla_version = _scylla_version.replace('-x86_64', '')
 
+        # NOTE: transform gce-image version like '2024.2.0.dev.0.20231219.c7cdb16538f2.1'
+        if gce_image_v_match := re.search(r"(\d+\.\d+\.\d+\.)([a-z]+\.)(.*)", _scylla_version):
+            _scylla_version = f"{gce_image_v_match[1][:-1]}-{gce_image_v_match[2][:-1]}-{gce_image_v_match[3]}"
+
         # NOTE: make short scylla version like '5.2' be correct semver string
         _scylla_version_parts = _scylla_version.split('.')
         if len(_scylla_version_parts) == 2:
@@ -157,7 +161,7 @@ class ComparableScyllaVersion:
 
         # NOTE: replace '.' with '+' symbol between build date and build commit
         #       to satisfy semver structure
-        if dotted_build_id_match := re.search(r"(.*\.20[0-9]{6})(\.)(\d\w+)", _scylla_version):
+        if dotted_build_id_match := re.search(r"(.*\.20[0-9]{6})(\.)([\.\d\w]+)", _scylla_version):
             _scylla_version = f"{dotted_build_id_match[1]}+{dotted_build_id_match[3]}"
 
         if match := SEMVER_REGEX.match(_scylla_version):

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -459,6 +459,7 @@ def test_get_docker_image_by_version_fallback_on_errors():
     ("5.2.0-dev-0.20230109.08b3a9c786d9", (5,  2, 0, "dev-0.20230109", "08b3a9c786d9")),
     ("5.2.0-dev-0.20230109.08b3a9c786d9-x86_64", (5, 2, 0, "dev-0.20230109", "08b3a9c786d9")),
     ("5.2.0-dev-0.20230109.08b3a9c786d9-aarch64", (5, 2, 0, "dev-0.20230109", "08b3a9c786d9")),
+    ("2024.2.0.dev.0.20231219.c7cdb16538f2.1", (2024, 2, 0, "dev-0.20231219", "c7cdb16538f2.1")),
 ))
 def test_comparable_scylla_version_init_positive(version_string, expected):
     comparable_scylla_version = ComparableScyllaVersion(version_string)


### PR DESCRIPTION
Make the `ComparableScyllaVersion` support versions like following:

```
  2024.2.0.dev.0.20231219.c7cdb16538f2.1
```

Such version structure may come from the GCE images.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
