### PR TITLE
improvement(cluster): configure and use independent network interfaces in AWS tests

### DIFF
--- a/configurations/network_config/two_interfaces.yaml
+++ b/configurations/network_config/two_interfaces.yaml
@@ -2,13 +2,13 @@ scylla_network_config:
 - address: listen_address  # Address Scylla listens for connections from other nodes. See storage_port and ssl_storage_ports.
   ip_type: ipv4
   public: false
-  listen_all: true  # Should be True when multiple interfaces - Scylla should be listening on all interfaces
+  listen_all: false
   use_dns: false
   nic: 1
 - address: rpc_address  # Address on which Scylla is going to expect Thrift and CQL client connections.
   ip_type: ipv4
   public: false
-  listen_all: true  # Should be True when multiple interfaces - Scylla should be listening on all interfaces
+  listen_all: false
   use_dns: false
   nic: 1
 - address: broadcast_rpc_address  # Address that is broadcasted to tell the clients to connect to. Related to rpc_address.
@@ -23,6 +23,6 @@ scylla_network_config:
   nic: 1  #  If ipv4 and public is True it has to be primary network interface (device index is 0)
 - address: test_communication  # Type of IP used to connect from test to DB/monitor instances
   ip_type: ipv4
-  public: true
+  public: false
   use_dns: false
   nic: 0  #  If ipv4 and public is True it has to be primary network interface (device index is 0)

--- a/sct.py
+++ b/sct.py
@@ -1532,10 +1532,12 @@ def create_runner_instance(cloud_provider, region, availability_zone, instance_t
     add_file_logger()
     sct_runner_ip_path = Path("sct_runner_ip")
     sct_runner_ip_path.unlink(missing_ok=True)
-    sct_runner = get_sct_runner(cloud_provider=cloud_provider, region_name=region, availability_zone=availability_zone)
 
     os.environ.setdefault('SCT_CLUSTER_BACKEND', cloud_provider)
     sct_config = SCTConfiguration()
+    sct_runner = get_sct_runner(cloud_provider=cloud_provider, region_name=region,
+                                availability_zone=availability_zone, params=sct_config)
+
     instance_type = instance_type or sct_config.get('instance_type_runner')
     root_disk_size_gb = root_disk_size_gb or sct_config.get('root_disk_size_runner')
     test_name = test_name or test_id

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1276,7 +1276,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def is_manager_agent_up(self, port=None):
         port = port if port else self.MANAGER_AGENT_PORT
         # When the agent is IP, it should answer an https request of https://NODE_IP:10001/ping with status code 204
-        response = requests.get(f"https://{normalize_ipv6_url(self.external_address)}:{port}/ping", verify=False)
+        response = requests.get(f"https://{normalize_ipv6_url(self.cql_address)}:{port}/ping", verify=False)
         return response.status_code == 204
 
     def wait_manager_agent_up(self, verbose=True, timeout=180):

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -209,8 +209,10 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         interfaces = []
         for i in range(interfaces_amount):
             interfaces.append({'DeviceIndex': i,
-                               'SubnetId': self._ec2_subnet_id[dc_idx][az_idx],
+                               'SubnetId': self._ec2_subnet_id[dc_idx][az_idx + i],
                                'Groups': self._ec2_security_group_ids[dc_idx]})
+        self.log.debug("interfaces: '%s' - to create_instances", interfaces)
+
         # Can only be associated with a single network interface only with the device index of 0:
         # https://docs.aws.amazon.com/sdkfornet1/latest/apidocs/html/P_Amazon_EC2_Model_InstanceNetworkInterfaceSpecification_
         # AssociatePublicIpAddress.htm

--- a/sdcm/provision/network_configuration.py
+++ b/sdcm/provision/network_configuration.py
@@ -110,14 +110,14 @@ def is_ip_ssh_connections_ipv6(params):
 
 
 def network_interfaces_count(params):
-    if params.get("scylla_network_config"):
+    if params and (scylla_network_config := params.get("scylla_network_config")):
         nics = set()
-        for interface in params.get("scylla_network_config"):
+        for interface in scylla_network_config:
             nics.add(interface["nic"])
         return len(nics)
 
-    # TODO: remove next lines when scylla_network_configuration is supported for all backends
     # For non-AWS clusters where new network configuration is not used and "extra_network_interface" parameter is not defined
+    # Another case - jenkins builder
     return 1
 
 

--- a/sdcm/sct_provision/aws/cluster.py
+++ b/sdcm/sct_provision/aws/cluster.py
@@ -22,6 +22,7 @@ from sdcm.provision.aws.provisioner import AWSInstanceProvisioner
 from sdcm.provision.common.provision_plan import ProvisionPlan
 from sdcm.provision.common.provision_plan_builder import ProvisionPlanBuilder
 from sdcm.provision.common.provisioner import TagsType
+from sdcm.provision.network_configuration import network_interfaces_count
 from sdcm.sct_config import SCTConfiguration
 from sdcm.sct_provision.aws.instance_parameters_builder import ScyllaInstanceParamsBuilder, \
     LoaderInstanceParamsBuilder, MonitorInstanceParamsBuilder, OracleScyllaInstanceParamsBuilder
@@ -288,6 +289,7 @@ class LoaderCluster(ClusterBase):
         return AWSInstanceUserDataBuilder(
             params=self.params,
             syslog_host_port=self._test_config.get_logging_service_host_port(),
+            aws_additional_interface=network_interfaces_count(self.params) > 1,
         ).to_string()
 
 

--- a/sdcm/sct_provision/aws/instance_parameters_builder.py
+++ b/sdcm/sct_provision/aws/instance_parameters_builder.py
@@ -12,6 +12,7 @@
 # Copyright (c) 2021 ScyllaDB
 
 import abc
+import logging
 from functools import cached_property
 from typing import Union, List, Optional, Tuple
 
@@ -23,7 +24,9 @@ from sdcm.provision.aws.instance_parameters_builder import AWSInstanceParamsBuil
 from sdcm.provision.common.user_data import UserDataBuilderBase
 from sdcm.provision.network_configuration import network_interfaces_count
 from sdcm.sct_config import SCTConfiguration
-from sdcm.utils.aws_utils import ec2_ami_get_root_device_name, get_ec2_network_configuration
+from sdcm.utils.aws_utils import ec2_ami_get_root_device_name, EC2NetworkConfiguration
+
+LOGGER = logging.getLogger(__name__)
 
 
 class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMeta):
@@ -67,10 +70,9 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
 
     @property
     def NetworkInterfaces(self) -> List[dict]:  # pylint: disable=invalid-name
-        output = [{'DeviceIndex': 0, **self._network_interface_params}]
-        # TODO: handle case when more then 1 additional interface should be added
-        if network_interfaces_count(self.params) > 1:
-            output.append({'DeviceIndex': 1, **self._network_interface_params})
+        output = []
+        for index in range(network_interfaces_count(self.params)):
+            output.append({'DeviceIndex': index, **self._network_interface_params(interface_index=index)})
         return output
 
     @property
@@ -115,11 +117,10 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
 
     @cached_property
     def _ec2_network_configuration(self) -> Tuple[List[str], List[List[str]]]:
-        return get_ec2_network_configuration(
-            regions=self.params.region_names,
-            availability_zones=self._availability_zones,
-            params=self.params
-        )
+        ec2_network_configuration = EC2NetworkConfiguration(regions=self.params.region_names,
+                                                            availability_zones=self._availability_zones,
+                                                            params=self.params)
+        return ec2_network_configuration.security_groups, ec2_network_configuration.subnets
 
     @cached_property
     def _ec2_subnet_ids(self) -> List[str]:
@@ -129,10 +130,9 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
     def _ec2_security_group_ids(self) -> List[str]:
         return self._ec2_network_configuration[0]
 
-    @property
-    def _network_interface_params(self):
+    def _network_interface_params(self, interface_index: int = 0):
         return {
-            'SubnetId': self._ec2_subnet_ids[self.region_id][self.availability_zone],  # pylint: disable=invalid-sequence-index
+            'SubnetId': self._ec2_subnet_ids[self.region_id][self.availability_zone + interface_index],  # pylint: disable=invalid-sequence-index
             'Groups': self._ec2_security_group_ids[self.region_id],  # pylint: disable=invalid-sequence-index
         }
 

--- a/sdcm/sct_provision/aws/user_data.py
+++ b/sdcm/sct_provision/aws/user_data.py
@@ -115,11 +115,12 @@ class ScyllaUserDataBuilder(ScyllaUserDataBuilderBase):
 class AWSInstanceUserDataBuilder(UserDataBuilderBase):
     params: Union[SCTConfiguration, dict] = Field(as_dict=False)
     syslog_host_port: tuple[str, int] = None
+    aws_additional_interface: bool = False
 
     def to_string(self) -> str:
         post_boot_script = AWSConfigurationScriptBuilder(
             # Monitoring and loader nodes does not use additional interface
-            aws_additional_interface=False,
+            aws_additional_interface=self.aws_additional_interface,
             aws_ipv6_workaround=is_ip_ssh_connections_ipv6(self.params),
             logs_transport=self.params.get('logs_transport'),
             syslog_host_port=self.syslog_host_port,

--- a/sdcm/utils/aws_builder.py
+++ b/sdcm/utils/aws_builder.py
@@ -97,13 +97,12 @@ class AwsBuilder:
     NUM_CPUS = 2
     NUM_EXECUTORS = 4
 
-    def __init__(self, region: AwsRegion, number=1):
+    def __init__(self, region: AwsRegion, params=None, number=1):
         self.region = region
         self.number = number
+        self.params = params
         self.jenkins_info = KeyStore().get_json("jenkins.json")
         self.jenkins = jenkins.Jenkins(**self.jenkins_info)
-        self.runner = AwsSctRunner(region_name=self.region.region_name,
-                                   availability_zone=self.region.availability_zones[0][-1])
 
     @cached_property
     def name(self):
@@ -170,7 +169,7 @@ class AwsBuilder:
 
     def create_launch_template(self):
         click.secho(f"{self.region.region_name}: create_launch_template")
-        runner = AwsSctRunner(region_name=self.region.region_name, availability_zone='a')
+        runner = AwsSctRunner(region_name=self.region.region_name, availability_zone='a', params=None)
         if not runner.image:
             runner.create_image()
         try:

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -22,7 +22,7 @@ from botocore.exceptions import ClientError
 from mypy_boto3_ec2 import EC2ServiceResource, EC2Client
 from mypy_boto3_ec2.literals import ArchitectureTypeType
 
-from sdcm.provision.network_configuration import ssh_connection_ip_type
+from sdcm.provision.network_configuration import ssh_connection_ip_type, network_interfaces_count
 from sdcm.utils.decorators import retrying
 from sdcm.utils.aws_region import AwsRegion
 from sdcm.wait import wait_for
@@ -283,15 +283,71 @@ def init_db_info_from_params(db_info: dict, params: dict, regions: List, root_de
     return db_info
 
 
+class EC2NetworkConfiguration:
+    def __init__(self, regions: list[str], availability_zones: list[str], params: dict):
+        self.regions = regions
+        self.availability_zones = availability_zones
+        self.params = params
+        self.network_interfaces_count = network_interfaces_count(params)
+
+    @property
+    def subnets_per_region(self) -> dict:
+        ec2_subnet_ids = {}
+        for region in self.regions:
+            aws_region = AwsRegion(region_name=region)
+            ec2_subnet_ids[region] = {}
+            for availability_zone in self.availability_zones:
+                ec2_subnet_ids[region][availability_zone] = self.subnets_per_availability_zone(region=region,
+                                                                                               aws_region=aws_region,
+                                                                                               availability_zone=availability_zone)
+        return ec2_subnet_ids
+
+    @property
+    def subnets(self) -> List[list]:
+        ec2_subnet_ids = []
+        for region in self.subnets_per_region.values():
+            for az_subnets_id in region.values():
+                ec2_subnet_ids.append(az_subnets_id)
+        return ec2_subnet_ids
+
+    def subnets_per_availability_zone(self, region: str, aws_region: AwsRegion, availability_zone: str) -> list:
+        region_subnets = []
+        for index in range(self.network_interfaces_count):
+            sct_subnet = aws_region.sct_subnet(region_az=region + availability_zone, subnet_index=index)
+            assert sct_subnet, f"No SCT subnet configured for {region}! Run 'hydra prepare-aws-region'"
+            region_subnets.append(sct_subnet.subnet_id)
+
+        return region_subnets
+
+    @property
+    def security_groups(self):
+        ec2_security_group_ids = []
+        for region in self.regions:
+            ec2_security_group_ids.append(self.region_security_groups(region=region,
+                                                                      aws_region=AwsRegion(region_name=region)))
+        return ec2_security_group_ids
+
+    def region_security_groups(self, region: str, aws_region: AwsRegion):
+        security_groups = []
+        sct_sg = aws_region.sct_security_group
+        assert sct_sg, f"No SCT security group configured for {region}! Run 'hydra prepare-aws-region'"
+        security_groups.append(sct_sg.group_id)
+
+        if ssh_connection_ip_type(self.params) == 'public':
+            test_config = TestConfig()
+            test_id = test_config.test_id()
+
+            test_sg = aws_region.provide_sct_test_security_group(test_id)
+            security_groups.append(test_sg.group_id)
+        return security_groups
+
+
 def get_common_params(params: dict, regions: List, credentials: List, services: List, availability_zone: str = None) -> dict:
     availability_zones = [availability_zone] if availability_zone else params.get('availability_zone').split(',')
-    ec2_security_group_ids, ec2_subnet_ids = get_ec2_network_configuration(
-        regions=regions,
-        availability_zones=availability_zones,
-        params=params
-    )
-    return dict(ec2_security_group_ids=ec2_security_group_ids,
-                ec2_subnet_id=ec2_subnet_ids,
+    ec2_network_configuration = EC2NetworkConfiguration(
+        regions=regions, availability_zones=availability_zones, params=params)
+    return dict(ec2_security_group_ids=ec2_network_configuration.security_groups,
+                ec2_subnet_id=ec2_network_configuration.subnets,
                 services=services,
                 credentials=credentials,
                 user_prefix=params.get('user_prefix'),
@@ -307,7 +363,7 @@ def get_ec2_network_configuration(regions: list[str], availability_zones: list[s
         ec2_subnet_ids.append(region_subnets)
         aws_region = AwsRegion(region_name=region)
         for availability_zone in availability_zones:
-            sct_subnet = aws_region.sct_subnet(region_az=region + availability_zone)
+            sct_subnet = aws_region.sct_subnet(region_az=region + availability_zone, subnet_index=0)
             assert sct_subnet, f"No SCT subnet configured for {region}! Run 'hydra prepare-aws-region'"
             region_subnets.append(sct_subnet.subnet_id)
 


### PR DESCRIPTION
This PR is a next step of a major refactoring (https://github.com/scylladb/scylla-cluster-tests/pull/6575) .

For this goal the second subnets were created in all supported by SCT regions and each availability zone. [This commit](https://github.com/scylladb/scylla-cluster-tests/pull/7273/commits/71e9e924f72c059d898b86716a79bfe5bcd30dc2) provides availability to configure regions with 2 (for now) subnets in each AZ.

Current PR presents ability to configure the instances (DB nodes, loaders, SCT runner) with two network interfaces on different subnets. This will allow us to cover complex network setups in the tests 

Task: https://github.com/scylladb/qa-tasks/issues/1217 

**This PR is depended by https://github.com/scylladb/scylla-cluster-tests/pull/7273. We need to re-base them together (in case of re-base)**


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [one interface](https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/Network/job/longevity-100gb-one-interface/12/)
- [x] [two interfaces](https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/Network/job/longevity-10gb-3h/41/)
- [x] [network nemeses](https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/longevity-200gb-48h-network-monkey-test/97/)
- [x] provision GCE test
- [x] provision Azure test
- [x] provision docker test
- [x] [longevity-scylla-operator-3h-eks](https://argus.scylladb.com/test/077e8557-322b-4d88-a6e2-6e2e9def9363/runs?additionalRuns[]=0531cfb7-8926-4413-9cf9-e41dea722c9f)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
