### PR TITLE
fix(manager): wait after Scylla config change to let SM pick up the change

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -695,16 +695,16 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         healthcheck_task = mgr_cluster.get_healthcheck_task()
 
         self.db_cluster.enable_client_encrypt()
-        time.sleep(30)  # Make sure healthcheck task is triggered
 
-        # Scylla-manager should pick up client encryption setting automatically
-        healthcheck_task.wait_for_status(list_status=[TaskStatus.DONE], step=5, timeout=240)
-
+        # SM caches scylla nodes configuration and the healthcheck svc is independent from the cache updates.
+        # Cache is being updated periodically, every 1 minute following the manager config for SCT.
+        # We need to wait until SM is aware about the configuration change.
         mgr_cluster.update(
             client_encrypt=True,
             force_non_ssl_session_port=mgr_cluster.sctool.is_minimum_3_2_6_or_snapshot
         )
-        time.sleep(30)  # Make sure healthcheck task is triggered
+        time.sleep(240)
+
         healthcheck_task.wait_for_status(list_status=[TaskStatus.DONE], step=5, timeout=240)
         sleep = 40
         self.log.debug('Sleep {} seconds, waiting for health-check task to run by schedule on first time'.format(sleep))

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2314,6 +2314,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         with self.remote_manager_yaml() as manager_yaml:
             manager_yaml["tls_cert_file"] = tls_cert_file
             manager_yaml["tls_key_file"] = tls_key_file
+            manager_yaml["config_cache"] = {"update_frequency": "1m"}
             manager_yaml["prometheus"] = f":{self.parent_cluster.params.get('manager_prometheus_port')}"
 
         if self.is_docker():


### PR DESCRIPTION
Scylla manager is not immediately being aware about the Scylla node config change.
It picks up for the node configuration periodically.

This PR extends the sleep to be sure that SM is updated with the latest node config.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/sct/job/manager-ubuntu-22-sanity/7 (PASSED)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
