### PR TITLE
test(perf): set initial tablets to 32 in perf tests

### DIFF
--- a/configurations/tablets-initial-32.yaml
+++ b/configurations/tablets-initial-32.yaml
@@ -1,0 +1,5 @@
+append_scylla_yaml: |
+  experimental_features:
+    - tablets
+    - consistent-topology-changes
+  tablets_initial_scale_factor: 4

--- a/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-grow-shrink-tablets.jenkinsfile
+++ b/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-grow-shrink-tablets.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     availability_zone: 'a,b,c',
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: """["test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml", "configurations/tablets.yaml"]""",
+    test_config: """["test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml", "configurations/tablets-initial-32.yaml"]""",
     sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
     test_email_title: "latency during grow-shrink (tablets)",
 )

--- a/jenkins-pipelines/performance/scylla-master/scylla-master-perf-regression-latency-650gb-grow-shrink-tablets.jenkinsfile
+++ b/jenkins-pipelines/performance/scylla-master/scylla-master-perf-regression-latency-650gb-grow-shrink-tablets.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     availability_zone: 'a,b,c',
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: """["test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml", "configurations/tablets.yaml"]""",
+    test_config: """["test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml", "configurations/tablets-initial-32.yaml"]""",
     sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
     test_email_title: "latency during grow-shrink (tablets)",
 )


### PR DESCRIPTION
Grow-shrink cluster scenario perf test with tablets inserts 650GB of data. This triggers split tablets in steps from 8->16->32->64 or even to
128. Splitting takes time and prolongs the test significantly.

Commit is about increasing initial tablets for ks created by c-s to 32 (8x4) so test is faster and we still can observe splitting to 64 and see effects of this dynamic split during the test.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
