### PR TITLE
fix(nodebootstrapabortmanager): always clean scylla data before rebootstrap

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -87,6 +87,7 @@ from sdcm.sct_events.group_common_events import (
     decorate_with_context,
     ignore_reactor_stall_errors,
     ignore_disk_quota_exceeded_errors,
+    ignore_raft_transport_failing,
     decorate_with_context_if_issues_open,
     ignore_take_snapshot_failing,
 )
@@ -133,7 +134,7 @@ from sdcm.utils.tablets.common import wait_for_tablets_balanced
 from sdcm.utils.toppartition_util import NewApiTopPartitionCmd, OldApiTopPartitionCmd
 from sdcm.utils.version_utils import MethodVersionNotFound, scylla_versions
 from sdcm.utils.raft import Group0MembersNotConsistentWithTokenRingMembersException, TopologyOperations
-from sdcm.utils.raft.common import NodeBootstrapAbortManager
+from sdcm.utils.raft.common import NodeBootstrapAbortManager, FailedDecommissionOperationMonitoring
 from sdcm.utils.issues import SkipPerIssues
 from sdcm.wait import wait_for, wait_for_log_lines
 from sdcm.exceptions import (
@@ -5058,7 +5059,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             raise AuditLogTestFailure("\n".join(errors))
 
     def disrupt_bootstrap_streaming_error(self):
-        """Abort bootstrap procces at different point
+        """Abort bootstrap process at different point
 
         During bootstrap new node stream data from token ring
         If bootstrap is aborted, according to Failed topology
@@ -5070,6 +5071,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         If node was not added anyway, clean it from cluster
         and return the cluster to initial state(by num of nodes)
         """
+        self.cluster.wait_all_nodes_un()
+
         new_node: BaseNode = skip_on_capacity_issues(self.cluster.add_nodes)(
             count=1, dc_idx=self.target_node.dc_idx, enable_auto_bootstrap=True, rack=self.target_node.rack)[0]
         self.monitoring_set.reconfigure_scylla_monitoring()
@@ -5080,21 +5083,26 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         bootstrapabortmanager = NodeBootstrapAbortManager(bootstrap_node=new_node, verification_node=self.target_node)
 
-        bootstrapabortmanager.run_bootstrap_and_abort_with_action(terminate_pattern, abort_action=new_node.stop_scylla)
-        bootstrapabortmanager.clean_and_restart_bootstrap_after_abort()
+        with ignore_stream_mutation_fragments_errors(), ignore_raft_topology_cmd_failing(), ignore_raft_transport_failing():
+            bootstrapabortmanager.run_bootstrap_and_abort_with_action(
+                terminate_pattern, abort_action=new_node.stop_scylla)
+            bootstrapabortmanager.clean_and_restart_bootstrap_after_abort()
 
-        if new_node.db_up() and not self.target_node.raft.is_cluster_topology_consistent():
-            LOGGER.error("New host %s was not properly bootstrapped. Terminate it", new_node.name)
-            bootstrapabortmanager.clean_unbootstrapped_node()
-            self.log.info("Failed bootstrapped node %s removed. Cluster is in initial state", new_node.name)
-            raise BootstrapStreamErrorFailure(f"Node {new_node.name} failed to bootstrap")
+            if not new_node.db_up() or (new_node.db_up() and not self.target_node.raft.is_cluster_topology_consistent()):
+                bootstrapabortmanager.clean_unbootstrapped_node()
+                raise BootstrapStreamErrorFailure(f"Node {new_node.name} failed to bootstrap. See log for more details")
 
         if new_node.db_up() and self.target_node.raft.is_cluster_topology_consistent():
             self.log.info("Wait 5 minutes with new topology")
             time.sleep(300)
+            self.log.info("Decommission added node")
+            decommission_timeout = 7200
+            monitoring_decommission_timeout = decommission_timeout + 100
+            un_nodes = self.cluster.get_nodes_up_and_normal()
+            with Nemesis.run_nemesis(node_list=un_nodes, nemesis_label="BootstrapStreaminError") as verification_node, \
+                    FailedDecommissionOperationMonitoring(target_node=new_node, verification_node=verification_node, timeout=monitoring_decommission_timeout):
 
-            self.log.info("Decommission added new node")
-            self.cluster.decommission(new_node, timeout=7200)
+                self.cluster.decommission(new_node, timeout=decommission_timeout)
 
     def disrupt_disable_binary_gossip_execute_major_compaction(self):
         with nodetool_context(node=self.target_node, start_command="disablebinary", end_command="enablebinary"):

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -333,6 +333,54 @@ def ignore_raft_topology_cmd_failing():
             regex=r".*raft_topology - send_raft_topology_cmd\(stream_ranges\) failed with exception \(node state is replacing\)",
             extra_time_to_expiration=30
         ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*raft_topology - send_raft_topology_cmd\(stream_ranges\) failed with exception \(node state is bootstrapping\)",
+            extra_time_to_expiration=30
+        ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*raft_topology - topology change coordinator fiber got error.*connection is closed",
+            extra_time_to_expiration=30
+        ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*raft_topology - topology change coordinator fiber got error.*failed status returned from",
+            extra_time_to_expiration=30
+        ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*raft_topology - raft_topology_cmd.*failed with: service::raft_group_not_found",
+            extra_time_to_expiration=30
+        ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*raft_topology - raft_topology_cmd.*failed with: service::wait_for_ip_timeout",
+            extra_time_to_expiration=30
+        ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*raft_topology - raft_topology_cmd.*failed with:.*abort requested",
+            extra_time_to_expiration=30
+        ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*raft_topology - drain rpc failed, proceed to fence old writes:.*connection is closed",
+            extra_time_to_expiration=30
+        ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*raft_topology - drain rpc failed, proceed to fence old writes:.*failed status returned from",
+            extra_time_to_expiration=30
+        ))
         yield
 
 
@@ -344,6 +392,12 @@ def ignore_raft_transport_failing():
             new_severity=Severity.WARNING,
             event_class=DatabaseLogEvent,
             regex=r".*raft::transport_error \(.*rpc::closed_error \(connection is closed\)",
+            extra_time_to_expiration=30
+        ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*raft - .* Transferring snapshot.*not found",
             extra_time_to_expiration=30
         ))
         yield

--- a/sdcm/utils/raft/__init__.py
+++ b/sdcm/utils/raft/__init__.py
@@ -3,13 +3,14 @@ import logging
 import random
 
 from enum import Enum
-from typing import Protocol, NamedTuple, Mapping, Iterable
+from abc import ABC, abstractmethod
+from typing import NamedTuple, Mapping, Iterable, Any
 
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.filters import EventsSeverityChangerFilter
 from sdcm.sct_events import Severity
 from sdcm.utils.features import is_consistent_topology_changes_feature_enabled, is_consistent_cluster_management_feature_enabled
-
+from sdcm.wait import wait_for
 
 LOGGER = logging.getLogger(__name__)
 RAFT_DEFAULT_SCYLLA_VERSION = "5.5.0-dev"
@@ -68,30 +69,38 @@ ABORT_BOOTSTRAP_LOG_PATTERNS: Iterable[MessagePosition] = [
 ]
 
 
-class RaftFeatureOperations(Protocol):
+class RaftFeatureOperations(ABC):
     _node: "BaseNode"  # noqa: F821
     TOPOLOGY_OPERATION_LOG_PATTERNS: dict[TopologyOperations, Iterable[MessagePosition]]
+    message_iter: Iterable | None = None
 
     @property
+    @abstractmethod
     def is_enabled(self) -> bool:
         ...
 
     @property
+    @abstractmethod
     def is_consistent_topology_changes_enabled(self) -> bool:
         ...
 
+    @abstractmethod
     def get_status(self) -> str:
         ...
 
+    @abstractmethod
     def is_ready(self) -> bool:
         ...
 
+    @abstractmethod
     def get_group0_members(self) -> list[str]:
         ...
 
+    @abstractmethod
     def get_group0_non_voters(self) -> list[dict[str, str]]:
         ...
 
+    @abstractmethod
     def clean_group0_garbage(self, raise_exception: bool = False) -> None:
         ...
 
@@ -189,29 +198,50 @@ class RaftFeature(RaftFeatureOperations):
         return diff
 
     def clean_group0_garbage(self, raise_exception: bool = False) -> None:
+        def is_node_down(removing_host_id: str) -> bool:
+            node_status = get_node_status_from_system_by(verification_node=self._node,
+                                                         host_id=removing_host_id)
+            return not node_status.get("up", False)
+
+        def is_node_in_bootstrapping_status(removing_host_id: str) -> bool:
+            node_status = get_node_status_from_system_by(verification_node=self._node,
+                                                         host_id=removing_host_id)
+            return node_status.get("status", "") == "BOOTSTRAPPING"
+
         LOGGER.debug("Clean group0 non-voter's members")
         host_ids = self.get_diff_group0_token_ring_members()
         if not host_ids:
             LOGGER.debug("Node could return to token ring but not yet bootstrap")
             host_ids = self.get_group0_non_voters()
+        attempt = 3
         while host_ids:
             removing_host_id = host_ids.pop(0)
-            ingore_dead_nodes_opt = f"--ignore-dead-nodes {','.join(host_ids)}" if host_ids else ""
+            wait_for(func=is_node_down, step=5, timeout=60, throw_exc=False,
+                     text=f"Waiting node with {removing_host_id} marked down", removing_host_id=removing_host_id)
+            wait_for(func=lambda: not is_node_in_bootstrapping_status(), step=5, timeout=120, throw_exc=False,
+                     text=f"Waiting node with {removing_host_id} doesn't have status BOOTSTRAPPING", removing_host_id=removing_host_id)
 
-            result = self._node.run_nodetool(f"removenode {removing_host_id} {ingore_dead_nodes_opt}",
+            ignore_dead_nodes_opt = f"--ignore-dead-nodes {','.join(host_ids)}" if host_ids else ""
+
+            result = self._node.run_nodetool(f"removenode {removing_host_id} {ignore_dead_nodes_opt}",
                                              ignore_status=True,
                                              verbose=True,
                                              retry=3)
             if not result.ok:
                 LOGGER.error("Removenode with host_id %s failed with %s",
                              removing_host_id, result.stdout + result.stderr)
-            if not host_ids:
+                LOGGER.debug("Return host id to pool for remove")
+                host_ids.append(removing_host_id)
+                attempt -= 1
+            if not host_ids or attempt < 1:
                 break
 
-        if missing_host_ids := self.get_diff_group0_token_ring_members():
+        missing_host_ids = self.get_diff_group0_token_ring_members() or self.get_group0_non_voters()
+        if missing_host_ids:
             token_ring_members = self._node.get_token_ring_members()
             group0_members = self.get_group0_members()
-            error_msg = f"Token ring {token_ring_members} and group0 {group0_members} are differs on: {missing_host_ids}"
+            error_msg = (f"Token ring {token_ring_members} and group0 {group0_members} are differs on: {missing_host_ids}"
+                         f" or/and has non-voter member {missing_host_ids}")
             LOGGER.error(error_msg)
             if raise_exception:
                 raise Group0MembersNotConsistentWithTokenRingMembersException(error_msg)
@@ -238,19 +268,11 @@ class RaftFeature(RaftFeatureOperations):
                                         extra_time_to_expiration=timeout),
             EventsSeverityChangerFilter(new_severity=Severity.WARNING,
                                         event_class=DatabaseLogEvent.RUNTIME_ERROR,
-                                        regex=r".*Startup failed: std::runtime_error.*is removed from the cluster",
+                                        regex=r".*Startup failed: std::runtime_error \(the topology coordinator rejected request to join the cluster",
                                         extra_time_to_expiration=timeout),
             EventsSeverityChangerFilter(new_severity=Severity.WARNING,
                                         event_class=DatabaseLogEvent.DATABASE_ERROR,
                                         regex=r".*gossip - is_safe_for_restart.*status=LEFT",
-                                        extra_time_to_expiration=timeout),
-            EventsSeverityChangerFilter(new_severity=Severity.WARNING,
-                                        event_class=DatabaseLogEvent.RUNTIME_ERROR,
-                                        regex=r".*init - Startup failed: std::runtime_error.*already exists, cancelling join",
-                                        extra_time_to_expiration=timeout),
-            EventsSeverityChangerFilter(new_severity=Severity.WARNING,
-                                        event_class=DatabaseLogEvent.RUNTIME_ERROR,
-                                        regex=r".*init - Startup failed: std::runtime_error.*repair_reason=bootstrap.*aborted_by_user=true",
                                         extra_time_to_expiration=timeout),
             EventsSeverityChangerFilter(new_severity=Severity.WARNING,
                                         event_class=DatabaseLogEvent,
@@ -258,6 +280,18 @@ class RaftFeature(RaftFeatureOperations):
             EventsSeverityChangerFilter(new_severity=Severity.WARNING,
                                         event_class=DatabaseLogEvent.DATABASE_ERROR,
                                         regex=r".*node_ops - bootstrap.*Operation failed.*seastar::abort_requested_exception",
+                                        extra_time_to_expiration=timeout),
+            EventsSeverityChangerFilter(new_severity=Severity.WARNING,
+                                        event_class=DatabaseLogEvent.DATABASE_ERROR,
+                                        regex=r".*raft - .* failed with: raft::transport_error .* connection is closed",
+                                        extra_time_to_expiration=timeout),
+            EventsSeverityChangerFilter(new_severity=Severity.WARNING,
+                                        event_class=DatabaseLogEvent.DATABASE_ERROR,
+                                        regex=r".*raft - .*Transferring snapshot to.*Request is aborted by a caller",
+                                        extra_time_to_expiration=timeout),
+            EventsSeverityChangerFilter(new_severity=Severity.WARNING,
+                                        event_class=DatabaseLogEvent.DATABASE_ERROR,
+                                        regex=r".*raft.*applier fiber stopped because of the error.*abort requested",
                                         extra_time_to_expiration=timeout),
         )
 
@@ -332,6 +366,35 @@ def get_raft_mode(node) -> RaftFeature | NoRaft:
         return RaftFeature(node) if is_consistent_cluster_management_feature_enabled(session) else NoRaft(node)
 
 
+def get_node_status_from_system_by(verification_node: "BaseNode", *, ip_address: str = "", host_id: str = "") -> dict[str, Any]:  # noqa: F821
+    """Get node status from system.cluster_status table
+
+    The table contains actual information about nodes statuses in cluster
+    updating by raft. it is faster to get required node state by ip or hostid
+    from this table
+    """
+    query = "select peer, host_id, status, up from system.cluster_status"
+    if ip_address:
+        query += f" where peer = '{ip_address}'"
+    elif host_id:
+        query += f" where host_id={host_id} ALLOW FILTERING"
+    else:
+        LOGGER.warning("Ip address or host id were not provided")
+        return {}
+
+    with verification_node.parent_cluster.cql_connection_patient(node=verification_node) as session:
+        session.default_timeout = 300
+        results = session.execute(query)
+        row = results.one()
+        if not row:
+            return {}
+        node_status = {"ip_address": row.peer, "host_id": str(
+            row.host_id), "state": row.status, "up": row.up}
+        LOGGER.debug("Node status: %s", node_status)
+        return node_status
+
+
 __all__ = ["get_raft_mode",
+           "get_node_status_from_system_by",
            "Group0MembersNotConsistentWithTokenRingMembersException",
            ]

--- a/sdcm/utils/raft/common.py
+++ b/sdcm/utils/raft/common.py
@@ -1,17 +1,20 @@
 import logging
 import contextlib
+import time
+import traceback
 
 from typing import Iterable, Callable
 from functools import partial
 
-from sdcm.exceptions import BootstrapStreamErrorFailure
-from sdcm.cluster import BaseNode, BaseScyllaCluster, BaseMonitorSet
+from sdcm.sct_events.decorators import raise_event_on_failure
+from sdcm.exceptions import BootstrapStreamErrorFailure, ExitByEventError
 from sdcm.wait import wait_for
-from sdcm.sct_events.group_common_events import decorate_with_context, \
-    ignore_stream_mutation_fragments_errors, ignore_ycsb_connection_refused, ignore_raft_topology_cmd_failing, ignore_raft_transport_failing
-from sdcm.utils.adaptive_timeouts import Operations, adaptive_timeout
-from sdcm.utils.common import ParallelObject
 
+from sdcm.sct_events.group_common_events import decorate_with_context, \
+    ignore_ycsb_connection_refused
+from sdcm.utils.common import ParallelObject
+from sdcm.utils.raft import get_node_status_from_system_by
+from sdcm.cluster import BaseMonitorSet, NodeSetupFailed, BaseScyllaCluster, BaseNode
 LOGGER = logging.getLogger(__name__)
 
 
@@ -19,7 +22,7 @@ class RaftException(Exception):
     """Raise if raft feature mode differs on nodes"""
 
 
-def validate_raft_on_nodes(nodes: list["BaseNode"]) -> None:
+def validate_raft_on_nodes(nodes: list[BaseNode]) -> None:
     LOGGER.debug("Check that raft is enabled on all the nodes")
     raft_enabled_on_nodes = [node.raft.is_enabled for node in nodes]
     if len(set(raft_enabled_on_nodes)) != 1:
@@ -48,18 +51,30 @@ class NodeBootstrapAbortManager:
     def __init__(self, bootstrap_node: BaseNode, verification_node: BaseNode):
         self.bootstrap_node = bootstrap_node
         self.verification_node = verification_node
-        self.db_cluster: BaseScyllaCluster = self.verification_node.parent_cluster
+        self.db_cluster: BaseScyllaCluster = verification_node.parent_cluster
         self.monitors: BaseMonitorSet = self.verification_node.test_config.tester_obj().monitors
 
     @property
     def host_id_searcher(self) -> Iterable[str]:
-        return self.bootstrap_node.follow_system_log(patterns=['Setting local host id to'])
+        return self.bootstrap_node.follow_system_log(patterns=['Setting local host id to'], start_from_beginning=True)
+
+    def get_host_ids_from_log(self) -> list[str]:
+        node_host_ids = []
+        found_strings = list(self.host_id_searcher)
+        LOGGER.debug("Found local host ids: %s", found_strings)
+        if found_strings:
+            for line in found_strings:
+                host_id = line.split(" ")[-1].strip()
+                node_host_ids.append(host_id)
+        LOGGER.debug("Found host ids %s for node %s", node_host_ids, self.bootstrap_node.name)
+        return node_host_ids
 
     def _set_wait_stop_event(self):
         if not self.bootstrap_node.stop_wait_db_up_event.is_set():
             self.bootstrap_node.stop_wait_db_up_event.set()
         LOGGER.debug("Stop event was set for node %s", self.bootstrap_node.name)
 
+    @raise_event_on_failure
     def _start_bootstrap(self):
         try:
             LOGGER.debug("Starting bootstrap process %s", self.bootstrap_node.name)
@@ -80,6 +95,9 @@ class NodeBootstrapAbortManager:
                      timeout=timeout,
                      throw_exc=True,
                      stop_event=self.bootstrap_node.stop_wait_db_up_event)
+            if self.bootstrap_node.db_up():
+                LOGGER.info("Node %s is bootstrapped. Cancel abort action", self.bootstrap_node.name)
+                return
             abort_action()
             LOGGER.info("Scylla was stopped successfully on node %s", self.bootstrap_node.name)
         except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
@@ -89,20 +107,15 @@ class NodeBootstrapAbortManager:
 
     @decorate_with_context(ignore_ycsb_connection_refused)
     def clean_unbootstrapped_node(self):
-        node_host_ids = []
-        if found_stings := list(self.host_id_searcher):
-            for line in found_stings:
-                new_node_host_id = line.split(" ")[-1].strip()
-                LOGGER.debug("Node %s has host id: %s in log", self.bootstrap_node.name, new_node_host_id)
-                node_host_ids.append(new_node_host_id)
+        node_host_ids = self.get_host_ids_from_log()
         self.bootstrap_node.log.debug("New host was not properly bootstrapped. Terminate it")
         self.db_cluster.terminate_node(self.bootstrap_node)
         self.monitors.reconfigure_scylla_monitoring()
-        self.verification_node.raft.clean_group0_garbage(raise_exception=True)
         if node_host_ids:
-            for host_id in node_host_ids:
+            for host_id in set(node_host_ids):
                 self.verification_node.run_nodetool(
-                    f"removenode {host_id}", ignore_status=True, retry=3, warning_event_on_exception=True)
+                    f"removenode {host_id}", ignore_status=True, retry=3)
+        self.verification_node.raft.clean_group0_garbage(raise_exception=True)
 
         assert self.verification_node.raft.is_cluster_topology_consistent(), \
             "Group0, Token Ring and number of node in cluster are differs. Check logs"
@@ -117,8 +130,7 @@ class NodeBootstrapAbortManager:
 
         wait_operations_timeout = (self.SUCCESS_BOOTSTRAP_TIMEOUT + self.INSTANCE_START_TIMEOUT
                                    + terminate_pattern.timeout + abort_action_timeout)
-        with ignore_stream_mutation_fragments_errors(), ignore_raft_topology_cmd_failing(), \
-                ignore_raft_transport_failing(), contextlib.ExitStack() as stack:
+        with contextlib.ExitStack() as stack:
             for expected_start_failed_context in self.verification_node.raft.get_severity_change_filters_scylla_start_failed(
                     terminate_pattern.timeout):
                 stack.enter_context(expected_start_failed_context)
@@ -131,6 +143,47 @@ class NodeBootstrapAbortManager:
         LOGGER.debug("Clear stop event for wait_for on node %s", self.bootstrap_node.name)
         self.bootstrap_node.stop_wait_db_up_event.clear()
 
+    def _rebootstrap_node(self):
+        self.bootstrap_node.start_scylla_server(verify_up_timeout=3600, verify_down=True)
+        self.bootstrap_node.start_scylla_jmx()
+        self.db_cluster.check_nodes_up_and_normal(
+            nodes=[self.bootstrap_node], verification_node=self.verification_node)
+        self._set_wait_stop_event()
+
+    def watch_startup_failed(self, timeout=600):
+        start_time = time.perf_counter()
+        log_follower = self.bootstrap_node.follow_system_log(patterns=[".*Startup failed.*"])
+        while time.perf_counter() - start_time < timeout and not self.bootstrap_node.stop_wait_db_up_event.is_set():
+            found_errors = list(log_follower)
+            if found_errors:
+                self._set_wait_stop_event()
+                raise NodeSetupFailed(node=self.bootstrap_node, error_msg=str(found_errors))
+            time.sleep(1)
+        self._set_wait_stop_event()
+
+    def is_bootstrapped_successfully(self):
+        """Check that bootstrap node was added to token ring and group0 on each node"""
+        host_ids = self.get_host_ids_from_log()
+        all_nodes_token_ring = []
+        all_nodes_group0 = []
+        if not host_ids:
+            return False
+        # check only latest host_id.
+        host_id = host_ids[-1]
+        LOGGER.info("Check group0 and token ring")
+        for node in [node for node in self.verification_node.parent_cluster.nodes if node != self.bootstrap_node]:
+            token_ring = node.get_token_ring_members()
+            group0 = node.raft.get_group0_members()
+            all_nodes_token_ring.append(host_id in [n["host_id"] for n in token_ring])
+
+            for n in group0:
+                if host_id == n["host_id"] and n['voter']:
+                    all_nodes_group0.append(True)
+                    break
+            else:
+                all_nodes_group0.append(False)
+        return all(all_nodes_group0) and all(all_nodes_token_ring)
+
     def clean_and_restart_bootstrap_after_abort(self):
         if self.bootstrap_node.db_up():
             LOGGER.debug("Node %s was bootstrapped")
@@ -138,19 +191,77 @@ class NodeBootstrapAbortManager:
         # stop scylla if it was started by scylla-manager-client during setup
         self.bootstrap_node.stop_scylla_server(ignore_status=True, timeout=600)
         # Clean garbage from group 0 and scylla data and restart setup
+        if self.verification_node.raft.get_diff_group0_token_ring_members() or \
+                self.verification_node.raft.get_group0_non_voters():
+            self.verification_node.raft.clean_group0_garbage(raise_exception=True)
+        if not self.is_bootstrapped_successfully():
+            LOGGER.debug("Clean old scylla data and restart scylla service")
+            self.bootstrap_node.clean_scylla_data()
+        watcher_startup_failed = partial(self.watch_startup_failed, timeout=3600)
         try:
-            if self.verification_node.raft.get_diff_group0_token_ring_members():
-                self.verification_node.raft.clean_group0_garbage(raise_exception=True)
-                LOGGER.debug("Clean old scylla data and restart scylla service")
-                self.bootstrap_node.clean_scylla_data()
-            with ignore_raft_topology_cmd_failing(), ignore_raft_transport_failing(), \
-                    adaptive_timeout(operation=Operations.NEW_NODE, node=self.verification_node, timeout=3600) as bootstrap_timeout:
+            LOGGER.debug("Start rebootstrap as new node")
+            ParallelObject(objects=[self._rebootstrap_node, watcher_startup_failed], timeout=3800).call_objects()
+            LOGGER.debug("Node is up")
+        except NodeSetupFailed as exc:
+            LOGGER.error("Scylla service restart failed: %s", exc)
+            self.clean_unbootstrapped_node()
+            raise BootstrapStreamErrorFailure(f"Rebootstrap failed with error: {exc}") from exc
+        except ExitByEventError as exc:
+            LOGGER.error("Event stopped: %s", exc)
+            if self.bootstrap_node.db_up():
+                LOGGER.info("Node is up")
+            else:
+                LOGGER.info("Clean node")
+                self.clean_unbootstrapped_node()
 
-                self.bootstrap_node.start_scylla_server(verify_up_timeout=bootstrap_timeout, verify_down=True)
-                self.bootstrap_node.start_scylla_jmx()
-            self.db_cluster.check_nodes_up_and_normal(
-                nodes=[self.bootstrap_node], verification_node=self.verification_node)
         except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
             LOGGER.error("Scylla service restart failed: %s", exc)
             self.clean_unbootstrapped_node()
             raise BootstrapStreamErrorFailure(f"Rebootstrap failed with error: {exc}") from exc
+        finally:
+            self.bootstrap_node.stop_wait_db_up_event.clear()
+
+
+class FailedDecommissionOperationMonitoring:
+    """Monitor decommission after operation failing
+
+    Sometimes decommission operation could fail for some reason
+    but decommission process is still running on the node and
+    could finished successfully.
+    The context manager allows to check whether decommission is still running
+    and it waits while decommission will be finished. Operation status is checked by
+    records in system table: system.cluster_status by target node ip
+
+    CM should be initialized before decommission operation started. It
+    get 2 required parameter:
+     - target node which will be decommissioning
+     - verification node which will be used to get target node status
+    """
+
+    def __init__(self, target_node: BaseNode, verification_node: BaseNode, timeout=7200):
+        self.timeout = timeout
+        self.target_node = target_node
+        self.db_cluster = verification_node.parent_cluster
+        self.target_node_ip = target_node.ip_address
+        self.verification_node = verification_node
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type:
+            LOGGER.warning("Decommission failed with error: %s",
+                           "".join(traceback.format_exception(exc_type, exc_val, exc_tb)))
+            LOGGER.debug("Check is decommission running..")
+            decommission_is_running = self.is_node_decommissioning()
+            if decommission_is_running:
+                wait_for(func=lambda: not self.is_node_decommissioning(), step=15,
+                         timeout=self.timeout,
+                         text=f"Waiting decommission is finished for {self.target_node.name}...")
+            self.db_cluster.verify_decommission(self.target_node)
+            return True
+
+    def is_node_decommissioning(self):
+        node_status = get_node_status_from_system_by(
+            self.verification_node, ip_address=self.target_node_ip)
+        return node_status["state"] == "DECOMMISSIONING" if node_status else False


### PR DESCRIPTION
With raft topology, node which failed to bootstrap , removed from cluster
and banned. It could be added to cluster but it need to clean all scylla data before rebootstrap.
Depending on log message after which bootstrap is going to be aborted,
Bootstrap process could be finished ealier than command for abort will be executed
and node could be added to cluster.
New:
 - Added additinal checks whether bootstrap finished successfull  before it would be aborted
 - Added additional changeseverity filters for error messages expected to appear during
bootstrap aborting process
 - Added decommission operation monitor, which allow to check whether decommission is running
after command failed for any reason and wait process to be finished.

### Testing
- [Test passed with single nemesis](https://jenkins.scylladb.com/job/scylla-staging/job/abykov/job/longevity-100gb-4h-bootstrap-test/103/)
- [Regular job](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/longevity-100gb-4h-bootstrap-test/110)
- [Regular jobs with single nemesis](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/longevity-100gb-4h/116)
- [Another test](https://jenkins.scylladb.com/job/scylla-staging/job/abykov/job/longevity-100gb-4h-bootstrap-test/109/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
