### PR TITLE
fix(PageFetcher): wait for first page correctly

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2597,7 +2597,7 @@ class PageFetcher:
         # wait for the first page to arrive, otherwise we may call
         # future.has_more_pages too early, since it should only be
         # called after the first page is returned
-        self.wait(seconds=30)
+        self.wait(seconds=self.future.timeout)
 
     def handle_page(self, rows):
         # occasionally get a final blank page that is useless


### PR DESCRIPTION
in e592c1ff662c4c7324a7cbef597d57135992e603 sesion timeout was set to 5min in `get_any_ks_cf_list`, but inside `PageFetcher` it was hardcoded 30s wait for the first page.

this change align that wait with the future/session timeout

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
