### PR TITLE
fix(oel8): revert usage of i4i

### DIFF
--- a/test-cases/artifacts/oel81.yaml
+++ b/test-cases/artifacts/oel81.yaml
@@ -3,7 +3,7 @@ ami_id_db_scylla: 'ami-0e883e67243efea62'
 root_disk_size_db: 50
 backtrace_decoding: false
 cluster_backend: 'aws'
-instance_type_db: 'i4i.large'
+instance_type_db: 'i3.large'
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
 logs_transport: 'ssh'


### PR DESCRIPTION
the image being used doesn't support the i4i family we are reverting back to i3

Ref: scylladb/scylla-cluster-tests#7271

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
