### PR TITLE
fix(teardown): stop sending email within SCT test

### DIFF
--- a/configurations/scale-up/scale-up-base.yaml
+++ b/configurations/scale-up/scale-up-base.yaml
@@ -23,5 +23,4 @@ gce_image_db: 'https://www.googleapis.com/compute/v1/projects/scylla-images/glob
 append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
 
 use_mgmt: false
-send_email: false
 email_recipients: ['scylla-perf-results@scylladb.com']

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -65,7 +65,6 @@ update_db_packages: ''
 logs_transport: "syslog-ng"
 
 store_perf_results: false
-send_email: false
 email_recipients: ['qa@scylladb.com']
 email_subject_postfix: ''
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -463,9 +463,6 @@ class SCTConfiguration(dict):
         dict(name="seeds_num", env="SCT_SEEDS_NUM", type=int,
              help="""Number of seeds to select"""),
 
-        dict(name="send_email", env="SCT_SEND_EMAIL", type=boolean,
-             help="""If true would send email out of the performance regression test"""),
-
         dict(name="email_recipients", env="SCT_EMAIL_RECIPIENTS", type=str_or_list,
              help="""list of email of send the performance regression test to"""),
 

--- a/test-cases/features/limit-streaming-io.yaml
+++ b/test-cases/features/limit-streaming-io.yaml
@@ -37,7 +37,6 @@ backtrace_decoding: false
 print_kernel_callstack: true
 
 store_perf_results: false
-send_email: true
 email_recipients: ["qa@scylladb.com"]
 
 append_scylla_yaml: |

--- a/test-cases/performance/perf-regression-2mv.yaml
+++ b/test-cases/performance/perf-regression-2mv.yaml
@@ -21,7 +21,6 @@ instance_type_monitor: 't3.small'
 user_prefix: 'perf-regression-mv'
 
 store_perf_results: true
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 backtrace_decoding: false
 print_kernel_callstack: true

--- a/test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml
@@ -52,5 +52,4 @@ backtrace_decoding: false
 print_kernel_callstack: true
 
 store_perf_results: true
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'alternator@scylladb.com']

--- a/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
@@ -53,7 +53,6 @@ user_prefix: 'perf-alternator'
 space_node_threshold: 644245094
 
 store_perf_results: true
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'alternator@scylladb.com']
 
 print_kernel_callstack: true

--- a/test-cases/performance/perf-regression-gradual-throughput-grow.yaml
+++ b/test-cases/performance/perf-regression-gradual-throughput-grow.yaml
@@ -31,5 +31,4 @@ backtrace_decoding: false
 use_mgmt: false
 
 store_perf_results: false
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']

--- a/test-cases/performance/perf-regression-latency-125gb.yaml
+++ b/test-cases/performance/perf-regression-latency-125gb.yaml
@@ -28,7 +28,6 @@ print_kernel_callstack: true
 use_mgmt: true
 
 store_perf_results: true
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 custom_es_index: 'performancestatsv2'
 use_hdr_cs_histogram: true

--- a/test-cases/performance/perf-regression-latency-1TB.yaml
+++ b/test-cases/performance/perf-regression-latency-1TB.yaml
@@ -24,7 +24,6 @@ round_robin: true
 append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
 
 store_perf_results: true
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 backtrace_decoding: false
 print_kernel_callstack: true

--- a/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
@@ -31,7 +31,6 @@ backtrace_decoding: false
 print_kernel_callstack: true
 
 store_perf_results: true
-send_email: true
 email_recipients: ["scylla-perf-results@scylladb.com"]
 use_prepared_loaders: true
 use_hdr_cs_histogram: true

--- a/test-cases/performance/perf-regression-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-latency-500gb-30min.yaml
@@ -30,5 +30,4 @@ append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --
 
 store_perf_results: true
 use_mgmt: false
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']

--- a/test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml
@@ -31,7 +31,6 @@ backtrace_decoding: false
 print_kernel_callstack: true
 
 store_perf_results: true
-send_email: true
 email_recipients: ["scylla-perf-results@scylladb.com"]
 use_prepared_loaders: true
 use_hdr_cs_histogram: true

--- a/test-cases/performance/perf-regression-latency-650gb-upgrade.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-upgrade.yaml
@@ -31,7 +31,6 @@ backtrace_decoding: false
 print_kernel_callstack: true
 
 store_perf_results: true
-send_email: true
 email_recipients: ["scylla-perf-results@scylladb.com"]
 use_prepared_loaders: true
 use_hdr_cs_histogram: true

--- a/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
@@ -31,7 +31,6 @@ backtrace_decoding: false
 print_kernel_callstack: true
 
 store_perf_results: true
-send_email: true
 email_recipients: ["scylla-perf-results@scylladb.com"]
 use_prepared_loaders: true
 use_hdr_cs_histogram: true

--- a/test-cases/performance/perf-regression-latency-cdc-mixed-poll-batching.yaml
+++ b/test-cases/performance/perf-regression-latency-cdc-mixed-poll-batching.yaml
@@ -24,7 +24,6 @@ space_node_threshold: 644245094
 store_perf_results: true
 append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
 
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'cdc@scylladb.com']
 backtrace_decoding: false
 print_kernel_callstack: true

--- a/test-cases/performance/perf-regression-latency-k8s-multitenant.yaml
+++ b/test-cases/performance/perf-regression-latency-k8s-multitenant.yaml
@@ -29,5 +29,4 @@ round_robin: true
 
 store_perf_results: true
 use_mgmt: false
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']

--- a/test-cases/performance/perf-regression-latency-lwt-big.yaml
+++ b/test-cases/performance/perf-regression-latency-lwt-big.yaml
@@ -56,6 +56,5 @@ backtrace_decoding: false
 print_kernel_callstack: true
 
 store_perf_results: true
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'lwt@scylladb.com']
 email_subject_postfix: 'disk-wise(big dataset)'

--- a/test-cases/performance/perf-regression-latency-lwt-small.yaml
+++ b/test-cases/performance/perf-regression-latency-lwt-small.yaml
@@ -56,6 +56,5 @@ backtrace_decoding: false
 print_kernel_callstack: true
 
 store_perf_results: true
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'lwt@scylladb.com']
 email_subject_postfix: 'memory-wise(small dataset)'

--- a/test-cases/performance/perf-regression-throughput-125gb.yaml
+++ b/test-cases/performance/perf-regression-throughput-125gb.yaml
@@ -31,7 +31,6 @@ print_kernel_callstack: true
 use_mgmt: true
 
 store_perf_results: true
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 
 email_subject_postfix: 'disk and cache'

--- a/test-cases/performance/perf-regression-throughput-baremetal-5gb.yaml
+++ b/test-cases/performance/perf-regression-throughput-baremetal-5gb.yaml
@@ -47,7 +47,6 @@ print_kernel_callstack: true
 
 
 store_perf_results: true
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 
 email_subject_postfix: 'disk and cache'

--- a/test-cases/performance/perf-regression-throughput-cdc-mixed-poll-batching.yaml
+++ b/test-cases/performance/perf-regression-throughput-cdc-mixed-poll-batching.yaml
@@ -28,7 +28,6 @@ append_scylla_yaml: |
   experimental_features:
     - cdc
 
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'cdc@scylladb.com']
 backtrace_decoding: false
 print_kernel_callstack: true

--- a/test-cases/performance/perf-regression-throughput-lwt-big.yaml
+++ b/test-cases/performance/perf-regression-throughput-lwt-big.yaml
@@ -58,6 +58,5 @@ backtrace_decoding: false
 print_kernel_callstack: true
 
 store_perf_results: true
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'lwt@scylladb.com']
 email_subject_postfix: 'disk-wise(big dataset)'

--- a/test-cases/performance/perf-regression-throughput-lwt-small.yaml
+++ b/test-cases/performance/perf-regression-throughput-lwt-small.yaml
@@ -57,6 +57,5 @@ backtrace_decoding: false
 print_kernel_callstack: true
 
 store_perf_results: true
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'lwt@scylladb.com']
 email_subject_postfix: 'memory-wise(small dataset)'

--- a/test-cases/performance/perf-regression-write-latency-cdc.yaml
+++ b/test-cases/performance/perf-regression-write-latency-cdc.yaml
@@ -17,7 +17,6 @@ store_perf_results: true
 append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
 
 
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'cdc@scylladb.com ']
 backtrace_decoding: false
 print_kernel_callstack: true

--- a/test-cases/performance/perf-regression-write-throughput-cdc.yaml
+++ b/test-cases/performance/perf-regression-write-throughput-cdc.yaml
@@ -21,7 +21,6 @@ append_scylla_yaml: |
   experimental_features:
     - cdc
 
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'cdc@scylladb.com ']
 backtrace_decoding: false
 print_kernel_callstack: true

--- a/test-cases/performance/perf-regression.100threads.100M-keys-z3-enterprise.yaml
+++ b/test-cases/performance/perf-regression.100threads.100M-keys-z3-enterprise.yaml
@@ -54,7 +54,6 @@ print_kernel_callstack: false
 
 store_perf_results: true
 use_mgmt: false
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 
 custom_es_index: 'performancestatsv2'

--- a/test-cases/performance/perf-regression.100threads.30M-keys-i4i-enterprise.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys-i4i-enterprise.yaml
@@ -40,7 +40,6 @@ print_kernel_callstack: true
 
 store_perf_results: true
 use_mgmt: false
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 
 custom_es_index: 'performancestatsv2'

--- a/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
@@ -41,7 +41,6 @@ print_kernel_callstack: true
 
 store_perf_results: true
 use_mgmt: false
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 
 custom_es_index: 'performancestatsv2'

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -39,7 +39,6 @@ print_kernel_callstack: true
 
 store_perf_results: true
 use_mgmt: false
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 
 custom_es_index: 'performancestatsv2'

--- a/test-cases/performance/perf-row-level-repair-1TB.yaml
+++ b/test-cases/performance/perf-row-level-repair-1TB.yaml
@@ -25,7 +25,6 @@ round_robin: 'true'
 append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
 
 store_perf_results: true
-send_email: 'true'
 
 backtrace_decoding: false
 print_kernel_callstack: true

--- a/test-cases/performance/perf-search-best-throughput-config.yaml
+++ b/test-cases/performance/perf-search-best-throughput-config.yaml
@@ -40,7 +40,6 @@ user_prefix: 'perf-search'
 backtrace_decoding: false
 
 use_mgmt: false
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 
 store_perf_results: false

--- a/test-cases/performance/ycsb/perf-base.yaml
+++ b/test-cases/performance/ycsb/perf-base.yaml
@@ -59,4 +59,3 @@ authorizer: 'CassandraAuthorizer'
 user_prefix: 'perf-ycsb-latency-nemesis'
 email_subject_postfix: 'YCSB workloads'
 store_perf_results: true
-send_email: true

--- a/unit_tests/test_data/test_scylla_yaml_builders/perf-regression.100threads.30M-keys.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/perf-regression.100threads.30M-keys.yaml
@@ -20,7 +20,6 @@ backtrace_decoding: false
 
 store_perf_results: true
 use_mgmt: false
-send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 
 scylla_network_config:

--- a/unit_tests/test_tester.py
+++ b/unit_tests/test_tester.py
@@ -94,7 +94,7 @@ class ClusterTesterForTests(ClusterTester):
         return None
 
     @silence()
-    def send_email(self):
+    def save_email_data(self):
         pass
 
     def tearDown(self):
@@ -187,7 +187,7 @@ class SubtestAndTeardownFailsTest(ClusterTesterForTests):
         raise ValueError('Main test also failed')
 
     @silence()
-    def send_email(self):
+    def save_email_data(self):
         raise ValueError()
 
     def _validate_results(self):
@@ -196,7 +196,7 @@ class SubtestAndTeardownFailsTest(ClusterTesterForTests):
         #  under hydra unit_test it stops running it and you don't see exception from next subtest.
         assert self.event_summary == {'NORMAL': 2, 'ERROR': 2}
         assert 'Subtest1 failed' in self.events['ERROR'][0]
-        assert 'send_email' in self.events['ERROR'][1]
+        assert 'save_email_data' in self.events['ERROR'][1]
         assert self.final_event.test_status == 'FAILED'
 
 
@@ -234,7 +234,7 @@ class SubtestAssertAndTeardownFailsTest(ClusterTesterForTests):
         assert False, 'Main test also failed'
 
     @silence()
-    def send_email(self):
+    def save_email_data(self):
         raise ValueError()
 
     def _validate_results(self):
@@ -243,7 +243,7 @@ class SubtestAssertAndTeardownFailsTest(ClusterTesterForTests):
         #  under hydra unit_test it stops running it and you don't see exception from next subtest.
         assert self.event_summary == {'NORMAL': 2, 'ERROR': 2}
         assert 'Subtest1 failed' in self.events['ERROR'][0]
-        assert 'send_email' in self.events['ERROR'][1]
+        assert 'save_email_data' in self.events['ERROR'][1]
         assert self.final_event.test_status == 'FAILED'
 
 
@@ -252,13 +252,13 @@ class TeardownFailsTest(ClusterTesterForTests):
         pass
 
     @silence()
-    def send_email(self):
+    def save_email_data(self):
         raise ValueError()
 
     def _validate_results(self):
         super()._validate_results()
         assert self.event_summary == {'NORMAL': 2, 'ERROR': 1}
-        assert 'send_email' in self.final_event.events['ERROR'][0]
+        assert 'save_email_data' in self.final_event.events['ERROR'][0]
         assert self.final_event.test_status == 'FAILED'
 
 


### PR DESCRIPTION
During SCT test we detect if it runs on jenkins. In that case we skip sending emails from within a test. But actually there's no point to send emails if not executed from jenkins either. If someone needs that, can use `hydra send-email` specifically.

Removed `send_email` from test teardown.
fixes: https://github.com/scylladb/scylla-cluster-tests/issues/7477

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [artifact test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/artifacts-ami-test/8/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
