### PR TITLE
fix(nemesis): increase session timeout for drop queries

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1567,8 +1567,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 # drop test tables one by one during repair
                 for i in range(10):
                     time.sleep(random.randint(0, 300))
-                    with self.cluster.cql_connection_patient(self.target_node) as session:
-                        session.execute(f'DROP TABLE drop_table_during_repair_ks_{i}.standard1')
+                    with self.cluster.cql_connection_patient(self.target_node, connect_timeout=600) as session:
+                        session.execute(SimpleStatement(
+                            f'DROP TABLE drop_table_during_repair_ks_{i}.standard1'), timeout=300)
             finally:
                 thread.result()
 
@@ -2898,9 +2899,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 if "keyspace_name" in chosen_snapshot_info.keys():
                     keyspace = chosen_snapshot_info["keyspace_name"]
                     InfoEvent(message=f'Removing test {keyspace=}', severity=Severity.WARNING)
-                    with self.cluster.cql_connection_patient(self.target_node) as session:
+                    with self.cluster.cql_connection_patient(self.target_node, connect_timeout=600) as session:
                         session.execute(SimpleStatement(
-                            f'DROP KEYSPACE IF EXISTS "{keyspace}"', fetch_size=1), timeout=300)
+                            f'DROP KEYSPACE IF EXISTS "{keyspace}"'), timeout=300)
 
     def _delete_existing_backups(self, mgr_cluster):
         deleted_tasks = []

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2899,7 +2899,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     keyspace = chosen_snapshot_info["keyspace_name"]
                     InfoEvent(message=f'Removing test {keyspace=}', severity=Severity.WARNING)
                     with self.cluster.cql_connection_patient(self.target_node) as session:
-                        session.execute(f'DROP KEYSPACE IF EXISTS "{keyspace}"')
+                        session.execute(SimpleStatement(
+                            f'DROP KEYSPACE IF EXISTS "{keyspace}"', fetch_size=1), timeout=300)
 
     def _delete_existing_backups(self, mgr_cluster):
         deleted_tasks = []


### PR DESCRIPTION
Timeout error:
```
cassandra.OperationTimedOut: errors={'10.12.3.55:9042': 'Client request timeout. See Session.execute[_async](timeout)'}, last_host=10.12.3.55:9042
```

while `disrupt_mgmt_restore` and `disrupt_no_corrupt_repair` nemeses. It may happens when the cluster is overloaded

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
