### PR TITLE
fix(sdcm/sct_config): Submit parsed scylla version to argus

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -69,6 +69,7 @@ SEMVER_REGEX = re.compile(
 )
 
 SCYLLA_VERSION_RE = re.compile(r"\d+(\.\d+)?\.[\d\w]+([.~][\d\w]+)?")
+ARGUS_VERSION_RE = re.compile(r'((?P<short>[\w.~]+)-(0\.)?(?P<date>[0-9]{8,8})\.(?P<commit>\w+).*)')
 SCYLLA_VERSION_GROUPED_RE = re.compile(r'(?P<version>[\w.~]+)-(?P<build>0|rc\d)?\.?(?P<date>[\d]+)\.(?P<commit_id>\w+)')
 SSTABLE_FORMAT_VERSION_REGEX = re.compile(r'Feature (.*)_SSTABLE_FORMAT is enabled')
 PRIMARY_XML_GZ_REGEX = re.compile(r'="(.*?primary.xml.gz)"')

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -25,6 +25,7 @@ from sdcm.utils.version_utils import (
     RepositoryDetails,
     ScyllaFileType,
     SCYLLA_VERSION_GROUPED_RE,
+    ARGUS_VERSION_RE,
     VERSION_NOT_FOUND_ERROR,
 )
 
@@ -398,6 +399,21 @@ def test_scylla_version_grouped_regexp(full_version, version, date, commit_id):
     assert parsed_version.group("version") == version
     assert parsed_version.group("date") == date
     assert parsed_version.group("commit_id") == commit_id
+
+
+@pytest.mark.parametrize("full_version,short,date,commit_id", (
+    ("5.1.dev-0.20220713.15ed0a441e18", "5.1.dev", "20220713", "15ed0a441e18"),
+    ("5.0.1-20220719.b177dacd3", "5.0.1", "20220719", "b177dacd3"),
+    ("5.0.1-20220719.b177dacd3 with build-id 217f31634f8c8722cadcfe57ade8da58af05d415", "5.0.1", "20220719", "b177dacd3"),
+    ("2022.1~rc5-20220515.6a1e89fbb", "2022.1~rc5", "20220515", "6a1e89fbb"),
+    ("2022.2.dev-20220715.6fd8d82112e1", "2022.2.dev", "20220715", "6fd8d82112e1"),
+    ("4.6.rc2-20220102.e8a1cfb6f", "4.6.rc2", "20220102", "e8a1cfb6f")
+))
+def test_scylla_version_for_argus_regexp(full_version, short, date, commit_id):
+    parsed_version = ARGUS_VERSION_RE.match(full_version)
+    assert parsed_version.group("short") == short
+    assert parsed_version.group("date") == date
+    assert parsed_version.group("commit") == commit_id
 
 
 @pytest.mark.integration


### PR DESCRIPTION
This change fixes an issue where argus would receive full version
unparsed when the job starts - this leads to issues on the dashboard
page where versions have too much granularity - ignoring the new
`build_version` field inside Argus.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Argus](https://argus.scylladb.com/test/b0b22734-758e-47b4-b6ec-29e64d212d52/runs?additionalRuns[]=7015c689-4321-44cf-b719-87d520c82184)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
