### PR TITLE
feature(mergify): introduce automatic backport process

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,103 @@
+pull_request_rules:
+  - name: put PR in draft if conflicts
+    conditions:
+      - label = conflicts
+      - author = mergify[bot]
+    actions:
+      edit:
+         draft: true
+  - name: Automate backport pull request 5.2
+    conditions:
+      - base=master # Ensure this rule only applies to PRs merged into the master branch
+      - label=backport/5.2 # The PR must have this label to trigger the backport
+    actions:
+      backport:
+        title: "[Backport 5.2] {{ title }}"
+        body: |
+          {{ body }}
+
+          {% for c in commits %}
+          (cherry picked from commit {{ c.sha }} )
+          {% endfor %}
+
+          Parent PR: #{{number}}
+        branches:
+          - branch-5.2
+        assignees:
+          - "{{ author }}"
+  - name: Automate backport pull request 5.4
+    conditions:
+      - base=master # Ensure this rule only applies to PRs merged into the master branch
+      - label=backport/5.4 # The PR must have this label to trigger the backport
+    actions:
+      backport:
+        title: "[Backport 5.4] {{ title }}"
+        body: |
+          {{ body }}
+
+          {% for c in commits %}
+          (cherry picked from commit {{ c.sha }})
+          {% endfor %}
+
+          Parent PR: #{{number}}
+        branches:
+          - branch-5.4
+        assignees:
+          - "{{ author }}"
+  - name: Automate backport pull request 6.0
+    conditions:
+      - base=master # Ensure this rule only applies to PRs merged into the master branch
+      - label=backport/6.0 # The PR must have this label to trigger the backport
+    actions:
+      backport:
+        title: "[Backport 6.0] {{ title }}"
+        body: |
+          {{ body }}
+
+          {% for c in commits %}
+          (cherry picked from commit {{ c.sha }})
+          {% endfor %}
+
+          Parent PR: #{{number}}
+        branches:
+          - branch-6.0
+        assignees:
+          - "{{ author }}"
+  - name: Automate backport pull request 2023.1
+    conditions:
+      - base=master # Ensure this rule only applies to PRs merged into the master branch
+      - label=backport/2023.1 # The PR must have this label to trigger the backport
+    actions:
+      backport:
+        title: "[Backport 2023.1] {{ title }}"
+        body: |
+          {{ body }}
+
+          {% for c in commits %}
+          (cherry picked from commit {{ c.sha }} )
+          {% endfor %}
+
+          Parent PR: #{{number}}
+        branches:
+          - branch-2023.1
+        assignees:
+          - "{{ author }}"
+  - name: Automate backport pull request 2024.1
+    conditions:
+      - base=master # Ensure this rule only applies to PRs merged into the master branch
+      - label=backport/2024.1 # The PR must have this label to trigger the backport
+    actions:
+      backport:
+        title: "[Backport 2024.1] {{ title }}"
+        body: |
+          {{ body }}
+
+          {% for c in commits %}
+          (cherry picked from commit {{ c.sha }})
+          {% endfor %}
+
+          Parent PR: #{{number}}
+        branches:
+          - branch-2024.1
+        assignees:
+          - "{{ author }}"


### PR DESCRIPTION
Same as scylladb and scylla-dtest, adding backport automation for SCT as well

since SCT doesn't have next process, no need for automatic labeling for PR that reached master, so backport PR would be open right after merge.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
