### PR TITLE
fix(EaR-KMS): change auto-enable of KMS to start working from 2023.1.3

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -799,7 +799,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         )
 
     def prepare_kms_host(self) -> None:
-        if (self.params.is_enterprise and ComparableScyllaVersion(self.params.scylla_version) >= '2023.2.0~rc0'
+        if (self.params.is_enterprise and ComparableScyllaVersion(self.params.scylla_version) >= '2023.1.3'
             and self.params.get('cluster_backend') == 'aws'
             and not self.params.get('scylla_encryption_options')
             and self.params.get("db_type") != "mixed_scylla"  # oracle probably doesn't support KMS

--- a/sdcm/utils/sstable/sstable_utils.py
+++ b/sdcm/utils/sstable/sstable_utils.py
@@ -65,7 +65,7 @@ class SstableUtils:
         if not sstables:
             raise SstablesNotFound(f"sstables for '{self.keyspace}.{self.table}' wasn't found")
 
-        if ComparableScyllaVersion(self.db_node.scylla_version) >= '2023.2.0~rc0':
+        if ComparableScyllaVersion(self.db_node.scylla_version) >= '2023.1.3':
             dump_cmd = (
                 f"{self.db_node.add_install_prefix('/usr/bin/scylla')} sstable dump-scylla-metadata"
                 f" --scylla-yaml-file {self.db_node.add_install_prefix(SCYLLA_YAML_PATH)}"

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -780,7 +780,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         keyspace = "keyspace_complex"
         table = "user_with_ck"
         if first_node.is_enterprise:
-            should_use_sstabledump = ComparableScyllaVersion(first_node.scylla_version) < "2023.2.0~rc0"
+            should_use_sstabledump = ComparableScyllaVersion(first_node.scylla_version) < "2023.1.3"
         else:
             should_use_sstabledump = ComparableScyllaVersion(first_node.scylla_version) < "5.4.0~rc0"
         if should_use_sstabledump:


### PR DESCRIPTION
code assumed it would be working only from 2023.2 up, but things had changed and now it's supported from 2023.1.3 up.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/39/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
