### PR TITLE
fix(upgrade): increase session default_timeout

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -59,6 +59,7 @@ def truncate_entries(func):
         node = args[0]
         with self.db_cluster.cql_connection_patient(node, keyspace='truncate_ks', connect_timeout=600) as session:
             InfoEvent(message="Start truncate simple tables").publish()
+            session.default_timeout = 60.0 * 5
             try:
                 self.cql_truncate_simple_tables(session=session, rows=NUMBER_OF_ROWS_FOR_TRUNCATE_TEST)
                 InfoEvent(message="Finish truncate simple tables").publish()
@@ -71,6 +72,7 @@ def truncate_entries(func):
 
         # re-new connection
         with self.db_cluster.cql_connection_patient(node, keyspace='truncate_ks', connect_timeout=600) as session:
+            session.default_timeout = 60.0 * 5
             self.validate_truncated_entries_for_table(session=session, system_truncated=True)
             self.read_data_from_truncated_tables(session=session)
             self.cql_insert_data_to_simple_tables(session=session, rows=NUMBER_OF_ROWS_FOR_TRUNCATE_TEST)


### PR DESCRIPTION
Increase session.default_timeout for truncate/insert/select while upgrade tests.

Error:
```
cassandra.OperationTimedOut: errors={'Connection defunct by heartbeat': 'Client request timeout. See Session.execute[_async](timeout)'}, last_host=10.4.2.126:9042
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
not run 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
