### PR TITLE
fix(integration_tests): add node_index to LocalNode

### DIFF
--- a/unit_tests/dummy_remote.py
+++ b/unit_tests/dummy_remote.py
@@ -45,8 +45,9 @@ class DummyRemote:
 
 class LocalNode(BaseNode):
     # pylint: disable=too-many-arguments
-    def __init__(self, name, parent_cluster, ssh_login_info=None, base_logdir=None, node_prefix=None, dc_idx=0):
+    def __init__(self, name, parent_cluster, ssh_login_info=None, base_logdir=None, node_prefix=None, dc_idx=0, node_index=1):
         super().__init__(name, parent_cluster)
+        self.node_index = node_index
         self.remoter = LocalCmdRunner()
         self.logdir = os.path.dirname(__file__)
 


### PR DESCRIPTION
in PR #7326 `node_index` was used in basis of stress object LocalNode was missing that property, hence lots of tests were failing

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
