### PR TITLE
fix(create role): fix role name in test_workload_types

### DIFF
--- a/sla_per_user_system_test.py
+++ b/sla_per_user_system_test.py
@@ -778,11 +778,11 @@ class SlaPerUserTest(LongevityTest):
         # Define Service Levels/Roles/Users
         interactive_role = Role(session=session, name="interactive",
                                 password="interactive", login=True, verbose=True, superuser=True).create()
-        batch_role = Role(session=session, name="batch", password="batch", login=True, verbose=True,
+        batch_role = Role(session=session, name="batch1", password="batch1", login=True, verbose=True,
                           superuser=True).create()
         interactive_sla = ServiceLevel(session=session, name="interactive", shares=None,
                                        workload_type="interactive").create()
-        batch_sla = ServiceLevel(session=session, name="batch", shares=None,
+        batch_sla = ServiceLevel(session=session, name="batch1", shares=None,
                                  workload_type="batch").create()
         interactive_role.attach_service_level(interactive_sla)
         batch_role.attach_service_level(batch_sla)


### PR DESCRIPTION
It is not allowed to create role/service level with name 'batch'. It cause to query failure with error:
```
cassandra.protocol.SyntaxException: <Error from server: code=2000 [Syntax error in CQL query] message=line 1:26 no viable alternative at input 'batch'
```

This word is reserved for workload type.

**Test:**
https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/features-sla-workload-types-test/3/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
