### PR TITLE
fix(alternator): skip YSCB `Connection refused` during restore nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2866,7 +2866,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                                                    timeout=6*60)  # giving 6 minutes to restore the schema
             assert restore_task.status == TaskStatus.DONE, \
                 f'Schema restoration of {chosen_snapshot_tag} has failed!'
-            self.cluster.restart_scylla()  # After schema restoration, you should restart the nodes
+
+            with ignore_ycsb_connection_refused():
+                self.cluster.restart_scylla()  # After schema restoration, you should restart the nodes
 
         restore_task = mgr_cluster.create_restore_task(restore_data=True,
                                                        location_list=location_list,


### PR DESCRIPTION
this nemesis is doing a full cluster restart, and that can cause YCSB get connection refuse errors, cause of the DNS based load balancer that we currently use.

those errors can be ignored.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
