### PR TITLE
fix(index/mv): enlarge timeout on creation of Indexes/MVs

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2371,7 +2371,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             query += ' AND COMPACT STORAGE'
 
         self.log.debug('MV create statement: {}'.format(query))
-        session.execute(query)
+        session.execute(query, timeout=600)
 
     def _wait_for_view(self, scylla_cluster, session, key_space, view):
         self.log.debug("Waiting for view {}.{} to finish building...".format(key_space, view))

--- a/sdcm/utils/nemesis_utils/indexes.py
+++ b/sdcm/utils/nemesis_utils/indexes.py
@@ -65,7 +65,7 @@ def get_random_column_name(session, ks, cf, filter_out_collections: bool = False
 def create_index(session, ks, cf, column) -> str:
     InfoEvent(message=f"Starting creating index: {ks}.{cf}({column})").publish()
     index_name = f"{cf}_{column}_nemesis".lower()
-    session.execute(f'CREATE INDEX {index_name} ON {ks}.{cf}("{column}")')
+    session.execute(f'CREATE INDEX {index_name} ON {ks}.{cf}("{column}")', timeout=600)
     return index_name
 
 


### PR DESCRIPTION
Those operation on a busy/loaded setup can take longer then the default 60s we have for CQL sessions.

this change is defaulting those operation to 10m timeout

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
