### PR TITLE
fix(nemesis): fix `disable_binary_gossip_execute_major_compaction`

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2747,7 +2747,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         return f'{cqlsh_cmd} {options} -e {command} {host}'
 
     def run_cqlsh(self, cmd, keyspace=None, timeout=120, verbose=True, split=False, connect_timeout=60,
-                  num_retry_on_failure=1):
+                  num_retry_on_failure=1, retry_interval=3):
         """Runs CQL command using cqlsh utility"""
         cmd = self._gen_cqlsh_cmd(command=cmd, keyspace=keyspace, timeout=timeout,
                                   connect_timeout=connect_timeout)
@@ -2760,6 +2760,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 num_retry_on_failure -= 1
                 if not num_retry_on_failure:
                     raise
+                time.sleep(retry_interval)
 
         # stdout of cqlsh example:
         #      pk


### PR DESCRIPTION
Check the gossip status and CQL workability in the end of the `disrupt_disable_binary_gossip_execute_major_compaction` nemesis instead of looking for the `gate closed` message in DB logs.

Fixes: #6819

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/job/scylla-staging/job/valerii/job/vp-longevity-scylla-operator-3h-eks-nodetool-flush-and-reshard/26

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
