### PR TITLE
fix(longevity-fips): Set the longevity to run non-disruptive nemesis

### DIFF
--- a/configurations/longevity-fips-and-encryptions.yaml
+++ b/configurations/longevity-fips-and-encryptions.yaml
@@ -7,3 +7,4 @@ server_encrypt: true
 internode_encryption: 'all'
 user_prefix: 'longevity-fips'
 test_duration: 400
+nemesis_selector: ["!disruptive"]


### PR DESCRIPTION
Since this longevity uses a special clean AMI and some nemesis do not handle that well and need to install scylla, this commit suggests a workaround to run only non-disruptive nemesis. There is nothing special with the longevity for fips and in term of coverage it would be better to cover some administrative commands than topology changes or things like that.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
