### PR TITLE
fix(data_validation longevity-large-partition-8h): set correct value

### DIFF
--- a/test-cases/longevity/longevity-large-partition-8h.yaml
+++ b/test-cases/longevity/longevity-large-partition-8h.yaml
@@ -68,4 +68,4 @@ data_validation: |
   primary_key_column: "pk"
   max_partitions_in_test_table: 400
   partition_range_with_data_validation: 0-100
-  limit_rows_number: 10000
+  limit_rows_number: 5555


### PR DESCRIPTION
It seems like a copy-paste mistake done when adding data_validation to this test. the number of rows the test writes during the prepare is 5555, then the validation is comparing the number of rows actually written to the "limit_rows_number" (very bad naming for parameter). If the value is less than this parameter, it generates an error saying: "Found missing rows for partitions".

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
