### PR TITLE
fix(test_default_filters): remove unneed log filter

### DIFF
--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -104,11 +104,6 @@ def enable_default_filters(sct_config: SCTConfiguration):  # pylint: disable=unu
                                     regex='ldap_connection - Seastar read failed: std::system_error '
                                     '(error system:104, read: Connection reset by peer)').publish()
 
-    if SkipPerIssues('scylladb/scylladb#15672', params=sct_config):
-        EventsSeverityChangerFilter(new_severity=Severity.WARNING,
-                                    event_class=DatabaseLogEvent.RUNTIME_ERROR,
-                                    regex='.*view update generator not plugged to push updates').publish()
-
     if sct_config.get('cluster_backend').startswith("k8s"):
         # cause of issue https://github.com/scylladb/scylla-cluster-tests/issues/6119
         EventsSeverityChangerFilter(new_severity=Severity.WARNING,

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -404,7 +404,7 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
         self.assertNotIn("this is filtered", log_content)
 
     def test_default_filters(self):
-        with self.wait_for_n_events(self.get_events_logger(), count=5):
+        with self.wait_for_n_events(self.get_events_logger(), count=4):
             DatabaseLogEvent.BACKTRACE() \
                 .add_info(node="A",
                           line_number=22,
@@ -413,12 +413,6 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
                 .publish()
             DatabaseLogEvent.BACKTRACE() \
                 .add_info(node="A", line_number=22, line="other back trace that shouldn't be filtered") \
-                .publish()
-            DatabaseLogEvent.RUNTIME_ERROR() \
-                .add_info(node="A",
-                          line_number=22,
-                          line="!ERR | scylla[5969]: [shard 1:stat] storage_proxy - exception during mutation write to "
-                               "10.12.0.219: std::runtime_error (view update generator not plugged to push updates)") \
                 .publish()
 
             DatabaseLogEvent.DATABASE_ERROR().add_info(
@@ -443,12 +437,10 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
         self.assertNotIn("supressed", log_content)
 
         warnings_log_content = self.get_event_log_file("warning.log")
-        assert 'std::runtime_error' in warnings_log_content
         assert 'data_dictionary::no_such_column_family' in warnings_log_content
         assert 'Authentication error' not in warnings_log_content
 
         error_log_content = self.get_event_log_file("error.log")
-        assert 'RUNTIME_ERROR' not in error_log_content
         assert 'data_dictionary::no_such_column_family' not in error_log_content
         assert 'Authentication error' in error_log_content
 


### PR DESCRIPTION
since scylladb/scylladb#15672 was closed, and the issue long fixed on master, we don't need this filter
and not the test logic testing the filter.

Ref: https://github.com/scylladb/scylladb/issues/15672

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
