### PR TITLE
fix(nemesis): support non RBNO rebuild logging

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4484,8 +4484,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     strategy.replication_factors.update({new_dc_name: 1})
                     replication_strategy_setter(**{keyspace: strategy})
                 InfoEvent(message='execute rebuild on new datacenter').publish()
-                with wait_for_log_lines(node=new_node, start_line_patterns=["rebuild.*started with keyspaces="],
-                                        end_line_patterns=["rebuild.*finished with keyspaces="],
+                with wait_for_log_lines(node=new_node, start_line_patterns=["rebuild.*started with keyspaces=", "Rebuild starts"],
+                                        end_line_patterns=["(rebuild.*finished with keyspaces=", "Rebuild succeeded"],
                                         start_timeout=60, end_timeout=600):
                     new_node.run_nodetool(sub_cmd=f"rebuild -- {datacenters[0]}", retry=0)
                 InfoEvent(message='Running full cluster repair on each node').publish()

--- a/unit_tests/test_wait.py
+++ b/unit_tests/test_wait.py
@@ -210,8 +210,8 @@ class TestWaitForLogLines:
         write_thread = threading.Thread(target=write_to_file, args=(file_path, lines))
         write_thread.daemon = True
         file_path.touch()
-        with wait_for_log_lines(node=node, start_line_patterns=["rebuild.*started with keyspaces="],
-                                end_line_patterns=["rebuild.*finished with keyspaces="],
+        with wait_for_log_lines(node=node, start_line_patterns=["rebuild.*started with keyspaces=", "Rebuild starts"],
+                                end_line_patterns=["rebuild.*finished with keyspaces=", "Rebuild succeeded"],
                                 start_timeout=3, end_timeout=5):
             write_thread.start()
 


### PR DESCRIPTION
this code was introduced after RBNO was default for all operations and in branch 2023.1 isn't not yet the cases, and log prints doesn't match.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
