### PR TITLE
fix(raft-exp-yaml): rename raft experimetal feature flag

### DIFF
--- a/configurations/raft/enable_raft_experimental.yaml
+++ b/configurations/raft/enable_raft_experimental.yaml
@@ -1,3 +1,3 @@
 append_scylla_yaml: |
   experimental_features:
-    - raft
+    - consistent-topology-changes


### PR DESCRIPTION
new raft experimental feature flag name is consistent-topology-changes.

### Testing
- [longevity-schema-topology-changes-12h-with-raft-test](https://jenkins.scylladb.com/job/scylla-master/job/raft/job/longevity-schema-topology-changes-12h-with-raft-test/3/console) - Passed
- [longevity-mv-si-4days-test](https://jenkins.scylladb.com/job/scylla-master/job/raft/job/longevity-mv-si-4days-test/3/) - Failed by reason not related to fix
- [longevity-100gb-4h-with-raft-test](https://jenkins.scylladb.com/job/scylla-master/job/raft/job/longevity-100gb-4h-with-raft-test/17) - Passed
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
