### PR TITLE
fix(cloud-init): make cloud init lock file kept across reboot

### DIFF
--- a/sdcm/provision/user_data.py
+++ b/sdcm/provision/user_data.py
@@ -18,7 +18,7 @@ from typing import List, Dict
 
 import yaml
 
-CLOUD_INIT_SCRIPTS_PATH = "/tmp/cloud-init"
+CLOUD_INIT_SCRIPTS_PATH = "/var/lib/sct/cloud-init"
 
 
 @dataclass

--- a/unit_tests/provisioner/test_provision_sct_resources.py
+++ b/unit_tests/provisioner/test_provision_sct_resources.py
@@ -20,7 +20,7 @@ from sdcm.test_config import TestConfig
 def test_can_provision_instances_according_to_sct_configuration(params, test_config, azure_service, fake_remoter):
     """Integration test for provisioning sct resources according to SCT configuration."""
     fake_remoter.result_map = {r"sudo cloud-init status --wait": Result(stdout="..... \n status: done", stderr="nic", exited=0),
-                               r"ls /tmp/cloud-init": Result(stdout="done", exited=0)}
+                               r"ls /var/lib/sct/cloud-init": Result(stdout="done", exited=0)}
     tags = TestConfig.common_tags()
     provision_sct_resources(params=params, test_config=test_config, azure_service=azure_service)
     provisioner_eastus = provisioner_factory.create_provisioner(
@@ -57,7 +57,7 @@ def test_can_provision_instances_according_to_sct_configuration(params, test_con
 def test_fallback_on_demand_when_spot_fails(fallback_on_demand, params, test_config, azure_service, fake_remoter):
     # pylint: disable=unused-argument
     fake_remoter.result_map = {r"sudo cloud-init status --wait": Result(stdout="..... \n status: done", stderr="nic", exited=0),
-                               r"ls /tmp/cloud-init": Result(stdout="done", exited=0)}
+                               r"ls /var/lib/sct/cloud-init": Result(stdout="done", exited=0)}
     provision_sct_resources(params=params, test_config=test_config, azure_service=azure_service)
     provisioner_eastus = provisioner_factory.create_provisioner(
         backend="azure", test_id=params.get("test_id"), region="eastus", availability_zone="1", azure_service=azure_service)

--- a/unit_tests/provisioner/test_user_data_builder.py
+++ b/unit_tests/provisioner/test_user_data_builder.py
@@ -67,13 +67,13 @@ def test_user_data_builder_generates_valid_yaml_from_single_user_data_object():
     assert user_data_yaml.startswith("#cloud-config\n"), "user-data yaml must start with #cloud-config"
     assert loaded_yaml['packages'] == ['some-pkg-to-install']
     assert loaded_yaml['runcmd'][0] == \
-        "cd /tmp/cloud-init; bash -eux /tmp/cloud-init/0_ExampleUserDataObject.sh; test  $? = 0 " \
-        "|| touch /tmp/cloud-init/0_ExampleUserDataObject.sh.failed"
+        "cd /var/lib/sct/cloud-init; bash -eux /var/lib/sct/cloud-init/0_ExampleUserDataObject.sh; test  $? = 0 " \
+        "|| touch /var/lib/sct/cloud-init/0_ExampleUserDataObject.sh.failed"
     script_file = loaded_yaml['write_files'][0]
-    assert script_file["path"] == "/tmp/cloud-init/0_ExampleUserDataObject.sh"
+    assert script_file["path"] == "/var/lib/sct/cloud-init/0_ExampleUserDataObject.sh"
     assert user_data_object_1.script_to_run in script_file["content"]
     assert script_file["permissions"] == '0644'
-    assert loaded_yaml['runcmd'][1] == "mkdir -p /tmp/cloud-init && touch /tmp/cloud-init/done"
+    assert loaded_yaml['runcmd'][1] == "mkdir -p /var/lib/sct/cloud-init && touch /var/lib/sct/cloud-init/done"
 
 
 def test_user_data_can_merge_user_data_objects_yaml():
@@ -100,7 +100,7 @@ def test_only_done_runcmd_in_yaml_when_no_user_data_objects():
 
     assert not loaded_yaml["packages"]
     assert not loaded_yaml["write_files"]
-    assert loaded_yaml["runcmd"] == ['mkdir -p /tmp/cloud-init && touch /tmp/cloud-init/done']
+    assert loaded_yaml["runcmd"] == ['mkdir -p /var/lib/sct/cloud-init && touch /var/lib/sct/cloud-init/done']
 
 
 def test_only_done_runcmd_in_yaml_when_no_applicable_user_data_objects():
@@ -110,4 +110,4 @@ def test_only_done_runcmd_in_yaml_when_no_applicable_user_data_objects():
 
     assert not loaded_yaml["packages"]
     assert not loaded_yaml["write_files"]
-    assert loaded_yaml["runcmd"] == ['mkdir -p /tmp/cloud-init && touch /tmp/cloud-init/done']
+    assert loaded_yaml["runcmd"] == ['mkdir -p /var/lib/sct/cloud-init && touch /var/lib/sct/cloud-init/done']


### PR DESCRIPTION
To mark cloud-init scripts (e.g. configuring syslogng) as executed, we create file in /tmp dir. This is wrong as it may not sustain machine reboots.

Move cloud-init lock file (and other related files) under `/var/lib/sct` so it's kept across reboot.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/7342

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - provision tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
