### PR TITLE
fix(disrupt_add_remove_dc): mark as disruptive=True

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5177,7 +5177,7 @@ class NoOpMonkey(Nemesis):
 
 class AddRemoveDcNemesis(Nemesis):
 
-    disruptive = False
+    disruptive = True
     kubernetes = False
     run_with_gemini = False
     limited = True


### PR DESCRIPTION
this nemesis is adding and removing a node.

currently from scylla POV it's disruptive, and we
can't do rolling restarts at that time.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
