### PR TITLE
feature(get_any_ks_cf_list): get more accurate data if table empty

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3524,8 +3524,12 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
 
                     has_data = False
                     try:
-                        stmt = SimpleStatement(f"SELECT * FROM {table_name}", fetch_size=10)
-                        has_data = bool(cql_session.execute(stmt).one())
+                        res = db_node.run_nodetool(sub_cmd='cfstats', args=table_name, timeout=300,
+                                                   warning_event_on_exception=(
+                                                       Failure, UnexpectedExit, Libssh2_UnexpectedExit,),
+                                                   publish_event=False, retry=0)
+                        cf_stats = db_node._parse_cfstats(res.stdout)  # pylint: disable=protected-access
+                        has_data = bool(cf_stats['Number of partitions (estimate)'])
                     except Exception as exc:  # pylint: disable=broad-except
                         self.log.warning(f'Failed to get rows from {table_name} table. Error: {exc}')
 


### PR DESCRIPTION
since in some cases (twcs as example), we have table with lots of tombstones, and our query with limit 10, can come up with no data cause of that, using cfstats would be bit more lengthy but more accurate for figuring if the table has data or not.

### Testing
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/EaR-longevity-kms-200gb-6h-test/33/
- [ ] ~~https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/EaR-longevity-kms-200gb-6h-test/35/~~
- [ ] ~~https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/EaR-longevity-kms-200gb-6h-test/36/~~
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/EaR-longevity-kms-200gb-6h-test/37/
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
