### PR TITLE
improvement(cluster): filter out keyspace by replication factor

### DIFF
--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -774,6 +774,36 @@ def test_get_any_ks_cf_list(docker_scylla, params, events):  # pylint: disable=u
     assert set(table_names) == {'mview.users', '"123_keyspace"."120users"', '"123_keyspace".users'}
 
 
+@pytest.mark.integration
+def test_filter_out_ks_with_rf_one(docker_scylla, params, events):  # pylint: disable=unused-argument
+
+    cluster = DummyScyllaCluster([docker_scylla])
+    cluster.params = params
+
+    with cluster.cql_connection_patient(docker_scylla) as session:
+        session.execute(
+            "CREATE KEYSPACE mview WITH replication = {'class': 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1'} "
+            "AND durable_writes = true AND tablets = {'enabled': false}")
+        session.execute(
+            "CREATE TABLE mview.users (username text, first_name text, last_name text, password text, email text, "
+            "last_access timeuuid, PRIMARY KEY(username))")
+        session.execute(
+            "INSERT INTO mview.users (username, first_name, last_name, password) VALUES "
+            "('fruch', 'Israel', 'Fruchter', '1111')")
+        session.execute(
+            "CREATE KEYSPACE mview2 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
+        session.execute(
+            "CREATE TABLE mview2.users (username text, first_name text, last_name text, password text, email text, "
+            "last_access timeuuid, PRIMARY KEY(username))")
+        session.execute(
+            "INSERT INTO mview2.users (username, first_name, last_name, password) VALUES "
+            "('fruch', 'Israel', 'Fruchter', '1111')")
+        docker_scylla.run_nodetool('flush')
+
+        table_names = cluster.get_non_system_ks_cf_list(docker_scylla, filter_func=cluster.is_ks_rf_one)
+        assert table_names == ['mview2.users']
+
+
 class TestNodetool(unittest.TestCase):
     def test_describering_parsing(self):  # pylint: disable=no-self-use
         """ Test "nodetool describering" output parsing """

--- a/unit_tests/test_replication_strategy_utils.py
+++ b/unit_tests/test_replication_strategy_utils.py
@@ -31,7 +31,7 @@ class TestReplicationStrategies:
 
         # test regex match is case insensitive and white spaces insensitive
         strategy = ReplicationStrategy.from_string(
-            "replication  ={'class': 'SimpleStrategy', 'replication_factor' : 4}")
+            "replication = {'class': 'SimpleStrategy', 'replication_factor': 4}")
         assert isinstance(strategy, SimpleReplicationStrategy)
         assert str(strategy) == "{'class': 'SimpleStrategy', 'replication_factor': 4}"
 
@@ -43,9 +43,15 @@ class TestReplicationStrategies:
 
     def test_can_create_network_topology_replication_strategy_from_string_with_replication_factor(self):  # pylint: disable=no-self-use
         strategy = ReplicationStrategy.from_string(
-            "REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2,}")
+            "REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2}")
         assert isinstance(strategy, NetworkTopologyReplicationStrategy)
         assert str(strategy) == "{'class': 'NetworkTopologyStrategy', 'replication_factor': 2}"
+
+    def test_get_replication_startegy_from_string_with_few_curly_braces(self):  # pylint: disable=no-self-use
+        strategy = ReplicationStrategy.from_string(
+            "replication = {'class': 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1'} "
+            "AND durable_writes = true AND tablets = {'enabled': false}")
+        assert str(strategy) == "{'class': 'SimpleStrategy', 'replication_factor': 1}"
 
     def test_cannot_create_network_topology_replication_strategy_without_replication_factor(self):  # pylint: disable=no-self-use
         with pytest.raises(ValueError):


### PR DESCRIPTION
There are Scylla operation that cannot be performed on table with RF one. This commit adds filtering out of all keyspaces with RF one to prevent this nemesis run.

The 'toggle_table_gc_mode' nemesis cannot be run on table with RF = 1 and fails with error: ConfigurationException: tombstone_gc option with mode = repair not supported for table with RF one or local replication strategy

If all tables are with RF 1, this nemesis should not be started

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-1-rf-s-b-test-12h](https://argus.scylladb.com/test/e6ef2a1c-7267-4566-9954-f49caa755c50/runs?additionalRuns[]=e736333c-3035-4966-8650-895b2bc7a8a2) - only 1 RF keyspace
- [x] [RF = 3](https://argus.scylladb.com/test/e6ef2a1c-7267-4566-9954-f49caa755c50/runs?additionalRuns[]=2f7095ce-e2ab-4006-a11b-1d62e6299fa3)
- [x] [longevity-100gb-4h](https://argus.scylladb.com/test/657bf1f3-69a5-4c36-bdbf-bf17718f7087/runs?additionalRuns[]=d7ae197c-77a1-4831-96a8-5a1acd6d8508) - different nemeses
- [x] [`disrupt_add_remove_dc` nemesis](https://argus.scylladb.com/test/22d76ec7-28e1-4f13-8c9a-9f6357bb3d8a/runs?additionalRuns[]=28b3e17f-0693-4c9e-9e11-17eae962c39c)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
