### PR TITLE
fix(cassandra-stress): use `hard_timeout` in `get_results()`

### DIFF
--- a/sdcm/stress/base.py
+++ b/sdcm/stress/base.py
@@ -34,6 +34,11 @@ class DockerBasedStressThread:  # pylint: disable=too-many-instance-attributes
         self.loader_set: BaseLoaderSet = loader_set
         self.stress_cmd = stress_cmd
         self.timeout = timeout
+        # prolong timeout by 10% to avoid killing stress process
+        self.hard_timeout = self.timeout + int(self.timeout * 0.1)
+        # prolong soft timeout by 5%
+        self.soft_timeout = self.timeout + int(self.timeout * 0.05)
+
         self.stress_num = stress_num
         self.node_list = node_list or []
         self.round_robin = round_robin
@@ -83,7 +88,7 @@ class DockerBasedStressThread:  # pylint: disable=too-many-instance-attributes
 
     def get_results(self):
         results = []
-        timeout = self.timeout + 120
+        timeout = self.hard_timeout + 120
         LOGGER.debug('Wait for %s stress threads results', self.max_workers)
         for future in concurrent.futures.as_completed(self.results_futures, timeout=timeout):
             results.append(future.result())
@@ -93,7 +98,7 @@ class DockerBasedStressThread:  # pylint: disable=too-many-instance-attributes
     def verify_results(self):
         results = []
         errors = []
-        timeout = self.timeout + 120
+        timeout = self.hard_timeout + 120
         LOGGER.debug('Wait for %s stress threads to verify', self.max_workers)
         for future in concurrent.futures.as_completed(self.results_futures, timeout=timeout):
             results.append(future.result())

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -361,12 +361,8 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
                 hdr_logger_context:
             publisher.event_id = cs_stress_event.event_id
             try:
-                # prolong timeout by 10% to avoid killing cassandra-stress process
-                hard_timeout = self.timeout + int(self.timeout * 0.1)
-                # prolong soft timeout by 5%
-                soft_timeout = self.timeout + int(self.timeout * 0.05)
-                with SoftTimeoutContext(timeout=soft_timeout, operation="cassandra-stress"):
-                    result = cmd_runner.run(cmd=node_cmd, timeout=hard_timeout, log_file=log_file_name, retry=0)
+                with SoftTimeoutContext(timeout=self.soft_timeout, operation="cassandra-stress"):
+                    result = cmd_runner.run(cmd=node_cmd, timeout=self.hard_timeout, log_file=log_file_name, retry=0)
             except Exception as exc:  # pylint: disable=broad-except
                 self.configure_event_on_failure(stress_event=cs_stress_event, exc=exc)
 


### PR DESCRIPTION
since we are using `SoftTimeoutContext` on the stress command with hard_timeout of 10% more the the time passed to the stress command, `get_results()` and likes should align to that time and let the ssh command itself to timeout first.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-10gb-3h-gce-test/42

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
