### PR TITLE
fix(k8s-eks): fix EKS iamserviceaccout creation on multitenant setups

### DIFF
--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -552,10 +552,10 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):  # pylint: disable=
     def get_ec2_instance_by_id(self, instance_id):
         return boto3.resource('ec2', region_name=self.region_name).Instance(id=instance_id)
 
-    def create_iamserviceaccount_for_s3_access(self, namespace: str = SCYLLA_NAMESPACE):
+    def create_iamserviceaccount_for_s3_access(self):
         tags = ",".join([f"{key}={value}" for key, value in self.tags.items()])
         LOCALRUNNER.run(
-            f'eksctl create iamserviceaccount --name {self.k8s_scylla_cluster_name}-member --namespace {namespace}'
+            f'eksctl create iamserviceaccount --name {self.short_cluster_name} --namespace kube-system'
             f' --cluster {self.short_cluster_name}'
             f' --attach-policy-arn arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Restore'
             f' --approve --role-name EKS_S3-{self.short_cluster_name} --region {self.region_name}'

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1690,10 +1690,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 node_pool_name=self.k8s_clusters[0].SCYLLA_POOL_NAME,
                 add_nodes=False,
             ))
-            if self.params.get('use_mgmt'):
+            if self.params.get('use_mgmt') and i == 0:
                 for k8s_cluster in self.k8s_clusters:
-                    k8s_cluster.create_iamserviceaccount_for_s3_access(
-                        namespace=self.db_clusters_multitenant[i].namespace)
+                    k8s_cluster.create_iamserviceaccount_for_s3_access()
         self.db_cluster = self.db_clusters_multitenant[0]
 
         if self.params.get("n_loaders"):


### PR DESCRIPTION
After merge of the PR (https://github.com/scylladb/scylla-cluster-tests/pull/7088) with the S3 usage in EKS deployments all our multitenant setups on this backend started failing the following way:

```
  Error: failed to create iamserviceaccount(s)
```

It is caused by the fact that there was attempt to create an iamserviceaccount per tenant.
But it must be done only per K8S cluster.

So, fix it by calling the appropriate function just once per K8S cluster.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/valerii/job/vp-longevity-scylla-operator-3h-multitenant-eks/61

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
