### PR TITLE
fix(hydra): remove call to awscli to download keys

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -363,10 +363,6 @@ if [[ -n "${AWS_MOCK}" ]]; then
     PREPARE_CMD+="; curl -sSk https://aws-mock.itself/install-ca.sh | bash"
 fi
 
-if [[ -z "${HYDRA_HELP}" ]]; then
-    PREPARE_CMD+="; ${SCT_DIR}/get-qa-ssh-keys.sh"
-fi
-
 COMMAND=${HYDRA_COMMAND[0]}
 
 if [[ "$COMMAND" == *'bash'* ]] || [[ "$COMMAND" == *'python'* ]]; then

--- a/sct.py
+++ b/sct.py
@@ -40,6 +40,7 @@ from argus.backend.util.enums import TestStatus
 
 import sct_ssh
 import sct_scan_issues
+from sdcm.keystore import KeyStore
 from sdcm.localhost import LocalHost
 from sdcm.provision import AzureProvisioner
 from sdcm.provision.provisioner import VmInstance
@@ -102,7 +103,7 @@ from sdcm.utils.sct_cmd_helpers import add_file_logger, CloudRegion, get_test_co
 from sdcm.send_email import get_running_instances_for_email_report, read_email_data_from_file, build_reporter, \
     send_perf_email
 from sdcm.parallel_timeline_report.generate_pt_report import ParallelTimelinesReportGenerator
-from sdcm.utils.aws_utils import AwsArchType
+from sdcm.utils.aws_utils import AwsArchType, is_using_aws_mock
 from sdcm.utils.aws_okta import try_auth_with_okta
 from sdcm.utils.gce_utils import SUPPORTED_PROJECTS, gce_public_addresses
 from sdcm.utils.context_managers import environment
@@ -188,6 +189,12 @@ class SctLoader(unittest.TestLoader):
 def cli():
     disable_loggers_during_startup()
     try_auth_with_okta()
+
+    if not is_using_aws_mock():
+        key_store = KeyStore()
+        key_store.sync(keys=['scylla-qa-ec2', 'scylla-test', 'scylla_test_id_ed25519'],
+                       local_path=Path('~/.ssh/').expanduser(), permissions=0o0600)
+
     docker_hub_login(remoter=LOCALRUNNER)
 
 

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -11,6 +11,7 @@
 #
 # Copyright (c) 2021 ScyllaDB
 import functools
+import socket
 import time
 import logging
 from functools import cached_property
@@ -405,3 +406,15 @@ def get_ssm_ami(parameter: str, region_name) -> str:
     client = boto3.client('ssm', region_name=region_name)
     value = client.get_parameter(Name=parameter)
     return value['Parameter']['Value']
+
+
+def is_using_aws_mock() -> bool:
+    """
+    check if the aws mock host is available or not
+    """
+
+    try:
+        socket.gethostbyname("aws-mock.itself")
+        return True
+    except socket.gaierror:
+        return False


### PR DESCRIPTION
this would complicate the sisuation once we need
want to use diffent aws profiles, so this move into `sct.py` itself, where we'll be able to even do that selectivly  as needed, or push is down further to places it's gonna be used (i.e. no every command need
validating/downloading those)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
