### PR TITLE
fix(aws_builder): change the builders to configure gp3 root disks

### DIFF
--- a/sdcm/utils/aws_builder.py
+++ b/sdcm/utils/aws_builder.py
@@ -51,7 +51,6 @@ config = [
 // https://github.com/jenkinsci/ec2-fleet-plugin/blob/master/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
 EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
   config.name, // fleetCloudName
-  "", // OldId
   "jenkins2 aws account", // awsCredentialsId
   "", // credentialsId
   config.region,
@@ -75,9 +74,10 @@ EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
   true, // disableTaskResubmit,
   600, // initOnlineTimeoutSec,
   60, // initOnlineCheckIntervalSec,
-  false, // scaleExecutorsByWeight,
   60, // cloudStatusIntervalSec,
   true, // noDelayProvision
+  false, // scaleExecutorsByWeight
+  new EC2FleetCloud.NoScaler(), // EC2FleetCloud.ExecutorScaler executorScaler
 )
 
 // get Jenkins instance

--- a/sdcm/utils/aws_builder.py
+++ b/sdcm/utils/aws_builder.py
@@ -19,7 +19,6 @@ import click
 import boto3
 import botocore
 import requests
-from mypy_boto3_ec2 import EC2ServiceResource
 
 from sdcm.utils.aws_region import AwsRegion
 from sdcm.sct_runner import AwsSctRunner
@@ -114,105 +113,6 @@ class AwsBuilder:
     @cached_property
     def jenkins_labels(self):
         return f"aws-sct-builders-{self.region.region_name}-v2-asg"
-
-    @cached_property
-    def instance(self) -> EC2ServiceResource.Instance:
-
-        if not self.runner.image:
-            LOGGER.error("SCT Runner image was not found in %s! "
-                         "Use `hydra create-runner-image --cloud-provider %s --region %s'",
-                         self.region.region_name, self.runner.CLOUD_PROVIDER, self.region.region_name)
-            return None
-
-        instances = self.region.client.describe_instances(Filters=[{"Name": "tag:Name",
-                                                                    "Values": [self.name]},
-                                                                   {"Name": "instance-state-name",
-                                                                    "Values": ["running"]}])
-
-        if instances["Reservations"] and instances["Reservations"][0]["Instances"]:
-            return self.region.resource.Instance(instances["Reservations"][0]["Instances"][0]['InstanceId'])
-
-        tags = {
-            "bastion": "true",
-            "NodeType": "builder",
-            "RunByUser": "QA",
-            "keep": "alive"
-        }
-
-        return self.runner._create_instance(  # pylint: disable=protected-access
-            instance_type=self.runner.REGULAR_TEST_INSTANCE_TYPE,
-            base_image=self.runner._get_base_image(self.runner.image),  # pylint: disable=protected-access
-            tags=tags,
-            instance_name=self.name,
-            region_az=self.region.availability_zones[0],
-        )
-
-    def add_to_jenkins(self):
-        LOGGER.info("Adding builder to jenkins:")
-        ssh_params = {
-            'port': '22',
-            'username': 'jenkins',
-            'credentialsId': 'user-jenkins_scylla-qa-ec2.pem',
-            'host': self.elastic_ip.public_ip,
-            "sshHostKeyVerificationStrategy": {
-                "$class": "hudson.plugins.sshslaves.verifiers.NonVerifyingKeyVerificationStrategy",
-                "stapler-class": "hudson.plugins.sshslaves.verifiers.NonVerifyingKeyVerificationStrategy"
-            },
-        }
-        try:
-            self.jenkins.create_node(
-                self.name,
-                numExecutors=15,
-                nodeDescription='QA Builder',
-                remoteFS='/home/jenkins/slave',
-                labels=self.jenkins_labels,
-                launcher=jenkins.LAUNCHER_SSH,
-                launcher_params=ssh_params)
-            LOGGER.info("%s added to jenkins successfully", self.name)
-        except jenkins.JenkinsException as ex:
-            if 'already exists' not in str(ex):
-                raise
-            LOGGER.info("%s was already added to jenkins", self.name)
-
-    @property
-    def elastic_ip(self) -> EC2ServiceResource.VpcAddress:
-        name = self.name
-        addresses = self.region.client.describe_addresses(Filters=[{"Name": "tag:Name",
-                                                                    "Values": [self.name]}])
-        LOGGER.debug("Found Address: %s", addresses)
-        existing_addresses = addresses.get("Addresses", [])
-        if len(existing_addresses) == 0:
-            return None
-        assert len(existing_addresses) == 1, \
-            f"More than 1 VpcAddress with {name} found " \
-            f"in {self.region.region_name}: {existing_addresses}!"
-        return self.region.resource.VpcAddress(existing_addresses[0]["AllocationId"])  # pylint: disable=no-member
-
-    def create_elastic_ip(self):
-        LOGGER.info("Creating elastic address...")
-        if eip := self.elastic_ip:
-            LOGGER.warning("elastic ip '%s' already exists! Id: '%s'.",
-                           self.name, eip.allocation_id)
-        else:
-            self.region.client.allocate_address(Domain='vpc', TagSpecifications=[{
-                'ResourceType': 'elastic-ip',
-                'Tags': [
-                    {'Key': 'Name', 'Value': self.name},
-                    {'Key': 'NodeType', 'Value': 'builder'},
-                    {'Key': 'RunByUser', 'Value': 'QA'}
-                ]
-            }])
-
-    def associate_elastic_ip(self):
-        LOGGER.info("associate addresss '%s' with '%s'", self.elastic_ip.public_ip, self.name)
-        self.region.client.associate_address(AllocationId=self.elastic_ip.allocation_id,
-                                             InstanceId=self.instance.instance_id)
-
-    def configure_one_builder(self):
-        self.region.create_sct_ssh_security_group()
-        self.create_elastic_ip()
-        self.associate_elastic_ip()
-        self.add_to_jenkins()
 
     @property
     def launch_template_name(self):

--- a/sdcm/utils/aws_builder.py
+++ b/sdcm/utils/aws_builder.py
@@ -43,7 +43,7 @@ config = [
     idleMinutes: 10,
     minSize: {min_size},
     maxSize: {max_size},
-    numExecutors: 4,
+    numExecutors: {num_executors},
     labels: "{jenkins_labels}",
 ]
 
@@ -96,6 +96,7 @@ jenkins.save()
 
 class AwsBuilder:
     NUM_CPUS = 2
+    NUM_EXECUTORS = 4
 
     def __init__(self, region: AwsRegion, number=1):
         self.region = region
@@ -364,6 +365,7 @@ class AwsBuilder:
         res = requests.post(url=f"{self.jenkins_info['url']}/scriptText",
                             auth=(self.jenkins_info['username'], self.jenkins_info['password']),
                             params=dict(script=ASG_CONFIG_FORMAT.format(name=self.name,
+                                                                        num_executors=self.NUM_EXECUTORS,
                                                                         region_name=self.region.region_name,
                                                                         min_size=0,
                                                                         max_size=100,
@@ -388,6 +390,7 @@ class AwsBuilder:
 
 class AwsCiBuilder(AwsBuilder):
     NUM_CPUS = 2
+    NUM_EXECUTORS = 1
 
     @cached_property
     def name(self):


### PR DESCRIPTION
update the launch templates to use gp3 disk,

and introduce code that can create new launch template version and update them to be the default, before this change the only check we did if the launch template existed or not, and never update anything with those templates
#### Testing
- [x] apply it on one region and test
- [x] apply it to all regions

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
