### PR TITLE
fix(log-tunnel): enable back log tunnelling

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -375,6 +375,14 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     def _init_port_mapping(self):
         if self.test_config.IP_SSH_CONNECTIONS == 'public':
+            if self.test_config.SYSLOGNG_ADDRESS:
+                try:
+                    ContainerManager.destroy_container(self, "auto_ssh:syslog_ng", ignore_keepalive=True)
+                except NotFound:
+                    pass
+                ContainerManager.run_container(self, "auto_ssh:syslog_ng",
+                                               local_port=self.test_config.SYSLOGNG_ADDRESS[1],
+                                               remote_port=self.test_config.SYSLOGNG_SSH_TUNNEL_LOCAL_PORT)
             if self.test_config.LDAP_ADDRESS and self.parent_cluster.node_type == "scylla-db":
                 try:
                     ContainerManager.destroy_container(self, "auto_ssh:ldap", ignore_keepalive=True)


### PR DESCRIPTION
when we connect to nodes via public network, we enable reverse tunneling for sending back the logs from the nodes,

as part of 4d68bf52165b54116683184f2a0561a13e3b95f3, we remove this part of the code (since it was labeled as rsyslog), this change it putting it back into the code

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- - [x] https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-5gb-1h-BlockNetworkMonkey-aws-test/3/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
