### PR TITLE
fix(scylla doctor): amazon2 tests

### DIFF
--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -113,6 +113,10 @@ class ScyllaDoctor:
                 collector in ["StorageConfigurationCollector", "PerftuneSystemConfigurationCollector"]):
             return True
 
+        # https://github.com/scylladb/scylladb/issues/18631
+        if self.node.distro.is_amazon2 and collector in ["CPUSetCollector", "PerftuneSystemConfigurationCollector"]:
+            return True
+
         return False
 
     def analyze_and_verify_results(self):


### PR DESCRIPTION
Skip 2 collectors because 'perftune.yaml' is missed on AL2 (opened scylladb issue #18631).

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [artifacts-amazon2-test](https://argus.scylladb.com/test/f810956d-24b5-4321-93b0-f7e62bb211d5/runs?additionalRuns[]=195557e0-d462-49ed-ac2e-a81d6abb7c2e)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
