### PR TITLE
improvement(manager): save Scylla manager version in Argus

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -57,6 +57,7 @@ from sdcm.cluster_aws import MonitorSetAWS
 from sdcm.cluster_k8s import mini_k8s, gke, eks
 from sdcm.cluster_k8s.eks import MonitorSetEKS
 from sdcm.cql_stress_cassandra_stress_thread import CqlStressCassandraStressThread
+from sdcm.mgmt import get_scylla_manager_tool
 from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.kafka.kafka_cluster import LocalKafkaCluster
 from sdcm.provision.azure.provisioner import AzureProvisioner
@@ -501,6 +502,20 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.test_config.argus_client().submit_packages(packages_to_submit)
         except Exception:  # pylint: disable=broad-except
             self.log.error("Unable to collect package versions for Argus - skipping...", exc_info=True)
+
+    def argus_collect_manager_version(self):
+        if self.params.get('use_mgmt'):
+            manager_tool = get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
+            self.log.info("Saving manager version in Argus...")
+            # sctool.version output:
+            #   [['Client version: 3.2.8-0.20240517.5f324acd2'], ['Server version: 3.2.8-0.20240517.5f324acd2']]
+            client_version, server_version, *_ = (version[0].split(":")[1].strip()
+                                                  for version in manager_tool.sctool.version)
+            manager_packages = [Package(name="scylla-manager-client", date="",
+                                        version=client_version, revision_id="", build_id=""),
+                                Package(name="scylla-manager-server", date="",
+                                        version=server_version, revision_id="", build_id="")]
+            self.test_config.argus_client().submit_packages(manager_packages)
 
     def generate_operator_packages(self) -> list[Package]:
         operator_packages = []
@@ -975,7 +990,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             futures = [
                 executor.submit(_db_post_validation),
                 executor.submit(self.argus_collect_packages),
-                executor.submit(self.argus_get_scylla_version)
+                executor.submit(self.argus_get_scylla_version),
+                executor.submit(self.argus_collect_manager_version),
             ]
 
             for db_cluster in self.db_clusters_multitenant:


### PR DESCRIPTION
Collect and save in Argus Scylla manager version

![Screenshot from 2024-06-03 18-12-08](https://github.com/scylladb/scylla-cluster-tests/assets/34435448/d91d7382-aa06-450e-ab56-064223889a13)



### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-100gb-4h](https://argus.scylladb.com/test/657bf1f3-69a5-4c36-bdbf-bf17718f7087/runs?additionalRuns[]=ea7e5f7b-34ec-4e41-a168-51024930ebfe)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
