### PR TITLE
fix(monitoring): don't specify scylla target ports

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5378,7 +5378,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
         for node in self.nodes:
             monitoring_targets = []
             for db_node in self.targets["db_cluster"].nodes:
-                monitoring_targets.append(f"{normalize_ipv6_url(getattr(db_node, self.DB_NODES_IP_ADDRESS))}:9180")
+                monitoring_targets.append(f"{normalize_ipv6_url(getattr(db_node, self.DB_NODES_IP_ADDRESS))}")
             monitoring_targets = " ".join(monitoring_targets)
             node.remoter.sudo(shell_script_cmd(f"""\
                 cd {self.monitor_install_path}


### PR DESCRIPTION
seems like since scylladb/scylla-monitoring#2000, cause we are specifying the ports, monitoring is using those also for the agents, and cause all scylla metric to be duplicated

Ref: scylladb/scylla-enterprise#3708

### Testing

- [x] - ipv6 - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-10gb-3h-ipv6-test/4/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
