### PR TITLE
fix(monitorstack): make it work when running hydra via podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ export AWS_PROFILE=DeveloperAccessRole
 
 # Install hydra (docker holding all requirements for running SCT)
 sudo ./install-hydra.sh
+
+# if using podman, we need to disable enforcing of short name usage, without it monitoring stack won't run from withing hydra
+echo 'unqualified-search-registries = ["registry.fedoraproject.org", "registry.access.redhat.com", "docker.io", "quay.io"]
+short-name-mode="permissive"
+' > ~/.config/containers/registries.conf
 ```
 
 ### Run a test


### PR DESCRIPTION
* podman now defaults to short-name-mode="enforcing", and the monitor stack doesn't able to pull images when working via socket, it doesn't have tty to offer which repository to alias it, setting short-name-mode="permissive" on ~/.config/containers/registries.conf alleviate this issue

* scylla-monitoring was using DOCKER_HOST inside it's start scripts, hence breaking our ability to use it to point to podman socket, a fix was subbmitted but until then we patch those out of the scripts so older collected monitoring data can be used

Ref: https://github.com/scylladb/scylla-monitoring/pull/2149
Fixes: #7080

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
