### PR TITLE
fix(python driver): use 'ssl_context' instead 'ssl_options'

### DIFF
--- a/sdcm/provision/helpers/certificate.py
+++ b/sdcm/provision/helpers/certificate.py
@@ -16,6 +16,10 @@ from textwrap import dedent
 from sdcm.remote import shell_script_cmd
 from sdcm.utils.common import get_data_dir_path
 
+CLIENT_KEYFILE = get_data_dir_path('ssl_conf', "client/test.key")
+CLIENT_CERTFILE = get_data_dir_path('ssl_conf', "client/test.crt")
+CLIENT_TRUSTSTORE = get_data_dir_path('ssl_conf', "client/catest.pem")
+
 
 def install_client_certificate(remoter):
     if remoter.run('ls /etc/scylla/ssl_conf', ignore_status=True).ok:

--- a/sdcm/provision/scylla_yaml/certificate_builder.py
+++ b/sdcm/provision/scylla_yaml/certificate_builder.py
@@ -10,13 +10,13 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2021 ScyllaDB
-
+import os
 from functools import cached_property
 from typing import Optional, Any
 
 from pydantic import Field
 
-from sdcm.provision.helpers.certificate import install_client_certificate
+from sdcm.provision.helpers.certificate import install_client_certificate, CLIENT_CERTFILE, CLIENT_KEYFILE, CLIENT_TRUSTSTORE
 from sdcm.provision.scylla_yaml.auxiliaries import ScyllaYamlAttrBuilderBase, ClientEncryptionOptions, \
     ServerEncryptionOptions
 
@@ -40,9 +40,9 @@ class ScyllaYamlCertificateAttrBuilder(ScyllaYamlAttrBuilderBase):
             return None
         return ClientEncryptionOptions(
             enabled=True,
-            certificate=self._ssl_files_path + '/client/test.crt',
-            keyfile=self._ssl_files_path + '/client/test.key',
-            truststore=self._ssl_files_path + '/client/catest.pem',
+            certificate=os.path.join(self._ssl_files_path, 'client', os.path.basename(CLIENT_CERTFILE)),
+            keyfile=os.path.join(self._ssl_files_path, 'client', os.path.basename(CLIENT_KEYFILE)),
+            truststore=os.path.join(self._ssl_files_path, 'client', os.path.basename(CLIENT_TRUSTSTORE)),
         )
 
     @property

--- a/unit_tests/test_python_driver.py
+++ b/unit_tests/test_python_driver.py
@@ -42,3 +42,26 @@ def test_01_test_python_driver_serverless_connectivity(params):
             output = res.all()
             log.debug(output)
             assert len(output) == 1
+
+
+@pytest.mark.parametrize('encrypted', [
+    pytest.param(True, marks=pytest.mark.docker_scylla_args(ssl=True), id='encrypted'),
+    pytest.param(False, marks=pytest.mark.docker_scylla_args(ssl=False), id='clear')
+])
+def test_02_test_python_driver(docker_scylla, params, encrypted):
+
+    params['client_encrypt'] = encrypted
+    node = docker_scylla
+    db_cluster = DummyDbCluster(nodes=[node], params=params)
+    node.parent_cluster = db_cluster
+
+    for func in [db_cluster.cql_connection_patient,
+                 db_cluster.cql_connection_patient_exclusive]:
+
+        with func(node) as session:
+            for host in session.cluster.metadata.all_hosts():
+                log.debug(host)
+            res = session.execute("SELECT * FROM system.local")
+            output = res.all()
+            log.debug(output)
+            assert len(output) == 1


### PR DESCRIPTION
SCT python driver is using ssl_options when create session and should be switching to use
ssl_context since ssl_options is deprecated (and also broken for scylla-driver==3.26.4 ontop
python 3.12)

Refs: https://github.com/scylladb/python-driver/issues/284

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] AWS, https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/staging-longevity-100gb-4h/98/
- [x] GCE, https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/longevity-5tb-1day-gce-test/3/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
