### PR TITLE
fix(kms): Detect `sstable not found` situation better

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4094,9 +4094,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         @retrying(n=4, sleep_time=30, allowed_exceptions=(AssertionError, ))
         def check_encryption_fact(sstable_util_instance, expected_bool_value):
-            encryption_results = sstable_util_instance.is_sstable_encrypted()
-            assert encryption_results
-            assert all(encryption_result is expected_bool_value for encryption_result in encryption_results)
+            sstable_util_instance.check_that_sstables_are_encrypted(expected_bool_value=expected_bool_value)
 
         def run_write_scylla_bench_load(write_cmd):
             # NOTE: 'scylla-bench' runs 'truncate' operation when 'validate-data' is used in addition


### PR DESCRIPTION
Also, allow some part of the sstables to fail the encryption check because we care about big picture and not concrete number.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [https://argus.scylladb.com/test/105e12f0-26ba-4d7d-b945-53e472772f3f/runs?additionalRuns[]=97f28117-6097-489a-93db-82787916131e](https://argus.scylladb.com/test/105e12f0-26ba-4d7d-b945-53e472772f3f/runs?additionalRuns%5B%5D=97f28117-6097-489a-93db-82787916131e)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
