### PR TITLE
test(longevity): add longevity with rf=1

### DIFF
--- a/jenkins-pipelines/oss/longevity/longevity-1-rf-test-12h.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-1-rf-test-12h.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    availability_zone: 'c',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/longevity/longevity-1-rf-test-12h.yaml',
+    instance_provision_fallback_on_demand: true
+)

--- a/test-cases/longevity/longevity-1-rf-test-12h.yaml
+++ b/test-cases/longevity/longevity-1-rf-test-12h.yaml
@@ -1,0 +1,33 @@
+test_duration: 800
+
+prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -replication-factor=1 -partition-count=100 -clustering-row-count=55555                       -clustering-row-size=uniform:1024..2048 -concurrency=10 -connection-count=10 -consistency-level=one -rows-per-request=10 -timeout=30s -validate-data" ,
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=1 -partition-count=100 -clustering-row-count=55555 -partition-offset=101 -clustering-row-size=uniform:1024..2048 -concurrency=10 -connection-count=10 -consistency-level=one -rows-per-request=10 -timeout=30s -validate-data",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=1 -partition-count=100 -clustering-row-count=55555 -partition-offset=201 -clustering-row-size=uniform:1024..2048 -concurrency=10 -connection-count=10 -consistency-level=one -rows-per-request=10 -timeout=30s -validate-data",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=1 -partition-count=100 -clustering-row-count=55555 -partition-offset=301 -clustering-row-size=uniform:1024..2048 -concurrency=10 -connection-count=10 -consistency-level=one -rows-per-request=10 -timeout=30s -validate-data",
+]
+
+prepare_verify_cmd: ["scylla-bench -workload=sequential -mode=read -replication-factor=1 -partition-count=200 -clustering-row-count=55555                      -clustering-row-size=uniform:1024..2048 -concurrency=10 -connection-count=10 -consistency-level=one -rows-per-request=10 -timeout=30s -iterations 0 -duration=30m -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=1 -partition-count=200 -clustering-row-count=55555  -partition-offset=201 -clustering-row-size=uniform:1024..2048 -concurrency=10 -connection-count=10 -consistency-level=one -rows-per-request=10 -timeout=30s -iterations 0 -duration=30m -validate-data"
+]
+
+stress_cmd: ["scylla-bench -workload=sequential -mode=write  -replication-factor=1 -partition-count=150 -clustering-row-count=75555                       -clustering-row-size=uniform:1024..3048   -concurrency=10 -connection-count=10 -consistency-level=one -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=600m -validate-data",
+             "scylla-bench -workload=sequential -mode=write  -replication-factor=1 -partition-count=150 -clustering-row-count=75555 -partition-offset=151  -clustering-row-size=uniform:1024..3048   -concurrency=10 -connection-count=10 -consistency-level=one -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=600m -validate-data",
+             "scylla-bench -workload=sequential -mode=write  -replication-factor=1 -partition-count=150 -clustering-row-count=75555 -partition-offset=301  -clustering-row-size=uniform:1024..3048   -concurrency=10 -connection-count=10 -consistency-level=one -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=600m -validate-data",
+             "scylla-bench -workload=sequential -mode=write  -replication-factor=1 -partition-count=150 -clustering-row-count=75555 -partition-offset=451  -clustering-row-size=uniform:1024..3048   -concurrency=10 -connection-count=10 -consistency-level=one -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=600m -validate-data",
+             "scylla-bench -workload=sequential -mode=read  -replication-factor=1 -partition-count=300 -clustering-row-count=75555                        -clustering-row-size=uniform:1024..3048   -concurrency=10 -connection-count=10 -consistency-level=one -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=600m -validate-data",
+             "scylla-bench -workload=sequential -mode=read  -replication-factor=1 -partition-count=300 -clustering-row-count=75555 -partition-offset=301  -clustering-row-size=uniform:1024..3048   -concurrency=10 -connection-count=10 -consistency-level=one -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=600m -validate-data",
+]
+
+n_db_nodes: 3
+n_loaders: 2
+n_monitor_nodes: 1
+round_robin: true
+
+instance_type_db: 'i4i.xlarge'
+instance_type_loader: 'c6i.4xlarge'
+
+nemesis_class_name: 'NonDisruptiveMonkey'
+nemesis_interval: 5
+
+user_prefix: 'longevity-1-rf-test-4h'
+space_node_threshold: 64424


### PR DESCRIPTION
This PR is trying to cover customer issue https://github.com/scylladb/scylladb/issues/16759.
This is from the issue description:
```
After Upgrading Scylla from 5.2.11 via 5.4.0 to 5.4.1, we started observing missing data in Scylla. 
Every once in a while, an INSERT is committed successfully but the inserted values are not visible 
until Scylla is restarted. 
As far as we can tell, version 5.2.11 was not affected while 5.4.1 is. 5.4.0 was not long enough 
in operation to make a reliable statement.

The suspected bug occurs extremely rarely, making it hard for us to reproduce. 
Out of ~800M inserts per day, only a dozen are affected.
```

The load is run on keyspace with RF 1 SCT test. 
We use scylla-bench because its validate data better then in cassandra-stress

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-1-rf-test-12h](https://argus.scylladb.com/test/e6ef2a1c-7267-4566-9954-f49caa755c50/runs?additionalRuns[]=e45799d2-84a2-4126-b279-720a37f5c17d) - Scylla version `5.4.1`
- [x] [longevity-1-rf-test-12h](https://argus.scylladb.com/test/e6ef2a1c-7267-4566-9954-f49caa755c50/runs?additionalRuns[]=9c2c48ba-045b-4ef3-90c4-268beca319f3) - Scylla version `5.4.6`

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
