### PR TITLE
fix(centos8): install epel, so syslog-ng would be available

### DIFF
--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -117,6 +117,7 @@ def install_syslogng_service():
                 yum reinstall -y syslog-ng
                 SYSLOG_NG_INSTALLED=1
             else
+                yum install -y epel-release
                 for n in 1 2 3 4 5 6 7 8 9; do # cloud-init is running it with set +o braceexpand
                     if yum install -y --downloadonly syslog-ng; then
                         break

--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -26,7 +26,7 @@ def configure_syslogng_target_script(host: str, port: int, throttle_per_second: 
                     mem-buf-size(1048576)
                     disk-buf-size(104857600)
                     reliable(yes)
-                    dir(\\\"/tmp\\\")
+                    dir(\\\"/var/log\\\")
                 )"
         fi
 


### PR DESCRIPTION
seems like for centos8, syslog-ng is available on from EPEL
```
+ yum install -y syslog-ng
No match for argument: syslog-ng
Error: Unable to find a match: syslog-ng
```

Ref: https://www.syslog-ng.com/community/b/blog/posts/state-of-syslog-ng-on-rhel-8-centos-8

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/rolling-upgrade-centos8-test/21/
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/rolling-upgrade-centos8-test/22/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
