### PR TITLE
fix(NodeBootstrapAbortManager): use correct timeouts for operations

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4914,7 +4914,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         bootstrapabortmanager = NodeBootstrapAbortManager(bootstrap_node=new_node, verification_node=self.target_node)
 
-        bootstrapabortmanager.run_bootsrap_and_abort_with_action(terminate_pattern, abort_action=new_node.stop_scylla)
+        bootstrapabortmanager.run_bootstrap_and_abort_with_action(terminate_pattern, abort_action=new_node.stop_scylla)
         bootstrapabortmanager.clean_and_restart_bootstrap_after_abort()
 
         if new_node.db_up() and not self.target_node.raft.is_cluster_topology_consistent():


### PR DESCRIPTION
NodeBootstrapAbortManager run in parallel two operations with ParallelObject:
1) bootstrap (node_setup)
2) abort_operation (stop_scylla)

ParallelObject has the common timeout for 2 operations equals
`Instance_start + log message wait timeout`

Bootstrap operation has default timeout 3600 ( but operation have to be aborted earlier)

abort_operation (stop_scylla) has wait timeout for log message equals
`Instance_start + log message wait timeout`

Usually abort operation triggered much earlier, when required log message appeared in log and
abort action is going to be executed.

But during job: `longevity-100gb-4h-fips-test`, required log message was not found during
required timeout. Parallel object exited and next steps of nemesis were started,
But because Threads initiated by ParallelObject are still in state running,
ParallelObject can't stop them and they still running in background.
It was the reason of race between threads, and that all scylla data were
removed while it had been starting and triggered coredump.

Fix changes expected timeouts to avoid races between threads
and sure that all operations finished as expected

Fix #6568


### Testing
- https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/longevity-100gb-4h-fips-test/3
- https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/longevity-100gb-4h-fips-test/2


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
