### PR TITLE
fix(upgrade): increase session timeouts in verify_db_data

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -3359,9 +3359,10 @@ class FillDatabaseData(ClusterTester):
     def verify_db_data(self):
         # Prepare connection
         node = self.db_cluster.nodes[0]
-        with self.db_cluster.cql_connection_patient(node, keyspace=self.base_ks) as session:
+        with self.db_cluster.cql_connection_patient(node, keyspace=self.base_ks, connect_timeout=600) as session:
             # override driver consistency level
             session.default_consistency_level = ConsistencyLevel.QUORUM
+            session.default_timeout = 60 * 5
             self.run_db_queries(session, session.default_fetch_size)
 
     def paged_query(self, keyspace='keyspace_complex'):


### PR DESCRIPTION
Increase session timeouts for data validation sdcm.fill_db_data.FillDatabaseData.verify_db_data:
```
cassandra.OperationTimedOut: errors={'10.4.3.124:9042': 'Client request timeout. See Session.execute[_async](timeout)'}, last_host=10.4.3.124:9042
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
