### PR TITLE
fix(CDC_OPTIONS): Use boolean value for cdc preimage option

### DIFF
--- a/sdcm/utils/cdc/options.py
+++ b/sdcm/utils/cdc/options.py
@@ -11,7 +11,7 @@ CDC_LOGTABLE_SUFFIX = "_scylla_cdc_log"
 CDC_SETTINGS_NAMES_VALUES = {
     "enabled": [True, False],
     "delta": ["full", "keys"],
-    "preimage": ["full", "true", "false"],
+    "preimage": ["full", True, False],
     "postimage": [True, False],
     "ttl": "86400"
 }


### PR DESCRIPTION
CDC_SETTINGS_NAMES_VALUES['preimage'] uses string values "true" "false" instead of bool True False. This cause assertion error if it was changed

```
AssertionError: CDC extension settings are differs.
Current: {'delta': 'full', 'enabled': True, 'preimage': True, 'postimage': True, 'ttl': '1800'}
expected: {'delta': 'full', 'enabled': True, 'preimage': 'true', 'postimage': True, 'ttl': '1800'}
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [Job with fix](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/longevity-cdc-100gb-4h-test/12/) - Passed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
