### PR TITLE
test(perf): i4i.4xlarge perf with split ranges

### DIFF
--- a/configurations/disable-ear.yaml
+++ b/configurations/disable-ear.yaml
@@ -1,1 +1,1 @@
-scylla_encryption_options: "{'key_provider': 'none'}"
+scylla_encryption_options: '{"key_provider": "none"}'

--- a/configurations/disable-ear.yaml
+++ b/configurations/disable-ear.yaml
@@ -1,0 +1,1 @@
+scylla_encryption_options: "{'key_provider': 'none'}"

--- a/configurations/perf-loaders-non-shard-aware-config.yaml
+++ b/configurations/perf-loaders-non-shard-aware-config.yaml
@@ -1,14 +1,2 @@
-# manual on creating loader AMI's: see docs/new_loader_ami.md
-# AMIs from branch-perf-v8 with non-shardware driver
-use_prepared_loaders: true
-ami_id_loader: 'scylla-qa-loader-ami-v9'
-regions_data:
-    us-east-1:
-      security_group_ids: 'sg-c5e1f7a0'
-      subnet_id: 'subnet-ec4a72c4'
-    eu-west-1:
-      security_group_ids: 'sg-059a7f66a947d4b5c'
-      subnet_id: 'subnet-088fddaf520e4c7a8'
-    us-west-2:
-      security_group_ids: 'sg-81703ae4'
-      subnet_id: 'subnet-5207ee37'
+append_scylla_yaml: |
+  enable_shard_aware_drivers: false

--- a/jenkins-pipelines/performance/scylla-enterprise/perf-regression-throughput-non-shard-aware-i4i-4xlarge-650gb.jenkinsfile
+++ b/jenkins-pipelines/performance/scylla-enterprise/perf-regression-throughput-non-shard-aware-i4i-4xlarge-650gb.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: "us-east-1",
+    test_name: "performance_regression_test.PerformanceRegressionTestSplitRanges",
+    test_config: '''["test-cases/performance/perf-regression-throughput-650gb.yaml","configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/disable_speculative_retry.yaml"]''',
+    sub_tests: ["test_write", "test_read", "test_mixed"],
+    test_email_title: "throughput - non-shard-aware - i4i - 4xlarge - 650gb",
+
+    timeout: [time: 350, unit: "MINUTES"]
+)

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -12,9 +12,10 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2016 ScyllaDB
-
+# pylint: disable=too-many-lines
 
 import os
+import re
 import time
 
 from enum import Enum
@@ -892,3 +893,127 @@ class PerformanceRegressionUpgradeTest(PerformanceRegressionTest, UpgradeTest): 
     def test_latency_mixed_with_upgrade(self):
         self._prepare_latency_with_upgrade()
         self.run_workload_and_upgrade(stress_cmd=self.params.get('stress_cmd_m'))
+
+
+class PerformanceRegressionTestSplitRanges(PerformanceRegressionTest):
+    """Tests where loaders use different ranges for stress operations.
+    Enforcing round_robin=True for all stress operations.
+    """
+
+    def preheat_cache(self):
+        base_cmd_r = self.params.get('stress_cmd_r')
+        if not isinstance(base_cmd_r, list):
+            base_cmd_r = [base_cmd_r]
+        stress_queue = []
+        for stress_cmd in base_cmd_r:
+            stress_cmd = re.sub(r'duration=\d+m', 'duration=15m', stress_cmd)
+            stress_queue.append(self.run_stress_thread(
+                stress_cmd=stress_cmd, stats_aggregate_cmds=False, round_robin=True))
+        for stress in stress_queue:
+            self.get_stress_results(queue=stress, store_results=False)
+
+    # Base Tests
+    def test_write(self):
+        """
+        Test steps:
+
+        1. Run a write workload
+        """
+        # run a write workload
+        base_cmd_w = self.params.get('stress_cmd_w')
+        stress_multiplier = self.params.get('stress_multiplier')
+        if stress_multiplier_w := self.params.get("stress_multiplier_w"):
+            stress_multiplier = stress_multiplier_w
+        # create new document in ES with doc_id = test_id + timestamp
+        # allow to correctly save results for future compare
+        self.create_test_stats(doc_id_with_timestamp=True)
+        self.run_fstrim_on_all_db_nodes()
+
+        # run a workload
+        stress_queue = []
+        if not isinstance(base_cmd_w, list):
+            base_cmd_w = [base_cmd_w]
+        for stress_cmd in base_cmd_w:
+            stress_queue.append(self.run_stress_thread(
+                stress_cmd=stress_cmd, stress_num=stress_multiplier, stats_aggregate_cmds=False, round_robin=True))
+        results = []
+        for stress in stress_queue:
+            results.append(self.get_stress_results(queue=stress, store_results=True))
+        self.build_histogram(PerformanceTestWorkload.WRITE, PerformanceTestType.THROUGHPUT)
+        self.update_test_details(scylla_conf=True)
+        self.display_results(results, test_name='test_write')
+        self.check_regression()
+
+    def test_read(self):
+        """
+        Test steps:
+
+        1. Run a write workload as a preparation
+        2. Run a read workload
+        """
+
+        base_cmd_r = self.params.get('stress_cmd_r')
+        stress_multiplier = self.params.get('stress_multiplier')
+        if stress_multiplier_r := self.params.get("stress_multiplier_r"):
+            stress_multiplier = stress_multiplier_r
+        self.run_fstrim_on_all_db_nodes()
+        # run a write workload
+        self.preload_data()
+        self.preheat_cache()
+        # create new document in ES with doc_id = test_id + timestamp
+        # allow to correctly save results for future compare
+        self.create_test_stats(doc_id_with_timestamp=True)
+        # wait compactions will be finished
+        self.wait_no_compactions_running(n=240, sleep_time=180)
+        self.run_fstrim_on_all_db_nodes()
+        # run a read workload
+        stress_queue = []
+        if not isinstance(base_cmd_r, list):
+            base_cmd_r = [base_cmd_r]
+        for stress_cmd in base_cmd_r:
+            stress_queue.append(self.run_stress_thread(
+                stress_cmd=stress_cmd, stress_num=stress_multiplier, stats_aggregate_cmds=False, round_robin=True))
+        results = []
+        for stress in stress_queue:
+            results.append(self.get_stress_results(queue=stress, store_results=True))
+        self.build_histogram(PerformanceTestWorkload.READ, PerformanceTestType.THROUGHPUT)
+        self.update_test_details(scylla_conf=True)
+        self.display_results(results, test_name='test_read')
+        self.check_regression()
+
+    def test_mixed(self):
+        """
+        Test steps:
+
+        1. Run a write workload as a preparation
+        2. Run a mixed workload
+        """
+
+        base_cmd_m = self.params.get('stress_cmd_m')
+        stress_multiplier = self.params.get('stress_multiplier')
+        if stress_multiplier_m := self.params.get("stress_multiplier_m"):
+            stress_multiplier = stress_multiplier_m
+        self.run_fstrim_on_all_db_nodes()
+        # run a write workload as a preparation
+        self.preload_data()
+        self.preheat_cache()
+        # run a mixed workload
+        # create new document in ES with doc_id = test_id + timestamp
+        # allow to correctly save results for future compare
+        self.create_test_stats(doc_id_with_timestamp=True)
+        # wait compactions will be finished
+        self.wait_no_compactions_running(n=240, sleep_time=180)
+        self.run_fstrim_on_all_db_nodes()
+        stress_queue = []
+        if not isinstance(base_cmd_m, list):
+            base_cmd_m = [base_cmd_m]
+        for stress_cmd in base_cmd_m:
+            stress_queue.append(self.run_stress_thread(
+                stress_cmd=stress_cmd, stress_num=stress_multiplier, stats_aggregate_cmds=False, round_robin=True))
+        results = []
+        for stress in stress_queue:
+            results.append(self.get_stress_results(queue=stress, store_results=True))
+        self.build_histogram(PerformanceTestWorkload.MIXED, PerformanceTestType.THROUGHPUT)
+        self.update_test_details(scylla_conf=True)
+        self.display_results(results, test_name='test_mixed')
+        self.check_regression()

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5060,6 +5060,9 @@ class BaseLoaderSet():
         result = node.remoter.run('test -e ~/PREPARED-LOADER', ignore_status=True)
         node.remoter.sudo("bash -cxe \"echo '*\t\thard\tcore\t\tunlimited\n*\t\tsoft\tcore\t\tunlimited' "
                           ">> /etc/security/limits.d/20-coredump.conf\"")
+        if self.params.get('non_shard_aware_loaders'):
+            node.remoter.sudo("iptables -A OUTPUT -p tcp --dport 19042 -j DROP", verbose=True)
+
         if result.exit_status == 0:
             self.log.debug('Skip loader setup for using a prepared AMI')
             return

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -295,6 +295,9 @@ class SCTConfiguration(dict):
         dict(name="scylla_repo_loader", env="SCT_SCYLLA_REPO_LOADER", type=str,
              help="Url to the repo of scylla version to install c-s for loader"),
 
+        dict(name="non_shard_aware_loaders", env="SCT_NON_SHARD_AWARE_LOADERS", type=boolean,
+             help="If True, loader will not use shard awareness by rejecting 19042 outgoing traffic"),
+
         dict(name="scylla_mgmt_address", env="SCT_SCYLLA_MGMT_ADDRESS",
              type=str,
              help="Url to the repo of scylla manager version to install for management tests"),

--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -641,7 +641,7 @@ def get_running_instances_for_email_report(test_id: str, ip_filter: str = None):
 
     tags = {"TestId": test_id, }
 
-    instances = list_instances_aws(tags_dict=tags, group_as_region=True, running=True)
+    instances = list_instances_aws(tags_dict=tags, group_as_region=True, running=True, verbose=True)
     for region in instances:
         for instance in instances[region]:
             # NOTE: K8S nodes created by autoscaler never have 'Name' set.

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -150,6 +150,8 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
             node_ip_list = [n.cql_address for n in node_list]
 
             stress_cmd += ",".join(node_ip_list)
+            if self.params.get("non_shard_aware_loaders"):
+                stress_cmd += " -port native=9042"
         return stress_cmd
 
     def adjust_cmd_connection_options(self, stress_cmd: str, loader, cmd_runner) -> str:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -820,6 +820,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.params['scylla_encryption_options'] = "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'KmsKeyProviderFactory', 'kms_host': 'auto'}"  # pylint: disable=line-too-long
         if not (scylla_encryption_options := self.params.get("scylla_encryption_options") or ''):
             return None
+        if scylla_encryption_options.get("key_provider") == 'none':
+            self.params['scylla_encryption_options'] = ''
+            return None
         kms_host = (yaml.safe_load(scylla_encryption_options) or {}).get("kms_host") or ''
         if 'auto' not in kms_host:
             return None

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -820,7 +820,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.params['scylla_encryption_options'] = "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'KmsKeyProviderFactory', 'kms_host': 'auto'}"  # pylint: disable=line-too-long
         if not (scylla_encryption_options := self.params.get("scylla_encryption_options") or ''):
             return None
-        if scylla_encryption_options.get("key_provider") == 'none':
+        if json.loads(scylla_encryption_options).get("key_provider") == 'none':
             self.params['scylla_encryption_options'] = ''
             return None
         kms_host = (yaml.safe_load(scylla_encryption_options) or {}).get("kms_host") or ''

--- a/test-cases/performance/perf-regression-throughput-650gb.yaml
+++ b/test-cases/performance/perf-regression-throughput-650gb.yaml
@@ -1,0 +1,61 @@
+test_duration: 300
+prepare_write_cmd: [
+  "cassandra-stress write no-warmup cl=ALL n=108333334 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)'  -pop seq=1..108333334",
+  "cassandra-stress write no-warmup cl=ALL n=108333334 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)'  -pop seq=108333335..216666668",
+  "cassandra-stress write no-warmup cl=ALL n=108333334 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)'  -pop seq=216666669..325000002",
+  "cassandra-stress write no-warmup cl=ALL n=108333334 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)'  -pop seq=325000003..433333336",
+  "cassandra-stress write no-warmup cl=ALL n=108333334 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)'  -pop seq=433333337..541666670",
+  "cassandra-stress write no-warmup cl=ALL n=108333334 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)'  -pop seq=541666671..650000004"
+]
+
+stress_cmd_w: [
+  "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=320 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..325000000",
+  "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=320 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=325000001..650000000",
+  "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=320 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=650000001..975000000",
+  "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=320 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=975000001..1300000000"
+]
+stress_cmd_r: [
+  "cassandra-stress read no-warmup cl=QUORUM duration=60m -mode cql3 native -rate threads=380 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..108333334,54166668,542209)'",
+  "cassandra-stress read no-warmup cl=QUORUM duration=60m -mode cql3 native -rate threads=380 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(108333335..216666668,162500002,542209)'",
+  "cassandra-stress read no-warmup cl=QUORUM duration=60m -mode cql3 native -rate threads=380 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(216666669..325000002,270833336,542209)'",
+  "cassandra-stress read no-warmup cl=QUORUM duration=60m -mode cql3 native -rate threads=380 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(325000003..433333336,379166670,542209)'",
+  "cassandra-stress read no-warmup cl=QUORUM duration=60m -mode cql3 native -rate threads=380 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(433333337..541666670,487500004,542209)'",
+  "cassandra-stress read no-warmup cl=QUORUM duration=60m -mode cql3 native -rate threads=380 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(541666671..650000004,595833338,542209)'"
+]
+stress_cmd_m: [
+  "cassandra-stress mixed no-warmup cl=QUORUM duration=60m -mode cql3 native -rate threads=350 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..108333334,54166668,542209)'",
+  "cassandra-stress mixed no-warmup cl=QUORUM duration=60m -mode cql3 native -rate threads=350 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(108333335..216666668,162500002,542209)'",
+  "cassandra-stress mixed no-warmup cl=QUORUM duration=60m -mode cql3 native -rate threads=350 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(216666669..325000002,270833336,542209)'",
+  "cassandra-stress mixed no-warmup cl=QUORUM duration=60m -mode cql3 native -rate threads=350 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(325000003..433333336,379166670,542209)'",
+  "cassandra-stress mixed no-warmup cl=QUORUM duration=60m -mode cql3 native -rate threads=350 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(433333337..541666670,487500004,542209)'",
+  "cassandra-stress mixed no-warmup cl=QUORUM duration=60m -mode cql3 native -rate threads=350 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(541666671..650000004,595833338,542209)'"
+]
+round_robin: true
+
+n_db_nodes: 3
+n_loaders: 6
+n_monitor_nodes: 1
+
+
+instance_type_db: 'i4i.4xlarge'
+instance_type_loader: 'c6i.4xlarge'
+instance_type_monitor: 't3.small'
+
+use_preinstalled_scylla: true
+
+user_prefix: 'perf-regression-i4i-4x-650gb'
+
+backtrace_decoding: false
+print_kernel_callstack: true
+
+store_perf_results: true
+use_mgmt: false
+send_email: true
+email_recipients: ['scylla-perf-results@scylladb.com']
+
+custom_es_index: 'performancestatsv2'
+use_hdr_cs_histogram: true
+
+append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
+
+use_placement_group: true

--- a/test-cases/performance/perf-regression-throughput-650gb.yaml
+++ b/test-cases/performance/perf-regression-throughput-650gb.yaml
@@ -59,3 +59,5 @@ use_hdr_cs_histogram: true
 append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
 
 use_placement_group: true
+use_prepared_loaders: true
+ami_id_loader: 'scylla-qa-loader-ami-v20-ubuntu22'

--- a/utils/split_c_s_to_ranges.py
+++ b/utils/split_c_s_to_ranges.py
@@ -1,0 +1,50 @@
+# pylint: skip-file
+import json
+import math
+
+loaders = 6
+multiplier = 1
+count = loaders*multiplier
+num_of_rows = 650000000
+gauss_ratio = 99.9  # higher value increases cache hit ratio
+rows_per_command = math.ceil(num_of_rows/count)
+prepare_write_cs = f"cassandra-stress write no-warmup cl=ALL n={rows_per_command} -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' "
+write_cs = "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=340 -col 'size=FIXED(128) n=FIXED(8)'"
+read_cs = "cassandra-stress read no-warmup cl=QUORUM duration=60m -mode cql3 native -rate threads=380 -col 'size=FIXED(128) n=FIXED(8)'"
+mixed_cs = "cassandra-stress mixed no-warmup cl=QUORUM duration=60m -mode cql3 native -rate threads=350 -col 'size=FIXED(128) n=FIXED(8)'"
+
+commands = []
+for idx in range(count):
+    rows = idx*rows_per_command
+    commands.append(f"{prepare_write_cs} -pop seq={rows + 1:.0f}..{rows + rows_per_command:.0f}")
+print("prepare write:")
+print(json.dumps(commands, indent=2))
+
+
+commands = []
+for idx in range(count):
+    rows = idx*rows_per_command
+    commands.append(f"{write_cs} -pop seq={rows + 1:.0f}..{rows + rows_per_command:.0f}")
+print("Write:")
+print(json.dumps(commands, indent=2))
+
+commands = []
+for idx in range(count):
+    min_row = idx * rows_per_command + 1
+    max_row = idx * rows_per_command + rows_per_command
+    mean = (min_row + max_row) / 2
+    commands.append(
+        f"{read_cs} -pop 'dist=gauss({min_row:.0f}..{max_row:.0f},{mean:.0f},{(mean - min_row) / gauss_ratio:.0f})'")
+print("Read:")
+print(json.dumps(commands, indent=2))
+
+commands = []
+for idx in range(count):
+    min_row = idx * rows_per_command + 1
+    max_row = idx * rows_per_command + rows_per_command
+    mean = (min_row + max_row) / 2
+    commands.append(
+        f"{mixed_cs} -pop 'dist=gauss({min_row:.0f}..{max_row:.0f},{mean:.0f},{(mean - min_row) / gauss_ratio:.0f})'")
+
+print("Mixed:")
+print(json.dumps(commands, indent=2))


### PR DESCRIPTION
We want each c-s to operate on own range so processes don't write the same rows. Also increase datasize and instance type (to minimize noisy-neighbor problem). Splitting manually to avoid too much code changes and risk regressions (added script for doing the split). Read&mixed test are aimed to close to 100% cache hit ratio. Used as a separate test class to not affect current tests. Also this test won't use node benchmarks for now, as there's no proof for relation between benchmark result and test result.

refs: https://github.com/scylladb/qa-tasks/issues/1508

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/perf-regression-throughput-non-shard-aware-i4i-4xlarge-test-650gb/52/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
