### PR TITLE
feature(sct-runner): collect runner metrics using node_exporter

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1535,7 +1535,7 @@ def configure_aws_peering(regions):
 @click.option("-r", "--region", required=True, type=CloudRegion(), help="Cloud region")
 @click.option("-z", "--availability-zone", default="", type=str, help="Name of availability zone, ex. 'a'")
 def create_runner_image(cloud_provider, region, availability_zone):
-    if cloud_provider == "aws" and availability_zone != "":
+    if cloud_provider == "aws":
         assert len(availability_zone) == 1, f"Invalid AZ: {availability_zone}, availability-zone is one-letter a-z."
     add_file_logger()
     sct_runner = get_sct_runner(cloud_provider=cloud_provider, region_name=region, availability_zone=availability_zone)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -110,6 +110,7 @@ from sdcm.utils.version_utils import (
     ComparableScyllaVersion,
     SCYLLA_VERSION_RE,
 )
+from sdcm.utils.net import get_my_ip
 from sdcm.utils.node import build_node_api_command
 from sdcm.sct_events import Severity
 from sdcm.sct_events.base import LogEvent, add_severity_limit_rules, max_severity
@@ -5396,6 +5397,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
 
             with node._remote_yaml(f'{self.monitoring_conf_dir}/node_exporter_servers.yml') as exporter_yaml:  # pylint: disable=protected-access
                 exporter_yaml[0]['targets'] += [f'{normalize_ipv6_url(node.private_ip_address)}:9100']
+                exporter_yaml[0]['targets'] += [f'{normalize_ipv6_url(get_my_ip())}:9100']
                 exporter_yaml[0]['targets'] = list(set(exporter_yaml[0]['targets']))  # remove duplicates
 
             if self.params.get("cloud_prom_bearer_token"):

--- a/sdcm/node_exporter_setup.py
+++ b/sdcm/node_exporter_setup.py
@@ -6,9 +6,12 @@ NODE_EXPORTER_VERSION = '1.7.0'
 
 class NodeExporterSetup:  # pylint: disable=too-few-public-methods
     @staticmethod
-    def install(node):
-        node.install_package('wget')
-        node.remoter.sudo(shell_script_cmd(f"""
+    def install(node: "BaseNode | None" = None, remoter: "Remoter | None" = None):
+        assert node or remoter, "node or remoter much be pass to this function"
+        if node:
+            node.install_package('wget')
+            remoter = node.remoter
+        remoter.sudo(shell_script_cmd(f"""
             if ! id node_exporter > /dev/null 2>&1; then
                 useradd -rs /bin/false node_exporter
             fi

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -62,6 +62,7 @@ from sdcm.utils.azure_utils import AzureService, list_instances_azure
 from sdcm.utils.azure_region import AzureOsState, AzureRegion, region_name_to_location
 from sdcm.utils.context_managers import environment
 from sdcm.test_config import TestConfig
+from sdcm.node_exporter_setup import NodeExporterSetup
 
 if TYPE_CHECKING:
     # pylint: disable=ungrouped-imports
@@ -129,7 +130,7 @@ class SctRunnerInfo:  # pylint: disable=too-many-instance-attributes
 
 class SctRunner(ABC):
     """Provision and configure the SCT runner."""
-    VERSION = "1.6"  # Version of the Image
+    VERSION = "1.7"  # Version of the Image
     NODE_TYPE = "sct-runner"
     RUNNER_NAME = "SCT-Runner"
     LOGIN_USER = "ubuntu"
@@ -242,6 +243,10 @@ class SctRunner(ABC):
             # Jenkins pipelines run /bin/sh for some reason.
             ln -sf /bin/bash /bin/sh
         """), ignore_status=True)
+
+        node_exporter_setup = NodeExporterSetup()
+        node_exporter_setup.install(remoter=remoter)
+
         remoter.stop()
         if result.ok:
             LOGGER.info("All packages successfully installed.")

--- a/sdcm/utils/azure_region.py
+++ b/sdcm/utils/azure_region.py
@@ -318,7 +318,7 @@ class AzureRegion:  # pylint: disable=too-many-public-methods
                         "caching": "ReadWrite",
                         "create_option": "FromImage",
                         "managed_disk": {
-                            "storage_account_type": "Premium_LRS",  # SSD
+                            "storage_account_type": "StandardSSD_LRS",  # SSD
                         },
                     } | ({} if disk_size is None else {
                         "disk_size_gb": disk_size,


### PR DESCRIPTION
* create a new version of sct-runner with node exporter baked in
* set it up on the monitoring stack

this would help use collect data about what's going on with the sct-runner, and help us pin point issues with the test code or the need to pick bigger instances/disks from some tests.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] provision test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
