### PR TITLE
fix(resolve_latest_repo_symlink): remove unneed logging prints

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -527,7 +527,7 @@ def resolve_latest_repo_symlink(url: str) -> str:
     # pylint: disable=too-many-branches
     base, sep, rest = url.partition(LATEST_SYMLINK_NAME)
     if sep != LATEST_SYMLINK_NAME:
-        LOGGER.info("%s doesn't contain `%s' substring, use URL as is", url, LATEST_SYMLINK_NAME)
+        LOGGER.debug("%s doesn't contain `%s' substring, use URL as is", url, LATEST_SYMLINK_NAME)
         return url
 
     parsed_base_url = urlparse(base)
@@ -582,7 +582,6 @@ def resolve_latest_repo_symlink(url: str) -> str:
             url=url,
             error=f"There is no a sibling directory which contains same repo file (ETag={latest_etag})"
         ).publish_or_dump(default_logger=LOGGER)
-        LOGGER.info("There is no a sibling directory which contains same repo file, use URL %s as is", url)
         return url
 
     if (timestamp, build) != build_list[0]:
@@ -590,10 +589,9 @@ def resolve_latest_repo_symlink(url: str) -> str:
             url=url,
             error=f"{url} doesn't point to the latest repo ({base}{build_list[0][1]}{rest})"
         ).publish_or_dump(default_logger=LOGGER)
-        LOGGER.info("Actual latest build is %s, not %s", build_list[0][1], build)
 
     resolved_url = f"{base}{build}{rest}"
-    LOGGER.info("%s resolved to %s", url, resolved_url)
+    LOGGER.debug("%s resolved to %s", url, resolved_url)
     return resolved_url
 
 


### PR DESCRIPTION
we don't need to see at the output, each this this function is not not doing anything, and the rest of the warning are raised as events that would be printed as warning level anyhow

Fixes: #7163

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
