### PR TITLE
ci(sct-runners): allow to list SCT runners per backend

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -1124,20 +1124,27 @@ def get_sct_runner(cloud_provider: str, region_name: str, availability_zone: str
     raise Exception(f'Unsupported Cloud provider: `{cloud_provider}')
 
 
-def list_sct_runners(test_runner_ip: str = None, verbose: bool = True) -> list[SctRunnerInfo]:
+def list_sct_runners(backend: str = None, test_runner_ip: str = None, verbose: bool = True) -> list[SctRunnerInfo]:
     if verbose:
         log = LOGGER.info
     else:
         log = LOGGER.debug
-    log("Looking for SCT runner instances...")
-    sct_runner_classes = (AwsSctRunner, GceSctRunner, AzureSctRunner, )
+    log("Looking for SCT runner instances (backend is '%s')...", backend)
+    if "aws" in (backend or "") or backend in ("k8s-eks", "docker"):
+        sct_runner_classes = (AwsSctRunner, )
+    elif "gce" in (backend or "") or backend == "k8s-gke":
+        sct_runner_classes = (GceSctRunner, )
+    elif "azure" in (backend or ""):
+        sct_runner_classes = (AzureSctRunner, )
+    else:
+        sct_runner_classes = (AwsSctRunner, GceSctRunner, AzureSctRunner, )
     sct_runners = chain.from_iterable(cls.list_sct_runners(verbose=False) for cls in sct_runner_classes)
 
     if test_runner_ip:
         if sct_runner_info := next((runner for runner in sct_runners if test_runner_ip in runner.public_ips), None):
             sct_runners = [sct_runner_info, ]
         else:
-            LOGGER.warning("No SCT Runners found to remove (IP: %s)", test_runner_ip)
+            LOGGER.warning("No SCT Runners were found (Backend: '%s', IP: '%s')", backend, test_runner_ip)
             return []
     else:
         sct_runners = list(sct_runners)
@@ -1147,7 +1154,7 @@ def list_sct_runners(test_runner_ip: str = None, verbose: bool = True) -> list[S
     return sct_runners
 
 
-def update_sct_runner_tags(test_runner_ip: str = None, test_id: str = None, tags: dict = None):
+def update_sct_runner_tags(backend: str = None, test_runner_ip: str = None, test_id: str = None, tags: dict = None):
     LOGGER.info("Test runner ip in update_sct_runner_tags: %s; test_id: %s", test_runner_ip, test_id)
     if not test_runner_ip and not test_id:
         raise ValueError("update_sct_runner_tags requires either the "
@@ -1156,9 +1163,9 @@ def update_sct_runner_tags(test_runner_ip: str = None, test_id: str = None, tags
     runner_to_update = None
 
     if test_runner_ip:
-        runner_to_update = list_sct_runners(test_runner_ip=test_runner_ip)
+        runner_to_update = list_sct_runners(backend=backend, test_runner_ip=test_runner_ip)
     elif test_id:
-        listed_runners = list_sct_runners(verbose=False)
+        listed_runners = list_sct_runners(backend=backend, verbose=False)
         runner_to_update = [runner for runner in listed_runners if runner.test_id == test_id]
 
     if not runner_to_update:
@@ -1205,10 +1212,11 @@ def _manage_runner_keep_tag_value(utc_now: datetime,
 
 def clean_sct_runners(test_status: str,
                       test_runner_ip: str = None,
+                      backend: str = None,
                       dry_run: bool = False,
                       force: bool = False) -> None:
     # pylint: disable=too-many-branches,too-many-statements
-    sct_runners_list = list_sct_runners(test_runner_ip=test_runner_ip)
+    sct_runners_list = list_sct_runners(backend=backend, test_runner_ip=test_runner_ip)
     timeout_flag = False
     runners_terminated = 0
     end_message = ""

--- a/vars/cleanSctRunners.groovy
+++ b/vars/cleanSctRunners.groovy
@@ -16,7 +16,8 @@ def call(Map params, RunWrapper currentBuild){
     echo "Starting to clean runner instances"
     if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" || "$cloud_provider" == "azure" ]]; then
         export RUNNER_IP=\$(cat sct_runner_ip||echo "")
-        ./docker/env/hydra.sh clean-runner-instances --test-status "$test_status" --runner-ip \${RUNNER_IP}
+        ./docker/env/hydra.sh clean-runner-instances \
+            --test-status "$test_status" --runner-ip \${RUNNER_IP} --backend "$cloud_provider"
 
     else
         echo "Not running on AWS, GCP nor Azure. Skipping cleaning runner instances."

--- a/vars/runCollectLogs.groovy
+++ b/vars/runCollectLogs.groovy
@@ -28,9 +28,9 @@ def call(Map params, String region){
     echo "start collect logs ..."
     RUNNER_IP=\$(cat sct_runner_ip||echo "")
     if [[ -n "\${RUNNER_IP}" ]] ; then
-        ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} collect-logs
+        ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} collect-logs --backend "${params.backend}"
     else
-        ./docker/env/hydra.sh collect-logs --logdir "`pwd`"
+        ./docker/env/hydra.sh collect-logs --backend "${params.backend}" --logdir "`pwd`"
     fi
     echo "end collect logs"
     """

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -187,7 +187,7 @@ def call(Map params, String region, functional_test = false, Map pipelineParams 
             sh """
                 RUNNER_IP=\$(cat sct_runner_ip||echo "")
                 if [[ -n "\${RUNNER_IP}" ]] ; then
-                    ./docker/env/hydra.sh fetch-junit-from-runner \${RUNNER_IP}
+                    ./docker/env/hydra.sh fetch-junit-from-runner \${RUNNER_IP} --backend ${params.backend}
                 fi
             """
             junit(testResults:"**/junit.xml", keepProperties:true)


### PR DESCRIPTION
For now, gathering logs we try to list SCT runners in each of the supported backends making, de-facto, redundant API calls. Also, it may cause undesired CI job failures like the bug#6837

So, do following:
- Update the `list_sct_runners` function to accept `backend` parameter.
- Update places where this function is consumed providing the new parameter.

Fixes: #6837

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
