### PR TITLE
fix(configure_remote_logging): wait for cloud-init

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -146,6 +146,7 @@ from sdcm.paths import (
     SCYLLA_MANAGER_TLS_KEY_FILE,
 )
 from sdcm.sct_provision.aws.user_data import ScyllaUserDataBuilder
+
 from sdcm.exceptions import (
     KillNemesis,
     NodeNotReady,
@@ -362,6 +363,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         # Start task threads after ssh is up, otherwise the dense ssh attempts from task
         # threads will make SCT builder to be blocked by sshguard of gce instance.
         self.wait_ssh_up(verbose=True)
+        self.wait_for_cloud_init()
         if not self.test_config.REUSE_CLUSTER:
             self.set_hostname()
             self.configure_remote_logging()
@@ -2834,6 +2836,9 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         result = self.remoter.run("sudo bash -ce '%s'" % cmds)
         LOGGER.debug(result.stdout)
 
+    def wait_for_cloud_init(self):
+        raise NotImplementedError()
+
     def set_hostname(self):
         self.log.warning('Method set_hostname is not implemented for %s' % self.__class__.__name__)
 
@@ -2843,7 +2848,6 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         script = ConfigurationScriptBuilder(
             syslog_host_port=self.test_config.get_logging_service_host_port(),
             logs_transport=self.parent_cluster.params.get('logs_transport'),
-            disable_ssh_while_running=False,
             hostname=self.name,
         ).to_string()
         self.remoter.sudo(shell_script_cmd(script, quote="'"))
@@ -5794,6 +5798,9 @@ class LocalNode(BaseNode):
         raise NotImplementedError()
 
     def _init_port_mapping(self):
+        pass
+
+    def wait_for_cloud_init(self):
         pass
 
     def _init_remoter(self, ssh_login_info):

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -42,6 +42,7 @@ from sdcm.provision.common.utils import configure_hosts_set_hostname_script
 from sdcm.provision.network_configuration import NetworkInterface, ScyllaNetworkConfiguration, is_ip_ssh_connections_ipv6, \
     network_interfaces_count, ssh_connection_ip_type
 from sdcm.provision.scylla_yaml import SeedProvider
+from sdcm.provision.helpers.cloud_init import wait_cloud_init_completes
 from sdcm.sct_provision.aws.cluster import PlacementGroup
 
 from sdcm.remote import LocalCmdRunner, shell_script_cmd, NETWORK_EXCEPTIONS
@@ -502,6 +503,9 @@ class AWSNode(cluster.BaseNode):
         self.log.debug("Node %s network_interfaces: %s", self.name,
                        self.scylla_network_configuration.network_interfaces)
         super().init()
+
+    def wait_for_cloud_init(self):
+        wait_cloud_init_completes(self.remoter, self)
 
     @property
     def short_hostname(self):

--- a/sdcm/cluster_azure.py
+++ b/sdcm/cluster_azure.py
@@ -69,6 +69,9 @@ class AzureNode(cluster.BaseNode):
         self.remoter.sudo("systemctl mask auditd", ignore_status=True)
         self.remoter.sudo("systemctl daemon-reload", ignore_status=True)
 
+    def wait_for_cloud_init(self):
+        pass  # azure for it, on resources creation
+
     @cached_property
     def tags(self) -> Dict[str, str]:
         return {**super().tags,

--- a/sdcm/cluster_baremetal.py
+++ b/sdcm/cluster_baremetal.py
@@ -54,6 +54,9 @@ class PhysicalMachineNode(cluster.BaseNode):
         self.set_hostname()
         self.run_startup_script()
 
+    def wait_for_cloud_init(self):
+        pass
+
     def _get_public_ip_address(self) -> Optional[str]:
         return self._public_ip
 

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -86,6 +86,9 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):  # pylint: disable=abstr
             assert int(container.labels["NodeIndex"]) == node_index, "Container labeled with wrong index."
             self._containers["node"] = container
 
+    def wait_for_cloud_init(self):
+        pass
+
     @property
     def network_interfaces(self):
         pass
@@ -402,6 +405,9 @@ class DockerMonitoringNode(cluster.BaseNode):  # pylint: disable=abstract-method
                          node_prefix=node_prefix,
                          ssh_login_info=ssh_login_info)
         self.node_index = node_index
+
+    def wait_for_cloud_init(self):
+        pass
 
     @staticmethod
     def is_docker() -> bool:

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -26,6 +26,7 @@ from google.cloud import compute_v1
 
 from sdcm import cluster
 from sdcm.provision.network_configuration import ssh_connection_ip_type
+from sdcm.provision.helpers.cloud_init import wait_cloud_init_completes
 from sdcm.sct_events import Severity
 from sdcm.sct_events.gce_events import GceInstanceEvent
 from sdcm.utils.gce_utils import (
@@ -110,6 +111,9 @@ class GCENode(cluster.BaseNode):
         time.sleep(10)
 
         super().init()
+
+    def wait_for_cloud_init(self):
+        wait_cloud_init_completes(self.remoter, self)
 
     @cached_property
     def tags(self) -> Dict[str, str]:

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1783,6 +1783,9 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
     def configure_remote_logging(self):
         self.k8s_cluster.log.debug("No need to configure remote logging on k8s")
 
+    def wait_for_cloud_init(self):
+        pass
+
     @staticmethod
     def is_docker() -> bool:
         return True

--- a/sdcm/provision/common/configuration_script.py
+++ b/sdcm/provision/common/configuration_script.py
@@ -33,7 +33,6 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
     syslog_host_port: tuple[str, int] = None
     logs_transport: str = 'syslog-ng'
     configure_sshd: bool = True
-    disable_ssh_while_running: bool = False
     hostname: str = ''
 
     def to_string(self) -> str:
@@ -60,14 +59,10 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
         script += 'set -x\n'
         script += self._wait_before_running_script()
         script += self._skip_if_already_run()
-        if self.disable_ssh_while_running:
-            script += 'systemctl stop sshd || true\n'
         return script
 
     def _end_script(self) -> str:
         script = ""
-        if self.disable_ssh_while_running:
-            script += 'systemctl start sshd || true\n'
         script += self._mark_script_as_done()
         return script
 
@@ -94,6 +89,5 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
             script += configure_sshd_script()
             script += configure_ssh_accept_rsa()
             script += restart_sshd_service()
-        elif self.disable_ssh_while_running:
-            script += 'systemctl start sshd || true\n'
+
         return script

--- a/sdcm/sct_provision/aws/user_data.py
+++ b/sdcm/sct_provision/aws/user_data.py
@@ -60,7 +60,6 @@ class ScyllaUserDataBuilder(ScyllaUserDataBuilderBase):
             aws_ipv6_workaround=is_ip_ssh_connections_ipv6(self.params),
             syslog_host_port=self.syslog_host_port,
             logs_transport=self.params.get('logs_transport'),
-            disable_ssh_while_running=True,
         ).to_string()
         LOGGER.debug("post_boot_script: %s", post_boot_script)
         return base64.b64encode(post_boot_script.encode('utf-8')).decode('ascii')
@@ -124,6 +123,5 @@ class AWSInstanceUserDataBuilder(UserDataBuilderBase):
             aws_ipv6_workaround=is_ip_ssh_connections_ipv6(self.params),
             logs_transport=self.params.get('logs_transport'),
             syslog_host_port=self.syslog_host_port,
-            disable_ssh_while_running=True,
         ).to_string()
         return post_boot_script

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -231,7 +231,6 @@ class TestConfig(metaclass=Singleton):  # pylint: disable=too-many-public-method
         return ConfigurationScriptBuilder(
             syslog_host_port=host_port,
             logs_transport=cls._tester_obj.params.get('logs_transport') if cls._tester_obj else "syslog-ng",
-            disable_ssh_while_running=True,
         ).to_string()
 
     @classmethod

--- a/unit_tests/dummy_remote.py
+++ b/unit_tests/dummy_remote.py
@@ -55,6 +55,9 @@ class LocalNode(BaseNode):
     def ip_address(self):
         return "127.0.0.1"
 
+    def wait_for_cloud_init(self):
+        pass
+
     @property
     def vm_region(self):
         return "eu-north-1"

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -496,6 +496,9 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method,too-many-instance-
         # disable all background threads
         pass
 
+    def wait_for_cloud_init(self):
+        pass
+
     def set_hostname(self):
         pass
 

--- a/unit_tests/test_sla_utils.py
+++ b/unit_tests/test_sla_utils.py
@@ -24,6 +24,9 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method
         super().init()
         self.remoter.stop()
 
+    def wait_for_cloud_init(self):
+        pass
+
     def jmx_up(self):
         return True
 

--- a/unit_tests/test_utils_common.py
+++ b/unit_tests/test_utils_common.py
@@ -140,6 +140,9 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method
     def system_log(self, log: str):
         self._system_log = log
 
+    def wait_for_cloud_init(self):
+        pass
+
     def set_hostname(self) -> None:
         pass
 


### PR DESCRIPTION
since one cases we run without provision phase, we might get into `configure_remote_logging`, before cloud-init has finished to installations of packages, and file we use to indicate no need to configure syslog-ng again isn't yet create, and we can run into case we might try to run `apt-get update` at the same time, and fail with what would look like premission issues

this change also remove the hack of disabling ssh at the start and at the end of cloud-init script, since we wait for cloud-init before doing any extra configuration.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested local the aws provision test
- [ ] all of the provision tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
