### PR TITLE
fix(longevity-2TB-*-1dis-2nondis): limit manager nemesis to on thread

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4275,12 +4275,11 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
     def add_nemesis(self, nemesis, tester_obj):
         for nem in nemesis:
-            for _ in range(nem['num_threads']):
-                nemesis_obj = nem['nemesis'](tester_obj=tester_obj,
-                                             termination_event=self.nemesis_termination_event,
-                                             nemesis_selector=nem['nemesis_selector'])
-                self.nemesis.append(nemesis_obj)
-        self.nemesis_count = sum(nem['num_threads'] for nem in nemesis)
+            nemesis_obj = nem['nemesis'](tester_obj=tester_obj,
+                                         termination_event=self.nemesis_termination_event,
+                                         nemesis_selector=nem['nemesis_selector'])
+            self.nemesis.append(nemesis_obj)
+        self.nemesis_count = len(nemesis)
 
     def clean_nemesis(self):
         self.nemesis = []

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1025,18 +1025,20 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if nemesis_selectors and isinstance(nemesis_selectors[0], str):
             nemesis_selectors = [nemesis_selectors[:]]
 
-        nemesis_class_names = list_class_name.split(' ')
-
-        for i, klass in enumerate(nemesis_class_names):
+        nemesis_class_names = []
+        for i, klass in enumerate(list_class_name.split(' ')):
             try:
                 nemesis_name, num = klass.strip().split(':')
                 nemesis_name = nemesis_name.strip()
-                num = num.strip()
+                num = int(num.strip())
 
             except ValueError:
                 nemesis_name = klass.split(':')[0]
                 num = 1
+            for _ in range(num):
+                nemesis_class_names.append(nemesis_name)
 
+        for i, nemesis_name in enumerate(nemesis_class_names):
             nemesis_selector = []
             if nemesis_selectors:
                 try:
@@ -1045,7 +1047,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                     self.log.warning("Missing nemesis selector. use default. %s", details)
 
             nemesis_threads.append({'nemesis': getattr(nemesis, nemesis_name),
-                                    'num_threads': int(num),
                                     'nemesis_selector': nemesis_selector})
 
         self.log.debug("Nemesis threads %s", nemesis_threads)

--- a/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -30,6 +30,7 @@ instance_type_runner: 'r5.2xlarge'
 
 cluster_health_check: false
 nemesis_class_name: 'DisruptiveMonkey:1 NonDisruptiveMonkey:2'
+nemesis_selector: [[],[],["!manager_operation"]]
 nemesis_interval: 30
 nemesis_during_prepare: false
 nemesis_filter_seeds: false

--- a/test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml
@@ -10,6 +10,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i4i.2xlarge'
 
 nemesis_class_name: 'DisruptiveMonkey:1 NonDisruptiveMonkey:2'
+nemesis_selector: [[],[],["!manager_operation"]]
 nemesis_interval: 5
 nemesis_during_prepare: false
 space_node_threshold: 64424

--- a/unit_tests/test_nemesis.py
+++ b/unit_tests/test_nemesis.py
@@ -303,25 +303,21 @@ class TestSisyphusMonkeyNemesisFilter:
         tester.db_cluster = Cluster(nodes=[Node(), Node()])
         tester.db_cluster.params = tester.params
         tester.params["nemesis_class_name"] = "SisyphusMonkey:1 SisyphusMonkey:2"
-        tester.params["nemesis_selector"] = [["topology_changes"], ["schema_changes"]]
+        tester.params["nemesis_selector"] = [["topology_changes"], ["schema_changes"], ["schema_changes"]]
         tester.params["nemesis_multiply_factor"] = 1
         nemesises = tester.get_nemesis_class()
 
-        expected_selectors = [["topology_changes"], ["schema_changes"]]
-        expected_num_threads = [1, 2]
+        expected_selectors = [["topology_changes"], ["schema_changes"], ["schema_changes"]]
         for i, nemesis_settings in enumerate(nemesises):
             assert nemesis_settings['nemesis'] == SisyphusMonkey, \
                 f"Wrong instance of nemesis class {nemesis_settings['nemesis']} expected SisyphusMonkey"
-            assert nemesis_settings['num_threads'] == expected_num_threads[i], \
-                f"Wrong number of nemesis threads {nemesis_settings['num_threads']} expected {expected_num_threads[i]}"
             assert nemesis_settings['nemesis_selector'] == expected_selectors[i], \
                 f"Wrong nemesis filter selecters {nemesis_settings['nemesis_selector']} expected {expected_selectors[i]}"
 
         active_nemesis = []
         for nemesis in nemesises:
-            for _ in range(nemesis["num_threads"]):
-                sisyphus = nemesis['nemesis'](tester, None, nemesis_selector=nemesis["nemesis_selector"])
-                active_nemesis.append(sisyphus)
+            sisyphus = nemesis['nemesis'](tester, None, nemesis_selector=nemesis["nemesis_selector"])
+            active_nemesis.append(sisyphus)
         expected_methods = [expected_topology_changes_methods,
                             expected_schema_changes_methods, expected_schema_changes_methods]
         LOGGER.warning(expected_methods)


### PR DESCRIPTION
since most manager task are on the whole cluster, we should limit them to be selected only on one `NonDisruptive` thread. otherwise it would generate lots of nice of failed manager tasks

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] parallel nemesis case with enterprise build - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis-test/4/ https://argus.scylladb.com/test/eedcde34-5d24-4c94-84d7-07608f49b9da/runs?additionalRuns[]=af0022c1-586b-4556-989f-f6aec800f2b2


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
