### PR TITLE
revert(instance type): use i3 type in SLA feature test

### DIFF
--- a/test-cases/features/system-sla-test.yaml
+++ b/test-cases/features/system-sla-test.yaml
@@ -4,7 +4,7 @@ n_db_nodes: 3
 n_loaders: 3
 n_monitor_nodes: 1
 
-instance_type_db: 'i4i.2xlarge'
+instance_type_db: 'i3.2xlarge'
 instance_type_loader: 'c5.2xlarge'
 
 user_prefix: 'system-sla'


### PR DESCRIPTION
DB instance type has been changed from i3 to i4i by https://github.com/scylladb/scylla-cluster-tests/pull/6354.
It's because i3 family was depricated in scylla-cloud. It caused to load decreasing in SLA longevities. And it is a critical problem for those longevities as we need almost 100% load during the tests. I revert this change for SLA longevities .

Fixs: https://github.com/scylladb/scylla-enterprise/issues/3693

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/yulia-sla-read-throughput-1to5-ratio-2021.1/69/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
