### PR TITLE
fix(manager): upgrade Scylla version used in Manager to latest

### DIFF
--- a/configurations/manager/debian10.yaml
+++ b/configurations/manager/debian10.yaml
@@ -1,4 +1,4 @@
 ami_id_monitor: 'ami-074f8bbb689b1c1a0'  # Debian buster image - debian-10-amd64-20230601-1398
 ami_monitor_user: 'admin'
 
-manager_scylla_backend_version: '2021'  # Notice: Uses 2021.1, while other (newer deb) use 2022, since we support both
+manager_scylla_backend_version: '2023'  # Notice: Uses 2023.1, while other (newer deb) use 2024, since we support both

--- a/defaults/manager_versions.yaml
+++ b/defaults/manager_versions.yaml
@@ -1,11 +1,11 @@
 manager_repos_by_version:
   "master_latest":
-    centos7: 'http://downloads.scylladb.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo'
-    centos8: 'http://downloads.scylladb.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo'
-    debian10: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
-    debian11: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
-    ubuntu20: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
-    ubuntu22: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
+    centos7: 'https://downloads.scylladb.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo'
+    centos8: 'https://downloads.scylladb.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo'
+    debian10: 'https://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
+    debian11: 'https://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
+    ubuntu20: 'https://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
+    ubuntu22: 'https://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
   "3.2":
     centos7: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.2.repo'
     centos8: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.2.repo'
@@ -29,16 +29,23 @@ manager_repos_by_version:
     ubuntu22: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.0-focal.list'
 
 scylla_backend_repo_by_version:
-  "2021":
-    centos7: 'http://downloads.scylladb.com/rpm/centos/scylla-2021.1.repo'
-    centos8: 'http://downloads.scylladb.com/rpm/centos/scylla-2021.1.repo'
-    debian10: 'http://downloads.scylladb.com/deb/ubuntu/scylla-2021.1.list'
-    debian11: 'http://downloads.scylladb.com/deb/ubuntu/scylla-2021.1.list'
-    ubuntu20: 'http://downloads.scylladb.com/deb/ubuntu/scylla-2021.1.list'
   "2022":
-    centos7: 'http://downloads.scylladb.com/rpm/centos/scylla-2022.1.repo'
-    centos8: 'http://downloads.scylladb.com/rpm/centos/scylla-2022.1.repo'
-    debian10: 'http://downloads.scylladb.com/deb/ubuntu/scylla-2022.1.list'
-    debian11: 'http://downloads.scylladb.com/deb/ubuntu/scylla-2022.1.list'
-    ubuntu20: 'http://downloads.scylladb.com/deb/ubuntu/scylla-2022.1.list'
-    ubuntu22: 'http://downloads.scylladb.com/deb/ubuntu/scylla-2022.1.list'
+    centos7: 'https://downloads.scylladb.com/rpm/centos/scylla-2022.1.repo'
+    centos8: 'https://downloads.scylladb.com/rpm/centos/scylla-2022.1.repo'
+    debian10: 'https://downloads.scylladb.com/deb/ubuntu/scylla-2022.1.list'
+    debian11: 'https://downloads.scylladb.com/deb/ubuntu/scylla-2022.1.list'
+    ubuntu20: 'https://downloads.scylladb.com/deb/ubuntu/scylla-2022.1.list'
+    ubuntu22: 'https://downloads.scylladb.com/deb/ubuntu/scylla-2022.1.list'
+  "2023":
+    centos7: 'https://downloads.scylladb.com/rpm/centos/scylla-2023.1.repo'
+    centos8: 'https://downloads.scylladb.com/rpm/centos/scylla-2023.1.repo'
+    debian10: 'https://downloads.scylladb.com/deb/ubuntu/scylla-2023.1.list'
+    debian11: 'https://downloads.scylladb.com/deb/ubuntu/scylla-2023.1.list'
+    ubuntu20: 'https://downloads.scylladb.com/deb/ubuntu/scylla-2023.1.list'
+  "2024":
+    centos7: 'https://downloads.scylladb.com/rpm/centos/scylla-2024.1.repo'
+    centos8: 'https://downloads.scylladb.com/rpm/centos/scylla-2024.1.repo'
+    debian10: 'https://downloads.scylladb.com/deb/ubuntu/scylla-2024.1.list'
+    debian11: 'https://downloads.scylladb.com/deb/ubuntu/scylla-2024.1.list'
+    ubuntu20: 'https://downloads.scylladb.com/deb/ubuntu/scylla-2024.1.list'
+    ubuntu22: 'https://downloads.scylladb.com/deb/ubuntu/scylla-2024.1.list'

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -9,8 +9,8 @@ ip_ssh_connections: 'private'
 scylla_repo: ''
 
 manager_version: '3.2'
-manager_scylla_backend_version: '2022'
-# Notice: that centos (default monitor), ubuntu 22, ubuntu 20 and debian 11 monitors use 2022, while debian 10 ubuntu 18 use 2021, since we support both
+manager_scylla_backend_version: '2024'
+# Notice: that centos (default monitor), ubuntu 22, ubuntu 20 and debian 11 monitors use 2024, while debian 10 ubuntu 18 use 2023, since we support both
 
 scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-5.2.repo'
 

--- a/unit_tests/test_sdcm_mgmt_common.py
+++ b/unit_tests/test_sdcm_mgmt_common.py
@@ -5,11 +5,11 @@ from sdcm.utils.distro import Distro
 class TestManagerVersions:
 
     def test_get_manager_scylla_backend_returns_repo_address(self):  # pylint: disable=no-self-use
-        url = get_manager_scylla_backend("2021", Distro.UBUNTU20)
+        url = get_manager_scylla_backend("2024", Distro.UBUNTU22)
 
-        assert url == 'http://downloads.scylladb.com/deb/ubuntu/scylla-2021.1.list'
+        assert url == 'https://downloads.scylladb.com/deb/ubuntu/scylla-2024.1.list'
 
     def test_get_manager_repo_from_defaults_returns_repo_address(self):  # pylint: disable=no-self-use
-        url = get_manager_repo_from_defaults("3.0", Distro.UBUNTU20)
+        url = get_manager_repo_from_defaults("3.2", Distro.UBUNTU22)
 
-        assert url == 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.0-focal.list'
+        assert url == 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.2.list'

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -72,7 +72,7 @@ def call(Map pipelineParams) {
 
 
             string(defaultValue: '', description: '', name: 'scylla_ami_id')
-            string(defaultValue: "${pipelineParams.get('scylla_version', '2022.2')}", description: '', name: 'scylla_version')
+            string(defaultValue: "${pipelineParams.get('scylla_version', '2024.1')}", description: '', name: 'scylla_version')
             // When branching to manager version branch, set scylla_version to the latest release
             string(defaultValue: '', description: '', name: 'scylla_repo')
             string(defaultValue: "${pipelineParams.get('gce_image_db', '')}",


### PR DESCRIPTION
Upgraded the version of Scylla used in Manager from 2022.1 (2021 for debian10) to the latest 2024.1 (2023 for debian10).

Should be merged together with https://github.com/scylladb/scylla-cluster-tests/pull/7435

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] The [CI run](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/sct/job/manager-centos-sanity/12/) from personal fork;
- [x] Argus [link](https://argus.scylladb.com/workspace?state=WyIxMzc2ODAyZC0xN2YxLTRiM2MtODhiMy0zNzcwOWI5NDMzZGYiXQ).

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)