### PR TITLE
fix(offline_installer): print io.conf from correct path

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4643,12 +4643,13 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
     def node_startup(self, node: BaseNode, verbose: bool = False, timeout: int = 3600):
         if not self.test_config.REUSE_CLUSTER:
-            self.log.debug('io.conf before reboot: %s', node.remoter.sudo('cat /etc/scylla.d/io.conf').stdout)
+            self.log.debug('io.conf before reboot: %s', node.remoter.sudo(
+                f'cat {node.add_install_prefix("/etc/scylla.d/io.conf")}').stdout)
             node.start_scylla_server(verify_up=False)
             if self.params.get("jmx_heap_memory"):
                 node.restart_scylla_jmx()
             self.log.debug(
-                'io.conf right after reboot: %s', node.remoter.sudo('cat /etc/scylla.d/io.conf').stdout)
+                'io.conf right after reboot: %s', node.remoter.sudo(f'cat {node.add_install_prefix("/etc/scylla.d/io.conf")}').stdout)
             if self.params.get('use_mgmt'):
                 node.remoter.sudo(shell_script_cmd("""\
                     systemctl restart scylla-manager-agent


### PR DESCRIPTION
since the path of io.conf is diffrent when using offline installers this print was move around, and now seems to be broken:

```
 sdcm.remote.libssh2_client.exceptions.UnexpectedExit: Encountered a bad command exit code!

 Command: 'sudo cat /etc/scylla.d/io.conf'

 Exit code: 1

 Stdout:

 Stderr:

 cat: /etc/scylla.d/io.conf: No such file or directory
```

this commit introduce using `add_install_prefix` so the path would be correct

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2204-test/42/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
