### PR TITLE
fix(hydra-list-images): don't fail on images that don't have `build-id`

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1932,7 +1932,7 @@ def get_ami_images(branch: str, region: str, arch: AwsArchType) -> list:
     for ami in amis:
         tags = {i['Key']: i['Value'] for i in ami.tags}
         rows.append(["AWS", ami.name, ami.image_id, ami.creation_date, tags.get("Name"), tags.get(
-            'build-id', tags.get("build_id"))[:6], tags.get('arch'), tags.get('ScyllaVersion'), ami.owner_id])
+            'build-id', tags.get("build_id", r"N\A"))[:6], tags.get('arch'), tags.get('ScyllaVersion'), ami.owner_id])
 
     return rows
 


### PR DESCRIPTION
the tag was remove from scylla-machine-image, and SCT should be assuming it's there, in any name.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] test locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
