### PR TITLE
improvement(cluster-docker): start container with custom number of cpus

### DIFF
--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -52,12 +52,18 @@ class NodeContainerMixin:
         volumes = {
             '/var/run/docker.sock': {"bind": '/var/run/docker.sock', "mode": "rw"},
         }
+
+        # TODO: add parsing of cpuset option from append_scylla_args parameter
+        scylla_args = self.parent_cluster.params.get('append_scylla_args')
+        smp_match = re.search(r'--smp\s(\d+)', scylla_args)
+        smp = int(smp_match.group(1)) if smp_match else 1
+
         return dict(name=self.name,
                     image=self.node_container_image_tag,
                     command=f'--seeds="{seed_ip}"' if seed_ip else None,
                     volumes=volumes,
                     network=self.parent_cluster.params.get('docker_network'),
-                    nano_cpus=10**9)  # Same as `docker run --cpus=1 ...' CLI command.
+                    nano_cpus=smp*10**9)  # Same as `docker run --cpus=N ...' CLI command.
 
 
 class DockerNode(cluster.BaseNode, NodeContainerMixin):  # pylint: disable=abstract-method


### PR DESCRIPTION
So far containers of Docker backend cluster were started with hardcoded number of cpus, which is 1. This resulted in containers of scylla cluster nodes being overloaded during c-s and/or s-b stress commands execution.

The commit allows to start the containers with the specified number of cpus. The number is based on "smp" option value from a test config.

The commit addresses issue scylladb/scylla-cluster-tests#7307.

### Testing
- [ ]

### PR pre-checks (self review)
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
