### PR TITLE
improvement(perf-report): added test_id to perf regression reports

### DIFF
--- a/sdcm/report_templates/results_performance.html
+++ b/sdcm/report_templates/results_performance.html
@@ -2,6 +2,7 @@
 {% block body %}
     {% block title %}
     <h3>Test: {{ test_name }}</h3>
+    <h3>Test ID: {{ test_id }}</h3>
     {% endblock %}
     <h3>
         <span>Test start time: </span>

--- a/sdcm/report_templates/results_performance_baseline.html
+++ b/sdcm/report_templates/results_performance_baseline.html
@@ -1,6 +1,7 @@
 {% extends 'results_base_custom.html' %}
 {% block body %}
     <h3>Test: {{ test_name }}</h3>
+    <h3>Test ID: {{ test_id }}</h3>
     <h3>
         <span>Test start time: </span>
         <span class="blue">{{ test_start_time }}</span>

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -844,6 +844,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
             "test_name": full_test_name,
             "test_start_time": str(test_start_time),
             "test_version": test_version_info,
+            "test_id": doc["_source"]["test_details"].get("test_id", ""),
             "res_list": res_list,
             "setup_details": self._get_setup_details(doc, is_gce),
             "prometheus_stats": {stat: doc["_source"]["results"].get(stat, {})
@@ -1066,6 +1067,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
         last_events, events_summary = self.get_events()
         results = {
             "test_name": full_test_name,
+            "test_id": doc["_source"]["test_details"].get("test_id", ""),
             "test_start_time": str(test_start_time),
             "test_version": test_version_info,
             "base_line": base_line,
@@ -1447,6 +1449,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
 
         last_events, events_summary = self.get_events()
         results = {
+            "test_id": test_id,
             "current_main_test": rp_main_test,
             "results": rp_metrics_table,
             "metric_info": rp_metric_info,
@@ -1480,6 +1483,7 @@ class ThroughputLatencyGradualGrowPayloadPerformanceAnalyzer(BaseResultsAnalyzer
 
     def check_regression(self, test_name, test_results, test_details):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
         results = dict(
+            test_id=test_details.get("test_id", ""),
             stats=test_results,
             test_name=test_name,
             test_details=test_details,
@@ -1505,6 +1509,7 @@ class SearchBestThroughputConfigPerformanceAnalyzer(BaseResultsAnalyzer):
     def check_regression(self, test_name, setup_details, test_results):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
         subject = f"Performance Regression Best throughput with configuation - {test_name} - {setup_details['start_time']}"
         results = {
+            "test_id": setup_details.get("test_id", ""),
             "test_name": test_name,
             "setup_details": setup_details,
             "test_results": test_results


### PR DESCRIPTION
Often when analyzing perf results emails, test_id might be needed to e.g. restore monitor.

This adds test_id to email reports.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
