### PR TITLE
feature(teardown-validators): nodetool scrub validate

### DIFF
--- a/configurations/nemesis/longevity-5gb-1h-nemesis.yaml
+++ b/configurations/nemesis/longevity-5gb-1h-nemesis.yaml
@@ -31,3 +31,7 @@ gce_n_local_ssd_disk_db: 1
 
 server_encrypt: true
 client_encrypt: true
+
+teardown_validators:
+  scrub:
+    enabled: true

--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -140,3 +140,5 @@ TestStepEvent: ERROR
 CpuNotHighEnoughEvent: ERROR
 HWPerforanceEvent: CRITICAL
 CommitLogCheckErrorEvent: ERROR
+ValidatorEvent: ERROR
+ScrubValidationErrorEvent: ERROR

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -242,3 +242,11 @@ validate_large_collections: false
 scylla_d_overrides_files: []
 
 run_commit_log_check_thread: true
+
+# teardown validators
+teardown_validators:
+  scrub:
+    enabled: false
+    timeout: 1200
+    keyspace: ''
+    table: ''

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -46,6 +46,7 @@ import yaml
 import requests
 from paramiko import SSHException
 from tenacity import RetryError
+from invoke import Result
 from invoke.exceptions import UnexpectedExit, Failure
 from cassandra import ConsistencyLevel
 from cassandra.auth import PlainTextAuthProvider
@@ -2562,9 +2563,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         return f"{self.add_install_prefix('/usr/bin/nodetool')} {options} {sub_cmd} {args}"
 
     # pylint: disable=inconsistent-return-statements
-    def run_nodetool(self, sub_cmd, args="", options="", timeout=None,
-                     ignore_status=False, verbose=True, coredump_on_timeout=False,
-                     warning_event_on_exception=None, error_message="", publish_event=True, retry=1):
+    def run_nodetool(self, sub_cmd: str, args: str = "", options: str = "", timeout: int = None,
+                     ignore_status: bool = False, verbose: bool = True, coredump_on_timeout: bool = False,
+                     warning_event_on_exception: Exception = None, error_message: str = "", publish_event: bool = True, retry: int = 1
+                     ) -> Result:
         """
             Wrapper for nodetool command.
             Command format: nodetool [options] command [args]
@@ -3180,7 +3182,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
 
         self.log = SDCMAdapter(LOGGER, extra={'prefix': str(self)})
         self.log.info('Init nodes')
-        self.nodes = []
+        self.nodes: List[BaseNode] = []
         self.instance_provision = params.get('instance_provision')
         self.params = params
         self.datacenter = region_names or []

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1534,6 +1534,8 @@ class SCTConfiguration(dict):
         dict(name="run_commit_log_check_thread", env="SCT_RUN_COMMIT_LOG_CHECK_THREAD", type=boolean,
              help="""Run commit log check thread if commitlog_use_hard_size_limit is True"""),
 
+        dict(name="teardown_validators", env="SCT_TEARDOWN_VALIDATORS", type=dict_or_str,
+             help="""Configuration for additional validations executed after the test""")
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',

--- a/sdcm/sct_events/teardown_validators.py
+++ b/sdcm/sct_events/teardown_validators.py
@@ -1,0 +1,25 @@
+from sdcm.sct_events import Severity
+from sdcm.sct_events.base import InformationalEvent
+
+
+class ValidatorEvent(InformationalEvent):
+    def __init__(self, message: str, severity: Severity = Severity.NORMAL):
+        super().__init__(severity)
+        self.message = message
+
+    @property
+    def msgfmt(self) -> str:
+        return super().msgfmt + ": message={0.message}"
+
+
+class ScrubValidationErrorEvent(InformationalEvent):
+
+    def __init__(self, node_name: str, sstables_link: str, severity: Severity = Severity.ERROR):
+        super().__init__(severity=severity)
+
+        self.message = (f"Nodetool scrub in validation mode found invalid sstables on node {node_name}."
+                        f"See more details in db logs and quarantined sstables link: {sstables_link}")
+
+    @property
+    def msgfmt(self) -> str:
+        return super().msgfmt + ": message={0.message}"

--- a/sdcm/teardown_validators/__init__.py
+++ b/sdcm/teardown_validators/__init__.py
@@ -1,0 +1,3 @@
+from sdcm.teardown_validators.sstables import SstablesValidator
+
+teardown_validators_list = [SstablesValidator]

--- a/sdcm/teardown_validators/base.py
+++ b/sdcm/teardown_validators/base.py
@@ -1,0 +1,21 @@
+import logging
+
+from sdcm.cluster import BaseCluster
+from sdcm.sct_config import SCTConfiguration
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TeardownValidator:  # pylint: disable=too-few-public-methods
+    validator_name = None  # must be defined by child classes
+
+    def __init__(self, params: SCTConfiguration, cluster: BaseCluster):
+        self.params = params
+        self.cluster = cluster
+        self.configuration = params.get(f"teardown_validators.{self.validator_name}")
+        self.is_enabled = self.configuration.get("enabled", False)
+        if not self.is_enabled:
+            self.validate = lambda: LOGGER.info("%s validator is disabled", self.validator_name)
+
+    def validate(self):  # pylint: disable=method-hidden
+        raise NotImplementedError()

--- a/sdcm/teardown_validators/sstables.py
+++ b/sdcm/teardown_validators/sstables.py
@@ -1,0 +1,68 @@
+import logging
+from functools import partial
+
+from sdcm.cluster import BaseNode
+from sdcm.sct_events import Severity
+from sdcm.sct_events.teardown_validators import ValidatorEvent, ScrubValidationErrorEvent
+from sdcm.teardown_validators.base import TeardownValidator
+from sdcm.utils.common import S3Storage, ParallelObject
+from sdcm.utils.s3_remote_uploader import upload_remote_files_directly_to_s3
+
+LOGGER = logging.getLogger(__name__)
+
+
+class SstablesValidator(TeardownValidator):  # pylint: disable=too-few-public-methods
+    validator_name = 'scrub'
+
+    def _upload_corrupted_files(self, node: BaseNode, quarantine_log_lines):
+        # get quarantine dir from lines:
+        # INFO  2024-04-02 12:40:24,787 [shard 0:stre] sstable - Moving sstable /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/me-3gey_0z3c_2h5vl2ogebmg26ku9t-big-Data.db to "/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/quarantine"  # pylint: disable=line-too-long
+        # print(log_lines)
+        quarantine_dirs = {line.split(' to "')[1][:-2]
+                           for line in quarantine_log_lines
+                           if 'sstable - Moving sstable' in line and 'quarantine' in line}
+        if not quarantine_dirs:
+            LOGGER.error('No quarantine directories found in db logs on node: %s', node.name)
+            return "<No quarantine directories found>"
+        s3_link = upload_remote_files_directly_to_s3(
+            node.ssh_login_info, list(quarantine_dirs), s3_bucket=S3Storage.bucket_name,
+            s3_key=f"{self.cluster.uuid}/{node.name}-corrupted-sstables.tar.gz",
+            max_size_gb=100, public_read_acl=True)
+        return s3_link
+
+    def _run_nodetool_scrub(self, node: BaseNode, keyspace: str, table: str, timeout=1200):
+        node.wait_db_up(timeout=300)
+        finish_scrub_follower = node.follow_system_log(patterns=['Finished scrubbing in validate mode'])
+        quarantine_lines = node.follow_system_log(patterns=['sstable - Moving sstable'], start_from_beginning=True)
+        result = node.run_nodetool(sub_cmd='scrub', args=f"--mode VALIDATE --no-snapshot {keyspace} {table}".strip(),
+                                   timeout=timeout, coredump_on_timeout=False, ignore_status=True)
+        if not result.ok:
+            ValidatorEvent(
+                message=f'Error running nodetool scrub on node {node.name}: {result.stdout}\n{result.stderr}',
+                severity=Severity.ERROR).publish()
+        scrub_finish_lines = list(finish_scrub_follower)
+        if not scrub_finish_lines:
+            ValidatorEvent(
+                message=f'No scrubbing validation message found in db logs on node: {node.name}', severity=Severity.ERROR).publish()
+            return
+        invalid_sstables = [line for line in scrub_finish_lines if 'sstable is invalid' in line]
+        if invalid_sstables:
+            LOGGER.error("Invalid sstables found: %s.", invalid_sstables)
+            s3_link = self._upload_corrupted_files(node, list(quarantine_lines))
+            ScrubValidationErrorEvent(node.name, s3_link).publish()
+
+    def validate(self):
+        keyspace = self.configuration.get("keyspace")
+        table = self.configuration.get("table")
+        timeout = self.configuration.get("timeout", 1200)
+        run_scrub = partial(self._run_nodetool_scrub, keyspace=keyspace, table=table, timeout=timeout)
+        run_scrub.__name__ = run_scrub.func.__name__
+        try:
+            LOGGER.info("Running nodetool scrub on all nodes in validation mode")
+            parallel_obj = ParallelObject(objects=self.cluster.nodes, timeout=timeout)
+            parallel_obj.run(run_scrub, ignore_exceptions=False, unpack_objects=True)
+            LOGGER.info("Nodetool scrub validation finished")
+        except Exception as exc:  # pylint: disable=broad-except
+            LOGGER.error("Error during nodetool scrub validation: %s", exc)
+            ValidatorEvent(
+                message=f'Error during nodetool scrub validation: {exc}', severity=Severity.ERROR).publish()

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -65,6 +65,7 @@ from sdcm.scan_operation_thread import ScanOperationThread
 from sdcm.nosql_thread import NoSQLBenchStressThread
 from sdcm.scylla_bench_thread import ScyllaBenchThread
 from sdcm.cassandra_harry_thread import CassandraHarryThread
+from sdcm.teardown_validators import teardown_validators_list
 from sdcm.tombstone_gc_verification_thread import TombstoneGcVerificationThread
 from sdcm.utils.alternator.consts import NO_LWT_TABLE_NAME
 from sdcm.utils.aws_kms import AwsKms
@@ -2798,6 +2799,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.teardown_started = True
         with silence(parent=self, name='Sending test end event'):
             InfoEvent(message="TEST_END").publish()
+        self.log.info("Post test validators are starting...")
+        for validator_class in teardown_validators_list:
+            for db_cluster in self.db_clusters_multitenant:
+                validator_class(self.params, db_cluster).validate()
         self.log.info('TearDown is starting...')
         self.stop_timeout_thread()
         self.stop_event_analyzer()

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -414,7 +414,7 @@ class ParallelObject:
         self.disable_logging = disable_logging
         self._thread_pool = ThreadPoolExecutor(max_workers=self.num_workers)  # pylint: disable=consider-using-with
 
-    def run(self, func: Callable, ignore_exceptions=False, unpack_objects: bool = False):
+    def run(self, func: Callable, ignore_exceptions=False, unpack_objects: bool = False) -> List[ParallelObjectResult]:
         """Run callable object "disrupt_func" in parallel
 
         Allow to run callable object in parallel.

--- a/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
@@ -30,3 +30,7 @@ space_node_threshold: 64424
 round_robin: true
 
 seeds_num: 3
+
+teardown_validators:
+  scrub:
+    enabled: true


### PR DESCRIPTION
We want to validate scylla cluster after longevity test to verify if it's in correct state. Aiming for checks that require no load and/or affect system performance and/or can be done once after the test.

Implemented first validator that verifies if sstables are not corrupted using `nodetool scrub`. In case corruption is found, quarantined by scrub sstables are uploaded to s3 and proper error event is raised with link.

refs: https://github.com/scylladb/qa-tasks/issues/1577

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] -  longevity (kill scylla nemesis) - https://argus.scylladb.com/test/38256c5f-88a2-4356-b777-c655de35e9cb/runs?additionalRuns[]=6dd23b42-74d7-436e-aa2a-80b50c959a40

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
