### PR TITLE
fix(decommissionstreamerr): Set valid decommission nodetool timeout

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3779,16 +3779,19 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.unset_current_running_nemesis(new_node)
             return new_node
 
-        trigger = partial(
-            self.target_node.run_nodetool, sub_cmd="decommission", timeout=180, warning_event_on_exception=(Exception,),
-            retry=0,
-        )
-
         terminate_pattern = self.target_node.raft.get_random_log_message(operation=TopologyOperations.DECOMMISSION,
                                                                          seed=self.tester.params.get("nemesis_seed"))
         self.log.debug("Reboot node after log message: '%s'", terminate_pattern.log_message)
 
+        nodetool_decommission_timeout = terminate_pattern.timeout + 600
+
         log_follower = self.target_node.follow_system_log(patterns=[terminate_pattern.log_message])
+
+        trigger = partial(self.target_node.run_nodetool,
+                          sub_cmd="decommission",
+                          timeout=nodetool_decommission_timeout,
+                          warning_event_on_exception=(Exception,),
+                          retry=0)
 
         watcher = partial(
             self._call_disrupt_func_after_expression_logged,
@@ -3797,13 +3800,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             disrupt_func_kwargs={"target_node": self.target_node, "hard": True, "verify_ssh": True},
             delay=0
         )
-
+        full_operations_timeout = nodetool_decommission_timeout + 600
         with contextlib.ExitStack() as stack:
             for expected_start_failed_context in self.target_node.raft.get_severity_change_filters_scylla_start_failed(
                     terminate_pattern.timeout):
                 stack.enter_context(expected_start_failed_context)
             with ignore_stream_mutation_fragments_errors():
-                ParallelObject(objects=[trigger, watcher], timeout=terminate_pattern.timeout).call_objects()
+                ParallelObject(objects=[trigger, watcher], timeout=full_operations_timeout).call_objects()
             if new_node := decommission_post_action():
                 new_node.wait_node_fully_start()
                 new_node.run_nodetool("rebuild", retry=0)


### PR DESCRIPTION
Timeout for nodetool decommission was set incorrectly for 180sec in DecommissionStreamErr nemesis. Decommission process could run much longer. If decommission should be aborted after log message which expected to be at the end of decommission process, nodetool decommission command will be terminated by timeout too earlier and next logic of nemesis failed because status of decommissioning node will be UL because decommission itself continue to run on the node.

Job which failed: https://argus.scylladb.com/test/a5d1f97b-064a-40ed-a517-70e2092b51c2/runs?additionalRuns%5B%5D=38e1b036-3163-4f2a-92f4-5f66f3b0a116

Set valid waiting timeouts for commands and ParalleObject to correctly abort decommission.

Fix issue #7067 


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [4 hours job master](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/longevity-cdc-100gb-4h-test/4)
- [9 hours job master](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/longevity-cdc-100gb-4h-test/5)
- [9 hours job 5.4](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/longevity-cdc-100gb-4h-test/6)
- [9 hours job 2024.1](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/longevity-cdc-100gb-4h-test/7)
2 latest job marked as failed, because some connections issue during rebuild 
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
