### PR TITLE
improvement(sla test): issue when scheduler is not created

### DIFF
--- a/sdcm/sla/libs/sla_utils.py
+++ b/sdcm/sla/libs/sla_utils.py
@@ -408,7 +408,7 @@ class SlaUtils:
                     node=node,
                     scheduler_group_name=service_level.scheduler_group_name)):
                 raise SchedulerGroupNotFound(f"Scheduler groups for {service_level.name} service levels is not created on the "
-                                             f"node '{node.name}'")
+                                             f"node '{node.name}'. Maybe the issue scylla-cluster-tests#7082")
 
             if len(scheduler_shares) != node.scylla_shards:
                 raise WrongServiceLevelShares(f"Expected that scheduler group is created on every Scylla shard for {service_level.name} "


### PR DESCRIPTION
Add info message about possible issue when error SchedulerGroupNotFound received

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
no need to run hte test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
