### PR TITLE
fix(alternator): enable back the ycsb based tests

### DIFF
--- a/sdcm/utils/alternator/api.py
+++ b/sdcm/utils/alternator/api.py
@@ -152,10 +152,6 @@ class Alternator:
                     batch.delete_item({key: item[key] for key in table_keys})
         return table
 
-    def compare_table_data(self, node, table_data, table_name=consts.TABLE_NAME) -> set:
-        data = self.scan_table(node=node, table_name=table_name)
-        return set(str(line) for line in table_data) - set(str(line) for line in data)
-
     def is_table_exists(self, node, table_name: consts.TABLE_NAME):
         dynamodb_api = self.get_dynamodb_api(node=node)
         is_table_exists = True

--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -26,11 +26,11 @@ from unit_tests.lib.alternator_utils import ALTERNATOR_PORT, ALTERNATOR, TEST_PA
 
 pytestmark = [
     pytest.mark.usefixtures("events", "create_table", "create_cql_ks_and_table"),
-    pytest.mark.skip(reason="those are integration tests only"),
+    pytest.mark.integration,
 ]
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def create_table(docker_scylla):
     def create_endpoint_url(node):
         if running_in_docker():
@@ -46,7 +46,7 @@ def create_table(docker_scylla):
     ALTERNATOR.create_table(node=docker_scylla, table_name=alternator.consts.TABLE_NAME)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def create_cql_ks_and_table(docker_scylla):
     if running_in_docker():
         address = f"{docker_scylla.internal_ip_address}:9042"
@@ -232,5 +232,6 @@ def test_04_insert_new_data(docker_scylla):
         new_items=new_items,
         schema=alternator.schemas.HASH_AND_STR_RANGE_SCHEMA,
     )
-    diff = ALTERNATOR.compare_table_data(node=docker_scylla, table_data=new_items)
-    assert diff
+    data = ALTERNATOR.scan_table(node=docker_scylla)
+    assert {row[schema_keys[0]]: row[schema_keys[1]]
+            for row in new_items} == {row[schema_keys[0]]: row[schema_keys[1]] for row in data}


### PR DESCRIPTION
those tests we skipped long time ago, and need
several fixs to be operational again

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] integration tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
