### PR TITLE
improvement(distro): use ubuntu for loader and monitor nodes

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -9,23 +9,23 @@ instance_type_monitor: 't3.large'
 # manual on creating loader AMI's: see docs/new_loader_ami.md
 regions_data:
   us-east-1: # US East (N. Virginia)
-    ami_id_loader: 'ami-04ba971b593b243c5' # Loader dedicated AMI v18
-    ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
+    ami_id_loader: 'ami-0915f1c89aa5deed7' # scylla-qa-loader-ami-v20-ubuntu22
+    ami_id_monitor: 'ami-0c7217cdde317cfec' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20231207
   us-west-2: # US West (Oregon)
-    ami_id_loader: 'ami-034e122f3d6577a73' # Loader dedicated AMI v18
-    ami_id_monitor: 'ami-01ed306a12b7d1c96' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
+    ami_id_loader: 'ami-021c384e804a5214a' # scylla-qa-loader-ami-v20-ubuntu22
+    ami_id_monitor: 'ami-008fe2fc65df48dac' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20231207
   eu-west-1: # Europe (Ireland)
-    ami_id_loader: 'ami-0f2aac9a9d7a29979' # Loader dedicated AMI v18
-    ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
+    ami_id_loader: 'ami-0f18f01a34f2b489c' # scylla-qa-loader-ami-v20-ubuntu22
+    ami_id_monitor: 'ami-0905a3c97561e0b69' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20231207
   eu-west-2: # Europe (London)
-    ami_id_loader: 'ami-099a7a92db81b3500' # Loader dedicated AMI v18
-    ami_id_monitor: 'ami-0eab3a90fc693af19' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
+    ami_id_loader: 'ami-06d13f74d77130f17' # scylla-qa-loader-ami-v20-ubuntu22
+    ami_id_monitor: 'ami-0e5f882be1900e43b' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20231207
   eu-north-1: # Europe (Stockholm)
-    ami_id_loader: 'ami-0f1099eae729b80f1' # Loader dedicated AMI v18
-    ami_id_monitor: 'ami-5ee66f20' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
+    ami_id_loader: 'ami-02fc787a21bb5f140' # scylla-qa-loader-ami-v20-ubuntu22
+    ami_id_monitor: 'ami-0014ce3e52359afbd' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20231207
   eu-central-1: # Europe (Frankfurt)
-    ami_id_loader: 'ami-0cc124517d1f5710e' # Loader dedicated AMI v18
-    ami_id_monitor: 'ami-04cf43aca3e6f3de3' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
+    ami_id_loader: 'ami-0b269807b3c56bde0' # scylla-qa-loader-ami-v20-ubuntu22
+    ami_id_monitor: 'ami-0faab6bdbac9486fb' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20231207
 
 availability_zone: 'a'
 aws_root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used
@@ -33,10 +33,8 @@ aws_root_disk_size_db: 30  # GB, increase root disk for larger swap (maximum: 16
 aws_root_disk_size_loader: 30  # GB, Increase loader disk in order to have extra space for a larger swap
 loader_swap_size: 10240  #10GB SWAP space
 ami_db_scylla_user: 'scyllaadm'
-# used prepared centos7 AMI for loader
-ami_loader_user: 'centos'
-# centos7 is used for monitor
-ami_monitor_user: 'centos'
+ami_loader_user: 'ubuntu'
+ami_monitor_user: 'ubuntu'
 aws_instance_profile_name_db: 'qa-scylla-manager-backup-instance-profile'
 
 ami_id_db_scylla: ''

--- a/defaults/azure_config.yaml
+++ b/defaults/azure_config.yaml
@@ -19,10 +19,9 @@ availability_zone: 'a'
 #root_disk_size_loader: 30  # GB, Increase loader disk in order to have extra space for a larger swap
 loader_swap_size: 10240  #10GB SWAP space
 azure_image_username: 'scyllaadm'
-# used prepared centos7 AMI for loader
-ami_loader_user: 'centos'
-# centos7 is used for monitor
-ami_monitor_user: 'centos'
+ami_loader_user: 'ubuntu'
+scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-5.2.list'
+ami_monitor_user: 'ubuntu'
 
 ami_id_db_scylla: ''
 ami_id_db_oracle: ''

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -4,8 +4,8 @@ gce_network: 'qa-vpc'
 gce_project: '' # empty mean default one, can be overwritten to use different one
 
 gce_image_db: '' # so we can use `scylla_version` as needed
-gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
-gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
+gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts'
+gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts'
 gce_image_username: 'scylla-test'
 
 gce_instance_type_loader: 'e2-standard-2'

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -1,7 +1,6 @@
 instance_provision: 'on_demand'
 gce_datacenter: 'us-east1-b'
 gce_network: 'qa-vpc'
-gce_image_username: 'scylla-test'
 
 gke_cluster_version: '1.20'
 gke_k8s_release_channel: ''
@@ -42,7 +41,6 @@ gce_instance_type_loader: 'e2-standard-4'
 
 n_loaders: 1
 
-gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
 gce_instance_type_monitor: 'e2-medium'
 gce_root_disk_type_monitor: 'pd-standard'
 gce_root_disk_size_monitor: 50

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -9,7 +9,7 @@ scylla_repo: ''
 manager_version: '3.2'
 manager_scylla_backend_version: '2021'  # Notice: that centos, ubuntu 20 and debian 10 monitors use 2021, while debian 9, ubuntu 16 and ubuntu 18 use 2020, since we support both
 
-scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.6.repo'
+scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-5.2.list'
 
 experimental: true
 round_robin: false
@@ -21,7 +21,7 @@ db_nodes_shards_selection: 'default'
 
 # for for version selection
 scylla_linux_distro: 'ubuntu-focal'
-scylla_linux_distro_loader: 'centos'
+scylla_linux_distro_loader: 'ubuntu-jammy'
 ssh_transport: 'libssh2'
 system_auth_rf: 3
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -209,10 +209,10 @@ class SCTConfiguration(dict):
                      WARNING: can't be used together with 'ami_id_db_oracle'"""),
 
         dict(name="scylla_linux_distro", env="SCT_SCYLLA_LINUX_DISTRO", type=str,
-             help="""The distro name and family name to use [centos/ubuntu-xenial/debian-jessie]"""),
+             help="""The distro name and family name to use. Example: 'ubuntu-jammy' or 'debian-bookworm'."""),
 
         dict(name="scylla_linux_distro_loader", env="SCT_SCYLLA_LINUX_DISTRO_LOADER", type=str,
-             help="""The distro name and family name to use [centos/ubuntu-xenial/debian-jessie]"""),
+             help="""The distro name and family name to use. Example: 'ubuntu-jammy' or 'debian-bookworm'."""),
 
         dict(name="scylla_repo_m", env="SCT_SCYLLA_REPO_M", type=str,
              help="Url to the repo of scylla version to install scylla from for managment tests"),

--- a/test-cases/manager/manager-backup-1TB-gce.yaml
+++ b/test-cases/manager/manager-backup-1TB-gce.yaml
@@ -31,7 +31,7 @@ nemesis_filter_seeds: false
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts'
 scylla_linux_distro: 'ubuntu-bionic'
 
-scylla_linux_distro_loader: 'centos'
+scylla_linux_distro_loader: 'ubuntu-jammy'
 
 space_node_threshold: 644245094
 

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -238,7 +238,8 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_SCYLLA_LINUX_DISTRO'] = 'ubuntu-xenial'
         os.environ['SCT_SCYLLA_LINUX_DISTRO_LOADER'] = 'ubuntu-xenial'
         os.environ['SCT_SCYLLA_VERSION'] = '3.0.3'
-        os.environ['SCT_GCE_IMAGE_DB'] = 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
+        os.environ['SCT_GCE_IMAGE_DB'] = (
+            'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7')
 
         expected_repo = 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-3.0-xenial.list'
         with unittest.mock.patch.object(sct_config, 'get_branch_version', return_value="4.7.dev", clear=True), \
@@ -250,14 +251,16 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertEqual(conf.get('scylla_repo'),
                          expected_repo)
         self.assertEqual(conf.get('scylla_repo_loader'),
-                         "https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.6.repo")
+                         "https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-5.2.list")
 
     def test_12_scylla_version_repo_ubuntu_loader_centos(self):  # pylint: disable=invalid-name
         os.environ['SCT_CLUSTER_BACKEND'] = 'gce'
         os.environ['SCT_SCYLLA_LINUX_DISTRO'] = 'ubuntu-xenial'
         os.environ['SCT_SCYLLA_LINUX_DISTRO_LOADER'] = 'centos'
         os.environ['SCT_SCYLLA_VERSION'] = '3.0.3'
-        os.environ['SCT_GCE_IMAGE_DB'] = 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
+        os.environ['SCT_GCE_IMAGE_DB'] = (
+            'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7')
+        os.environ['SCT_SCYLLA_REPO_LOADER'] = 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-5.2.repo'
 
         expected_repo = 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-3.0-xenial.list'
         with unittest.mock.patch.object(sct_config, 'get_branch_version', return_value="4.7.dev", clear=True), \
@@ -275,6 +278,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_CLUSTER_BACKEND'] = 'k8s-local-kind'
         os.environ['SCT_SCYLLA_LINUX_DISTRO'] = 'ubuntu-xenial'
         os.environ['SCT_SCYLLA_LINUX_DISTRO_LOADER'] = 'centos'
+        os.environ['SCT_SCYLLA_REPO_LOADER'] = 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-5.2.repo'
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 


### PR DESCRIPTION
Centos-7 is EOL.
So, switch our loader and monitor VMs to use 'ubuntu' images.

(cherry picked from commit 42a54efb8034bd3edfb1542e084dc49ec2f5b658)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
