### PR TITLE
fix(docker): copy cqlshrc for older scylla branches

### DIFF
--- a/docker/scylla-sct/ubuntu/Dockerfile
+++ b/docker/scylla-sct/ubuntu/Dockerfile
@@ -22,7 +22,9 @@ RUN apt-get update && \
     adduser --disabled-password --gecos "" $USER || true  && \
     usermod -aG sudo $USER && \
     sudo -Hu $USER sh -c "mkdir -m 700 ~/.ssh" && \
-    sudo -Hu $USER sh -c "echo 'mkdir -p /home/$USER/.cassandra && ! test -f /home/$USER/.cassandra/cqlshrc && sudo cp /root/.cassandra/cqlshrc /home/$USER/.cassandra/cqlshrc' >> ~/.ssh/rc" && \
+    sudo -Hu $USER sh -c "echo 'mkdir -p /home/$USER/.cassandra' > ~/.ssh/rc" && \
+    sudo -Hu $USER sh -c "echo 'sudo test -f /root/.cqlshrc && sudo cp /root/.cqlshrc /home/$USER/.cassandra/cqlshrc' >> ~/.ssh/rc" && \
+    sudo -Hu $USER sh -c "echo 'sudo test -f /root/.cassandra/cqlshrc && sudo cp /root/.cassandra/cqlshrc /home/$USER/.cassandra/cqlshrc' >> ~/.ssh/rc" && \
     echo "$USER  ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers && \
     apt install --no-install-recommends -y \
         iproute2 \


### PR DESCRIPTION
PR #7087 has introduced code, that doesn't work with older branchs of scylla, this commit fixes that, and copy the cqlshrc file from what locations it might be

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
