### PR TITLE
feature(tablets): add trigger for one tablets case in weekly runs

### DIFF
--- a/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-grow-shrink-tablets.jenkinsfile
+++ b/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-grow-shrink-tablets.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    availability_zone: 'a,b,c',
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: """["test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml", "configurations/tablets.yaml"]""",
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
+    test_email_title: "latency during grow-shrink (tablets)",
+)

--- a/jenkins-pipelines/performance/scylla-master/scylla-master-perf-regression-latency-650gb-grow-shrink-tablets.jenkinsfile
+++ b/jenkins-pipelines/performance/scylla-master/scylla-master-perf-regression-latency-650gb-grow-shrink-tablets.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    availability_zone: 'a,b,c',
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: """["test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml", "configurations/tablets.yaml"]""",
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
+    test_email_title: "latency during grow-shrink (tablets)",
+)

--- a/jenkins-pipelines/performance/scylla-master/weekly-enterprise-performance-trigger.xml
+++ b/jenkins-pipelines/performance/scylla-master/weekly-enterprise-performance-trigger.xml
@@ -30,7 +30,7 @@ provision_type=on_demand</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>../scylla-enterprise/scylla-enterprise-perf-regression-latency-shard-aware-1TB-test,../scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-with-nemesis,../scylla-enterprise/scylla-enterprise-perf-regression-throughput-non-shard-aware-i4i-test,../scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-grow-shrink</projects>
+          <projects>../scylla-enterprise/scylla-enterprise-perf-regression-latency-shard-aware-1TB-test,../scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-with-nemesis,../scylla-enterprise/scylla-enterprise-perf-regression-throughput-non-shard-aware-i4i-test,../scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-grow-shrink,../scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-grow-shrink-tablets</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>

--- a/jenkins-pipelines/performance/scylla-master/weekly-master-performance-trigger.xml
+++ b/jenkins-pipelines/performance/scylla-master/weekly-master-performance-trigger.xml
@@ -44,7 +44,7 @@ availability_zone=b</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>scylla-master-perf-regression-latency-650gb-with-nemesis,scylla-master-perf-regression-latency-650gb-grow-shrink</projects>
+          <projects>scylla-master-perf-regression-latency-650gb-with-nemesis,scylla-master-perf-regression-latency-650gb-grow-shrink,scylla-master-perf-regression-latency-650gb-grow-shrink-tablets</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>


### PR DESCRIPTION
this introduce one pipeline across both OSS/enterprise that would enable tablets on the latency during grow shirnk case

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
