### PR TITLE
fix(dns): Change monitor instance type

### DIFF
--- a/test-cases/features/dns-cluster-5min.yaml
+++ b/test-cases/features/dns-cluster-5min.yaml
@@ -10,6 +10,5 @@ n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
 instance_type_loader: 'c5.4xlarge'
-instance_type_monitor: 't2.small'
 
 user_prefix: 'cases-dns'


### PR DESCRIPTION
The Scylla server for scylla-manager failed to start on t2.small instance type on the monitoring node in features-dns test. Removed the paramter from thsi test yaml config file.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)


The test passed in my staging folder with bigger instance for the monitoring node:

https://jenkins.scylladb.com/job/scylla-staging/job/mark/job/features-dns-cluster-5min-test/

https://argus.scylladb.com/workspace?state=WyIxMzBhODk4YS0wMWZlLTQyODQtODg1My05ODE2NmQ5ZGYwOGUiXQ