### PR TITLE
improvement(sct.py): Add junit argus client call

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1161,8 +1161,7 @@ def run_pytest(target, backend, config, logdir):
         sys.exit(1)
     return_code = pytest.main(['-s', '-v', f'--junit-xml={junit_file}', '-p', 'no:warnings', target])
     test_config = get_test_config()
-    # temp, until we'll have API for sending it
-    test_config.argus_client().submit_sct_logs([LogLink(log_name=junit_file.name, log_link=str(junit_file))])
+    test_config.argus_client().sct_submit_junit_report(file_name=junit_file.name, raw_content=junit_file.read_text())
     sys.exit(return_code)
 
 


### PR DESCRIPTION
This change updates the Junit collect stage to submit the resulting xml
file to argus, allowing Argus to store JUnit results

Fixes #7252

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Jenkins](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/functional-k8s-local-kind-aws-junit-test-test/2)
- [x] [Argus](https://argus.scylladb.com/test/afbd4be7-a69c-4b1c-bb04-3aaba5e99771/runs?additionalRuns[]=6a12936c-4da7-45fc-83d0-41500e964093)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
