### PR TITLE
test(many-clients): add authenticator

### DIFF
--- a/test-cases/scale/longevity-many-clients-4h.yaml
+++ b/test-cases/scale/longevity-many-clients-4h.yaml
@@ -1,9 +1,9 @@
-test_duration: 360
+test_duration: 420
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=20 -pop seq=1..20971520 -col 'n=FIXED(2) size=FIXED(256)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 -pop seq=1..20971520 -col 'n=FIXED(2) size=FIXED(256)' -log interval=5"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=240m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=4 -pop seq=1..20971520 -col 'n=FIXED(2) size=FIXED(256)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=240m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=4 -pop seq=1..20971520 -col 'n=FIXED(2) size=FIXED(256)' -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=240m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native connectionsPerHost=500 -rate threads=4 -pop seq=1..20971520 -col 'n=FIXED(2) size=FIXED(256)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=240m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native connectionsPerHost=500 -rate threads=4 -pop seq=1..20971520 -col 'n=FIXED(2) size=FIXED(256)' -log interval=5"
              ]
 
 n_db_nodes: 4
@@ -11,7 +11,7 @@ n_loaders: 50
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.metal'
-instance_type_loader: 'c5.large'
+instance_type_loader: 'c7i.large'
 instance_type_monitor: 'm5.2xlarge'
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '031'
@@ -24,3 +24,8 @@ keyspace_num: 50
 
 user_prefix: 'longevity-many-clients-4h'
 space_node_threshold: 64424
+
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'


### PR DESCRIPTION
We want to test many-clients scenario with authentication enabled to see the impact on the performance (and other possible aspects).

Added auth to c-s load for it.
Also increased number of connections, reaching 100k connections per db instance.


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - https://argus.scylladb.com/test/06f4ed0f-f137-4779-8169-d8cfad14103d/runs?additionalRuns[]=4c6880aa-ab60-497f-af20-d322ac2b8cc7

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
