### PR TITLE
fix(c-s): use 5.4.6 image for c-s

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -209,7 +209,7 @@ stress_image:
   ndbench: 'scylladb/hydra-loaders:ndbench-jdk8-20210720'
   ycsb: 'scylladb/hydra-loaders:ycsb-jdk8-20220918'
   nosqlbench: 'scylladb/hydra-loaders:nosqlbench-4.15.49'
-  cassandra-stress: '' # default would be same version as scylla under test
+  cassandra-stress: 'scylladb/scylla:5.4.6' # empty default would be same version as scylla under test
   scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.20'
   gemini: 'scylladb/hydra-loaders:gemini-v1.8.6'
   alternator-dns: 'scylladb/hydra-loaders:alternator-dns-0.1'


### PR DESCRIPTION
Recently scylla-tools package is not installed in scylladb docker images. This makes c-s not being installed in docker images we use for loaders.

Workaround by pinning version with c-s installed.

workarounds: https://github.com/scylladb/scylla-cluster-tests/issues/7430

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/longevity-5gb-1h-ScyllaKillMonkey-aws-test/11/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
