### PR TITLE
fix(logging): add __str__ to some class for readability

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3194,6 +3194,9 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         self.coredumps = {}
         super().__init__()
 
+    def __str__(self):
+        return f"{self.__class__.__name__}:{self.name}"
+
     @cached_property
     def test_config(self) -> TestConfig:  # pylint: disable=no-self-use
         return TestConfig()

--- a/sdcm/localhost.py
+++ b/sdcm/localhost.py
@@ -29,6 +29,9 @@ class LocalHost(SyslogNGContainerMixin, GcloudContainerMixin, HelmContainerMixin
         self.tags = {}
         self.name = (f"{user_prefix}-" if user_prefix else "") + "localhost" + (f"-{test_id}" if test_id else "")
 
+    def __str__(self):
+        return f"{self.__class__.__name__}: {self.name}"
+
     @property
     def ldap_ports(self) -> Optional[dict]:
         return {'ldap_port': ContainerManager.get_container_port(self, "ldap", LDAP_PORT),

--- a/sdcm/provision/azure/provisioner.py
+++ b/sdcm/provision/azure/provisioner.py
@@ -61,6 +61,9 @@ class AzureProvisioner(Provisioner):  # pylint: disable=too-many-instance-attrib
             except KeyError as exc:
                 LOGGER.warning("Failed to cache %s instance. Probably is pending deletion. Error: %s", v_m.name, exc)
 
+    def __str__(self):
+        return f"{self.__class__.__name__}(region={self.region}, az={self.availability_zone})"
+
     @staticmethod
     def _convert_az_to_zone(availability_zone: str) -> str:
         """Azure uses numbers for availiability zones, while in tests we use letters.


### PR DESCRIPTION
those were printing like that:
```
<sdcm.cluster_azure.ScyllaAzureCluster object at 0x7f7faee61930>
```

and now would be like that:
```
ScyllaAzureCluster:cluster-36ea8d10
```

Fixes: #4805

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
