### PR TITLE
fix(kms): make KMS logic be stable having multiple test keyspaces

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4389,8 +4389,18 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                     target_node = [node for node in db_cluster.nodes if not node.running_nemesis][0]
                     self.log.debug("Target node for 'rotate_kms_key' is %s", target_node.name)
                     with run_nemesis(node=target_node, nemesis_name="KMS encryption check"):
-                        ks_cf = db_cluster.get_non_system_ks_cf_list(db_node=target_node, filter_out_mv=True)[0]
-                        SstableUtils(db_node=target_node, ks_cf=ks_cf).check_that_sstables_are_encrypted()
+                        ks_cf_list = db_cluster.get_non_system_ks_cf_list(
+                            db_node=target_node, filter_out_table_with_counter=True, filter_out_mv=True,
+                            filter_empty_tables=True)
+                        chosen_ks_cf, chosen_ks_cf_sstables_num = 'keyspace1.standard1', 0
+                        for ks_cf in ks_cf_list:
+                            res = target_node.run_nodetool(
+                                sub_cmd='cfstats', args=ks_cf, timeout=300, retry=3, publish_event=False,
+                                warning_event_on_exception=(Failure, UnexpectedExit, Libssh2_UnexpectedExit))
+                            cf_stats = target_node._parse_cfstats(res.stdout)  # pylint: disable=protected-access
+                            if int(cf_stats["SSTable count"]) > chosen_ks_cf_sstables_num:
+                                chosen_ks_cf, chosen_ks_cf_sstables_num = ks_cf, int(cf_stats["SSTable count"])
+                        SstableUtils(db_node=target_node, ks_cf=chosen_ks_cf).check_that_sstables_are_encrypted()
                 except SstablesNotFound as exc:
                     self.log.warning(f"Couldn't check the fact of encryption (KMS) for sstables: {exc}")
                 except IndexError:


### PR DESCRIPTION
The KMS logic we have works fine if we have just one test keyspace.
If we have multiple additional keyspaces then we may get following errors:

```
  error processing arguments: could not load schema via schema-tables: \
    std::runtime_error (Failed to find keyspace1.standard1 in schema tables)
```

Such additional keyspaces may be added by multiple nemesis such as:
- `disrupt_load_and_stream`
- `disrupt_nodetool_refresh`
- `disrupt_mgmt_restore`

So, fix it by reading 'cfstats' and picking up the keyspace with the biggest number of sstables. It is going to be the keyspace+table generated by the main load/stress commands.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
Example of the failure without this fix:
- https://argus.scylladb.com/test/bb28c47f-3f97-4357-b520-8151420427e9/runs?additionalRuns%5B%5D=1eb61c51-3a04-4f1c-9174-00b18402160c

Example of the fix:
- https://argus.scylladb.com/test/116f89d3-7b3a-4cae-b8bc-5a5cb8306acf/runs?additionalRuns[]=26922fba-846d-4145-90ad-ebb1b5141a3a
- https://argus.scylladb.com/test/105e12f0-26ba-4d7d-b945-53e472772f3f/runs?additionalRuns[]=bdda8670-739f-4687-bd21-e8fb14afac34


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
