### PR TITLE
fix(c-s): ignore audit related consistency error

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -83,7 +83,7 @@ from sdcm.results_analyze import PerformanceResultsAnalyzer, SpecifiedStatsPerfo
     LatencyDuringOperationsPerformanceAnalyzer
 from sdcm.sct_config import init_and_verify_sct_config
 from sdcm.sct_events import Severity
-from sdcm.sct_events.setup import start_events_device, stop_events_device
+from sdcm.sct_events.setup import start_events_device, stop_events_device, enable_default_filters
 from sdcm.sct_events.system import InfoEvent, TestFrameworkEvent, TestResultEvent, TestTimeoutEvent
 from sdcm.sct_events.file_logger import get_events_grouped_by_category, get_logger_event_summary
 from sdcm.sct_events.events_analyzer import stop_events_analyzer
@@ -374,6 +374,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         # Cover multi-tenant configuration. Prevent event device double initiate
         start_events_device(log_dir=self.logdir,
                             _registry=getattr(self, "_registry", None) or self.events_processes_registry)
+        enable_default_filters(sct_config=self.params)
 
         time.sleep(0.5)
         InfoEvent(message=f"TEST_START test_id={self.test_config.test_id()}").publish()

--- a/unit_tests/lib/events_utils.py
+++ b/unit_tests/lib/events_utils.py
@@ -17,11 +17,12 @@ import tempfile
 import unittest.mock
 from contextlib import contextmanager
 
-from sdcm.sct_events.setup import EVENTS_DEVICE_START_DELAY, start_events_device, stop_events_device
+from sdcm.sct_events.setup import EVENTS_DEVICE_START_DELAY, start_events_device, stop_events_device, enable_default_filters
 from sdcm.sct_events.events_device import start_events_main_device, get_events_main_device
 from sdcm.sct_events.file_logger import get_events_logger
 from sdcm.sct_events.events_processes import EventsProcessesRegistry
 from sdcm.sct_events.event_counter import get_events_counter
+from sdcm.sct_config import SCTConfiguration
 
 
 class EventsUtilsMixin:
@@ -43,6 +44,7 @@ class EventsUtilsMixin:
             cls.events_processes_registry_patcher.start()
         if events_device:
             start_events_device(_registry=cls.events_processes_registry)
+            enable_default_filters(SCTConfiguration())
         elif events_main_device:
             start_events_main_device(_registry=cls.events_processes_registry)
             time.sleep(EVENTS_DEVICE_START_DELAY)


### PR DESCRIPTION
By default audit is disabled by default in in 20223.1 and up by https://github.com/scylladb/scylla-enterprise/pull/3094. But it won't be disabled in 2022.1 and 2022.2.

This message generates too much noise for us. We do not need it will fail the test and create WARNING message, not ERROR.

issue that should be track https://github.com/scylladb/scylla-enterprise/issues/3148

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] no testing is needed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
