### PR TITLE
fix(disrupt_memory_stress): Change the SkipPerIssue to actual issue

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4332,8 +4332,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self._k8s_disrupt_memory_stress()
             return
 
-        if SkipPerIssues(['scylladb/scylla-cluster-tests#7098',
-                          'scylladb/scylla-cluster-tests#6928'], params=self.tester.params):
+        if SkipPerIssues('scylladb/scylladb#11807', params=self.tester.params):
             # since we might get into uncontrolled situations with this nemesis
             # see https://github.com/scylladb/scylla-cluster-tests/issues/6928
             raise UnsupportedNemesis("Disabled cause of https://github.com/scylladb/scylla-cluster-tests/issues/6928")


### PR DESCRIPTION
Changing the SkipPerIssue that memory_stress nemesis is skipped from the SCT issue to the actual issue that causing the tests to fail. Leaving the comment to refer to the SCT issue where the discussion is held.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
