### PR TITLE
fix(disrupt_abort_repair): enable verbose for repair command

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3008,10 +3008,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         @raise_event_on_failure
         def silenced_nodetool_repair_to_fail():
             try:
-                self.target_node.run_nodetool("repair", verbose=False,
+                self.target_node.run_nodetool("repair", verbose=True,
                                               warning_event_on_exception=(UnexpectedExit, Libssh2UnexpectedExit),
                                               error_message="Repair failed as expected. ",
-                                              publish_event=False)
+                                              publish_event=False,
+                                              retry=0)
             except (UnexpectedExit, Libssh2UnexpectedExit):
                 self.log.info('Repair failed as expected')
             except Exception:


### PR DESCRIPTION
the thread running the reapair seems to be retring the command and there no enough verbosity to see if that's really thre case

removing any retries, and add verbose

Ref: #7226

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
