### PR TITLE
fix(perf): prolong wait for no compactions

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -612,21 +612,21 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
     def test_latency_read_with_nemesis(self):
         self.run_fstrim_on_all_db_nodes()
         self.preload_data()
-        self.wait_no_compactions_running()
+        self.wait_no_compactions_running(n=160)
         self.run_fstrim_on_all_db_nodes()
         self.run_workload(stress_cmd=self.params.get('stress_cmd_r'), nemesis=True)
 
     def test_latency_write_with_nemesis(self):
         self.run_fstrim_on_all_db_nodes()
         self.preload_data()
-        self.wait_no_compactions_running()
+        self.wait_no_compactions_running(n=160)
         self.run_fstrim_on_all_db_nodes()
         self.run_workload(stress_cmd=self.params.get('stress_cmd_w'), nemesis=True)
 
     def test_latency_mixed_with_nemesis(self):
         self.run_fstrim_on_all_db_nodes()
         self.preload_data()
-        self.wait_no_compactions_running()
+        self.wait_no_compactions_running(n=160)
         self.run_fstrim_on_all_db_nodes()
         self.run_workload(stress_cmd=self.params.get('stress_cmd_m'), nemesis=True)
 


### PR DESCRIPTION
When using tablets, splitting them is treated as compaction and may take very long. This causes latency during grow-shrink perf test with tablets to fail.

Fix is by prolonging this timeout so there's enough room for that.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
