### PR TITLE
improvement(log info): add datacenter and rack info

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -439,12 +439,12 @@ class AWSNode(cluster.BaseNode):
         else:
             node_private_ip = self.private_ip_address
 
-        return 'Node %s [%s | %s%s] (seed: %s)' % (
+        return 'Node %s [%s | %s%s]%s' % (
             self.name,
             self.public_ip_address,
             node_private_ip,
             " | %s" % self.ipv6_ip_address if self.test_config.IP_SSH_CONNECTIONS == "ipv6" else "",
-            self.is_seed)
+            self._dc_info_str())
 
     @property
     def network_interfaces(self):

--- a/unit_tests/dummy_remote.py
+++ b/unit_tests/dummy_remote.py
@@ -24,6 +24,7 @@ from sdcm.cluster import BaseNode, BaseCluster, BaseScyllaCluster
 class DummyOutput:
     def __init__(self, stdout):
         self.stdout = stdout
+        self.stderr = stdout
 
 
 class DummyRemote:

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -409,6 +409,8 @@ class DummyCluster(BaseScyllaCluster, BaseCluster):  # pylint: disable=too-few-p
         self.nodes = []
         self.params = params
         self.name = 'dummy_cluster'
+        self.node_type = "scylla-db"
+        self.racks_count = 0
 
     @property
     def seed_nodes_addresses(self):

--- a/unit_tests/test_seed_selector.py
+++ b/unit_tests/test_seed_selector.py
@@ -5,6 +5,7 @@ import shutil
 import os.path
 
 import sdcm.cluster
+from sdcm import sct_config
 from sdcm.test_config import TestConfig
 from unit_tests.dummy_remote import DummyRemote
 
@@ -34,12 +35,15 @@ class DummyNode(sdcm.cluster.BaseNode):  # pylint: disable=abstract-method
 
 class DummyCluster(sdcm.cluster.BaseScyllaCluster):
     def __init__(self, *args, **kwargs):
-        self.params = {}
-        self.nodes = []
         super().__init__(*args, **kwargs)
+        self.params = sct_config.SCTConfiguration()
+        self.params["region_name"] = "test_region"
+        self.racks_count = 0
+        self.nodes = []
+        self.node_type = "scylla-db"
 
     def set_test_params(self, seeds_selector, seeds_num, db_type):
-        self.params = {'seeds_selector': seeds_selector, 'seeds_num': seeds_num, 'db_type': db_type}
+        self.params.update({'seeds_selector': seeds_selector, 'seeds_num': seeds_num, 'db_type': db_type})
 
 
 logging.basicConfig(format="%(asctime)s - %(levelname)-8s - %(name)-10s: %(message)s", level=logging.DEBUG)
@@ -61,7 +65,7 @@ class TestSeedSelector(unittest.TestCase):
         self.cluster = DummyCluster()
         # Add 3 nodes
         for i in range(1, nodes_number+1):
-            self.cluster.nodes.append(DummyNode(name='node%d' % i, parent_cluster=None,
+            self.cluster.nodes.append(DummyNode(name='node%d' % i, parent_cluster=self.cluster,
                                                 base_logdir=self.temp_dir,
                                                 ssh_login_info=dict(key_file='~/.ssh/scylla-test')))
         for node in self.cluster.nodes:


### PR DESCRIPTION
When the test runs in multi DC environment it is helpful to get information
about the node: in which datacenter and rack this node is located.

For this goal update node information the the log. So it is not needed to
search for this through the log

Task: https://github.com/scylladb/qa-tasks/issues/1180

Example:
```
< t:2024-03-31 16:00:58,727 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:INFO  > 2024-03-31 16:00:58.725: (CassandraStressEvent Severity.NORMAL) period_type=end event_id=22a4b06b-d208-4492-99e8-73d0b392d38f duration=22s: 
node=Node lwt-longevity-multi-dc-24h-add-data-loader-node-969d36e8-3 [35.172.234.245 | 10.12.3.80] (dc name: us-east-1)
```

```
< t:2024-03-31 14:20:17,074 f:cluster.py      l:1081 c:sdcm.cluster_aws     p:INFO  > 
Node lwt-longevity-multi-dc-24h-add-data-loader-node-969d36e8-2 [54.245.179.85 | 10.15.2.246] (dc name: us-west-2): node_type = loader
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [one datacenter and rack (AWS)](https://argus.scylladb.com/test/22d76ec7-28e1-4f13-8c9a-9f6357bb3d8a/runs?additionalRuns[]=4fa06cab-8b74-44a7-b5d9-8dac7e7a27de)
- [x] [multi dc test (AWS)](https://argus.scylladb.com/test/50e0c80c-ad3b-4c9e-93c7-69b30dd821f2/runs?additionalRuns[]=ac49eba0-2cd2-4082-974d-e2be141fa0a4)
- [x] [simulated racks test (AWS)](https://argus.scylladb.com/test/542be83d-1af8-4f1f-af9b-9f6db33afd0c/runs?additionalRuns[]=e25dd0c6-c9bb-4509-bbe2-d64c64bfcdab)
- [x] Agure (provision) PASSED
- [x] GCE (provision) 
- [x] [K8s multidc](https://argus.scylladb.com/test/d752f73a-07a2-4a21-a2c0-9fc8a7153452/runs?additionalRuns[]=de513831-e99c-4644-9df5-28d5ee43efab)
- [x] local docker (one dc) (provision) PASSED

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
