### PR TITLE
fix(managerPipeline): add provision stage to pipeline

### DIFF
--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -214,6 +214,32 @@ def call(Map pipelineParams) {
                     }
                 }
             }
+            stage('Provision Resources') {
+                steps {
+                    catchError() {
+                        script {
+                            wrap([$class: 'BuildUser']) {
+                                dir('scylla-cluster-tests') {
+                                    timeout(time: 30, unit: 'MINUTES') {
+                                        if (params.backend == 'aws' || params.backend == 'azure') {
+                                            provisionResources(params, builder.region)
+                                        } else if (params.backend.contains('docker')) {
+                                            sh """
+                                                echo 'Tests are to be executed on Docker backend in SCT-Runner. No additional resources to be provisioned.'
+                                            """
+                                        } else {
+                                            sh """
+                                                echo 'Skipping because non-AWS/Azure backends are not supported'
+                                            """
+                                        }
+                                        completed_stages['provision_resources'] = true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             stage('Run SCT Test') {
                 steps {
                     catchError(stageResult: 'FAILURE') {
@@ -309,6 +335,7 @@ def call(Map pipelineParams) {
                                         fi
                                         echo "end test ....."
                                         """
+                                        completed_stages['run_tests'] = true
                                     }
                                 }
                             }
@@ -359,6 +386,7 @@ def call(Map pipelineParams) {
                                 dir('scylla-cluster-tests') {
                                     timeout(time: collectLogsTimeout, unit: 'MINUTES') {
                                         runCollectLogs(params, builder.region)
+                                        completed_stages['collect_logs'] = true
                                     }
                                 }
                             }
@@ -406,6 +434,7 @@ def call(Map pipelineParams) {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {
                                     cleanSctRunners(params, currentBuild)
+                                    completed_stages['clean_sct_runner'] = true
                                 }
                             }
                         }
@@ -432,13 +461,19 @@ def call(Map pipelineParams) {
         post {
             always {
                 script {
+                    def provision_resources = completed_stages['provision_resources']
+                    def run_tests = completed_stages['run_tests']
                     def collect_logs = completed_stages['collect_logs']
                     def clean_resources = completed_stages['clean_resources']
                     def send_email = completed_stages['send_email']
+                    def clean_sct_runner = completed_stages['clean_sct_runner']
                     sh """
-                        echo "$collect_logs"
-                        echo "$clean_resources"
-                        echo "$send_email"
+                        echo "'provision_resources' stage is completed: $provision_resources"
+                        echo "'run_tests' stage is completed: $run_tests"
+                        echo "'collect_logs' stage is completed: $collect_logs"
+                        echo "'clean_resources' stage is completed: $clean_resources"
+                        echo "'send_email' stage is completed: $send_email"
+                        echo "'clean_sct_runner' stage is completed: $clean_sct_runner"
                     """
                     if (!completed_stages['clean_resources']) {
                         catchError {


### PR DESCRIPTION
for long time we are having this stage for most of the SCT pipelines, and manager is missing that, it could speed things up for how long the test would be taking.

also it would walk the same code paths as other test, and hopfully avoid unique issues to the manager jobs

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/manager-ubuntu20-sanity-test/4/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
