### PR TITLE
fix(k8s-ci): make weekly triggers use proper CI jobs and it's parameters

### DIFF
--- a/jenkins-pipelines/operator/functional/weekly-trigger.xml
+++ b/jenkins-pipelines/operator/functional/weekly-trigger.xml
@@ -24,11 +24,11 @@ H 02 * * 0</spec>
 scylla_version=latest
 k8s_scylla_operator_helm_repo=https://storage.googleapis.com/scylla-operator-charts/latest
 k8s_scylla_operator_chart_version=latest
-k8s_enable_tls=true</properties>
+k8s_enable_tls=false</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>functional-k8s-local-kind-aws,functional-eks</projects>
+          <projects>functional-k8s-local-kind-aws-test,functional-eks-test</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>
@@ -40,11 +40,27 @@ k8s_enable_tls=true</properties>
 scylla_version=%(release_version)s
 k8s_scylla_operator_helm_repo=https://storage.googleapis.com/scylla-operator-charts/latest
 k8s_scylla_operator_chart_version=latest
-k8s_enable_tls=true</properties>
+k8s_enable_tls=false</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
           <projects>functional-k8s-local-kind-aws-test,functional-eks-test</projects>
+          <condition>SUCCESS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <triggerFromChildProjects>false</triggerFromChildProjects>
+        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>docker_image=scylladb/scylla-enterprise
+scylla_version=%(release_version)s
+k8s_scylla_operator_helm_repo=https://storage.googleapis.com/scylla-operator-charts/latest
+k8s_scylla_operator_chart_version=latest
+k8s_enable_tls=false</properties>
+              <textParamValueOnNewLine>false</textParamValueOnNewLine>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>functional-eks-arm-test</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>


### PR DESCRIPTION
Updates:
- Make the parameter `k8s_enable_tls` be set to `false` value. Existing `true` is a mistake.
- Use proper CI jobs with `-test` suffix which get generated by SCT.
  Doing so stop using CI jobs without that prefix which were created manually.
- Start triggering the `functional-eks-arm-test` weekly because
  `Arm` support will be part of the `scylla-operator-v1.12` release.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
