### PR TITLE
fix(kms_key_rotation): add error 'failed to get a table'

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4335,6 +4335,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                         traceback=traceback.format_exc()).publish()
                 try:
                     target_node = [node for node in db_cluster.nodes if not node.running_nemesis][0]
+                    self.log.debug("Target node for 'rotate_kms_key' is %s", target_node.name)
                     with run_nemesis(node=target_node, nemesis_name="KMS encryption check"):
                         ks_cf = db_cluster.get_non_system_ks_cf_list(db_node=target_node, filter_out_mv=True)[0]
                         sstable_util = SstableUtils(db_node=target_node, ks_cf=ks_cf)
@@ -4344,6 +4345,11 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
                 except SstablesNotFound as exc:
                     self.log.warning(f"Couldn't check the fact of encryption (KMS) for sstables: {exc}")
+
+                except IndexError:
+                    AwsKmsEvent(
+                        message="Failed to get any table for the KMS key rotation thread",
+                        traceback=traceback.format_exc()).publish()
 
                 except Exception:  # pylint: disable=broad-except
                     AwsKmsEvent(


### PR DESCRIPTION
If a test table was not received while `sdcm.cluster.BaseScyllaCluster.start_kms_key_rotation_thread` due to any reason (a session can not be created, any table was not created yet), send an error that any table was not received.

Now the error 'Failed to check the fact of encryption (KMS) for sstables' message is published with 'IndexError: list index out of range'. It is not clear enough.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
