### PR TITLE
fix(upgrade_test): Extend connection timeout for query session

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -57,7 +57,7 @@ def truncate_entries(func):
     @wraps(func)
     def inner(self, *args, **kwargs):
         node = args[0]
-        with self.db_cluster.cql_connection_patient(node, keyspace='truncate_ks') as session:
+        with self.db_cluster.cql_connection_patient(node, keyspace='truncate_ks', connect_timeout=600) as session:
             InfoEvent(message="Start truncate simple tables").publish()
             try:
                 self.cql_truncate_simple_tables(session=session, rows=NUMBER_OF_ROWS_FOR_TRUNCATE_TEST)
@@ -70,7 +70,7 @@ def truncate_entries(func):
         func_result = func(self, *args, **kwargs)
 
         # re-new connection
-        with self.db_cluster.cql_connection_patient(node, keyspace='truncate_ks') as session:
+        with self.db_cluster.cql_connection_patient(node, keyspace='truncate_ks', connect_timeout=600) as session:
             self.validate_truncated_entries_for_table(session=session, system_truncated=True)
             self.read_data_from_truncated_tables(session=session)
             self.cql_insert_data_to_simple_tables(session=session, rows=NUMBER_OF_ROWS_FOR_TRUNCATE_TEST)


### PR DESCRIPTION
In some cases of large queries in this test like in truncate_ks, the session times out with an error: 'Connection defunct by heartbeat': 'Client request timeout.'
It's possible that it won't solve the issue, but at least it'll eliminate client side connection timeout.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
