### PR TITLE
feature(start_scylla_server): add adaptive timeout

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2317,7 +2317,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         verify_up_timeout = verify_up_timeout or self.verify_up_timeout
         if verify_down:
             self.wait_db_down(timeout=timeout)
-        self.start_service(service_name='scylla-server', timeout=timeout)
+        with adaptive_timeout(operation=Operations.START_SCYLLA, node=self, timeout=timeout):
+            self.start_service(service_name='scylla-server', timeout=timeout * 4)
         if verify_up:
             self.wait_db_up(timeout=verify_up_timeout)
 

--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -55,6 +55,7 @@ class Operations(Enum):
     DECOMMISSION = ("decommission", _get_decommission_timeout, ())
     NEW_NODE = ("new_node", _get_soft_timeout, ("timeout",))
     CREATE_INDEX = ("create_index", _get_soft_timeout, ("timeout",))
+    START_SCYLLA = ("start_scylla", _get_soft_timeout, ("timeout",))
     CREATE_MV = ("create_mv", _get_soft_timeout, ("timeout",))
     MAJOR_COMPACT = ("major_compact", _get_soft_timeout, ("timeout",))
     REPAIR = ("repair", _get_soft_timeout, ("timeout",))


### PR DESCRIPTION
since we have seen a few time scylla might take more time to start then we might anticipate:

```
sdcm.remote.libssh2_client.exceptions.CommandTimedOut: Command did not complete within 500 seconds!
Command: 'sudo systemctl start scylla-server.service'
Stdout:
Stderr:
```

we now default to soft timeout of 500s same the timeout before, and hard timeout of 2000s (~30min)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - provision test
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-5gb-1h-StopWaitStartMonkey-aws-test/2

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
