### PR TITLE
improvement(k8s-eks): use real S3 service running on K8S-EKS backend

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -56,9 +56,6 @@ k8s_instance_type_auxiliary: 't3.large'
 append_scylla_args: '--abort-on-lsa-bad-alloc 1 --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'
 docker_image: ''
 
-backup_bucket_backend: 's3'
-backup_bucket_location: 'minio-bucket'
-
 # NOTE: Define a separate image for the 'cassandra stress' that supports 'serverless' feature.
 #       It will allow to test 'serverless' feature against any stable Scylla release
 #       with old 'cassandra-stress' binary.

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2458,7 +2458,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         self.k8s_scylla_manager_auth_token = None
         kwargs = {}
         for k8s_cluster in k8s_clusters:
-            if not kwargs and params.get('use_mgmt'):
+            if not kwargs and params.get('use_mgmt') and k8s_cluster.cluster_backend != "k8s-eks":
                 kwargs["s3_provider_endpoint"] = k8s_cluster.s3_provider_endpoint
             k8s_cluster.deploy_scylla_cluster(
                 node_pool_name=node_pool_name,

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2844,11 +2844,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         if not (self.cluster.params.get('use_mgmt') or self.cluster.params.get('use_cloud_manager')):
             raise UnsupportedNemesis('Scylla-manager configuration is not defined!')
-        if self.cluster.params.get('cluster_backend') != 'aws':
-            raise UnsupportedNemesis("The restore test only supports AWS at the moment")
+        if self.cluster.params.get('cluster_backend') not in ('aws', 'k8s-eks'):
+            raise UnsupportedNemesis("The restore test only supports 'AWS' and 'K8S-EKS' backends.")
 
         mgr_cluster = self.cluster.get_cluster_manager()
         cluster_backend = self.cluster.params.get('cluster_backend')
+        if cluster_backend == 'k8s-eks':
+            cluster_backend = 'aws'
         persistent_manager_snapshots_dict = get_persistent_snapshots()
         target_bucket = persistent_manager_snapshots_dict[cluster_backend]["bucket"]
         chosen_snapshot_tag, chosen_snapshot_info = (

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1662,7 +1662,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.monitors = NoMonitorSet()
             self.monitors_multitenant = [self.monitors]
 
-    def get_cluster_k8s_eks(self, n_k8s_clusters: int):
+    def get_cluster_k8s_eks(self, n_k8s_clusters: int):  # pylint: disable=too-many-branches
         region_names = self.params.region_names
         availability_zones = self.params.get('availability_zone').split(',')
         for _ in range(n_k8s_clusters):
@@ -1690,6 +1690,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 node_pool_name=self.k8s_clusters[0].SCYLLA_POOL_NAME,
                 add_nodes=False,
             ))
+            if self.params.get('use_mgmt'):
+                for k8s_cluster in self.k8s_clusters:
+                    k8s_cluster.create_iamserviceaccount_for_s3_access(
+                        namespace=self.db_clusters_multitenant[i].namespace)
         self.db_cluster = self.db_clusters_multitenant[0]
 
         if self.params.get("n_loaders"):


### PR DESCRIPTION
Stop using S3-compatible K8S-based service for scylla-manager backups.
Start using real AWS S3 service like in the VM deployments.

This switch allows us to start running `mgmt restore` nemesis,
because it uses real backups stored in the real S3 service. 
So, update the appropriate logic to allow running it on EKS backend.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
