### PR TITLE
fix(alter_test_tables_encryption): fix the walrus operation

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -804,10 +804,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     def prepare_kms_host(self) -> None:
         if (self.params.is_enterprise and ComparableScyllaVersion(self.params.scylla_version) >= '2023.2.0~rc0'
-                    and self.params.get('cluster_backend') == 'aws'
-                    and not self.params.get('scylla_encryption_options')
-                    and self.params.get("db_type") != "mixed_scylla"  # oracle probably doesn't support KMS
-                ):
+            and self.params.get('cluster_backend') == 'aws'
+            and not self.params.get('scylla_encryption_options')
+            and self.params.get("db_type") != "mixed_scylla"  # oracle probably doesn't support KMS
+            ):
             self.params['scylla_encryption_options'] = "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'KmsKeyProviderFactory', 'kms_host': 'auto'}"  # pylint: disable=line-too-long
         if not (scylla_encryption_options := self.params.get("scylla_encryption_options") or ''):
             return None
@@ -2926,7 +2926,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         """
         append_scylla_yaml = yaml.safe_load(self.params.get("append_scylla_yaml") or '') or {}
 
-        if (scylla_encryption_options := self.params.get('scylla_encryption_options')
+        if ((scylla_encryption_options := self.params.get('scylla_encryption_options'))
             and 'write' in stress_command
                 and 'user_info_encryption' not in append_scylla_yaml):
 


### PR DESCRIPTION
in PR #6980, by mistake the walrus operator was inside a parentheses, and was returning a boolean instead of `scylla_encryption_options` it should have returned.

in turns it was casuing failure like that:
```
<Error from server: code=0000 [Server error] message="Malformed extension">})
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
