### PR TITLE
fix(sct_config): send argus resolved scylla_versions

### DIFF
--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -258,11 +258,11 @@ class TestConfig(metaclass=Singleton):  # pylint: disable=too-many-public-method
         return cls._argus_client
 
     @classmethod
-    def init_argus_client(cls, params: dict):
+    def init_argus_client(cls, params: dict, test_id: str | None = None):
         if params.get("enable_argus"):
             LOGGER.info("Initializing Argus connection...")
             try:
-                cls._argus_client = get_argus_client(run_id=cls.test_id())
+                cls._argus_client = get_argus_client(run_id=cls.test_id() if not test_id else test_id)
                 return
             except ArgusError as exc:
                 LOGGER.warning("Failed to initialize argus client: %s", exc.message)


### PR DESCRIPTION
in order that argus would be able to know what is the target version for a run, as soon as the test start (including the target versions for upgrade), so we can filter better even in the case of error to provision/configure scylla, or failure to start the upgrades.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
