### PR TITLE
improvement(tooling_reporter.py): Report cassandra-stress version once

### DIFF
--- a/sdcm/reporting/tooling_reporter.py
+++ b/sdcm/reporting/tooling_reporter.py
@@ -1,4 +1,5 @@
 import logging
+from functools import lru_cache
 
 from cassandra import __version__ as PYTHON_DRIVER_VERSION
 from argus.client.sct.client import ArgusSCTClient
@@ -9,6 +10,13 @@ from sdcm.remote.base import CommandRunner
 LOGGER = logging.getLogger(__name__)
 
 
+@lru_cache
+def report_package_to_argus(client: ArgusSCTClient, tool_name: str, package_version: str, additional_data: str = None):
+    package = Package(name=f"{tool_name}", version=package_version,
+                      date=None, revision_id=None, build_id=additional_data)
+    client.submit_packages([package])
+
+
 class ToolReporterBase():
 
     TOOL_NAME = None
@@ -17,6 +25,7 @@ class ToolReporterBase():
         self.runner = runner
         self.command_prefix = command_prefix
         self.argus_client = argus_client
+        self.additional_data = None
         self.version: str | None = None
 
     def __str__(self) -> str:
@@ -29,10 +38,7 @@ class ToolReporterBase():
         if not self.argus_client:
             LOGGER.warning("%s: Skipping reporting to argus, client not initialized.", self)
             return
-
-        package = Package(name=f"{self.TOOL_NAME}", version=self.version,
-                          date=None, revision_id=None, build_id=None)
-        self.argus_client.submit_packages([package])
+        report_package_to_argus(self.argus_client, self.TOOL_NAME, self.version, self.additional_data)
 
     def _collect_version_info(self) -> None:
         raise NotImplementedError()
@@ -84,4 +90,18 @@ class CassandraStressVersionReporter(ToolReporterBase):
         LOGGER.info("Result:\n%s", result)
         self.version = f"{result.get('cassandra-stress', '#FAILED_CHECK_LOGS')}"
         if driver_version := result.get("scylla-java-driver"):
-            self.version += f" (with java-driver {driver_version})"
+            self.additional_data = f"java-driver: {driver_version}"
+            CassandraStressJavaDriverVersionReporter(
+                driver_version=driver_version, command_prefix=None, runner=None, argus_client=self.argus_client).report()
+
+
+class CassandraStressJavaDriverVersionReporter(ToolReporterBase):
+    # pylint: disable=too-few-public-methods
+    TOOL_NAME = "java-driver"
+
+    def __init__(self, driver_version: str, runner: CommandRunner, command_prefix: str = None, argus_client: ArgusSCTClient = None) -> None:
+        super().__init__(runner, command_prefix, argus_client)
+        self.version = driver_version
+
+    def _collect_version_info(self) -> None:
+        pass

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -349,7 +349,7 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
                 cmd_runner, prefix, loader.parent_cluster.test_config.argus_client())
             reporter.report()
         except Exception:  # pylint: disable=broad-except
-            LOGGER.info("Failed to collect cassandra-stress version information")
+            LOGGER.info("Failed to collect cassandra-stress version information", exc_info=True)
         with cleanup_context, \
                 CassandraStressExporter(instance_name=cmd_runner_name,
                                         metrics=nemesis_metrics_obj(),


### PR DESCRIPTION
This commit adds caching for cassandra-stress versions (drivers
included)

Fixes #7276

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] [Argus](#)
- [ ] [Jenkins](#)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
