### PR TITLE
fix(service level): increate session default timeout

### DIFF
--- a/test_lib/sla.py
+++ b/test_lib/sla.py
@@ -69,6 +69,7 @@ class ServiceLevel:
                  timeout: str = None,
                  workload_type: str = None):
         self.session = session
+        self.session.default_timeout = 600
         self._name = f"'{name}'"
         self.verbose = True
         self._created = False
@@ -208,6 +209,7 @@ class UserRoleBase:
         self._name = name
         self.password = password
         self.session = session
+        self.session.default_timeout = 600
         self.superuser = superuser
         self.verbose = verbose
         self._attached_service_level = None

--- a/unit_tests/test_sla_utils.py
+++ b/unit_tests/test_sla_utils.py
@@ -85,6 +85,11 @@ class FakePrometheus:
         return 100
 
 
+# pylint: disable=too-few-public-methods
+class FakeSession:
+    default_timeout = 0
+
+
 class TestSlaUtilsTest(unittest.TestCase, SlaUtils):
     def test_less_runtime_than_expected_error(self):
         node = DummyNode(name='test_node',
@@ -93,7 +98,7 @@ class TestSlaUtilsTest(unittest.TestCase, SlaUtils):
 
         db_cluster = DummyDbCluster(nodes=[node])
         prometheus_stats = FakePrometheus()
-        session = None
+        session = FakeSession()
 
         role_low = self.create_sla_auth(session=session, shares=50, index="abc")
         role_high = self.create_sla_auth(session=session, shares=200, index="abc")


### PR DESCRIPTION
We receive timeouts on service level/roles creation/alter/drop operations from time to time, especially when a node(s) runs heavy operations.
```
cassandra.OperationTimedOut: errors={'Connection defunct by heartbeat': 'Client request timeout. See Session.execute[_async](timeout)'}, last_host=10.4.1.7:9042
```

This commit increases 'session.default_timeout' to wait more time for the answer

Fixes: https://github.com/scylladb/scylla-enterprise/issues/3755

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
