### PR TITLE
CentOS7 deprecation adjustments for manager tests

### DIFF
--- a/configurations/manager/ubuntu22.yaml
+++ b/configurations/manager/ubuntu22.yaml
@@ -1,2 +1,0 @@
-ami_id_monitor: 'ami-09db26f1ef0a9f406'  # Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-05-06
-ami_monitor_user: 'ubuntu'

--- a/jenkins-pipelines/manager/ubuntu22-manager-sanity-ipv6.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-sanity-ipv6.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    region: 'us-west-1',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
+    test_config: '''["test-cases/manager/manager-regression-ipv6.yaml", "configurations/network_config/all_addresses_ipv6_public.yaml"]''',
+
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+)

--- a/jenkins-pipelines/manager/ubuntu22-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-sanity.jenkinsfile
@@ -7,7 +7,7 @@ managerPipeline(
     backend: 'aws',
     region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
-    test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu22.yaml"]''',
+    test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
 
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
@@ -12,7 +12,7 @@ managerPipeline(
     manager_version: '3.1',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
-    test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu22.yaml"]''',
+    test_config: 'test-cases/upgrades/manager-upgrade.yaml',
 
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/test-cases/manager/manager-regression-ipv6.yaml
+++ b/test-cases/manager/manager-regression-ipv6.yaml
@@ -18,6 +18,3 @@ user_prefix: manager-regression
 space_node_threshold: 6442
 
 aws_instance_profile_name_db: 'qa-scylla-manager-backup-instance-profile'
-
-ami_monitor_user: 'centos'
-ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01

--- a/test-cases/manager/manager-regression-multiDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-multiDC-set-distro.yaml
@@ -19,6 +19,3 @@ user_prefix: manager-regression
 space_node_threshold: 6442
 
 aws_instance_profile_name_db: 'qa-scylla-manager-backup-instance-profile'
-
-ami_monitor_user: 'centos'
-ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01

--- a/test-cases/upgrades/manager-upgrade.yaml
+++ b/test-cases/upgrades/manager-upgrade.yaml
@@ -22,6 +22,3 @@ ip_ssh_connections: 'private'
 manager_prometheus_port: 10091
 
 aws_instance_profile_name_db: 'qa-scylla-manager-backup-instance-profile'
-
-ami_monitor_user: 'centos'
-ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01


### PR DESCRIPTION
The PR addresses the CentOS7 deprecation changes:
- sanity tests switched to use Ubuntu image instead of centos;
- ipv6 tests switched to Ubuntu as well.

Addresses https://github.com/scylladb/scylla-manager/issues/3840

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/sct/job/manager-ubuntu-22-sanity/7/
- [x] https://argus.scylladb.com/workspace?state=WyIzMTI3MTYyMS00ZGVkLTRmNDItYmYzYS1hMWE4OTFiNDUwODkiXQ

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)