### PR TITLE
fix(k8s): allow to specify full registry path for operator images

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -647,12 +647,12 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
                 values.set('image.tag', mgmt_docker_image_tag)
 
             scylla_operator_repo_base = self.params.get(
-                'k8s_scylla_operator_docker_image').split('/')[0]
+                'k8s_scylla_operator_docker_image').rsplit('/', 1)[0]
             if scylla_operator_repo_base:
                 values.set('controllerImage.repository', scylla_operator_repo_base)
 
             scylla_operator_image_tag = self.params.get(
-                'k8s_scylla_operator_docker_image').split(':')[-1]
+                'k8s_scylla_operator_docker_image').split(':', 1)[-1]
             if scylla_operator_image_tag:
                 values.set('controllerImage.tag', scylla_operator_image_tag)
 
@@ -730,12 +730,12 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             # image.tag        -> self.params.get('k8s_scylla_operator_docker_image').split(':')[-1]
 
             scylla_operator_repo_base = self.params.get(
-                'k8s_scylla_operator_docker_image').split('/')[0]
+                'k8s_scylla_operator_docker_image').rsplit('/', 1)[0]
             if scylla_operator_repo_base:
                 values.set('image.repository', scylla_operator_repo_base)
 
             scylla_operator_image_tag = self.params.get(
-                'k8s_scylla_operator_docker_image').split(':')[-1]
+                'k8s_scylla_operator_docker_image').split(':', 1)[-1]
             if scylla_operator_image_tag:
                 values.set('image.tag', scylla_operator_image_tag)
 


### PR DESCRIPTION
Before we were supporting only 'user/project:version' value structure for operator docker images.

If we provide "sha" part or registry site then it gets incorrectly parsed and we get failures provisioning scylla-operator.

So, fix it by properly splitting input lines.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
