### PR TITLE
fix(get_builder_by_test_id): don't list stopped builders

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2278,7 +2278,7 @@ SSH_KEY_AWS_DEFAULT = "scylla-qa-ec2"
 SSH_KEY_GCE_DEFAULT = "scylla-test"
 
 
-def get_aws_builders(tags=None, running=False):
+def get_aws_builders(tags=None, running=True):
     builders = []
     ssh_key_path = os.path.join(SSH_KEY_DIR, SSH_KEY_AWS_DEFAULT)
 
@@ -2287,7 +2287,7 @@ def get_aws_builders(tags=None, running=False):
     for aws_builder in aws_builders:
         builder_name = [tag["Value"] for tag in aws_builder["Tags"] if tag["Key"] == "Name"][0]
         builders.append({"builder": {
-            "public_ip": aws_builder["PublicIpAddress"],
+            "public_ip": aws_builder.get("PublicIpAddress"),
             "name": builder_name,
             "user": "jenkins",
             "key_file": os.path.expanduser(ssh_key_path)
@@ -2296,7 +2296,7 @@ def get_aws_builders(tags=None, running=False):
     return builders
 
 
-def get_gce_builders(tags=None, running=False):
+def get_gce_builders(tags=None, running=True):
     builders = []
     ssh_key_path = os.path.join(SSH_KEY_DIR, SSH_KEY_GCE_DEFAULT)
 
@@ -2313,7 +2313,7 @@ def get_gce_builders(tags=None, running=False):
     return builders
 
 
-def list_builders(running=False):
+def list_builders(running=True):
     builder_tag = {"NodeType": "Builder"}
     aws_builders = get_aws_builders(builder_tag, running=running)
     gce_builders = get_gce_builders(builder_tag, running=running)
@@ -2325,7 +2325,7 @@ def get_builder_by_test_id(test_id):
     base_path_on_builder = "/home/jenkins/slave/workspace"
     found_builders = []
 
-    builders = list_builders()
+    builders = list_builders(running=True)
 
     def search_test_id_on_builder(builder):
         remoter = RemoteCmdRunnerBase.create_remoter(


### PR DESCRIPTION
Since we stopped recently a few builders

`get_builder_by_test_id` started failing with this error

```
KeyError: 'PublicIpAddress'
```

stopped instances doesn't have public address, and anyhow we shouldn't be listing them, by default.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
