### PR TITLE
fix(rolling-upgrade): Set of commits to fix rolling upgrade from 6.0-6.1

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -35,6 +35,7 @@ from sdcm.remote import LOCALRUNNER
 from sdcm.utils.common import ParallelObject, DEFAULT_AWS_REGION
 from sdcm.sct_events.system import ScyllaRepoEvent
 from sdcm.utils.decorators import retrying
+from sdcm.utils.features import get_enabled_features
 
 # Examples of ScyllaDB version strings:
 #   - 666.development-0.20200205.2816404f575
@@ -72,6 +73,7 @@ SCYLLA_VERSION_RE = re.compile(r"\d+(\.\d+)?\.[\d\w]+([.~][\d\w]+)?")
 ARGUS_VERSION_RE = re.compile(r'((?P<short>[\w.~]+)-(0\.)?(?P<date>[0-9]{8,8})\.(?P<commit>\w+).*)')
 SCYLLA_VERSION_GROUPED_RE = re.compile(r'(?P<version>[\w.~]+)-(?P<build>0|rc\d)?\.?(?P<date>[\d]+)\.(?P<commit_id>\w+)')
 SSTABLE_FORMAT_VERSION_REGEX = re.compile(r'Feature (.*)_SSTABLE_FORMAT is enabled')
+ENABLED_SSTABLE_FORMAT_VERSION_REGEXP = re.compile(r'(.*)_SSTABLE_FORMAT')
 PRIMARY_XML_GZ_REGEX = re.compile(r'="(.*?primary.xml.gz)"')
 
 # Example of output for `systemctl --version' command:
@@ -454,6 +456,15 @@ def get_node_supported_sstable_versions(node_system_log) -> List[str]:
             if match := SSTABLE_FORMAT_VERSION_REGEX.search(line):
                 output.append(match.group(1).lower())
     return output
+
+
+def get_node_enabled_sstable_version(session) -> list[str]:
+    enabled_sstable_format_features = []
+    all_features = get_enabled_features(session)
+    for feature in all_features:
+        if match := ENABLED_SSTABLE_FORMAT_VERSION_REGEXP.search(feature):
+            enabled_sstable_format_features.append(match.group(1).lower())
+    return enabled_sstable_format_features
 
 
 def get_systemd_version(output: str) -> int:

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -35,7 +35,8 @@ gemini_cmd: "gemini -d --duration 2h \
 --max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
 --async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \
 --replication-strategy \"{'class': 'NetworkTopologyStrategy', 'replication_factor': '3'}\" \
---table-options \"cdc={'enabled': true}\" --test-username cassandra --test-password cassandra"
+--test-username cassandra --test-password cassandra"
+
 gemini_seed: 66
 
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -356,6 +356,8 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             self.upgradesstables_if_command_available(node)
             InfoEvent(message='upgrade_node - ended to "upgradesstables_if_command_available"').publish()
 
+        self.db_cluster.wait_all_nodes_un()
+
     @truncate_entries
     # https://github.com/scylladb/scylla/issues/10447#issuecomment-1194155163
     def rollback_node(self, node, upgrade_sstables=True):
@@ -456,6 +458,8 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
 
         if upgrade_sstables:
             self.upgradesstables_if_command_available(node)
+
+        self.db_cluster.wait_all_nodes_un()
 
     @staticmethod
     def upgradesstables_if_command_available(node, queue=None):  # pylint: disable=invalid-name

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -98,14 +98,14 @@ def backup_conf(node):
         node.remoter.run(
             r'for conf in $( rpm -qc $(rpm -qa | grep scylla) | grep -v contains ) '
             r'/etc/systemd/system/{var-lib-scylla,var-lib-systemd-coredump}.mount; '
-            r'do sudo cp -v $conf $conf.autobackup; done')
+            r'do if test -e $conf; then sudo cp -v $conf $conf.autobackup; fi; done')
     else:
         node.remoter.run(
             r'for conf in $(cat /var/lib/dpkg/info/scylla-*server.conffiles '
             r'/var/lib/dpkg/info/scylla-*conf.conffiles '
             r'/var/lib/dpkg/info/scylla-*jmx.conffiles | grep -v init ) '
             r'/etc/systemd/system/{var-lib-scylla,var-lib-systemd-coredump}.mount; '
-            r'do sudo cp -v $conf $conf.backup; done')
+            r'do if test -e $conf; then sudo cp -v $conf $conf.backup; fi; done')
 
 
 def recover_conf(node):
@@ -113,13 +113,13 @@ def recover_conf(node):
         node.remoter.run(
             r'for conf in $( rpm -qc $(rpm -qa | grep scylla) | grep -v contains ) '
             r'/etc/systemd/system/{var-lib-scylla,var-lib-systemd-coredump}.mount; '
-            r'do test -e $conf.autobackup && sudo cp -v $conf.autobackup $conf; done')
+            r'do if test -e $conf.backup; then sudo cp -v $conf.backup $conf; fi; done')
     else:
         node.remoter.run(
             r'for conf in $(cat /var/lib/dpkg/info/scylla-*server.conffiles '
             r'/var/lib/dpkg/info/scylla-*conf.conffiles '
             r'/var/lib/dpkg/info/scylla-*jmx.conffiles | grep -v init ); do '
-            r'test -e $conf.backup && sudo cp -v $conf.backup $conf; done')
+            r'if test -e $conf.backup; then sudo cp -v $conf.backup $conf; fi; done')
 
 
 # pylint: disable=too-many-instance-attributes, too-many-public-methods


### PR DESCRIPTION
Set of commits which are fix several issues in rolling upgrades from 6.0 to 6.1

[fix(restore-backup): Restore only existent files](https://github.com/scylladb/scylla-cluster-tests/pull/7525/commits/0fec37f69d339ace09f30355a8917c3029b9c7aa) - Fixing script error when try to restore backup config files which could be missing

[fix(fill_db-UP): Temprorary disable cdc for rolling upgrade](https://github.com/scylladb/scylla-cluster-tests/pull/7525/commits/7cae54dc8d86b12abaf16b6a063a13c9bb8f9e51) - Disable creating table with cdc options because it is not supported with tablets

[fix(upgrade_test): Wait while all nodes up after rollback](https://github.com/scylladb/scylla-cluster-tests/pull/7525/commits/4a923f8705b2e9a2e66a1695dc3982c8b2a0d569) - need to wait after node upgrade/rollback that all nodes are up and normal. it is required by raft topology feature

[fix(get_highest_sstable_version): get enabled sstable version from db](https://github.com/scylladb/scylla-cluster-tests/pull/7525/commits/99d7eebd37bbf467ca86bbc5b56b00590418521a) - Log message with enabled format sstable is dissappeared from log file. Added new methods to get supported sstable format from system_local

[fix(upgrade): no assert on upggrade sstable](https://github.com/scylladb/scylla-cluster-tests/pull/7525/commits/b07f1b9219426e0cf159d87fdde8c1f5ecacba16) - change assert to log error for current sstable format.

Latest to commits could be https://github.com/scylladb/scylladb/issues/18995

### Testing
- [Job with fixes](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/rolling-upgrade-staging-abykov/job/rolling-upgrade-ubuntu22.04-test/8)



### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
