### PR TITLE
fix(manager): add -y to utils gce packages installation cmd

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -91,8 +91,9 @@ class BackupFunctionsMixIn(LoaderUtilsMixin):
             cmd = dedent("""
                 echo 'deb https://packages.cloud.google.com/apt cloud-sdk main' | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
                 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-                sudo apt-get update && sudo apt-get install google-cloud-cli
+                sudo apt-get update
             """)
+            node.install_package("google-cloud-cli")
         else:
             raise NotImplementedError("At the moment, we only support debian installation")
         self._run_cmd_with_retry(executor=node.remoter.run, cmd=shell_script_cmd(cmd))


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-manager/issues/3863

Since `google-cloud-cli` started to require additional package to be installed `google-cloud-cli-anthoscli`, the apt install command should come with `-y` option.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/sct/job/sct-feature-test-backup-gce/4/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
