### PR TITLE
feature(monitoring): switch to use prepared images

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -8,6 +8,7 @@ instance_type_loader: 'c6i.xlarge'
 instance_type_monitor: 't3.large'
 # manual on creating loader AMI's: see docs/new_loader_ami.md
 ami_id_loader: 'scylla-qa-loader-ami-v20-ubuntu22'
+# manual on updating monitor images see: docs/monitoring-images.md
 ami_id_monitor: 'scylladb-monitor-4-6-2-2024-02-13t08-06-04z'
 
 availability_zone: 'a'

--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -8,7 +8,7 @@ instance_type_loader: 'c6i.xlarge'
 instance_type_monitor: 't3.large'
 # manual on creating loader AMI's: see docs/new_loader_ami.md
 ami_id_loader: 'scylla-qa-loader-ami-v20-ubuntu22'
-ami_id_monitor: 'ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20231207' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20231207Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2023-12-07
+ami_id_monitor: 'scylladb-monitor-4-6-2-2024-02-13t08-06-04z'
 
 availability_zone: 'a'
 root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used
@@ -69,3 +69,6 @@ scylla_network_config:
   use_dns: false
   nic: 0  #  If ipv4 and public is True it has to be primary network interface (device index is 0)
 # TODO: end
+
+# we are using monitor images, see `ami_id_monitor`
+monitor_branch: null

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -5,6 +5,7 @@ gce_project: '' # empty mean default one, can be overwritten to use different on
 
 gce_image_db: '' # so we can use `scylla_version` as needed
 gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts'
+# manual on updating monitor images see: docs/monitoring-images.md
 gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-6-2-2024-03-07t12-47-59z'
 gce_image_username: 'scylla-test'
 

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -5,7 +5,7 @@ gce_project: '' # empty mean default one, can be overwritten to use different on
 
 gce_image_db: '' # so we can use `scylla_version` as needed
 gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts'
-gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts'
+gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-6-2-2024-03-07t12-47-59z'
 gce_image_username: 'scylla-test'
 
 gce_instance_type_loader: 'e2-standard-2'
@@ -34,3 +34,6 @@ backup_bucket_location: 'manager-backup-tests-sct-project-1-us-east1'
 backup_bucket_backend: 'gcs'
 
 use_preinstalled_scylla: true
+
+# we are using monitor images, see `gce_image_monitor`
+monitor_branch: null

--- a/docs/monitoring-images.md
+++ b/docs/monitoring-images.md
@@ -1,0 +1,12 @@
+# Update monitoring images/branch
+
+This docs show how to update monitor images
+
+* currently we have images for AWS and GCP (and not for Azure)
+
+* AWS image get created on us-east-1, and named like `scylladb-monitor-4-6-2-2024-02-13t08-06-04z`
+  `utils/copy_ami_to_all_regions.sh` can be used to copy the AMIs to multiple region
+
+* GCP images are named as following `scylladb-monitor-4-6-2-2024-03-07t12-47-59z
+
+* when updating images, one should also update the `monitor_branch` for the backend that doesn't have images yet.

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5392,7 +5392,12 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
         prepared_image = node.remoter.run('test -e ~/PREPARED-MONITOR', ignore_status=True)
         if prepared_image.ok or self.is_formal_monitor_image:
             node.log.debug('Skip monitor `install_scylla_monitoring_prereqs` for using a prepared AMI')
-            if self.formal_monitor_image:
+            if self.is_formal_monitor_image:
+                # own the monitoring folder, since in some of the images (GCE), it's under the same user we
+                # are using for testing
+                user = node.ssh_login_info['user']
+                node.remoter.sudo(f"chown -R {user}:{user} {self.monitor_install_path_base}")
+
                 node.install_package('unzip')
                 node.remoter.run("sudo usermod -aG docker $USER", change_context=True)
                 node.remoter.run(cmd='sudo systemctl restart docker', timeout=60)

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -489,7 +489,7 @@ class MonitorSetDocker(cluster.BaseMonitorSet, DockerCluster):  # pylint: disabl
             except Exception as exc:  # pylint: disable=broad-except
                 self.log.error(f"Stopping scylla monitoring failed with {str(exc)}")
             try:
-                node.remoter.sudo(f"rm -rf '{self._monitor_install_path_base}'")
+                node.remoter.sudo(f"rm -rf '{self.monitor_install_path_base}'")
                 self.log.error("Cleaning up scylla monitoring succeeded")
             except Exception as exc:  # pylint: disable=broad-except
                 self.log.error(f"Cleaning up scylla monitoring failed with {str(exc)}")

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -144,13 +144,14 @@ class BaseMonitoringEntity(BaseLogEntity):
         try:
             basedir = self.get_monitoring_base_dir(node)
             result = node.remoter.run(
-                f'ls {basedir} | grep scylla-monitoring-src', ignore_status=True, verbose=False)
+                rf"ls {basedir} | grep 'scylla-monitoring-src\|scylla-grafana-monitoring-scylla-monitoring'",
+                ignore_status=True, verbose=False)
             name = result.stdout.strip()
             if not name:
                 LOGGER.error("Dir with scylla monitoring stack was not found")
                 return None, None, None
             result = node.remoter.run(
-                f"cat {basedir}/scylla-monitoring-src/monitor_version", ignore_status=True, verbose=False)
+                f"cat {basedir}/{name}/monitor_version", ignore_status=True, verbose=False)
         except Exception as details:  # pylint: disable=broad-except
             LOGGER.error("Failed to get monitoring version: %s", details)
             return None, None, None

--- a/utils/copy_ami_to_all_regions.sh
+++ b/utils/copy_ami_to_all_regions.sh
@@ -1,5 +1,5 @@
-AMI_ID=ami-00c1a16b5136fbb7c
-AMI_NAME='scylla-qa-loader-ami-v19'
+AMI_ID=ami-0c4e5a2331f97fd0d
+AMI_NAME='scylladb-monitor-4-6-2-2024-02-13t08-06-04z'
 SOURCE_REGION=us-east-1
 TARGET_REGIONS='us-west-2 eu-west-1 eu-west-2 eu-north-1 eu-central-1'
 


### PR DESCRIPTION
* change aws to use prepare image for monitoring 4.6.2
* change the code to be able to skip installations of packages and monitor

Ref: scylladb/qa-tasks#993

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] provision tests
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/43/
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
