### PR TITLE
test(multi-dc): reproduce issue with QUORUM read workload

### DIFF
--- a/jenkins-pipelines/longevity-multi-dc-quorum-read.jenkinsfile
+++ b/jenkins-pipelines/longevity-multi-dc-quorum-read.jenkinsfile
@@ -1,0 +1,14 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: '["eu-west-1", "eu-west-2"]',
+
+    availability_zone: 'c',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/longevity/longevity-multidc-quorum-read.yaml',
+    internode_compression: 'all'
+)

--- a/test-cases/longevity/longevity-multidc-quorum-read.yaml
+++ b/test-cases/longevity/longevity-multidc-quorum-read.yaml
@@ -1,0 +1,34 @@
+test_duration: 360
+
+# Workloads
+
+prepare_write_cmd:
+  [
+    "cassandra-stress write no-warmup cl=ALL n=10100200 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compression=LZ4Compressor compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native compression=lz4 -rate threads=1000 -pop seq=1..10100200 -log interval=5",
+    "cassandra-stress write no-warmup cl=QUORUM n=20100200 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compression=LZ4Compressor compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native compression=lz4 -rate threads=60 -pop seq=10100201..30200400 -log interval=5"
+  ]
+
+stress_cmd: "cassandra-stress read no-warmup cl=QUORUM n=30200400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compression=LZ4Compressor' -mode cql3 native compression=lz4 -rate threads=1000 -pop seq=1..30200400 -log interval=5"
+
+instance_type_db: 'i4i.2xlarge'
+n_db_nodes: '3 3'
+n_loaders: '1 1'
+n_monitor_nodes: 1
+region_aware_loader: true
+region_name: 'eu-west-1 eu-west-2'
+
+user_prefix: 'multi-dc-QUORUM'
+
+server_encrypt: true
+authenticator: 'PasswordAuthenticator'
+authenticator_user: 'cassandra'
+authenticator_password: 'cassandra'
+
+internode_compression: 'all'
+
+use_mgmt: false
+
+nemesis_class_name: 'NoOpMonkey'
+nemesis_seed: '032'
+nemesis_interval: 5
+nemesis_filter_seeds: false


### PR DESCRIPTION
same workload as used in `multi-dc-rolling-upgrade.yaml` but ontop a longevity run, with no upgrades

Ref: scylladb/scylla-enterprise#3735

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
