### PR TITLE
feature(restart_scylla_server): add adaptive timeout

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2362,12 +2362,14 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if verify_down:
             self.wait_jmx_down(timeout=timeout)
 
-    def restart_scylla_server(self, verify_up_before=False, verify_up_after=True, timeout=500, ignore_status=False):
+    def restart_scylla_server(self, verify_up_before=False, verify_up_after=True, timeout=1800, verify_up_timeout=None):
+        verify_up_timeout = verify_up_timeout or self.verify_up_timeout
         if verify_up_before:
-            self.wait_db_up(timeout=timeout)
-        self.restart_service(service_name='scylla-server', timeout=timeout, ignore_status=ignore_status)
+            self.wait_db_up(timeout=verify_up_timeout)
+        with adaptive_timeout(operation=Operations.START_SCYLLA, node=self, timeout=timeout):
+            self.restart_service(service_name='scylla-server', timeout=timeout * 2)
         if verify_up_after:
-            self.wait_db_up(timeout=timeout)
+            self.wait_db_up(timeout=verify_up_timeout)
 
     def restart_scylla_jmx(self, verify_up_before=False, verify_up_after=True, timeout=300):
         if verify_up_before:
@@ -2377,7 +2379,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.wait_jmx_up(timeout=timeout)
 
     @log_run_info
-    def restart_scylla(self, verify_up_before=False, verify_up_after=True, timeout=500):
+    def restart_scylla(self, verify_up_before=False, verify_up_after=True, timeout=1800):
         self.restart_scylla_server(verify_up_before=verify_up_before, verify_up_after=verify_up_after, timeout=timeout)
         if verify_up_after:
             self.wait_jmx_up(timeout=timeout)

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2082,17 +2082,18 @@ class BaseScyllaPodContainer(BasePodContainer):  # pylint: disable=abstract-meth
     def node_name(self) -> str:  # pylint: disable=invalid-overridden-method
         return self._pod.spec.node_name
 
-    def restart_scylla_server(self, verify_up_before=False, verify_up_after=True, timeout=300,
-                              ignore_status=False):
+    def restart_scylla_server(self, verify_up_before=False, verify_up_after=True, timeout=1800,
+                              verify_up_timeout=None):
+        verify_up_timeout = verify_up_timeout or self.verify_up_timeout
         if verify_up_before:
-            self.wait_db_up(timeout=timeout)
+            self.wait_db_up(timeout=verify_up_timeout)
         self.remoter.run('sh -c "supervisorctl restart scylla || supervisorctl restart scylla-server"',
                          timeout=timeout)
         if verify_up_after:
-            self.wait_db_up(timeout=timeout)
+            self.wait_db_up(timeout=verify_up_timeout)
 
     @cluster.log_run_info
-    def restart_scylla(self, verify_up_before=False, verify_up_after=True, timeout=300):
+    def restart_scylla(self, verify_up_before=False, verify_up_after=True, timeout=1800):
         self.restart_scylla_server(
             verify_up_before=verify_up_before, verify_up_after=verify_up_after, timeout=timeout)
 

--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -56,6 +56,7 @@ class Operations(Enum):
     NEW_NODE = ("new_node", _get_soft_timeout, ("timeout",))
     CREATE_INDEX = ("create_index", _get_soft_timeout, ("timeout",))
     START_SCYLLA = ("start_scylla", _get_soft_timeout, ("timeout",))
+    RESTART_SCYLLA = ("restart_scylla", _get_soft_timeout, ("timeout",))
     CREATE_MV = ("create_mv", _get_soft_timeout, ("timeout",))
     MAJOR_COMPACT = ("major_compact", _get_soft_timeout, ("timeout",))
     REPAIR = ("repair", _get_soft_timeout, ("timeout",))


### PR DESCRIPTION
since we have seen a few time scylla might take more time to start then we might anticipate:

```
sdcm.remote.libssh2_client.exceptions.CommandTimedOut: Command did not complete within 500 seconds!
Command: 'sudo systemctl restart scylla-server.service'
Stdout:
Stderr:
```

we now default to soft timeout of 1800s (900s for stop / 900s for start), and hard timeout of 3600s (~1h)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
