### PR TITLE
fix(longevity-large-partitions): disable nemesis during prepare

### DIFF
--- a/test-cases/longevity/longevity-large-partition-3h.yaml
+++ b/test-cases/longevity/longevity-large-partition-3h.yaml
@@ -41,6 +41,7 @@ instance_type_db: 'i4i.2xlarge'
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '013'
 nemesis_interval: 15
+nemesis_during_prepare: false
 
 user_prefix: 'longevity-large-partitions-3h'
 

--- a/test-cases/longevity/longevity-large-partition-8h.yaml
+++ b/test-cases/longevity/longevity-large-partition-8h.yaml
@@ -51,6 +51,7 @@ gce_n_local_ssd_disk_db: 8
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '015'
 nemesis_interval: 15
+nemesis_during_prepare: false
 
 user_prefix: 'longevity-large-partitions-8h'
 


### PR DESCRIPTION
Since large partition data validation was introduced and runs after every nemesis, it's impossible to run the nemesis during prepare because it won't find the data or partial data during the validation.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
