### PR TITLE
improvement(metrics): allow to disable node metrics

### DIFF
--- a/sdcm/utils/scylla_metrics_ctrl.py
+++ b/sdcm/utils/scylla_metrics_ctrl.py
@@ -1,0 +1,22 @@
+from typing import Literal
+
+from sdcm.cluster import BaseNode
+
+
+class ScyllaMetricsController:  # pylint: disable=too-few-public-methods
+    """Class to control Scylla metrics using API. Ref: https://github.com/scylladb/scylladb/pull/12670
+    issue about missing docs: https://github.com/scylladb/scylla-monitoring/issues/2196"""
+    curl_cmd = "curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json'"  # pylint: disable=line-too-long
+    endpoint = "http://localhost:10000/v2/metrics-config/"
+
+    @classmethod
+    def modify_scylla_metrics(cls, nodes: list[BaseNode],
+                              action: Literal["drop", "keep"] = "drop",
+                              target_label: str = "level",
+                              regex: str = ".*"
+                              ) -> None:
+        """Disables/Enables metrics based on the action provided.
+        When specifying regex, first part of metric 'scylla_' is ignored, so e.g. use 'transport_.*' to keep/drop transport metrics."""
+        payload = f'[{{"source_labels": ["__name__"], "action": "{action}", "target_label": "{target_label}", "regex": "{regex}"}}]'
+        for node in nodes:
+            node.remoter.run(f'{cls.curl_cmd} -d \'{payload}\' {cls.endpoint}')


### PR DESCRIPTION
For testing purposes we tried to disable metrics to see performance impact of collecting them. This is the code to disable metrics with api

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] -  tested locally with docker backend

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
