### PR TITLE
improvement(k8s): use newest scylla-manager version - 3.2.6

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -158,8 +158,8 @@ jepsen_test_count: 1
 jepsen_test_run_policy: all
 
 max_events_severities: ""
-scylla_mgmt_agent_version: '3.2.5'
-mgmt_docker_image: 'scylladb/scylla-manager:3.2.5'
+scylla_mgmt_agent_version: '3.2.6'
+mgmt_docker_image: 'scylladb/scylla-manager:3.2.6'
 k8s_log_api_calls: false
 k8s_deploy_monitoring: false
 k8s_minio_storage_size: '10Gi'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -37,7 +37,7 @@
 | **<a href="#user-content-manager_version" name="manager_version">manager_version</a>**  | Branch of scylla manager server and agent to install. Options in defaults/manager_versions.yaml | 3.2 | SCT_MANAGER_VERSION
 | **<a href="#user-content-target_manager_version" name="target_manager_version">target_manager_version</a>**  | Branch of scylla manager server and agent to upgrade to. Options in defaults/manager_versions.yaml | N/A | SCT_TARGET_MANAGER_VERSION
 | **<a href="#user-content-manager_scylla_backend_version" name="manager_scylla_backend_version">manager_scylla_backend_version</a>**  | Branch of scylla db enterprise to install. Options in defaults/manager_versions.yaml | 2022 | SCT_MANAGER_SCYLLA_BACKEND_VERSION
-| **<a href="#user-content-scylla_mgmt_agent_version" name="scylla_mgmt_agent_version">scylla_mgmt_agent_version</a>**  |  | 3.2.5 | SCT_SCYLLA_MGMT_AGENT_VERSION
+| **<a href="#user-content-scylla_mgmt_agent_version" name="scylla_mgmt_agent_version">scylla_mgmt_agent_version</a>**  |  | 3.2.6 | SCT_SCYLLA_MGMT_AGENT_VERSION
 | **<a href="#user-content-scylla_mgmt_pkg" name="scylla_mgmt_pkg">scylla_mgmt_pkg</a>**  | Url to the scylla manager packages to install for management tests | N/A | SCT_SCYLLA_MGMT_PKG
 | **<a href="#user-content-stress_cmd_lwt_i" name="stress_cmd_lwt_i">stress_cmd_lwt_i</a>**  | Stress command for LWT performance test for INSERT baseline | N/A | SCT_STRESS_CMD_LWT_I
 | **<a href="#user-content-stress_cmd_lwt_d" name="stress_cmd_lwt_d">stress_cmd_lwt_d</a>**  | Stress command for LWT performance test for DELETE baseline | N/A | SCT_STRESS_CMD_LWT_D
@@ -218,7 +218,7 @@
 | **<a href="#user-content-k8s_use_chaos_mesh" name="k8s_use_chaos_mesh">k8s_use_chaos_mesh</a>**  | enables chaos-mesh for k8s testing | N/A | SCT_K8S_USE_CHAOS_MESH
 | **<a href="#user-content-k8s_n_auxiliary_nodes" name="k8s_n_auxiliary_nodes">k8s_n_auxiliary_nodes</a>**  | Number of nodes in auxiliary pool | N/A | SCT_K8S_N_AUXILIARY_NODES
 | **<a href="#user-content-k8s_n_monitor_nodes" name="k8s_n_monitor_nodes">k8s_n_monitor_nodes</a>**  | Number of nodes in monitoring pool that will be used for scylla-operator's deployed monitoring pods. | N/A | SCT_K8S_N_MONITOR_NODES
-| **<a href="#user-content-mgmt_docker_image" name="mgmt_docker_image">mgmt_docker_image</a>**  | Scylla manager docker image, i.e. 'scylladb/scylla-manager:2.2.1' | scylladb/scylla-manager:3.2.5 | SCT_MGMT_DOCKER_IMAGE
+| **<a href="#user-content-mgmt_docker_image" name="mgmt_docker_image">mgmt_docker_image</a>**  | Scylla manager docker image, i.e. 'scylladb/scylla-manager:2.2.1' | scylladb/scylla-manager:3.2.6 | SCT_MGMT_DOCKER_IMAGE
 | **<a href="#user-content-docker_image" name="docker_image">docker_image</a>**  | Scylla docker image repo, i.e. 'scylladb/scylla', if omitted is calculated from scylla_version | N/A | SCT_DOCKER_IMAGE
 | **<a href="#user-content-docker_network" name="docker_network">docker_network</a>**  | local docker network to use, if there's need to have db cluster connect to other services running in docker | N/A | SCT_DOCKER_NETWORK
 | **<a href="#user-content-s3_baremetal_config" name="s3_baremetal_config">s3_baremetal_config</a>**  |  | N/A | SCT_S3_BAREMETAL_CONFIG

--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -400,7 +400,7 @@ def test_scylla_cluster_monitoring_type_platform(db_cluster: ScyllaPodCluster):
 #       - '2.3.x' and ''2.4.x' are not covered as old ones.
 @pytest.mark.requires_mgmt
 @pytest.mark.parametrize("manager_version", (
-    "3.2.5",
+    "3.2.6",
 ))
 def test_mgmt_repair(db_cluster, manager_version):
     reinstall_scylla_manager(db_cluster, manager_version)
@@ -426,7 +426,7 @@ def test_mgmt_repair(db_cluster, manager_version):
 #       - '2.3.x' and ''2.4.x' are not covered as old ones.
 @pytest.mark.requires_mgmt
 @pytest.mark.parametrize("manager_version", (
-    "3.2.5",
+    "3.2.6",
 ))
 def test_mgmt_backup(db_cluster, manager_version):
     reinstall_scylla_manager(db_cluster, manager_version)

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -127,10 +127,7 @@ SCYLLA_CONFIG_NAME = "scylla-config"
 SCYLLA_AGENT_CONFIG_NAME = "scylla-agent-config"
 
 K8S_LOCAL_VOLUME_PROVISIONER_VERSION = "0.3.0"  # without 'v' prefix
-# NOTE: these values are taken from the default values of the "scylla-manager" helm chart.
-#       Needs to be defined separately to be able to reuse for image caching running on local K8S
-SCYLLA_VERSION_IN_SCYLLA_MANAGER = "5.2.11"
-SCYLLA_MANAGER_AGENT_VERSION_IN_SCYLLA_MANAGER = "3.2.5"
+SCYLLA_MANAGER_AGENT_VERSION_IN_SCYLLA_MANAGER = "3.2.6"
 
 # NOTE: add custom annotations to a ServiceAccount used by a ScyllaCluster
 #       It is needed to make sure that annotations survive operator upgrades
@@ -632,7 +629,6 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             values.set("scylla", {
                 "developerMode": True,
                 "datacenter": "manager-dc",
-                "scyllaImage": {"tag": SCYLLA_VERSION_IN_SCYLLA_MANAGER},
                 "agentImage": {"tag": SCYLLA_MANAGER_AGENT_VERSION_IN_SCYLLA_MANAGER},
                 "racks": [{
                     "name": "manager-rack",

--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -42,7 +42,6 @@ from sdcm.cluster_k8s import (
     OPERATOR_CONTAINERS_RESOURCES,
     SCYLLA_MANAGER_AGENT_RESOURCES,
     SCYLLA_MANAGER_AGENT_VERSION_IN_SCYLLA_MANAGER,
-    SCYLLA_VERSION_IN_SCYLLA_MANAGER,
 )
 from sdcm.utils.k8s import TokenUpdateThread, HelmValues
 from sdcm.utils.k8s.chaos_mesh import ChaosMesh
@@ -632,7 +631,6 @@ class LocalKindCluster(LocalMinimalClusterBase):
             images_to_cache.append(self.scylla_image)
         if self.params.get("use_mgmt"):
             images_to_cache.extend(self.minio_images)
-            images_to_cache.append(f"scylladb/scylla:{SCYLLA_VERSION_IN_SCYLLA_MANAGER}")
             images_to_cache.append(
                 f"scylladb/scylla-manager-agent:{SCYLLA_MANAGER_AGENT_VERSION_IN_SCYLLA_MANAGER}")
             if self.params.get("mgmt_docker_image"):


### PR DESCRIPTION
Also, stop specifying our own scylla version which gets used as a backend for the scylla-manager. Rely on the default value.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/valerii/job/vp-functional-eks/71
- https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/valerii/job/vp-functional-k8s-local-kind-aws/324

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
