### PR TITLE
fix(snapshot_operations): remove quotes from keyspaces/columnfamilies

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3075,6 +3075,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         """
         snapshot_params = nodetool_cmd.split()
         ks_cf = self.cluster.get_any_ks_cf_list(db_node=self.target_node, filter_empty_tables=False)
+        # remove quotes from keyspace or column family, since output of `nodetool listsnapshots` isn't returning them quoted
+        ks_cf = [k_c.replace('"', '') for k_c in ks_cf]
         keyspace_table = []
         if len(snapshot_params) > 1:
             if snapshot_params[1] == "-kc":


### PR DESCRIPTION
since #7104 introduced quotes for keyspaces and column families, for usage in CQL, but in case like this one, when it's used for comparing with outputs other then CQL, it's was breaking the logic, like the following

```
Traceback (most recent call last):
  File ".../sdcm/nemesis.py", line 5059, in wrapper
    result = method(*args[1:], **kwargs)
  File ".../sdcm/nemesis.py", line 3200, in disrupt_snapshot_operations
    self._validate_snapshot(nodetool_cmd=nodetool_cmd, snapshot_content=snapshot_content)
  File ".../sdcm/nemesis.py", line 3098, in _validate_snapshot
    raise AssertionError(f"Snapshot content not as expected. \n"
AssertionError: Snapshot content not as expected.
Expected content: [ ... ['system', '"IndexInfo"'], ... ]
Actual snapshot content: [ ... ['system', 'IndexInfo'], ... ]
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
