### PR TITLE
fix(longevity-mv-si-4days.yaml): enlarge runner disk

### DIFF
--- a/test-cases/longevity/longevity-mv-si-4days.yaml
+++ b/test-cases/longevity/longevity-mv-si-4days.yaml
@@ -20,6 +20,8 @@ gce_n_local_ssd_disk_db: 16
 
 instance_type_monitor: 't3.xlarge'
 
+root_disk_size_runner: 120
+
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '023'
 nemesis_interval: 30


### PR DESCRIPTION
on run in 2024.1 we are getting into case the runner is running out of disk space, after ~3 days, so we need a bigger one for now

until we could detect it and handle it in some automatic fashion

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- no testing is needed for this config change 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
