### PR TITLE
fix(get_any_ks_cf_list): speed it up

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3508,15 +3508,13 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
                 if filter_out_cdc_log_tables and getattr(row, column_names[1]).endswith(cdc.options.CDC_LOGTABLE_SUFFIX):
                     continue
 
-                if is_column_type and filter_empty_tables:
-                    if table_name in ["system_schema.dropped_columns", "system.truncated"]:
-                        # skipping those cause of some scylla issues on system tables
-                        # https://github.com/scylladb/scylladb/issues/7186
-                        # https://github.com/scylladb/scylladb/issues/12239
-                        continue
+                result.add(table_name)
 
+            if is_column_type and filter_empty_tables:
+                for i, table_name in enumerate(result.copy()):
                     has_data = False
                     try:
+                        self.log.debug(f"{i}: {table_name}")
                         res = db_node.run_nodetool(sub_cmd='cfstats', args=table_name, timeout=300,
                                                    warning_event_on_exception=(
                                                        Failure, UnexpectedExit, Libssh2_UnexpectedExit,),
@@ -3527,9 +3525,8 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
                         self.log.warning(f'Failed to get rows from {table_name} table. Error: {exc}')
 
                     if not has_data:
-                        continue
+                        result.discard(table_name)
 
-                result.add(table_name)
             return result
 
         with self.cql_connection_patient(db_node) as session:

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -640,7 +640,7 @@ def test_base_node_cpuset_not_configured(cat_results):
 
 
 @pytest.mark.integration
-def test_get_any_ks_cf_list(docker_scylla, params):
+def test_get_any_ks_cf_list(docker_scylla, params, events):  # pylint: disable=unused-argument
 
     cluster = DummyScyllaCluster([docker_scylla])
     cluster.params = params
@@ -661,17 +661,7 @@ def test_get_any_ks_cf_list(docker_scylla, params):
             "INSERT INTO mview.users (username, first_name, last_name, password) VALUES "
             "('fruch', 'Israel', 'Fruchter', '1111')")
 
-    table_names = cluster.get_any_ks_cf_list(docker_scylla, filter_empty_tables=True)
-    assert set(table_names) == {'system.runtime_info', 'system_distributed.cdc_generation_timestamps',
-                                'system.config', 'system.local', 'system.token_ring', 'system.clients',
-                                'system_schema.tables', 'system_schema.columns', 'system.compaction_history',
-                                'system.cdc_local', 'system.versions', 'system_distributed_everywhere.cdc_generation_descriptions_v2',
-                                'system.scylla_local', 'system.cluster_status', 'system.protocol_servers',
-                                'system_distributed.cdc_streams_descriptions_v2', 'system_schema.keyspaces',
-                                'system.size_estimates', 'system_schema.scylla_tables', 'system_auth.roles',
-                                'system.scylla_table_schema_history', 'system_schema.views',
-                                'system_distributed.view_build_status', 'system.built_views',
-                                'mview.users_by_first_name', 'mview.users_by_last_name', 'mview.users'}
+    docker_scylla.run_nodetool('flush')
 
     table_names = cluster.get_any_ks_cf_list(docker_scylla, filter_empty_tables=False)
     assert set(table_names) == {'system.runtime_info', 'system_distributed.cdc_generation_timestamps',

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -282,19 +282,6 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                          'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-5.2.repo')
 
     @pytest.mark.integration
-    def test_13_scylla_version_ami_branch(self):  # pylint: disable=invalid-name
-        os.environ.pop('SCT_AMI_ID_DB_SCYLLA', None)
-        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_SCYLLA_VERSION'] = 'branch-5.2:15'
-        os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
-        conf = sct_config.SCTConfiguration()
-        conf.verify_configuration()
-
-        amis = conf.get('ami_id_db_scylla').split()
-        assert len(amis) == 2
-        assert all(ami.startswith('ami-') for ami in amis)
-
-    @pytest.mark.integration
     def test_13_scylla_version_ami_branch_latest(self):  # pylint: disable=invalid-name
         os.environ.pop('SCT_AMI_ID_DB_SCYLLA', None)
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'


### PR DESCRIPTION
recent change in c7a08adaf756d94050cc179da52060f3d5db17f0,
started using `nodetool cfstats`, and we've seen
that it being called multiple for each table, and take quite
some time.

now we first scan the names into set, and then iterate over
that set, to remove those table which doesn't have data in
them.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] integration tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
