### PR TITLE
switch oracle cluster to i4i for gemini tests

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -112,7 +112,7 @@ authenticator_password: ''
 # gemini defaults
 n_test_oracle_db_nodes: 1
 gemini_seed: 0
-oracle_scylla_version: '2021.1.23'
+oracle_scylla_version: '2022.1.14'
 append_scylla_args_oracle: '--enable-cache false'
 
 # cassandra-stress defaults

--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -24,4 +24,4 @@ gemini_cmd: "gemini -d --duration 8h --warmup 2h -c 50 \
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
 db_type: mixed_scylla
-instance_type_db_oracle: 'i3.16xlarge'
+instance_type_db_oracle: 'i4i.16xlarge'

--- a/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
@@ -30,4 +30,4 @@ gemini_table_options:
 stress_cdclog_reader_cmd: "cdc-stressor -duration 215m -stream-query-round-duration 30s"
 
 db_type: mixed_scylla
-instance_type_db_oracle: 'i3.8xlarge'
+instance_type_db_oracle: 'i4i.8xlarge'

--- a/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
@@ -22,4 +22,4 @@ gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 50 -m mixed -f --non-
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
 db_type: mixed_scylla
-instance_type_db_oracle: 'i3.8xlarge'
+instance_type_db_oracle: 'i4i.8xlarge'

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -27,4 +27,4 @@ gemini_cmd: "gemini -d --duration 3h --warmup 30m \
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
 db_type: mixed_scylla
-instance_type_db_oracle: 'i3.8xlarge'
+instance_type_db_oracle: 'i4i.8xlarge'

--- a/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
@@ -24,4 +24,4 @@ gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 50 \
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
 db_type: mixed_scylla
-instance_type_db_oracle: 'i3.8xlarge'
+instance_type_db_oracle: 'i4i.8xlarge'

--- a/test-cases/gemini/gemini-basic-3h-ics.yaml
+++ b/test-cases/gemini/gemini-basic-3h-ics.yaml
@@ -20,4 +20,4 @@ gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 50 -m mixed -f --non-
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
 db_type: mixed_scylla
-instance_type_db_oracle: 'i3.8xlarge'
+instance_type_db_oracle: 'i4i.8xlarge'

--- a/test-cases/gemini/gemini-basic-3h.yaml
+++ b/test-cases/gemini/gemini-basic-3h.yaml
@@ -21,4 +21,4 @@ gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 50 \
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
 db_type: mixed_scylla
-instance_type_db_oracle: 'i3.8xlarge'
+instance_type_db_oracle: 'i4i.8xlarge'


### PR DESCRIPTION
according to https://github.com/scylladb/qa-tasks/issues/1430 latest gemini jobs with ics start failing because
of timeout upon get results from oracle.
It could be related to slow instance for oracle

this PR switch oracle_scylla_version to 2023.1 and instance_type_db_oracle to i4i.8xlarge

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/artsiom_mishuta/job/sct_gemini_tests/job/gemini-3h-ics-test/16/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
