### PR TITLE
fix(KMS_encryption_check): make the node used as `running_nemesis`

### DIFF
--- a/sdcm/utils/context_managers.py
+++ b/sdcm/utils/context_managers.py
@@ -43,3 +43,12 @@ def nodetool_context(node, start_command, end_command):
         yield result
     finally:
         node.run_nodetool(end_command)
+
+
+@contextmanager
+def run_nemesis(node: 'BaseNode', nemesis_name: str):
+    node.running_nemesis = nemesis_name
+    try:
+        yield node
+    finally:
+        node.running_nemesis = None


### PR DESCRIPTION
since we can be using this node for quite some time, we don't want nemesis to pick it while this check is using it. using a context manager to make sure the node isn't left with the marking


### Testing
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/EaR-longevity-kms-200gb-6h-test/34/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
