### PR TITLE
feature(perf_date): script to change job-name of results

### DIFF
--- a/utils/update_field.py
+++ b/utils/update_field.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+import sys
+import os.path
+import logging
+import logging.config
+
+import click
+from elasticsearch import Elasticsearch
+from elasticsearch.helpers import scan
+from sdcm.keystore import KeyStore
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def configure_logging():
+    logging.basicConfig(level=logging.DEBUG)
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": True,
+            "formatters": {
+                "standard": {
+                    "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+                },
+            },
+            "handlers": {
+                "default": {
+                    "level": "INFO",
+                    "formatter": "standard",
+                    "class": "logging.StreamHandler",
+                    "stream": "ext://sys.stdout",  # Default is stderr
+                },
+            },
+            "loggers": {
+                "": {  # root logger
+                    "handlers": ["default"],
+                    "level": "WARNING",
+                    "propagate": False,
+                },
+                "__main__": {  # if __name__ == '__main__'
+                    "handlers": ["default"],
+                    "level": "DEBUG",
+                    "propagate": False,
+                },
+            },
+        }
+    )
+
+
+@click.command(help="edit specific values in ES")
+@click.argument("index_name", default="performanceregressiontest", type=str)
+@click.argument("test_id", type=str)
+@click.argument("new_job_name", type=str)
+def update_value(index_name, test_id, new_job_name):
+    """
+    helper script to move results in index to a different job
+    as needed
+
+    for example, we had a bad run that we want to exclude and move to different job-name:
+
+        ./utils/update_field.py performanceregressiontest 456cb6da-e315-4f38-bde5-28eba9e386b9 \
+            scylla-master/scylla-master-perf-regression-latency-650gb-grow-shrink
+
+    """
+    configure_logging()
+
+    ks = KeyStore()
+    es_conf = ks.get_elasticsearch_credentials()
+    elastic_search = Elasticsearch(
+        hosts=[es_conf["es_url"]],
+        verify_certs=True,
+        http_auth=(es_conf["es_user"], es_conf["es_password"]),
+    )
+
+    res = scan(
+        elastic_search,
+        index=index_name,
+        query={
+            "query": {"query_string": {"query": f'test_details.test_id: "{test_id}"'}}
+        },
+        size=300,
+        scroll="3h",
+    )
+
+    for num, hit in enumerate(res):
+        test_data = hit["_source"]
+        LOGGER.info(
+            "%s: %s - %s",
+            num,
+            test_data["test_details"]["test_id"],
+            test_data["test_details"]["job_name"],
+        )
+        test_data["test_details"]["job_name"] = new_job_name
+        elastic_search.update(   # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
+            index=index_name, id=hit["_id"], doc_type="test_stats", doc=test_data
+        )
+        click.secho(f"updated {test_data['test_details']['test_id']}", fg="green")
+
+
+if __name__ == "__main__":
+    update_value()  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
a new script that can be used to change the job-name on specific test_ids

for case we want to exclude wrong/bad results from history
```bash
./utils/update_field.py [index_name] [test_id] [new_job_name]
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
