### PR TITLE
fix(alternator): use admin user for role creation

### DIFF
--- a/configurations/rolling-upgrade-alternator.yaml
+++ b/configurations/rolling-upgrade-alternator.yaml
@@ -18,6 +18,10 @@ alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'
 alternator_secret_access_key: 'password'
 
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
 
 alternator_port: 8080
 alternator_use_dns_routing: true

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1866,6 +1866,11 @@ class SCTConfiguration(dict):
                 raise ValueError("For PasswordAuthenticator authenticator authenticator_user and authenticator_password"
                                  " have to be provided")
 
+        if self.get('alternator_enforce_authorization'):
+            if not self.get('authenticator') or not self.get('authorizer'):
+                raise ValueError(
+                    "When enabling `alternator_enforce_authorization` both `authenticator` and `authorizer` should be defined")
+
         # 13) validate stress and prepare duration:
         if stress_duration := self.get('stress_duration'):
             try:

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -135,7 +135,7 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
         if 'dynamodb' in self.stress_cmd:
             dynamodb_teample = dedent('''
                 measurementtype=hdrhistogram
-                dynamodb.awsCredentialsFile = /tmp/aws_empty_file
+                dynamodb.awsCredentialsFile = /tmp/aws_dummy_credentials_file
                 dynamodb.endpoint = {0}://{1}:{2}
                 dynamodb.connectMax = 200
                 requestdistribution = uniform
@@ -157,11 +157,16 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
                     dynamodb.primaryKey = {alternator.consts.HASH_KEY_NAME}
                     dynamodb.primaryKeyType = {alternator.enums.YCSBSchemaTypes.HASH_SCHEMA.value}
                 ''')
-
-            aws_empty_file = dedent(f""""
-                accessKey = {self.params.get('alternator_access_key_id')}
-                secretKey = {alternator.api.Alternator.get_salted_hash(node=self.node_list[0], username=self.params.get('alternator_secret_access_key'))}
-            """)
+            if self.params.get('alternator_enforce_authorization'):
+                aws_credentials_content = dedent(f""""
+                    accessKey = {self.params.get('alternator_access_key_id')}
+                    secretKey = {alternator.api.Alternator.get_salted_hash(node=self.node_list[0], username=self.params.get('alternator_access_key_id'))}
+                """)
+            else:
+                aws_credentials_content = dedent(f""""
+                    accessKey = {self.params.get('alternator_access_key_id')}
+                    secretKey = {self.params.get('alternator_secret_access_key')}
+                """)
 
             with tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8') as tmp_file:
                 tmp_file.write(dynamodb_teample)
@@ -169,9 +174,9 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
                 cmd_runner.send_files(tmp_file.name, os.path.join('/tmp', 'dynamodb.properties'))
 
             with tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8') as tmp_file:
-                tmp_file.write(aws_empty_file)
+                tmp_file.write(aws_credentials_content)
                 tmp_file.flush()
-                cmd_runner.send_files(tmp_file.name, os.path.join('/tmp', 'aws_empty_file'))
+                cmd_runner.send_files(tmp_file.name, os.path.join('/tmp', 'aws_dummy_credentials_file'))
             if is_kubernetes:
                 if web_protocol == "https":
                     if ca_bundle_path := getattr(self.node_list[0], "alternator_ca_bundle_path", None):

--- a/test-cases/features/alternator-ttl/longevity-alternator-1h-scan-12h-ttl-no-lwt-2h-grace-4loaders-sisyphus.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-1h-scan-12h-ttl-no-lwt-2h-grace-4loaders-sisyphus.yaml
@@ -57,6 +57,11 @@ alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'
 alternator_secret_access_key: 'password'
 
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
 # Set Alternator TTL parameters
 # ---------------------------------------------
 # TTL mode is experimental in version 5.1.

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired-data.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired-data.yaml
@@ -48,6 +48,11 @@ alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'
 alternator_secret_access_key: 'password'
 
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
 # Set Alternator TTL parameters
 # ---------------------------------------------
 # TTL mode is experimental in version 5.1.

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-no-lwt-8m-grace-sisyphus.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-no-lwt-8m-grace-sisyphus.yaml
@@ -41,6 +41,11 @@ alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'
 alternator_secret_access_key: 'password'
 
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
 # Set Alternator TTL parameters
 # ---------------------------------------------
 # Enable TTL feature in Scylla.

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-multiple-ttl-8m-grace.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-multiple-ttl-8m-grace.yaml
@@ -95,6 +95,11 @@ alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'
 alternator_secret_access_key: 'password'
 
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
 # Set Alternator TTL parameters
 # ---------------------------------------------
 # TTL mode is experimental in version 5.1.

--- a/test-cases/features/alternator-ttl/longevity-alternator-disable-enable-ttl.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-disable-enable-ttl.yaml
@@ -46,6 +46,11 @@ alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'
 alternator_secret_access_key: 'password'
 
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
 # Set Alternator TTL parameters
 # ---------------------------------------------
 # TTL mode is experimental in version 5.1.

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-big-dataset.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-big-dataset.yaml
@@ -53,6 +53,11 @@ alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'
 alternator_secret_access_key: 'password'
 
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
 # Set Alternator TTL parameters
 # ---------------------------------------------
 # TTL mode is experimental in version 5.1.

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-large-writes.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-large-writes.yaml
@@ -52,6 +52,11 @@ alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'
 alternator_secret_access_key: 'password'
 
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
 # Set Alternator TTL parameters
 # ---------------------------------------------
 # TTL mode is experimental in version 5.1.

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-lwt.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-lwt.yaml
@@ -35,6 +35,11 @@ alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'
 alternator_secret_access_key: 'password'
 
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
 # Set Alternator TTL parameters
 # ---------------------------------------------
 # TTL mode is experimental in version 5.1.

--- a/test-cases/scylla-operator/longevity-scylla-operator-alternator-http-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-alternator-http-3h.yaml
@@ -62,6 +62,12 @@ alternator_port: 8000
 alternator_enforce_authorization: true
 alternator_access_key_id: "alternator"
 alternator_secret_access_key: "password"
+
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
 dynamodb_primarykey_type: HASH_AND_RANGE
 # NOTE: 'alternator_use_dns_routing' is not applicable in K8S case and will be ignored.
 alternator_use_dns_routing: false

--- a/test-cases/scylla-operator/longevity-scylla-operator-alternator-https-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-alternator-https-3h.yaml
@@ -62,6 +62,12 @@ alternator_port: 8043
 alternator_enforce_authorization: true
 alternator_access_key_id: "alternator"
 alternator_secret_access_key: "password"
+
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
 dynamodb_primarykey_type: HASH_AND_RANGE
 # NOTE: 'alternator_use_dns_routing' is not applicable in K8S case and will be ignored.
 alternator_use_dns_routing: false


### PR DESCRIPTION
PR #7422 was merged before validated, and now is failing with the following error:

```
cassandra.Unauthorized: Error from server: code=2100 [Unauthorized]
message="You have to be logged in and not anonymous to perform this request"
```

need to enable `authenticator` and `authorizer` in order to be able to create roles

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-alternator-ttl-big-dataset-test/7/ (job timeout, but it still proved this code to be working)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
