### PR TITLE
Revert "fix(nodetool): workaround wrong placement of cassandra-rackdc.properties"

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -17,7 +17,6 @@
 import traceback
 from itertools import zip_longest, chain, count as itertools_count
 import json
-from pathlib import Path
 import random
 import time
 import re
@@ -464,25 +463,6 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         if "yes" in upgradesstables_supported.stdout:
             upgradesstables_available = True
             InfoEvent(message="calling upgradesstables").publish()
-
-            # NOTE: some 4.3.x and 4.4.x scylla images have nodetool with bug [1]
-            # that is not yet fixed [3] there.
-            # So, in such case we must use '/etc/scylla/cassandra' path for
-            # the 'cassandra-rackdc.properties' file instead of the expected
-            # one - '/etc/scylla' [2].
-            # Example of the error:
-            #     WARN  16:42:29,831 Unable to read cassandra-rackdc.properties
-            #     error: DC or rack not found in snitch properties,
-            #         check your configuration in: cassandra-rackdc.properties
-            #
-            # [1] https://github.com/scylladb/scylla-tools-java/commit/3eca0e35
-            # [2] https://github.com/scylladb/scylla/issues/7930
-            # [3] https://github.com/scylladb/scylla-tools-java/pull/232
-            main_dir, subdir = Path("/etc/scylla"), "cassandra"
-            filename = "cassandra-rackdc.properties"
-            node.remoter.sudo(
-                f"cp {main_dir / filename} {main_dir / subdir / filename}")
-
             node.run_nodetool(sub_cmd="upgradesstables")
         if queue:
             queue.put(upgradesstables_available)


### PR DESCRIPTION


This reverts commit f87e8c7ec371c631f92a1a6b0fad600b0c40f260.

issue scylladb/scylla#7930 was fixed long long time ago and now since scylla-java-tools isn't part of scylla installation anymore, there no `/etc/scylla/cassandra/` direcotry anymore so this hack is breaking upgrade tests

Ref: https://github.com/scylladb/scylla/issues/7930

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
