### PR TITLE
fix(pipelines): dereference all symlink

### DIFF
--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-amazon2-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-amazon2-arm.jenkinsfile
@@ -1,1 +1,14 @@
-../artifacts/artifacts-amazon2-arm.jenkinsfile
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: '''["test-cases/artifacts/amazon2.yaml", "configurations/arm/amazon2.yaml"]''',
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'spot_low_price',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-amazon2.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-amazon2.jenkinsfile
@@ -1,1 +1,14 @@
-../artifacts/artifacts-amazon2.jenkinsfile
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/amazon2.yaml',
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'spot_low_price',
+
+    timeout: [time: 60, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-centos7.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-centos7.jenkinsfile
@@ -1,1 +1,13 @@
-../artifacts/artifacts-centos7.jenkinsfile
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/centos7.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-centos8-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-centos8-arm.jenkinsfile
@@ -1,1 +1,14 @@
-../artifacts/artifacts-centos8-arm.jenkinsfile
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: '''["test-cases/artifacts/centos8.yaml", "configurations/arm/centos8.yaml"]''',
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'spot_low_price',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-centos8-selinux.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-centos8-selinux.jenkinsfile
@@ -1,1 +1,13 @@
-../artifacts/artifacts-centos8-selinux.jenkinsfile
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/centos8-selinux.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-centos8.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-centos8.jenkinsfile
@@ -1,1 +1,13 @@
-../artifacts/artifacts-centos8.jenkinsfile
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/centos8.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-debian10-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-debian10-arm.jenkinsfile
@@ -1,1 +1,14 @@
-../artifacts/artifacts-debian10-arm.jenkinsfile
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: '''["test-cases/artifacts/debian10.yaml", "configurations/arm/debian10.yaml"]''',
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'spot_low_price',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-debian10.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-debian10.jenkinsfile
@@ -1,1 +1,13 @@
-../artifacts/artifacts-debian10.jenkinsfile
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/debian10.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-debian11.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-debian11.jenkinsfile
@@ -1,1 +1,13 @@
-../artifacts/artifacts-debian11.jenkinsfile
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/debian11.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-oel76.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-oel76.jenkinsfile
@@ -1,1 +1,14 @@
-../artifacts/artifacts-oel76.jenkinsfile
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/oel76.yaml',
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'spot_low_price',
+
+    timeout: [time: 60, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-oel81.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-oel81.jenkinsfile
@@ -1,1 +1,14 @@
-../artifacts/artifacts-oel81.jenkinsfile
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/oel81.yaml',
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'spot_low_price',
+
+    timeout: [time: 60, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-rocky8.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-rocky8.jenkinsfile
@@ -1,1 +1,13 @@
-../artifacts/artifacts-rocky8.jenkinsfile
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/rocky8.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-rocky9.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-rocky9.jenkinsfile
@@ -1,1 +1,13 @@
-../artifacts/artifacts-rocky9.jenkinsfile
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/rocky9.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2004-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2004-arm.jenkinsfile
@@ -1,1 +1,14 @@
-../artifacts/artifacts-ubuntu2004-arm.jenkinsfile
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: '''["test-cases/artifacts/ubuntu2004.yaml", "configurations/arm/ubuntu2004.yaml"]''',
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'spot_low_price',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2004.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2004.jenkinsfile
@@ -1,1 +1,13 @@
-../artifacts/artifacts-ubuntu2004.jenkinsfile
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/ubuntu2004.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+
+    timeout: [time: 35, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2204-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2204-arm.jenkinsfile
@@ -1,1 +1,14 @@
-../artifacts/artifacts-ubuntu2204-arm.jenkinsfile
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: '''["test-cases/artifacts/ubuntu2204.yaml", "configurations/arm/ubuntu2204.yaml"]''',
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'spot_low_price',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2204.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2204.jenkinsfile
@@ -1,1 +1,13 @@
-../artifacts/artifacts-ubuntu2204.jenkinsfile
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/ubuntu2204.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+
+    timeout: [time: 35, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade.jenkinsfile
+++ b/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade.jenkinsfile
@@ -1,1 +1,12 @@
-../scylla-master/scylla-master-perf-regression-latency-650gb-during-rolling-upgrade.jenkinsfile
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    base_versions: '',  // auto mode
+    backend: "aws",
+    test_name: "performance_regression_test.PerformanceRegressionUpgradeTest",
+    test_config: """["test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml", "configurations/perf-regression-upgrade.yaml"]""",
+    sub_tests: ["test_latency_write_with_upgrade", "test_latency_read_with_upgrade", "test_latency_mixed_with_upgrade"]
+)

--- a/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-grow-shrink.jenkinsfile
+++ b/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-grow-shrink.jenkinsfile
@@ -1,1 +1,12 @@
-../scylla-master/scylla-master-perf-regression-latency-650gb-grow-shrink.jenkinsfile
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    availability_zone: 'a,b,c',
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: """["test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml"]""",
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"]
+)

--- a/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-with-nemesis.jenkinsfile
@@ -1,1 +1,11 @@
-../scylla-master/scylla-master-perf-regression-latency-650gb-with-nemesis.jenkinsfile
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: """["test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml"]""",
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"]
+)

--- a/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-regression-latency-shard-aware-1TB.jenkinsfile
+++ b/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-regression-latency-shard-aware-1TB.jenkinsfile
@@ -1,1 +1,13 @@
-../scylla-master/scylla-master-perf-regression-latency-shard-aware-1TB.jenkinsfile
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/perf-loaders-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
+    sub_tests: ["test_latency"],
+    test_email_title: "shard-aware"
+)

--- a/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-simple-query-weekly-microbenchmark.jenkinsfile
+++ b/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-simple-query-weekly-microbenchmark.jenkinsfile
@@ -1,1 +1,12 @@
-../scylla-master/scylla-master-perf-simple-query-weekly-microbenchmark.jenkinsfile
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'microbenchmarking_test.PerfSimpleQueryTest.test_perf_simple_query',
+    test_config: 'test-cases/microbenchmarking/amazon_perf_simple_query_ARM.yaml',
+    email_recipients: "scylla-perf-results@scylladb.com"
+)

--- a/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64.jenkinsfile
+++ b/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64.jenkinsfile
@@ -1,1 +1,12 @@
-../scylla-master/scylla-master-perf-simple-query-weekly-microbenchmark_x86_64.jenkinsfile
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'microbenchmarking_test.PerfSimpleQueryTest.test_perf_simple_query',
+    test_config: """[ 'test-cases/microbenchmarking/amazon_perf_simple_query_ARM.yaml', 'test-cases/microbenchmarking/amazon_perf_simple_query_x86.yaml' ]""",
+    email_recipients: "scylla-perf-results@scylladb.com"
+)


### PR DESCRIPTION
seems like jenkinks doesn't run pipelines which are symlink and fails like the following:

```
09:48:17  org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
09:48:17  WorkflowScript: 1: unexpected token: .. @ line 1, column 1.
09:48:17     ../artifacts/artifacts-centos8.jenkinsfile
09:48:17     ^
09:48:17
09:48:17  1 error
```

so we'll copy all the symlink, until we can figure out a better option for this use case of identical pipelines, we need in multiple locations

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
