### PR TITLE
fix(commitlint.config.js): enlarge headline length

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,11 +1,11 @@
 module.exports = {
     rules: {
         // Header
-        "header-max-length": [2, "always", 72],
+        "header-max-length": [2, "always", 100],
         // Subject
         'subject-empty': [2, 'never'],
         'subject-full-stop': [2, 'never', '.'],
-        'subject-max-length': [2, 'always', 85],
+        'subject-max-length': [2, 'always', 100],
         'subject-min-length': [2, 'always', 10],
         // Type
         'type-enum': [2,'always',['ci','docs','feature','fix','improvement','perf','refactor','revert','style','test', 'unit-test']],


### PR DESCRIPTION
too many time we have case the headline is more then 72 that seems a bit too small to be descriptive

updating it to be bigger

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
