### PR TITLE
fix(gke): use `gce_config.yaml` as basis for GKE setups

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1617,7 +1617,7 @@ class SCTConfiguration(dict):
         "k8s-local-kind-gce": [
             sct_abs_path('defaults/k8s_local_kind_gce_config.yaml'),
             sct_abs_path('defaults/k8s_local_kind_config.yaml')],
-        "k8s-gke": [sct_abs_path('defaults/k8s_gke_config.yaml')],
+        "k8s-gke": [sct_abs_path('defaults/gce_config.yaml'), sct_abs_path('defaults/k8s_gke_config.yaml')],
         "k8s-eks": [sct_abs_path('defaults/aws_config.yaml'), sct_abs_path('defaults/k8s_eks_config.yaml')],
     }
 


### PR DESCRIPTION
Started required after merge of the following PR:
https://github.com/scylladb/scylla-cluster-tests/pull/7362

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
