### PR TITLE
New trigger for tablets longevities and new multi dc and multi rack tablets longevity

### DIFF
--- a/configurations/tablets_multidc_multirack.yaml
+++ b/configurations/tablets_multidc_multirack.yaml
@@ -1,0 +1,2 @@
+n_db_nodes: '4 4'
+simulated_racks: 4

--- a/jenkins-pipelines/master-triggers/tablets_weekly_trigger.xml
+++ b/jenkins-pipelines/master-triggers/tablets_weekly_trigger.xml
@@ -27,7 +27,7 @@ email_recipients=qa@scylladb.com,tablets@scylladb.com</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>tablets/longevity-100gb-4h-test,tablets/longevity-harry-2h-test,tablets/longevity-large-partition-8h-test</projects>
+          <projects>tablets/longevity-100gb-4h-test,tablets/longevity-harry-2h-test,tablets/longevity-large-partition-8h-test,tablets/longevity-multidc-multirack-test</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>

--- a/jenkins-pipelines/master-triggers/tablets_weekly_trigger.xml
+++ b/jenkins-pipelines/master-triggers/tablets_weekly_trigger.xml
@@ -1,0 +1,39 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?><project>
+  <actions/>
+  <description>Triggers Tablets Tests on weekly basis, every Saturday at 10:00
+</description>
+  <scm class="hudson.scm.NullSCM"/>
+  <disabled>false</disabled>
+  <triggers>
+    <hudson.triggers.TimerTrigger>
+      <spec>00 10 * * 6</spec>
+    </hudson.triggers.TimerTrigger>
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers>
+    <hudson.plugins.parameterizedtrigger.BuildTrigger>
+      <configs>
+        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>scylla_version=enterprise:latest
+region=random
+provision_type=spot
+post_behavior_db_nodes=destroy
+post_behavior_loader_nodes=destroy
+post_behavior_monitor_nodes=destroy
+email_recipients=qa@scylladb.com,tablets@scylladb.com</properties>
+              <textParamValueOnNewLine>false</textParamValueOnNewLine>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>tablets/longevity-100gb-4h-test,tablets/longevity-harry-2h-test,tablets/longevity-large-partition-8h-test</projects>
+          <condition>SUCCESS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <triggerFromChildProjects>false</triggerFromChildProjects>
+        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+      </configs>
+    </hudson.plugins.parameterizedtrigger.BuildTrigger>
+  </publishers>
+  <buildWrappers/>
+</project>

--- a/jenkins-pipelines/oss/tablets/longevity-multidc-multirack.jenkinsfile
+++ b/jenkins-pipelines/oss/tablets/longevity-multidc-multirack.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: '''["eu-west-1", "eu-west-2"]''',
+    test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
+    test_config: '''["test-cases/longevity/longevity-multi-dc-rack-aware.yaml", "configurations/tablets.yaml", "configurations/tablets_supported_nemeses.yaml", "configurations/tablets_multidc_multirack.yaml"]'''
+
+)


### PR DESCRIPTION
### Testing
https://argus.scylladb.com/workspace?state=WyJhZjVkYmYyOS0wMjYwLTRmNzktOGNjYS1hZDVhZWUyMWVjM2EiXQ (currently fails)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
