### PR TITLE
fix(hydra): remove the `awscli` dependency

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -166,15 +166,6 @@ else
     echo "There is ${DOCKER_REPO}:${VERSION} in local cache, using it."
 fi
 
-# Check for SSH keys
-if [[ -z "$HYDRA_HELP" ]]; then
-    if [ -z "$HYDRA_DRY_RUN" ]; then
-        ${SCT_DIR}/get-qa-ssh-keys.sh
-    else
-        echo ${SCT_DIR}/get-qa-ssh-keys.sh
-    fi
-fi
-
 if [ -z "$HYDRA_DRY_RUN" ]; then
     DOCKER_GROUP_ARGS=()
 else

--- a/unit_tests/test_hydra_sh.py
+++ b/unit_tests/test_hydra_sh.py
@@ -109,7 +109,6 @@ class LongevityPipelineTest:
         docker_run_prefix = self.docker_run_prefix(runner)
         sct_dir = self.sct_path(runner)
         expected = (
-            f'{self.sct_base_path}/get-qa-ssh-keys.sh',
             re.compile(f"{docker_run_prefix} -l TestId=11111111-1111-1111-1111-111111111111"),
             re.compile(f"{docker_run_prefix} -v {sct_dir}:{sct_dir} .* -v /var/run:/run"),
             re.compile(f"{docker_run_prefix} --group-add 1 --group-add 2 --group-add 3"),


### PR DESCRIPTION
we don't need to fetch the keys, we can fetch them as needed inside the code, but we should do that inside the hydra docker image, and not outside of it.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] provision tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
