### PR TITLE
refactor(tablets/longevity-100gb-4h): Disable hinted handoff

### DIFF
--- a/configurations/disable_hinted_handoff.yaml
+++ b/configurations/disable_hinted_handoff.yaml
@@ -1,0 +1,1 @@
+hinted_handoff: 'disabled'

--- a/jenkins-pipelines/oss/tablets/longevity-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/oss/tablets/longevity-100gb-4h.jenkinsfile
@@ -8,6 +8,6 @@ longevityPipeline(
     region: 'eu-west-1',
     availability_zone: 'c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/tablets.yaml", "configurations/tablets_supported_nemeses.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/disable_hinted_handoff.yaml, "configurations/tablets.yaml", "configurations/tablets_supported_nemeses.yaml"]''',
     instance_provision_fallback_on_demand: true
 )


### PR DESCRIPTION
Since it is disabled in pretty much every customer cluster, there's no point in leaving it enabled in all but one scenario. Hence, I'm disabling it in the tablets 4h 100gb scenario

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
