### PR TITLE
improvement(k8s): stabilize namespace deletions in quasi-multidc test

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -206,13 +206,18 @@ def test_deploy_quasi_multidc_db_cluster(db_cluster: ScyllaPodCluster):  # pylin
                         assert row["rack"] == k8s_cluster.rack_name
                         assert row["data_center"] == ip_to_dc_map[row["peer"]]
             need_to_collect_logs = False
+            log.info("DB cluster's peers info is correct")
+            return None
         finally:
             if need_to_collect_logs:
                 KubernetesOps.gather_k8s_logs(
                     logdir_path=logdir, kubectl=kubectl, namespaces=[namespace, namespace2])
                 need_to_collect_logs = False
             k8s_cluster.helm(f"uninstall {target_chart_name2} --timeout 120s", namespace=namespace2)
-            kubectl(f"delete namespace {namespace2}", ignore_status=True, timeout=120)
+            try:
+                kubectl(f"delete namespace {namespace2}", ignore_status=True, timeout=120)
+            except invoke.exceptions.CommandTimedOut as exc:
+                log.warning("Deletion of the '%s' namespace timed out: %s", namespace2, exc)
 
     finally:
         if need_to_collect_logs:


### PR DESCRIPTION
In the `test_deploy_quasi_multidc_db_cluster` K8S functional test we create 2 additional namespaces and in the end of the test delete it. 
The problem with it is that we can get random command timeouts there still having the expected effect - deleted namespaces.

So, add try-catch block for second namespace too because it also happens to fail.

Also, do use `return None` in the end of the main logic before cleanups to avoid propagation of cleanup exceptions as test results.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
