### PR TITLE
fix(FullPartitionScanOperation): print diff output to log files

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1011,6 +1011,8 @@ class BaseSCTLogCollector(LogCollector):
         FileLog(name=r'*debug.json',
                 search_locally=True),
         FileLog(name='result_gradual_increase.log'),
+        FileLog(name='partition_range_scan_diff_*.log',
+                search_locally=True),
     ]
     cluster_log_type = 'sct-runner-events'
     cluster_dir_prefix = 'sct-runner-events'


### PR DESCRIPTION
the check was generating too much output into warning level and chocking the jenkins builder, making it hard to debug jobs using this fullscan thread.

now the diff should be printed into a log file, that later would be upload with the rest of the sct-runner logs

Fixes: #6573
Fixes: #6056

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-large-partition-8h-test/7
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-large-partition-200k-pks-4days-test/2/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
