### PR TITLE
feature(teardown-validators): validator to work on test context

### DIFF
--- a/sdcm/teardown_validators/base.py
+++ b/sdcm/teardown_validators/base.py
@@ -1,6 +1,6 @@
 import logging
 
-from sdcm.cluster import BaseCluster
+from sdcm.tester import ClusterTester
 from sdcm.sct_config import SCTConfiguration
 
 LOGGER = logging.getLogger(__name__)
@@ -9,9 +9,9 @@ LOGGER = logging.getLogger(__name__)
 class TeardownValidator:  # pylint: disable=too-few-public-methods
     validator_name = None  # must be defined by child classes
 
-    def __init__(self, params: SCTConfiguration, cluster: BaseCluster):
+    def __init__(self, params: SCTConfiguration, tester: ClusterTester):
         self.params = params
-        self.cluster = cluster
+        self.tester = tester
         self.configuration = params.get(f"teardown_validators.{self.validator_name}")
         self.is_enabled = self.configuration.get("enabled", False)
         if not self.is_enabled:

--- a/sdcm/teardown_validators/sstables.py
+++ b/sdcm/teardown_validators/sstables.py
@@ -14,7 +14,8 @@ LOGGER = logging.getLogger(__name__)
 class SstablesValidator(TeardownValidator):  # pylint: disable=too-few-public-methods
     validator_name = 'scrub'
 
-    def _upload_corrupted_files(self, node: BaseNode, quarantine_log_lines):
+    @staticmethod
+    def _upload_corrupted_files(node: BaseNode, quarantine_log_lines):
         # get quarantine dir from lines:
         # INFO  2024-04-02 12:40:24,787 [shard 0:stre] sstable - Moving sstable /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/me-3gey_0z3c_2h5vl2ogebmg26ku9t-big-Data.db to "/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/quarantine"  # pylint: disable=line-too-long
         # print(log_lines)
@@ -26,7 +27,7 @@ class SstablesValidator(TeardownValidator):  # pylint: disable=too-few-public-me
             return "<No quarantine directories found>"
         s3_link = upload_remote_files_directly_to_s3(
             node.ssh_login_info, list(quarantine_dirs), s3_bucket=S3Storage.bucket_name,
-            s3_key=f"{self.cluster.uuid}/{node.name}-corrupted-sstables.tar.gz",
+            s3_key=f"{node.parent_cluster.cluster.uuid}/{node.name}-corrupted-sstables.tar.gz",
             max_size_gb=100, public_read_acl=True)
         return s3_link
 
@@ -52,17 +53,18 @@ class SstablesValidator(TeardownValidator):  # pylint: disable=too-few-public-me
             ScrubValidationErrorEvent(node.name, s3_link).publish()
 
     def validate(self):
-        keyspace = self.configuration.get("keyspace")
-        table = self.configuration.get("table")
-        timeout = self.configuration.get("timeout", 1200)
-        run_scrub = partial(self._run_nodetool_scrub, keyspace=keyspace, table=table, timeout=timeout)
-        run_scrub.__name__ = run_scrub.func.__name__
-        try:
-            LOGGER.info("Running nodetool scrub on all nodes in validation mode")
-            parallel_obj = ParallelObject(objects=self.cluster.nodes, timeout=timeout)
-            parallel_obj.run(run_scrub, ignore_exceptions=False, unpack_objects=True)
-            LOGGER.info("Nodetool scrub validation finished")
-        except Exception as exc:  # pylint: disable=broad-except
-            LOGGER.error("Error during nodetool scrub validation: %s", exc)
-            ValidatorEvent(
-                message=f'Error during nodetool scrub validation: {exc}', severity=Severity.ERROR).publish()
+        for cluster in self.tester.iter_all_db_cluster():
+            keyspace = self.configuration.get("keyspace")
+            table = self.configuration.get("table")
+            timeout = self.configuration.get("timeout", 1200)
+            run_scrub = partial(self._run_nodetool_scrub, keyspace=keyspace, table=table, timeout=timeout)
+            run_scrub.__name__ = run_scrub.func.__name__
+            try:
+                LOGGER.info("Running nodetool scrub on all nodes in validation mode")
+                parallel_obj = ParallelObject(objects=cluster.nodes, timeout=timeout)
+                parallel_obj.run(run_scrub, ignore_exceptions=False, unpack_objects=True)
+                LOGGER.info("Nodetool scrub validation finished")
+            except Exception as exc:  # pylint: disable=broad-except
+                LOGGER.error("Error during nodetool scrub validation: %s", exc)
+                ValidatorEvent(
+                    message=f'Error during nodetool scrub validation: {exc}', severity=Severity.ERROR).publish()

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2797,14 +2797,17 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         self.destroy_credentials()
 
+    def iter_all_db_cluster(self):
+        for db_cluster in self.db_clusters_multitenant:
+            yield db_cluster
+
     def tearDown(self):
         self.teardown_started = True
         with silence(parent=self, name='Sending test end event'):
             InfoEvent(message="TEST_END").publish()
         self.log.info("Post test validators are starting...")
         for validator_class in teardown_validators_list:
-            for db_cluster in self.db_clusters_multitenant:
-                validator_class(self.params, db_cluster).validate()
+            validator_class(self.params, self).validate()
         self.log.info('TearDown is starting...')
         self.stop_timeout_thread()
         self.stop_event_analyzer()


### PR DESCRIPTION
since we have more types of validators which are not depended on db cluster alone, we change the parameter to validators to be a the tester instance, and not a db cluster as before.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
