### PR TITLE
fix(artifact_test): fix disable commitlog check

### DIFF
--- a/sdcm/commit_log_check_thread.py
+++ b/sdcm/commit_log_check_thread.py
@@ -199,12 +199,14 @@ class CommitLogCheckThread:
             CommitLogCheckErrorEvent(
                 severity=Severity.WARNING,
                 message="CommitLogCheckThread will not start due to no monitors in the cluster").publish()
+            return
 
         if "Not found" in get_max_disk_size_metric(custer_tester.db_cluster):
             CommitLogCheckErrorEvent(
                 severity=Severity.WARNING,
                 message="CommitLogCheckThread will not start due to current scylla version has no "
                         "commitlog/metrics/max_disk_size endpoint ").publish()
+            return
 
         try:
             thread = CommitLogCheckThread(custer_tester, duration)


### PR DESCRIPTION
In case there's no Prometheus instance (no monitor) commitlog checker
should not be executed as it will fail.

Fixed skip of starting commitlog checker in when it is known it
will not work.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/artifact-centos8-sheduler-error/15/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
