### PR TITLE
Fix the manager installation process

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -695,16 +695,16 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         healthcheck_task = mgr_cluster.get_healthcheck_task()
 
         self.db_cluster.enable_client_encrypt()
-        time.sleep(30)  # Make sure healthcheck task is triggered
 
-        # Scylla-manager should pick up client encryption setting automatically
-        healthcheck_task.wait_for_status(list_status=[TaskStatus.DONE], step=5, timeout=240)
-
+        # SM caches scylla nodes configuration and the healthcheck svc is independent from the cache updates.
+        # Cache is being updated periodically, every 1 minute following the manager config for SCT.
+        # We need to wait until SM is aware about the configuration change.
         mgr_cluster.update(
             client_encrypt=True,
             force_non_ssl_session_port=mgr_cluster.sctool.is_minimum_3_2_6_or_snapshot
         )
-        time.sleep(30)  # Make sure healthcheck task is triggered
+        time.sleep(90)
+
         healthcheck_task.wait_for_status(list_status=[TaskStatus.DONE], step=5, timeout=240)
         sleep = 40
         self.log.debug('Sleep {} seconds, waiting for health-check task to run by schedule on first time'.format(sleep))

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2316,6 +2316,13 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             manager_yaml["tls_key_file"] = tls_key_file
             manager_yaml["prometheus"] = f":{self.parent_cluster.params.get('manager_prometheus_port')}"
 
+            # `config_cache` parameter was introduced in version 3.2.7-0.20240509, skip this for older versions.
+            version = self.remoter.run(
+                "sctool version | grep 'Client version:' | awk -F': ' '{print $2}'").stdout.strip()
+            # example of version returned - 3.2.3~0.20231019.5b0db89a
+            if ComparableScyllaVersion(version) >= "3.2.7-0.20240509":
+                manager_yaml["config_cache"] = {"update_frequency": "1m"}
+
         if self.is_docker():
             self.remoter.sudo("supervisorctl restart scylla-manager")
             res = self.remoter.sudo("supervisorctl status scylla-manager")


### PR DESCRIPTION
`config_cache` parameter was introduced in version 3.2.7-0.20240509, skip the parameter setup part for older versions.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
Jenkins pipelines:
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/sct/job/manager-master/job/sct-feature-test-backup/
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/sct/job/manager-master/job/ubuntu22-sanity-test/
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/sct/job/manager-master/job/ubuntu22-upgrade-test/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
