### PR TITLE
test(perf): increase n_db_nodes by 3 in perf upgrade test

### DIFF
--- a/configurations/perf-regression-upgrade.yaml
+++ b/configurations/perf-regression-upgrade.yaml
@@ -1,5 +1,0 @@
-cluster_health_check: false
-nemesis_interval: 2
-
-user_prefix: 'perf-latency-upgrade'
-email_subject_postfix: 'latency during upgrades'

--- a/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade.jenkinsfile
+++ b/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade.jenkinsfile
@@ -7,6 +7,6 @@ perfRegressionParallelPipeline(
     base_versions: '',  // auto mode
     backend: "aws",
     test_name: "performance_regression_test.PerformanceRegressionUpgradeTest",
-    test_config: """["test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml", "configurations/perf-regression-upgrade.yaml"]""",
+    test_config: """["test-cases/performance/perf-regression-upgrade.yaml"]""",
     sub_tests: ["test_latency_write_with_upgrade", "test_latency_read_with_upgrade", "test_latency_mixed_with_upgrade"]
 )

--- a/jenkins-pipelines/performance/scylla-master/scylla-master-perf-regression-latency-650gb-during-rolling-upgrade.jenkinsfile
+++ b/jenkins-pipelines/performance/scylla-master/scylla-master-perf-regression-latency-650gb-during-rolling-upgrade.jenkinsfile
@@ -7,6 +7,6 @@ perfRegressionParallelPipeline(
     base_versions: '',  // auto mode
     backend: "aws",
     test_name: "performance_regression_test.PerformanceRegressionUpgradeTest",
-    test_config: """["test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml", "configurations/perf-regression-upgrade.yaml"]""",
+    test_config: """["test-cases/performance/perf-regression-upgrade.yaml"]""",
     sub_tests: ["test_latency_write_with_upgrade", "test_latency_read_with_upgrade", "test_latency_mixed_with_upgrade"]
 )

--- a/test-cases/performance/perf-regression-upgrade.yaml
+++ b/test-cases/performance/perf-regression-upgrade.yaml
@@ -1,0 +1,41 @@
+test_duration: 3000
+prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=250 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..162500000",
+                    "cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=250 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=162500000..325000000",
+                    "cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=250 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=325000000..487500000",
+                    "cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=250 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=487500000..650000000"]
+
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=2850m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=40664/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=20620/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=17500/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,6500000)' "
+
+n_db_nodes: 6
+nemesis_add_node_cnt: 3
+n_loaders: 4
+n_monitor_nodes: 1
+
+instance_type_loader: 'c6i.2xlarge'
+instance_type_monitor: 't3.large'
+instance_type_db: 'i3en.2xlarge'
+
+nemesis_class_name: 'NemesisSequence'
+nemesis_interval: 2
+nemesis_sequence_sleep_between_ops: 10
+
+user_prefix: 'perf-latency-upgrade'
+space_node_threshold: 644245094
+ami_id_db_scylla_desc: 'VERSION_DESC'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
+backtrace_decoding: false
+print_kernel_callstack: true
+
+store_perf_results: true
+send_email: true
+email_recipients: ["scylla-perf-results@scylladb.com"]
+use_prepared_loaders: true
+use_hdr_cs_histogram: true
+use_placement_group: true
+email_subject_postfix: 'latency during upgrades'
+
+cluster_health_check: false


### PR DESCRIPTION
In order to stabilise performance upgrade test, increase number of nodes by 3. Doubled c-s throughput limit to adjust cluster load accordingly.

refs: https://github.com/scylladb/scylladb/issues/16189

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
