### PR TITLE
feature(artifact-tests): introduce Amazon Linux 2023 tests

### DIFF
--- a/configurations/arm/amazon2023.yaml
+++ b/configurations/arm/amazon2023.yaml
@@ -1,0 +1,6 @@
+ami_id_db_scylla: 'resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-arm64'  # Amazon Linux 2023 LTS Arm64 latest AMI
+instance_type_db: 'im4gn.xlarge'
+use_preinstalled_scylla: false
+# enhanced network isn't supported
+append_scylla_setup_args: ' --no-ec2-check '
+use_mgmt: false

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-amazon2023-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-amazon2023-arm.jenkinsfile
@@ -1,0 +1,14 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: '''["test-cases/artifacts/amazon2023.yaml", "configurations/arm/amazon2023.yaml"]''',
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'spot_low_price',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-amazon2023-nonroot.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-amazon2023-nonroot.jenkinsfile
@@ -1,0 +1,16 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/amazon2023.yaml',
+    backend: 'aws',
+    region: 'eu-west-1',
+    nonroot_offline_install: true,
+
+    provision_type: 'spot_low_price',
+
+    timeout: [time: 60, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-amazon2023.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-amazon2023.jenkinsfile
@@ -1,0 +1,14 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/amazon2023.yaml',
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'spot_low_price',
+
+    timeout: [time: 60, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts/artifacts-amazon2023-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-amazon2023-arm.jenkinsfile
@@ -1,0 +1,14 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: '''["test-cases/artifacts/amazon2023.yaml", "configurations/arm/amazon2023.yaml"]''',
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'spot_low_price',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts/artifacts-amazon2023.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-amazon2023.jenkinsfile
@@ -1,0 +1,14 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/amazon2023.yaml',
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'spot_low_price',
+
+    timeout: [time: 60, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -18,7 +18,8 @@ def get_persistent_snapshots():  # Snapshot sizes (dict keys) are in GB
 
 def get_distro_name(distro_object):
     known_distro_dict = {
-        Distro.AMAZON2: "centos7",
+        Distro.AMAZON2: "centos8",
+        Distro.AMAZON2023: "centos8",
         Distro.CENTOS7: "centos7",
         Distro.CENTOS8: "centos8",
         Distro.DEBIAN10: "debian10",

--- a/sdcm/utils/distro.py
+++ b/sdcm/utils/distro.py
@@ -35,7 +35,7 @@ KNOWN_OS = (
     ("CENTOS", "centos", ["7", "8"], DistroBase.RHEL),
     ("RHEL", "rhel", ["7", "8"], DistroBase.RHEL),
     ("OEL", "ol", ["7", "8"], DistroBase.RHEL),
-    ("AMAZON", "amzn", ["2"], DistroBase.RHEL),
+    ("AMAZON", "amzn", ["2", "2023"], DistroBase.RHEL),
     ("ROCKY", "rocky", ["8", "9"], DistroBase.RHEL),
     ("DEBIAN", "debian", ["10", "11"], DistroBase.DEBIAN),
     ("UBUNTU", "ubuntu", ["20.04", "21.04", "21.10", "22.04", "24.04"], DistroBase.DEBIAN),

--- a/test-cases/artifacts/amazon2023.yaml
+++ b/test-cases/artifacts/amazon2023.yaml
@@ -1,0 +1,20 @@
+ami_db_scylla_user: 'ec2-user'
+ami_id_db_scylla: 'resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64'
+root_disk_size_db: 50
+backtrace_decoding: false
+cluster_backend: 'aws'
+instance_type_db: 'i4i.large'
+instance_provision: "spot"
+instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
+n_db_nodes: 1
+n_loaders: 0
+n_monitor_nodes: 0
+nemesis_class_name: 'NoOpMonkey'
+scylla_linux_distro: 'centos'
+test_duration: 60
+use_preinstalled_scylla: false
+user_prefix: 'artifacts-al2023'
+aws_fallback_to_next_availability_zone: true
+
+user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/unit_tests/test_utils_distro.py
+++ b/unit_tests/test_utils_distro.py
@@ -211,6 +211,25 @@ CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
 HOME_URL="https://amazonlinux.com/"
 """,
 
+    "Amazon Linux 2023": """\
+NAME="Amazon Linux"
+VERSION="2023"
+ID="amzn"
+ID_LIKE="fedora"
+VERSION_ID="2023"
+PLATFORM_ID="platform:al2023"
+PRETTY_NAME="Amazon Linux 2023.4.20240513"
+ANSI_COLOR="0;33"
+CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2023"
+HOME_URL="https://aws.amazon.com/linux/amazon-linux-2023/"
+DOCUMENTATION_URL="https://docs.aws.amazon.com/linux/"
+SUPPORT_URL="https://aws.amazon.com/premiumsupport/"
+BUG_REPORT_URL="https://github.com/amazonlinux/amazon-linux-2023"
+VENDOR_NAME="AWS"
+VENDOR_URL="https://aws.amazon.com/"
+SUPPORT_END="2028-03-15"
+""",
+
     "Rocky Linux 8": """\
 NAME="Rocky Linux"
 VERSION="8.5 (Green Obsidian)"
@@ -333,6 +352,12 @@ class TestDistro(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertTrue(Distro.AMAZON2.is_amazon2)
         distro = Distro.from_os_release(DISTROS_OS_RELEASE["Amazon Linux 2"])
         self.assertTrue(distro.is_amazon2)
+        self.assertTrue(distro.is_rhel_like)
+
+    def test_amazon2023(self):
+        self.assertTrue(Distro.AMAZON2023.is_amazon2023)
+        distro = Distro.from_os_release(DISTROS_OS_RELEASE["Amazon Linux 2023"])
+        self.assertTrue(distro.is_amazon2023)
         self.assertTrue(distro.is_rhel_like)
 
     def test_rocky8(self):


### PR DESCRIPTION
Amazon Linux 2 is gonna be deprecated in the upcoming year and we want to start our support of the next version of it

this commit introduces 5 tests:

- x86 based one, and offline installer of it
- arm64 based one, and offline installer of it
- x86 offline install non-root

Closes: scylladb/scylla-cluster-tests#7475

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-amazon2023-arm-test/3/
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-amazon2023-test/2/
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-amazon2023-offline_install-test/2/
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-amazon2023-offline_install-nonroot-test/2/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
