### PR TITLE
fix(test_default_filters): take it out of unittest

### DIFF
--- a/unit_tests/lib/events_utils.py
+++ b/unit_tests/lib/events_utils.py
@@ -17,13 +17,11 @@ import tempfile
 import unittest.mock
 from contextlib import contextmanager
 
-from sdcm.sct_events.setup import EVENTS_DEVICE_START_DELAY, start_events_device, stop_events_device, enable_default_filters
+from sdcm.sct_events.setup import EVENTS_DEVICE_START_DELAY, start_events_device, stop_events_device
 from sdcm.sct_events.events_device import start_events_main_device, get_events_main_device
 from sdcm.sct_events.file_logger import get_events_logger
 from sdcm.sct_events.events_processes import EventsProcessesRegistry
 from sdcm.sct_events.event_counter import get_events_counter
-from sdcm.sct_config import SCTConfiguration
-from sdcm.utils.context_managers import environment
 
 
 class EventsUtilsMixin:
@@ -45,8 +43,6 @@ class EventsUtilsMixin:
             cls.events_processes_registry_patcher.start()
         if events_device:
             start_events_device(_registry=cls.events_processes_registry)
-            with environment(SCT_CLUSTER_BACKEND='docker'):
-                enable_default_filters(SCTConfiguration())
         elif events_main_device:
             start_events_main_device(_registry=cls.events_processes_registry)
             time.sleep(EVENTS_DEVICE_START_DELAY)

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -34,6 +34,9 @@ from sdcm.sct_events.nemesis import DisruptionEvent
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.file_logger import get_logger_event_summary
 from sdcm.sct_events.event_counter import EventCounterContextManager
+from sdcm.sct_events.setup import enable_default_filters
+from sdcm.sct_config import SCTConfiguration
+from sdcm.utils.context_managers import environment
 
 from unit_tests.lib.events_utils import EventsUtilsMixin
 
@@ -403,7 +406,12 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
         self.assertIn("this is not filtered", log_content)
         self.assertNotIn("this is filtered", log_content)
 
+    @pytest.mark.integration
     def test_default_filters(self):
+
+        with environment(SCT_CLUSTER_BACKEND='docker'):
+            enable_default_filters(SCTConfiguration())
+
         with self.wait_for_n_events(self.get_events_logger(), count=4):
             DatabaseLogEvent.BACKTRACE() \
                 .add_info(node="A",


### PR DESCRIPTION
since this test is depened on github API calls, and we are hitting the rate-limitting for them a bit too often now.

moving this test to integration test, and removeing the event default filter code from the test code,
so non of the test would be using it.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
