### PR TITLE
fix(artifact test): check 'node_boot_time_seconds' instead available memory

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -342,7 +342,7 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
         with self.subTest("check node_exporter liveness"):
             node_info_service = NodeLoadInfoServices().get(self.node)
             assert node_info_service.cpu_load_5
-            assert node_info_service.get_memory_available()
+            assert node_info_service.get_node_boot_time_seconds()
 
         # We don't install any time sync service in docker, so the test is unnecessary:
         # https://github.com/scylladb/scylla/tree/master/dist/docker/etc/supervisord.conf.d

--- a/sdcm/utils/adaptive_timeouts/load_info_store.py
+++ b/sdcm/utils/adaptive_timeouts/load_info_store.py
@@ -87,9 +87,9 @@ class NodeLoadInfoService:
             load_1, load_5, load_15 = self.remoter.run('uptime').stdout.split("load average: ")[1].split(",")
             return float(load_1), float(load_5), float(load_15)
 
-    def get_memory_available(self) -> float:
+    def get_node_boot_time_seconds(self) -> float:
         metrics = self._get_node_exporter_metrics()
-        mem_available = float(metrics['node_memory_MemAvailable_bytes'])
+        mem_available = float(metrics['node_boot_time_seconds'])
         return mem_available
 
     @retrying(n=5, sleep_time=1, allowed_exceptions=(ValueError,))


### PR DESCRIPTION
Check node exporter liveness was presented by https://github.com/scylladb/scylla-cluster-tests/ pull/6885/commits/a63b1f1ac31c1bd85385b69968997d1c204b4473 As part of this available memory is validated ('node_memory_MemAvailable_bytes' metric). Later was found that available memory is 0 in centos8-arm test (issue scylladb/scylla-enterprise#3989). The issue was closed and won't be handled. It was decided to replace 'node_memory_MemAvailable_bytes' metric with another - 'node_boot_time_seconds'.

Task: https://github.com/scylladb/qa-tasks/issues/1658

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [artifacts-centos8-arm-test ](https://argus.scylladb.com/test/4a6c7102-4b35-4fc1-9c5e-3b078f3813d7/runs?additionalRuns[]=949a5021-9aa8-46a2-9900-95d8b2af1254)
- [x] [artifacts-ami-test](https://argus.scylladb.com/test/c29b1204-20a2-4c4c-9864-b0c47e80efc6/runs?additionalRuns[]=d57f4c13-5125-4e3f-abee-b51a88e4b32f)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
