### PR TITLE
improvement(aws region): configure region with few subnets

### DIFF
--- a/sdcm/utils/aws_peering.py
+++ b/sdcm/utils/aws_peering.py
@@ -71,19 +71,20 @@ class AwsVpcPeering:
 
     @staticmethod
     def configure_route_tables(origin_region, target_region, vpc_peering_id):
-        route_table = origin_region.sct_route_table
-        try:
-            route_table.create_route(DestinationCidrBlock=str(target_region.vpc_ipv4_cidr),
-                                     VpcPeeringConnectionId=vpc_peering_id)
-        except ClientError as ex:
-            if 'already exists' not in str(ex):
-                raise
-        try:
-            route_table.create_route(DestinationIpv6CidrBlock=str(target_region.vpc_ipv6_cidr),
-                                     VpcPeeringConnectionId=vpc_peering_id)
-        except ClientError as ex:
-            if 'already exists' not in str(ex):
-                raise
+        for index in range(AwsRegion.SCT_SUBNET_PER_AZ):
+            route_table = origin_region.sct_route_table(index=index)
+            try:
+                route_table.create_route(DestinationCidrBlock=str(target_region.vpc_ipv4_cidr),
+                                         VpcPeeringConnectionId=vpc_peering_id)
+            except ClientError as ex:
+                if 'already exists' not in str(ex):
+                    raise
+            try:
+                route_table.create_route(DestinationIpv6CidrBlock=str(target_region.vpc_ipv6_cidr),
+                                         VpcPeeringConnectionId=vpc_peering_id)
+            except ClientError as ex:
+                if 'already exists' not in str(ex):
+                    raise
 
     @staticmethod
     def open_security_group(origin_region, target_region):

--- a/sdcm/utils/aws_region.py
+++ b/sdcm/utils/aws_region.py
@@ -20,6 +20,7 @@ import botocore
 from mypy_boto3_ec2 import EC2Client, EC2ServiceResource
 
 from sdcm.keystore import KeyStore
+from sdcm.utils.decorators import retrying
 from sdcm.utils.get_username import get_username
 
 LOGGER = logging.getLogger(__name__)
@@ -31,11 +32,12 @@ class AwsRegion:
     SCT_VPC_CIDR_TMPL = "10.{}.0.0/16"
     SCT_SECURITY_GROUP_NAME = "SCT-2-sg"
     SCT_TEST_SECURITY_GROUP_NAME_TMPL = "SCT-2-sg-{}"
-    SCT_SUBNET_NAME = "SCT-2-subnet-{availability_zone}"
+    SCT_SUBNET_NAME = "SCT-2-subnet-{availability_zone}{subnet_index}"
     SCT_INTERNET_GATEWAY_NAME = "SCT-2-igw"
-    SCT_ROUTE_TABLE_NAME = "SCT-2-rt"
+    SCT_ROUTE_TABLE_NAME = "SCT-2-rt{index}"
     SCT_KEY_PAIR_NAME = "scylla-qa-ec2"  # TODO: change legacy name to sct-keypair-aws
     SCT_SSH_GROUP_NAME = 'SCT-ssh-sg'
+    SCT_SUBNET_PER_AZ = 2  # how many subnets to configure in each region.
 
     def __init__(self, region_name):
         self.region_name = region_name
@@ -99,11 +101,18 @@ class AwsRegion:
     def vpc_ipv6_cidr(self):
         return ip_network(self.sct_vpc.ipv6_cidr_block_association_set[0]["Ipv6CidrBlock"])
 
-    def az_subnet_name(self, region_az):
-        return self.SCT_SUBNET_NAME.format(availability_zone=region_az)
+    def az_subnet_name(self, region_az, subnet_index):  # pylint: disable=arguments-differ
+        # To support existing VPC/subnet names convention, ignore the index number for first subnet
+        return self.SCT_SUBNET_NAME.format(availability_zone=region_az,
+                                           subnet_index="" if not subnet_index else f"-{subnet_index}")
 
-    def sct_subnet(self, region_az) -> EC2ServiceResource.Subnet:
-        subnet_name = self.az_subnet_name(region_az)
+    def sct_subnet(self, region_az, subnet_index: int = None) -> EC2ServiceResource.Subnet:
+        @retrying(n=5, message="Wait for subnet became available...")
+        def wait_for_subnet_available():
+            assert existing_subnets[0]['State'] == 'available', \
+                f"State of {subnet_name} is not available. Fix it (delete or make it available) and re-run"
+
+        subnet_name = self.az_subnet_name(region_az, subnet_index=subnet_index)
         subnets = self.client.describe_subnets(Filters=[{"Name": "tag:Name", "Values": [subnet_name]}])
         LOGGER.debug("Found Subnets: %s", subnets)
         existing_subnets = subnets.get("Subnets", [])
@@ -111,39 +120,79 @@ class AwsRegion:
             return None
         assert len(existing_subnets) == 1, \
             f"More than 1 Subnet with {subnet_name} found in {self.region_name}: {existing_subnets}!"
+        wait_for_subnet_available()
         return self.resource.Subnet(existing_subnets[0]["SubnetId"])  # pylint: disable=no-member
 
-    def create_sct_subnet(self, region_az, ipv4_cidr, ipv6_cidr):
-        LOGGER.info("Creating subnet for %s...", region_az)
-        subnet_name = self.az_subnet_name(region_az)
-        if self.sct_subnet(region_az):
-            subnet_id = self.sct_subnet(region_az).subnet_id
+    def create_sct_subnet(self, region_az, ipv4_cidr, ipv6_cidr, subnet_index: int = None):
+        LOGGER.info("Creating subnet(s) for %s...", region_az)
+        subnet_name = self.az_subnet_name(region_az, subnet_index=subnet_index)
+        if subnet := self.sct_subnet(region_az, subnet_index=subnet_index):
+            subnet_id = subnet.subnet_id
             LOGGER.warning("Subnet '%s' already exists!  Id: '%s'.", subnet_name, subnet_id)
-        else:
+            return
 
-            result = self.client.create_subnet(CidrBlock=str(ipv4_cidr), Ipv6CidrBlock=str(ipv6_cidr),
-                                               VpcId=self.sct_vpc.vpc_id, AvailabilityZone=region_az)
-            subnet_id = result["Subnet"]["SubnetId"]
-            subnet = self.resource.Subnet(subnet_id)  # pylint: disable=no-member
-            subnet.create_tags(Tags=[{"Key": "Name", "Value": subnet_name}])
-            LOGGER.info("Configuring to automatically assign public IPv4 and IPv6 addresses...")
-            self.client.modify_subnet_attribute(
-                MapPublicIpOnLaunch={"Value": True},
-                SubnetId=subnet_id
-            )
-            # for some reason boto3 throws error when both AssignIpv6AddressOnCreation and MapPublicIpOnLaunch are used
-            self.client.modify_subnet_attribute(
-                AssignIpv6AddressOnCreation={"Value": True},
-                SubnetId=subnet_id
-            )
-            LOGGER.info("'%s' with id '%s' created.", subnet_name, subnet_id)
+        result = self.client.create_subnet(CidrBlock=str(ipv4_cidr), Ipv6CidrBlock=str(ipv6_cidr),
+                                           VpcId=self.sct_vpc.vpc_id, AvailabilityZone=region_az)
+        subnet_id = result["Subnet"]["SubnetId"]
+        subnet = self.resource.Subnet(subnet_id)  # pylint: disable=no-member
+        subnet.create_tags(Tags=[{"Key": "Name", "Value": subnet_name}])
+        LOGGER.info("Configuring to automatically assign public IPv4 and IPv6 addresses...")
+        self.client.modify_subnet_attribute(
+            MapPublicIpOnLaunch={"Value": True},
+            SubnetId=subnet_id
+        )
+        # for some reason boto3 throws error when both AssignIpv6AddressOnCreation and MapPublicIpOnLaunch are used
+        self.client.modify_subnet_attribute(
+            AssignIpv6AddressOnCreation={"Value": True},
+            SubnetId=subnet_id
+        )
+        LOGGER.info("'%s' with id '%s' created.", subnet_name, subnet_id)
 
     def create_sct_subnets(self):
-        num_subnets = len(self.availability_zones)
-        ipv4_cidrs = list(self.vpc_ipv4_cidr.subnets(6))[:num_subnets]
-        ipv6_cidrs = list(self.vpc_ipv6_cidr.subnets(8))[:num_subnets]
-        for i, az_name in enumerate(self.availability_zones):
-            self.create_sct_subnet(region_az=az_name, ipv4_cidr=ipv4_cidrs[i], ipv6_cidr=ipv6_cidrs[i])
+        ipv4_cidrs_iter = self.vpc_ipv4_cidr.subnets(6)
+        ipv6_cidrs_iter = self.vpc_ipv6_cidr.subnets(8)
+        # First subnet in each availability zone already exists.
+        # It means that first range of CIDRs are in used.
+        # For example:
+        #    There are 2 availability zone.
+        #    Zone A with IPv4 CIDR "10.0.0.0"
+        #    Zone B with IPv4 CIDR "10.0.4.0"
+        #    ipv4_cidrs_iter = ["10.0.0.0", "10.0.4.0", "10.0.8.0", "10.0.12.0"]
+        # If we try to create sequentially [A-1, A-2, B-1, B2], the cidr "10.0.4.0" will be taken for A-2 and fails,
+        # because of this cidr is in use by B-1
+        # To prevent this failure, first the primary subnets in all AZ will be created and then the secondary subnets in all AZ
+        for range_index in range(self.SCT_SUBNET_PER_AZ):
+            for az_name in self.availability_zones:
+                self.create_sct_subnet(region_az=az_name, ipv4_cidr=next(ipv4_cidrs_iter), ipv6_cidr=next(ipv6_cidrs_iter),
+                                       subnet_index=range_index)
+                self.create_sct_subnet_route_table(subnet_name=self.az_subnet_name(region_az=az_name, subnet_index=range_index),
+                                                   index=range_index)
+                self.associate_subnet_with_route_table(region_az=az_name, index=range_index)
+
+    def associate_subnet_with_route_table(self, region_az: str, index: int = None):
+        subnet = self.sct_subnet(region_az, subnet_index=index)
+        sct_route_table = self.sct_route_table(index=index)
+        response = self.client.describe_route_tables(
+            Filters=[{'Name': 'association.subnet-id', 'Values': [subnet.subnet_id]}])
+
+        # If subnet is not associated with route table or associated with main route table
+        if not (associated_route_table := response['RouteTables']):
+            self.client.associate_route_table(RouteTableId=sct_route_table.route_table_id, SubnetId=subnet.subnet_id)
+            LOGGER.info("Subnet '%s' has been associated with '%s' route table.",
+                        subnet.subnet_id, sct_route_table.route_table_id)
+            return
+
+        associated_route_table_id = associated_route_table[0].get('RouteTableId')
+        # If subnet is associated with route table but not that was created for this subnet
+        if associated_route_table_id != sct_route_table.route_table_id:
+            self.client.replace_route_table_association(
+                AssociationId=associated_route_table_id, RouteTableId=sct_route_table.route_table_id)
+            LOGGER.info("Subnet '%s' has been associated with '%s' route table.",
+                        subnet.subnet_id, sct_route_table.route_table_id)
+        # If subnet is associated with appropriate route table
+        else:
+            LOGGER.info("Subnet '%s' is already associated with '%s' route table.",
+                        subnet.subnet_id, sct_route_table.route_table_id)
 
     @property
     def sct_internet_gateway(self) -> EC2ServiceResource.InternetGateway:
@@ -172,41 +221,67 @@ class AwsRegion:
                         self.SCT_INTERNET_GATEWAY_NAME, igw_id, self.sct_vpc.vpc_id)
             igw.attach_to_vpc(VpcId=self.sct_vpc.vpc_id)
 
-    @cached_property
-    def sct_route_table(self) -> EC2ServiceResource.RouteTable:
+    def sct_route_table_name(self, index: int = None):
+        """
+        :param index: suffix of the route table name
+        """
+        # For first subnet the main rout table will be used, so ignore the index number
+        return self.SCT_ROUTE_TABLE_NAME.format(index="" if not index else f"-{index}")
+
+    def sct_route_table(self, index: int = None) -> EC2ServiceResource.RouteTable:
+        sct_route_table_name = self.sct_route_table_name(index=index)
         route_tables = self.client.describe_route_tables(Filters=[{"Name": "tag:Name",
-                                                                   "Values": [self.SCT_ROUTE_TABLE_NAME]}])
+                                                                   "Values": [sct_route_table_name]}])
         LOGGER.debug("Found Route Tables: %s", route_tables)
         existing_rts = route_tables.get("RouteTables", [])
         if len(existing_rts) == 0:
             return None
         assert len(existing_rts) == 1, \
-            f"More than 1 Route Table with {self.SCT_ROUTE_TABLE_NAME} found " \
-            f"in {self.region_name}: {existing_rts}!"
+            f"More than 1 Route Table with {sct_route_table_name} found in {self.region_name}: {existing_rts}!"
         return self.resource.RouteTable(existing_rts[0]["RouteTableId"])  # pylint: disable=no-member
 
-    def configure_sct_route_table(self):
+    def create_sct_subnet_route_table(self, subnet_name: str, index: int = None):
+        subnet_route_table = self.sct_route_table_name(index=index)
+        LOGGER.info("Configuring SCT subnet Route Table %s for subnet %s...", subnet_route_table, subnet_name)
+        if sct_route_table := self.sct_route_table(index=index):
+            LOGGER.warning("Route Table '%s' already exists! Id: '%s'.",
+                           subnet_route_table, sct_route_table.route_table_id)
+            return
+
+        self.client.create_route_table(DryRun=False,
+                                       VpcId=self.sct_vpc.vpc_id,
+                                       TagSpecifications=[
+                                           {'ResourceType': "route-table",
+                                            'Tags': [{'Key': 'Name',
+                                                      'Value': subnet_route_table
+                                                      }]
+                                            }],
+                                       )
+        LOGGER.info("Setting routing of all outbound traffic via Internet Gateway...")
+        route_table = self.sct_route_table(index=index)
+        route_table.create_route(DestinationCidrBlock="0.0.0.0/0",
+                                 GatewayId=self.sct_internet_gateway.internet_gateway_id)
+        route_table.create_route(DestinationIpv6CidrBlock="::/0",
+                                 GatewayId=self.sct_internet_gateway.internet_gateway_id)
+
+    def configure_sct_route_table(self, index: int = None):
         # add route to Internet: 0.0.0.0/0 -> igw
         LOGGER.info("Configuring main Route Table...")
-        if self.sct_route_table:
+        if sct_route_table := self.sct_route_table(index=index):
             LOGGER.warning("Route Table '%s' already exists! Id: '%s'.",
-                           self.SCT_ROUTE_TABLE_NAME, self.sct_route_table.route_table_id)
+                           self.sct_route_table_name(index=index), sct_route_table.route_table_id)
         else:
             route_tables = list(self.sct_vpc.route_tables.all())
             assert len(route_tables) == 1, f"Only one main route table should exist for {self.SCT_VPC_NAME}. " \
                                            f"Found {len(route_tables)}!"
             route_table: EC2ServiceResource.RouteTable = route_tables[0]
-            route_table.create_tags(Tags=[{"Key": "Name", "Value": self.SCT_ROUTE_TABLE_NAME}])
+
+            route_table.create_tags(Tags=[{"Key": "Name", "Value": self.sct_route_table_name(index=index)}])
             LOGGER.info("Setting routing of all outbound traffic via Internet Gateway...")
             route_table.create_route(DestinationCidrBlock="0.0.0.0/0",
                                      GatewayId=self.sct_internet_gateway.internet_gateway_id)
             route_table.create_route(DestinationIpv6CidrBlock="::/0",
                                      GatewayId=self.sct_internet_gateway.internet_gateway_id)
-            LOGGER.info("Going to associate all Subnets with the Route Table...")
-            for az_name in self.availability_zones:
-                subnet_id = self.sct_subnet(az_name).subnet_id
-                LOGGER.info("Associating Route Table with '%s' [%s]...", self.az_subnet_name(az_name), subnet_id)
-                route_table.associate_with_subnet(SubnetId=subnet_id)
 
     @property
     def sct_security_group(self) -> EC2ServiceResource.SecurityGroup:
@@ -544,9 +619,9 @@ class AwsRegion:
     def configure(self):
         LOGGER.info("Configuring '%s' region...", self.region_name)
         self.create_sct_vpc()
-        self.create_sct_subnets()
         self.create_sct_internet_gateway()
         self.configure_sct_route_table()
+        self.create_sct_subnets()
         self.create_sct_security_group()
         self.create_sct_ssh_security_group()
         self.create_sct_key_pair()


### PR DESCRIPTION
### After this commit is merged we need to create second subnet in every region/availability zone


This commit is a next step of a major refactoring (https://github.com/scylladb/scylla-cluster-tests/pull/6575) of how to configure and control an address goes to which interface.
We were doing it for the network nemesis cases, but it complicated the setup, and forced 
us to use public networks, and listen on 0.0.0.0, which wasn't exactly target and not as 
recommended in Scylla.

This commit present changes that allow to create a few subnets in every availability zone
(or region/zone by request). With those subnets we'll be able to create undependent networks 
on the instance and cover more complex networking setup.

Primary and secondary subnets are connected to its own route tables.
All primary subnets of one region are connected to one route table.
All secondary subnets of same region are connected to another route table.

Task: https://github.com/scylladb/qa-tasks/issues/1217

Existing subnets are kept without changes and won't have an impact

![Screenshot from 2024-03-14 18-43-26](https://github.com/scylladb/scylla-cluster-tests/assets/34435448/39a5c67c-b91d-4edc-b785-f1fee6b9b271)


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
added second subnet to `eu-north-1c`. 
- [x] [basic artifact test](https://argus.scylladb.com/test/c29b1204-20a2-4c4c-9864-b0c47e80efc6/runs?additionalRuns[]=af1e847f-84c8-44a6-bc54-6baef0c4c55b)
- [x] [one interface](https://argus.scylladb.com/test/657bf1f3-69a5-4c36-bdbf-bf17718f7087/runs?additionalRuns[]=9f11c50d-db46-4882-994b-add6db2ba9ee)
- [x] [two interfaces](https://argus.scylladb.com/test/4cc93a2a-db6c-4fe2-8dc3-a7827093d793/runs?additionalRuns[]=6130a7cf-9110-4924-9116-99342fbab108)
- [x] `./sct.py create-runner-instance -c aws -r eu-north-1 --test-id 123456 -z c -d 10`
- [x]  I checked it manually `sdcm.utils.aws_region.AwsRegion.configure` in my environment for `eu-north-1c`. The names are correct and existing subnets/route tables are found (I do not want to create new subnets for now)
- [x] [mocked functional test](https://github.com/scylladb/scylla-cluster-tests/blob/master/functional_tests/mocked/test_aws_region.py) for region configure that runs as part of PR check

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
