### PR TITLE
fix(multidc): run test from local machine

### DIFF
--- a/sdcm/provision/scylla_yaml/auxiliaries.py
+++ b/sdcm/provision/scylla_yaml/auxiliaries.py
@@ -18,7 +18,6 @@ from typing import Literal, List, Union, Optional
 from pydantic import Field, validator, BaseModel  # pylint: disable=no-name-in-module
 
 from sdcm.provision.common.builders import AttrBuilder
-from sdcm.provision.network_configuration import ssh_connection_ip_type
 from sdcm.sct_config import SCTConfiguration
 
 
@@ -178,8 +177,5 @@ class ScyllaYamlAttrBuilderBase(AttrBuilder):
             'org.apache.cassandra.locator.GossipingPropertyFileSnitch',
             'org.apache.cassandra.locator.Ec2Snitch']:
         if self._cluster_backend == 'aws':
-            if ssh_connection_ip_type(self.params) == 'public':
-                return 'org.apache.cassandra.locator.Ec2MultiRegionSnitch'
-            else:
-                return 'org.apache.cassandra.locator.Ec2Snitch'
+            return 'org.apache.cassandra.locator.Ec2Snitch'
         return 'org.apache.cassandra.locator.GossipingPropertyFileSnitch'


### PR DESCRIPTION
Running multiDC cluster test from local machine failed to setup the cluster. Error:
```
    init - Startup failed: std::runtime_error (Use broadcast_address for seeds list)
```
    
The problem that after presenting of new networking setup (https://github.com/scylladb/scylla-cluster-tests/pull/6575) choosing of endpoint snitch became wrong and should be 'Ec2Snitch'. It was decided to set it 'Ec2Snitch' because we do not have a case when we need to use `Ec2MultiRegionSnitch`.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/7381

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] local `manager-regression-multiDC-set-distro`
- [x] [manager-ubuntu20-sanity-test](https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/manager-ubuntu20-sanity-test/2/) - Scylla on all nodes initialised successfully. Failure in the test does not connected to this commit

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
