### PR TITLE
fix(docker-backend): start Scylla server as 'scylla' user

### DIFF
--- a/docker/scylla-sct/centos/Dockerfile
+++ b/docker/scylla-sct/centos/Dockerfile
@@ -19,7 +19,9 @@ RUN yum -y install \
         rsync && \
     yum clean all && \
     echo "autostart=false" >> /etc/supervisord.conf.d/scylla-server.conf && \
+    echo "user=scylla" >> /etc/supervisord.conf.d/scylla-server.conf && \
     echo "autostart=false" >> /etc/supervisord.conf.d/scylla-housekeeping.conf && \
+    echo "user=scylla" >> /etc/supervisord.conf.d/scylla-housekeeping.conf && \
     sed -i "\:/dev/stderr:d" /etc/bashrc && \
     useradd -G wheel -p 00hzYw5m.HyAY $USER && \
     echo "$USER  ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers && \

--- a/docker/scylla-sct/ubuntu/Dockerfile
+++ b/docker/scylla-sct/ubuntu/Dockerfile
@@ -33,7 +33,9 @@ RUN apt-get update && \
         docker-ce-cli && \
     rm -rf /var/lib/apt/lists/* && \
     echo "autostart=false" >> /etc/supervisord.conf.d/scylla-server.conf && \
-    echo "autostart=false" >> /etc/supervisord.conf.d/scylla-housekeeping.conf
+    echo "user=scylla" >> /etc/supervisord.conf.d/scylla-server.conf && \
+    echo "autostart=false" >> /etc/supervisord.conf.d/scylla-housekeeping.conf && \
+    echo "user=scylla" >> /etc/supervisord.conf.d/scylla-housekeeping.conf
 
 COPY ./etc/scylla-manager.conf /etc/supervisord.conf.d/scylla-manager.conf
 COPY ./etc/sshd.conf /etc/supervisord.conf.d/sshd.conf

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1257,10 +1257,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         mark_exists = self.remoter.run('test -e %s' % mark_path, ignore_status=True, verbose=verbose).ok
         if self.uuid and not mark_exists:
             self.remoter.run(cmd % self.uuid, ignore_status=True)
-            if self.is_docker():
-                self.remoter.sudo('touch %s' % mark_path, verbose=verbose)
-            else:
-                self.remoter.sudo('touch %s' % mark_path, verbose=verbose, user='scylla')
+            self.remoter.sudo('touch %s' % mark_path, verbose=verbose, user='scylla')
 
     def wait_db_up(self, verbose=True, timeout=3600):
         text = None

--- a/sdcm/utils/sstable/load_utils.py
+++ b/sdcm/utils/sstable/load_utils.py
@@ -99,12 +99,7 @@ class SstableLoadUtils:
         table_folder = f"/var/lib/scylla/data/{keyspace_name}/{upload_dir}" if not table_name else upload_dir
 
         # Extract tarball again (in case create_schema=True) directly to Scylla table upload folder to simplify the code
-        # and prevent changes of permissions and increasing possibility of failures with "Permission denied" error
-        if node.is_docker():
-            node.remoter.run(f'tar xvfz {test_data.sstable_file} -C {table_folder}/upload/')
-        else:
-            node.remoter.sudo(
-                f'tar xvfz {test_data.sstable_file} -C {table_folder}/upload/', user='scylla')
+        node.remoter.sudo(f'tar xvfz {test_data.sstable_file} -C {table_folder}/upload/', user='scylla')
 
         # Scylla Enterprise 2019.1 doesn't support to load schema.cql and manifest.json, let's remove them
         node.remoter.sudo(f'rm -f {table_folder}/upload/schema.cql')


### PR DESCRIPTION
In docker backend environment the scylla services are controlled by supervisord.
At the moment the scylla services configuration files in Docker images do not have
user attribute specified (opposite to backends where systemd controls the processes -
there the user is explicitly specified in systemd unit files).
As a result the file permissions of data that the services create are of a user
that starts the processes. In the tests it is usually root user.
Some Nemesis scenarios, when are executed for Docker backend, try to update scylla data on behalf
of 'scylla-test' user and fail with 'permission denied' error.

The change sets the user attribute in scylla-sct Docker files, to explicitly run scylla
services on behalf of 'scylla' user.
It also reverts few changes introduced in the past, where calls of node.remoter.run
method were done differently for Docker backend runs, compared to other backends,
because of the described issue.

The change fixes https://github.com/scylladb/scylla-cluster-tests/issues/6962.

### Testing
The change was tested by executing Nemeses that were previously failing on Docker backend during disruption
with 'permission denied' error, due to the described issue.
With the applied fix the Nemeses are passing:
[LoadAndStreamMonkey on Docker backend](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-5gb-1h-docker-test/43/)
[RefreshMonkey on Docker backend](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-5gb-1h-docker-test/44/)
[RefreshBigMonkey on Docker backend](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-5gb-1h-docker-test/45/)

### PR pre-checks (self review)
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders
- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
