### PR TITLE
fix(cs-profiles): use user profiles located at `/tmp` be used `as-is`

### DIFF
--- a/sdcm/utils/user_profile.py
+++ b/sdcm/utils/user_profile.py
@@ -130,7 +130,14 @@ def get_profile_content(stress_cmd):
     else:
         raise FileNotFoundError(f"Profile is not found in stress command: '{stress_cmd}'")
 
-    cs_profile = find_file_under_sct_dir(filename=profile_file, sub_folder=profile_path)
+    try:
+        cs_profile = find_file_under_sct_dir(filename=profile_file, sub_folder=profile_path)
+    except FileNotFoundError as exc:
+        # NOTE: filenames may be dynamically updated with some suffixes and be placed under the '/tmp' dir.
+        if profile_path.startswith("/tmp"):
+            cs_profile = f"{profile_path}/{profile_file}"
+        else:
+            raise FileNotFoundError from exc
 
     with open(cs_profile, encoding="utf-8") as yaml_stream:
         profile = yaml.safe_load(yaml_stream)


### PR DESCRIPTION
For the moment, when we use c-s user profiles in CI jobs we get following error:

```
  FileNotFoundError: User profile file templated_tables_mvs3ysgyis.yaml \
    not found under /home/ubuntu/scylla-cluster-tests
```

The file that was attempted to be found under the SCT dir has dynamically added suffix `s3ysgyis` and was doomed to be not found.

So, fix it by not trying to find dynamically created files in the `/tmp` dir and return it's path `as-is`.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
