### PR TITLE
fix(k8s-multitenant): add `kafka_cluster` to __init__

### DIFF
--- a/sdcm/utils/operator/multitenant_common.py
+++ b/sdcm/utils/operator/multitenant_common.py
@@ -35,6 +35,7 @@ class TenantMixin:  # pylint: disable=too-many-instance-attributes
         self.monitors = monitors
         self.prometheus_db = prometheus_db
         self.params = copy.deepcopy(params)
+        self.kafka_cluster = None
         self.log = logging.getLogger(self.__class__.__name__)
         self._es_doc_type = "test_stats"
         self._stats = self._init_stats()


### PR DESCRIPTION
if we don't have it in `TenantMixin`, we have failure like the following, when the test try to check if we have kafaka_cluster configured:

```
AttributeError: 'TenantForLongevityTest-2' object has no attribute 'kafka_cluster'.
Did you mean: 'k8s_cluster'?
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
