### PR TITLE
fix(mgmt-restore): report proper `mgmt-restore` nemesis results

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2885,7 +2885,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                                                       keyspace_name=chosen_snapshot_info["keyspace_name"],
                                                       number_of_rows=chosen_snapshot_info["number_of_rows"])
         for stress in stress_queue:
-            self.tester.verify_stress_thread(cs_thread_pool=stress)
+            is_passed = self.tester.verify_stress_thread(cs_thread_pool=stress)
+            assert is_passed, (
+                "Data verification stress command, triggered by the 'mgmt_restore' nemesis, has failed")
 
     def _delete_existing_backups(self, mgr_cluster):
         deleted_tasks = []

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2106,6 +2106,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         errors = errors[-5:]
         if errors:
             self.log.warning("cassandra-stress errors on nodes:\n%s", "\n".join(errors))
+        return results and not errors
 
     def get_stress_results(self, queue, store_results=True) -> list[dict | None]:
         results = queue.get_results()


### PR DESCRIPTION
When we run `mgmt_restore` nemesis we may get failed stress commands which get triggered by this nemesis.
And when it fails, nemesis doesn't catch errors and reports 'Success'.

So, fix it by checking the stress commands results.

Related: #7122

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/job/scylla-staging/job/valerii/job/vp-longevity-scylla-operator-3h-eks-mgmt-restore/10

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
