### PR TITLE
fix(gce_builder): set `keep: alive` labels

### DIFF
--- a/sdcm/utils/gce_builder.py
+++ b/sdcm/utils/gce_builder.py
@@ -210,8 +210,10 @@ class GceBuilder:
         metadata.items += [{"key": "RunByUser", "value": "QA"}]
         metadata.items += [{"key": "NodeType", "value": "builder"}]
         metadata.items += [{"key": "keep", "value": "alive"}]
-
         template.properties.metadata = metadata
+
+        template.properties.labels = {"runbyuser": "qa", "nodetype": "builder", "keep": "alive"}
+
         template_client = compute_v1.InstanceTemplatesClient(credentials=self.credentials)
         try:
             operation = template_client.insert(


### PR DESCRIPTION
`keep: alive` was added to metadata, but cleanup scripts are reading the labels, hence were stopping builder in gce after 12 hours.

add needed label, and recreate all instnace templates in all of our gce projects

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
