### PR TITLE
fix(azure): fix loader disk size

### DIFF
--- a/defaults/azure_config.yaml
+++ b/defaults/azure_config.yaml
@@ -16,7 +16,6 @@ azure_image_monitor: 'Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.0
 availability_zone: ''
 root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used
 root_disk_size_db: 30  # GB, increase root disk for larger swap (maximum: 16G)
-root_disk_size_loader: 20  # GB, Increase loader disk in order to have extra space for a larger swap
 azure_image_username: 'scyllaadm'
 ami_loader_user: 'ubuntu'
 scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-5.2.list'


### PR DESCRIPTION
Recent reduction of loader disk size caused issue with provision as 20GB is lower than image requires.

Fix by not specifying it at all so image decides on the size.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - provision azure

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
