### PR TITLE
fix(scale-cluster): Reduce load by 75%

### DIFF
--- a/test-cases/scale/scale-cluster.yaml
+++ b/test-cases/scale/scale-cluster.yaml
@@ -6,15 +6,15 @@ prepare_write_cmd:  [ "cassandra-stress write cl=ALL n=500000 -schema 'replicati
                       "cassandra-stress write cl=ALL n=500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=100 -pop seq=1500001..2000000  -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5"
                     ]
 
-stress_cmd: [ "cassandra-stress mixed cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=100 -pop seq=1..500000          -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5",
-              "cassandra-stress mixed cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=100 -pop seq=500001..1000000   -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5",
-              "cassandra-stress mixed cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=100 -pop seq=1000001..1500000  -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5",
-              "cassandra-stress mixed cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=100 -pop seq=1500001..2000000  -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5"
+stress_cmd: [ "cassandra-stress mixed cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=1..500000          -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5",
+              "cassandra-stress mixed cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=500001..1000000   -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5",
+              "cassandra-stress mixed cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=1000001..1500000  -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5",
+              "cassandra-stress mixed cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=1500001..2000000  -col 'n=FIXED(16) size=FIXED(8192)' -log interval=5"
              ]
 
 round_robin: true
 
-n_db_nodes: 20
+n_db_nodes: 15
 add_node_cnt: 1
 cluster_target_size: 25
 n_loaders: 4


### PR DESCRIPTION
Current load with the very large blob being used in this test is too heavy for the i3.large nodes and disk can't handle the load.

Reducing the load by 75% reduced the throughput only by 10%, Now compaction bandwidth is around 200MB/s compared to almost 8GB/s previosuly.

We can probably push more, but it's not the intention of the test.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
