### PR TITLE
fix(artifact-centos8-arm): update to lastet AMI

### DIFF
--- a/configurations/arm/centos8.yaml
+++ b/configurations/arm/centos8.yaml
@@ -1,5 +1,5 @@
 ami_db_scylla_user: 'centos'
-ami_id_db_scylla: 'ami-05b7b54d9a348ef3e' # CentOS Stream 8 aarch64 20231127
+ami_id_db_scylla: 'ami-044e1f226cce29d51' # CentOS Stream 8 aarch64 20240520'
 region_name: 'eu-west-1'
 instance_type_db: 'im4gn.xlarge'
 use_preinstalled_scylla: false


### PR DESCRIPTION
the AMI we had was deprecated, hence the metadata
retrvial of it fails like the following:
```
Traceback (most recent call last):
  File ".../sdcm/tester.py", line 182, in wrapper
    return method(*args, **kwargs)
  File ".../sdcm/utils/decorators.py", line 119, in inner
    res = func(*args, **kwargs)
  File ".../sdcm/tester.py", line 895, in setUp
    self.init_resources()
  File ".../sdcm/tester.py", line 1846, in init_resources
    self.get_cluster_aws(loader_info=loader_info, db_info=db_info,
  File ".../sdcm/tester.py", line 1327, in get_cluster_aws
    init_db_info_from_params(db_info, params=self.params, regions=regions)
  File ".../sdcm/utils/aws_utils.py", line 252, in init_db_info_from_params
    root_device = root_device if root_device else ec2_ami_get_root_device_name(
  File ".../sdcm/utils/aws_utils.py", line 417, in ec2_ami_get_root_device_name
    if image.root_device_name:
  File ".../boto3/resources/factory.py", line 386, in property_loader
    return self.meta.data.get(name)
AttributeError: 'NoneType' object has no attribute 'get'
```

Fixes: #7500

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] run this artifact test locally, and it was passing with this new AMI

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
