### PR TITLE
test(network configuration): add test splitted broadcast and listening addresses

### DIFF
--- a/configurations/network_config/scylla_addresses_on_different_interfaces.yaml
+++ b/configurations/network_config/scylla_addresses_on_different_interfaces.yaml
@@ -1,0 +1,28 @@
+scylla_network_config:
+- address: listen_address  # Address Scylla listens for connections from other nodes. See storage_port and ssl_storage_ports.
+  ip_type: ipv4
+  public: false
+  listen_all: false
+  use_dns: false
+  nic: 0
+- address: rpc_address  # Address on which Scylla is going to expect Thrift and CQL client connections.
+  ip_type: ipv4
+  public: false
+  listen_all: false
+  use_dns: false
+  nic: 1
+- address: broadcast_rpc_address  # Address that is broadcasted to tell the clients to connect to. Related to rpc_address.
+  ip_type: ipv4
+  public: false  # Should be False when multiple interfaces
+  use_dns: false
+  nic: 1
+- address: broadcast_address  # Address that is broadcasted to tell other Scylla nodes to connect to. Related to listen_address above.
+  ip_type: ipv4
+  public: false  # Should be False when multiple interfaces
+  use_dns: false
+  nic: 0  #  If ipv4 and public is True it has to be primary network interface (device index is 0)
+- address: test_communication  # Type of IP used to connect from test to DB/monitor instances
+  ip_type: ipv4
+  public: false
+  use_dns: false
+  nic: 0  #  If ipv4 and public is True it has to be primary network interface (device index is 0)

--- a/jenkins-pipelines/oss/longevity/longevity-100gb-splitted-networks-4h.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-100gb-splitted-networks-4h.jenkinsfile
@@ -6,8 +6,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
+    availability_zone: 'c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-parallel-schema-changes-12h.yaml", "configurations/network_config/scylla_addresses_on_different_interfaces.yaml"]''',
-
-    timeout: [time: 820, unit: 'MINUTES']
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/network_config/scylla_addresses_on_different_interfaces.yaml"]''',
+    instance_provision_fallback_on_demand: true
 )

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2780,8 +2780,8 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
                       auth_params=auth_params, use_keyspace=use_keyspace, timeout=timeout,
                       connect_timeout=connect_timeout, ssl_params=ssl_params)
 
+        # cqlsh uses rpc_address/broadcast_rps_address.
         host = '' if self.is_docker() else self.cql_address
-        # host = '' if self.is_docker() else self.scylla_listen_address
         # escape double quotes, that might be on keyspace/tables names
         command = '"{}"'.format(command.strip().replace('"', '\\"'))
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2780,7 +2780,8 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
                       auth_params=auth_params, use_keyspace=use_keyspace, timeout=timeout,
                       connect_timeout=connect_timeout, ssl_params=ssl_params)
 
-        host = '' if self.is_docker() else self.scylla_listen_address
+        host = '' if self.is_docker() else self.cql_address
+        # host = '' if self.is_docker() else self.scylla_listen_address
         # escape double quotes, that might be on keyspace/tables names
         command = '"{}"'.format(command.strip().replace('"', '\\"'))
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1348,7 +1348,9 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
     def is_manager_agent_up(self, port=None):
         port = port if port else self.MANAGER_AGENT_PORT
         # When the agent is IP, it should answer an https request of https://NODE_IP:10001/ping with status code 204
-        response = requests.get(f"https://{normalize_ipv6_url(self.cql_address)}:{port}/ping", verify=False)
+        # Scylla Manager Agent uses Scylla listen/broadcast address - https://manager.docs.scylladb.com/stable/config/
+        # scylla-manager-agent-config.html#:~:text=value.%0A%23auth_token%3A-,%23%20Bind%20REST%20API%20to,-the%20specified%20TCP
+        response = requests.get(f"https://{normalize_ipv6_url(self.scylla_listen_address)}:{port}/ping", verify=False)
         return response.status_code == 204
 
     def wait_manager_agent_up(self, verbose=True, timeout=180):

--- a/test-cases/longevity/longevity-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-100gb-4h.yaml
@@ -6,8 +6,8 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=240m -schema 'replicatio
              "cassandra-stress read  cl=QUORUM duration=240m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
              ]
 
-n_db_nodes: 3
-n_loaders: 1
+n_db_nodes: 6
+n_loaders: 2
 n_monitor_nodes: 1
 seeds_num: 3
 

--- a/test-cases/longevity/longevity-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-100gb-4h.yaml
@@ -6,8 +6,8 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=240m -schema 'replicatio
              "cassandra-stress read  cl=QUORUM duration=240m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
              ]
 
-n_db_nodes: 6
-n_loaders: 2
+n_db_nodes: 3
+n_loaders: 1
 n_monitor_nodes: 1
 seeds_num: 3
 


### PR DESCRIPTION
1. Add new network configuration based on the customer network configuration as described in the issue https://github.com/scylladb/scylla-manager/issues/3411.
 2. Add longevity test 100g 4 hours test using new configuration
 3. Use listen address instead rpc for manager agent
 4. Use rpc address instead listen for cqlsh


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-100gb-splitted-networks-4h](https://argus.scylladb.com/test/3df6777a-795c-4ffe-827b-9b4c75793390/runs?additionalRuns[]=1c881c11-b99a-4b6b-a1f6-4db3f5068876) - with Scylla latest master
- [x] [longevity-100gb-splitted-networks-4h](https://argus.scylladb.com/test/3df6777a-795c-4ffe-827b-9b4c75793390/runs?additionalRuns[]=36157e4c-839c-495d-9196-6126811647d3) - with Scylla `2023.1.0`, manager version `3.1`
- [x] [longevity-200gb-48h-network-monkey-test](https://argus.scylladb.com/test/2c68c0a8-c176-4dde-9e12-a695dc06e2f7/runs?additionalRuns[]=eb8be2aa-4868-4e58-a612-036d6ad19d1d)
- [x] [longevity-100gb-4h (one-interface)](https://argus.scylladb.com/test/a2b4b1af-a5c3-43a6-965f-c0ae9500370c/runs?additionalRuns[]=464df96c-a2d5-40ec-bd5f-d9094ac3d36b)
- [x] [longevity-10gb-3h-ipv6-test](https://argus.scylladb.com/test/f4a292e9-e796-4467-91c2-2c2f9a77c96b/runs?additionalRuns[]=f4dd1250-b77c-4f1e-9a01-2f9f24c634c6)
- [ ] [longevity-schema-topology-changes-splitted_networks-12h](https://argus.scylladb.com/test/ed048b23-03ef-4486-a005-3cbac0163c87/runs?additionalRuns[]=11b14811-f8be-4052-88fa-669f283e5a8f)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
