### PR TITLE
fix(sct-runner): remove keep-alive network tag on GCE

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -11,7 +11,7 @@
 #
 # Copyright (c) 2021 ScyllaDB
 
-#pylint: disable=too-many-lines
+# pylint: disable=too-many-lines
 from __future__ import annotations
 
 import logging
@@ -825,7 +825,6 @@ class GceSctRunner(SctRunner):  # pylint: disable=too-many-instance-attributes
                                        "block-project-ssh-keys": "true",
                                        "ssh-keys": f"{self.LOGIN_USER}:{self.key_pair.public_key.decode()}",
                                    },
-                                   network_tags=["keep-alive"],
                                    service_accounts=[{
                                        'email': KeyStore().get_gcp_credentials()['client_email'],
                                        'scopes': ['https://www.googleapis.com/auth/cloud-platform'],


### PR DESCRIPTION
We no longer need to add `keep-alive` network tag for sct runners on GCE as `keep` metadata with proper value is added anyway. Having `keep-alive` network tag prevents cleanup script from properly and timely cleanup of these runners.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] - tested locally with `./sct.py  create-runner-instance --cloud-provider gce --region us-east1 --availability-zone c --test-id 59e411d8-1481-4758-9b5b-f3e0b10d7219 --duration 1935 --test-name longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity`

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
