### PR TITLE
fix(monitoringstack): add zero to the list of ports

### DIFF
--- a/sdcm/monitorstack/__init__.py
+++ b/sdcm/monitorstack/__init__.py
@@ -393,9 +393,9 @@ def restore_annotations_data(monitoring_stack_dir, grafana_docker_port):
 
 @retrying(n=3, sleep_time=5, message='Start docker containers')
 def start_dockers(monitoring_dockers_dir, monitoring_stack_data_dir, scylla_version, tenants_number):  # pylint: disable=unused-argument
-    graf_port = get_free_port(ports_to_try=(GRAFANA_DOCKER_PORT + i for i in range(tenants_number)))
-    alert_port = get_free_port(ports_to_try=(ALERT_DOCKER_PORT + i for i in range(tenants_number)))
-    prom_port = get_free_port(ports_to_try=(PROMETHEUS_DOCKER_PORT + i for i in range(tenants_number)))
+    graf_port = get_free_port(ports_to_try=[GRAFANA_DOCKER_PORT + i for i in range(tenants_number)] + [0])
+    alert_port = get_free_port(ports_to_try=[ALERT_DOCKER_PORT + i for i in range(tenants_number)] + [0])
+    prom_port = get_free_port(ports_to_try=[PROMETHEUS_DOCKER_PORT + i for i in range(tenants_number)] + [0])
 
     lr = LocalCmdRunner()  # pylint: disable=invalid-name
     lr.run('cd {monitoring_dockers_dir}; ./kill-all.sh -g {graf_port} -m {alert_port} -p {prom_port}'.format(**locals()),
@@ -432,7 +432,9 @@ def start_dockers(monitoring_dockers_dir, monitoring_stack_data_dir, scylla_vers
     if res.ok:
         LOGGER.info("Docker containers for monitoring stack are started")
     else:
-        LOGGER.error("Failure to start monitoring stack: %s", res.stderr)
+        LOGGER.error("Failure to start monitoring stack stderr: %s", res.stderr)
+        LOGGER.error("Failure to start monitoring stack stdout: %s", res.stdout)
+
         raise Exception("fail to start monitoring stack")
     return {"grafana_docker_port": graf_port,
             "alert_docker_port": alert_port,


### PR DESCRIPTION
in cases of port being taken, or other errors
retries are not working as expect since the zero
port were taken out of the list.

those zero port are what enable us to randomly select ports of the diffrent monitoring services

Fixes: #7093

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
