### PR TITLE
'die' function was missing from hydra.sh

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -24,6 +24,18 @@ AWS_MOCK=""
 HYDRA_DRY_RUN=""
 HYDRA_HELP=""
 
+function die () {
+    msg="$1"
+    if [[ -n "$msg" ]]; then
+        echo "$(basename $0): $msg." 1>&2
+    fi
+    cat <<EOF 1>&2
+
+Run \`$0 --help' to print the full help message.
+EOF
+    exit 1
+}
+
 export SCT_TEST_ID=${SCT_TEST_ID:-$(uuidgen)}
 export GIT_USER_EMAIL=$(git config --get user.email)
 


### PR DESCRIPTION
Used in an error case.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/7337

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested manually

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
