### PR TITLE
feature(artifacts-tests): add support for ubuntu 24.04

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -161,8 +161,10 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
         #     "scylla-housekeeping-restart.service: Succeeded" - ubuntu, centos
         #     "RUNNING" - docker
         #     "Started Scylla Housekeeping restart mode" - other
+        #     "Started scylla-housekeeping-restart.service - Scylla Housekeeping restart mode" - ubuntu24
         if "scylla-housekeeping-restart.service: Succeeded" in status or \
                 "Started Scylla Housekeeping restart mode" in status or \
+                "Started scylla-housekeeping-restart.service - Scylla Housekeeping restart mode" in status or \
                 "RUNNING" in status:
             ScyllaHousekeepingServiceEvent(message="scylla-housekeeping-restart service running",
                                            severity=Severity.NORMAL).publish()

--- a/configurations/arm/ubuntu2404.yaml
+++ b/configurations/arm/ubuntu2404.yaml
@@ -1,0 +1,9 @@
+ami_db_scylla_user: 'ubuntu'
+ami_id_db_scylla: 'resolve:ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/arm64/hvm/ebs-gp3/ami-id'
+instance_type_db: 'im4gn.xlarge'
+use_preinstalled_scylla: false
+# enhanced network isn't supported
+append_scylla_setup_args: ' --no-ec2-check '
+# use_mgmt: false
+
+user_credentials_path: '~/.ssh/scylla-qa-ec2'

--- a/defaults/manager_versions.yaml
+++ b/defaults/manager_versions.yaml
@@ -6,6 +6,7 @@ manager_repos_by_version:
     debian11: 'https://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
     ubuntu20: 'https://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
     ubuntu22: 'https://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
+    ubuntu24: 'https://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
   "3.2":
     centos7: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.2.repo'
     centos8: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.2.repo'
@@ -13,6 +14,7 @@ manager_repos_by_version:
     debian11: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/debian/scylladb-manager-3.2.list'
     ubuntu20: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.2.list'
     ubuntu22: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.2.list'
+    ubuntu24: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.2.list'
   "3.1":
     centos7: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.1.repo'
     centos8: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.1.repo'
@@ -20,6 +22,7 @@ manager_repos_by_version:
     debian11: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/debian/scylladb-manager-3.1.list'
     ubuntu20: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.1.list'
     ubuntu22: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.1.list'
+    ubuntu24: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.1.list'
   "3.0":
     centos7: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.0.repo'
     centos8: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.0.repo'
@@ -27,6 +30,7 @@ manager_repos_by_version:
     debian11: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/debian/scylladb-manager-3.0.list'
     ubuntu20: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.0-focal.list'
     ubuntu22: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.0-focal.list'
+    ubuntu24: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.0-focal.list'
 
 scylla_backend_repo_by_version:
   "2022":

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2404-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2404-arm.jenkinsfile
@@ -1,0 +1,14 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: '''["test-cases/artifacts/ubuntu2404.yaml", "configurations/arm/ubuntu2404.yaml"]''',
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'spot_low_price',
+
+    timeout: [time: 35, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2404-nonroot.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2404-nonroot.jenkinsfile
@@ -1,0 +1,15 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/ubuntu2204.yaml',
+    backend: 'gce',
+    nonroot_offline_install: true,
+    provision_type: 'spot',
+    manager_version: '',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2404.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2404.jenkinsfile
@@ -1,0 +1,13 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/ubuntu2404.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+
+    timeout: [time: 35, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts/artifacts-ubuntu2404-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-ubuntu2404-arm.jenkinsfile
@@ -1,0 +1,14 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: '''["test-cases/artifacts/ubuntu2404.yaml", "configurations/arm/ubuntu2404.yaml"]''',
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'spot_low_price',
+
+    timeout: [time: 35, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts/artifacts-ubuntu2404.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-ubuntu2404.jenkinsfile
@@ -1,0 +1,13 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/ubuntu2404.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+
+    timeout: [time: 35, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -25,6 +25,7 @@ def get_distro_name(distro_object):
         Distro.DEBIAN11: "debian11",
         Distro.UBUNTU20: "ubuntu20",
         Distro.UBUNTU22: "ubuntu22",
+        Distro.UBUNTU24: "ubuntu24",
         Distro.OEL7: "centos7",
         Distro.OEL8: "centos8",
         Distro.ROCKY8: "centos8",

--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -91,17 +91,17 @@ def configure_sshd_script():
 def configure_ssh_accept_rsa():
     return dedent("""
     if (( $(ssh -V 2>&1 | tr -d "[:alpha:][:blank:][:punct:]" | cut -c-2) >= 88 )); then
-        systemctl stop sshd || true
+        systemctl stop sshd || systemctl stop ssh || true
         sed -i "s/#PubkeyAuthentication \(.*\)$/PubkeyAuthentication yes/" /etc/ssh/sshd_config || true
         sed -i -e "\\$aPubkeyAcceptedAlgorithms +ssh-rsa" /etc/ssh/sshd_config || true
         sed -i -e "\\$aHostKeyAlgorithms +ssh-rsa" /etc/ssh/sshd_config || true
-        systemctl restart sshd || true
+        systemctl restart sshd || systemctl restart ssh || true
     fi
     """)
 
 
 def restart_sshd_service():
-    return "systemctl restart sshd || true\n"
+    return "systemctl restart sshd || systemctl restart ssh || true\n"
 
 
 def restart_syslogng_service():

--- a/sdcm/utils/distro.py
+++ b/sdcm/utils/distro.py
@@ -38,7 +38,7 @@ KNOWN_OS = (
     ("AMAZON", "amzn", ["2"], DistroBase.RHEL),
     ("ROCKY", "rocky", ["8", "9"], DistroBase.RHEL),
     ("DEBIAN", "debian", ["10", "11"], DistroBase.DEBIAN),
-    ("UBUNTU", "ubuntu", ["20.04", "21.04", "21.10", "22.04"], DistroBase.DEBIAN),
+    ("UBUNTU", "ubuntu", ["20.04", "21.04", "21.10", "22.04", "24.04"], DistroBase.DEBIAN),
     ("SLES", "sles", ["15"], DistroBase.UNKNOWN),
     ("FEDORA", "fedora", ["34", "35", "36"], DistroBase.RHEL),
     ("MINT", "linuxmint", ["20", "21"], DistroBase.DEBIAN),

--- a/test-cases/artifacts/ubuntu2404.yaml
+++ b/test-cases/artifacts/ubuntu2404.yaml
@@ -1,0 +1,21 @@
+backtrace_decoding: false
+cluster_backend: 'gce'
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64'
+gce_instance_type_db: 'n1-standard-2'
+gce_root_disk_type_db: 'pd-ssd'
+root_disk_size_db: 50
+gce_n_local_ssd_disk_db: 1
+instance_provision: "spot"
+instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
+n_db_nodes: 1
+n_loaders: 0
+n_monitor_nodes: 0
+nemesis_class_name: 'NoOpMonkey'
+scylla_linux_distro: 'ubuntu-noble'
+test_duration: 60
+user_prefix: 'artifacts-ubuntu2404'
+use_preinstalled_scylla: false
+aws_fallback_to_next_availability_zone: true
+
+user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -955,6 +955,16 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                           {'address': 'broadcast_address', 'ip_type': 'ipv4', 'public': False, 'use_dns': False, 'nic': 0},
                           {'address': 'test_communication', 'ip_type': 'ipv4', 'public': False, 'use_dns': False, 'nic': 0}])
 
+    @pytest.mark.integration
+    def test_32_resolve_aws_ssm_links(self):
+        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'resolve:ssm:/aws/service/debian/release/11/latest/amd64'
+
+        conf = sct_config.SCTConfiguration()
+        conf.verify_configuration()
+
+        assert conf["ami_id_db_scylla"].startswith('ami-')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
as part of an effort to start supporting using ubuntu 24.04 as the basis for scylla images, we are introducing a new artifact tests to cover it

Closes: scylladb/scylla-cluster-tests#7410

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] run local from dev machine
- [x] x86: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2404-test/2/
- [x] arm: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2404-arm-test/5/
- [x] offline installer: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2404-test/6/
- [x] offline installer non-root: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2404-test/5/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
