### PR TITLE
improvement(init): skip instance setup script if already ran

### DIFF
--- a/sdcm/provision/common/configuration_script.py
+++ b/sdcm/provision/common/configuration_script.py
@@ -21,7 +21,7 @@ from sdcm.provision.common.utils import (
     configure_syslogng_target_script,
     restart_syslogng_service,
     configure_ssh_accept_rsa)
-
+from sdcm.provision.user_data import CLOUD_INIT_SCRIPTS_PATH
 
 SYSLOGNG_SSH_TUNNEL_LOCAL_PORT = 5000
 SYSLOGNG_LOG_THROTTLE_PER_SECOND = 10000
@@ -44,18 +44,30 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
     def _wait_before_running_script() -> str:
         return ''
 
+    @staticmethod
+    def _skip_if_already_run() -> str:
+        """syslog-ng requires restart to retrigger sending logs in case it was configured before sct-runner"""
+        return f'if [ -f {CLOUD_INIT_SCRIPTS_PATH}/done ]; then sudo systemctl restart syslog-ng; exit 0; fi\n'
+
+    @staticmethod
+    def _mark_script_as_done() -> str:
+        return f"mkdir -p {CLOUD_INIT_SCRIPTS_PATH} && touch {CLOUD_INIT_SCRIPTS_PATH}/done"
+
     def _start_script(self) -> str:
         script = '#!/bin/bash\n'
         script += 'set -x\n'
         script += self._wait_before_running_script()
+        script += self._skip_if_already_run()
         if self.disable_ssh_while_running:
             script += 'systemctl stop sshd || true\n'
         return script
 
     def _end_script(self) -> str:
+        script = ""
         if self.disable_ssh_while_running:
-            return 'systemctl start sshd || true\n'
-        return ''
+            script += 'systemctl start sshd || true\n'
+        script += self._mark_script_as_done()
+        return script
 
     def _script_body(self) -> str:
         # Whenever you change it please keep in mind that:

--- a/sdcm/sct_provision/aws/user_data.py
+++ b/sdcm/sct_provision/aws/user_data.py
@@ -62,7 +62,7 @@ class ScyllaUserDataBuilder(ScyllaUserDataBuilderBase):
             logs_transport=self.params.get('logs_transport'),
             disable_ssh_while_running=True,
         ).to_string()
-        LOGGER.info("post_boot_script: %s", post_boot_script)
+        LOGGER.debug("post_boot_script: %s", post_boot_script)
         return base64.b64encode(post_boot_script.encode('utf-8')).decode('ascii')
 
     def to_string(self) -> str:


### PR DESCRIPTION
Setup script is executed during cloud init phase and later it is run again during resources `init` phase and takes time.

Skip rerunning init script if was already executed by verifying if 'lock' file is present (created at the end of init script).

refs: https://github.com/scylladb/scylla-cluster-tests/issues/7242

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - included provision tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
