### PR TITLE
feature(nemesis): introduce lock for target selection

### DIFF
--- a/sdcm/utils/context_managers.py
+++ b/sdcm/utils/context_managers.py
@@ -43,12 +43,3 @@ def nodetool_context(node, start_command, end_command):
         yield result
     finally:
         node.run_nodetool(end_command)
-
-
-@contextmanager
-def run_nemesis(node: 'BaseNode', nemesis_name: str):
-    node.running_nemesis = nemesis_name
-    try:
-        yield node
-    finally:
-        node.running_nemesis = None


### PR DESCRIPTION
since we run into multiple cases on parallel nemesis that there were multiple nemesis using the same node

we are introducing a lock over the selection of target nodes so we won't be able to pick it multiple times

Fixes: #6553

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] parallel nemesis case with enterprise build - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis-test/4/ https://argus.scylladb.com/test/eedcde34-5d24-4c94-84d7-07608f49b9da/runs?additionalRuns[]=af0022c1-586b-4556-989f-f6aec800f2b2
- [x] provision tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
