### PR TITLE
fix(perf): fix display_single_result method

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -102,8 +102,8 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
                       result['latency 95th percentile'],
                       result['latency 99th percentile'],
                       result['latency 99.9th percentile'],
-                      result['Total partitions'],
-                      result['Total errors'])
+                      result['total partitions'],
+                      result['total errors'])
 
     def get_test_xml(self, result, test_name=''):
         test_content = """
@@ -155,8 +155,8 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
             result['latency 95th percentile'],
             result['latency 99th percentile'],
             result['latency 99.9th percentile'],
-            result['Total partitions'],
-            result['Total errors'])
+            result['total partitions'],
+            result['total errors'])
 
         return test_content
 


### PR DESCRIPTION
Performance results json is searched for `Total partitions` and `Total errors` while these don't exist, causing exception raised and full logic of `display_results` method of `PerformanceRegressionTest` class not executed.

Fix is about to select proper (not capitalized) keys: `total partitions` and `total errors`.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
