### PR TITLE
fix(k8s): support master Scylla version in cleanup messages checks

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -301,7 +301,8 @@ def test_add_new_node_and_check_old_nodes_are_cleaned_up(db_cluster):
     for node in db_cluster.nodes:
         for keyspace in db_cluster.nodes[0].run_cqlsh('describe keyspaces').stdout.split():
             log_followers[f"{node.name}--{keyspace}"] = node.follow_system_log(patterns=[
-                f"api - force_keyspace_cleanup: keyspace={keyspace} "])
+                f"api - force_keyspace_cleanup: keyspace={keyspace} ",
+                f"api - Keyspace {keyspace} does not require cleanup"])
 
     def wait_for_cleanup_logs(log_follower_name, log_follower, db_cluster):
         db_rf = len(db_cluster.nodes)


### PR DESCRIPTION
Scylla master (5.5-dev) started having following kind of messages:
- `api - Keyspace {keyspace} does not require cleanup`

In addition to the following one supported by all other existing Scylla versions:
- `api - force_keyspace_cleanup: keyspace={keyspace} `

So, add support for the new message type to make the `test_add_new_node_and_check_old_nodes_are_cleaned_up` K8S functional test work correctly with any Scylla version.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
