### PR TITLE
fix(hydra): improve integration with podman

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -221,6 +221,7 @@ function run_in_docker () {
     if [ -z "$is_podman" ]; then
         docker_common_args+=(
            -v /var/run:/run
+           -v /dev:/dev:rw
            )
     else
         PODMAN_PORT=$(EPHEMERAL_PORT)
@@ -258,7 +259,6 @@ function run_in_docker () {
         -v /etc/sudoers:/etc/sudoers:ro \
         -v /etc/sudoers.d/:/etc/sudoers.d:ro \
         -v /etc/shadow:/etc/shadow:ro \
-        -v /dev:/dev:rw \
         ${DOCKER_GROUP_ARGS[@]} \
         ${DOCKER_ADD_HOST_ARGS[@]} \
         ${docker_common_args[@]} \


### PR DESCRIPTION
The script that launches hydra doesn't work with podman:

    Error: crun: chown `/dev/pts/16`: Operation not permitted: OCI permission denied

It turns out the problem is passing /dev. Fix that by only passing /dev if the container engine is docker.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] did not test - should not affect anything

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
