### PR TITLE
ci(manager): switch singleDC jobs to us-east-1 region

### DIFF
--- a/configurations/manager/debian10.yaml
+++ b/configurations/manager/debian10.yaml
@@ -1,4 +1,4 @@
-ami_id_monitor: 'ami-074f8bbb689b1c1a0'  # Debian buster image - debian-10-amd64-20230601-1398
+ami_id_monitor: 'ami-074f8bbb689b1c1a0'  # Debian buster image - debian-10-amd64-20230601-1398, region - us-east-1
 ami_monitor_user: 'admin'
 
 manager_scylla_backend_version: '2023'  # Notice: Uses 2023.1, while other (newer deb) use 2024, since we support both

--- a/configurations/manager/debian11.yaml
+++ b/configurations/manager/debian11.yaml
@@ -1,2 +1,2 @@
-ami_id_monitor: 'ami-09a41e26df464c548'  # Debian Bullseye image - debian-11-amd64-20220503-998
+ami_id_monitor: 'ami-09a41e26df464c548'  # Debian Bullseye image - debian-11-amd64-20220503-998, region - us-east-1
 ami_monitor_user: 'admin'

--- a/configurations/manager/ubuntu20.yaml
+++ b/configurations/manager/ubuntu20.yaml
@@ -1,2 +1,2 @@
-ami_id_monitor: 'ami-042e8287309f5df03'  # Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2021-02-23
+ami_id_monitor: 'ami-042e8287309f5df03'  # Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2021-02-23, region - us-east-1
 ami_monitor_user: 'ubuntu'

--- a/jenkins-pipelines/manager/debian10-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-sanity.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
     backend: 'aws',
-    region: 'us-west-2',
+    region: 'us-east-1',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/manager/debian10.yaml"]''',
 

--- a/jenkins-pipelines/manager/debian11-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian11-manager-sanity.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
     backend: 'aws',
-    region: 'us-west-2',
+    region: 'us-east-1',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/manager/debian11.yaml"]''',
 

--- a/jenkins-pipelines/manager/ubuntu22-manager-sanity-ipv6.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-sanity-ipv6.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
     backend: 'aws',
-    region: 'us-west-1',
+    region: 'us-east-1',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-ipv6.yaml", "configurations/network_config/all_addresses_ipv6_public.yaml"]''',
 


### PR DESCRIPTION
Currently selected us-west-2 region doesn't contain all required AMI images what results in jobs failure.

`AssertionError: Image 'ami-09a41e26df464c548' details not found in 'us-west-2'`

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/scylla-manager/job/manager-master/job/debian11-sanity-test/214/ (The job where us-east-1 region is used. The failure isn't related to region, but manager specific issue)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)