### PR TITLE
fix(large-partitions): disable validation part

### DIFF
--- a/test-cases/longevity/longevity-large-partition-3h.yaml
+++ b/test-cases/longevity/longevity-large-partition-3h.yaml
@@ -52,9 +52,11 @@ run_fullscan:
 
 # To validate rows in partitions: collect data about partitions and their rows amount
 # before and after running nemesis and compare it
-data_validation: |
-  validate_partitions: true
-  table_name: "scylla_bench.test"
-  primary_key_column: "pk"
-  max_partitions_in_test_table: 400
-  partition_range_with_data_validation: 0-100
+
+# TODO: enable it back once https://github.com/scylladb/qa-tasks/issues/1578 is handled
+# data_validation: |
+#  validate_partitions: true
+#  table_name: "scylla_bench.test"
+#  primary_key_column: "pk"
+#  max_partitions_in_test_table: 400
+#  partition_range_with_data_validation: 0-100

--- a/test-cases/longevity/longevity-large-partition-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-4days.yaml
@@ -38,13 +38,15 @@ space_node_threshold: 644245094
 
 # To validate rows in partitions: collect data about partitions and their rows amount
 # before and after running nemesis and compare it
-data_validation: |
-  validate_partitions: true
-  table_name: "scylla_bench.test"
-  primary_key_column: "pk"
-  max_partitions_in_test_table: 60
-  partition_range_with_data_validation: 0-50
-  limit_rows_number: 20000
+
+# TODO: enable it back once https://github.com/scylladb/qa-tasks/issues/1578 is handled
+# data_validation: |
+#  validate_partitions: true
+#  table_name: "scylla_bench.test"
+#  primary_key_column: "pk"
+#  max_partitions_in_test_table: 60
+#  partition_range_with_data_validation: 0-50
+#  limit_rows_number: 20000
 
 # TODO: uncomment the fullscan part when following bug gets fixed:
 #       https://github.com/scylladb/scylla-cluster-tests/issues/6056

--- a/test-cases/longevity/longevity-large-partition-8h.yaml
+++ b/test-cases/longevity/longevity-large-partition-8h.yaml
@@ -61,10 +61,12 @@ run_fullscan: ['{"mode": "partition", "ks_cf": "scylla_bench.test", "interval": 
 use_preinstalled_scylla: true
 # To validate rows in partitions: collect data about partitions and their rows amount
 # before and after running nemesis and compare it
-data_validation: |
-  validate_partitions: true
-  table_name: "scylla_bench.test"
-  primary_key_column: "pk"
-  max_partitions_in_test_table: 400
-  partition_range_with_data_validation: 0-100
-  limit_rows_number: 10000
+
+# TODO: enable it back once https://github.com/scylladb/qa-tasks/issues/1578 is handled
+#data_validation: |
+#  validate_partitions: true
+#  table_name: "scylla_bench.test"
+#  primary_key_column: "pk"
+#  max_partitions_in_test_table: 400
+#  partition_range_with_data_validation: 0-100
+#  limit_rows_number: 10000

--- a/test-cases/longevity/longevity-large-partitions-deletions-and-reversed-queries.yaml
+++ b/test-cases/longevity/longevity-large-partitions-deletions-and-reversed-queries.yaml
@@ -33,12 +33,14 @@ user_prefix: 'longevity-large-partitions-2d-order-by-desc'
 
 # To validate rows in partitions: collect data about partitions and their rows amount
 # before and after running nemesis and compare it
-data_validation: |
-  validate_partitions: true
-  table_name: "scylla_bench.test"
-  primary_key_column: "pk"
-  max_partitions_in_test_table: 1000
-  partition_range_with_data_validation: 0-800
+
+# TODO: enable it back once https://github.com/scylladb/qa-tasks/issues/1578 is handled
+# data_validation: |
+#  validate_partitions: true
+#  table_name: "scylla_bench.test"
+#  primary_key_column: "pk"
+#  max_partitions_in_test_table: 1000
+#  partition_range_with_data_validation: 0-800
 
 
 run_fullscan: ['{"mode": "random", "ks_cf": "scylla_bench.test", "interval": 3600, "pk_name":"pk", "rows_count": 50000, "validate_data": true}']


### PR DESCRIPTION
the validation code isn't yet fully working
and can stop/fail the nemesis thread in the middle of a test case, for now it's going to be disabled

Ref: https://github.com/scylladb/qa-tasks/issues/1578

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - no testing is needed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
