### PR TITLE
fix(test): increase load for compaction throughput test

### DIFF
--- a/test-cases/features/compaction-throughput-limit.yaml
+++ b/test-cases/features/compaction-throughput-limit.yaml
@@ -1,13 +1,13 @@
 test_duration: 240
 
-stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM n=20000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 -pop seq=1..20000000 -col 'n=FIXED(10) size=FIXED(256)' -log interval=5"
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM n=20000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=150 -pop seq=1..20000000 -col 'n=FIXED(10) size=FIXED(256)' -log interval=5"
 
 n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
 
 instance_type_db: 'i4i.xlarge'
-instance_type_loader: 'c5.large'
+instance_type_loader: 'c7i.large'
 instance_type_monitor: 't3.small'
 
 user_prefix: 'compaction-limit'

--- a/throughput_limit_test.py
+++ b/throughput_limit_test.py
@@ -120,7 +120,7 @@ class ThroughputLimitFunctionalTest(ClusterTester):
 
         LOGGER.info("measure base latency and ops/s - without setting limits")
         base_write_result = self._measure_latency_and_ops(stress_cmd=stress_write_cmd, conditions="base write")
-        for limit in [0.7, 0.45, 0.2, 0.01]:
+        for limit in [0.45, 0.2, 0.01]:
             LOGGER.info("measure latency and ops/s - with setting compaction limit to %s of disk write bandwidth", limit)
             self._truncate_table(table=table)
             time.sleep(60)  # to make scylla complete truncate and make clear gap between load
@@ -189,6 +189,7 @@ class ThroughputLimitFunctionalTest(ClusterTester):
             node.reload_config()
             node.follow_system_log(patterns=[f"Set compaction bandwidth to {limit_mb}MB/s"], start_from_beginning=True)
             self._wait_for_compaction_limit_set(node, mark=mark, limit_mb=limit_mb)
+        time.sleep(60)  # wait for scylla to stabilse after config change
 
     @staticmethod
     def _wait_for_compaction_limit_set(node, mark, limit_mb, timeout=60):


### PR DESCRIPTION
Seems load is too small to show the benefits of latency improvements when compaction throughput is limited.

Switched to latest generation loader (c7i) should increase the load.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - https://jenkins.scylladb.com/job/scylla-staging/job/lukasz/job/compaction-throughput-limit-test/22/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
