### PR TITLE
improvement(distro): use ubuntu for loader and monitor nodes

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -7,7 +7,7 @@ user_credentials_path: '~/.ssh/scylla-qa-ec2'
 instance_type_loader: 'c5.xlarge'
 instance_type_monitor: 't3.large'
 # manual on creating loader AMI's: see docs/new_loader_ami.md
-ami_id_loader: 'scylla-qa-loader-ami-v19'
+ami_id_loader: 'scylla-qa-loader-ami-v20-ubuntu22'
 ami_id_monitor: 'ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20231207' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20231207Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2023-12-07
 
 availability_zone: 'a'
@@ -16,9 +16,7 @@ root_disk_size_db: 30  # GB, increase root disk for larger swap (maximum: 16G)
 root_disk_size_loader: 30  # GB, Increase loader disk in order to have extra space for a larger swap
 loader_swap_size: 10240  #10GB SWAP space
 ami_db_scylla_user: 'scyllaadm'
-# used prepared centos7 AMI for loader
-ami_loader_user: 'centos'
-# ubuntu is used for monitor
+ami_loader_user: 'ubuntu'
 ami_monitor_user: 'ubuntu'
 aws_instance_profile_name_db: 'qa-scylla-manager-backup-instance-profile'
 

--- a/defaults/azure_config.yaml
+++ b/defaults/azure_config.yaml
@@ -19,10 +19,8 @@ root_disk_size_db: 30  # GB, increase root disk for larger swap (maximum: 16G)
 root_disk_size_loader: 30  # GB, Increase loader disk in order to have extra space for a larger swap
 loader_swap_size: 10240  #10GB SWAP space
 azure_image_username: 'scyllaadm'
-# used prepared centos7 AMI for loader
 ami_loader_user: 'ubuntu'
 scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-5.2.list'
-# centos7 is used for monitor
 ami_monitor_user: 'ubuntu'
 
 ami_id_db_scylla: ''

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -4,8 +4,8 @@ gce_network: 'qa-vpc'
 gce_project: '' # empty mean default one, can be overwritten to use different one
 
 gce_image_db: '' # so we can use `scylla_version` as needed
-gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
-gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
+gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts'
+gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts'
 gce_image_username: 'scylla-test'
 
 gce_instance_type_loader: 'e2-standard-2'

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -2,7 +2,6 @@ instance_provision: 'on_demand'
 gce_datacenter: 'us-east1'
 availability_zone: 'c'
 gce_network: 'qa-vpc'
-gce_image_username: 'scylla-test'
 
 gke_cluster_version: '1.27'
 gke_k8s_release_channel: ''
@@ -50,7 +49,6 @@ gce_instance_type_loader: 'e2-standard-4'
 # NOTE: if we do not specify 'k8s_n_loader_pods_per_cluster' then value of the 'n_loaders' is used
 n_loaders: 1
 
-gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
 gce_instance_type_monitor: 'e2-medium'
 gce_root_disk_type_monitor: 'pd-standard'
 root_disk_size_monitor: 50

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -12,7 +12,7 @@ manager_version: '3.2'
 manager_scylla_backend_version: '2022'
 # Notice: that centos (default monitor), ubuntu 22, ubuntu 20 and debian 11 monitors use 2022, while debian 10 ubuntu 18 use 2021, since we support both
 
-scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-5.2.repo'
+scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-5.2.list'
 
 round_robin: false
 
@@ -23,7 +23,7 @@ db_nodes_shards_selection: 'default'
 
 # for for version selection
 scylla_linux_distro: 'ubuntu-focal'
-scylla_linux_distro_loader: 'centos'
+scylla_linux_distro_loader: 'ubuntu-jammy'
 ssh_transport: 'libssh2'
 
 monitor_branch: 'branch-4.6'

--- a/sct_ssh.py
+++ b/sct_ssh.py
@@ -92,8 +92,6 @@ def guess_username(instance: dict | compute_v1.Instance) -> str:
 
     node_type = get_tags(instance).get('NodeType')
     node_type = node_type.lower() if node_type else node_type
-    if node_type in ['monitor', 'loader']:
-        return 'centos'
     if node_type == 'builder':
         return 'jenkins'
     elif node_type == 'db-cluster':

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -282,10 +282,10 @@ class SCTConfiguration(dict):
                      WARNING: can't be used together with 'ami_id_db_oracle'"""),
 
         dict(name="scylla_linux_distro", env="SCT_SCYLLA_LINUX_DISTRO", type=str,
-             help="""The distro name and family name to use [centos/ubuntu-xenial/debian-jessie]"""),
+             help="""The distro name and family name to use. Example: 'ubuntu-jammy' or 'debian-bookworm'."""),
 
         dict(name="scylla_linux_distro_loader", env="SCT_SCYLLA_LINUX_DISTRO_LOADER", type=str,
-             help="""The distro name and family name to use [centos/ubuntu-xenial/debian-jessie]"""),
+             help="""The distro name and family name to use. Example: 'ubuntu-jammy' or 'debian-bookworm'."""),
 
         dict(name="scylla_repo_m", env="SCT_SCYLLA_REPO_M", type=str,
              help="Url to the repo of scylla version to install scylla from for managment tests"),

--- a/test-cases/manager/manager-backup-1TB-gce.yaml
+++ b/test-cases/manager/manager-backup-1TB-gce.yaml
@@ -30,7 +30,7 @@ nemesis_filter_seeds: false
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts'
 scylla_linux_distro: 'ubuntu-bionic'
 
-scylla_linux_distro_loader: 'centos'
+scylla_linux_distro_loader: 'ubuntu-jammy'
 
 space_node_threshold: 644245094
 

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -236,7 +236,8 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_SCYLLA_LINUX_DISTRO'] = 'ubuntu-xenial'
         os.environ['SCT_SCYLLA_LINUX_DISTRO_LOADER'] = 'ubuntu-xenial'
         os.environ['SCT_SCYLLA_VERSION'] = '3.0.3'
-        os.environ['SCT_GCE_IMAGE_DB'] = 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
+        os.environ['SCT_GCE_IMAGE_DB'] = (
+            'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7')
 
         expected_repo = 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-3.0-xenial.list'
         with unittest.mock.patch.object(sct_config, 'get_branch_version', return_value="4.7.dev", clear=True), \
@@ -248,14 +249,16 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertEqual(conf.get('scylla_repo'),
                          expected_repo)
         self.assertEqual(conf.get('scylla_repo_loader'),
-                         "https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-5.2.repo")
+                         "https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-5.2.list")
 
     def test_12_scylla_version_repo_ubuntu_loader_centos(self):  # pylint: disable=invalid-name
         os.environ['SCT_CLUSTER_BACKEND'] = 'gce'
         os.environ['SCT_SCYLLA_LINUX_DISTRO'] = 'ubuntu-xenial'
         os.environ['SCT_SCYLLA_LINUX_DISTRO_LOADER'] = 'centos'
         os.environ['SCT_SCYLLA_VERSION'] = '3.0.3'
-        os.environ['SCT_GCE_IMAGE_DB'] = 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
+        os.environ['SCT_GCE_IMAGE_DB'] = (
+            'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7')
+        os.environ['SCT_SCYLLA_REPO_LOADER'] = 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-5.2.repo'
 
         expected_repo = 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-3.0-xenial.list'
         with unittest.mock.patch.object(sct_config, 'get_branch_version', return_value="4.7.dev", clear=True), \
@@ -273,6 +276,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_CLUSTER_BACKEND'] = 'k8s-local-kind'
         os.environ['SCT_SCYLLA_LINUX_DISTRO'] = 'ubuntu-xenial'
         os.environ['SCT_SCYLLA_LINUX_DISTRO_LOADER'] = 'centos'
+        os.environ['SCT_SCYLLA_REPO_LOADER'] = 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-5.2.repo'
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 


### PR DESCRIPTION
Centos-7 is EOL.
So, switch our loader and monitor VMs to use 'ubuntu' images.

(cherry picked from commit 42a54efb8034bd3edfb1542e084dc49ec2f5b658)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
