### PR TITLE
Switch manager tests to run on singleDC environment

### DIFF
--- a/jenkins-pipelines/manager/centos-manager-backup-200gb.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-backup-200gb.jenkinsfile
@@ -5,9 +5,9 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
     backend: 'aws',
-    region: '''["us-east-1", "us-west-2"]''',
+    region: 'us-west-2',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_backup_feature',
-    test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/200gb_dataset.yaml"]''',
+    test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/manager/200gb_dataset.yaml"]''',
 
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/jenkins-pipelines/manager/centos-manager-backup.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-backup.jenkinsfile
@@ -5,9 +5,9 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
     backend: 'aws',
-    region: '''["us-east-1", "us-west-2"]''',
+    region: 'us-west-2',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_backup_feature',
-    test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
+    test_config: 'test-cases/manager/manager-regression-singleDC-set-distro.yaml',
 
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
@@ -5,9 +5,9 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
     backend: 'aws',
-    region: '''["us-east-1", "us-west-2"]''',
+    region: 'us-west-2',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
-    test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
+    test_config: 'test-cases/manager/manager-regression-singleDC-set-distro.yaml',
 
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/jenkins-pipelines/manager/debian10-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-sanity.jenkinsfile
@@ -5,9 +5,9 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
     backend: 'aws',
-    region: '''["us-east-1", "us-west-2"]''',
+    region: 'us-west-2',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
-    test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/debian10.yaml"]''',
+    test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/manager/debian10.yaml"]''',
 
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/jenkins-pipelines/manager/debian11-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian11-manager-sanity.jenkinsfile
@@ -5,9 +5,9 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
     backend: 'aws',
-    region: '''["us-east-1", "us-west-2"]''',
+    region: 'us-west-2',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
-    test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/debian11.yaml"]''',
+    test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/manager/debian11.yaml"]''',
 
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/jenkins-pipelines/manager/manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/manager-sanity.jenkinsfile
@@ -5,9 +5,9 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
     backend: 'aws',
-    region: '''["us-east-1", "us-west-2"]''',
+    region: 'us-east-1',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
-    test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
+    test_config: 'test-cases/manager/manager-regression-singleDC-set-distro.yaml',
 
     timeout: [time: 500, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/ubuntu20-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-sanity.jenkinsfile
@@ -5,9 +5,9 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
     backend: 'aws',
-    region: '''["us-east-1", "us-west-2"]''',
+    region: 'us-east-1',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
-    test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu20.yaml"]''',
+    test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/manager/ubuntu20.yaml"]''',
 
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/jenkins-pipelines/manager/ubuntu22-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-sanity.jenkinsfile
@@ -5,9 +5,9 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
     backend: 'aws',
-    region: '''["us-east-1", "us-west-2"]''',
+    region: 'us-east-1',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
-    test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
+    test_config: 'test-cases/manager/manager-regression-singleDC-set-distro.yaml',
 
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -349,9 +349,8 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
             self.test_mgmt_cluster_crud()
         with self.subTest('Mgmt cluster Health Check'):
             self.test_mgmt_cluster_healthcheck()
-        # test_healthcheck_change_max_timeout requires a multi dc run. And since ipv6 cannot run in multi dc, this test
-        # function will be skipped for ipv6 runs.
-        if self.db_cluster.nodes[0].test_config.IP_SSH_CONNECTIONS != "ipv6":
+        # test_healthcheck_change_max_timeout requires a multi dc run
+        if self.db_cluster.nodes[0].test_config.MULTI_REGION:
             with self.subTest('Basic test healthcheck change max timeout'):
                 self.test_healthcheck_change_max_timeout()
         with self.subTest('Basic test suspend and resume'):

--- a/test-cases/manager/manager-regression-singleDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-singleDC-set-distro.yaml
@@ -1,0 +1,21 @@
+test_duration: 240
+
+stress_cmd: "cassandra-stress write cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
+stress_read_cmd: "cassandra-stress read cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
+
+instance_type_db: 'i4i.large'
+instance_type_loader: 'c6i.large'
+
+region_name: 'us-east-1'
+n_db_nodes: '3'
+n_loaders: 1
+n_monitor_nodes: 1
+
+post_behavior_db_nodes: "destroy"
+post_behavior_loader_nodes: "destroy"
+post_behavior_monitor_nodes: "destroy"
+
+user_prefix: manager-regression
+space_node_threshold: 6442
+
+aws_instance_profile_name_db: 'qa-scylla-manager-backup-instance-profile'


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-manager/issues/3850

Should be merged together with https://github.com/scylladb/scylla-cluster-tests/pull/7365

Since there is an issue with multiDC cluster restore when the EaR is turned on (https://github.com/scylladb/scylla-manager/issues/3829), it was decided to:
- switch them to use single-DC cluster;
- leave one test with multiDC cluster for enterprise version 2022 (no encryption feature implemented).

After https://github.com/scylladb/scylla-manager/issues/3829 resolution, multiDC cluster would be returned back.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Jenkins jobs:
- https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/sct/job/manager-master-versions-update/job/sct-feature-test-backup/
- https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/sct/job/manager-master-versions-update/job/ubuntu22-sanity-test/
- https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/sct/job/manager-master-versions-update/job/older-enterprise-ami-sanity-test/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
