### PR TITLE
fix(get_any_ks_cf_list): return keyspaces and tables quoted if needed

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -62,7 +62,6 @@ from sdcm.log import SDCMAdapter
 from sdcm.provision.common.configuration_script import ConfigurationScriptBuilder
 from sdcm.provision.scylla_yaml import ScyllaYamlNodeAttrBuilder
 from sdcm.provision.scylla_yaml.certificate_builder import ScyllaYamlCertificateAttrBuilder
-
 from sdcm.provision.scylla_yaml.cluster_builder import ScyllaYamlClusterAttrBuilder
 from sdcm.provision.scylla_yaml.scylla_yaml import ScyllaYaml
 from sdcm.provision.helpers.certificate import install_client_certificate, install_encryption_at_rest_files
@@ -77,6 +76,7 @@ from sdcm.snitch_configuration import SnitchConfig
 from sdcm.utils import properties
 from sdcm.utils.adaptive_timeouts import Operations, adaptive_timeout
 from sdcm.utils.aws_kms import AwsKms
+from sdcm.utils.cql_utils import cql_quote_if_needed
 from sdcm.utils.benchmarks import ScyllaClusterBenchmarkManager
 from sdcm.utils.common import (
     S3Storage,
@@ -3536,7 +3536,9 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         if not regular_table_names:
             return []
 
-        return list(regular_table_names - materialized_view_table_names)
+        ks_cf_list = list(regular_table_names - materialized_view_table_names)
+        ks_cf_list = ['.'.join([cql_quote_if_needed(v) for v in ks_cf.split('.', maxsplit=1)]) for ks_cf in ks_cf_list]
+        return ks_cf_list
 
     def is_table_has_data(self, session, table_name: str) -> (bool, Optional[Exception]):
         """

--- a/sdcm/utils/cql_utils.py
+++ b/sdcm/utils/cql_utils.py
@@ -1,0 +1,29 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2024 ScyllaDB
+
+import re
+
+
+def cql_quote_if_needed(identifier: str) -> str:
+    """
+    quote cql identifier if needed
+
+    cql identifiers that start with a digit, or that aren't lower case ascii
+    should be quoted
+
+    https://cassandra.apache.org/doc/stable/cassandra/cql/definitions.html#identifiers
+    """
+    identifier_regex = re.compile(r'^[^0-9][a-z0-9_]+$')
+    if not identifier_regex.match(identifier):
+        return f'"{identifier}"'
+    return identifier


### PR DESCRIPTION
PR #6897 handled calls to cqlsh to keep the quotes, but we do have other places when we supply quoted identifiers and it might break like the following:

```
Executing CQL 'CREATE INDEX standard1_c4_nemesis ON 100gb_sizetiered.standard1("C4")' ...
...
cassandra.protocol.SyntaxException: <Error from server: code=2000 [Syntax
error in CQL query] message="line 1:37 no viable alternative at input '100'">
```

Fixes: #6790

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] integration tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
