### PR TITLE
fix(offline ubuntu24.04) skip python2 installation

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2005,7 +2005,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if not nonroot:
             self.install_package(package_name='xfsprogs mdadm')
 
-        if not self.distro.is_rocky9:  # centos/rocky 9 and above don't have python2 anymore
+        if not self.distro.is_rocky9 and not self.distro.is_ubuntu24:  # centos/rocky9/ubuntu24.04 and above don't have python2 anymore
             self.install_package(package_name='python2')
         # Offline install does't provide openjdk-11, it has to be installed in advance
         # https://github.com/scylladb/scylla-jmx/issues/127


### PR DESCRIPTION
failed in https://jenkins.scylladb.com/job/scylla-master/job/releng-testing/job/artifacts-offline-install/job/artifacts-ubuntu2404-test/3 with the following error:
```
11:07:40  Command: 'sudo DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" install -y python2'
```

Since in ubuntu24.04 we don't have python2 package we should skip it