### PR TITLE
fix(logging): improve logging for deleting placement groups

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -3207,7 +3207,7 @@ def clean_placement_groups_aws(tags_dict: dict, regions=None, dry_run=False):
 
     for region, instance_list in aws_placement_groups.items():
         if not instance_list:
-            LOGGER.info("There are no placement groups to remove in AWS region %s", region)
+            LOGGER.debug("There are no placement groups to remove in AWS region %s", region)
             continue
         client: EC2Client = boto3.client('ec2', region_name=region)
         for instance in instance_list:
@@ -3216,8 +3216,8 @@ def clean_placement_groups_aws(tags_dict: dict, regions=None, dry_run=False):
             if not dry_run:
                 try:
                     response = client.delete_placement_group(GroupName=name)
-                    LOGGER.debug("Done. Result: %s\n", response)
+                    LOGGER.info("Placement group deleted: %s\n", response)
                 except Exception as ex:  # pylint: disable=broad-except
-                    LOGGER.info("Failed with: %s", str(ex))
+                    LOGGER.debug("Failed to delete placement group: %s", str(ex))
                     raise
 # ----------


### PR DESCRIPTION
Currently logging scheme confuses about not being able to delete placement groups, while it is working correctly due to retrying.

Fix logging to have less confusing info logs.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/6742

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
