### PR TITLE
feature(github-actions): add all open issues to QA board

### DIFF
--- a/.github/workflows/opend-issues-new.yaml
+++ b/.github/workflows/opend-issues-new.yaml
@@ -1,0 +1,25 @@
+name: Project automations
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+
+# map fields with customized labels
+env:
+  new: NEW
+
+jobs:
+  issue_opened_or_reopened:
+    name: issue_opened_or_reopened
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'reopened')
+    steps:
+      - name: Move issue to ${{ env.new }}
+        uses: leonsteinhaeuser/project-beta-automations@v2.0.0
+        with:
+          gh_token:  ${{ secrets.GITHUB_TOKEN }}
+          organization: scylladb
+          project_id: 13
+          resource_node_id: ${{ github.event.issue.node_id }}
+          status_value: ${{ env.new }} # Target status


### PR DESCRIPTION
Since we are working mainly with the boards, we want to see SCT issue appear on them once they are created/reopened

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
