### PR TITLE
fix(fetch_all_rows): handle default `timeout=None` correctly

### DIFF
--- a/sdcm/utils/database_query_utils.py
+++ b/sdcm/utils/database_query_utils.py
@@ -209,7 +209,8 @@ def fetch_all_rows(session, default_fetch_size, statement, retries: int = 4, tim
         LOGGER.debug("Fetch all rows by statement: %s", statement)
     session.default_fetch_size = default_fetch_size
     session.default_consistency_level = ConsistencyLevel.QUORUM
-    session.default_timeout = timeout
+    if timeout:
+        session.default_timeout = timeout
 
     @retrying(n=retries, sleep_time=5, message='Fetch all rows', raise_on_exceeded=raise_on_exceeded)
     def _fetch_rows() -> list:

--- a/unit_tests/test_utils_database_query_utils.py
+++ b/unit_tests/test_utils_database_query_utils.py
@@ -1,0 +1,26 @@
+import pytest
+
+from sdcm.utils.database_query_utils import fetch_all_rows
+from unit_tests.test_cluster import DummyScyllaCluster
+
+
+@pytest.mark.integration
+def test_fetch_all_rows(docker_scylla, params, events):  # pylint: disable=unused-argument
+
+    cluster = DummyScyllaCluster([docker_scylla])
+    cluster.params = params
+
+    with cluster.cql_connection_patient(docker_scylla) as session:
+        session.execute(
+            "CREATE KEYSPACE mview WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
+        session.execute(
+            "CREATE TABLE mview.users (username text, first_name text, last_name text, password text, email text, "
+            "last_access timeuuid, PRIMARY KEY(username))")
+        for i in range(10):
+            session.execute(
+                "INSERT INTO mview.users (username, first_name, last_name, password) VALUES "
+                f"('fruch', 'Israel', 'Fruchter', '{i}')")
+
+        statement = 'select * from  mview.users;'
+        full_res = fetch_all_rows(session=session, default_fetch_size=100, statement=statement)
+        assert full_res


### PR DESCRIPTION
25d8252 introduced getting the timeout of the future been returned from `execute_async`, it was tested and working o.k. except one path that `fetch_all_rows` was given `timeout=None` (which is the default)

then `fetch_all_rows` blindly put the `None` into
`session.default_timeout`, we never want unlimited timeout set.

fix is to not set `default_timeout` with `None`

Fixes: #7232

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] introduced a new integration test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
