### PR TITLE
fix(cloud-init): stabilise syslogng installation

### DIFF
--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -148,7 +148,7 @@ def install_syslogng_service():
                 done
 
                 for n in 1 2 3; do # cloud-init is running it with set +o braceexpand
-                    apt-get install -o DPkg::Lock::Timeout=300 -y syslog-ng || true
+                    DEBIAN_FRONTEND=noninteractive apt-get install -o DPkg::Lock::Timeout=300 -y syslog-ng || true
                     if dpkg-query --show syslog-ng ; then
                         SYSLOG_NG_INSTALLED=1
                         break


### PR DESCRIPTION
Sometimes syslogng fails with installation. Possibly due to requiring terminal which is not available.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
