### PR TITLE
fix(nemesis): disable `disrupt_memory_stress`

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4277,17 +4277,21 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if self._is_it_on_kubernetes():
             self._k8s_disrupt_memory_stress()
             return
-        if self.target_node.distro.is_rhel_like:
-            self.target_node.install_epel()
-            self.target_node.remoter.sudo('yum install -y stress-ng')
-        elif self.target_node.distro.is_ubuntu:
-            self.target_node.remoter.sudo('apt-get -y install stress-ng')
-        else:
-            raise UnsupportedNemesis(f"{self.target_node.distro} OS not supported!")
+        # if self.target_node.distro.is_rhel_like:
+        #    self.target_node.install_epel()
+        #    self.target_node.remoter.sudo('yum install -y stress-ng')
+        # elif self.target_node.distro.is_ubuntu:
+        #    self.target_node.remoter.sudo('apt-get -y install stress-ng')
+        # else:
+        #    raise UnsupportedNemesis(f"{self.target_node.distro} OS not supported!")
+        #
+        # self.log.info('Try to allocate 90% total memory, the allocated memory will be swaped out')
+        # self.target_node.remoter.run(
+        #    "stress-ng --vm-bytes $(awk '/MemTotal/{printf \"%d\\n\", $2 * 0.9;}' < /proc/meminfo)k --vm-keep -m 1 -t 100")
 
-        self.log.info('Try to allocate 90% total memory, the allocated memory will be swaped out')
-        self.target_node.remoter.run(
-            "stress-ng --vm-bytes $(awk '/MemTotal/{printf \"%d\\n\", $2 * 0.9;}' < /proc/meminfo)k --vm-keep -m 1 -t 100")
+        # since we might get into uncontrolled situations with this nemesis
+        # see https://github.com/scylladb/scylla-cluster-tests/issues/6928
+        raise UnsupportedNemesis("Disabled cause of https://github.com/scylladb/scylla-cluster-tests/issues/6928")
 
     def disrupt_toggle_cdc_feature_properties_on_table(self):
         """Manipulate cdc feature settings


### PR DESCRIPTION
since we might get into uncontrolled situations with this nemesis see scylladb/scylla-cluster-tests#6928 for more details

Ref: scylladb/scylla-cluster-tests#6928

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
