### PR TITLE
fix(RemoteBrowser): stop assuming `parent_cluster` exists

### DIFF
--- a/sdcm/utils/remotewebbrowser.py
+++ b/sdcm/utils/remotewebbrowser.py
@@ -64,7 +64,8 @@ class WebDriverContainerMixin:
 class RemoteBrowser:
     def __init__(self, node, use_tunnel=True):
         self.node = node
-        backend = self.node.parent_cluster.params.get("cluster_backend")
+        backend = self.node.parent_cluster.params.get(
+            "cluster_backend") if hasattr(self.node, 'parent_cluster') else None
         self.use_tunnel = bool(self.node.ssh_login_info and use_tunnel and backend not in ('docker',))
 
     @cached_property


### PR DESCRIPTION
cause of supporting docker backend, we introduce a check of the backend to decide if tunnelling is needed.

this broke the log collection phase, since `CollectingNode` doesn't have `parent_cluster` or access to SCT configuration.

for now we can assume if we don't have `parent_cluster` we should enable tunneling even that tunneling is only needed when working from diffrent regions (or from local env)

Fix #7323

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
