### PR TITLE
fix(audit-test-cases): change audit to use `syslog`

### DIFF
--- a/configurations/audit.yaml
+++ b/configurations/audit.yaml
@@ -1,5 +1,5 @@
 append_scylla_yaml: |
-  audit: "table"
+  audit: "syslog"
   audit_categories: "DCL,DDL,AUTH,ADMIN"
   audit_tables: "keyspace1.standard1,scylla_bench.test"
   audit_keyspaces: "keyspace1,scylla_bench"


### PR DESCRIPTION
since `table` option is problemtic, and can cause some quries to fail cause audit is with CL=ONE. we should be defaulting to `syslog`

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/enterprise-2024.1/job/reproducers/job/audit_longevity-schema-changes-3h-test/3/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
