### PR TITLE
fix(tablets_weekly_trigger.xml): changed predefined properties

### DIFF
--- a/jenkins-pipelines/master-triggers/tablets_weekly_trigger.xml
+++ b/jenkins-pipelines/master-triggers/tablets_weekly_trigger.xml
@@ -17,12 +17,12 @@
         <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
           <configs>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-              <properties>scylla_version=enterprise:latest
-region=random
-provision_type=spot
-post_behavior_db_nodes=destroy
+              <properties>scylla_version=master:latest
+new_scylla_repo=https://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list
+provision_type=on_demand
+post_behavior_db_nodes=keep-on-failure
 post_behavior_loader_nodes=destroy
-post_behavior_monitor_nodes=destroy
+post_behavior_monitor_nodes=keep-on-failure
 email_recipients=qa@scylladb.com,tablets@scylladb.com</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>


### PR DESCRIPTION
Since one of the scenarios that are triggered is multi dc, we can't pass on the region param. Also chose to use OSS master instead of enterprise and kept db and monitor nodes alive

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
