### PR TITLE
improvement(get_username.py): User impersonation for automated builds

### DIFF
--- a/sdcm/utils/get_username.py
+++ b/sdcm/utils/get_username.py
@@ -25,7 +25,12 @@ def get_email_user(email_addr: str) -> str:
 
 
 def get_username() -> str:  # pylint: disable=too-many-return-statements
-    # First check that we running on Jenkins try to get user email
+    # First we check if user is being impersonated by an api call
+    actual_user_from_request = os.environ.get('BUILD_USER_REQUESTED_BY')
+    if actual_user_from_request:
+        return actual_user_from_request
+
+    # Then check that we running on Jenkins try to get user email
     email = os.environ.get('BUILD_USER_EMAIL')
     if is_email_in_scylladb_domain(email):
         return get_email_user(email)

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -81,6 +81,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('gce_project', '')}",
                description: 'Gce project to use',
                name: 'gce_project')
+            string(defaultValue: '',
+                   description: 'Actual user requesting job start, for automated job builds (e.g. through Argus)',
+                   name: 'requested_by_user')
         }
         options {
             timestamps()
@@ -146,6 +149,9 @@ def call(Map pipelineParams) {
                                                     # clean the old sct_runner_ip file
                                                     rm -fv ./sct_runner_ip
 
+                                                    if [[ -n "${params.requested_by_user}" ]] ; then
+                                                        export BUILD_USER_REQUESTED_BY=${params.requested_by_user}
+                                                    fi
                                                     export SCT_COLLECT_LOGS=false
                                                     export SCT_CONFIG_FILES=${test_config}
                                                     if [[ -n "${params.region ? params.region : ''}" ]] ; then

--- a/vars/createArgusTestRun.groovy
+++ b/vars/createArgusTestRun.groovy
@@ -6,7 +6,9 @@ def call(Map params) {
         set -xe
 
         echo "Creating Argus test run ..."
-
+        if [[ -n "${params.requested_by_user}" ]] ; then
+            export BUILD_USER_REQUESTED_BY=${params.requested_by_user}
+        fi
         export SCT_CLUSTER_BACKEND="${params.backend}"
         export SCT_CONFIG_FILES=${test_config}
 

--- a/vars/createSctRunner.groovy
+++ b/vars/createSctRunner.groovy
@@ -36,6 +36,10 @@ def call(Map params, Integer test_duration, String region) {
         export SCT_CLUSTER_BACKEND="${params.backend}"
         export SCT_CONFIG_FILES=${test_config}
 
+        if [[ -n "${params.requested_by_user}" ]] ; then
+            export BUILD_USER_REQUESTED_BY=${params.requested_by_user}
+        fi
+
         ./docker/env/hydra.sh create-runner-instance \
             --cloud-provider ${cloud_provider} \
             $region_zone_arg \

--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -68,6 +68,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('test_name', '')}",
                    description: 'Name of the test to run',
                    name: 'test_name')
+            string(defaultValue: '',
+                   description: 'Actual user requesting job start, for automated job builds (e.g. through Argus)',
+                   name: 'requested_by_user')
         }
         options {
             timestamps()
@@ -157,6 +160,9 @@ def call(Map pipelineParams) {
                                 export SCT_CONFIG_FILES=${params.test_config}
                                 export SCT_COLLECT_LOGS=false
 
+                                if [[ -n "${params.requested_by_user}" ]] ; then
+                                    export BUILD_USER_REQUESTED_BY=${params.requested_by_user}
+                                fi
                                 if [[ ! -z "${params.scylla_version}" ]]; then
                                     export SCT_SCYLLA_VERSION="${params.scylla_version}"
                                 elif [[ ! -z "${params.scylla_repo}" ]]; then

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -139,6 +139,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('gce_project', '')}",
                description: 'Gce project to use',
                name: 'gce_project')
+            string(defaultValue: '',
+                   description: 'Actual user requesting job start, for automated job builds (e.g. through Argus)',
+                   name: 'requested_by_user')
         }
         options {
             timestamps()

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -145,6 +145,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('downstream_jobs_to_run', '')}",
                    description: 'Comma separated list of downstream jobs to run when the job passes',
                    name: 'downstream_jobs_to_run')
+            string(defaultValue: '',
+                   description: 'Actual user requesting job start, for automated job builds (e.g. through Argus)',
+                   name: 'requested_by_user')
         }
         options {
             timestamps()

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -92,6 +92,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('k8s_enable_tls', '')}",
                    description: 'if true, enable operator tls, and install haproxy ingress controller',
                    name: 'k8s_enable_tls')
+            string(defaultValue: '',
+                   description: 'Actual user requesting job start, for automated job builds (e.g. through Argus)',
+                   name: 'requested_by_user')
         }
         options {
             timestamps()
@@ -232,6 +235,9 @@ def call(Map pipelineParams) {
 
                                                         rm -fv ./latest
 
+                                                        if [[ -n "${params.requested_by_user}" ]] ; then
+                                                            export BUILD_USER_REQUESTED_BY=${params.requested_by_user}
+                                                        fi
                                                         export SCT_CLUSTER_BACKEND=${params.backend}
                                                         if [[ -n "${params.region}" ]]; then
                                                             export SCT_REGION_NAME=${params.region}

--- a/vars/provisionResources.groovy
+++ b/vars/provisionResources.groovy
@@ -14,6 +14,10 @@ def call(Map params, String region){
     export SCT_CONFIG_FILES=${test_config}
     export SCT_COLLECT_LOGS=false
 
+    if [[ -n "${params.requested_by_user}" ]] ; then
+        export BUILD_USER_REQUESTED_BY=${params.requested_by_user}
+    fi
+
     if [[ -n "${params.region ? params.region : ''}" ]] ; then
         export SCT_REGION_NAME=${current_region}
     fi

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -69,6 +69,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('test_name', '')}",
                    description: 'Name of the test to run',
                    name: 'test_name')
+            string(defaultValue: '',
+                   description: 'Actual user requesting job start, for automated job builds (e.g. through Argus)',
+                   name: 'requested_by_user')
         }
         options {
             timestamps()

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -70,6 +70,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('gce_project', '')}",
                    description: 'Gce project to use',
                    name: 'gce_project')
+            string(defaultValue: '',
+                   description: 'Actual user requesting job start, for automated job builds (e.g. through Argus)',
+                   name: 'requested_by_user')
         }
         options {
             timestamps()
@@ -188,6 +191,10 @@ def call(Map pipelineParams) {
                                                             env
 
                                                             rm -fv ./latest
+
+                                                            if [[ -n "${params.requested_by_user}" ]] ; then
+                                                                export BUILD_USER_REQUESTED_BY=${params.requested_by_user}
+                                                            fi
 
                                                             export SCT_CLUSTER_BACKEND=${params.backend}
 

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -27,6 +27,10 @@ def call(Map params, String region, functional_test = false, Map pipelineParams 
     export SCT_CONFIG_FILES=${test_config}
     export SCT_COLLECT_LOGS=false
 
+    if [[ -n "${params.requested_by_user}" ]] ; then
+        export BUILD_USER_REQUESTED_BY=${params.requested_by_user}
+    fi
+
     if [[ -n "${params.stress_duration ? params.stress_duration : ''}" ]] ; then
         export SCT_STRESS_DURATION=${params.stress_duration}
     fi


### PR DESCRIPTION
This commit adds a new job parameter to job pipelines intended to be
filled by job automation - requested_by_user. This allows SCT to
properly track resources if a job was started by a third party API
call, e.g. through Argus.

Task: scylladb/qa-tasks#1612

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Argus](https://argus.scylladb.com/test/b0b22734-758e-47b4-b6ec-29e64d212d52/runs?additionalRuns[]=aa930251-34da-480c-bd90-ef87e3092a34)
- [x] [Jenkins](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/alexey-argus-testing/69/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
