### PR TITLE
improvement(bisection): add bisect decorator

### DIFF
--- a/docs/bisecting-with-sct.md
+++ b/docs/bisecting-with-sct.md
@@ -1,0 +1,50 @@
+# Bisecting with SCT
+There was an effort to make it easier to bisect with SCT (performance tests). The following is a guide on how to do it.
+currently works with ubuntu/debian only.
+
+# steps
+## modify test
+1. decorate the test you want to bisect with the `@bisect_test` decorator (from `from sdcm.utils.bisect_test import bisect_test`)
+2. Decorator will add two class variables to the test class:
+    * `bisect_result_value` - defines current test result value as comparable number
+    * `bisect_ref_value` - define reference test result value as comparable number
+3. Make the test to set `bisect_ref_value` only for the first test run
+4. Each run should also update `bisect_result_value` with the result value for further comparison
+3. Upon test end, decorator will compare `bisect_result_value` and `bisect_ref_value` - if result value is greater than reference value, will mark current
+Scylla version as 'good', otherwise as 'bad'
+4. bisect decorator will erase data, reinstall Scylla to next bisected version (based on result) and rerun the test
+
+## run test
+Run test with providing `bisect_start_date` and `bisect_end_date` (optionally) sct config variables.
+Also adapt `test_duration` to larger value (e.g. 8x current duration).
+Based on these dates, decorator will
+find available packages and start bisecting process.
+Verify logs to see last good and bad Scylla versions.
+
+# example
+```python
+from sdcm.utils.bisect_test import bisect_test
+
+@bisect_test
+def test_write(self):
+    base_cmd_w = self.params.get('stress_cmd_w')
+    stress_multiplier = self.params.get('stress_multiplier')
+    if stress_multiplier_w := self.params.get("stress_multiplier_w"):
+        stress_multiplier = stress_multiplier_w
+
+    self.create_test_stats(doc_id_with_timestamp=True)
+    self.run_fstrim_on_all_db_nodes()
+
+    stress_queue = self.run_stress_thread(
+        stress_cmd=base_cmd_w, stress_num=stress_multiplier, stats_aggregate_cmds=False)
+    results = self.get_stress_results(queue=stress_queue)
+
+    # set bisect_ref_value only for the first test run
+    self.bisect_ref_value = self.bisect_result_value * 0.95 if self.bisect_ref_value is None else self.bisect_ref_value
+    # update bisect_result_value with the result value for further comparison
+    self.bisect_result_value = sum([int(result['op rate']) for result in results])
+    self.build_histogram(PerformanceTestWorkload.WRITE, PerformanceTestType.THROUGHPUT)
+    self.update_test_details(scylla_conf=True)
+    self.display_results(results, test_name='test_write')
+    self.check_regression()
+```

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1542,6 +1542,13 @@ class SCTConfiguration(dict):
         dict(name="use_capacity_reservation", env="SCT_USE_CAPACITY_RESERVATION", type=boolean,
              help="""reserves instances capacity for whole duration of the test run (AWS only).
              Fallbacks to next availabilit zone if capacity is not available"""),
+
+        dict(name="bisect_start_date", env="SCT_BISECT_START_DATE", type=str,
+             help="""Scylla build date from which bisecting should start.
+              Setting this date enables bisection. Format: YYYY-MM-DD"""),
+
+        dict(name="bisect_end_date", env="SCT_BISECT_END_DATE", type=str,
+             help="""Scylla build date until which bisecting should run. Format: YYYY-MM-DD"""),
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -389,6 +389,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         time.sleep(0.5)
         InfoEvent(message=f"TEST_START test_id={self.test_config.test_id()}").publish()
+        self.bisect_ref_value = None
+        self.bisect_result_value = None
 
     def _init_test_duration(self):
         self._stress_duration: int = self.params.get('stress_duration')

--- a/sdcm/utils/bisect_test.py
+++ b/sdcm/utils/bisect_test.py
@@ -1,0 +1,134 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2024 ScyllaDB
+
+from datetime import datetime
+from logging import getLogger
+from functools import wraps
+
+import boto3
+import requests
+from sdcm.utils.common import ParallelObject
+from sdcm.sct_events.system import TestFrameworkEvent
+from sdcm.sct_events import Severity
+
+
+logger = getLogger(__name__)
+
+
+def get_repo_urls(start_date: datetime, end_date: datetime, is_enterprise: bool = False):
+    bucket = 'downloads.scylladb.com'
+    logger.debug("getting repo urls for is_enterprise: %s date range: %s - %s", is_enterprise, start_date, end_date)
+    if is_enterprise:
+        prefix = 'unstable/scylla-enterprise/enterprise/deb/unified/'
+        suffix = 'scylladb-enterprise/scylla.list'
+    else:
+        prefix = 'unstable/scylla/master/deb/unified/'
+        suffix = 'scylladb-master/scylla.list'
+    response = boto3.client('s3').list_objects_v2(Bucket=bucket, Prefix=prefix, Delimiter='/')
+    dates = [obj['Prefix'].rsplit('/', 2)[-2]
+             for obj in response.get("CommonPrefixes", []) if obj['Prefix'].endswith("Z/")]
+    repos = [f"https://{bucket}/{prefix}{date}/{suffix}" for date in dates if
+             start_date <= datetime.strptime(date, '%Y-%m-%dT%H:%M:%SZ') <= end_date]
+    repos = [repo for repo in repos if requests.head(repo).ok]  # filter out non-existing repos
+    logger.debug("Repos to bisect: %s", repos)
+    return repos
+
+
+def bisect_test(test_func):  # pylint: disable=too-many-statements
+    """
+    decorator for bisecting tests.
+
+    Wrap a test function with this decorator and supply `bisect_start_date` and `bisect_end_date` to sct_config class to bisect it.
+    Before bisecting, test function will be called once with the initial binaries and must set the reference value
+    (`bisect_ref_value` attribute of tester class, int type).
+    Test function should update `bisect_result_value` attribute (int type) of tester class on each run.
+    On each iteration, the decorator will update the binaries according to bisection algorithm
+    and `tester.bisect_result_value` >= `bisect_ref_value` comparison result - if is true, means result is ok (no regression).
+    """
+
+    @wraps(test_func)
+    def wrapper(*args, **kwargs):  # pylint: disable=too-many-locals, too-many-statements
+        tester_obj = args[0]
+        start_date = tester_obj.params.get('bisect_start_date')
+        test_func(*args, **kwargs)
+        if not start_date:
+            # no bisect start date, no need to bisect
+            return
+        cluster = tester_obj.db_cluster
+        tester_obj.create_stats = False
+
+        def update_binaries(node):
+            node.stop_scylla()
+            cluster._scylla_install(node)  # pylint: disable=protected-access
+
+        end_date = tester_obj.params.get('bisect_end_date')
+        bisect_start_date = datetime.strptime(start_date, '%Y-%m-%d')
+        bisect_end_date = datetime.strptime(end_date, '%Y-%m-%d') if end_date else datetime.today()
+        repo_urls = get_repo_urls(bisect_start_date, bisect_end_date, is_enterprise=cluster.nodes[0].is_enterprise)
+
+        low, high = 0, len(repo_urls) - 1
+        last_good_version = 'unknown'
+        first_bad_version = 'unknown'
+        version = 'unknown'
+        while low <= high:
+            tester_obj.stop_timeout_thread()
+            tester_obj._init_test_timeout_thread()  # pylint: disable=protected-access
+            mid = (low + high) // 2
+            repo_url = repo_urls[mid]
+            tester_obj.params['scylla_repo'] = repo_url
+            logger.info("Updating binaries from repo: %s", repo_url)
+            parallel_object = ParallelObject(cluster.nodes, num_workers=len(cluster.nodes), timeout=500)
+            try:
+                parallel_object.run(update_binaries)
+                for idx, node in enumerate(cluster.nodes):
+                    logger.info('starting updated node: %s', node.name)
+                    if idx == 0:  # make first node a seed to bootstrap it properly after full cluster cleanup
+                        with node.remote_scylla_yaml() as scylla_yml:
+                            current_seed_provider = scylla_yml.seed_provider
+                            original_seed_provider = current_seed_provider.copy()
+                            current_seed_provider[0].parameters = [{"seeds": str(node.private_ip_address)}]
+                            scylla_yml.seed_provider = current_seed_provider
+                        node.start_scylla()
+                        node.wait_db_up()
+                        # and recover seeds to original state
+                        with node.remote_scylla_yaml() as scylla_yml:
+                            scylla_yml.seed_provider = original_seed_provider
+                    else:
+                        node.start_scylla()
+                        node.wait_db_up()
+                    version = node.get_scylla_binary_version()
+                    if not version:
+                        raise ValueError('failed to get version from node: ', node.name)
+                    logger.info('successfully updated binaries to version: %s', version)
+
+            except Exception as exc:  # pylint: disable=broad-except
+                logger.warning('error during upgrade: %s \n verifying next closest version.', exc)
+                del repo_urls[mid]
+                high -= 1
+                continue
+
+            TestFrameworkEvent(source="bisection", message=f"Updated Scylla binaries to: {version}",
+                               severity=Severity.WARNING).publish_or_dump()
+            test_func(*args, **kwargs)
+            logger.info("Evaluating regression: %s >= %s", tester_obj.bisect_result_value, tester_obj.bisect_ref_value)
+            if tester_obj.bisect_result_value >= tester_obj.bisect_ref_value:
+                last_good_version = version
+                logger.info("Version %s evaluates to False -> it's ok. Checking later versions.", version)
+                low = mid + 1
+            else:
+                first_bad_version = version
+                logger.info("Version %s evaluates to True -> it's bad. Checking earlier versions.", version)
+                high = mid - 1
+        logger.info("Last good version: %s, first bad version: %s", last_good_version, first_bad_version)
+
+    return wrapper


### PR DESCRIPTION
Added bisect decorator that adds bisection functionality to given test. Used by wrapping a test case (e.g. test_write) and by provide `bisect_start_date` and optionally `bisect_end_date` (if not provided, most recent build is used as last).

Idea of the decorator is to first run a test case which should set value for `self.bisect_ref_value` which will be used for evaluation for other Scylla versions to determine regression. Then using bisection algorithm the decorator will be updating Scylla binaries, cleaning up all data and reruning test which should update `self.bisect_result_value`. When test finishes, evaluates if regression happened by comparing `self.bisect_ref_value` >= `self.bisect_result_value`.

Binaries are taken from repo files - currently works only with ubuntu/debian only.
Bisection resolution depends on builds availabilty at downloads.scylladb.com.

Potentially `bisect_test` decorator can be easily reused for any other test.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - tested in https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/bisect-scylla-master-perf-regression-throughput-non-shard-aware-i4i-test/16/ which didn't find regression in perf test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
