### PR TITLE
improvement(event): add AuthenticationError c-s subevent

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -88,6 +88,7 @@ CassandraStressLogEvent.TooManyHintsInFlight: ERROR
 CassandraStressLogEvent.ShardAwareDriver: NORMAL
 CassandraStressLogEvent.SchemaDisagreement: WARNING
 CqlStressCassandraStressLogEvent.ReadValidationError: CRITICAL
+CassandraStressLogEvent.AuthenticationError: WARNING
 SchemaDisagreementErrorEvent: ERROR
 ScyllaBenchLogEvent.ConsistencyError: ERROR
 ScyllaBenchLogEvent.DataValidationError: CRITICAL

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -174,6 +174,7 @@ class CassandraStressLogEvent(LogEvent, abstract=True):
     TooManyHintsInFlight: Type[LogEventProtocol]
     ShardAwareDriver: Type[LogEventProtocol]
     SchemaDisagreement: Type[LogEventProtocol]
+    AuthenticationError: Type[LogEventProtocol]
 
 
 class SchemaDisagreementErrorEvent(SctEvent):
@@ -223,15 +224,22 @@ CassandraStressLogEvent.add_subevent_type("ShardAwareDriver", severity=Severity.
                                           regex="Using optimized driver")
 CassandraStressLogEvent.add_subevent_type("SchemaDisagreement", severity=Severity.WARNING,
                                           regex="No schema agreement")
-
+# By default audit is disabled in 20223.1 by https://github.com/scylladb/scylla-enterprise/pull/3094.
+# But it won't be disabled in 2022.1 and 2022.2.
+# This message generates too much noise for us. We do not need it will fail the test. Create WARNING message, not ERROR.
+# This event will be cretaed in branch 2023.1, not in 2022.x
+CassandraStressLogEvent.add_subevent_type("AuthenticationError", severity=Severity.WARNING,
+                                          regex="Authentication error on host.*Cannot achieve consistency level for cl ONE")
 
 CS_ERROR_EVENTS = (
     CassandraStressLogEvent.TooManyHintsInFlight(),
     CassandraStressLogEvent.OperationOnKey(),
     CassandraStressLogEvent.IOException(),
+    CassandraStressLogEvent.AuthenticationError(),
     CassandraStressLogEvent.ConsistencyError(),
     CassandraStressLogEvent.SchemaDisagreement(),
 )
+
 CS_NORMAL_EVENTS = (CassandraStressLogEvent.ShardAwareDriver(), )
 
 CS_ERROR_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \

--- a/unit_tests/test_sct_events_loaders.py
+++ b/unit_tests/test_sct_events_loaders.py
@@ -399,6 +399,7 @@ class TestCassandraStressLogEvent(unittest.TestCase):
         self.assertTrue(issubclass(CassandraStressLogEvent.OperationOnKey, CassandraStressLogEvent))
         self.assertTrue(issubclass(CassandraStressLogEvent.TooManyHintsInFlight, CassandraStressLogEvent))
         self.assertTrue(issubclass(CassandraStressLogEvent.SchemaDisagreement, CassandraStressLogEvent))
+        self.assertTrue(issubclass(CassandraStressLogEvent.AuthenticationError, CassandraStressLogEvent))
 
     def test_known_cs_normal(self):
         self.assertTrue(issubclass(CassandraStressLogEvent.ShardAwareDriver, CassandraStressLogEvent))
@@ -436,6 +437,11 @@ class TestCassandraStressLogEvent(unittest.TestCase):
                        'Requires 2, alive 1',
                        expected_type='ConsistencyError',
                        expected_severity=Severity.ERROR)
+
+        self.get_event(line='ERROR 13:04:18,965 Authentication error on host rolling-upgrade-sla--centos-8-db-node-373473f1-0-3.c.'
+                            'sct-project-1.internal/10.142.1.41:9042: Cannot achieve consistency level for cl ONE. Requires 1, alive 0',
+                       expected_type='AuthenticationError',
+                       expected_severity=Severity.WARNING)
 
     def test_cs_normal_shared_awarnes_event(self):
         self.get_event(line='com.datastax.driver.core.Cluster - ===== Using optimized driver!!! =====',


### PR DESCRIPTION
Add CassandraStressLogEvent.add_subevent_type WARNING for cassandra-stress error:
```
ERROR 13:04:18,965 Authentication error on host: Cannot achieve consistency level for cl ONE. Requires 1, alive 0
```

This error caused by audit enabled. And during rollback test may cause to error from c-s. By default audit is disabled in 20223.1 by scylladb/scylla-enterprise#3094. But it won't be disabled in 2022.1 and 2022.2.
This message generates too much noise for us. We do not need it will fail the test.

This change was added to branch-2023.1 only by https://github.com/scylladb/scylla-cluster-tests/pull/6590. But was missed when the branch was recreated


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
