### PR TITLE
fix(disrupt_resetlocalschema): stop calling `nodetool help`

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -829,10 +829,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.repair_nodetool_repair()
 
     def disrupt_resetlocalschema(self):  # pylint: disable=invalid-name
-        result = self.target_node.run_nodetool(sub_cmd='help', args='resetlocalschema')
-        if 'Unknown command resetlocalschema' in result.stdout:
-            raise UnsupportedNemesis("nodetool doesn't support resetlocalschema")
-
         rlocal_schema_res = self.target_node.follow_system_log(patterns=["schema_tables - Schema version changed to"])
         self.target_node.run_nodetool("resetlocalschema")
 


### PR DESCRIPTION
since now there are multiple tools implementing the nodetool commands, help command goes to the scylla-nodetool, and `resetlocalschema` isn't yet implmented there

cause `resetlocalschema` exist for long enough in scylla (since 2019), we can't directly call it assuming it's there and not need to first check the help for existence of the command.

Ref: scylladb/scylladb#16669

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] no testing is needed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
