### PR TITLE
test(longevity): run multiDC test with IPv6 network config

### DIFF
--- a/jenkins-pipelines/oss/tier1/longevity-multidc-schema-topology-changes-12h.jenkinsfile
+++ b/jenkins-pipelines/oss/tier1/longevity-multidc-schema-topology-changes-12h.jenkinsfile
@@ -8,7 +8,7 @@ longevityPipeline(
     availability_zone: 'a,b,c',
     region: '''["eu-west-1", "eu-west-2"]''',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml", "configurations/network_config/all_addresses_ipv6_public.yaml"]''',
 
     timeout: [time: 820, unit: 'MINUTES']
 )


### PR DESCRIPTION
Change longevity mulitDC parallel-topology-schema-changes test to be run 
with IPv6 network configuration.

Task: https://github.com/scylladb/qa-tasks/issues/1647

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-multidc-schema-topology-changes-ipv6-12h](https://argus.scylladb.com/test/1c6a8408-05db-4dcb-8960-baee6b6eef82/runs?additionalRuns[]=54e412f0-b21c-4bc1-945f-9ee4ed0af7cd) - there are different issues in the run, but the failures are not connected to IPv6 address

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
