### PR TITLE
fix(ubuntu2004-fips): add the 2024 ScyllaDB Package Signing Key

### DIFF
--- a/test-cases/artifacts/ubuntu2004-fips.yaml
+++ b/test-cases/artifacts/ubuntu2004-fips.yaml
@@ -20,3 +20,5 @@ internode_encryption: 'all'
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2004-fips'
 aws_fallback_to_next_availability_zone: true
+scylla_apt_keys:
+  - '491C93B9DE7496A7'  # ScyllaDB Package Signing Key 2024 <security@scylladb.com>


### PR DESCRIPTION
Added the up to date GPG key so that the Scylla package will be able to be downlaoded Ref: https://github.com/scylladb/scylla-cluster-tests/pull/7002

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
