### PR TITLE
fix(upgrade): set default CL = QUORUM

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -26,6 +26,7 @@ from typing import List
 import contextlib
 
 from argus.client.sct.types import Package
+from cassandra import ConsistencyLevel
 
 from sdcm import wait
 from sdcm.cluster import BaseNode
@@ -60,6 +61,7 @@ def truncate_entries(func):
         with self.db_cluster.cql_connection_patient(node, keyspace='truncate_ks', connect_timeout=600) as session:
             InfoEvent(message="Start truncate simple tables").publish()
             session.default_timeout = 60.0 * 5
+            session.default_consistency_level = ConsistencyLevel.QUORUM
             try:
                 self.cql_truncate_simple_tables(session=session, rows=NUMBER_OF_ROWS_FOR_TRUNCATE_TEST)
                 InfoEvent(message="Finish truncate simple tables").publish()
@@ -73,6 +75,7 @@ def truncate_entries(func):
         # re-new connection
         with self.db_cluster.cql_connection_patient(node, keyspace='truncate_ks', connect_timeout=600) as session:
             session.default_timeout = 60.0 * 5
+            session.default_consistency_level = ConsistencyLevel.QUORUM
             self.validate_truncated_entries_for_table(session=session, system_truncated=True)
             self.read_data_from_truncated_tables(session=session)
             self.cql_insert_data_to_simple_tables(session=session, rows=NUMBER_OF_ROWS_FOR_TRUNCATE_TEST)


### PR DESCRIPTION
Error:
```
cassandra.OperationTimedOut: errors=ReadTimeout: Operation timed out for truncate_ks.truncate_table0 - received only 0 responses from 1 CL=ONE.
```

Run all queries with QUORUM

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
