### PR TITLE
Support for manager-master jenkins pipeline

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -700,7 +700,10 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         # Scylla-manager should pick up client encryption setting automatically
         healthcheck_task.wait_for_status(list_status=[TaskStatus.DONE], step=5, timeout=240)
 
-        mgr_cluster.update(client_encrypt=True, force_non_ssl_session_port=mgr_cluster.sctool.is_minimum_3_2_6_version)
+        mgr_cluster.update(
+            client_encrypt=True,
+            force_non_ssl_session_port=mgr_cluster.sctool.is_minimum_3_2_6_or_snapshot
+        )
         time.sleep(30)  # Make sure healthcheck task is triggered
         healthcheck_task.wait_for_status(list_status=[TaskStatus.DONE], step=5, timeout=240)
         sleep = 40

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -1304,8 +1304,8 @@ class SCTool:
         return self.parsed_client_version >= new_command_structure_minimum_version
 
     @property
-    def is_minimum_3_2_6_version(self):
-        return self.parsed_client_version >= forcing_tls_minimum_version
+    def is_minimum_3_2_6_or_snapshot(self):
+        return self.parsed_client_version >= forcing_tls_minimum_version or self.client_version == "Snapshot"
 
 
 class ScyllaMgmt:


### PR DESCRIPTION
Manager jenkins CI consist of separated flows per different manager version.
https://jenkins.scylladb.com/view/scylla-manager/

In one of the recent commits to manager-3.2 (and master)  675e26fdd7ac91903c960cd62907ff908466adc8 , we introduced manager version check.
Unfortunately, manager on master branch keeps the version "Snapshot", so the code guarded with the version check is not applied on manager master jenkins CI.

This PR addresses this issue.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/karol-kokoszka/job/manager-master-centos-sanity-test/1/ (PASS)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [X] I added the relevant `backport` labels
- [X] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
