### PR TITLE
fix(is_cluster_topology_consistent): Make sure non-voters don't remain in the group0.

### DIFF
--- a/sdcm/utils/raft/__init__.py
+++ b/sdcm/utils/raft/__init__.py
@@ -265,8 +265,9 @@ class RaftFeature(RaftFeatureOperations):
         LOGGER.debug("Difference between group0 and token ring: %s", diff)
         num_of_nodes = len(self._node.parent_cluster.nodes)
         LOGGER.debug("Number of nodes in sct cluster %s", num_of_nodes)
+        non_voters_ids = self.get_group0_non_voters()
 
-        return not diff and len(group0_ids) == len(token_ring_ids) == num_of_nodes
+        return not diff and not non_voters_ids and len(group0_ids) == len(token_ring_ids) == num_of_nodes
 
 
 class NoRaft(RaftFeatureOperations):


### PR DESCRIPTION
Cluster topology consistent means that token ring and group0 doesn't have garbage host ids and host id as non-voter after topology operation done.
Add to check that non-voter nodes stay in cluster.

### Testing
- [Job passed with BootStreamingErr](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/longevity-100gb-4h/91/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
