### PR TITLE
Revert "fix(getJobTimeouts.groovy): Increase testStartupTimeout to 80 minutes"

### DIFF
--- a/vars/getJobTimeouts.groovy
+++ b/vars/getJobTimeouts.groovy
@@ -36,7 +36,7 @@ List<Integer> call(Map params, String region){
         Integer stressEndup = 10
         testDuration = prepareDuration + stressDuration + stressEndup
     }
-    Integer testStartupTimeout = 80
+    Integer testStartupTimeout = 20
     Integer testTeardownTimeout = 40
     Integer collectLogsTimeout = 90
     Integer resourceCleanupTimeout = 30


### PR DESCRIPTION
Reverts scylladb/scylla-cluster-tests#7393