### PR TITLE
improvement(cluster): setup nodes in parallel

### DIFF
--- a/sdcm/cluster_azure.py
+++ b/sdcm/cluster_azure.py
@@ -245,6 +245,9 @@ class AzureCluster(cluster.BaseCluster):   # pylint: disable=too-many-instance-a
         # todo lukasz: why gce cluster didn't have to implement this?
         raise NotImplementedError("node_setup should not run")
 
+    def node_startup(self, node, verbose=False, timeout=3600):
+        raise NotImplementedError("'node_startup' should not run")
+
     def wait_for_init(self):
         # todo lukasz: why gce cluster didn't have to implement this?
         raise NotImplementedError("wait_for_init should not run")

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -312,6 +312,8 @@ class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):  # pylint: 
 
         node.stop_scylla_server(verify_down=False)
         node.remoter.sudo('rm -Rf /var/lib/scylla/data/*')  # Clear data folder to drop wrong cluster name data.
+
+    def node_startup(self, node, verbose=False, timeout=3600):
         node.start_scylla_server(verify_up=False)
 
         node.wait_db_up(verbose=verbose, timeout=timeout)

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2396,6 +2396,9 @@ class PodCluster(cluster.BaseCluster):
     def node_setup(self, node, verbose=False, timeout=3600):
         raise NotImplementedError("Derived class must implement 'node_setup' method!")
 
+    def node_startup(self, node, verbose=False, timeout=3600):
+        raise NotImplementedError("Derived class must implement 'node_startup' method!")
+
     def get_node_ips_param(self, public_ip=True):
         raise NotImplementedError("Derived class must implement 'get_node_ips_param' method!")
 
@@ -2466,8 +2469,6 @@ class PodCluster(cluster.BaseCluster):
 
 
 class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disable=too-many-public-methods
-    node_setup_requires_scylla_restart = False
-
     def __init__(self,
                  k8s_clusters: List[KubernetesCluster],
                  scylla_cluster_name: Optional[str] = None,
@@ -2707,6 +2708,9 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         if self.test_config.BACKTRACE_DECODING:
             node.install_scylla_debuginfo()
         self.node_config_setup()
+
+    def node_startup(self, node: BaseScyllaPodContainer, verbose: bool = False, timeout: int = 3600):
+        pass
 
     @cached_property
     def scylla_manager_cluster_name(self):  # pylint: disable=invalid-overridden-method
@@ -3068,6 +3072,10 @@ class LoaderPodCluster(cluster.BaseLoaderSet, PodCluster):
 
         if self.params.get('client_encrypt'):
             node.config_client_encrypt()
+
+    def node_startup(self, node: BasePodContainer, verbose: bool = False,
+                     db_node_address: Optional[str] = None, **kwargs) -> None:
+        pass
 
     def _get_docker_image(self):
         if loader_image := self.params.get('stress_image.cassandra-stress'):

--- a/sdcm/utils/raft/common.py
+++ b/sdcm/utils/raft/common.py
@@ -64,6 +64,7 @@ class NodeBootstrapAbortManager:
         try:
             LOGGER.debug("Starting bootstrap process %s", self.bootstrap_node.name)
             self.bootstrap_node.parent_cluster.node_setup(self.bootstrap_node, verbose=True)
+            self.bootstrap_node.parent_cluster.node_startup(self.bootstrap_node, verbose=True)
             LOGGER.debug("Node %s was bootstrapped", self.bootstrap_node.name)
         except Exception as exc:  # pylint: disable=broad-except
             LOGGER.error("Setup failed for node %s with err %s", self.bootstrap_node.name, exc)


### PR DESCRIPTION
Before this change we were running `node_setup` methods serially.
In majority of cases the time gap is not critical.
But there are cases such as setting up `hybrid disks` on GCE
where setup of disks on a single DB node takes more than 20 minutes.
And we have setups with 6 nodes.

So, mitigate this waste of time and money by parallelizing the setup of DB nodes
and do serially only startup where we have limitation for bootstrap stage.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
