### PR TITLE
fix(monitor): replace with newer ubuntu image

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -8,7 +8,7 @@ instance_type_loader: 'c5.xlarge'
 instance_type_monitor: 't3.large'
 # manual on creating loader AMI's: see docs/new_loader_ami.md
 ami_id_loader: 'scylla-qa-loader-ami-v19'
-ami_id_monitor: 'ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221206' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221206 Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
+ami_id_monitor: 'ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20231207' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20231207Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2023-12-07
 
 availability_zone: 'a'
 root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used


### PR DESCRIPTION
something got this image broken and we can't get it's metadata

```
   File ".../sdcm/utils/aws_utils.py", line 360, in ec2_ami_get_root_device_name
     if image.root_device_name:
   File ".../site-packages/boto3/resources/factory.py", line 386, in property_loader
     return self.meta.data.get(name)
AttributeError: 'NoneType' object has no attribute 'get'
```

replacing it with newer working image

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] provision test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
