### PR TITLE
fix(install_packages): add proper frontent and options

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1720,7 +1720,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             pkg_cmd = 'zypper'
             package_name = f"{package_name}-{package_version}" if package_version else package_name
         else:
-            pkg_cmd = 'apt-get'
+            pkg_cmd = 'DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef"'
             version_prefix = f"={package_version}*" if package_version else ""
             # A workaround for: https://github.com/scylladb/scylla-pkg/issues/2578
             if package_name == "scylla-manager-agent":
@@ -1856,7 +1856,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 self.remoter.sudo('apt-get clean all')
                 self.remoter.sudo('rm -rf /var/cache/apt/')
                 self.remoter.sudo('apt-get update', retry=3)
-                self.remoter.run("echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections")
         except Exception as ex:  # pylint: disable=broad-except
             self.log.error('Failed to update repo cache: %s', ex)
 


### PR DESCRIPTION
There's an issue with recent ubuntu images that fail on setting `debconf-set-selections`. Remove it and add proper apt settings when installing packages.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/6443

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] - tested with use_preinstalled_scylla: false and using repo file on GCE: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/c3-scale-up-test/29/
- [x] - artifact test: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/artifacts-debian10-test/17/
- [x] - upgrade test: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/rolling-multi-dc-upgrade-ami-test-staging2/53/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
