### PR TITLE
fix(cluster): ipv6 address in network_interfaces object

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2744,7 +2744,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         for row in cql_results:
             peer = row.peer
             try:
-                ipaddress.ip_address(row.peer)
+                # make sure we use ipv6 long format (some tools remove leading zeros)
+                peer = ipaddress.ip_address(row.peer).exploded
             except ValueError as exc:
                 current_err = f"Peer '{peer}' is not an IP address, err: {exc}\n"
                 LOGGER.warning(current_err)
@@ -2776,7 +2777,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             if line.startswith('SCHEMA:'):
                 schema = line.replace('SCHEMA:', '')
             elif line.startswith('RPC_ADDRESS:'):
-                ip = line.replace('RPC_ADDRESS:', '')
+                # make sure we use ipv6 long format (some tools remove leading zeros)
+                ip = ipaddress.ip_address(line.replace('RPC_ADDRESS:', '')).exploded
             elif line.startswith('STATUS:'):
                 status = line.replace('STATUS:', '').split(',')[0]
             elif line.startswith('DC:'):

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -12,7 +12,7 @@
 # Copyright (c) 2020 ScyllaDB
 
 # pylint: disable=too-many-lines, too-many-public-methods
-
+import ipaddress
 import json
 import logging
 import os
@@ -460,7 +460,9 @@ class AWSNode(cluster.BaseNode):
         for interface in self._instance.network_interfaces:
             private_ip_addresses = [private_address["PrivateIpAddress"]
                                     for private_address in interface.private_ip_addresses]
-            ipv6_addresses = [ipv6_address['Ipv6Address'] for ipv6_address in interface.ipv6_addresses]
+            # make sure we use ipv6 long format (some tools remove leading zeros)
+            ipv6_addresses = [ipaddress.ip_address(
+                ipv6_address['Ipv6Address']).exploded for ipv6_address in interface.ipv6_addresses]
             device_indexes.append(interface.attachment['DeviceIndex'])
             ipv4_public_address = interface.association_attribute['PublicIp'] if interface.association_attribute else None
             dns_public_name = interface.association_attribute['PublicDnsName'] if interface.association_attribute else None


### PR DESCRIPTION
The problem was found during IPv6 test.
IPv6 was converted to full format when parse nodetool status result. This change was represented by  https://github.com/scylladb/scylla-cluster-tests/pull/7047

But IPv6 address was not converted when collected info about nodes network interfaces (AWS).

During checking nodes status, we compare between 'nodetool status' output and node address that kept in the network_interfaces object. It fails because the IPv6 address miss leading zeros. As result the test fails with errors 'Failed to find a node in cluster by IP'

Also fix the same problem for peer and gossip output.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/7447

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-10gb-3h-ipv6-test](https://argus.scylladb.com/test/f4a292e9-e796-4467-91c2-2c2f9a77c96b/runs?additionalRuns[]=b05b2283-2dd3-4542-b631-e682064a1ef5) - IPv6 test
- [x] [longevity-100gb-4h](https://argus.scylladb.com/test/a2b4b1af-a5c3-43a6-965f-c0ae9500370c/runs?additionalRuns[]=73db56bd-e3a4-49e7-86d1-a11da908b917) - IPv4 test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
