### PR TITLE
fix(k8s-eks): properly name the service account with S3 access

### DIFF
--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -559,8 +559,8 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):  # pylint: disable=
     def create_iamserviceaccount_for_s3_access(self):
         tags = ",".join([f"{key}={value}" for key, value in self.tags.items()])
         LOCALRUNNER.run(
-            f'eksctl create iamserviceaccount --name {self.short_cluster_name} --namespace kube-system'
-            f' --cluster {self.short_cluster_name}'
+            f'eksctl create iamserviceaccount --name s3-sa-for-{self.short_cluster_name.lower()}'
+            f' --namespace kube-system --cluster {self.short_cluster_name}'
             f' --attach-policy-arn arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Restore'
             f' --approve --role-name EKS_S3-{self.short_cluster_name} --region {self.region_name}'
             f' --tags {tags} --override-existing-serviceaccounts')


### PR DESCRIPTION
Recently, we started getting following error:

```
  failed to create service account kube-system/functional-PR-7174-832d6dde: \
  ServiceAccount "functional-PR-7174-832d6dde" is invalid: metadata.name: \
  Invalid value: "functional-PR-7174-832d6dde": a lowercase RFC 1123 subdomain \
  must consist of lower case alphanumeric characters, '-' or '.', \
  and must start and end with an alphanumeric character (e.g. 'example.com', \
  regex used for validation is \
  '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

So, transform all uppercase symbols to the lowercase ones.
Also, add prefix in the same refering to the target resources access - `s3`.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
