### PR TITLE
fix(rolling_restart): Wait all nodes to be UN after each restart

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4746,6 +4746,12 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             node.stop_scylla(verify_down=True)
             node.start_scylla(verify_up=True)
             self.log.debug("'%s' restarted.", node.name)
+            self.wait_all_nodes_un()  # wait for all nodes to be up due to issue https://github.com/scylladb/scylladb/issues/18647
+
+    @retrying(n=15, sleep_time=5, allowed_exceptions=ClusterNodesNotReady)
+    def wait_all_nodes_un(self):
+        for node in self.nodes:
+            self.check_nodes_up_and_normal(verification_node=node)
 
     def restart_binary_protocol(self, nodes=None, random_order=False, verify_up=True):
         nodes_to_restart = (nodes or self.nodes)[:]  # create local copy of nodes list

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -50,7 +50,6 @@ from sdcm.cluster import (
     BaseCluster,
     BaseNode,
     BaseScyllaCluster,
-    ClusterNodesNotReady,
     DB_LOG_PATTERN_RESHARDING_START,
     DB_LOG_PATTERN_RESHARDING_FINISH,
     MAX_TIME_WAIT_FOR_NEW_NODE_UP,
@@ -3345,7 +3344,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     self.target_node, duration, rate=rate_limit, limit=limit, buffer=10000)
         experiment.start()
         experiment.wait_until_finished()
-        self._wait_all_nodes_un()
+        self.cluster.wait_all_nodes_un()
 
     def disrupt_network_random_interruptions(self):  # pylint: disable=invalid-name
         # pylint: disable=too-many-locals
@@ -3394,7 +3393,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             time.sleep(wait_time)
         finally:
             self.target_node.traffic_control(None)
-            self._wait_all_nodes_un()
+            self.cluster.wait_all_nodes_un()
 
     def _disrupt_network_block_k8s(self, list_of_timeout_options):
         duration = f"{random.choice(list_of_timeout_options)}s"
@@ -3402,7 +3401,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         experiment.start()
         experiment.wait_until_finished()
         time.sleep(15)
-        self._wait_all_nodes_un()
+        self.cluster.wait_all_nodes_un()
 
     def disrupt_network_block(self):
         list_of_timeout_options = [10, 60, 120, 300, 500]
@@ -3425,12 +3424,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             time.sleep(wait_time)
         finally:
             self.target_node.traffic_control(None)
-            self._wait_all_nodes_un()
-
-    @retrying(n=15, sleep_time=5, allowed_exceptions=ClusterNodesNotReady)
-    def _wait_all_nodes_un(self):
-        for node in self.cluster.nodes:
-            self.cluster.check_nodes_up_and_normal(verification_node=node)
+            self.cluster.wait_all_nodes_un()
 
     def disrupt_remove_node_then_add_node(self):  # pylint: disable=too-many-branches
         """
@@ -3755,7 +3749,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             time.sleep(wait_time)
         finally:
             self.target_node.start_network_interface()
-            self._wait_all_nodes_un()
+            self.cluster.wait_all_nodes_un()
 
     def _call_disrupt_func_after_expression_logged(self,
                                                    log_follower: Iterable[str],


### PR DESCRIPTION
In issue https://github.com/scylladb/scylladb/issues/18647 it was found that when a node restart it's insufficient now just to wait for cql port to be up and the safer way is to validate that all nodes are UN.

This commit moves the method wait_all_nodes_un to where it belongs in BaseScyllaCluster.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] @aleksbykov / @xtrey  to run a job with this nemesis

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
