### PR TITLE
fix(disrupt_add_remove_mv): Increase session connection timeout

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4744,7 +4744,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     'Non-system keyspace and table are not found. nemesis can\'t be run')
             ks_name, base_table_name = random.choice(ks_cfs).split('.')
             view_name = f'{base_table_name}_view'
-            with self.cluster.cql_connection_patient(cql_query_executor_node) as session:
+            with self.cluster.cql_connection_patient(node=cql_query_executor_node, connect_timeout=600) as session:
                 primary_key_columns = get_column_names(
                     session=session, ks=ks_name, cf=base_table_name, is_primary_key=True)
                 # selecting a supported column for creating a materialized-view (not a collection type).


### PR DESCRIPTION
The default connection timeout of 100 isn't enough in some cases after the view building in cases of large partitions.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
