### PR TITLE
feature(jenkins): New jobs with gossip-topology-changes

### DIFF
--- a/configurations/raft/consistent_topology_changes_off.yaml
+++ b/configurations/raft/consistent_topology_changes_off.yaml
@@ -1,0 +1,2 @@
+append_scylla_yaml: |
+  force-gossip-topology-changes: true

--- a/jenkins-pipelines/oss/gossip-topology-changes/longevity-100gb-4h-gossip-topology.jenkinsfile
+++ b/jenkins-pipelines/oss/gossip-topology-changes/longevity-100gb-4h-gossip-topology.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    availability_zone: 'c',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/raft/consistent_topology_changes_off.yaml"]''',
+    instance_provision_fallback_on_demand: true
+)

--- a/jenkins-pipelines/oss/gossip-topology-changes/longevity-150gb-asymmetric-cluster-12h-gce-gossip-topology.jenkinsfile
+++ b/jenkins-pipelines/oss/gossip-topology-changes/longevity-150gb-asymmetric-cluster-12h-gce-gossip-topology.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'gce',
+    region: 'us-east1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml", "configurations/db-nodes-shards-random.yaml", "configurations/raft/consistent_topology_changes_off.yaml"]'''
+)

--- a/jenkins-pipelines/oss/gossip-topology-changes/longevity-cdc-100gb-4h-gossip-topology.jenkinsfile
+++ b/jenkins-pipelines/oss/gossip-topology-changes/longevity-cdc-100gb-4h-gossip-topology.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    availability_zone: 'a,b,c',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-cdc-100gb-4h.yaml", "configurations/raft/consistent_topology_changes_off.yaml"]''',
+
+)


### PR DESCRIPTION
Raft topology changes feature is enabled by default and always run for new and upgraded cluster starting from version 6.0

to run cluster with gossip topology operations, parameter force-gossip-topology-changes: true should be added to scylla.yaml

Created 3 simple jobs as example and for test purposes

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
