### PR TITLE
Revert "fix(update_repo_cache): stop calling `debconf-set-selections`"

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1856,6 +1856,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 self.remoter.sudo('apt-get clean all')
                 self.remoter.sudo('rm -rf /var/cache/apt/')
                 self.remoter.sudo('apt-get update', retry=3)
+                self.remoter.run("echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections")
         except Exception as ex:  # pylint: disable=broad-except
             self.log.error('Failed to update repo cache: %s', ex)
 


### PR DESCRIPTION
Reverts scylladb/scylla-cluster-tests#7246