### PR TITLE
fix(nemesis): mark 3 SLA nemeses as disruptive

### DIFF
--- a/data_dir/nemesis.yml
+++ b/data_dir/nemesis.yml
@@ -11,7 +11,7 @@
   - schema_changes = True
   - free_tier_set = True
 - disrupt_add_remove_dc:
-  - disruptive = False
+  - disruptive = True
   - kubernetes = False
   - run_with_gemini = False
   - limited = True
@@ -71,6 +71,9 @@
 - disrupt_enable_disable_table_encryption_aws_kms_provider_without_rotation:
   - disruptive = True
   - kubernetes = False
+- disrupt_end_of_quota_nemesis:
+  - disruptive = True
+  - config_changes = True
 - disrupt_grow_shrink_cluster:
   - disruptive = True
   - kubernetes = True
@@ -88,7 +91,7 @@
   - disruptive = False
   - config_changes = True
 - disrupt_increase_shares_by_attach_another_sl_during_load:
-  - disruptive = False
+  - disruptive = True
   - sla = True
 - disrupt_kill_scylla:
   - disruptive = True
@@ -124,7 +127,6 @@
   - manager_operation = True
   - disruptive = True
   - kubernetes = True
-  - limited = True
 - disrupt_mgmt_repair_cli:
   - manager_operation = True
   - disruptive = False
@@ -222,10 +224,10 @@
   - kubernetes = True
   - free_tier_set = True
 - disrupt_replace_service_level_using_detach_during_load:
-  - disruptive = False
+  - disruptive = True
   - sla = True
 - disrupt_replace_service_level_using_drop_during_load:
-  - disruptive = False
+  - disruptive = True
   - sla = True
 - disrupt_resetlocalschema:
   - disruptive = False
@@ -332,6 +334,3 @@
   - disruptive = False
   - kubernetes = True
   - free_tier_set = True
-- disrupt_end_of_quota_nemesis:
-  - disruptive = True
-  - kubernetes = False

--- a/data_dir/nemesis_classes.yml
+++ b/data_dir/nemesis_classes.yml
@@ -24,6 +24,7 @@
 - DrainerMonkey
 - EnableDisableTableEncryptionAwsKmsProviderWithRotationMonkey
 - EnableDisableTableEncryptionAwsKmsProviderWithoutRotationMonkey
+- EndOfQuotaNemesis
 - EnospcAllNodesMonkey
 - EnospcMonkey
 - GrowShrinkClusterNemesis

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -6376,7 +6376,10 @@ class SlaDecreaseSharesDuringLoad(Nemesis):
 
 
 class SlaReplaceUsingDetachDuringLoad(Nemesis):
-    disruptive = False
+    # TODO: This SLA nemesis uses binary disable/enable workaround that in a test with parallel nemeses can cause to the errors and
+    #  failures that is not a problem of Scylla. The option "disruptive" was set to True to prevent irrelevant failures. Should be changed
+    #  to False when the issue https://github.com/scylladb/scylla-enterprise/issues/2572 will be fixed.
+    disruptive = True
     sla = True
 
     def disrupt(self):
@@ -6384,7 +6387,10 @@ class SlaReplaceUsingDetachDuringLoad(Nemesis):
 
 
 class SlaReplaceUsingDropDuringLoad(Nemesis):
-    disruptive = False
+    # TODO: This SLA nemesis uses binary disable/enable workaround that in a test with parallel nemeses can cause to the errors and
+    #  failures that is not a problem of Scylla. The option "disruptive" was set to True to prevent irrelevant failures. Should be changed
+    #  to False when the issue https://github.com/scylladb/scylla-enterprise/issues/2572 will be fixed.
+    disruptive = True
     sla = True
 
     def disrupt(self):
@@ -6392,7 +6398,10 @@ class SlaReplaceUsingDropDuringLoad(Nemesis):
 
 
 class SlaIncreaseSharesByAttachAnotherSlDuringLoad(Nemesis):
-    disruptive = False
+    # TODO: This SLA nemesis uses binary disable/enable workaround that in a test with parallel nemeses can cause to the errors and
+    #  failures that is not a problem of Scylla. The option "disruptive" was set to True to prevent irrelevant failures. Should be changed
+    #  to False when the issue https://github.com/scylladb/scylla-enterprise/issues/2572 will be fixed.
+    disruptive = True
     sla = True
 
     def disrupt(self):

--- a/test-cases/enterprise-features/workload-prioritization/longevity/longevity-sla-system-24h.yaml
+++ b/test-cases/enterprise-features/workload-prioritization/longevity/longevity-sla-system-24h.yaml
@@ -18,8 +18,10 @@ instance_type_db: 'i3.2xlarge'
 instance_type_loader: 'c5.2xlarge'
 
 run_fullscan: ['{"mode": "random", "ks_cf": "keyspace1.standard1", "interval": 5}'] # 'ks.cf|random, interval(min)'
-nemesis_class_name: 'SlaNemeses:1 SisyphusMonkey:1'
-nemesis_selector: ['!sla']
+nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
+# There are SLA nemeses that uses binary disable/enable workaround that in a test with parallel nemeses can cause to the errors and
+# failures that is not a problem of Scylla. The option "!disruptive" is added to prevent irrelevant failures.
+nemesis_selector: [['sla', '!disruptive'], ['!sla']]
 nemesis_interval: 5
 nemesis_during_prepare: false
 


### PR DESCRIPTION
3 SLA nemeses use binary disable/enable workaround that in a test with parallel nemeses can cause to the errors and failures that is not a problem of Scylla. Mark them as "disruptive" to prevent irrelevant failures.
Should be changed back when the issue https://github.com/scylladb/scylla-enterprise/issues/2572 will be fixed.

Example of such failure here: https://argus.scylladb.com/test/1aebcb86-a767-4ce5-a88a-c977ab077ddc/runs?additionalRuns[]=d38963cd-e9ea-45ae-98ce-fa346afb89b8. The nemesis "disrupt_remove_node_then_add_node" failed because of this

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
