### PR TITLE
fix(azure): find formal images in community gallary

### DIFF
--- a/docker/env/version
+++ b/docker/env/version
@@ -1,1 +1,1 @@
-1.59-pygithub
+1.60-update-azure-compute

--- a/requirements.in
+++ b/requirements.in
@@ -41,7 +41,7 @@ google-cloud-storage==2.10.0
 google-cloud-compute==1.13.0
 pip-tools==6.13.0
 azure-identity==1.6.1
-azure-mgmt-compute==23.0.0
+azure-mgmt-compute==30.5.0
 azure-mgmt-network==19.0.0
 azure-mgmt-resource==20.0.0
 azure-mgmt-subscription==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,9 +53,9 @@ azure-identity==1.6.1 \
     --hash=sha256:69035c81f280fac5fa9c55f87be3a359b264853727486e3568818bb43988080e \
     --hash=sha256:6f4f8c1ba2887cf3e1663be324fde278fce52d781123ad95c07d2c9d9cdeef5a
     # via -r requirements.in
-azure-mgmt-compute==23.0.0 \
-    --hash=sha256:1eb26b965ba4049ddcf10d4f25818725fc03c491c3be76537d0d74ceb1146b04 \
-    --hash=sha256:3efc8084744d1f275a6eb2ed8c920da34f54b0c8c97acb217ea34c9f6821824e
+azure-mgmt-compute==30.5.0 \
+    --hash=sha256:b65a6c1e22be7334604257d8d9f96a9c6dc4c6d4869f95d0d551c7c8170a2e71 \
+    --hash=sha256:ed3ea34b799db0d52ee55e2f1ab4b0f09fa4a08f35e061ecb9aad9fb5a218844
     # via -r requirements.in
 azure-mgmt-core==1.4.0 \
     --hash=sha256:81071675f186a585555ef01816f2774d49c1c9024cb76e5720c3c0f6b337bb7d \
@@ -132,9 +132,9 @@ botocore==1.31.4 \
     #   awscli
     #   boto3
     #   s3transfer
-botocore-stubs==1.34.34 \
-    --hash=sha256:34f4d446f9eed92bee62a0fc303b712d112a84aa356e3dccea2863ac79d9ef14 \
-    --hash=sha256:38baf7068641edf57a215970caf273aad2e959ce0c5b93b39e9fa37ba49c30db
+botocore-stubs==1.34.40 \
+    --hash=sha256:50870a5ac8b638dac575aa26d92506dda8cc38e179f93ce2ffe48197ce054dbf \
+    --hash=sha256:d6322bfb9aa882006fe7f8fc3d8a933a66c5627dcf571e65d65a5233c6c172be
     # via boto3-stubs
 build==1.0.3 \
     --hash=sha256:538aab1b64f9828977f84bc63ae570b060a8ed1be419e7870b8b4fc5e6ea553b \
@@ -410,9 +410,9 @@ geomet==0.2.1.post1 \
     --hash=sha256:91d754f7c298cbfcabd3befdb69c641c27fe75e808b27aa55028605761d17e95 \
     --hash=sha256:a41a1e336b381416d6cbed7f1745c848e91defaa4d4c1bdc1312732e46ffad2b
     # via scylla-driver
-google-api-core[grpc]==2.16.2 \
-    --hash=sha256:032d37b45d1d6bdaf68fb11ff621e2593263a239fa9246e2e94325f9c47876d2 \
-    --hash=sha256:449ca0e3f14c179b4165b664256066c7861610f70b6ffe54bb01a04e9b466929
+google-api-core[grpc]==2.17.0 \
+    --hash=sha256:08ed79ed8e93e329de5e3e7452746b734e6bf8438d8d64dd3319d21d3164890c \
+    --hash=sha256:de7ef0450faec7c75e0aea313f29ac870fdc44cfaec9d6499a9a17305980ef66
     # via
     #   google-api-python-client
     #   google-cloud-compute
@@ -604,9 +604,9 @@ humanreadable==0.4.0 \
     --hash=sha256:2879a146f0602512addfcfba227956a3f1d23b99e9f938ff91b2085a170519ba \
     --hash=sha256:5b70257a8e88856f9b64a1f0a6fb7535c9002818465e298ca27d745b25e5675d
     # via tcconfig
-identify==2.5.33 \
-    --hash=sha256:161558f9fe4559e1557e1bff323e8631f6a0e4837f7497767c1782832f16b62d \
-    --hash=sha256:d40ce5fcd762817627670da8a7d8d8e65f24342d14539c59488dc603bf662e34
+identify==2.5.34 \
+    --hash=sha256:a4316013779e433d08b96e5eabb7f641e6c7942e4ab5d4c509ebd2e7a8994aed \
+    --hash=sha256:ee17bc9d499899bc9eaec1ac7bf2dc9eedd480db9d88b96d123d3b64a9d34f5d
     # via pre-commit
 idna==3.6 \
     --hash=sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca \
@@ -627,6 +627,7 @@ isodate==0.6.1 \
     --hash=sha256:0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96 \
     --hash=sha256:48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9
     # via
+    #   azure-mgmt-compute
     #   azure-storage-blob
     #   msrest
 isort==5.13.2 \
@@ -787,7 +788,6 @@ msrest==0.7.1 \
     --hash=sha256:21120a810e1233e5e6cc7fe40b474eeb4ec6f757a15d7cf86702c369f9567c32 \
     --hash=sha256:6e7661f46f3afd88b75667b7187a92829924446c7ea1d169be8c4bb7eeb788b9
     # via
-    #   azure-mgmt-compute
     #   azure-mgmt-network
     #   azure-mgmt-resource
     #   azure-mgmt-resourcegraph
@@ -1123,8 +1123,9 @@ pyproject-hooks==1.0.0 \
     --hash=sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8 \
     --hash=sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5
     # via build
-pyroute2==0.7.11 \
-    --hash=sha256:95852e702149b3d6abc8484d3291c38c45660168e8db76e5566a60ef0e133d5b
+pyroute2==0.7.12 \
+    --hash=sha256:54d226fc3ff2732f49bac9b26853c50c9d05be05a4d9daf09c7cf6d77301eff3 \
+    --hash=sha256:9df8d0fcb5fb0a724603bcfdef76ffbd287f00f69e9fb660c20a06962b24691a
     # via tcconfig
 pytest==7.2.0 \
     --hash=sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71 \
@@ -1568,9 +1569,9 @@ pip==24.0 \
     --hash=sha256:ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc \
     --hash=sha256:ea9bd1a847e8c5774a5777bb398c19e80bcd4e2aa16a4b301b718fe6f593aba2
     # via pip-tools
-setuptools==69.0.3 \
-    --hash=sha256:385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05 \
-    --hash=sha256:be1af57fc409f93647f2e8e4573a142ed38724b8cdd389706a867bb4efcf1e78
+setuptools==69.1.0 \
+    --hash=sha256:850894c4195f09c4ed30dba56213bf7c3f21d86ed6bdaafb5df5972593bfc401 \
+    --hash=sha256:c054629b81b946d63a9c6e732bc8b2513a7c3ea645f11d0139a2191d735c60c6
     # via
     #   anyconfig
     #   astroid

--- a/sct.py
+++ b/sct.py
@@ -635,10 +635,10 @@ def list_images(cloud_provider: str, branch: str, version: str, region: str, arc
             case "azure":
                 if arch:
                     click.echo("WARNING:--arch option not implemented currently for Azure machine images.")
-                azure_images = azure_utils.get_scylla_images(scylla_version=version, region_name=region)
+                azure_images = azure_utils.get_released_scylla_images(scylla_version=version, region_name=region)
                 rows = []
                 for image in azure_images:
-                    rows.append(['Azure', image.name, image.id, 'N/A'])
+                    rows.append(['Azure', image.name, image.unique_id, 'N/A'])
                 click.echo(
                     create_pretty_table(rows=rows, field_names=version_fields).get_string(
                         title="Azure Machine Images by version")

--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -212,6 +212,11 @@ class VirtualMachineProvider:
                 "image_reference": {"id": image_id},
                 "deleteOption": "Delete"
             })
+        elif image_id.startswith("/CommunityGalleries/"):
+            storage_profile['storage_profile'].update({
+                "image_reference": {"community_gallery_image_id": image_id},
+                "deleteOption": "Delete"
+            })
         else:
             image_reference_values = image_id.split(":")
             storage_profile['storage_profile'].update({

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1751,14 +1751,20 @@ class SCTConfiguration(dict):
 
                 for region in azure_region_names:
                     try:
-                        azure_image = azure_utils.get_scylla_images(scylla_version, region)[0]
+                        if ":" in scylla_version:
+                            azure_image = azure_utils.get_scylla_images(
+                                scylla_version=scylla_version, region_name=region)[0]
+                        else:
+                            azure_image = azure_utils.get_released_scylla_images(
+                                scylla_version=scylla_version, region_name=region)[0]
                     except Exception as ex:
                         raise ValueError(
                             f"Azure Image for scylla_version='{scylla_version}' not found in {region}") from ex
                     self.log.debug("Found Azure Image %s for scylla_version='%s' in %s",
                                    azure_image.name, scylla_version, region)
                     scylla_azure_images.append(azure_image)
-                self["azure_image_db"] = " ".join(image.id for image in scylla_azure_images)
+                self["azure_image_db"] = " ".join(getattr(image, 'id', None) or getattr(
+                    image, 'unique_id', None) for image in scylla_azure_images)
             elif not self.get('scylla_repo'):
                 self['scylla_repo'] = find_scylla_repo(scylla_version, dist_type, dist_version)
             else:


### PR DESCRIPTION
since this is the way to lookup the images our use would use we are switching to this method, without it we can pickup unpromoated images, which can lead to rolling upgrades to fail, since base and target would be identical

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] azure provision test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
