### PR TITLE
fix(alternator-dns): move ycsb runs into it's own docker network

### DIFF
--- a/configurations/rolling-upgrade-alternator.yaml
+++ b/configurations/rolling-upgrade-alternator.yaml
@@ -21,3 +21,4 @@ alternator_secret_access_key: 'password'
 
 alternator_port: 8080
 alternator_use_dns_routing: true
+docker_network: 'ycsb_net'

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -256,11 +256,13 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
             if self.params.get('alternator_use_dns_routing'):
                 dns = RemoteDocker(loader, dns_image,
                                    command_line=dns_cmd,
-                                   extra_docker_opts=f'--label shell_marker={self.shell_marker}')
+                                   extra_docker_opts=f'--label shell_marker={self.shell_marker}',
+                                   docker_network=self.params.get('docker_network'))
                 dns_options += f'--dns {dns.internal_ip_address} --dns-option use-vc'
             cmd_runner = RemoteDocker(
                 loader, self.docker_image_name,
-                extra_docker_opts=f'{dns_options} {cpu_options} --label shell_marker={self.shell_marker}')
+                extra_docker_opts=f'{dns_options} {cpu_options} --label shell_marker={self.shell_marker}',
+                docker_network=self.params.get('docker_network'))
             cmd_runner_name = str(loader)
 
         self.copy_template(cmd_runner, loader.name)

--- a/test-cases/features/alternator-ttl/longevity-alternator-1h-scan-12h-ttl-no-lwt-2h-grace-4loaders-sisyphus.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-1h-scan-12h-ttl-no-lwt-2h-grace-4loaders-sisyphus.yaml
@@ -51,6 +51,7 @@ user_prefix: 'alternator-ttl-4-loaders-no-lwt-sisyphus'
 
 alternator_port: 8080
 alternator_use_dns_routing: true
+docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired-data.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired-data.yaml
@@ -42,6 +42,7 @@ user_prefix: '4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired'
 
 alternator_port: 8080
 alternator_use_dns_routing: true
+docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-no-lwt-8m-grace-sisyphus.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-no-lwt-8m-grace-sisyphus.yaml
@@ -35,6 +35,7 @@ user_prefix: '4m-scan-36m-ttl-8m-grace-sisyphus'
 
 alternator_port: 8080
 alternator_use_dns_routing: true
+docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-multiple-ttl-8m-grace.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-multiple-ttl-8m-grace.yaml
@@ -89,6 +89,7 @@ user_prefix: 'longevity-alternator-multiple-ttl'
 
 alternator_port: 8080
 alternator_use_dns_routing: true
+docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'

--- a/test-cases/features/alternator-ttl/longevity-alternator-disable-enable-ttl.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-disable-enable-ttl.yaml
@@ -40,6 +40,7 @@ user_prefix: 'alternator-disable-enable-ttl'
 
 alternator_port: 8080
 alternator_use_dns_routing: true
+docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-big-dataset.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-big-dataset.yaml
@@ -47,6 +47,7 @@ user_prefix: 'alternator-ttl-big-data-set'
 
 alternator_port: 8080
 alternator_use_dns_routing: true
+docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-large-writes.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-large-writes.yaml
@@ -46,6 +46,7 @@ user_prefix: 'alternator-ttl-large-writes'
 
 alternator_port: 8080
 alternator_use_dns_routing: true
+docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-lwt.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-lwt.yaml
@@ -29,6 +29,7 @@ user_prefix: 'alternator-lwt-ttl'
 
 alternator_port: 8080
 alternator_use_dns_routing: true
+docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'

--- a/test-cases/longevity/longevity-alternator-200GB-48h.yaml
+++ b/test-cases/longevity/longevity-alternator-200GB-48h.yaml
@@ -50,6 +50,7 @@ user_prefix: 'alternator-48h'
 
 alternator_port: 8080
 alternator_use_dns_routing: true
+docker_network: 'ycsb_net'
 
 alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'

--- a/test-cases/longevity/longevity-alternator-3h-multidc.yaml
+++ b/test-cases/longevity/longevity-alternator-3h-multidc.yaml
@@ -46,3 +46,4 @@ space_node_threshold: 64424
 alternator_port: 8080
 dynamodb_primarykey_type: HASH_AND_RANGE
 alternator_use_dns_routing: true
+docker_network: 'ycsb_net'

--- a/test-cases/longevity/longevity-alternator-3h.yaml
+++ b/test-cases/longevity/longevity-alternator-3h.yaml
@@ -49,3 +49,4 @@ space_node_threshold: 64424
 alternator_port: 8080
 dynamodb_primarykey_type: HASH_AND_RANGE
 alternator_use_dns_routing: true
+docker_network: 'ycsb_net'

--- a/test-cases/longevity/longevity-alternator-streams-100gb-12h.yaml
+++ b/test-cases/longevity/longevity-alternator-streams-100gb-12h.yaml
@@ -52,5 +52,6 @@ experimental_features:
 alternator_port: 8080
 dynamodb_primarykey_type: HASH
 alternator_use_dns_routing: true
+docker_network: 'ycsb_net'
 
 use_mgmt: false # just to make setup quicker for now

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -80,8 +80,6 @@ def fixture_docker_scylla(request: pytest.FixtureRequest):  # pylint: disable=to
     extra_docker_opts = (f'-p 8000 -p {BaseNode.CQL_PORT} --cpus="1" -v {entryfile_path}:/entry.sh'
                          f' -v {ssl_dir}:/etc/scylla/ssl_conf'
                          ' --entrypoint /entry.sh')
-    if docker_network:
-        extra_docker_opts += f' --network={docker_network}'
 
     scylla = RemoteDocker(LocalNode("scylla", cluster), image_name=docker_version,
                           command_line=f"--smp 1 {alternator_flags}",

--- a/unit_tests/lib/alternator_utils.py
+++ b/unit_tests/lib/alternator_utils.py
@@ -17,6 +17,7 @@ TEST_PARAMS = dict(
     dynamodb_primarykey_type="HASH_AND_RANGE",
     alternator_use_dns_routing=True,
     alternator_port=ALTERNATOR_PORT,
+    docker_network='ycsb_net',
 )
 ALTERNATOR = alternator.api.Alternator(
     sct_params={

--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -76,6 +76,7 @@ def create_cql_ks_and_table(docker_scylla):
     )
 
 
+@pytest.mark.docker_scylla_args(docker_network='ycsb_net')
 def test_01_dynamodb_api(request, docker_scylla, prom_address, params):
     loader_set = LocalLoaderSetDummy()
     params.update(TEST_PARAMS)


### PR DESCRIPTION
since moby/moby#47538, dns isn't forward automaticlly into internal networks, and we need to create a specfic network that has a gatway, for it to work as we expect and forward DNS requests out

Fixes: #7302
Ref: https://github.com/moby/moby/pull/47538

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/rolling-upgrade-alternator-test/2/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
