### PR TITLE
fix(test): increase load in per partition limit test

### DIFF
--- a/test-cases/features/per-partition-limit.yaml
+++ b/test-cases/features/per-partition-limit.yaml
@@ -17,7 +17,7 @@ n_loaders: 1
 n_monitor_nodes: 1
 
 instance_type_db: 'i4i.large'
-instance_type_loader: 'c5.large'
+instance_type_loader: 'c7i.large'
 instance_type_monitor: 't3.small'
 
 user_prefix: 'per-part-limit'


### PR DESCRIPTION
Due to better performance of Scylla Enterprise test became unstable as impact was too little.

Increase load by switching to newer loaders c5->c7i.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - https://argus.scylladb.com/test/a13564b7-3152-4e97-a346-29d8f78fa88c/runs?additionalRuns[]=cc37035d-260b-4140-b863-386a1d024096

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
