### PR TITLE
fix(end_of_quota_nemesis): parse mounts correctly

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1707,11 +1707,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if self._is_it_on_kubernetes():
             raise UnsupportedNemesis("Skipping nemesis for kubernetes")
 
-        # Need to check on a live cluster with GCP and Azure how the quota configuration works / fails
-        # SCT Issue REF: https://github.com/scylladb/scylla-cluster-tests/issues/6915
-        if self.cluster.params.get('cluster_backend') != 'aws':
-            raise UnsupportedNemesis("The end of quota test only supports AWS at the moment")
-
         result = node.remoter.run('cat /proc/mounts')
         if '/var/lib/scylla' not in result.stdout:
             raise UnsupportedNemesis("Scylla doesn't use an individual storage, skip end of quota test")

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -140,21 +140,25 @@ def ignore_disk_quota_exceeded_errors(node):
             db_event=DatabaseLogEvent.BACKTRACE,
             line="Disk quota exceeded",
             node=node,
+            extra_time_to_expiration=3600,  # one hour
         ))
         stack.enter_context(DbEventsFilter(
             db_event=DatabaseLogEvent.FILESYSTEM_ERROR,
             line="Disk quota exceeded",
             node=node,
+            extra_time_to_expiration=3600,  # one hour
         ))
         stack.enter_context(DbEventsFilter(
             db_event=DatabaseLogEvent.DATABASE_ERROR,
             line="Disk quota exceeded",
             node=node,
+            extra_time_to_expiration=3600,  # one hour
         ))
         stack.enter_context(DbEventsFilter(
             db_event=DatabaseLogEvent.DISK_ERROR,
             line="Disk quota exceeded",
             node=node,
+            extra_time_to_expiration=3600,  # one hour
         ))
         yield
 

--- a/sdcm/utils/quota.py
+++ b/sdcm/utils/quota.py
@@ -32,9 +32,9 @@ def enable_quota_on_node(node):
 def is_quota_enabled_on_node(node):
     """ Verify usrquota is enabled on scylla user. """
     LOGGER.info("Verifying quota is configured on the node {}".format(node.name))
-    verify_usrquot_in_mount_cmd = "mount | grep /var/lib/scylla | awk {'print $6'} | cut -d ',' -f 8"
-    result = node.remoter.run(cmd=verify_usrquot_in_mount_cmd).stdout.rstrip().replace(")", "")
-    if not result == "usrquota":
+    verify_usrquot_in_mount_cmd = "cat /proc/mounts | grep /var/lib/scylla | awk {'print $4'}"
+    result = node.remoter.run(cmd=verify_usrquot_in_mount_cmd).stdout.strip()
+    if "usrquota" not in result:
         LOGGER.warning("User quota on user scylla at /var/lib/scylla is not enabled")
         return False
     return True


### PR DESCRIPTION
Read all the mount options, and look in them for the expected value

Fixes: #6936

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-5gb-1h-EndOfQuotaNemesis-aws-test/3
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-5gb-1h-EndOfQuotaNemesis-gce-test/3
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-5gb-1h-EndOfQuotaNemesis-azure-test/4

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
