### PR TITLE
Fix Manager installation on Debian

### DIFF
--- a/configurations/manager/debian10.yaml
+++ b/configurations/manager/debian10.yaml
@@ -1,4 +1,5 @@
 ami_id_monitor: 'ami-074f8bbb689b1c1a0'  # Debian buster image - debian-10-amd64-20230601-1398
 ami_monitor_user: 'admin'
+monitor_branch: 'branch-4.6'  # Pass it as debian image is not the formal monitor image
 
 manager_scylla_backend_version: '2023'  # Notice: Uses 2023.1, while other (newer deb) use 2024, since we support both

--- a/configurations/manager/debian11.yaml
+++ b/configurations/manager/debian11.yaml
@@ -1,2 +1,3 @@
 ami_id_monitor: 'ami-09a41e26df464c548'  # Debian Bullseye image - debian-11-amd64-20220503-998
 ami_monitor_user: 'admin'
+monitor_branch: 'branch-4.6'  # Pass it as debian image is not the formal monitor image

--- a/configurations/manager/ubuntu20.yaml
+++ b/configurations/manager/ubuntu20.yaml
@@ -1,2 +1,3 @@
 ami_id_monitor: 'ami-042e8287309f5df03'  # Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2021-02-23
 ami_monitor_user: 'ubuntu'
+monitor_branch: 'branch-4.6'  # Pass it as debian image is not the formal monitor image

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5426,7 +5426,8 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
         elif node.distro.is_debian:
             node.install_package(
                 package_name='apt-transport-https ca-certificates curl software-properties-common gnupg2')
-            node.remoter.sudo('curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -', retry=3)
+            node.remoter.sudo(
+                'bash -ce "curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -"', retry=3)
             node.remoter.sudo(
                 cmd='add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"')
             node.remoter.sudo(cmd="apt update")


### PR DESCRIPTION
**Fixes:**

1. The cmd `apt-key add -` should be run as sudo otherwise the error `E: This command can only be used by root.` returns on Debian distro.

```
11:29:40  Command: 'sudo curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -'
11:29:40  Exit code: 1
11:29:40  Stdout:
11:29:40  Stderr:
11:29:40  Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
11:29:40  E: This command can only be used by root.
```
Failed Jenkins job - https://jenkins.scylladb.com/view/scylla-manager/job/manager-master/job/debian11-sanity-test/210

2. The `monitor_branch` parameter is `null` by default. If another value is not provided in config and image differs from formal (Ubuntu), the monitor installation flow tries to download from monitoring branch which is None:

```
12:36:07  Command: "bash -ce '\nrm -rf /home/admin/sct-monitoring\nmkdir -p /home/admin/sct-monitoring\ncd /home/admin/sct-monitoring\nwget [https://github.com/scylladb/scylla-monitoring/archive/None.zip\nrm](https://github.com/scylladb/scylla-monitoring/archive/None.zip/nrm) -rf ./tmp /home/admin/sct-monitoring/scylla-monitoring-src 2>/dev/null\nunzip None.zip -d ./tmp\nmv ./tmp/scylla-monitoring-None/ /home/admin/sct-monitoring/scylla-monitoring-src\nrm -rf ./tmp 2>/dev/null\n'"
12:36:07  
12:36:07  Exit code: 8
12:36:07  
12:36:07  Stdout:
12:36:07  
12:36:07  
12:36:07  
12:36:07  Stderr:
12:36:07  
12:36:07  Resolving github.com (github.com)... 140.82.113.3
12:36:07  Connecting to github.com (github.com)|140.82.113.3|:443... connected.
12:36:07  HTTP request sent, awaiting response... 302 Found
12:36:07  Location: https://codeload.github.com/scylladb/scylla-monitoring/zip/None [following]
12:36:07  --2024-05-16 10:28:51--  https://codeload.github.com/scylladb/scylla-monitoring/zip/None
12:36:07  Resolving codeload.github.com (codeload.github.com)... 140.82.113.9
12:36:07  Connecting to codeload.github.com (codeload.github.com)|140.82.113.9|:443... connected.
12:36:07  HTTP request sent, awaiting response... 404 Not Found
12:36:07  2024-05-16 10:28:51 ERROR 404: Not Found.
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/scylla-manager/job/manager-master/job/debian11-sanity-test/216

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels (No need to backport into manager-3.2 since the branch doesn't contain the changes that broke the command).
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
