### PR TITLE
fix(service level): fix hardcoded name

### DIFF
--- a/sdcm/sla/sla_tests.py
+++ b/sdcm/sla/sla_tests.py
@@ -176,7 +176,7 @@ class SlaTests(Steps):
     # pylint: disable=too-many-arguments
     def _create_new_service_level(self, session, auth_entity_name_index, shares, db_cluster, service_level_for_test_step: str = None):
         new_sl = ServiceLevel(session=session,
-                              name=SERVICE_LEVEL_NAME_TEMPLATE % ('50', auth_entity_name_index),
+                              name=SERVICE_LEVEL_NAME_TEMPLATE % (shares, auth_entity_name_index),
                               shares=shares).create()
         with adaptive_timeout(Operations.SERVICE_LEVEL_PROPAGATION, node=db_cluster.nodes[0], timeout=15,
                               service_level_for_test_step=service_level_for_test_step):


### PR DESCRIPTION
In this test every service level has name as 'sla<shares>_<auth_entity_name_index>. Fix harcoded name that remained by mistake

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
