### PR TITLE
fix(cloud-cleanup): enforce terminate as default for Azure

### DIFF
--- a/utils/cloud_cleanup/azure/clean_azure.py
+++ b/utils/cloud_cleanup/azure/clean_azure.py
@@ -78,7 +78,10 @@ def get_rg_creation_time(resource_group):
 
 
 def get_keep_action(v_m) -> Callable:
-    return v_m.tags.get('keep_action', "terminate").lower() if v_m.tags else "terminate"
+    keep_action = v_m.tags.get('keep_action', "terminate").lower() if v_m.tags else "terminate"
+    if not keep_action:
+        keep_action = "terminate"
+    return keep_action
 
 
 def should_keep(creation_time, keep_hours):


### PR DESCRIPTION
Monitor instances specify `keep_action` as empty value. This is making the script to stop these instances instead of termination.

Set `keep_action` to `terminate` if was empty, so instances are terminated by default.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] - tested locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
