### PR TITLE
fix(disrupt_add_drop_column): to not pick audit tables

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2017,7 +2017,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         with self.cluster.cql_connection_patient(self.tester.db_cluster.nodes[0]) as session:
             query_result = session.execute('SELECT keyspace_name FROM system_schema.keyspaces;')
             for result_rows in query_result:
-                keyspaces.extend([row.lower() for row in result_rows if not row.lower().startswith("system")])
+                keyspaces.extend([row.lower()
+                                 for row in result_rows if not row.lower().startswith(("system", "audit"))])
             for ks in keyspaces:
                 to_be_skipped = tables_to_skip.get(ks, None)
                 if to_be_skipped is None:


### PR DESCRIPTION
`disrupt_add_drop_column` ignores system keyspace, but should also ignore the audit keyspace, those tables should be modifiable

Fixes: #6736

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
