### PR TITLE
fix(jupyter): fix import problem

### DIFF
--- a/jupyter/provision-test.ipynb
+++ b/jupyter/provision-test.ipynb
@@ -52,6 +52,7 @@
     "os.chdir(sct_abs_path(relative_filename=\"\"))\n",
     "tester_inst = LongevityTest()\n",
     "tester_inst.setUpClass()\n",
+    "from sdcm.utils.cloud_monitor.common import InstanceLifecycle\n",
     "tester_inst.setUp()\n",
     "cluster = tester_inst.db_cluster\n"
    ]


### PR DESCRIPTION
When running test on jupyter using notebook provided in SCT, it fails with circular error.

Quick fix for that by importing `InstanceLifecycle` before SCT does it.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] - tested locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
