### PR TITLE
improvement(kms): improve KMS enc-on checks when nodetool cfstats fails

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4389,9 +4389,12 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                             res = target_node.run_nodetool(
                                 sub_cmd='cfstats', args=ks_cf, timeout=300, retry=3, publish_event=False,
                                 warning_event_on_exception=(Failure, UnexpectedExit, Libssh2_UnexpectedExit))
-                            cf_stats = target_node._parse_cfstats(res.stdout)  # pylint: disable=protected-access
-                            if int(cf_stats["SSTable count"]) > chosen_ks_cf_sstables_num:
-                                chosen_ks_cf, chosen_ks_cf_sstables_num = ks_cf, int(cf_stats["SSTable count"])
+                            if res:
+                                cf_stats = target_node._parse_cfstats(res.stdout)  # pylint: disable=protected-access
+                                if int(cf_stats["SSTable count"]) > chosen_ks_cf_sstables_num:
+                                    chosen_ks_cf, chosen_ks_cf_sstables_num = ks_cf, int(cf_stats["SSTable count"])
+                            else:
+                                self.log.warning("Failed to get cf_stats for the '%s' table", ks_cf)
                         SstableUtils(db_node=target_node, ks_cf=chosen_ks_cf).check_that_sstables_are_encrypted()
                 except SstablesNotFound as exc:
                     self.log.warning(f"Couldn't check the fact of encryption (KMS) for sstables: {exc}")


### PR DESCRIPTION
In the `start_kms_key_rotation_thread` it is possible to face the situation when the `nodetool cfstats` command fails (i.e. during `upgrade` test).
And we do not handle the case when it fails leading to the following error:

```
  Traceback (most recent call last):
  File "scylla-cluster-tests/sdcm/cluster.py", line 4371, in _rotate_kms_key
  cf_stats = target_node._parse_cfstats(res.stdout)
  AttributeError: 'NoneType' object has no attribute 'stdout'
```

So, handle the case of the 'None' value as a return value for the call of the `target_node._parse_cfstats` function.

Note that, in good case, we should fix SCT the way that a node that is being upgraded should not be picked up by the KMS encryption checks and node upgrade should wait while the KMS encryption check finishes (several minutes).

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
