### PR TITLE
fix(scylla doctor): read vitals file

### DIFF
--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -98,8 +98,7 @@ class ScyllaDoctor:
         LOGGING.debug(pprint.pformat(result))
 
     def analyze_and_verify_results(self):
-        scylla_doctor_result = json.loads(self.node.remoter.run(
-            f"cat {self.json_result_file}", verbose=False).stdout.strip())
+        scylla_doctor_result = json.loads(self.run(f"cat {self.json_result_file}"))
 
         LOGGING.debug("Scylla-doctor output: %s", pprint.pformat(scylla_doctor_result))
 


### PR DESCRIPTION
'artifacts-oel81-test' failed to read vitals file that was created with sudo. 
It happened because it try to read with non-root user.
Change to use 'utils.scylla_doctor.ScyllaDoctor.run' function that knows to use correct remoter function, 'sudo' or 'run'.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [artifacts-oel81-test](https://argus.scylladb.com/test/5380690f-0e83-474e-b2f8-d2610b885bbf/runs?additionalRuns[]=32ab5578-c339-455c-a264-17c08aab5285)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
