### PR TITLE
fix(nemesis-list): import test code inline

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -111,7 +111,7 @@ import sdcm.provision.azure.utils as azure_utils
 from utils.build_system.create_test_release_jobs import JenkinsPipelines  # pylint: disable=no-name-in-module,import-error
 from utils.get_supported_scylla_base_versions import UpgradeBaseVersion  # pylint: disable=no-name-in-module,import-error
 from utils.mocks.aws_mock import AwsMock  # pylint: disable=no-name-in-module,import-error
-from unit_tests.test_nemesis import FakeTester
+
 
 SUPPORTED_CLOUDS = ("aws", "gce", "azure",)
 DEFAULT_CLOUD = SUPPORTED_CLOUDS[0]
@@ -1721,6 +1721,11 @@ def get_nemesis_list(backend, config):
     hydra nemesis-list
 
     """
+
+    # NOTE: this import messes up logging for the test, since it's importing tester.py
+    # directly down the line
+    from unit_tests.test_nemesis import FakeTester  # pylint: disable=import-outside-toplevel
+
     add_file_logger()
     logging.basicConfig(level=logging.WARNING)
 


### PR DESCRIPTION
242d72ac365e575d379a71d7b02d9448d6fb76a3 introduce new hydra command, and added an import to some test code.

that was causing log collection to fail, since it was missing the latest symlink, that wasn't create in the correct place cause of this import

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] provision tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
