### PR TITLE
ci(longevity): add 1 loader to longevity-large-partition-200k_pks-4days

### DIFF
--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -58,7 +58,7 @@ stress_read_cmd: [
 post_prepare_cql_cmds: "CREATE MATERIALIZED VIEW scylla_bench.view_test AS SELECT * FROM scylla_bench.test where ck IS NOT NULL AND v is not null PRIMARY KEY (v, pk, ck) with comment = 'TEST VIEW'"
 
 n_db_nodes: 5
-n_loaders: 4
+n_loaders: 5
 n_monitor_nodes: 1
 
 round_robin: true


### PR DESCRIPTION
`scylla-bench` may use much more memory than it is expected, i.e. leak for some period of time.
And if we run too many `scylla-bench` commands on a single loader node then we may get crashes of stress commands.
So, avoid it, add one more loader node to reduce utilization of loader nodes.

Ref: #6992

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
