### PR TITLE
fix(k8s): make 'latest' tag parsing logic work correctly

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -552,7 +552,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
         #       in each 'minor' family.
         current_newest_version, current_newest_version_str = None, ''
         for version_object in all_versions:
-            if version_object["version"].count('-') not in (0, 3):
+            if version_object["version"].count('-') == 1:
                 continue
             if ComparableScyllaOperatorVersion(version_object["version"]) > (
                     current_newest_version or '0.0.0'):


### PR DESCRIPTION
The most recent dev versions of the scylla operator started looking like the following: `v1.12.0-alpha.1-78-ge5a1c9b-latest` Before it was like following: `v1.12.0-alpha.0-144-g60f7824`.

We were depending on the number of the `-` symbols and it now leads to the filtering out of the new kind of chart versions. 
So, fix it by properly checking helm chart versions.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
