### PR TITLE
test(longevity): change 50gb test to be run with 2 interfaces

### DIFF
--- a/jenkins-pipelines/oss/tier1/longevity-50gb-3days.jenkinsfile
+++ b/jenkins-pipelines/oss/tier1/longevity-50gb-3days.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml'
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/network_config/two_interfaces.yaml"]'''
 
 )

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -593,9 +593,7 @@ class AWSNode(cluster.BaseNode):
 
     @cached_property
     def private_dns_name(self) -> str:
-        result = self.remoter.run(
-            'curl http://169.254.169.254/latest/meta-data/local-hostname', verbose=False)
-        return result.stdout.strip()
+        return self.scylla_network_configuration.dns_private_name
 
     def _get_ipv6_ip_address(self) -> Optional[str]:
         return self.scylla_network_configuration.interface_ipv6_address

--- a/sdcm/provision/network_configuration.py
+++ b/sdcm/provision/network_configuration.py
@@ -51,6 +51,16 @@ class ScyllaNetworkConfiguration:
         return self.listen_address
 
     @property
+    def dns_private_name(self):
+        if broadcast_address_config := [conf for conf in self.scylla_network_config if conf["address"] == "broadcast_address"]:
+            if not (interface := [conf for conf in self.network_interfaces if broadcast_address_config[0]["nic"] == conf.device_index]):
+                raise NetworkInterfaceNotFound(f"Not found network interface with device_index {broadcast_address_config[0]['nic']}. "
+                                               f"Check 'scylla_network_config' definition in the test configuration")
+            return interface[0].dns_private_name
+
+        return self.network_interfaces[0].dns_private_name
+
+    @property
     def broadcast_address_ip_type(self):
         # If multiple network interface is defined on the node, private address in the `nodetool status` is IP that defined in
         # broadcast_address. Keep this output in correlation with `nodetool status`


### PR DESCRIPTION
2 commits:
1. Change 'longevity-50gb-3days' to be run with 2 intefaces:
- Scylla addresses on one interface
- runner on another interface

2. set private_dns_name of right network inteface
    
    Set private_dns_name of correct inteface according to test network
    configuration.
    The issue is in test with 2 NICs and 'use_dns_names' is True.
    
    In this case seed IP in scylla.yaml should be private host name of second
    NIC (according to broadcast_address).
    
    When instance is just created, seed is defined as private host name of first
    NIC in the scylla.yaml. It is wrong and Scylla fails to start at first time.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-50gb-two-interfaces-test](https://argus.scylladb.com/test/b08fa1c7-ae96-4a5b-be2d-98db30813a00/runs?additionalRuns[]=271640b3-f1d0-4038-858e-61670ade2fb7)  - Scylla version `5.4`
- [x] [longevity-50gb-two-interfaces-test](https://argus.scylladb.com/test/b08fa1c7-ae96-4a5b-be2d-98db30813a00/runs?additionalRuns[]=79e341fb-e39a-44c3-a1f2-fed656eb2a84) - Scylla version `6.0-dev`, fails with https://github.com/scylladb/scylladb/issues/18647. Cluster created and ran, load started successfully.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
