### PR TITLE
fix(group_common_events): filter expected raft_topology error messages

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -298,6 +298,42 @@ def ignore_stream_mutation_fragments_errors():
         yield
 
 
+@contextmanager
+def ignore_raft_topology_cmd_failing():
+    with ExitStack() as stack:
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*raft_topology - raft_topology_cmd failed with: seastar::abort_requested_exception \(abort requested\)",
+            extra_time_to_expiration=30
+        ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*raft_topology - raft_topology_cmd failed with: raft::request_aborted \(Request is aborted by a caller\)",
+            extra_time_to_expiration=30
+        ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*raft_topology - send_raft_topology_cmd\(stream_ranges\) failed with exception \(node state is decommissioning\)",
+            extra_time_to_expiration=30
+        ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*raft_topology - send_raft_topology_cmd\(stream_ranges\) failed with exception \(node state is rebuilding\)",
+            extra_time_to_expiration=30
+        ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*raft_topology - send_raft_topology_cmd\(stream_ranges\) failed with exception \(node state is replacing\)",
+            extra_time_to_expiration=30
+        ))
+        yield
+
+
 def decorate_with_context(context_list: list[Callable | ContextManager] | Callable | ContextManager):
     """
     helper to decorate a function to run with a list of callables that return context managers


### PR DESCRIPTION
Raft topology features bring new error messages, which could appear in logs when any topology operation aborted/failed.
Add common_group_events context manager which will Change event severity of expected error log messages from error to warning when topology operations is failed 

Fixes: #7426, #7425

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [JOb #18](https://argus.scylladb.com/test/3a2ae2f0-dc08-409e-85ba-b28f7ccc456f/runs?additionalRuns[]=08cea091-d408-413c-8f68-796ec271a599) - job failed due to spot termination, but events have changed sererites
- [Job #17](https://argus.scylladb.com/test/3a2ae2f0-dc08-409e-85ba-b28f7ccc456f/runs?additionalRuns[]=3ba35b53-e896-46ca-9c7a-63b756a03a52) - Job is passed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
