### PR TITLE
fix(OutputWatcher): use formatted string in log message

### DIFF
--- a/sdcm/remote/base.py
+++ b/sdcm/remote/base.py
@@ -222,13 +222,13 @@ class OutputWatcher(StreamWatcher):  # pylint: disable=too-few-public-methods
 
         while '\n' in stream_buffer:
             out_buf, rest_buf = stream_buffer.split('\n', 1)
-            self.log.debug("<%s>: " + out_buf, self.hostname)
+            self.log.debug("<%s>: %s", self.hostname, out_buf)
             stream_buffer = rest_buf
         self.len = len(stream) - len(stream_buffer)
         return []
 
     def submit_line(self, line: str):
-        self.log.debug("<%s>: " + line.rstrip('\n'), self.hostname)
+        self.log.debug("<%s>: %s", self.hostname, line.rstrip('\n'))
 
 
 class LogWriteWatcher(StreamWatcher):  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
Sometimes line for output  could contain '%s' or '0.0%' and this break OutputWatcher log function with error:
```
18:42:47      msg = msg % self.args
18:42:47  ValueError: incomplete format

File "/home/ubuntu/scylla-cluster-tests/sdcm/remote/libssh2_client/__init__.py",
    line 449, in _process_output
      watcher.submit_line(data)
File "/home/ubuntu/scylla-cluster-tests/sdcm/remote/base.py",
    line 231, in submit_line
      self.log.debug("<%s>: " + line.rstrip('\n'), self.hostname)
Message: '<%s>: Percent Repaired       : 0.0%'
Arguments: ('10.4.0.228',)
```

Change format for log message info

self.log.debug("%s - %s', self.hostname, line)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
