### PR TITLE
fix(audit): add 'ignore_ycsb_connection_refused' to audit config

### DIFF
--- a/sdcm/audit.py
+++ b/sdcm/audit.py
@@ -18,6 +18,7 @@ from typing import Literal, Optional, List
 from cassandra.util import uuid_from_time, datetime_from_uuid1  # pylint: disable=no-name-in-module
 
 from sdcm.sct_events import Severity
+from sdcm.sct_events.group_common_events import decorate_with_context, ignore_ycsb_connection_refused
 from sdcm.sct_events.system import InfoEvent
 
 LOGGER = logging.getLogger(__name__)
@@ -187,6 +188,7 @@ class Audit:
                               severity=Severity.ERROR).publish()
         return audit_config
 
+    @decorate_with_context(ignore_ycsb_connection_refused)
     def configure(self, audit_configuration: AuditConfiguration):
         """Configure audit on all nodes in the cluster and restart them."""
         LOGGER.debug("Configuring audit on all nodes: %s", audit_configuration)


### PR DESCRIPTION
Error 
`ERROR site.ycsb.db.DynamoDBClient  -com.amazonaws.SdkClientException: Unable to execute HTTP request: Connect to alternator:8080` 
may be received during Scylla restart while `toggle_audit` nemesis.
This is a cosmetic thing, since our alternator setup doesn't a full fledged load balancer. So we will  ignore this error.

The error received in longevity-alternator-3h-test (https://argus.scylladb.com/test/1ebc75a8-1976-412b-8aaa-38fdaecd54b7/runs?additionalRuns[]=66b70923-5a26-42aa-a7fa-97d6d07bec67).

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
