### PR TITLE
fix(loaders): use proper loader indexes - part2

### DIFF
--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -377,7 +377,8 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
 
     def run(self):
         self.configure_executer()
-        for loader_idx, loader in enumerate(self.loaders):
+        for loader in self.loaders:
+            loader_idx = loader.node_index
             for cpu_idx in range(self.stress_num):
                 for ks_idx in range(1, self.keyspace_num + 1):
                     self.results_futures += [self.executor.submit(self._run_cs_stress,


### PR DESCRIPTION
This change is addition to the already merged PR (https://github.com/scylladb/scylla-cluster-tests/pull/7326) which fixed only part of loaders.
So, do it for every loader by fixing second place with wrong loader indexes usage.

Fixes: #7277

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevent to this change (if needed)
