### PR TITLE
fix(set-tags): fix setting of tags onto SCT runners

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -43,7 +43,13 @@ from sct_ssh import ssh_run_cmd
 from sdcm.keystore import KeyStore
 from sdcm.provision.provisioner import InstanceDefinition, PricingModel, VmInstance, provisioner_factory
 from sdcm.remote import RemoteCmdRunnerBase, shell_script_cmd
-from sdcm.utils.common import list_instances_aws, aws_tags_to_dict, list_instances_gce, gce_meta_to_dict
+from sdcm.utils.common import (
+    aws_tags_to_dict,
+    gce_meta_to_dict,
+    list_instances_aws,
+    list_instances_gce,
+    str_to_bool,
+)
 from sdcm.utils.aws_utils import ec2_instance_wait_public_ip, ec2_ami_get_root_device_name, tags_as_ec2_tags, EC2NetworkConfiguration
 from sdcm.utils.aws_region import AwsRegion
 from sdcm.utils.gce_utils import (
@@ -679,7 +685,7 @@ class AwsSctRunner(SctRunner):
                     launch_time=instance["LaunchTime"],
                     keep=tags.get("keep"),
                     keep_action=tags.get("keep_action"),
-                    logs_collected=tags.get("logs_collected")
+                    logs_collected=str_to_bool(tags.get("logs_collected")),
                 ))
         return sct_runners
 
@@ -765,16 +771,16 @@ class GceSctRunner(SctRunner):  # pylint: disable=too-many-instance-attributes
             return None
 
     @staticmethod
-    def set_tags(sct_runner_info: SctRunnerInfo,
-                 tags: dict):
-        LOGGER.info("Setting SCT runner labels to: %s", tags)
+    def set_tags(sct_runner_info: SctRunnerInfo, tags: dict):
+        tags_to_create = {str(k): str(v).lower() for k, v in tags.items()}
+        LOGGER.info("Setting SCT runner labels to: %s", tags_to_create)
         instances_client, info = get_gce_compute_instances_client()
         gce_set_labels(instances_client=instances_client,
                        instance=sct_runner_info.instance,
-                       new_labels=tags,
+                       new_labels=tags_to_create,
                        project=info['project_id'],
                        zone=sct_runner_info.region_az)
-        LOGGER.info("SCT runner tags set to: %s", tags)
+        LOGGER.info("SCT runner tags set to: %s", tags_to_create)
 
     @staticmethod
     def tags_to_labels(tags: dict[str, str]) -> dict[str, str]:
@@ -903,7 +909,7 @@ class GceSctRunner(SctRunner):  # pylint: disable=too-many-instance-attributes
                 launch_time=launch_time,
                 keep=tags.get("keep"),
                 keep_action=tags.get("keep_action"),
-                logs_collected=tags.get("logs_collected")
+                logs_collected=str_to_bool(tags.get("logs_collected")),
             ))
         return sct_runners
 
@@ -1088,7 +1094,7 @@ class AzureSctRunner(SctRunner):
                 test_id=instance.tags.get("TestId"),
                 keep=instance.tags.get("keep"),
                 keep_action=instance.tags.get("keep_action"),
-                logs_collected=instance.tags.get("logs_collected")
+                logs_collected=str_to_bool(instance.tags.get("logs_collected")),
             ))
         return sct_runners
 
@@ -1097,21 +1103,22 @@ class AzureSctRunner(SctRunner):
         sct_runner_info.cloud_service_instance.delete_virtual_machine(virtual_machine=sct_runner_info.instance)
 
     @staticmethod
-    def set_tags(sct_runner_info: SctRunnerInfo,
-                 tags: dict):
+    def set_tags(sct_runner_info: SctRunnerInfo, tags: dict):
         resource_mgmt_client = sct_runner_info.cloud_service_instance.resource
         instance: VirtualMachine = sct_runner_info.instance
 
+        tags_to_create = {str(k): str(v) for k, v in tags.items()}
         params = TagsPatchResource.from_dict(
             {
                 "operation": TagsPatchOperation.MERGE.value,  # pylint:disable=no-member
                 "properties": {
-                    "tags": tags
+                    "tags": tags_to_create,
                 }
             }
         )
-
-        resource_mgmt_client.tags.create_or_update_at_scope(scope=instance.id, parameters=params)
+        LOGGER.info("Setting SCT runner labels to: %s", tags_to_create)
+        resource_mgmt_client.tags.update_at_scope(scope=instance.id, parameters=params)
+        LOGGER.info("SCT runner tags set to: %s", tags_to_create)
 
 
 def get_sct_runner(cloud_provider: str, region_name: str, availability_zone: str = "", params: SCTConfiguration | None = None) -> SctRunner:

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -182,6 +182,16 @@ def generate_random_string(length):
         random.choice(string.ascii_uppercase + string.digits) for x in range(length - 1))
 
 
+def str_to_bool(bool_as_str: str) -> bool:
+    if isinstance(bool_as_str, bool):
+        return bool_as_str
+    elif isinstance(bool_as_str, str):
+        return bool_as_str.lower() in ("true", "yes", "y", "1")
+    elif bool_as_str is None:
+        return False
+    raise ValueError("'bool_as_str' is of the unexpected type: %s" % type(bool_as_str))
+
+
 def get_data_dir_path(*args):
     sct_root_path = get_sct_root_path()
     data_dir = os.path.join(sct_root_path, "data_dir", *args)


### PR DESCRIPTION
Fixes:
- GCE, translate boolean tag value to str with lowercase.
- Azure, use proper API method for setting tags - `update_at_scope`. It will allow us to fix following error:
```
    (InvalidRequestContent) The request content was invalid and could not \
      be deserialized: 'Could not find member 'operation' on object of type \
        'TagsDefinition'. Path 'operation', line 1, position 13.'.
```
- All, make `logs_collected` bool attr have correct value instead of the `false positive` all the time where any non-empty str value was considered to be `True`.

Fixes: #7375
Fixes: #7376

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-longevity-10gb-3h-test#79](https://argus.scylladb.com/test/631c0991-5548-434e-b7a3-f47eb2db8777/runs?additionalRuns[]=96d5419b-a234-4fcd-9072-11132090f56a)
- [scylla-staging/valerii/vp-longevity-10gb-3h-gce-test#22](https://argus.scylladb.com/test/f20862ff-cf95-44cf-8d5a-78da3d9b1f0e/runs?additionalRuns[]=76c4526b-3c91-4279-afdf-d177929dd46f)
- [scylla-staging/valerii/vp-longevity-10gb-3h-azure-test#25](https://argus.scylladb.com/test/bc3f0da1-8e01-4885-9d0c-687b1b64ac7e/runs?additionalRuns[]=3cde7ee0-a86b-4eb5-a9b0-39644af6adf5)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
