### PR TITLE
fix(docker-backend): remove all sudo usage from the flow

### DIFF
--- a/sdcm/remote/remote_file.py
+++ b/sdcm/remote/remote_file.py
@@ -36,9 +36,9 @@ def remote_file(remoter, remote_path, serializer=StringIO.getvalue, deserializer
                 preserve_ownership=True, preserve_permissions=True, log_change=True):
     filename = os.path.basename(remote_path)
     local_tempfile = os.path.join(tempfile.mkdtemp(prefix='sct'), filename)
-    if preserve_ownership:
+    if preserve_ownership and sudo:
         ownership = remoter.sudo(cmd='stat -c "%U:%G" ' + remote_path).stdout.strip()
-    if preserve_permissions:
+    if preserve_permissions and sudo:
         permissions = remoter.sudo(cmd='stat -c "%a" ' + remote_path).stdout.strip()
 
     wait.wait_for(remoter.receive_files,
@@ -81,9 +81,9 @@ def remote_file(remoter, remote_path, serializer=StringIO.getvalue, deserializer
         else:
             remoter.run(remote_tempfile_move_cmd)
 
-        if preserve_ownership:
+        if preserve_ownership and sudo:
             remoter.sudo(f"chown {ownership} {remote_path}")
-        if preserve_permissions:
+        if preserve_permissions and sudo:
             remoter.sudo(f"chmod {permissions} {remote_path}")
 
     os.unlink(local_tempfile)

--- a/sdcm/utils/docker_utils.py
+++ b/sdcm/utils/docker_utils.py
@@ -485,6 +485,9 @@ def docker_hub_login(remoter: CommandRunner) -> None:
     if "Podman Engine" in remoter.run("docker version", ignore_status=True).stdout:
         remoter.log.info("When Podman daemon is used we don't login")
         return
+    if not os.environ.get('JENKINS_URL'):
+        remoter.log.debug("not in jenkins, skipping login to docker hub")
+        return
     docker_hub_creds = get_docker_hub_credentials()
     password_file = remoter.run("mktemp").stdout.strip()
     with remote_file(remoter=remoter, remote_path=password_file) as fobj:

--- a/unit_tests/test_remoter.py
+++ b/unit_tests/test_remoter.py
@@ -466,7 +466,7 @@ class TestRemoteFile(unittest.TestCase):
         remoter = self.remoter_cls()
         some_file = "/some/path/some.file"
         with remote_file(remoter=remoter, remote_path=some_file,
-                         preserve_ownership=True, preserve_permissions=False) as fobj:
+                         preserve_ownership=True, preserve_permissions=False, sudo=True) as fobj:
             fobj.write("test data")
             assert remoter.command_to_run == f'stat -c "%U:%G" {some_file}'
         assert f"chown bentsi:bentsi {some_file}" == remoter.command_to_run
@@ -475,7 +475,7 @@ class TestRemoteFile(unittest.TestCase):
         remoter = self.remoter_cls()
         some_file = "/some/path/some.file"
         with remote_file(remoter=remoter, remote_path=some_file,
-                         preserve_ownership=False, preserve_permissions=True) as fobj:
+                         preserve_ownership=False, preserve_permissions=True, sudo=True) as fobj:
             fobj.write("test data")
             assert remoter.command_to_run == f'stat -c "%a" {some_file}'
         assert f"chmod 644 {some_file}" == remoter.command_to_run
@@ -484,7 +484,7 @@ class TestRemoteFile(unittest.TestCase):
         remoter = self.remoter_cls()
         some_file = "/some/path/some.file"
         with remote_file(remoter=remoter, remote_path=some_file,
-                         preserve_ownership=False, preserve_permissions=True) as fobj:
+                         preserve_ownership=False, preserve_permissions=True, sudo=True) as fobj:
             fobj.write(remoter.rf_data)
             assert remoter.command_to_run == f'stat -c "%a" {some_file}'
 


### PR DESCRIPTION
Remove all unneeded sudo usage from the flow of running
a test with docker backend

* mostly from the monitoring stack that we run locally

Ref: https://github.com/scylladb/scylla-cluster-tests/issues/7251

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] provision tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
