### PR TITLE
feature(provision): enable capacity reservation for aws

### DIFF
--- a/configurations/capacity_reservation.yaml
+++ b/configurations/capacity_reservation.yaml
@@ -1,0 +1,2 @@
+use_capacity_reservation: true
+instance_provision: 'on_demand'

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -236,6 +236,7 @@ simulated_racks: 0
 use_dns_names: false
 
 use_placement_group: false
+use_capacity_reservation: false
 
 validate_large_collections: false
 

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -148,6 +148,8 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         subnet_info = ec2.get_subnet_info(interfaces[0]["SubnetId"])
         region_name_with_az = subnet_info['AvailabilityZone']
         ec2.add_placement_group_name_param(params, self.placement_group_name)
+        if params.get('use_capacity_reservation'):
+            ec2.add_capacity_reservation_param(params, region_name_with_az[-1])
         LOGGER.debug('Sending an On-Demand request with params: %s', params)
         LOGGER.debug('Using EC2 service with DC-index: %s, (associated with region: %s)',
                      dc_idx, self.region_names[dc_idx])

--- a/sdcm/ec2_client.py
+++ b/sdcm/ec2_client.py
@@ -8,6 +8,7 @@ from mypy_boto3_ec2 import EC2Client, EC2ServiceResource
 from mypy_boto3_ec2.service_resource import Instance
 from botocore.exceptions import ClientError, NoRegionError
 
+from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.utils.decorators import retrying
 from sdcm.utils.aws_utils import tags_as_ec2_tags
 from sdcm.test_config import TestConfig
@@ -381,3 +382,12 @@ class EC2ClientWrapper():
             else:
                 error_message = f"use_placement_group param is true but no placement group with tags {placement_group_tags} found"
                 raise GetPlacementGroupError(error_message)
+
+    @staticmethod
+    def add_capacity_reservation_param(boto3_params, availability_zone):
+        if cr_id := SCTCapacityReservation.reservations.get(availability_zone).get(boto3_params["InstanceType"]):
+            boto3_params['CapacityReservationSpecification'] = {
+                'CapacityReservationTarget': {
+                    'CapacityReservationId': cr_id
+                }
+            }

--- a/sdcm/exceptions.py
+++ b/sdcm/exceptions.py
@@ -79,3 +79,7 @@ class ExitByEventError(Exception):
 
 class SstablesNotFound(Exception):
     pass
+
+
+class CapacityReservationError(Exception):
+    pass

--- a/sdcm/provision/aws/capacity_reservation.py
+++ b/sdcm/provision/aws/capacity_reservation.py
@@ -1,0 +1,236 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2024 ScyllaDB
+import logging
+import time
+from datetime import datetime, timedelta
+from typing import List, Dict, Tuple
+
+from botocore.exceptions import ClientError
+import boto3
+
+from sdcm.exceptions import CapacityReservationError
+
+LOGGER = logging.getLogger(__name__)
+
+
+class SCTCapacityReservation:
+    """Class for managing capacity reservations for AWS instances.
+
+    Serves namespacing for capacity reservations and provides methods for creating and cancelling reservations."""
+    reservations: Dict[str, Dict[str, str]] = {}
+
+    @staticmethod
+    def _get_cr_request_based_on_sct_config(params) -> Tuple[dict[str, int], int]:
+        instance_counts = {}
+        nemesis_node_count = params.get("nemesis_add_node_cnt") or 0
+        cluster_max_size = (params.get("cluster_target_size") or params.get("n_db_nodes")) + nemesis_node_count
+        instance_counts[params.get("instance_type_db")] = instance_counts.get(
+            params.get("instance_type_db"), 0) + cluster_max_size
+        instance_counts[params.get("instance_type_loader")] = instance_counts.get(params.get("instance_type_loader"),
+                                                                                  0) + params.get("n_loaders")
+        # don't reserve capacity for monitor - as usually it's not a problem to spin it
+        duration = params.get("test_duration") + 60  # 60 to have margin for test setup
+        instance_counts = {k: v for k, v in instance_counts.items() if v > 0}  # remove 0 values
+        return instance_counts, duration
+
+    @classmethod
+    def get_cr_from_aws(cls, params) -> None:
+        """Retrieves capacity reservations for given test_id from AWS."""
+        if not cls.is_capacity_reservation_enabled(params):
+            LOGGER.info("Capacity reservation is not enabled. Skipping reservation.")
+            return
+        test_id = params.get("reuse_cluster") or params.get("test_id")
+        ec2 = boto3.client('ec2', region_name=params.region_names[0])
+        reservations = ec2.describe_capacity_reservations(
+            Filters=[
+                {
+                    'Name': 'tag:test_id',
+                    'Values': [test_id]
+                },
+                {
+                    'Name': 'state',
+                    'Values': ['active']
+                }
+            ]
+        )
+        result = {}
+        availability_zone = params.get("availability_zone")
+        for reservation in reservations['CapacityReservations']:
+            availability_zone = reservation['AvailabilityZone'][-1]
+            instance_type = reservation['InstanceType']
+            if availability_zone not in result:
+                result[availability_zone] = {}
+            result[availability_zone][instance_type] = reservation['CapacityReservationId']
+        if result:
+            LOGGER.info("Found capacity reservations: %s", result)
+            params["availability_zone"] = availability_zone
+        else:
+            LOGGER.info("No capacity reservations found.")
+        cls.reservations = result
+
+    @staticmethod
+    def _get_supported_availability_zones(ec2, instance_types: List[str], initial_az: str) -> List[str]:
+        response = ec2.describe_instance_type_offerings(
+            LocationType='availability-zone',
+            Filters=[
+                {
+                    'Name': 'instance-type',
+                    'Values': list(instance_types)
+                },
+            ]
+        )
+        offerings = response['InstanceTypeOfferings']
+        azs = set.intersection(
+            *[{offering['Location'] for offering in offerings if offering['InstanceType'] == instance_type}
+              for instance_type in instance_types]
+        )
+        azs = list(azs)
+        try:  # put initial az as first one to try
+            azs.remove(initial_az)
+            azs.insert(0, initial_az)
+        except ValueError:
+            LOGGER.warning("Initial availability zone %s does not support required instances", initial_az)
+        LOGGER.info("Supported availability zones for instance types %s: %s", instance_types, azs)
+        return azs
+
+    @staticmethod
+    def is_capacity_reservation_enabled(params: dict) -> bool:
+        """Returns True if capacity reservation is enabled."""
+        return (params.get("cluster_backend") == "aws"
+                and (params.get("test_id") or params.get("reuse_cluster"))
+                and params.get('use_capacity_reservation') is True
+                and params.get('instance_provision') == 'on_demand')
+
+    @classmethod
+    def reserve(cls, params) -> None:
+        """Reserves capacity for given test params: detects required instance types and counts and creates capacity reservations.
+        """
+        if not cls.is_capacity_reservation_enabled(params):
+            LOGGER.info("Capacity reservation is not enabled. Skipping reservation.")
+            return
+        cls.get_cr_from_aws(params)
+        if cls.reservations:
+            LOGGER.info("Capacity reservation already created. Skipping reservation.")
+            return
+        region = params.region_names[0]
+        test_id = params.get("reuse_cluster") or params.get("test_id")
+        ec2 = boto3.client('ec2', region_name=region)
+        placement_group_arn = None
+
+        if params.get("use_placement_group"):
+            response = ec2.describe_placement_groups(
+                Filters=[
+                    {
+                        'Name': 'tag:TestId',
+                        'Values': [test_id]
+                    }
+                ]
+            )
+            if response['PlacementGroups']:
+                placement_group_arn = [group['GroupArn']
+                                       for group in response['PlacementGroups'] if group['State'] == 'available'][0]
+                LOGGER.info("Using placement group '%s' for capacity reservation.", placement_group_arn)
+            else:
+                LOGGER.error("Available placement group not found while should.")
+                raise CapacityReservationError("Failed to find available placement group.")
+        request, duration = cls._get_cr_request_based_on_sct_config(params)
+        LOGGER.info("Creating capacity reservation for test %s with request: %s", test_id, request)
+        reservations = {}
+        for availability_zone in cls._get_supported_availability_zones(ec2=ec2, instance_types=list(request.keys()),
+                                                                       initial_az=region+params.get("availability_zone")):
+            reservations[availability_zone[-1]] = {}
+            LOGGER.info("Creating capacity reservation in %s", availability_zone)
+            for instance_type, instance_count in request.items():
+                cr_id = cls._create(ec2=ec2, test_id=test_id, availability_zone=availability_zone,
+                                    instance_type=instance_type, instance_count=instance_count, duration=duration,
+                                    placement_group_arn=placement_group_arn)
+                if cr_id:
+                    reservations[availability_zone[-1]][instance_type] = cr_id
+                    LOGGER.info("Capacity reservation created for %s", instance_type)
+                else:
+                    LOGGER.info("Failed to create capacity reservation in %s", availability_zone)
+                    cls._cancel_reservations(ec2, reservations)
+                    if placement_group_arn:
+                        LOGGER.info("waiting 30s before falling back to next AZ to release placement group")
+                        time.sleep(30)
+                    reservations = {}
+                    LOGGER.info("Falling back to next availability zone.")
+                    break
+            if reservations:
+                params["availability_zone"] = availability_zone[-1]
+                cls.reservations = reservations
+                LOGGER.info("Capacity reservations created in '%s' az: %s for duration: %s",
+                            availability_zone, reservations, duration)
+                return
+
+        raise CapacityReservationError("Failed to create capacity reservation in any availability zone.")
+
+    @classmethod
+    def get_id(cls, availability_zone, instance_type: str) -> str:
+        """Returns capacity reservation id for given instance type for provided az."""
+        return cls.reservations[availability_zone][instance_type]
+
+    @staticmethod
+    # pylint: disable=too-many-arguments
+    def _create(ec2, test_id, availability_zone, instance_type, instance_count, duration, placement_group_arn=None) -> str | None:
+        additional_params = {}
+        if placement_group_arn:
+            additional_params["PlacementGroupArn"] = placement_group_arn
+            LOGGER.info("using placement group for CR: %s", placement_group_arn)
+        try:
+            response = ec2.create_capacity_reservation(
+                InstanceType=instance_type,
+                InstancePlatform='Linux/UNIX',
+                InstanceMatchCriteria='targeted',
+                AvailabilityZone=availability_zone,
+                InstanceCount=instance_count,
+                EndDateType='limited',
+                EndDate=datetime.utcnow() + timedelta(minutes=duration),
+                TagSpecifications=[
+                    {
+                        'ResourceType': 'capacity-reservation',
+                        'Tags': [
+                            {
+                                'Key': 'test_id',
+                                'Value': test_id
+                            },
+                        ]
+                    },
+                ],
+                **additional_params
+            )
+            return response['CapacityReservation']['CapacityReservationId']
+        except Exception as exc:  # pylint: disable=broad-except
+            LOGGER.info("Failed to create capacity reservation for %s. Error: %s", instance_type, exc)
+            return None
+
+    @classmethod
+    def cancel(cls, params) -> None:
+        """Cancels all capacity reservations."""
+        if not cls.reservations:
+            LOGGER.info("No capacity reservations to cancel.")
+            return
+        ec2 = boto3.client('ec2', region_name=params.region_names[0])
+        cls._cancel_reservations(ec2, cls.reservations)
+        cls.reservations = {}
+
+    @staticmethod
+    def _cancel_reservations(ec2, reservations: Dict[str, Dict[str, str]]) -> None:
+        """Cancels all capacity reservations."""
+        for reservation in reservations.values():
+            for instance_type, cr_id in reservation.items():
+                try:
+                    ec2.cancel_capacity_reservation(CapacityReservationId=cr_id)
+                    LOGGER.info("Capacity reservation %s for %s cancelled successfully.", cr_id, instance_type)
+                except ClientError as exp:
+                    LOGGER.error("Failed to cancel capacity reservation %s. Error: %s", cr_id, exp)

--- a/sdcm/sct_provision/aws/layout.py
+++ b/sdcm/sct_provision/aws/layout.py
@@ -13,6 +13,7 @@
 
 from functools import cached_property
 
+from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.sct_provision.aws.cluster import (
     OracleDBCluster, DBCluster, LoaderCluster, MonitoringCluster, PlacementGroup)
 from sdcm.sct_provision.common.layout import SCTProvisionLayout
@@ -28,6 +29,7 @@ class SCTProvisionAWSLayout(SCTProvisionLayout, cluster_backend='aws'):
     def provision(self):
         if self.placement_group:
             self.placement_group.provision()
+        SCTCapacityReservation.reserve(self._params)
         if self.db_cluster:
             self.db_cluster.provision()
         if self.monitoring_cluster:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -57,6 +57,7 @@ from sdcm.cluster_aws import MonitorSetAWS
 from sdcm.cluster_k8s import mini_k8s, gke, eks
 from sdcm.cluster_k8s.eks import MonitorSetEKS
 from sdcm.cql_stress_cassandra_stress_thread import CqlStressCassandraStressThread
+from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.provision.azure.provisioner import AzureProvisioner
 from sdcm.provision.network_configuration import ssh_connection_ip_type
 from sdcm.provision.provisioner import provisioner_factory
@@ -2706,6 +2707,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     @silence()
     def stop_resources(self):  # pylint: disable=no-self-use
         self.log.debug('Stopping all resources')
+        SCTCapacityReservation.cancel(self.params)
         with silence(parent=self, name="Kill Stress Threads"):
             self.kill_stress_thread()
 

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -65,6 +65,7 @@ from google.cloud.compute_v1 import ListImagesRequest, Image as GceImage
 from packaging.version import Version
 from prettytable import PrettyTable
 
+from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.provision.azure.provisioner import AzureProvisioner
 from sdcm.sct_events import Severity
 from sdcm.sct_events.system import CpuNotHighEnoughEvent, SoftTimeoutEvent
@@ -628,6 +629,7 @@ def clean_cloud_resources(tags_dict, config=None, dry_run=False):  # pylint: dis
 
     if cluster_backend in ('aws', 'k8s-eks', ''):
         clean_instances_aws(tags_dict, regions=aws_regions, dry_run=dry_run)
+        SCTCapacityReservation.cancel(config)
         clean_elastic_ips_aws(tags_dict, regions=aws_regions, dry_run=dry_run)
         clean_test_security_groups(tags_dict, regions=aws_regions, dry_run=dry_run)
         clean_placement_groups_aws(tags_dict, regions=aws_regions, dry_run=dry_run)

--- a/test-cases/performance/perf-regression-latency-1TB.yaml
+++ b/test-cases/performance/perf-regression-latency-1TB.yaml
@@ -32,3 +32,4 @@ custom_es_index: 'performancestatsv2'
 use_hdr_cs_histogram: true
 
 use_placement_group: true
+use_capacity_reservation: true

--- a/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
@@ -36,4 +36,5 @@ email_recipients: ["scylla-perf-results@scylladb.com"]
 use_prepared_loaders: true
 use_hdr_cs_histogram: true
 use_placement_group: true
+use_capacity_reservation: true
 email_subject_postfix: 'latency during operations'

--- a/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
@@ -50,3 +50,4 @@ use_hdr_cs_histogram: true
 append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
 
 use_placement_group: true
+use_capacity_reservation: true

--- a/unit_tests/provisioner/test_capacity_reservation.py
+++ b/unit_tests/provisioner/test_capacity_reservation.py
@@ -1,0 +1,109 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2024 ScyllaDB
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
+from sdcm.exceptions import CapacityReservationError
+
+
+@pytest.fixture(autouse=True)
+def reset_reservations():
+    SCTCapacityReservation.reservations = {}
+
+
+@pytest.fixture(name="params")
+def params_fixture():
+    class DotDict(dict):
+        __getattr__ = dict.__getitem__
+        __setattr__ = dict.__setitem__
+        __delattr__ = dict.__delitem__
+
+    return DotDict({"test_id": "example-test-id", "region_name": ["us-east-1"], "use_capacity_reservation": True,
+                    "instance_provision": "on_demand",
+                    "availability_zone": "d",
+                    "cluster_backend": "aws", "region_names": ["us-east-1"],
+                    "n_db_nodes": 1, "instance_type_db": "i4i.large", "cluster_target_size": 1, "n_loaders": 1,
+                    "instance_type_loader": "t3.small", "n_monitor_nodes": 1, "instance_type_monitor": "t3.small", "test_duration": 180})
+
+
+@pytest.fixture(name="mock_ec2")
+def mock_ec2_fixture():
+    with patch('boto3.client') as mock_boto3_client:
+        mock_ec2 = MagicMock()
+        mock_boto3_client.return_value = mock_ec2
+        mock_ec2.describe_instance_type_offerings.return_value = {
+            'InstanceTypeOfferings': [{'Location': 'us-east-1a', 'InstanceType': 'i4i.large'},
+                                      {'Location': 'us-east-1b', 'InstanceType': 'i4i.large'},
+                                      {'Location': 'us-east-1d', 'InstanceType': 'i4i.large'},
+                                      {'Location': 'us-east-1a', 'InstanceType': 't3.small'},
+                                      {'Location': 'us-east-1d', 'InstanceType': 't3.small'},
+                                      {'Location': 'us-east-1c', 'InstanceType': 't3.micro'}]}
+        yield mock_ec2
+
+
+def test_reserve_success(mock_ec2, params):
+    mock_ec2.create_capacity_reservation.side_effect = [{'CapacityReservation': {'CapacityReservationId': 'cr-0e2dec33c962ffa7d'}},
+                                                        {'CapacityReservation': {'CapacityReservationId': 'cr-0e2dec33c962ffa7e'}}]
+
+    SCTCapacityReservation.reserve(params)
+    reservations = SCTCapacityReservation.reservations
+    assert len(reservations.keys()) == 1
+    for key, value in reservations.items():
+        assert key == "d"  # initial availability zone
+        assert value == {"i4i.large": "cr-0e2dec33c962ffa7d", "t3.small": "cr-0e2dec33c962ffa7e"}
+
+
+def test_reserve_failure(mock_ec2, params):
+    mock_ec2.create_capacity_reservation.side_effect = Exception("Failed to create capacity reservation")
+
+    with pytest.raises(CapacityReservationError):
+        SCTCapacityReservation.reserve(params)
+
+
+def test_reserve_fallback(mock_ec2, params):
+    mock_ec2.create_capacity_reservation.side_effect = [Exception("Failed to create capacity reservation"),
+                                                        {'CapacityReservation': {'CapacityReservationId': 'cr-0e2dec33c962ffa7d'}},
+                                                        {'CapacityReservation': {'CapacityReservationId': 'cr-0e2dec33c962ffa7e'}}]
+    SCTCapacityReservation.reserve(params)
+    result = SCTCapacityReservation.reservations
+    assert len(result.keys()) == 1
+    for value in result.values():
+        assert value == {"i4i.large": "cr-0e2dec33c962ffa7d", "t3.small": "cr-0e2dec33c962ffa7e"}
+
+
+def test_reservation_cancelled_when_one_reservation_fails(mock_ec2, params):
+    mock_ec2.create_capacity_reservation.side_effect = [
+        {'CapacityReservation': {'CapacityReservationId': 'cr-0e2dec33c962ffa7d'}},
+        Exception("Failed to create capacity reservation"),
+        {'CapacityReservation': {'CapacityReservationId': 'cr-0e2dec33c962ffa7e'}},
+        {'CapacityReservation': {'CapacityReservationId': 'cr-0e2dec33c962ffa7f'}}]
+    SCTCapacityReservation.reserve(params)
+    result = SCTCapacityReservation.reservations
+    assert len(result.keys()) == 1
+    for value in result.values():
+        assert value == {"i4i.large": "cr-0e2dec33c962ffa7e", "t3.small": "cr-0e2dec33c962ffa7f"}
+
+    # verify can be cancelled
+    SCTCapacityReservation.cancel(params)
+    assert SCTCapacityReservation.reservations == {}
+
+
+def test_can_cancel_reservation(mock_ec2, params):
+    mock_ec2.describe_capacity_reservations.return_value =\
+        {'CapacityReservations': [{'AvailabilityZone': 'us-east-1b', 'CapacityReservationId': 'cr-0e2dec33c962ffa7d',
+                                   'InstanceType': 'i4i.large', 'State': 'active'}]}
+    SCTCapacityReservation.get_cr_from_aws(params)
+    SCTCapacityReservation.cancel(params)
+    mock_ec2.cancel_capacity_reservation.assert_called_with(CapacityReservationId='cr-0e2dec33c962ffa7d')


### PR DESCRIPTION
Sometimes we get failures due no capacity (also for on_demand instances) and it's hard to trigger a test at all. This is often a problem for performance tests where we use older instance types.

Introducing capacity reservation feature for AWS cloud. It works by first reserving capacity for all instance types used by test for test duration (reserves predicted max number of nodes that test may use based on test config parameters) and during instance creation uses it to spin it. In case given AZ cannot serve requested instances, it fallback to
another one until successful.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - https://argus.scylladb.com/workspace?state=WyJhMmFmMDkxZS0zY2JkLTQwNjgtYjgyNS0zNWQ1MTFmMTVkMTciXQ (grow shrink cluster test)
- [x] perf test - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/scylla-enterprise-perf-regression-latency-shard-aware-1TB-test/9 (acutally it did fallback to another AZ in this run)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
