### PR TITLE
fix(raft): Raft always enabled

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -662,6 +662,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def raft(self):
         return get_raft_mode(self)
 
+    def drop_raft_property(self):
+        self.__dict__.pop('raft', None)
+
     @staticmethod
     def is_kubernetes() -> bool:
         return False

--- a/sdcm/utils/health_checker.py
+++ b/sdcm/utils/health_checker.py
@@ -271,7 +271,7 @@ def check_group0_tokenring_consistency(group0_members: list[dict[str, str]],
     if not current_node.raft.is_enabled:
         LOGGER.debug("Raft feature is disabled on node %s (host_id=%s)", current_node.name, current_node.host_id)
         return
-    LOGGER.debug("Check group0 and tokenring consistency on node %s (host_id=%s)...",
+    LOGGER.debug("Check group0 and token ring consistency on node %s (host_id=%s)...",
                  current_node.name, current_node.host_id)
     token_ring_node_ids = [member["host_id"] for member in tokenring_members]
     for member in group0_members:

--- a/sdcm/utils/raft/common.py
+++ b/sdcm/utils/raft/common.py
@@ -38,7 +38,6 @@ def validate_raft_on_nodes(nodes: list["BaseNode"]) -> None:
         LOGGER.error("Node %s has raft status: %s", node.name, node.raft.get_status())
     if not all(nodes_raft_status):
         raise RaftException("Raft is not ready")
-
     LOGGER.debug("Raft is ready!")
 
 

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -333,6 +333,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             self._update_scylla_yaml_on_node(node_to_update=node, updates=scylla_yaml_updates)
             InfoEvent(message='upgrade_node - ended to "update_scylla_yaml"').publish()
         node.forget_scylla_version()
+        node.drop_raft_property()
         InfoEvent(message='upgrade_node - starting to "start_scylla_server"').publish()
         node.start_scylla_server(verify_up_timeout=500)
         InfoEvent(message='upgrade_node - ended to "start_scylla_server"').publish()
@@ -431,6 +432,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         if self.params.get('test_upgrade_from_installed_3_1_0'):
             node.remoter.run(
                 r'sudo sed -i -e "s/enable_3_1_0_compatibility_mode:/#enable_3_1_0_compatibility_mode:/g" /etc/scylla/scylla.yaml')
+        node.drop_raft_property()
         # Current default 300s aren't enough for upgrade test of Debian 9.
         # Related issue: https://github.com/scylladb/scylla-cluster-tests/issues/1726
         node.run_scylla_sysconfig_setup()


### PR DESCRIPTION
    Raft feature is enabled by default starting from
    scylla 5.5 (master) and options consistent-cluster-management is
    depricated by default.
    Added to new checks for scylla version on node. If scylla version
    is >= 5.5, always enable raft, otherwise keep old logic based on
    consistent-cluster-management flag


### Testing
scylla version 5.5:
- https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/longevity-100gb-4h-no-raft/6
scylla version 5.4:
- https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/longevity-100gb-4h-no-raft/7
scylla version 5.4 with disabled raft
- https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/longevity-100gb-4h-no-raft/8


All jobs are passed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
