### PR TITLE
test(perf): added perf-simple-query perf jobs to release

### DIFF
--- a/jenkins-pipelines/performance/Perf-Regression/scylla-release-perf-simple-query-microbenchmark.jenkinsfile
+++ b/jenkins-pipelines/performance/Perf-Regression/scylla-release-perf-simple-query-microbenchmark.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'microbenchmarking_test.PerfSimpleQueryTest.test_perf_simple_query',
+    test_config: 'test-cases/microbenchmarking/amazon_perf_simple_query_ARM.yaml',
+    email_recipients: "scylla-perf-results@scylladb.com"
+)

--- a/jenkins-pipelines/performance/Perf-Regression/scylla-release-perf-simple-query-microbenchmark_x86_64.jenkinsfile
+++ b/jenkins-pipelines/performance/Perf-Regression/scylla-release-perf-simple-query-microbenchmark_x86_64.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'microbenchmarking_test.PerfSimpleQueryTest.test_perf_simple_query',
+    test_config: """[ 'test-cases/microbenchmarking/amazon_perf_simple_query_ARM.yaml', 'test-cases/microbenchmarking/amazon_perf_simple_query_x86.yaml' ]""",
+    email_recipients: "scylla-perf-results@scylladb.com"
+)


### PR DESCRIPTION
Each release should run perf-simple-query performance jobs to find regressions in that matter. Especially important for enterprise releases where error in PGO profiles update may cause regressions and these tests find it easily.

refs: https://github.com/scylladb/qa-tasks/issues/1643

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - not tested yet. Need to create these jobs and add to release job triggers
- [ ] adding it to triggers of release

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
