### PR TITLE
fix(k8s): update pkg info before installing packages inside of K8S pods

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1733,6 +1733,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 packages_to_install = [f"{pkg}{version_prefix}" for pkg in [
                     package_name] + list(set(result.stdout.splitlines()))]
                 package_name = " ".join(packages_to_install)
+        if self.is_kubernetes():
+            # NOTE: run "update" command because on K8S after each pod recreation we lose previous "update" results.
+            #       And running some old Scylla docker images we may get errors refering to old/removed mirrors.
+            self.remoter.sudo(f"{pkg_cmd} update", ignore_status=ignore_status)
         self.remoter.sudo(f'{pkg_cmd} install -y {package_name}', ignore_status=ignore_status)
 
     def is_apt_lock_free(self) -> bool:


### PR DESCRIPTION
Due to the K8S specifics, we may lose `apt update` cmd call results after a pod recreation.
So, it means running not recent Scylla docker images we may get errors like following:

```
  E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/i/\
    iptables/libxtables12_1.8.7-1ubuntu5.1_amd64.deb  404  Not Found [IP: <some-ip>]
  E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

So, do `apt update` in the `install_package` function running on K8S.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/valerii/job/vp-functional-eks/72

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
