### PR TITLE
fix(nemesis): disable end_of_quota nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1731,6 +1731,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         8. Restart scylla server.
         9. Verify scylla is up.
         """
+        # Temporary disable due to https://github.com/scylladb/scylla-enterprise/issues/3736
+        if SkipPerIssues('https://github.com/scylladb/scylla-enterprise/issues/3736', self.tester.params):
+            raise UnsupportedNemesis('Disabled due to https://github.com/scylladb/scylla-enterprise/issues/3736')
 
         node = self.target_node
         if self._is_it_on_kubernetes():


### PR DESCRIPTION
Temporary disable disrupt_end_of_quota_nemesis due to issue https://github.com/scylladb/scylla-enterprise/issues/3736 won't be handle meanwhile

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
