### PR TITLE
fix(test_base_version): stop hardcoding the current latest branch

### DIFF
--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+from sdcm.utils.version_utils import ComparableScyllaVersion
+
 from utils.get_supported_scylla_base_versions import UpgradeBaseVersion  # pylint: disable=no-name-in-module, import-error
 
 
@@ -34,7 +36,8 @@ class TestBaseVersion(unittest.TestCase):
         scylla_repo = self.url_base + '/master/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
         linux_distro = 'centos'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(version_list, ['6.0'])
+        assert len(version_list) == 1
+        assert ComparableScyllaVersion(version_list[0]) > '5.4'
 
     def test_ubuntu_22_azure_5_3(self):
         scylla_repo = self.url_base + '/branch-5.3/deb/unified/2023-05-23T22:36:08Z/scylladb-5.3/scylla.list'
@@ -79,7 +82,8 @@ class TestBaseVersion(unittest.TestCase):
         scylla_repo = self.url_base + '-enterprise/enterprise/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
         linux_distro = 'centos'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(version_list, ['2024.1'])
+        assert len(version_list) == 1
+        assert ComparableScyllaVersion(version_list[0]) >= '2024.1'
 
     def test_2021_1(self):
         scylla_repo = self.url_base + '-enterprise/branch-2021.1/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'


### PR DESCRIPTION
since we run into this again and again, on every new release branch created, we shouldn't pin this test to specific one checking it's greater then current known version it enough

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
