### PR TITLE
improvement(loader-latte): build small latte image

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -216,7 +216,7 @@ stress_image:
   cdc-stresser: 'scylladb/hydra-loaders:cdc-stresser-20210630'
   kcl: 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC'
   harry: 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816'
-  latte: 'scylladb/hydra-loaders:latte-rust1_73-20231025'
+  latte: 'scylladb/hydra-loaders:latte-0.25.1-scylladb'
   cql-stress-cassandra-stress: 'scylladb/hydra-loaders:cql-stress-cassandra-stress-20240119'
 
 service_level_shares: [1000]

--- a/docker/latte/Dockerfile
+++ b/docker/latte/Dockerfile
@@ -1,6 +1,12 @@
-FROM rust:1.73
+FROM rust:1.77-buster AS builder
+RUN cargo install --git https://github.com/scylladb/latte --branch main
 
-RUN cargo install --version 0.23.0  latte-cli
-
+FROM debian:buster-slim
+# NOTE: 'libfontconfig openssl' libs are required by the 'latte' binary during execution
+RUN apt update && apt -y install \
+    libfontconfig \
+    openssl \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/cargo/bin/latte /bin/latte
 
 CMD ["bash -c"]

--- a/docker/latte/README.md
+++ b/docker/latte/README.md
@@ -1,5 +1,7 @@
 ```
-export LATTE_DOCKER_IMAGE=scylladb/hydra-loaders:latte-rust1_73-$(date +'%Y%m%d')
+# See latte version at the 'Cargo.toml' file in the 'latte' repo
+export LATTE_VERSION=0.25.1-scylladb
+export LATTE_DOCKER_IMAGE=scylladb/hydra-loaders:latte-${LATTE_VERSION}
 docker build . -t ${LATTE_DOCKER_IMAGE}
 docker push ${LATTE_DOCKER_IMAGE}
 echo "${LATTE_DOCKER_IMAGE}" > image

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -666,7 +666,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                           'ycsb': 'scylladb/something_else',
                           'kcl': 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC',
                           'harry': 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816',
-                          'latte': 'scylladb/hydra-loaders:latte-rust1_73-20231025',
+                          'latte': 'scylladb/hydra-loaders:latte-0.25.1-scylladb',
                           'cql-stress-cassandra-stress': 'scylladb/hydra-loaders:cql-stress-cassandra-stress-20240119'})
 
         self.assertEqual(conf.get('stress_image.gemini'), 'scylladb/hydra-loaders:gemini-v1.8.6')


### PR DESCRIPTION
Using current approach we minimize latte image size as following:
- Compressed variant from `580.71Mb` to `34.96Mb`.
- Not compressed variant from `1.63Gb` to `92.7Mb`.

Also, switch the default latte image to be the latest available latte package version built using the new dockerfile added here.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
