### PR TITLE
fix(cluster): remove deprecated `system_init` property

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -86,7 +86,6 @@ from sdcm.utils.common import (
     S3Storage,
     ScyllaCQLSession,
     PageFetcher,
-    deprecation,
     get_data_dir_path,
     verify_scylla_repo_file,
     normalize_ipv6_url,
@@ -279,7 +278,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self._db_log_reader_thread = None
         self._scylla_manager_journal_thread = None
         self._decoding_backtraces_thread = None
-        self._init_system = None
         self.db_init_finished = False
 
         self._short_hostname = None
@@ -930,19 +928,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self._spot_monitoring_thread = threading.Thread(
             target=self.spot_monitoring_thread, name='SpotMonitoringThread', daemon=True)
         self._spot_monitoring_thread.start()
-
-    @property
-    def init_system(self):
-        deprecation("consider to use node.distro.uses_systemd property instead")
-        if self._init_system is None:
-            result = self.remoter.run('journalctl --version',
-                                      ignore_status=True)
-            if result.exit_status == 0:
-                self._init_system = 'systemd'
-            else:
-                self._init_system = 'sysvinit'
-
-        return self._init_system
 
     def start_journal_thread(self):
         logs_transport = self.parent_cluster.params.get("logs_transport")
@@ -1699,10 +1684,13 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             elif self.distro.is_sles:
                 self.remoter.sudo("zypper install -y scylla-gdb", verbose=True, ignore_status=True)
 
-        if self.init_system == "systemd":
-            self.fix_scylla_server_systemd_config()
+        self.fix_scylla_server_systemd_config()
 
     def fix_scylla_server_systemd_config(self):
+        if self.is_docker():
+            # we don't have systemd working inside docker
+            return
+
         systemd_version = get_systemd_version(self.remoter.run("systemctl --version", ignore_status=True).stdout)
         if systemd_version >= 240:
             self.log.debug("systemd version %d >= 240: we can change FinalKillSignal", systemd_version)

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -200,11 +200,6 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):  # pylint: disable=abstr
         return self.parent_cluster.source_image
 
     @property
-    def init_system(self):
-        """systemd is not used in Docker"""
-        return "docker"
-
-    @property
     def vm_region(self):
         return "docker"
 

--- a/sdcm/utils/remote_logger.py
+++ b/sdcm/utils/remote_logger.py
@@ -581,7 +581,7 @@ def get_system_logging_thread(logs_transport, node, target_log_file):  # pylint:
     if logs_transport == 'k8s_client':
         return K8sClientLogger(node, target_log_file)
     if logs_transport == 'ssh':
-        if node.init_system == 'systemd':
+        if node.distro.uses_systemd:
             if 'db-node' in node.name and node.is_nonroot_install and node.remoter.run(
                     'sudo test -e /var/log/journal', ignore_status=True).exit_status != 0:
                 return SSHNonRootScyllaSystemdLogger(node, target_log_file)

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -486,10 +486,6 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method,too-many-instance-
     def process_scylla_args(self, append_scylla_args=''):
         pass
 
-    @property
-    def init_system(self):
-        return 'systemd'
-
     def fix_scylla_server_systemd_config(self):
         pass
 


### PR DESCRIPTION
for long we have it inside the `Distro` class, and there's no need for it on the cluster class

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-docker-test/22/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
