### PR TITLE
ci(pipeline): add possibility to byo scylladb for longevity and upgrades

### DIFF
--- a/vars/byoScylladb.groovy
+++ b/vars/byoScylladb.groovy
@@ -1,0 +1,118 @@
+#!groovy
+
+def call(Map params, boolean build_image){
+    if (! (params.byo_scylla_repo && params.byo_scylla_branch) ) {
+        println("BYO scylladb is not provided. Skipping this step.")
+        return ''
+    }
+    config_conflict_error_msg_suffix = ' and "byo_scylla_repo"+"byo_scylla_branch" are mutually exclusive params.'
+    if (params.backend == "aws" && params.scylla_ami_id && build_image) {
+        error('CONFLICT: "scylla_ami_id"' + config_conflict_error_msg_suffix)
+    } else if (params.backend == "gce" && params.gce_image_db && build_image) {
+        error('CONFLICT: "gce_image_db"' + config_conflict_error_msg_suffix)
+    } else if (params.backend == "azure" && params.azure_image_db && build_image) {
+        error('CONFLICT: "azure_image_db"' + config_conflict_error_msg_suffix)
+    } else if (params.new_scylla_repo && !build_image) {
+        // NOTE: rolling upgrade case
+        error('CONFLICT: "new_scylla_repo"' + config_conflict_error_msg_suffix)
+    } else if (params.backend == 'docker' || params.backend.startsWith("k8s")) {
+        // TODO: add docker image building support
+        error('BYO Scylladb is not supported yet for building docker image in SCT.')
+    }
+
+    if (params.byo_job_path) {
+        jobToTrigger = params.byo_job_path
+    } else {
+        jobToTrigger = "./byo"
+    }
+    if (jobToTrigger.startsWith("./")) {
+        currentJobDirectoryPath = JOB_NAME.substring(0, JOB_NAME.lastIndexOf('/'))
+        jobToTrigger = currentJobDirectoryPath + '/' + jobToTrigger[2..-1].trim()
+    }
+
+    byoParameterList = [
+        string(name: 'DEFAULT_PRODUCT', value: params.byo_default_product),
+        string(name: 'DEFAULT_BRANCH', value: params.byo_default_branch),
+        string(name: 'SCYLLA_REPO', value: "git@github.com:scylladb/${params.byo_default_product}.git"),
+        string(name: 'SCYLLA_BRANCH', value: params.byo_default_branch),
+        string(name: 'SCYLLA_FORK_REPO', value: params.byo_scylla_repo),
+        string(name: 'SCYLLA_FORK_BRANCH', value: params.byo_scylla_branch),
+        //
+        string(name: 'MACHINE_IMAGE_REPO',
+               value: "git@github.com:scylladb/${params.byo_default_product}-machine-image.git"),
+        string(name: 'MACHINE_IMAGE_BRANCH', value: params.byo_default_branch),
+        // NOTE: SCT repo is used only for benchmarking which we disable here.
+        //       So, hardcode 'master' SCT version for all cases.
+        string(name: 'SCT_REPO', value: 'git@github.com:scylladb/scylla-cluster-tests.git'),
+        string(name: 'SCT_BRANCH', value: 'master'),
+        string(name: 'RELENG_REPO', value: "git@github.com:vponomaryov/${params.byo_default_product}-pkg.git"),
+        string(name: 'RELENG_BRANCH', value: params.byo_default_branch),
+        //
+        booleanParam(name: 'BUILD_WITH_CMAKE', value: false),
+        // NOTE: 'BUILD_MODE' must be empty string for '5.4'/'2024.1' and older branches
+        string(name: 'BUILD_MODE', value: 'ALL'),
+        booleanParam(name: 'CODE_COVERAGE', value: false),
+        booleanParam(name: 'TEST_DEBUG_INFO', value: false),
+        // SPECIAL_CONFIGURE_PY_PARAMS = '' // TODO: add it's support?
+        //
+        booleanParam(name: 'ENABLE_MICRO_BENCHMARKS', value: false),
+        booleanParam(name: 'ENABLE_TESTS', value: false),
+        string(name: 'X86_NUM_OF_UNITTEST_REPEATS', value: '1'),
+        string(name: 'INCLUDE_TESTS', value: ''),
+        //
+        booleanParam(name: 'ENABLE_DTEST', value: false),
+        //
+        booleanParam(name: 'CREATE_CENTOS_RPM', value: false),
+        booleanParam(name: 'CREATE_UNIFIED_DEB', value:  true),
+        booleanParam(name: 'CREATE_DOCKER', value: false),
+        booleanParam(name: 'CREATE_AMI', value: (params.backend == 'aws' && build_image)),
+        string(name: 'COPY_AMI_TO_REGIONS', value: params.region),
+        booleanParam(name: 'CREATE_GCE', value: (params.backend == 'gce' && build_image)),
+        booleanParam(name: 'CREATE_AZURE', value: (params.backend == 'azure' && build_image)),
+        //
+        string(name: 'ARCH', value: 'x86_64'),
+        string(name: 'TIMEOUT_PARAM', value: '4'), // reduced because dtests don't get run
+        booleanParam(name: 'DEBUG_MAIL', value: true),
+        booleanParam(name: 'DRY_RUN', value: false),
+    ]
+    try {
+        jobResults=build job: jobToTrigger,
+            parameters: byoParameterList,
+            propagate: true,
+            wait: true
+    } catch(Exception ex) {
+        echo "Could not trigger jon $jobToTrigger due to"
+        println(ex.toString())
+    }
+    def byoBuildInfo = jobResults.getBuildVariables();
+    try {
+        println('byoBuildInfo=' + byoBuildInfo)
+    } catch(Exception ex) {
+        println('Failed to print BYO ScyllaDB build info')
+    }
+    scyllaBuildFailed = !(jobResults.result == "SUCCESS")
+    if (scyllaBuildFailed) {
+        currentBuild.description = ('BYO ScyllaDB failed')
+        currentBuild.result = 'FAILED'
+        error('BYO ScyllaDB failed')
+    }
+
+    // NOTE: export appropriate env vars to be reused further by the SCT
+    if (build_image) {
+        // NOTE: longevity case
+        if (params.backend == "aws") {
+            env.SCT_AMI_ID_DB_SCYLLA = byoBuildInfo.BYO_AMI_ID
+        } else if (params.backend == "gce") {
+            env.SCT_GCE_IMAGE_DB = byoBuildInfo.BYO_GCE_IMAGE_DB_URL
+        } else if (params.backend == "azure") {
+            env.SCT_AZURE_IMAGE_DB = byoBuildInfo.BYO_AZURE_IMAGE_NAME
+        }
+    } else {
+        // NOTE: rolling upgrade case
+        if (byoBuildInfo.BYO_SCYLLA_DEB_LIST_FILE_URL.startsWith("http")) {
+            env.SCT_NEW_SCYLLA_REPO = byoBuildInfo.BYO_SCYLLA_DEB_LIST_FILE_URL
+        } else {
+            env.SCT_NEW_SCYLLA_REPO = 'https://' + byoBuildInfo.BYO_SCYLLA_DEB_LIST_FILE_URL
+        }
+    }
+}

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -146,6 +146,23 @@ def call(Map pipelineParams) {
             string(defaultValue: '',
                    description: 'Actual user requesting job start, for automated job builds (e.g. through Argus)',
                    name: 'requested_by_user')
+
+            // NOTE: Optional parameters for BYO ScyllaDB stage
+            string(defaultValue: '',
+                   description: 'Custom "scylladb" repo to use. Leave empty if byo is not needed. If specified then need to define "base_versions" param explicitly.',
+                   name: 'byo_scylla_repo')
+            string(defaultValue: '',
+                   description: 'Branch of the custom "scylladb" repo. Leave empty if byo is not needed.',
+                   name: 'byo_scylla_branch')
+            string(defaultValue: './byo',
+                   description: 'Used when byo scylladb repo+branch is provided. Default "./byo"',
+                   name: 'byo_job_path')
+            string(defaultValue: 'scylla',
+                   description: '"scylla" or "scylla-enterprise". Default is "scylla".',
+                   name: 'byo_default_product')
+            string(defaultValue: 'next',
+                   description: 'Default branch to be used for scylla and other repositories. Default is "next".',
+                   name: 'byo_default_branch')
         }
         options {
             timestamps()
@@ -205,6 +222,21 @@ def call(Map pipelineParams) {
                                 wrap([$class: 'BuildUser']) {
                                     dir('scylla-cluster-tests') {
                                         (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout) = getJobTimeouts(params, builder.region)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            stage('BYO Scylladb [optional]') {
+                steps {
+                    catchError(stageResult: 'FAILURE') {
+                        script {
+                            wrap([$class: 'BuildUser']) {
+                                dir('scylla-cluster-tests') {
+                                    timeout(time: 240, unit: 'MINUTES') {
+                                        byoScylladb(params, true)
                                     }
                                 }
                             }

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -227,7 +227,7 @@ def call(Map pipelineParams) {
             }
             stage('Provision Resources') {
                 steps {
-                    catchError() {
+                    catchError(stageResult: 'FAILURE') {
                         script {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -211,7 +211,7 @@ def call(Map pipelineParams) {
                                         }
 
                                         stage("Provision Resources for ${sub_test}") {
-                                                catchError() {
+                                                catchError(stageResult: 'FAILURE') {
                                                     script {
                                                         wrap([$class: 'BuildUser']) {
                                                             dir('scylla-cluster-tests') {

--- a/vars/provisionResources.groovy
+++ b/vars/provisionResources.groovy
@@ -67,19 +67,21 @@ def call(Map params, String region){
 
     if [[ -n "${params.scylla_ami_id ? params.scylla_ami_id : ''}" ]] ; then
         export SCT_AMI_ID_DB_SCYLLA="${params.scylla_ami_id}"
-    elif [[ -n "${params.gce_image_db ? params.gce_image_db : ''}" ]] ; then
+    fi
+    if [[ -n "${params.gce_image_db ? params.gce_image_db : ''}" ]] ; then
         export SCT_GCE_IMAGE_DB="${params.gce_image_db}"
-    elif [[ -n "${params.azure_image_db ? params.azure_image_db : ''}" ]] ; then
+    fi
+    if [[ -n "${params.azure_image_db ? params.azure_image_db : ''}" ]] ; then
         export SCT_AZURE_IMAGE_DB="${params.azure_image_db}"
-    elif [[ -n "${params.scylla_version ? params.scylla_version : ''}" ]] ; then
+    fi
+    if [[ -n "${params.scylla_version ? params.scylla_version : ''}" ]] ; then
         export SCT_SCYLLA_VERSION="${params.scylla_version}"
-    elif [[ -n "${params.scylla_repo ? params.scylla_repo : ''}" ]] ; then
+    fi
+    if [[ -n "${params.scylla_repo ? params.scylla_repo : ''}" ]] ; then
         export SCT_SCYLLA_REPO="${params.scylla_repo}"
-    elif [[ "${params.backend ? params.backend : ''}" == *"k8s"* ]] ; then
-        echo "Kubernetes backend can have empty scylla version. It will be taken from defaults of the scylla helm chart"
-    else
-        echo "need to choose one of SCT_AMI_ID_DB_SCYLLA | SCT_SCYLLA_VERSION | SCT_SCYLLA_REPO | SCT_GCE_IMAGE_DB"
-        exit 1
+    fi
+    if [[ -n "${params.new_scylla_repo ? params.new_scylla_repo : ''}" ]] ; then
+        export SCT_NEW_SCYLLA_REPO="${params.new_scylla_repo}"
     fi
 
     if [[ -n "${params.oracle_scylla_version ? params.oracle_scylla_version : ''}" ]] ; then

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -106,19 +106,21 @@ def call(Map params, String region, functional_test = false, Map pipelineParams 
 
     if [[ -n "${params.scylla_ami_id ? params.scylla_ami_id : ''}" ]] ; then
         export SCT_AMI_ID_DB_SCYLLA="${params.scylla_ami_id}"
-    elif [[ -n "${params.gce_image_db ? params.gce_image_db : ''}" ]] ; then
+    fi
+    if [[ -n "${params.gce_image_db ? params.gce_image_db : ''}" ]] ; then
         export SCT_GCE_IMAGE_DB="${params.gce_image_db}"
-    elif [[ -n "${params.azure_image_db ? params.azure_image_db : ''}" ]] ; then
+    fi
+    if [[ -n "${params.azure_image_db ? params.azure_image_db : ''}" ]] ; then
         export SCT_AZURE_IMAGE_DB="${params.azure_image_db}"
-    elif [[ -n "${params.scylla_version ? params.scylla_version : ''}" ]] ; then
+    fi
+    if [[ -n "${params.scylla_version ? params.scylla_version : ''}" ]] ; then
         export SCT_SCYLLA_VERSION="${params.scylla_version}"
-    elif [[ -n "${params.scylla_repo ? params.scylla_repo : ''}" ]] ; then
+    fi
+    if [[ -n "${params.scylla_repo ? params.scylla_repo : ''}" ]] ; then
         export SCT_SCYLLA_REPO="${params.scylla_repo}"
-    elif [[ "${params.backend ? params.backend : ''}" == *"k8s"* ]] ; then
-        echo "Kubernetes backend can have empty scylla version. It will be taken from defaults of the scylla helm chart"
-    else
-        echo "need to choose one of SCT_AMI_ID_DB_SCYLLA | SCT_SCYLLA_VERSION | SCT_SCYLLA_REPO | SCT_GCE_IMAGE_DB | SCT_AZURE_IMAGE_DB"
-        exit 1
+    fi
+    if [[ -n "${params.new_scylla_repo ? params.new_scylla_repo : ''}" ]] ; then
+        export SCT_NEW_SCYLLA_REPO="${params.new_scylla_repo}"
     fi
 
     if [[ -n "${params.oracle_scylla_version ? params.oracle_scylla_version : ''}" ]] ; then


### PR DESCRIPTION
It becomes more and more useful to build custom scylladb images
with unmerged changes to the scylladb repo.

So, add possibility to do it by utilizing the "byo" pipeline available
in the "scylla-pkg" project. This pipeline gets utilized as an existing
Jenkins CI job which must be refered to in the "byo_job_path" parameter
like the following:
 
```   
./my-custom-scylla-byo-job/
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
