### PR TITLE
ci(k8s): add scylla upgrade jobs using pod IPs

### DIFF
--- a/configurations/operator/expose-pod-ips.yaml
+++ b/configurations/operator/expose-pod-ips.yaml
@@ -1,0 +1,3 @@
+k8s_db_node_service_type: Headless
+k8s_db_node_to_node_broadcast_ip_type: PodIP
+k8s_db_node_to_client_broadcast_ip_type: PodIP

--- a/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-podips-k8s-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-podips-k8s-eks.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+rollingOperatorUpgradePipeline(
+    backend: 'k8s-eks',
+    region: 'eu-north-1',
+    availability_zone: 'c',
+    // NOTE: the lowest Scylla version which can be used for exposing Pod IPs is '2023.1.x'
+    base_versions: '["2023.1.2"]',
+    // TODO: set the new version as '2024.1.x' when gets released
+    new_version: '2024.1.0-rc2',
+    test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',
+    test_config: '''["test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml", "configurations/operator/expose-pod-ips.yaml"]''',
+)

--- a/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-podips-k8s-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-podips-k8s-gke.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+rollingOperatorUpgradePipeline(
+    backend: 'k8s-gke',
+    region: 'us-east1',
+    availability_zone: 'c',
+    // NOTE: the lowest Scylla version which can be used for exposing Pod IPs is '2023.1.x'
+    base_versions: '["2023.1.2"]',
+    // TODO: set the new version as '2024.1.x' when gets released
+    new_version: '2024.1.0-rc2',
+    test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',
+    test_config: '''["test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml", "configurations/operator/expose-pod-ips.yaml"]''',
+)


### PR DESCRIPTION
It will cover the following fixed scylla-operator bug:

https://github.com/scylladb/scylla-operator/issues/1638

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
