### PR TITLE
fix(longevity-2TB-48h-*-ssl-1dis-2nondis): strong sct runner

### DIFF
--- a/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -26,6 +26,7 @@ n_monitor_nodes: 1
 
 instance_type_db: 'i3en.3xlarge'
 instance_type_loader: 'c5.2xlarge'
+instance_type_runner: 'r5.2xlarge'
 
 cluster_health_check: false
 nemesis_class_name: 'DisruptiveMonkey:1 NonDisruptiveMonkey:2'


### PR DESCRIPTION
this case seem to be generating lots of logs, and we seen multiple case where the offset of the log reading was more then 15min, we might minimize this offset by using a stronger machine for the runner

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x]  https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis-test/2/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
