### PR TITLE
fix(k8s): make static loaders work

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -3113,7 +3113,7 @@ class LoaderPodCluster(cluster.BaseLoaderSet, PodCluster):
                     "POD_MEMORY_LIMIT": self.k8s_clusters[current_dc_idx].calculated_loader_memory_limit,
                 },
             )
-            self.k8s_clusters[current_dc_idx].debug(
+            self.k8s_clusters[current_dc_idx].log.debug(
                 "Check the '%s' loaders cluster in the '%s' namespace",
                 self.loader_cluster_name, self.namespace)
             self.k8s_clusters[current_dc_idx].kubectl("get statefulset", namespace=self.namespace)


### PR DESCRIPTION
With merge of the (https://github.com/scylladb/scylla-cluster-tests/pull/6773) PR the static loaders became broken with the following error:

```
  File "sdcm/cluster_k8s/__init__.py", line 3140, in add_nodes
    self.k8s_clusters[current_dc_idx].debug(
  AttributeError: 'EksCluster' object has no attribute 'debug'
```

So, fix it by using missing `log` attr.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
