### PR TITLE
fix(featrues-testcases): disable manager on too small monitor nodes

### DIFF
--- a/query_limits_test.py
+++ b/query_limits_test.py
@@ -45,7 +45,7 @@ class QueryLimitsTest(ClusterTester):
         db_info = {'n_nodes': 1, 'device_mappings': bdm,
                    'type': 'm4.4xlarge'}
         monitor_info = {'n_nodes': 1, 'device_mappings': None,
-                        'type': 't2.small'}
+                        'type': 't3.small'}
         # Use big instance to be not throttled by the network
         self.init_resources(loader_info=loader_info, db_info=db_info,
                             monitor_info=monitor_info)

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -440,7 +440,7 @@ class AwsSctRunner(SctRunner):
     CLOUD_PROVIDER = "aws"
     BASE_IMAGE = "ami-07c2ae35d31367b3e"  # Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-01
     SOURCE_IMAGE_REGION = "eu-west-2"  # where the source Runner image will be created and copied to other regions
-    IMAGE_BUILDER_INSTANCE_TYPE = "t2.small"
+    IMAGE_BUILDER_INSTANCE_TYPE = "t3.small"
     REGULAR_TEST_INSTANCE_TYPE = "t3.large"  # 2 vcpus, 8G, 36 CPU credits/hour
     LONGTERM_TEST_INSTANCE_TYPE = "r5.large"  # 2 vcpus, 16G
 

--- a/test-cases/features/compaction-throughput-limit.yaml
+++ b/test-cases/features/compaction-throughput-limit.yaml
@@ -8,7 +8,7 @@ n_monitor_nodes: 1
 
 instance_type_db: 'i4i.xlarge'
 instance_type_loader: 'c5.large'
-instance_type_monitor: 't2.small'
+instance_type_monitor: 't3.small'
 
 user_prefix: 'compaction-limit'
 append_scylla_yaml: |

--- a/test-cases/features/compaction-throughput-limit.yaml
+++ b/test-cases/features/compaction-throughput-limit.yaml
@@ -13,3 +13,5 @@ instance_type_monitor: 't2.small'
 user_prefix: 'compaction-limit'
 append_scylla_yaml: |
   auto_snapshot: false
+
+use_mgmt: false

--- a/test-cases/features/enospc-30mins.yaml
+++ b/test-cases/features/enospc-30mins.yaml
@@ -9,7 +9,7 @@ n_monitor_nodes: 1
 
 instance_type_db: 'c3.large' # for cassandra we'll use 'm3.large'
 instance_type_loader: 'c5.4xlarge'
-instance_type_monitor: 't2.small'
+instance_type_monitor: 't3.small'
 
 user_prefix: 'cases-enospc'
 

--- a/test-cases/features/enospc-30mins.yaml
+++ b/test-cases/features/enospc-30mins.yaml
@@ -12,3 +12,5 @@ instance_type_loader: 'c5.4xlarge'
 instance_type_monitor: 't2.small'
 
 user_prefix: 'cases-enospc'
+
+use_mgmt: false

--- a/test-cases/features/per-partition-limit.yaml
+++ b/test-cases/features/per-partition-limit.yaml
@@ -18,7 +18,7 @@ n_monitor_nodes: 1
 
 instance_type_db: 'i4i.large'
 instance_type_loader: 'c5.large'
-instance_type_monitor: 't2.small'
+instance_type_monitor: 't3.small'
 
 user_prefix: 'per-part-limit'
 

--- a/test-cases/features/per-partition-limit.yaml
+++ b/test-cases/features/per-partition-limit.yaml
@@ -21,3 +21,5 @@ instance_type_loader: 'c5.large'
 instance_type_monitor: 't2.small'
 
 user_prefix: 'per-part-limit'
+
+use_mgmt: false


### PR DESCRIPTION
those case doesn't need manager installed, and they are fine with having smaller monitor node, that manager (scylla) can't be installed on.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] no testing is needed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
