### PR TITLE
fix(c-s): fix audit related consistency error filter

### DIFF
--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -129,7 +129,7 @@ def enable_default_filters(sct_config: SCTConfiguration):  # pylint: disable=unu
     # issue that should be track https://github.com/scylladb/scylla-enterprise/issues/3148
     EventsSeverityChangerFilter(new_severity=Severity.WARNING,
                                 event_class=CassandraStressLogEvent.ConsistencyError,
-                                regex="Authentication error on host.*Cannot achieve consistency level for cl ONE").publish()
+                                regex=r".*Authentication error on host.*Cannot achieve consistency level for cl ONE").publish()
 
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: supressed').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: suppressed').publish()


### PR DESCRIPTION
b33d585488b6f0209538327bd11c631828e9211f introduce a filter that wasn't totally working, this commit fixes the regex and introduce a unittest coverage for it

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] unittests only

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
