### PR TITLE
improvement(docker-backend): add a dedicated test config for local runs

### DIFF
--- a/configurations/nemesis/additional_configs/docker_backend_local.yaml
+++ b/configurations/nemesis/additional_configs/docker_backend_local.yaml
@@ -1,0 +1,31 @@
+test_duration: 90
+
+prepare_write_cmd:
+    - "cassandra-stress write cl=QUORUM n=1048576 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+    - "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10000 -clustering-row-count=100 -clustering-row-size=uniform:128..2048 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
+
+stress_cmd:
+    - "cassandra-stress write cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=30 throttle=2000/s -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+    - "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=30 throttle=2000/s -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+    - "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=70 -connection-count=70 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data -max-rate=3000"
+
+user_prefix: 'longevity-1gb-1h-nemesis'
+
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1
+seeds_num: 3
+
+nemesis_interval: 3
+nemesis_filter_seeds: false
+nemesis_during_prepare: true
+
+# NOTE: the parameters reduce footprint of scylla cluster for docker backend, comparing to default values
+append_scylla_args: '--smp 1 --memory 5G'
+use_mgmt: false
+monitor_swap_size: 0
+
+# NOTE: encryption should be disabled until
+#       https://github.com/scylladb/scylla-cluster-tests/issues/7287 is fixed
+server_encrypt: false
+client_encrypt: false


### PR DESCRIPTION
When trying to execute Nemesis test cases on Docker backend locally, using the default test configuration [longevity-5gb-1h-nemesis.yaml](https://github.com/scylladb/scylla-cluster-tests/blob/ba3f94836b1f6e75e7c3a90b488e312fc83f726f/configurations/nemesis/longevity-5gb-1h-nemesis.yaml), the load eventually kills the local env/laptop, as scylla claims all available HW resources (particularly memory).

The change adds a dedicated test configuration to be able to run individual nemesis test cases on Docker backend  locally, on an average-spec laptop/computer with 32GB of RAM.

The tuned parameters comparing to the default config are:
- reduced data size from 5GB to 1GB
- rate limiting / throttling applied to c-s and s-b stress commands, to keep load per db instance within 50-70% range during a test, when no Nemesis is applied
- limit scylla memory usage to 5GB per node
- disable scylla manager
- disable swap for monitors

The change addresses task: https://github.com/scylladb/qa-tasks/issues/1636

### Testing
Local env with 32 GB of RAM.
Example of average resources utilization of host system, during a Nemesis:
```
❯ docker stats --no-stream --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}"
NAME                                                      CPU %     MEM USAGE / LIMIT   MEM %
clever_keldysh                                            77.33%    150.1MiB / 31GiB    0.47%
exciting_merkle                                           39.07%    570.8MiB / 31GiB    1.80%
brave_shirley                                             46.44%    592.6MiB / 31GiB    1.87%
agraf                                                     0.20%     107.4MiB / 31GiB    0.34%
agrafrender                                               0.00%     64.26MiB / 31GiB    0.20%
aprom                                                     0.03%     149.1MiB / 31GiB    0.47%
promtail                                                  0.28%     19.49MiB / 31GiB    0.06%
loki                                                      0.61%     59.04MiB / 31GiB    0.19%
aalert                                                    0.32%     24.58MiB / 31GiB    0.08%
longevity-1gb-1h-nemesis-dmitriy-loader-node-7c5095d7-0   0.14%     166.3MiB / 31GiB    0.52%
longevity-1gb-1h-nemesis-dmitriy-db-node-7c5095d7-2       79.24%    5.114GiB / 31GiB    16.50%
longevity-1gb-1h-nemesis-dmitriy-db-node-7c5095d7-1       78.30%    5.116GiB / 31GiB    16.50%
longevity-1gb-1h-nemesis-dmitriy-db-node-7c5095d7-0       53.81%    5.238GiB / 31GiB    16.90%
```

### PR pre-checks (self review)
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
