### PR TITLE
fix(tier1): longevity-schema-topology-changes-12h bigger runner

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -446,8 +446,8 @@ class AwsSctRunner(SctRunner):
     BASE_IMAGE = "ami-07c2ae35d31367b3e"  # Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-01
     SOURCE_IMAGE_REGION = "eu-west-2"  # where the source Runner image will be created and copied to other regions
     IMAGE_BUILDER_INSTANCE_TYPE = "t3.small"
-    REGULAR_TEST_INSTANCE_TYPE = "t3.large"  # 2 vcpus, 8G, 36 CPU credits/hour
-    LONGTERM_TEST_INSTANCE_TYPE = "r5.large"  # 2 vcpus, 16G
+    REGULAR_TEST_INSTANCE_TYPE = "m7i-flex.large"  # 2 vcpus, 8G
+    LONGTERM_TEST_INSTANCE_TYPE = "m7i-flex.xlarge"  # 4 vcpus, 16G
 
     def __init__(self, region_name: str, availability_zone: str):
         super().__init__(region_name=region_name, availability_zone=availability_zone)


### PR DESCRIPTION
this case is running multiple nemesis threads and
it keeps showing the ssh `Bad packet length` issue

now that we are collecting metrics of runner, it shows we are getting into 100% cpu.

trying this change to see if it help with this issue

Ref: https://github.com/scylladb/scylladb/issues/14004

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-mv-si-4days-test/7/
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-mv-si-4days-test/8/
- [ ] ~~https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-mv-si-4days-test/9/~~
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-mv-si-4days-test/10/
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-mv-si-4days-test/11/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
