### PR TITLE
fix(k8s-eks): make iamserviceaccount for s3 access be shorter

### DIFF
--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -559,7 +559,7 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):  # pylint: disable=
     def create_iamserviceaccount_for_s3_access(self):
         tags = ",".join([f"{key}={value}" for key, value in self.tags.items()])
         LOCALRUNNER.run(
-            f'eksctl create iamserviceaccount --name s3-sa-for-{self.short_cluster_name.lower()}'
+            'eksctl create iamserviceaccount --name s3-access-sa'
             f' --namespace kube-system --cluster {self.short_cluster_name}'
             f' --attach-policy-arn arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Restore'
             f' --approve --role-name EKS_S3-{self.short_cluster_name} --region {self.region_name}'


### PR DESCRIPTION
It comes out that we may get following error deploying EKS cluster:

```
  creating CloudFormation stack "eksctl-longev-scylla-operat-3h-master-\
    85a635da-addon-iamserviceaccount-kube-system-s3-sa-for-longev-scylla-\
    operat-3h-master-85a635da": operation error CloudFormation: \
    CreateStack, https response error StatusCode: 400, \
    RequestID: 71e436e2-620f-40b3-a20d-f765c402e503, \
    api error ValidationError: Stack name cannot exceed 128 characters
```

So, make the iamserviceaccount dedicated
for providing access to the S3 service have shorter name to avoid described errors.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
