### PR TITLE
fix(nemesis): `set_target_node` should first give up current target

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -387,6 +387,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if is_seed is DefaultValue - if self.filter_seed is True it act as if is_seed=False,
           otherwise it will act as if is_seed is None
         """
+        # first give up the current target node
+        self.unset_current_running_nemesis(self.target_node)
+
         with NEMESIS_TARGET_SELECTION_LOCK:
             nodes = self._get_target_nodes(is_seed=is_seed, dc_idx=dc_idx, rack=rack)
             if not nodes:


### PR DESCRIPTION
in PR #7016 there was a change that drop this part from the code without it, we can get into case that nemesis which are calling this function directly, might leave some nodes mark with `running_nemesis` while no cleaup code can figure it out, and would unmark only the current target selected.

Fixes: #7220

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
