### PR TITLE
fix(provision): fix when capacity reservation is not set

### DIFF
--- a/sdcm/provision/aws/provisioner.py
+++ b/sdcm/provision/aws/provisioner.py
@@ -105,7 +105,8 @@ class AWSInstanceProvisioner(InstanceProvisionerBase):  # pylint: disable=too-fe
             tags: List[TagsType]) -> List[Instance]:
         instance_parameters_dict = instance_parameters.dict(
             exclude_none=True, exclude_defaults=True, exclude_unset=True, encode_user_data=False)
-        if cr_id := SCTCapacityReservation.reservations.get(provision_parameters.availability_zone).get(instance_parameters.InstanceType):
+        if cr_id := SCTCapacityReservation.reservations.get(provision_parameters.availability_zone, {}).get(
+                instance_parameters.InstanceType):
             instance_parameters_dict['CapacityReservationSpecification'] = {
                 'CapacityReservationTarget': {
                     'CapacityReservationId': cr_id


### PR DESCRIPTION
When CR is not set error `AttributeError: 'NoneType' object has no attribute 'get'` when querying for cr_id. Failing provision step..

Fix by returning dict by default if az is not found in reservations (CR is not used).

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
