### PR TITLE
fix(get_nodetool_status): convert ipv6 to full format

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4102,7 +4102,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 if not match:
                     continue
                 node_info = match.groupdict()
-                node_ip = node_info.pop("ip")
+                # make sure we use ipv6 long format (some tools remove leading zeros)
+                node_ip = ipaddress.ip_address(node_info.pop("ip")).exploded
                 # NOTE: following replacement is needed for the K8S case where
                 #       registered IP is different than the one used for network connections
                 if verification_node.is_kubernetes():

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -523,11 +523,11 @@ class TestNodetoolStatus(unittest.TestCase):
         status = db_cluster.get_nodetool_status()
 
         assert status == {'eu-north':
-                          {'2a05:d016:cf8:de00:e07d:5832:c5c0:36a0':
+                          {'2a05:d016:0cf8:de00:e07d:5832:c5c0:36a0':
                            {'state': 'UN', 'load': '774KB', 'tokens': '256', 'owns': '?',
                             'host_id': 'e2ed6943', 'rack': '1a'},
-                           '2a05:d016:cf8:de00:339e:d0d:9446:1980': {'state': 'UN', 'load': '1.04MB', 'tokens': '256', 'owns': '?',
-                                                                     'host_id': 'd67e8502', 'rack': '1a'}}}
+                           '2a05:d016:0cf8:de00:339e:0d0d:9446:1980': {'state': 'UN', 'load': '1.04MB', 'tokens': '256', 'owns': '?',
+                                                                       'host_id': 'd67e8502', 'rack': '1a'}}}
 
     def test_can_get_nodetool_status_azure(self):  # pylint: disable=no-self-use
         resp = "\n".join(["Datacenter: eastus",


### PR DESCRIPTION
recent change to some java libraries used by nodetool is causing ipv6 to be presented as rfc5952 section-4 without leading zeros, and SCT was comapring those as string with other places we get addresses from.

now we convert it to the full form, after getting
it from nodetool, and still keep it as string

Ref: https://www.rfc-editor.org/rfc/rfc5952#section-4

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-10gb-3h-ipv6-test/5/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
