### PR TITLE
fix(nemesis): improve user_info_encryption check on KMS nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4144,7 +4144,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             check_encryption_fact(sstable_util, True)
 
             with self.target_node.remote_scylla_yaml() as scylla_yaml:
-                user_info_encryption_enabled = scylla_yaml.user_info_encryption.get('enabled', False)
+                user_info_encryption_enabled = scylla_yaml.user_info_encryption \
+                    and scylla_yaml.user_info_encryption.get('enabled', False)
 
             # if encryption is enabled by default, we currently can't disable it
             if not user_info_encryption_enabled:


### PR DESCRIPTION
the check assumed `user_info_encryption` is always defined, and it's not yet true for 2023.1 branch, and fails like the following:

```
File ".../sdcm/nemesis.py", line 4150, in _enable_disable_table_encryption
user_info_encryption_enabled = scylla_yaml.user_info_encryption.get('enabled', False)
AttributeError: 'NoneType' object has no attribute 'get'
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] no need for testing

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
