### PR TITLE
fix(s3_uploader): fix class for mimicking a file

### DIFF
--- a/sdcm/utils/s3_remote_uploader.py
+++ b/sdcm/utils/s3_remote_uploader.py
@@ -39,6 +39,9 @@ class SshOutAsFile(StreamingBody):
                 break
         return buff
 
+    def readable(self):
+        return True
+
 
 def upload_remote_files_directly_to_s3(ssh_info: dict[str, str], files: List[str],  # pylint: disable=too-many-arguments
                                        s3_bucket: str, s3_key: str, max_size_gb: int = 400, public_read_acl: bool = False):


### PR DESCRIPTION
boto3 client `upload_fileobj` method requires file-like object that returns `True` for `readable` method. It started to be required after boto3 lib update.

Made `readable` method to return always `True` for `SshOutAsFile` class.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/7344

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] - tested it when working with Teardown Validators task where issue was spotted and fixed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
