### PR TITLE
fix(getJobTimeouts.groovy): Increase testStartupTimeout to 80 minutes

### DIFF
--- a/vars/getJobTimeouts.groovy
+++ b/vars/getJobTimeouts.groovy
@@ -36,7 +36,7 @@ List<Integer> call(Map params, String region){
         Integer stressEndup = 10
         testDuration = prepareDuration + stressDuration + stressEndup
     }
-    Integer testStartupTimeout = 20
+    Integer testStartupTimeout = 80
     Integer testTeardownTimeout = 40
     Integer collectLogsTimeout = 90
     Integer resourceCleanupTimeout = 30


### PR DESCRIPTION
This fixes an issue with certain jobs that spend a lot of time on
prepare stress stage / setup stage, as current calculation results in a
way closer timeout to the timeout thread, leading to interruptions

Fixes #7385

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
