### PR TITLE
fix(perf): fix steady state latency measurement in perf upgrade test

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -843,6 +843,7 @@ class PerformanceRegressionUpgradeTest(PerformanceRegressionTest, UpgradeTest): 
         test_index = f'latency-during-upgrade-{sub_type}'
         self.create_test_stats(sub_type=sub_type, append_sub_test_to_name=False, test_index=test_index)
         stress_queue = self.run_stress_thread(stress_cmd=stress_cmd, stress_num=1, stats_aggregate_cmds=False)
+        time.sleep(60)  # postpone measure steady state latency to skip c-s start period when latency is high
         self.steady_state_latency()
         versions_list = []
 


### PR DESCRIPTION
Latency measured during c-s startup can be high and should not be counted as 'steady'.

Postpone latency measurement in perf upgrade test by 60 secs to skip c-s startup period.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
