### PR TITLE
fix(manager_cli): set --force-non-ssl-session-port if encryption enabled but port not defined

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -700,7 +700,7 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         # Scylla-manager should pick up client encryption setting automatically
         healthcheck_task.wait_for_status(list_status=[TaskStatus.DONE], step=5, timeout=240)
 
-        mgr_cluster.update(client_encrypt=True)
+        mgr_cluster.update(client_encrypt=True, force_non_ssl_session_port=mgr_cluster.sctool.is_minimum_3_2_6_version())
         time.sleep(30)  # Make sure healthcheck task is triggered
         healthcheck_task.wait_for_status(list_status=[TaskStatus.DONE], step=5, timeout=240)
         sleep = 40

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -43,6 +43,8 @@ REPAIR_TIMEOUT_SEC = 7200  # 2 hours
 
 
 new_command_structure_minimum_version = LooseVersion("3.0")
+forcing_tls_minimum_version = LooseVersion("3.2.6")
+
 # TODO: remove these checks once manager 2.6 is no longer supported
 
 
@@ -692,7 +694,7 @@ class ManagerCluster(ScyllaManagerBase):
         cmd = "cluster delete -c {}".format(self.id)
         self.sctool.run(cmd=cmd, is_verify_errorless_result=True)
 
-    def update(self, name=None, host=None, client_encrypt=None):  # pylint: disable=too-many-arguments
+    def update(self, name=None, host=None, client_encrypt=None, force_non_ssl_session_port=False):  # pylint: disable=too-many-arguments
         """
         $ sctool cluster update --help
         Modify a cluster
@@ -712,6 +714,8 @@ class ManagerCluster(ScyllaManagerBase):
             cmd += " --host={}".format(host)
         if client_encrypt:
             cmd += " --ssl-user-cert-file {} --ssl-user-key-file {}".format(SSL_USER_CERT_FILE, SSL_USER_KEY_FILE)
+        if force_non_ssl_session_port:
+            cmd += "  --force-non-ssl-session-port"
         self.sctool.run(cmd=cmd, is_verify_errorless_result=True)
 
     def delete_task(self, task: ManagerTask):
@@ -1298,6 +1302,10 @@ class SCTool:
     @property
     def is_v3_cli(self):
         return self.parsed_client_version >= new_command_structure_minimum_version
+
+    @property
+    def is_minimum_3_2_6_version(self):
+        return self.parsed_client_version >= forcing_tls_minimum_version
 
 
 class ScyllaMgmt:


### PR DESCRIPTION
There is long lasting issue in Scylla https://github.com/scylladb/scylladb/issues/7206#issuecomment-689598343
which causes Scylla to fallback the SSL port to non-SSL one when the encryption on session is enabled, but SSL port is not defined in config.
Manager sanity tests checks if the healthcheck works with encryption enabled, but at the same time, the scylla configuration used for this test, doesn't specify SSL port (so, it fallsback to non-SSL).
See the `scylla.yaml` from test
```
alternator_enforce_authorization: false
api_address: 127.0.0.1
api_doc_dir: /opt/scylladb/api/api-doc/
api_port: 10000
api_ui_dir: /opt/scylladb/swagger-ui/dist/
audit: table
audit_categories: DCL,DDL,AUTH,ADMIN
auto_bootstrap: true
batch_size_fail_threshold_in_kb: 1024
batch_size_warn_threshold_in_kb: 128
broadcast_rpc_address: 10.15.3.97
cas_contention_timeout_in_ms: 1000
client_encryption_options:
  certificate: /etc/scylla/ssl_conf/client/test.crt
  enabled: true               <---------------------------- ENABLED but native_transport_port_ssl is missing
  keyfile: /etc/scylla/ssl_conf/client/test.key
  truststore: /etc/scylla/ssl_conf/client/catest.pem
cluster_name: manager-regression-manager--db-cluster-53ae9be8
commitlog_segment_size_in_mb: 32
commitlog_sync: periodic
commitlog_sync_period_in_ms: 10000
commitlog_total_space_in_mb: -1
enable_ipv6_dns_lookup: false
endpoint_snitch: org.apache.cassandra.locator.Ec2Snitch
experimental: true
force_schema_commit_log: true
hinted_handoff_enabled: false
listen_address: 10.15.3.97
murmur3_partitioner_ignore_msb_bits: 12
native_shard_aware_transport_port: 19042
native_transport_port: 9042
num_tokens: 256
partitioner: org.apache.cassandra.dht.Murmur3Partitioner
prometheus_address: 0.0.0.0
read_request_timeout_in_ms: 5000
rpc_address: 10.15.3.97
rpc_port: 9160
seed_provider:
- class_name: org.apache.cassandra.locator.SimpleSeedProvider
  parameters:
  - seeds: 10.12.3.185,10.12.1.112,10.15.3.97
write_request_timeout_in_ms: 2000
```

According to the scylla's behavior, manager is expected to fallback to non-SSL port. The point is that it a bad habit on SM side to always try to connect to this SSL port first and then fallback to non-SSL if connection cannot be established. This check is the only way SM could realize that SSL port is not specified.

Starting with manager-3.2.6, CLI supports additional flag/parameter on cluster. It's `--force-non-ssl-session-port` which defines to always use non-SSL port, even if the encryption is enabled.
The fallback and the check if SSL port is opened is removed from SM 3.2.6.

This PR updates manager test to update cluster with `--force-non-ssl-session-port` when the encryption is enabled.

SCT sanity fails without it https://jenkins.scylladb.com/view/scylla-manager/job/manager-3.2/job/centos-sanity-test/25

I'm unable to prove directly that this PR solves the issue without starting the SCT test locally, but I failed in doing that. More info in one of the comments below (that's why it's DRAFT).

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
