### PR TITLE
fix(RollingConfigChangeInternodeCompression): properly identify None

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -971,7 +971,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_rolling_config_change_internode_compression(self):
         def get_internode_compression_new_value_randomly(current_compression):
             self.log.debug(f"Current compression is {current_compression}")
-            values = ['dc', 'all', 'none']
+            values = ['dc', 'all', None]
             values_to_toggle = list(filter(lambda value: value != current_compression, values))
             return random.choice(values_to_toggle)
 


### PR DESCRIPTION
When the current internode_compression value in the scylla.yaml is "none", it is represented as None when being read by python. So, when get_internode_compression_new_value_randomly tries to find the current value of internode_compression in the values list ['dc', 'all', 'none'] it cannot find it, since the none in the list is a string. As a result, the value of the new internode_compression chosen by the nemesis could be 'none' again, and thus it has not changed at all, and the nemesis did not execute its primary function.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
