### PR TITLE
fix(stress): prolong stress timeout

### DIFF
--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -329,9 +329,11 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
                 hdr_logger_context:
             publisher.event_id = cs_stress_event.event_id
             try:
-                # prolong timeout by 5% to avoid killing cassandra-stress process
-                hard_timeout = self.timeout + int(self.timeout * 0.05)
-                with SoftTimeoutContext(timeout=self.timeout, operation="cassandra-stress"):
+                # prolong timeout by 10% to avoid killing cassandra-stress process
+                hard_timeout = self.timeout + int(self.timeout * 0.1)
+                # prolong soft timeout by 5%
+                soft_timeout = self.timeout + int(self.timeout * 0.05)
+                with SoftTimeoutContext(timeout=soft_timeout, operation="cassandra-stress"):
                     result = cmd_runner.run(cmd=node_cmd, timeout=hard_timeout, log_file=log_file_name, retry=0)
             except Exception as exc:  # pylint: disable=broad-except
                 self.configure_event_on_failure(stress_event=cs_stress_event, exc=exc)


### PR DESCRIPTION
Increate stress soft timeout to prevent killing cassandra-stress process

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
