### PR TITLE
fix(loaders): use proper loader indexes when `round_robin` is enabled

### DIFF
--- a/sdcm/stress/base.py
+++ b/sdcm/stress/base.py
@@ -77,9 +77,9 @@ class DockerBasedStressThread:  # pylint: disable=too-many-instance-attributes
 
     def run(self):
         self.configure_executer()
-        for loader_idx, loader in enumerate(self.loaders):
+        for loader in self.loaders:
             for cpu_idx in range(self.stress_num):
-                self.results_futures += [self.executor.submit(self._run_stress, *(loader, loader_idx, cpu_idx))]
+                self.results_futures += [self.executor.submit(self._run_stress, *(loader, loader.node_index, cpu_idx))]
 
         return self
 


### PR DESCRIPTION
When we use `round_robin=true` we provide list of one loader node to the stress commands handling code then use `enumerate` func incorrectly providing the index as `0`.

Fix it by switching usage of the `enumerate` func to the `node_index` attribute of loader node objects.

Side effect is that in all `round_robin=false` cases the first index will be `1`, not `0` as has always been.

Fixes: #7277

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
