### PR TITLE
fix(ignore_no_space_errors): add 30min to the ignore time

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -104,31 +104,37 @@ def ignore_no_space_errors(node):
         stack.enter_context(DbEventsFilter(
             db_event=DatabaseLogEvent.NO_SPACE_ERROR,
             node=node,
+            extra_time_to_expiration=1800,  # 30min
         ))
         stack.enter_context(DbEventsFilter(
             db_event=DatabaseLogEvent.BACKTRACE,
             line="No space left on device",
             node=node,
+            extra_time_to_expiration=1800,  # 30min
         ))
         stack.enter_context(DbEventsFilter(
             db_event=DatabaseLogEvent.DATABASE_ERROR,
             line="No space left on device",
             node=node,
+            extra_time_to_expiration=1800,  # 30min
         ))
         stack.enter_context(DbEventsFilter(
             db_event=DatabaseLogEvent.FILESYSTEM_ERROR,
             line="No space left on device",
             node=node,
+            extra_time_to_expiration=1800,  # 30min
         ))
         stack.enter_context(DbEventsFilter(
             db_event=DatabaseLogEvent.DATABASE_ERROR,
             line="No such file or directory",
             node=node,
+            extra_time_to_expiration=1800,  # 30min
         ))
         stack.enter_context(DbEventsFilter(
             db_event=DatabaseLogEvent.FILESYSTEM_ERROR,
             line="No such file or directory",
             node=node,
+            extra_time_to_expiration=1800,  # 30min
         ))
         yield
 


### PR DESCRIPTION
we are seeing case that even smallest lag in the logging system of less then 5min, can cause this nemesis to generate error on those log lines, adding 30min to the ignore, should be sufficent.

bigger lag then that in the logging systeam would be addresssed on it's own

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - no test are needed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
