### PR TITLE
fix(nemesis): increase session timeout for drop view queries

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -20,6 +20,7 @@ import time
 from enum import Enum
 
 import yaml
+from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
 
 from upgrade_test import UpgradeTest
 from sdcm.tester import ClusterTester, teardown_on_exception
@@ -677,8 +678,9 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
             query = 'drop materialized view {}'.format(mv_name)
 
             try:
-                with self.db_cluster.cql_connection_patient_exclusive(self.db_cluster.nodes[0]) as session:
+                with self.db_cluster.cql_connection_patient_exclusive(self.db_cluster.nodes[0], connect_timeout=300) as session:
                     self.log.debug('Run query: {}'.format(query))
+                    session.execute(SimpleStatement(query), timeout=300)
                     session.execute(query)
             except Exception as ex:
                 self.log.debug('Failed to drop materialized view using query {0}. Error: {1}'.format(query, str(ex)))

--- a/sdcm/utils/nemesis_utils/indexes.py
+++ b/sdcm/utils/nemesis_utils/indexes.py
@@ -113,7 +113,7 @@ def verify_query_by_index_works(session, ks, cf, column) -> None:
 
 def drop_index(session, ks, index_name) -> None:
     InfoEvent(message=f"Starting dropping index: {ks}.{index_name}").publish()
-    session.execute(f'DROP INDEX {ks}.{index_name}')
+    session.execute(SimpleStatement(f'DROP INDEX {ks}.{index_name}'), timeout=300)
 
 
 def drop_materialized_view(session, ks, view_name) -> None:
@@ -122,4 +122,4 @@ def drop_materialized_view(session, ks, view_name) -> None:
             event_class=DatabaseLogEvent.DATABASE_ERROR,
             regex=".*Error applying view update.*",
             extra_time_to_expiration=180):
-        session.execute(f'DROP MATERIALIZED VIEW {ks}.{view_name}')
+        session.execute(SimpleStatement(f'DROP MATERIALIZED VIEW {ks}.{view_name}'), timeout=300)


### PR DESCRIPTION
Timeout error:
```
cassandra.OperationTimedOut: errors={'10.12.3.55:9042': 'Client request timeout. See Session.execute[_async](timeout)'}, last_host=10.12.3.55:9042
```

while `disrupt_create_index` and `disrupt_add_remove_mv`  nemeses. It may happens when the cluster is overloaded

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
