### PR TITLE
fix(modify_table_speculative_retry): Set to reasonable numbers

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2661,8 +2661,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             default: speculative_retry = '99.0PERCENTILE';
         """
         options = ("'ALWAYS'",
-                   "'%spercentile'" % random.randint(1, 99),
-                   "'%sms'" % random.randint(1, 1000))
+                   "'%spercentile'" % random.randint(95, 99),
+                   "'%sms'" % random.randint(300, 1000))
         self._modify_table_property(name="speculative_retry", val=random.choice(options))
 
     def modify_table_twcs_window_size(self):


### PR DESCRIPTION
The modify_table nemesis which picks one of the table properties and alter them can choose a very low percentile or value for the speculative_retry which can cause high load of retries that may fail the stress eventually.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
