### PR TITLE
fix(wait_for_cloud_init): cases cloud-init isn't installed

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -505,7 +505,8 @@ class AWSNode(cluster.BaseNode):
         super().init()
 
     def wait_for_cloud_init(self):
-        wait_cloud_init_completes(self.remoter, self)
+        if self.remoter.sudo('command -v cloud-init', ignore_status=True).ok:
+            wait_cloud_init_completes(self.remoter, self)
 
     @property
     def short_hostname(self):

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -113,7 +113,8 @@ class GCENode(cluster.BaseNode):
         super().init()
 
     def wait_for_cloud_init(self):
-        wait_cloud_init_completes(self.remoter, self)
+        if self.remoter.sudo('command -v cloud-init', ignore_status=True).ok:
+            wait_cloud_init_completes(self.remoter, self)
 
     @cached_property
     def tags(self) -> Dict[str, str]:


### PR DESCRIPTION
in some artifact test we do have cases the distro isn't installing cloud-init by default, and we should be calling it at all.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
