### PR TITLE
fix(nemesis): fix typo in disrupt_add_remove_dc

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4485,7 +4485,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     replication_strategy_setter(**{keyspace: strategy})
                 InfoEvent(message='execute rebuild on new datacenter').publish()
                 with wait_for_log_lines(node=new_node, start_line_patterns=["rebuild.*started with keyspaces=", "Rebuild starts"],
-                                        end_line_patterns=["(rebuild.*finished with keyspaces=", "Rebuild succeeded"],
+                                        end_line_patterns=["rebuild.*finished with keyspaces=", "Rebuild succeeded"],
                                         start_timeout=60, end_timeout=600):
                     new_node.run_nodetool(sub_cmd=f"rebuild -- {datacenters[0]}", retry=0)
                 InfoEvent(message='Running full cluster repair on each node').publish()


### PR DESCRIPTION
b5808cefa7f91f5202ec65ac2f72694a97b246f7 fix introduced extra parentheses in one of the regex to look for

it was breaking the test like this:

```
Traceback (most recent call last):
File ".../sdcm/nemesis.py", line 5062, in wrapper
result = method(*args[1:], **kwargs)
File ".../sdcm/nemesis.py", line 4488, in disrupt_add_remove_dc
with wait_for_log_lines(node=new_node,
   start_line_patterns=["rebuild.*started with keyspaces=", "Rebuild starts"],
File "/usr/local/lib/python3.10/contextlib.py", line 135, in __enter__
return next(self.gen)
File "/home/ubuntu/scylla-cluster-tests/sdcm/wait.py", line 144, in wait_for_log_lines
end_follower = node.follow_system_log(patterns=end_line_patterns)
File ".../sdcm/cluster.py", line 1383, in follow_system_log
regexps.append(re.compile(pattern, flags=re.IGNORECASE))
File "/usr/local/lib/python3.10/re.py", line 251, in compile
return _compile(pattern, flags)
File "/usr/local/lib/python3.10/re.py", line 303, in _compile
p = sre_compile.compile(pattern, flags)
File "/usr/local/lib/python3.10/sre_compile.py", line 788, in compile
p = sre_parse.parse(p, flags)
File "/usr/local/lib/python3.10/sre_parse.py", line 955, in parse
p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
File "/usr/local/lib/python3.10/sre_parse.py", line 444, in _parse_sub
itemsappend(_parse(source, state, verbose, nested + 1,
File "/usr/local/lib/python3.10/sre_parse.py", line 843, in _parse
raise source.error("missing ), unterminated subpattern",
re.error: missing ), unterminated subpattern at position 0
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
