### PR TITLE
improvement(speed-up): move syslogng-exporter install to cloud-init

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -56,7 +56,7 @@ from cassandra.policies import RetryPolicy
 from cassandra.policies import WhiteListRoundRobinPolicy, HostFilterPolicy, RoundRobinPolicy
 from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
 from argus.backend.util.enums import ResourceState
-from sdcm.node_exporter_setup import NodeExporterSetup, SyslogNgExporterSetup
+from sdcm.node_exporter_setup import NodeExporterSetup
 from sdcm.db_log_reader import DbLogReader
 from sdcm.mgmt import AnyManagerCluster, ScyllaManagerError
 from sdcm.mgmt.common import get_manager_repo_from_defaults, get_manager_scylla_backend
@@ -4596,8 +4596,6 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             return
 
         node.disable_daily_triggered_services()
-        if self.params.get('logs_transport') == 'syslog-ng':
-            SyslogNgExporterSetup().install(node)
 
         nic_devname = node.get_nic_devices()[0]
         if install_scylla:

--- a/sdcm/node_exporter_setup.py
+++ b/sdcm/node_exporter_setup.py
@@ -9,13 +9,12 @@ class NodeExporterSetup:  # pylint: disable=too-few-public-methods
     def install(node: "BaseNode | None" = None, remoter: "Remoter | None" = None):
         assert node or remoter, "node or remoter much be pass to this function"
         if node:
-            node.install_package('wget')
             remoter = node.remoter
         remoter.sudo(shell_script_cmd(f"""
             if ! id node_exporter > /dev/null 2>&1; then
                 useradd -rs /bin/false node_exporter
             fi
-            wget https://github.com/prometheus/node_exporter/releases/download/v{NODE_EXPORTER_VERSION}/node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
+            curl -L -O https://github.com/prometheus/node_exporter/releases/download/v{NODE_EXPORTER_VERSION}/node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
             tar -xzvf node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
             mv node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64/node_exporter /usr/local/bin
 
@@ -41,43 +40,4 @@ class NodeExporterSetup:  # pylint: disable=too-few-public-methods
             systemctl daemon-reload
             systemctl enable node_exporter.service
             systemctl start node_exporter.service
-        """))
-
-
-class SyslogNgExporterSetup:  # pylint: disable=too-few-public-methods
-    @staticmethod
-    def install(node: "BaseNode | None" = None, remoter: "Remoter | None" = None):
-        assert node or remoter, "node or remoter much be pass to this function"
-        if node:
-            node.install_package('wget')
-            remoter = node.remoter
-        remoter.sudo(shell_script_cmd("""
-            wget https://github.com/brandond/syslog_ng_exporter/releases/download/0.1.0/syslog_ng_exporter
-            chmod +x syslog_ng_exporter
-            mv syslog_ng_exporter /usr/local/bin
-
-            if [ -e /etc/systemd/system/syslog_ng_exporter.service ]; then
-                rm /etc/systemd/system/syslog_ng_exporter.service
-            fi
-
-            cat <<EOM >> /etc/systemd/system/syslog_ng_exporter.service
-            [Unit]
-            Description=Syslog-ng metrics Exporter
-            Wants=network.target network-online.target
-            After=network.target network-online.target
-
-            [Service]
-            Type=simple
-            ExecStart=/usr/local/bin/syslog_ng_exporter
-            StandardOutput=journal
-            StandardError=journal
-            Restart=on-failure
-
-            [Install]
-            WantedBy=multi-user.target
-            EOM
-
-            systemctl daemon-reload
-            systemctl enable syslog_ng_exporter.service
-            systemctl start syslog_ng_exporter.service
         """))

--- a/sdcm/provision/common/configuration_script.py
+++ b/sdcm/provision/common/configuration_script.py
@@ -20,7 +20,9 @@ from sdcm.provision.common.utils import (
     install_syslogng_service,
     configure_syslogng_target_script,
     restart_syslogng_service,
-    configure_ssh_accept_rsa)
+    configure_ssh_accept_rsa,
+    install_syslogng_exporter,
+)
 from sdcm.provision.user_data import CLOUD_INIT_SCRIPTS_PATH
 
 SYSLOGNG_SSH_TUNNEL_LOCAL_PORT = 5000
@@ -86,6 +88,7 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
                 hostname=self.hostname,
             )
             script += restart_syslogng_service()
+            script += install_syslogng_exporter()
 
         if self.configure_sshd:
             script += configure_sshd_script()

--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -162,3 +162,36 @@ def install_syslogng_service():
             echo "Unsupported distro"
         fi
     """)
+
+
+def install_syslogng_exporter():
+    return dedent("""\
+    curl -L -O https://github.com/brandond/syslog_ng_exporter/releases/download/0.1.0/syslog_ng_exporter
+    chmod +x syslog_ng_exporter
+    mv syslog_ng_exporter /usr/local/bin
+
+    if [ -e /etc/systemd/system/syslog_ng_exporter.service ]; then
+        rm /etc/systemd/system/syslog_ng_exporter.service
+    fi
+
+    cat <<EOM >> /etc/systemd/system/syslog_ng_exporter.service
+    [Unit]
+    Description=Syslog-ng metrics Exporter
+    Wants=network.target network-online.target
+    After=network.target network-online.target
+
+    [Service]
+    Type=simple
+    ExecStart=/usr/local/bin/syslog_ng_exporter
+    StandardOutput=journal
+    StandardError=journal
+    Restart=on-failure
+
+    [Install]
+    WantedBy=multi-user.target
+    EOM
+
+    systemctl daemon-reload
+    systemctl enable syslog_ng_exporter.service
+    systemctl start syslog_ng_exporter.service
+""")

--- a/sdcm/sct_provision/region_definition_builder.py
+++ b/sdcm/sct_provision/region_definition_builder.py
@@ -23,7 +23,7 @@ from sdcm.sct_provision.common.types import NodeTypeType
 from sdcm.sct_provision.user_data_objects import SctUserDataObject
 from sdcm.sct_provision.user_data_objects.scylla import ScyllaUserDataObject
 from sdcm.sct_provision.user_data_objects.sshd import SshdUserDataObject
-from sdcm.sct_provision.user_data_objects.syslog_ng import SyslogNgUserDataObject
+from sdcm.sct_provision.user_data_objects.syslog_ng import SyslogNgUserDataObject, SyslogNgExporterUserDataObject
 from sdcm.test_config import TestConfig
 
 
@@ -139,6 +139,7 @@ class DefinitionBuilder(abc.ABC):
     def _get_user_data_objects(self, instance_name: str, node_type: NodeTypeType) -> List[SctUserDataObject]:
         user_data_object_classes: List[Type[SctUserDataObject]] = [
             SyslogNgUserDataObject,
+            SyslogNgExporterUserDataObject,
             SshdUserDataObject,
             ScyllaUserDataObject,
         ]

--- a/sdcm/sct_provision/user_data_objects/syslog_ng.py
+++ b/sdcm/sct_provision/user_data_objects/syslog_ng.py
@@ -13,7 +13,7 @@
 from dataclasses import dataclass
 
 from sdcm.provision.common.configuration_script import SYSLOGNG_LOG_THROTTLE_PER_SECOND
-from sdcm.provision.common.utils import configure_syslogng_target_script, restart_syslogng_service
+from sdcm.provision.common.utils import configure_syslogng_target_script, restart_syslogng_service, install_syslogng_exporter
 from sdcm.sct_provision.user_data_objects import SctUserDataObject
 
 
@@ -37,3 +37,15 @@ class SyslogNgUserDataObject(SctUserDataObject):
                                                   hostname=self.instance_name)
         script += restart_syslogng_service()
         return script
+
+
+@dataclass
+class SyslogNgExporterUserDataObject(SctUserDataObject):
+
+    @property
+    def is_applicable(self) -> bool:
+        return self.params.get('logs_transport') == 'syslog-ng'
+
+    @property
+    def script_to_run(self) -> str:
+        return install_syslogng_exporter()


### PR DESCRIPTION
It should be faster to install syslogng-exporter during cloud-init. Replaced wget with curl to skip wget installation.

closes: https://github.com/scylladb/qa-tasks/issues/1694

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - provision tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
