### PR TITLE
fix(nemesis): ignore "ycsb connection refused" in kms nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4047,6 +4047,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             enable_kms_key_rotation=True,
             additional_scylla_encryption_options={'key_provider': 'KmsKeyProviderFactory'})
 
+    @decorate_with_context(ignore_ycsb_connection_refused)
     @scylla_versions(("2023.1.1-dev", None))
     def _enable_disable_table_encryption(self, enable_kms_key_rotation, additional_scylla_encryption_options=None):
         if self.cluster.params.get("cluster_backend") != "aws":


### PR DESCRIPTION
since those nemesis might be doing rolling restart to apply KMS configuration, it might trigger those errors in YCSB since we don't have a fully functioning loader balancer for alternantor

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] no need testing

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
