### PR TITLE
fix(rolling-upgrade): set raft upgrade test only from 2022.2

### DIFF
--- a/jenkins-pipelines/upgrade-with-raft/rolling-upgrade-centos8-with-raft.jenkinsfile
+++ b/jenkins-pipelines/upgrade-with-raft/rolling-upgrade-centos8-with-raft.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '',  // auto mode
+    base_versions: '["2022.2"]'
     linux_distro: 'centos-8',
     disable_raft: false,
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-8',

--- a/jenkins-pipelines/upgrade-with-raft/rolling-upgrade-debian11-with-raft.jenkinsfile
+++ b/jenkins-pipelines/upgrade-with-raft/rolling-upgrade-debian11-with-raft.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '',  // auto mode
+    base_versions: '["2022.2"]'
     linux_distro: 'debian-bullseye',
     disable_raft: false,
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-11',

--- a/jenkins-pipelines/upgrade-with-raft/rolling-upgrade-ubuntu22.04-with-raft.jenkinsfile
+++ b/jenkins-pipelines/upgrade-with-raft/rolling-upgrade-ubuntu22.04-with-raft.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '',  // auto mode
+    base_versions: '["2022.2"]'
     linux_distro: 'ubuntu-jammy',
     disable_raft: false,
     use_preinstalled_scylla: true,


### PR DESCRIPTION
5.4 and 2023.1 already have Raft enabled by default when starting fresh as base versions. So there's no need to test it in separate job.

Fix by specifying base_version explicitly instead of automatic resolver.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
