### PR TITLE
fix(artifact-tests): prolong housekeeping verification

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -59,7 +59,7 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
 
     # since this logic id depended on code run by SCT to mark uuid as test, since commit 617026aa, this code it run in the background
     # and not being waited for, so we need to compensate for it here with retries
-    @retrying(n=5, sleep_time=10, allowed_exceptions=(AssertionError,))
+    @retrying(n=15, sleep_time=10, allowed_exceptions=(AssertionError,))
     def check_scylla_version_in_housekeepingdb(self, prev_id: int, expected_status_code: str,
                                                new_row_expected: bool, backend: str) -> int:
         """


### PR DESCRIPTION
Still housekeepingdb is not updated in timely manner. Prolonged the waiting to stabilise test.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/7487

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
