### PR TITLE
fix(perf_simple_query_x86): switch to c7i.large

### DIFF
--- a/test-cases/microbenchmarking/amazon_perf_simple_query_x86.yaml
+++ b/test-cases/microbenchmarking/amazon_perf_simple_query_x86.yaml
@@ -1,2 +1,2 @@
-instance_type_db: 'c6i.large'
+instance_type_db: 'c7i.large'
 user_prefix: 'perf-microbenchmarking-amazon-x86'


### PR DESCRIPTION
since c6i instances didn't had instructions_per_op metric we needed, we are switching to the c7i instances

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] no testing is needed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
