### PR TITLE
fix(alternator): use CREATE ROLE for `alternator_enforce_authorization`

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -37,7 +37,6 @@ from invoke.exceptions import UnexpectedExit, Failure
 from cassandra.concurrent import execute_concurrent_with_args  # pylint: disable=no-name-in-module
 from cassandra import ConsistencyLevel
 from cassandra.cluster import Session  # pylint: disable=no-name-in-module
-from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
 
 from argus.client.sct.client import ArgusSCTClient
 from argus.client.base import ArgusClientError
@@ -1010,9 +1009,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.log.info("Going to create alternator tables")
             if self.params.get('alternator_enforce_authorization'):
                 with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
-                    session.execute(SimpleStatement("""
-                        INSERT INTO system_auth.roles (role, salted_hash) VALUES (%s, %s)
-                    """, consistency_level=ConsistencyLevel.ALL),
+                    session.execute("CREATE ROLE %s WITH PASSWORD = %s",
                                     (self.params.get('alternator_access_key_id'),
                                      self.params.get('alternator_secret_access_key')))
 

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -160,7 +160,7 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
 
             aws_empty_file = dedent(f""""
                 accessKey = {self.params.get('alternator_access_key_id')}
-                secretKey = {self.params.get('alternator_secret_access_key')}
+                secretKey = {alternator.api.Alternator.get_salted_hash(node=self.node_list[0], username=self.params.get('alternator_secret_access_key'))}
             """)
 
             with tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8') as tmp_file:


### PR DESCRIPTION
instead of writing directly into system_auth table, gonna use `CREATE ROLE` and read the salted_hash for using with alternator APIs

Fixes: #7405

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-alternator-ttl-big-dataset-test/4/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
