### PR TITLE
Revert "fix(manager): wait after Scylla config change to let SM pick up the change"

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -695,16 +695,16 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         healthcheck_task = mgr_cluster.get_healthcheck_task()
 
         self.db_cluster.enable_client_encrypt()
+        time.sleep(30)  # Make sure healthcheck task is triggered
 
-        # SM caches scylla nodes configuration and the healthcheck svc is independent from the cache updates.
-        # Cache is being updated periodically, every 1 minute following the manager config for SCT.
-        # We need to wait until SM is aware about the configuration change.
+        # Scylla-manager should pick up client encryption setting automatically
+        healthcheck_task.wait_for_status(list_status=[TaskStatus.DONE], step=5, timeout=240)
+
         mgr_cluster.update(
             client_encrypt=True,
             force_non_ssl_session_port=mgr_cluster.sctool.is_minimum_3_2_6_or_snapshot
         )
-        time.sleep(240)
-
+        time.sleep(30)  # Make sure healthcheck task is triggered
         healthcheck_task.wait_for_status(list_status=[TaskStatus.DONE], step=5, timeout=240)
         sleep = 40
         self.log.debug('Sleep {} seconds, waiting for health-check task to run by schedule on first time'.format(sleep))

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2314,7 +2314,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         with self.remote_manager_yaml() as manager_yaml:
             manager_yaml["tls_cert_file"] = tls_cert_file
             manager_yaml["tls_key_file"] = tls_key_file
-            manager_yaml["config_cache"] = {"update_frequency": "1m"}
             manager_yaml["prometheus"] = f":{self.parent_cluster.params.get('manager_prometheus_port')}"
 
         if self.is_docker():


### PR DESCRIPTION
Reverts scylladb/scylla-cluster-tests#7412

This change doesn't work with manager 3.2.7, and break all weekly runs