### PR TITLE
fix(nemesis): disrupt_modify_table failure

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2687,8 +2687,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                      "dttl": 86400}
 
             """
-            current_unit = settings["compaction"]["compaction_window_unit"]
-            current_size = int(settings["compaction"]["compaction_window_size"])
+            # It is allowed that compaction strategy has only "class" defined, and "compaction_window_size" and "compaction_window_unit"
+            # are not defined.
+            current_unit = settings["compaction"].get("compaction_window_unit") or "DAYS"  # default value
+            current_size = int(settings["compaction"].get("compaction_window_size") or 1)  # default value
             multiplier = 3600 if current_unit in ["DAYS", "HOURS"] else 60
             expected_sstable_number = 35
 


### PR DESCRIPTION
It is allowed that compaction strategy has only 'class' defined, and 'compaction_window_size' and 'compaction_window_unit' are not defined. Like:
```
compaction = {'class': 'TimeWindowCompactionStrategy'}
```

In this case the nemesis fails with error:
```
KeyError: 'compaction_window_unit'
```

Example of failed test:
https://argus.scylladb.com/test/079cddb4-4eac-4594-a2f0-8452dab5eb40/runs?additionalRuns[]=73ec8004-3881-4cbb-b37b-11c75c1c1126

It first time from 2022 that this nemesis was run

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
