### PR TITLE
fix(kafka-localstack): fix broken configuration file

### DIFF
--- a/test-cases/kafka/longevity-kafka-cdc.yaml
+++ b/test-cases/kafka/longevity-kafka-cdc.yaml
@@ -26,7 +26,7 @@ docker_network: 'kafka-stack-docker-compose_default'
 kafka_backend: 'localstack'
 
 kafka_connectors:
-  - version: 'hub:scylladb/scylla-cdc-source-connector:1.1.2'
+  - source: 'hub:scylladb/scylla-cdc-source-connector:1.1.2'
     name: "QuickstartConnector"
     config:
       "connector.class": "com.scylladb.cdc.debezium.connector.ScyllaConnector"


### PR DESCRIPTION
name of a property was changed from `version` to `source` and was missed on one of the configurtion files introduce in #6946

and it started failing on test case linting right after the merge

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
