### PR TITLE
fix(cluster): increase the aio-nr to 30000000

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1954,19 +1954,17 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 self.remoter.run('env', verbose=True, change_context=True)
                 assert 'XDG_RUNTIME_DIR' in self.remoter.run('env', verbose=True).stdout
             if package_version < packaging.version.parse('3'):
-                install_cmds = dedent("""
-                    tar xvfz ./unified_package.tar.gz
-                    ./install.sh --nonroot
-                    sudo rm -f /tmp/scylla.yaml
-                """)
+                pkg_scylla_dir = '.'
             else:
-                install_cmds = dedent("""
-                    tar xvfz ./unified_package.tar.gz
-                    cd ./scylla-*
-                    ./install.sh --nonroot
-                    cd -
-                    sudo rm -f /tmp/scylla.yaml
-                """)
+                pkg_scylla_dir = 'scylla-*'
+
+            install_cmds = dedent(f"""
+                tar xvfz ./unified_package.tar.gz
+                cd {pkg_scylla_dir}
+                ./install.sh --nonroot
+                cd -
+                sudo rm -f /tmp/scylla.yaml
+            """)
             # Known issue: https://github.com/scylladb/scylla/issues/7071
             self.remoter.run('bash -cxe "%s"' % install_cmds)
         else:


### PR DESCRIPTION
we start to using a native nodetool which is implemented using
Seastar framework recently. but scylla instance would take
all aio slots on system if it is not able to provide enough aio
slots for performing disk and networking io. this has been working
fine even in the non-root installations. but this setting
practically prevents us from running another Seastar application
even if it's not a long-running service.

so, in this change, when installing packages in non-root mode, we
increase the number of aio slots to the number used by scylla's
sysctl.d/99-scylla-aio.conf, which is distributed as part of
scylla's deb/rpm scylla-kernel-conf package. and the setting is
applied when the server installs this package. this would allow
us to run for instance, `scylla nodetool` after scylla server
is running on the same host.

so this also provides a more consistent testing environment for
the offline-installation test in comparision to the tests which
install deb/rpm packages.

Fixes https://github.com/scylladb/scylladb/issues/17412
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2204-test/39/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
