### PR TITLE
feature(sdcm/reporting): Initial tooling version reporting

### DIFF
--- a/sdcm/reporting/tooling_reporter.py
+++ b/sdcm/reporting/tooling_reporter.py
@@ -1,0 +1,87 @@
+import logging
+
+from cassandra import __version__ as PYTHON_DRIVER_VERSION
+from argus.client.sct.client import ArgusSCTClient
+from argus.client.sct.types import Package
+
+from sdcm.remote.base import CommandRunner
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ToolReporterBase():
+
+    TOOL_NAME = None
+
+    def __init__(self, runner: CommandRunner, command_prefix: str = None, argus_client: ArgusSCTClient = None) -> None:
+        self.runner = runner
+        self.command_prefix = command_prefix
+        self.argus_client = argus_client
+        self.version: str | None = None
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}()"
+
+    def _report_to_log(self) -> None:
+        LOGGER.info("%s: %s version is %s", self, self.TOOL_NAME, self.version)
+
+    def _report_to_argus(self) -> None:
+        if not self.argus_client:
+            LOGGER.warning("%s: Skipping reporting to argus, client not initialized.", self)
+            return
+
+        package = Package(name=f"{self.TOOL_NAME}", version=self.version,
+                          date=None, revision_id=None, build_id=None)
+        self.argus_client.submit_packages([package])
+
+    def _collect_version_info(self) -> None:
+        raise NotImplementedError()
+
+    def report(self) -> None:
+        self._collect_version_info()
+        if not self.version:
+            LOGGER.warning("%s: Version not collected, skipping report...", self)
+            return
+        self._report_to_log()
+        self._report_to_argus()
+
+
+class PythonDriverReporter(ToolReporterBase):
+    # pylint: disable=too-few-public-methods
+    """
+        Reports python-driver version used for SCT operations.
+    """
+
+    TOOL_NAME = "scylla-cluster-tests/python-driver"
+
+    def __init__(self, argus_client: ArgusSCTClient = None) -> None:
+        super().__init__(None, "", argus_client)
+
+    def _collect_version_info(self):
+        self.version = PYTHON_DRIVER_VERSION
+
+
+class CassandraStressVersionReporter(ToolReporterBase):
+    # pylint: disable=too-few-public-methods
+    TOOL_NAME = "cassandra-stress"
+
+    def _collect_version_info(self) -> None:
+        output = self.runner.run(f"{self.command_prefix} {self.TOOL_NAME} version")
+        LOGGER.info("%s: Collected cassandra-stress output:\n%s", self, output.stdout)
+        field_map = {
+            "Version": "cassandra-stress",
+            "scylla-java-driver": "scylla-java-driver",
+        }
+        result = {}
+        for line in output.stdout.splitlines():
+            try:
+                key, value = line.split(":", 2)
+                if not (field_name := field_map.get(key)):
+                    continue
+                result[field_name] = value.strip()
+            except ValueError:
+                continue
+        LOGGER.info("Result:\n%s", result)
+        self.version = f"{result.get('cassandra-stress', '#FAILED_CHECK_LOGS')}"
+        if driver_version := result.get("scylla-java-driver"):
+            self.version += f" (with java-driver {driver_version})"

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -59,6 +59,7 @@ from sdcm.cql_stress_cassandra_stress_thread import CqlStressCassandraStressThre
 from sdcm.provision.azure.provisioner import AzureProvisioner
 from sdcm.provision.network_configuration import ssh_connection_ip_type
 from sdcm.provision.provisioner import provisioner_factory
+from sdcm.reporting.tooling_reporter import PythonDriverReporter
 from sdcm.scan_operation_thread import ScanOperationThread
 from sdcm.nosql_thread import NoSQLBenchStressThread
 from sdcm.scylla_bench_thread import ScyllaBenchThread
@@ -359,6 +360,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         self.init_argus_run()
         self.argus_heartbeat_stop_signal = self.start_argus_heartbeat_thread()
+        PythonDriverReporter(argus_client=self.test_config.argus_client()).report()
         self.localhost = self._init_localhost()
 
         if self.params.get("logs_transport") == 'syslog-ng':


### PR DESCRIPTION
This commit adds a helper class and an interface to report versions of
various tools used in SCT test runs. Currently, the example
implementation includes support for reporting scylla's python-driver
version to both log and argus. Each class receives a node and
(optionally) an argus client and then user calls .report() method to
collect the data (tool implementation specific, for other tools the plan
is to use node.remoter to get specific versions and report them as
'node.name/tool_version' to both log and argus.

Task: scylladb/qa-tasks#1543

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Jenkins](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/alexey/job/alexey-argus-testing/64/)
- [x] [Argus](https://argus.scylladb.com/test/b0b22734-758e-47b4-b6ec-29e64d212d52/runs?additionalRuns[]=a71a7de0-5848-4c05-8fa8-99231d5ce817)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
