### PR TITLE
fix(sct.py): make `scan-skip-issues` more smart

### DIFF
--- a/sct_scan_issues.py
+++ b/sct_scan_issues.py
@@ -50,8 +50,10 @@ def scan_issue_skips():
 
     params = SCTConfiguration()
     for file_path in Path(get_sct_root_path()).glob("**/*.py"):
-        if file_path.name.startswith("test_") or file_path.name == Path(__file__).name:
-            # skip tests
+        if (file_path.name.startswith("test_")
+                or file_path.name == Path(__file__).name
+                or any(subdir in str(file_path) for subdir in (".tox/", ".venv/", ".env/"))):
+            # skip tests and virtual env files
             continue
         for node in ast.walk(ast.parse(file_path.read_text())):
             if isinstance(node, ast.Call):

--- a/sdcm/utils/issues.py
+++ b/sdcm/utils/issues.py
@@ -62,9 +62,10 @@ class SkipPerIssues:
             match = pattern.search(issue_str.strip())
             if match:
                 obj = match.groupdict()
+                repo_id = obj.get("repo_id") or "scylladb"
                 return Issue(
                     user_id=obj.get("user_id") or "scylladb",
-                    repo_id=obj.get("repo_id") or "scylladb",
+                    repo_id=(repo_id if repo_id != "scylla" else "scylladb"),
                     issue_id=int(obj.get("issue_id"))
                 )
         return None


### PR DESCRIPTION
By doing following changes:
- Make it skip scanning files which are located in the virtual environment directories.
- Transform `scylladb/scylla` to `scylladb/scylladb` to avoid automatic redirections which lead to following useless output:

```
nemesis.py:3605: SkipPerIssues(['https://github.com/scylladb/scylla/issues/6522', 'self.tester.params'])
Following Github server redirection from /repos/scylladb/scylla/issues/6522 to /repositories/28449431/issues/6522
Following Github server redirection from /repos/scylladb/scylla/issues/6522 to /repositories/28449431/issues/6522
```

  Instead it will look like following:
```
nemesis.py:3605: SkipPerIssues(['https://github.com/scylladb/scylla/issues/6522', 'self.tester.params'])
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
