### PR TITLE
Fix base trigger

### DIFF
--- a/jenkins-pipelines/upgrade-with-raft/rolling-upgrade-centos8-with-raft.jenkinsfile
+++ b/jenkins-pipelines/upgrade-with-raft/rolling-upgrade-centos8-with-raft.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '["2022.2"]',
+    base_versions: 2022.2,
     linux_distro: 'centos-8',
     disable_raft: false,
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-8',

--- a/jenkins-pipelines/upgrade-with-raft/rolling-upgrade-debian11-with-raft.jenkinsfile
+++ b/jenkins-pipelines/upgrade-with-raft/rolling-upgrade-debian11-with-raft.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '["2022.2"]',
+    base_versions: 2022.2,
     linux_distro: 'debian-bullseye',
     disable_raft: false,
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-11',

--- a/jenkins-pipelines/upgrade-with-raft/rolling-upgrade-ubuntu22.04-with-raft.jenkinsfile
+++ b/jenkins-pipelines/upgrade-with-raft/rolling-upgrade-ubuntu22.04-with-raft.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '["2022.2"]',
+    base_versions: 2022.2,
     linux_distro: 'ubuntu-jammy',
     disable_raft: false,
     use_preinstalled_scylla: true,


### PR DESCRIPTION
In commit https://github.com/roydahan/scylla-cluster-tests/commit/ae7c72858034e350637a9d0cdffe593be88ddc61 the trigger was
changed to run only with 2022.2 as a base version. However, the
format that was used is wrong and the tests failed with the error
"couldn't find version". this format works.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
