### PR TITLE
feature(artifact-tests): add tests using centos9

### DIFF
--- a/configurations/arm/centos9.yaml
+++ b/configurations/arm/centos9.yaml
@@ -1,0 +1,8 @@
+ami_db_scylla_user: 'ec2-user'
+ami_id_db_scylla: 'ami-0e35cc6c9c975d78f' # CentOS Stream 9 aarch64
+region_name: 'eu-west-1'
+instance_type_db: 'im4gn.xlarge'
+use_preinstalled_scylla: false
+# enhanced network isn't supported
+append_scylla_setup_args: ' --no-ec2-check '
+use_mgmt: false

--- a/configurations/gce/new_ssh_key.yaml
+++ b/configurations/gce/new_ssh_key.yaml
@@ -1,0 +1,1 @@
+user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -313,9 +313,11 @@ if [[ -n "$RUNNER_IP" ]]; then
     if [ -z "$HYDRA_DRY_RUN" ]; then
         ssh-add ~/.ssh/scylla-qa-ec2
         ssh-add ~/.ssh/scylla-test
+        ssh-add ~/.ssh/scylla_test_id_ed25519
     else
         echo ssh-add ~/.ssh/scylla-qa-ec2
         echo ssh-add ~/.ssh/scylla-test
+        echo ssh-add ~/.ssh/scylla_test_id_ed25519
     fi
 
     echo "Going to run a Hydra commands on SCT runner '$RUNNER_IP'..."

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-centos9-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-centos9-arm.jenkinsfile
@@ -1,0 +1,14 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: '''["test-cases/artifacts/centos9.yaml", "configurations/arm/centos9.yaml"]''',
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'spot_low_price',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-centos9-nonroot.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-centos9-nonroot.jenkinsfile
@@ -1,0 +1,15 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/centos9.yaml',
+    backend: 'gce',
+    nonroot_offline_install: true,
+    provision_type: 'spot',
+    manager_version: '',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-centos9-selinux.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-centos9-selinux.jenkinsfile
@@ -1,0 +1,13 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/centos9-selinux.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-centos9.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-centos9.jenkinsfile
@@ -1,0 +1,13 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/centos9.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts/artifacts-centos9-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-centos9-arm.jenkinsfile
@@ -1,0 +1,14 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: '''["test-cases/artifacts/centos9.yaml", "configurations/arm/centos9.yaml"]''',
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'spot_low_price',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts/artifacts-centos9-selinux.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-centos9-selinux.jenkinsfile
@@ -1,0 +1,13 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/centos9-selinux.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts/artifacts-centos9-web.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-centos9-web.jenkinsfile
@@ -1,0 +1,14 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: '''["test-cases/artifacts/centos9.yaml", "configurations/web_install.yaml"]''',
+    backend: 'gce',
+    provision_type: 'spot',
+    scylla_mgmt_repo: '',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts/artifacts-centos9.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-centos9.jenkinsfile
@@ -1,0 +1,13 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/centos9.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-centos9.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-centos9.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+rollingUpgradePipeline(
+    backend: 'gce',
+    base_versions: '',  // auto mode
+    linux_distro: 'centos-9',
+    gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-9',
+
+    test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
+    test_config: '''["test-cases/upgrades/rolling-upgrade.yaml", "configurations/gce/n2-highmem-16.yaml", "configurations/gce/new_ssh_key.yaml"]''',
+    internode_compression: 'all'
+)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1940,7 +1940,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         self.install_package(package_name="rsync")
         if self.distro.is_rhel_like:
             # `screen' package is missed in CentOS/RHEL 8. Should be installed from EPEL repository.
-            if (self.distro.is_centos8 or self.distro.is_rhel8 or self.distro.is_oel8 or self.distro.is_rocky8 or
+            if (self.distro.is_centos9 or self.distro.is_rhel8 or self.distro.is_oel8 or self.distro.is_rocky8 or
                     self.distro.is_rocky9):
                 self.install_epel()
             self.remoter.run("sudo yum remove -y abrt")  # https://docs.scylladb.com/operating-scylla/admin/#core-dumps
@@ -1967,7 +1967,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         if not nonroot:
             self.install_package(package_name='xfsprogs mdadm')
 
-        if not any((self.distro.is_rocky9, self.distro.is_ubuntu24, self.distro.is_amazon2023)):
+        if not any((self.distro.is_rocky9, self.distro.is_ubuntu24, self.distro.is_amazon2023, self.distro.is_centos9)):
             # centos/rocky9/ubuntu24.04/amazon2023 and above don't have python2 anymore
             self.install_package(package_name='python2')
         # Offline install does't provide openjdk-11, it has to be installed in advance
@@ -4531,7 +4531,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
     def node_setup(self, node: BaseNode, verbose: bool = False, timeout: int = 3600):  # pylint: disable=too-many-branches,too-many-statements,too-many-locals
         node.wait_ssh_up(verbose=verbose, timeout=timeout)
-        if node.distro.is_centos8 or node.distro.is_rhel8 or node.distro.is_oel8 or node.distro.is_rocky8 or node.distro.is_rocky9:
+        if node.distro.is_centos9 or node.distro.is_rhel8 or node.distro.is_oel8 or node.distro.is_rocky8 or node.distro.is_rocky9:
             node.remoter.sudo('systemctl stop iptables', ignore_status=True)
             node.remoter.sudo('systemctl disable iptables', ignore_status=True)
             node.remoter.sudo('systemctl stop firewalld', ignore_status=True)

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -22,6 +22,7 @@ def get_distro_name(distro_object):
         Distro.AMAZON2023: "centos8",
         Distro.CENTOS7: "centos7",
         Distro.CENTOS8: "centos8",
+        Distro.CENTOS9: "centos8",
         Distro.DEBIAN10: "debian10",
         Distro.DEBIAN11: "debian11",
         Distro.UBUNTU20: "ubuntu20",

--- a/sdcm/utils/distro.py
+++ b/sdcm/utils/distro.py
@@ -32,8 +32,8 @@ class DistroBase(enum.Enum):
 # A tuple of tuples of the form:
 # (enum_prefix, os name, versions list (format is either "major.minor" or "major"), boolean - debian_like == True else rhel_like)
 KNOWN_OS = (
-    ("CENTOS", "centos", ["7", "8"], DistroBase.RHEL),
-    ("RHEL", "rhel", ["7", "8"], DistroBase.RHEL),
+    ("CENTOS", "centos", ["7", "8", "9"], DistroBase.RHEL),
+    ("RHEL", "rhel", ["7", "8", "9"], DistroBase.RHEL),
     ("OEL", "ol", ["7", "8"], DistroBase.RHEL),
     ("AMAZON", "amzn", ["2", "2023"], DistroBase.RHEL),
     ("ROCKY", "rocky", ["8", "9"], DistroBase.RHEL),

--- a/test-cases/artifacts/centos9-selinux.yaml
+++ b/test-cases/artifacts/centos9-selinux.yaml
@@ -1,0 +1,21 @@
+backtrace_decoding: false
+cluster_backend: 'gce'
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-9'
+gce_instance_type_db: 'n1-standard-2'
+gce_root_disk_type_db: 'pd-ssd'
+root_disk_size_db: 50
+gce_n_local_ssd_disk_db: 1
+instance_provision: "spot"
+instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
+n_db_nodes: 1
+n_loaders: 0
+n_monitor_nodes: 0
+nemesis_class_name: 'NoOpMonkey'
+scylla_linux_distro: 'centos'
+test_duration: 60
+user_prefix: 'artifacts-centos9-selinux'
+append_scylla_setup_args: '--no-selinux-setup'
+use_preinstalled_scylla: false
+
+user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/test-cases/artifacts/centos9.yaml
+++ b/test-cases/artifacts/centos9.yaml
@@ -1,0 +1,21 @@
+backtrace_decoding: false
+cluster_backend: 'gce'
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-9'
+gce_instance_type_db: 'n1-standard-2'
+gce_root_disk_type_db: 'pd-ssd'
+root_disk_size_db: 50
+gce_n_local_ssd_disk_db: 1
+instance_provision: "spot"
+instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
+n_db_nodes: 1
+n_loaders: 0
+n_monitor_nodes: 0
+nemesis_class_name: 'NoOpMonkey'
+scylla_linux_distro: 'centos'
+test_duration: 60
+user_prefix: 'artifacts-centos9'
+use_preinstalled_scylla: false
+aws_fallback_to_next_availability_zone: true
+
+user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -104,6 +104,12 @@ class TestBaseVersion(unittest.TestCase):
         version_list = general_test(scylla_repo, linux_distro)
         self.assertEqual(['5.0', '2021.1', '2022.1'], version_list)
 
+    def test_2024_1_with_centos9(self):
+        scylla_repo = self.url_base + '-enterprise/enterprise-2024.1/rpm/centos/latest/scylla.repo'
+        linux_distro = 'centos-9'
+        version_list = general_test(scylla_repo, linux_distro)
+        self.assertEqual(['5.4', '2024.1'], version_list)
+
     def test_2022_2(self):
         scylla_repo = self.url_base + '-enterprise/enterprise-2022.2/rpm/centos/2022-10-09T10:39:11Z/scylla.repo'
         linux_distro = 'centos'

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -16,7 +16,8 @@ LOGGER = logging.getLogger(__name__)
 # We support to migrate from specific OSS version to enterprise
 supported_src_oss = {'2021.1': '4.3', '2022.1': '5.0', '2022.2': '5.1', '2023.1': '5.2', '2024.1': '5.4'}
 # If new support distro shared repo with others, we need to assign the start support versions. eg: centos8
-start_support_versions = {'centos-8': {'scylla': '4.1', 'enterprise': '2021.1'}}
+start_support_versions = {'centos-8': {'scylla': '4.1', 'enterprise': '2021.1'},
+                          'centos-9': {'scylla': '5.4', 'enterprise': '2024.1'}}
 start_support_backend = {'azure': {'scylla': '5.2', 'enterprise': '2023.1'}}
 
 # list of version that are available, but aren't supported, and we should test upgrades from


### PR DESCRIPTION
now that centos8 is deprecated, we introduce the exact same tests but ontop of centos9

Ref: #7543

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-centos9-test/8/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-centos9-web-test/6/
- [x] 🟢   https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-centos9-arm-test/10/
- [x] 🔴  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-centos9-selinux-test/6/ - https://github.com/scylladb/scylladb/issues/19325
- [x] 🟠  rolling upgrades: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/rolling-upgrade-centos9-test/7/ - running into #7602
- [x] 🟢  nonroot offline: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-centos9-test/11/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
