### PR TITLE
fix(integration-tests): use latest OSS image

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1129,13 +1129,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 f"Failed to get 'ss' binary version\n"
                 f"stdout: {ss_version_result.stdout}\n"
                 f"stderr: {ss_version_result.stderr}")
-            if self.distro.is_rhel_like:
-                self.remoter.sudo("yum install -y iproute", ignore_status=True)
-            elif self.distro.is_sles:
-                self.remoter.sudo("zypper install -y iproute", ignore_status=True)
+            if self.distro.is_rhel_like or self.distro.is_sles:
+                self.install_package("iproute", ignore_status=True)
             else:
-                self.remoter.sudo("apt-get install -y iproute2", ignore_status=True)
-
+                self.install_package("iproute2", ignore_status=True)
         try:
             # Path to `ss' is /usr/sbin/ss for RHEL-like distros and /bin/ss for Debian-based.  Unfortunately,
             # /usr/sbin is not always in $PATH, so need to set it explicitly.

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -66,7 +66,7 @@ def fixture_docker_scylla(request: pytest.FixtureRequest):  # pylint: disable=to
     entryfile_path = entryfile_path / 'docker' / 'scylla-sct' / ('entry_ssl.sh' if ssl else 'entry.sh')
 
     alternator_flags = "--alternator-port 8000 --alternator-write-isolation=always"
-    docker_version = "scylladb/scylla-nightly:5.2.0-dev-0.20220820.516089beb0b8"
+    docker_version = docker_scylla_args.get('image', "scylladb/scylla-nightly:5.5.0-dev-0.20240213.314fd9a11f23")
     cluster = LocalScyllaClusterDummy()
 
     if ssl:
@@ -104,6 +104,7 @@ def fixture_docker_scylla(request: pytest.FixtureRequest):  # pylint: disable=to
             logging.error("Error checking for scylla up normal: %s", details)
             return False
 
+    scylla.remoter.run('apt-get update')
     wait.wait_for(func=db_up, step=1, text='Waiting for DB services to be up', timeout=120, throw_exc=True)
     wait.wait_for(func=db_alternator_up, step=1, text='Waiting for DB services to be up alternator)',
                   timeout=120, throw_exc=True)

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -711,6 +711,8 @@ def test_get_any_ks_cf_list(docker_scylla, params, events):  # pylint: disable=u
     table_names = cluster.get_any_ks_cf_list(docker_scylla, filter_empty_tables=False)
     assert set(table_names) == {'system.runtime_info', 'system_distributed.cdc_generation_timestamps',
                                 'system.config', 'system.local', 'system.token_ring', 'system.clients',
+                                'system.commitlog_cleanups', 'system.discovery', 'system.group0_history',
+                                'system.raft', 'system.raft_snapshot_config', 'system.raft_snapshots', 'system.raft_state',
                                 'system_schema.tables', 'system_schema.columns', 'system.compaction_history',
                                 'system.cdc_local', 'system.versions', 'system_distributed_everywhere.cdc_generation_descriptions_v2',
                                 'system.scylla_local', 'system.cluster_status', 'system.protocol_servers',


### PR DESCRIPTION
those test were using hard-coded 5.2 develeopment version new we are using newer version, and have ability to select specific docker images per tests.

also fixing an issue with the new docker images, that they were failing to fetch the packages needed for installing iproute package. so `apt-get update` was add before we start calling `is_port_used()`

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
