### PR TITLE
fix(logging): add hostname to RemoteCommandRunner output watcher

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1718,9 +1718,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def process_scylla_args(self, append_scylla_args=''):
         if append_scylla_args:
             scylla_help = self.remoter.run(
-                f"{self.add_install_prefix('/usr/bin/scylla')} --help", ignore_status=True).stdout
+                f"{self.add_install_prefix('/usr/bin/scylla')} --help", ignore_status=True, verbose=False).stdout
             scylla_help_seastar = self.remoter.run(
-                f"{self.add_install_prefix('/usr/bin/scylla')} --help-seastar", ignore_status=True).stdout
+                f"{self.add_install_prefix('/usr/bin/scylla')} --help-seastar", ignore_status=True, verbose=False).stdout
             scylla_arg_parser = ScyllaArgParser.from_scylla_help(
                 help_text=f"{scylla_help}\n{scylla_help_seastar}",
                 duplicate_cb=lambda dups: ScyllaHelpErrorEvent.duplicate(

--- a/sdcm/remote/base.py
+++ b/sdcm/remote/base.py
@@ -84,7 +84,7 @@ class CommandRunner(metaclass=ABCMeta):
     def _setup_watchers(self, verbose: bool, log_file: str, additional_watchers: list) -> List[StreamWatcher]:
         watchers = additional_watchers if additional_watchers else []
         if verbose:
-            watchers.append(OutputWatcher(self.log))
+            watchers.append(OutputWatcher(self.log, self.hostname))
         if log_file:
             watchers.append(LogWriteWatcher(log_file))
         return watchers
@@ -211,8 +211,9 @@ class CommandRunner(metaclass=ABCMeta):
 
 
 class OutputWatcher(StreamWatcher):  # pylint: disable=too-few-public-methods
-    def __init__(self, log: logging.Logger):
+    def __init__(self, log: logging.Logger, hostname: str):
         super().__init__()
+        self.hostname = hostname
         self.len = 0
         self.log = log
 
@@ -221,13 +222,13 @@ class OutputWatcher(StreamWatcher):  # pylint: disable=too-few-public-methods
 
         while '\n' in stream_buffer:
             out_buf, rest_buf = stream_buffer.split('\n', 1)
-            self.log.debug(out_buf)
+            self.log.debug("<%s>: " + out_buf, self.hostname)
             stream_buffer = rest_buf
         self.len = len(stream) - len(stream_buffer)
         return []
 
     def submit_line(self, line: str):
-        self.log.debug(line.rstrip('\n'))
+        self.log.debug("<%s>: " + line.rstrip('\n'), self.hostname)
 
 
 class LogWriteWatcher(StreamWatcher):  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
When investigating parallel commands it's hard to diffirentiate their outputs. Fix to add hostname to each output line.

Also removing dozens of lines of `scylla --help` in sct logs as they don't bring us any benefit.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
