### PR TITLE
fix(scylla-setup): stop calling scylla-jmx.service if it doesn't exist

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -125,8 +125,9 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
 
     def check_scylla(self):
         self.node.run_nodetool("status")
-        self.run_cassandra_stress("write n=10000 -mode cql3 native -pop seq=1..10000")
-        self.run_cassandra_stress("mixed duration=1m -mode cql3 native -rate threads=10 -pop seq=1..10000")
+        if self.node.remoter.run(f"test -e '{STRESS_CMD}'", ignore_status=True).return_code == 0:
+            self.run_cassandra_stress("write n=10000 -mode cql3 native -pop seq=1..10000")
+            self.run_cassandra_stress("mixed duration=1m -mode cql3 native -rate threads=10 -pop seq=1..10000")
 
     def check_cqlsh(self):
         output = self.node.run_cqlsh("desc keyspaces")


### PR DESCRIPTION
Since scylladb/scylladb#18487 scylla-jmx isn't being installed by default, hence we need to be able to run SCT without doing any of the calls to start/stop/wait/configure the JMX service

Closes: #7392
Fixes: #7397

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-rocky9-test/32/
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2204-test/48/
- [x]  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-rocky9-test/34/
- [x]  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2204-test/50/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
