### PR TITLE
fix(manager): update debian10 image used in tests

### DIFF
--- a/configurations/manager/debian10.yaml
+++ b/configurations/manager/debian10.yaml
@@ -1,4 +1,4 @@
-ami_id_monitor: 'ami-074f8bbb689b1c1a0'  # Debian buster image - debian-10-amd64-20230601-1398, region - us-east-1
+ami_id_monitor: 'ami-0d164bbd0c3b2cbd5'  # Debian buster image - debian-10-amd64-20240430-1733, region - us-east-1
 ami_monitor_user: 'admin'
 monitor_branch: 'branch-4.6'  # Pass it as debian image is not the formal monitor image
 


### PR DESCRIPTION
Closed https://github.com/scylladb/scylla-cluster-tests/issues/7453

The currently used image is outdated and has some issues with apt repos (details https://github.com/scylladb/scylla-cluster-tests/issues/7453). So, this change replaces this image with a more recent one `debian-10-amd64-20240430-1733`.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Jenkins job https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/sct/job/manager-master/job/installation-tests/job/debian10-installation/5/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)