### PR TITLE
fix(cluster): fix get_nodetool_status

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4134,7 +4134,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             r"(?P<load>[\d.]+ [\w]+|\?)\s+"
             r"(?P<tokens>[\d]+)\s+"
             r"(?P<owns>[\w?]+)\s+"
-            r"(?P<host_id>[\w-]+)\s{2,}"
+            r"(?P<host_id>[\w-]+)\s+"
             r"(?P<rack>[\w]+|$)")
 
         for dc in data_centers:

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -481,6 +481,27 @@ class TestNodetoolStatus(unittest.TestCase):
                            '10.0.198.153': {'state': 'UN', 'load': '?', 'tokens': '256', 'owns': '?',
                                             'host_id': 'fba174cd-917a-40f6-ab62-cc58efaaf301', 'rack': '1a'}}}
 
+    def test_can_get_nodetool_status_typical_with_one_space_after_host_id(self):  # pylint: disable=no-self-use
+        """case for https://github.com/scylladb/scylla-cluster-tests/issues/7274"""
+        resp = "\n".join(["Datacenter: datacenter1",
+                          "=======================",
+                          "Status=Up/Down",
+                          "|/ State=Normal/Leaving/Joining/Moving",
+                          "-- Address    Load      Tokens Owns Host ID                              Rack ",
+                          "UN 172.17.0.2 202.92 KB 256    ?    7b8f86bf-c70c-4246-a273-146057e12431 rack1",
+                          ]
+                         )
+        node = NodetoolDummyNode(resp=resp)
+        db_cluster = DummyScyllaCluster([node])
+
+        status = db_cluster.get_nodetool_status()
+
+        assert status == {'datacenter1':
+                          {'172.17.0.2':
+                           {'state': 'UN', 'load': '202.92KB', 'tokens': '256', 'owns': '?',
+                            'host_id': '7b8f86bf-c70c-4246-a273-146057e12431', 'rack': 'rack1'},
+                           }}
+
     def test_datacenter_name_per_region(self):  # pylint: disable=no-self-use
         resp = "\n".join(["Datacenter: eastus",
                           "==================",


### PR DESCRIPTION
`get_nodetool_status` method was assuming at least 2 spaces after `host id` field which is not true anymore (or never was).

Fixed regexp for getting nodetool status fields and added new unit test for such caase.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/7274

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/artifacts-ubuntu2204-test/2/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
