### PR TITLE
feature(syslog-ng): collect syslog-ng stats

### DIFF
--- a/data_dir/scylla-dash-per-server-nemesis.master.json
+++ b/data_dir/scylla-dash-per-server-nemesis.master.json
@@ -7628,6 +7628,141 @@
         "yaxis": {
           "align": false
         }
+      },
+      {
+        "class": "text_panel",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "editable": true,
+        "error": false,
+        "gridPos": {
+          "h": 3,
+          "w": 24,
+          "x": 0,
+          "y": 287
+        },
+        "links": [],
+        "options": {
+          "code": {
+            "language": "plaintext",
+            "showLineNumbers": false,
+            "showMiniMap": false
+          },
+          "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Syslog-ng logging</h1>",
+          "mode": "html"
+        },
+        "pluginVersion": "10.2.2",
+        "style": {},
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "smooth",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": true,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "mps"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 290
+        },
+        "links": [],
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "10.2.2",
+        "targets": [
+          {
+            "datasource": "prometheus",
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "increase(syslog_ng_destination_messages_processed_total[10m])",
+            "format": "time_series",
+            "instant": false,
+            "intervalFactor": 1,
+            "legendFormat": "Processed {{instance}}",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": "prometheus",
+            "editorMode": "code",
+            "expr": "increase(syslog_ng_destination_messages_dropped_total[10m])",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Dropped {{instance}}",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "title": "Logs create/drop rates",
+        "type": "timeseries"
       }
     ],
     "refresh": false,

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -53,7 +53,7 @@ from cassandra.policies import WhiteListRoundRobinPolicy, HostFilterPolicy, Roun
 from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
 
 from argus.backend.util.enums import ResourceState
-from sdcm.node_exporter_setup import NodeExporterSetup
+from sdcm.node_exporter_setup import NodeExporterSetup, SyslogNgExporterSetup
 from sdcm.db_log_reader import DbLogReader
 from sdcm.mgmt import AnyManagerCluster, ScyllaManagerError
 from sdcm.mgmt.common import get_manager_repo_from_defaults, get_manager_scylla_backend
@@ -4419,6 +4419,9 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
         if not self.test_config.REUSE_CLUSTER:
             node.disable_daily_triggered_services()
+            if self.params.get('logs_transport') == 'syslog-ng':
+                SyslogNgExporterSetup().install(node)
+
             nic_devname = node.get_nic_devices()[0]
             if install_scylla:
                 self._scylla_install(node)
@@ -5388,8 +5391,10 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
     def reconfigure_scylla_monitoring(self):
         for node in self.nodes:
             monitoring_targets = []
+            syslog_ng_stats_targets = []
             for db_node in self.targets["db_cluster"].nodes:
                 monitoring_targets.append(f"{normalize_ipv6_url(getattr(db_node, self.DB_NODES_IP_ADDRESS))}")
+                syslog_ng_stats_targets += [f'{normalize_ipv6_url(getattr(db_node, self.DB_NODES_IP_ADDRESS))}:9577']
             monitoring_targets = " ".join(monitoring_targets)
             node.remoter.sudo(shell_script_cmd(f"""\
                 cd {self.monitor_install_path}
@@ -5400,6 +5405,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
 
             with node._remote_yaml(f'{self.monitoring_conf_dir}/node_exporter_servers.yml') as exporter_yaml:  # pylint: disable=protected-access
                 exporter_yaml[0]['targets'] += [f'{normalize_ipv6_url(node.private_ip_address)}:9100']
+                exporter_yaml[0]['targets'] += syslog_ng_stats_targets
                 exporter_yaml[0]['targets'] += [f'{normalize_ipv6_url(get_my_ip())}:9100']
                 exporter_yaml[0]['targets'] = list(set(exporter_yaml[0]['targets']))  # remove duplicates
 


### PR DESCRIPTION
so we can track rate/drop of logging, we introduce an exporter for syslog-ng.

example of the metrics we will have:
```
syslog_ng_destination_messages_dropped_total{destination="...",id="remote_sct#0",type="dst.syslog"} 0
syslog_ng_destination_messages_processed_total{destination="...",id="remote_sct#0",type="dst.syslog"} 18137
syslog_ng_destination_messages_stored_total{destination="...",id="remote_sct#0",type="dst.syslog"} 25617
syslog_ng_destination_messages_written_total{destination="...",id="remote_sct#0",type="dst.syslog"} 0
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] aws provision test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
