### PR TITLE
ci(k8s): Update `50GB-3days-authorization-and-tls-ssl` CI job for K8S

### DIFF
--- a/configurations/operator/50GB-no-tls.yaml
+++ b/configurations/operator/50GB-no-tls.yaml
@@ -1,5 +1,6 @@
 user_prefix: 'longevity-operator-50gb-3d'
 nemesis_selector: ['kubernetes']
+nemesis_add_node_cnt: 1
 
 k8s_minio_storage_size: '1024Gi'
 
@@ -10,6 +11,8 @@ authenticator: 'AllowAllAuthenticator'
 authenticator_user: ''
 authenticator_password: ''
 authorizer: 'AllowAllAuthenticator'
+
+use_dns_names: false
 
 n_db_nodes: 7
 k8s_n_scylla_pods_per_cluster: 6


### PR DESCRIPTION
- Set `nemesis_add_node_cnt=1` instead of the `3` for K8S to avoid provisioning failures, because we have only 1 additional K8S Scylla nodes.
- Set `use_dns_names=false` for K8S because it is not supported there.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
