### PR TITLE
fix(fetch_all_rows): pass down timeout correctly

### DIFF
--- a/sdcm/utils/database_query_utils.py
+++ b/sdcm/utils/database_query_utils.py
@@ -209,6 +209,7 @@ def fetch_all_rows(session, default_fetch_size, statement, retries: int = 4, tim
         LOGGER.debug("Fetch all rows by statement: %s", statement)
     session.default_fetch_size = default_fetch_size
     session.default_consistency_level = ConsistencyLevel.QUORUM
+    session.default_timeout = timeout
 
     @retrying(n=retries, sleep_time=5, message='Fetch all rows', raise_on_exceeded=raise_on_exceeded)
     def _fetch_rows() -> list:


### PR DESCRIPTION
`fetch_all_rows` was passing timeout only to `request_all` call while the inital request of the first page was using the default timeout which isn't always enough, and can lead to the following error:
```
(TestFrameworkEvent Severity.ERROR) period_type=one-time
event_id=e2d16764-de17-4150-bc90-ba2c6f5e5b90,
source=PartitionsValidationAttributes
message=Failed to collect partition info. Error details:
Requested pages were not delivered before timeout. Requested: 1; retrieved: 0; empty retrieved 0
```

in this change we change the session default timeout, assuming this session is used mostly for those calls

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
