### PR TITLE
fix(alternator): auth_v2 now default to using system keyspace

### DIFF
--- a/sdcm/utils/alternator/api.py
+++ b/sdcm/utils/alternator/api.py
@@ -48,7 +48,7 @@ class Alternator:
     @staticmethod
     def get_salted_hash(node: BaseNode, username: str) -> str:
         with node.parent_cluster.cql_connection_patient_exclusive(node) as session:
-            for ks in ("system_auth_v2", "system_auth"):
+            for ks in ("system", "system_auth_v2", "system_auth"):
                 try:
                     response = session.execute(f"SELECT salted_hash FROM {ks}.roles WHERE role=%s;", (username,))
                 except InvalidRequest:


### PR DESCRIPTION
we introduce the read of `salted_hash` the possible names were `system_auth_v2`, `system_auth`.

now the first one to try out is `system`

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
