### PR TITLE
fix(issues): revert logic when hitting github ratelimit

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1074,10 +1074,11 @@ def integration_tests(test):
     # setup prerequisites for the integration test is identical
     # to the kind local functional tests
     # TODO: to refactor setup_prerequisites out of LocalKindCluster
+    sct_config = SCTConfiguration()
     local_cluster = mini_k8s.LocalKindCluster(
         software_version="",
         user_prefix="",
-        params={},
+        params=sct_config,
     )
     local_cluster.setup_prerequisites()
 

--- a/sdcm/utils/issues.py
+++ b/sdcm/utils/issues.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 import github
 import github.Auth
+import github.Issue
 from github.GithubException import UnknownObjectException, RateLimitExceededException
 
 from sdcm.keystore import KeyStore
@@ -91,7 +92,10 @@ class SkipPerIssues:
             return None
         except RateLimitExceededException as exc:
             logging.debug('RateLimitExceededException raise: %s', str(exc))
-            return None
+            # as a temporary measure return an "open" issue each time we hit rate limiting
+            # this would mean that we would assume issue is open, and enable the skips needed, without having the
+            # actual data of the issue
+            return github.Issue.Issue(requester=None, headers={}, attributes=dict(state='open'), completed=True)
         except Exception as exc:  # pylint: disable=broad-except
             logging.warning("failed to get issue: %s", issue)
             TestFrameworkEvent(source=self.__class__.__name__,


### PR DESCRIPTION
since we are hitting this rate limit quite often, we should assume the issue we are looking for it opened, and not like we return today None, we translated to close / non existing issue

in this way we won't be that much affect from the rate limiting until we can have some work around it (centralized cached of it)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] integration tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
