### PR TITLE
fix(nemesis): flush system_schema before doing encryption check

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4099,6 +4099,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 self.log.info("Upgradesstables on the '%s' node for the new encrypted table", node.name)
                 # NOTE: 'flush' is needed in case there are no sstables yet
                 node.remoter.run(f'nodetool flush -- {keyspace_name} {table_name}', verbose=True)
+                # NOTE: 'flush' is needed for system_schema, to make sure the new table info
+                # is on disk, `scylla sstable` reads only from disk
+                node.remoter.run('nodetool flush -- system_schema', verbose=True)
                 time.sleep(2)
                 node.remoter.run(f'nodetool upgradesstables -a -- {keyspace_name} {table_name}', verbose=True)
 

--- a/sdcm/utils/sstable/sstable_utils.py
+++ b/sdcm/utils/sstable/sstable_utils.py
@@ -87,7 +87,7 @@ class SstableUtils:
                 if dump_cmd == 'sstabledump':
                     sstables_encrypted_mapping[sstable] = False
                 else:
-                    scylla_metadata = json.loads(sstables_res.stdout)['sstables']
+                    scylla_metadata = json.loads(sstables_res.stdout, strict=False)['sstables']
                     sstables_encrypted_mapping[sstable] = all('scylla_encryption_options' in metadata.get('extension_attributes', {})
                                                               for table, metadata in scylla_metadata.items())
             # NOTE: case when sstable exists and it is encrypted:


### PR DESCRIPTION
To avoid those errors, when checking a newly created table:
```
error processing arguments: could not load schema via schema-tables:
std::runtime_error (Failed to find keyspace1.tmp_encrypted_table in schema tables)
```

Fixes: #6825

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/38/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
