### PR TITLE
fix(k8s-eks): make S3 access really work on multi-tenant setups

### DIFF
--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -556,14 +556,14 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):  # pylint: disable=
     def get_ec2_instance_by_id(self, instance_id):
         return boto3.resource('ec2', region_name=self.region_name).Instance(id=instance_id)
 
-    def create_iamserviceaccount_for_s3_access(self):
+    def create_iamserviceaccount_for_s3_access(self, db_cluster_name: str, namespace: str = SCYLLA_NAMESPACE):
         tags = ",".join([f"{key}={value}" for key, value in self.tags.items()])
         LOCALRUNNER.run(
-            'eksctl create iamserviceaccount --name s3-access-sa'
-            f' --namespace kube-system --cluster {self.short_cluster_name}'
+            f'eksctl create iamserviceaccount --name {db_cluster_name}-member'
+            f' --namespace {namespace} --cluster {self.short_cluster_name}'
             f' --attach-policy-arn arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Restore'
-            f' --approve --role-name EKS_S3-{self.short_cluster_name} --region {self.region_name}'
-            f' --tags {tags} --override-existing-serviceaccounts')
+            f' --approve --role-name EKS_S3-{self.short_cluster_name}--{db_cluster_name}'
+            f' --region {self.region_name} --tags {tags} --override-existing-serviceaccounts')
 
     def create_scylla_manager_agent_config(self, s3_provider_endpoint: str = None, namespace: str = SCYLLA_NAMESPACE):
         if s3_provider_endpoint:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1691,9 +1691,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 node_pool_name=self.k8s_clusters[0].SCYLLA_POOL_NAME,
                 add_nodes=False,
             ))
-            if self.params.get('use_mgmt') and i == 0:
+            if self.params.get('use_mgmt'):
                 for k8s_cluster in self.k8s_clusters:
-                    k8s_cluster.create_iamserviceaccount_for_s3_access()
+                    k8s_cluster.create_iamserviceaccount_for_s3_access(
+                        db_cluster_name=self.db_clusters_multitenant[i].scylla_cluster_name,
+                        namespace=self.db_clusters_multitenant[i].namespace)
         self.db_cluster = self.db_clusters_multitenant[0]
 
         if self.params.get("n_loaders"):


### PR DESCRIPTION
Create separate unique AWS IAM role for each of the K8S service accounts used by Scylla clusters we create.
It will enable the possibility to use scylla manager in each of the Scylla tenants.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
