### PR TITLE
fix(disrupt_show_toppartitions): stop using `nodetool help`

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3220,9 +3220,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.log.debug(
             "Running 'disrupt_show_toppartitions' method using %s API.",
             "new and old" if allow_new_api else "old")
-        result = self.target_node.run_nodetool(sub_cmd='help', args='toppartitions')
-        if 'Unknown command toppartitions' in result.stdout:
-            raise UnsupportedNemesis("nodetool doesn't support toppartitions")
         ks_cf_list = self.cluster.get_any_ks_cf_list(self.target_node)
         if not ks_cf_list:
             raise UnsupportedNemesis('User-defined Keyspace and ColumnFamily are not found.')


### PR DESCRIPTION
cause of the recent scylla-nodetool warpper script, we are getting this error, when using help, since toppartitions isn't implmented on `scylla nodetool` while `help` command is implmented:

```
sdcm.remote.libssh2_client.exceptions.UnexpectedExit: Encountered a bad command exit code!
Command: '/usr/bin/nodetool  help toppartitions'
Exit code: 1
Stdout:
Stderr:
error processing arguments: unknown command toppartitions
```

removing this check that was introduced of scylla 2019.1 we don't support this version any more, and we have other mean of checking which version is used to decide skipping nemesis.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] no testing is needed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
