### PR TITLE
feature(adaptive_timeouts): collect number of db nodes

### DIFF
--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -74,6 +74,14 @@ class Operations(Enum):
                                  ("timeout", "service_level_for_test_step"))
 
 
+class TestInfoServices:  # pylint: disable=too-few-public-methods
+    @staticmethod
+    def get(node: "BaseNode") -> dict:
+        return dict(
+            n_db_nodes=len(node.parent_cluster.nodes),
+        )
+
+
 @contextmanager
 def adaptive_timeout(operation: Operations, node: "BaseNode", stats_storage: AdaptiveTimeoutStore = ESAdaptiveTimeoutStore(), **kwargs):
     """
@@ -87,6 +95,7 @@ def adaptive_timeout(operation: Operations, node: "BaseNode", stats_storage: Ada
         assert arg in kwargs, f"Argument '{arg}' is required for operation {operation.name}"
         args[arg] = kwargs[arg]
     timeout, load_metrics = operation.value[1](node_info_service=NodeLoadInfoServices().get(node), **args)
+    load_metrics = load_metrics | TestInfoServices.get(node)
     start_time = time.time()
     timeout_occurred = False
     try:

--- a/unit_tests/test_adaptive_timeouts.py
+++ b/unit_tests/test_adaptive_timeouts.py
@@ -23,7 +23,7 @@ from invoke import Result
 from sdcm.remote import RemoteCmdRunnerBase
 from sdcm.utils.adaptive_timeouts.load_info_store import AdaptiveTimeoutStore
 from sdcm.utils.adaptive_timeouts import Operations, adaptive_timeout
-from unit_tests.lib.fake_remoter import FakeRemoter
+from unit_tests.test_cluster import DummyDbCluster
 
 LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +34,7 @@ class FakeNode():
         self.name = name
         self.remoter = remoter
         self.scylla_version_detailed = "2042.1.12-0.20220620.e23889f17"
+        self.parent_cluster = DummyDbCluster(nodes=[self], params={'n_db_nodes': 1})
 
 
 class MemoryAdaptiveTimeoutStore(AdaptiveTimeoutStore):


### PR DESCRIPTION
since in some cases we will want to use that number as a scale for selecting timeouts
so we'll start collecting it now

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
