### PR TITLE
fix(cleanup): make cleanup terminate by default

### DIFF
--- a/utils/cloud_cleanup/aws/clean_aws.py
+++ b/utils/cloud_cleanup/aws/clean_aws.py
@@ -327,7 +327,7 @@ if __name__ == "__main__":
                             default=os.environ.get('DRY_RUN', False))
     arg_parser.add_argument("--default-action",
                             help="The default action when stopping an image (stop/terminate)",
-                            default=os.environ.get('DEFAULT_ACTION', "stop"))
+                            default=os.environ.get('DEFAULT_ACTION', "terminate"))
 
     arguments = arg_parser.parse_args()
 

--- a/utils/cloud_cleanup/azure/clean_azure.py
+++ b/utils/cloud_cleanup/azure/clean_azure.py
@@ -78,7 +78,7 @@ def get_rg_creation_time(resource_group):
 
 
 def get_keep_action(v_m) -> Callable:
-    return v_m.tags.get('keep_action', "stop").lower() if v_m.tags else "stop"
+    return v_m.tags.get('keep_action', "terminate").lower() if v_m.tags else "terminate"
 
 
 def should_keep(creation_time, keep_hours):


### PR DESCRIPTION
In case there's no keep_action tag set we stop by default - I suppose we should be terminating instances to avoid growing number of stopped instances.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
