### PR TITLE
fix(rolling-upgrades): ignore audit related log errors

### DIFF
--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -131,6 +131,16 @@ def enable_default_filters(sct_config: SCTConfiguration):  # pylint: disable=unu
                                 event_class=CassandraStressLogEvent.ConsistencyError,
                                 regex=r".*Authentication error on host.*Cannot achieve consistency level for cl ONE").publish()
 
+    if sct_config.get('new_scylla_repo') or sct_config.get('new_version'):
+        # scylladb/scylla-enterprise#3814
+        # scylladb/scylla-enterprise#3092
+        # skip audit related issue when upgrading from older versions it's default in
+        # TODO: remove when branch 2022.2 is deprecated
+        EventsSeverityChangerFilter(new_severity=Severity.WARNING,
+                                    event_class=DatabaseLogEvent.DATABASE_ERROR,
+                                    regex=r".*audit - Unexpected exception when writing login.*"
+                                          r"Cannot achieve consistency level for cl ONE").publish()
+
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: supressed').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: suppressed').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.WARNING, line='abort_requested_exception').publish()


### PR DESCRIPTION
Cause audit is enabled by default in 2022.1/2, we are getting those errors after/during upgrades, and we should ignore them until scylladb/scylla-enterprise#3814 is fixed

Ref: scylladb/scylla-enterprise#3092
Ref: scylladb/scylla-enterprise#3814

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
