### PR TITLE
test(manager): introduce Manager installation test on different OS

### DIFF
--- a/jenkins-pipelines/manager/debian10-manager-install.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-install.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    region: 'us-east-1',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_installed_and_functional',
+    test_config: '''["test-cases/manager/manager-installation-set-distro.yaml", "configurations/manager/debian10.yaml"]''',
+
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+)

--- a/jenkins-pipelines/manager/debian11-manager-install.jenkinsfile
+++ b/jenkins-pipelines/manager/debian11-manager-install.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    region: 'us-east-1',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_installed_and_functional',
+    test_config: '''["test-cases/manager/manager-installation-set-distro.yaml", "configurations/manager/debian11.yaml"]''',
+
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+)

--- a/jenkins-pipelines/manager/ubuntu20-manager-install.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-install.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    region: 'us-east-1',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_installed_and_functional',
+    test_config: '''["test-cases/manager/manager-installation-set-distro.yaml", "configurations/manager/ubuntu20.yaml"]''',
+
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+)

--- a/jenkins-pipelines/manager/ubuntu22-manager-install.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-install.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    region: 'us-east-1',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_installed_and_functional',
+    test_config: 'test-cases/manager/manager-installation-set-distro.yaml',
+
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+)

--- a/test-cases/manager/manager-installation-set-distro.yaml
+++ b/test-cases/manager/manager-installation-set-distro.yaml
@@ -1,0 +1,9 @@
+test_duration: 60
+
+instance_type_db: 'i4i.large'
+
+n_db_nodes: 1
+n_loaders: 0
+n_monitor_nodes: 1
+
+user_prefix: manager-installation


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-manager/issues/3852

The test is designed for execution on non-main OS distributions (for example, debian10) where the main goal is to execute installation test and verify manager + agent are up and running.

The motivation of having such a test:
- We have never faced OS-specific failures in backup/restore/repair functionality. Thus, there is no need to run the sanity test (which includes these functionality verification) against non-main operation systems;
- Installation test takes only 20 minutes in average against ~2 hours for Manager sanity test;
- The Manager sanity is still here and will be executed on the main OS - Ubuntu 22.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] The folder with Manager installation jobs (https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/sct/job/manager-master/job/installation-tests/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
