### PR TITLE
improvement(sct-config): convert append_scylla_yaml to dict

### DIFF
--- a/configurations/audit.yaml
+++ b/configurations/audit.yaml
@@ -1,5 +1,5 @@
-append_scylla_yaml: |
-  audit: "syslog"
-  audit_categories: "DCL,DDL,AUTH,ADMIN"
-  audit_tables: "keyspace1.standard1,scylla_bench.test"
-  audit_keyspaces: "keyspace1,scylla_bench"
+append_scylla_yaml:
+  audit: 'syslog'
+  audit_categories: 'DCL,DDL,AUTH,ADMIN'
+  audit_tables: 'keyspace1.standard1,scylla_bench.test'
+  audit_keyspaces: 'keyspace1,scylla_bench'

--- a/configurations/hytrust-kmip-ear.yaml
+++ b/configurations/hytrust-kmip-ear.yaml
@@ -2,17 +2,16 @@
 scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'KmipKeyProviderFactory', 'kmip_host': 'kmip_test'}"
 
 # enable system_info_encryption, config kmip_hosts
-append_scylla_yaml: |
-  system_key_directory: /etc/encrypt_conf/
+append_scylla_yaml:
+  system_key_directory: '/etc/encrypt_conf/'
   system_info_encryption:
-      enabled: True  # system_info_encryption
-      key_provider: LocalFileSystemKeyProviderFactory  # system_info_encryption
-      secret_key_file: '/etc/scylla/encrypt_conf/system_info_encryption_keyfile'
-
+    enabled: true  # system_info_encryption
+    key_provider: 'LocalFileSystemKeyProviderFactory'  # system_info_encryption
+    secret_key_file: '/etc/scylla/encrypt_conf/system_info_encryption_keyfile'
   kmip_hosts:
-       kmip_test:
-           hosts: 52.21.171.245
-           certificate: /etc/encrypt_conf/hytrust-kmip-scylla.pem
-           keyfile: /etc/encrypt_conf/hytrust-kmip-scylla.pem
-           truststore: /etc/encrypt_conf/hytrust-kmip-cacert.pem
-           priority_string: 'SECURE128:+RSA:-VERS-TLS1.0:-ECDHE-ECDSA'
+    kmip_test:
+      hosts: '52.21.171.245'
+      certificate: '/etc/encrypt_conf/hytrust-kmip-scylla.pem'
+      keyfile: '/etc/encrypt_conf/hytrust-kmip-scylla.pem'
+      truststore: '/etc/encrypt_conf/hytrust-kmip-cacert.pem'
+      priority_string: 'SECURE128:+RSA:-VERS-TLS1.0:-ECDHE-ECDSA'

--- a/configurations/kmip-ear.yaml
+++ b/configurations/kmip-ear.yaml
@@ -2,17 +2,14 @@
 scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'KmipKeyProviderFactory', 'kmip_host': 'kmip_test'}"
 
 # enable system_info_encryption, config kmip_hosts
-append_scylla_yaml: |
-  system_key_directory: /etc/encrypt_conf/
+append_scylla_yaml:
+  system_key_directory: '/etc/encrypt_conf/'
   system_info_encryption:
-      enabled: True  # system_info_encryption
-      key_provider: LocalFileSystemKeyProviderFactory  # system_info_encryption
-      secret_key_file: '/etc/scylla/encrypt_conf/system_info_encryption_keyfile'
-
+    enabled: true  # system_info_encryption
+    key_provider: 'LocalFileSystemKeyProviderFactory'  # system_info_encryption
+    secret_key_file: '/etc/scylla/encrypt_conf/system_info_encryption_keyfile'
   kmip_hosts:
-       kmip_test:
-           hosts: kmip-interop1.cryptsoft.com
-           certificate: /etc/encrypt_conf/SCYLLADB.pem
-           keyfile: /etc/encrypt_conf/SCYLLADB.pem
-           truststore: /etc/encrypt_conf/CA.pem
-           priority_string: 'SECURE128:+RSA:-VERS-TLS1.0:-ECDHE-ECDSA'
+    kmip_test:
+      hosts: 'kmip-interop1.cryptsoft.com'
+      certificate: '/etc/encrypt_conf/SCYLLADB.pem'
+      keyfile: '/etc/encrypt_conf/SCYLLADB.pem'

--- a/configurations/local-ear.yaml
+++ b/configurations/local-ear.yaml
@@ -1,8 +1,8 @@
 scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'LocalFileSystemKeyProviderFactory', 'secret_key_file': '/etc/scylla/encrypt_conf/secret_key'}"
 pre_create_schema: true
-append_scylla_yaml: |
-  system_key_directory: /etc/encrypt_conf/
+append_scylla_yaml:
+  system_key_directory: '/etc/encrypt_conf/'
   system_info_encryption:
-      enabled: True  # system_info_encryption
-      key_provider: LocalFileSystemKeyProviderFactory  # system_info_encryption
-      secret_key_file: '/etc/scylla/encrypt_conf/system_info_encryption_keyfile'
+    enabled: true  # system_info_encryption
+    key_provider: 'LocalFileSystemKeyProviderFactory'  # system_info_encryption
+    secret_key_file: '/etc/scylla/encrypt_conf/system_info_encryption_keyfile'

--- a/configurations/raft/consistent_cluster_management_off.yaml
+++ b/configurations/raft/consistent_cluster_management_off.yaml
@@ -1,2 +1,2 @@
-append_scylla_yaml: |
+append_scylla_yaml:
   consistent_cluster_management: false

--- a/configurations/raft/enable_raft_experimental.yaml
+++ b/configurations/raft/enable_raft_experimental.yaml
@@ -1,3 +1,2 @@
-append_scylla_yaml: |
-  experimental_features:
-    - consistent-topology-changes
+experimental_features:
+  - consistent-topology-changes

--- a/configurations/replicated-ear.yaml
+++ b/configurations/replicated-ear.yaml
@@ -2,5 +2,5 @@
 scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'ReplicatedKeyProviderFactory'}"
 
 # set system_key_directory
-append_scylla_yaml: |
-  system_key_directory: /etc/encrypt_conf/
+append_scylla_yaml:
+  system_key_directory: '/etc/encrypt_conf/'

--- a/configurations/tablets-initial-32.yaml
+++ b/configurations/tablets-initial-32.yaml
@@ -1,5 +1,5 @@
-append_scylla_yaml: |
-  experimental_features:
-    - tablets
-    - consistent-topology-changes
+experimental_features:
+  - tablets
+  - consistent-topology-changes
+append_scylla_yaml:
   tablets_initial_scale_factor: 4

--- a/configurations/tablets.yaml
+++ b/configurations/tablets.yaml
@@ -1,4 +1,3 @@
-append_scylla_yaml: |
-  experimental_features:
-    - tablets
-    - consistent-topology-changes
+experimental_features:
+  - tablets
+  - consistent-topology-changes

--- a/configurations/toggle-audit-nemesis.yaml
+++ b/configurations/toggle-audit-nemesis.yaml
@@ -1,3 +1,3 @@
 nemesis_class_name: 'ToggleAuditNemesisSyslog'
-append_scylla_yaml: |
-  audit: "none"
+append_scylla_yaml:
+  audit: 'none'

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -499,9 +499,8 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             scylla_yml.replace_address_first_boot = self.replacement_node_ip
         if self.replacement_host_id:
             scylla_yml.replace_node_first_boot = self.replacement_host_id
-        if append_scylla_yaml := self.parent_cluster.params.get('append_scylla_yaml'):
-            append_scylla_yaml = yaml.safe_load(append_scylla_yaml)
-            if any(substr in append_scylla_yaml for substr in (
+        if append_scylla_yaml := self.parent_cluster.params.get('append_scylla_yaml') or {}:
+            if any(key in append_scylla_yaml for key in (
                     "system_key_directory", "system_info_encryption", "kmip_hosts")):
                 install_encryption_at_rest_files(self.remoter)
             for kms_host_name, kms_host_data in append_scylla_yaml.get("kms_hosts", {}).items():
@@ -4434,7 +4433,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             return None
         kms_key_rotation_interval = self.params.get("kms_key_rotation_interval") or 60
         kms_key_alias_name = ""
-        append_scylla_yaml = yaml.safe_load(self.params.get("append_scylla_yaml") or "") or {}
+        append_scylla_yaml = self.params.get("append_scylla_yaml") or {}
         for kms_host_name, kms_host_data in append_scylla_yaml.get("kms_hosts", {}).items():
             if "auto" in kms_host_name:
                 kms_key_alias_name = kms_host_data["master_key"]

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2764,11 +2764,11 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         if self.params.get("server_encrypt"):
             raise NotImplementedError("server_encrypt is not supported by k8s-* backends yet")
 
-        append_scylla_yaml = self.params.get("append_scylla_yaml")
+        append_scylla_yaml = self.params.get("append_scylla_yaml") or {}
 
         if append_scylla_yaml:
-            unsupported_options = ("system_key_directory", "system_info_encryption", "kmip_hosts:", )
-            if any(substr in append_scylla_yaml for substr in unsupported_options):
+            unsupported_options = ("system_key_directory", "system_info_encryption", "kmip_hosts", )
+            if any(option in append_scylla_yaml for option in unsupported_options):
                 raise NotImplementedError(
                     f"{unsupported_options} are not supported in append_scylla_yaml by k8s-* backends yet")
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -536,7 +536,7 @@ class SCTConfiguration(dict):
         dict(name="append_scylla_args_oracle", env="SCT_APPEND_SCYLLA_ARGS_ORACLE", type=str,
              help="More arguments to append to oracle command line"),
 
-        dict(name="append_scylla_yaml", env="SCT_APPEND_SCYLLA_YAML", type=str,
+        dict(name="append_scylla_yaml", env="SCT_APPEND_SCYLLA_YAML", type=dict_or_str,
              help="More configuration to append to /etc/scylla/scylla.yaml"),
 
         # Nemesis config options

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -827,7 +827,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         return append_scylla_yaml and (
             'system_key_directory' in append_scylla_yaml or
             'system_info_encryption' in append_scylla_yaml or
-            'kmip_hosts:' in append_scylla_yaml
+            'kmip_hosts' in append_scylla_yaml
         )
 
     def prepare_kms_host(self) -> None:
@@ -848,7 +848,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         aws_kms.create_alias(kms_key_alias_name=alias_name)
 
         # Add kms_host with the dynamically created alias to the 'append_scylla_yaml'
-        append_scylla_yaml = yaml.safe_load(self.params.get("append_scylla_yaml") or '') or {}
+        append_scylla_yaml = self.params.get("append_scylla_yaml") or {}
         if "kms_hosts" not in append_scylla_yaml:
             append_scylla_yaml["kms_hosts"] = {}
         append_scylla_yaml["kms_hosts"][kms_host] = {
@@ -868,7 +868,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             'kms_host': kms_host,
         }
         self.log.warning("`user_info_encryption` and `system_info_encryption` are configured to use KMS by default")
-        self.params["append_scylla_yaml"] = yaml.safe_dump(append_scylla_yaml)
+        self.params["append_scylla_yaml"] = append_scylla_yaml
         return None
 
     def kafka_configure(self):
@@ -3071,7 +3071,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         Configure encryption at-rest for all test tables if needed,
         sleep a while to wait the workload starts and test tables are created
         """
-        append_scylla_yaml = yaml.safe_load(self.params.get("append_scylla_yaml") or '') or {}
+        append_scylla_yaml = self.params.get("append_scylla_yaml") or {}
 
         if ((scylla_encryption_options := self.params.get('scylla_encryption_options'))
             and 'write' in stress_command

--- a/test-cases/features/alternator-ttl/longevity-alternator-1h-scan-12h-ttl-no-lwt-2h-grace-4loaders-sisyphus.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-1h-scan-12h-ttl-no-lwt-2h-grace-4loaders-sisyphus.yaml
@@ -69,7 +69,7 @@ authorizer: 'CassandraAuthorizer'
 # Set 'alternator_ttl_period_in_seconds' to 1 hour for the TTL scan interval.
 experimental_features:
   - alternator-ttl
-append_scylla_yaml: |
+append_scylla_yaml:
   alternator_ttl_period_in_seconds: 3600
 
 # Set 'gc_grace_seconds' for 2 hours

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired-data.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired-data.yaml
@@ -61,7 +61,7 @@ authorizer: 'CassandraAuthorizer'
 # Set 'gc_grace_seconds' for 8 minutes.
 experimental_features:
   - alternator-ttl
-append_scylla_yaml: |
+append_scylla_yaml:
   alternator_ttl_period_in_seconds: 240
 
 post_prepare_cql_cmds: "ALTER TABLE alternator_usertable_no_lwt.usertable_no_lwt with gc_grace_seconds = 480;"

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-no-lwt-8m-grace-sisyphus.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-no-lwt-8m-grace-sisyphus.yaml
@@ -52,7 +52,7 @@ authorizer: 'CassandraAuthorizer'
 # Set 'alternator_ttl_period_in_seconds' to 4 minutes for the TTL scan interval.
 # YCSB TTL value is 36 minutes.
 # Set 'gc_grace_seconds' for 8 minutes.
-append_scylla_yaml: |
+append_scylla_yaml:
   alternator_ttl_period_in_seconds: 240
 
 post_prepare_cql_cmds: "ALTER TABLE alternator_usertable_no_lwt.usertable_no_lwt with gc_grace_seconds = 480;"

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-multiple-ttl-8m-grace.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-multiple-ttl-8m-grace.yaml
@@ -109,7 +109,7 @@ authorizer: 'CassandraAuthorizer'
 # GC Grace: 8 minutes
 experimental_features:
   - alternator-ttl
-append_scylla_yaml: |
+append_scylla_yaml:
   alternator_ttl_period_in_seconds: 240
 
 post_prepare_cql_cmds: "ALTER TABLE alternator_usertable_no_lwt.usertable_no_lwt with gc_grace_seconds = 480;"

--- a/test-cases/features/alternator-ttl/longevity-alternator-disable-enable-ttl.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-disable-enable-ttl.yaml
@@ -60,7 +60,7 @@ authorizer: 'CassandraAuthorizer'
 # Set 'gc_grace_seconds' for 8 minutes,
 experimental_features:
   - alternator-ttl
-append_scylla_yaml: |
+append_scylla_yaml:
   alternator_ttl_period_in_seconds: 240
 
 post_prepare_cql_cmds: "ALTER TABLE alternator_usertable_no_lwt.usertable_no_lwt with gc_grace_seconds = 480;"

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-big-dataset.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-big-dataset.yaml
@@ -66,7 +66,7 @@ authorizer: 'CassandraAuthorizer'
 # gc_grace_seconds: 2 hours.
 experimental_features:
   - alternator-ttl
-append_scylla_yaml: |
+append_scylla_yaml:
   alternator_ttl_period_in_seconds: 3600
 
 

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-large-writes.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-large-writes.yaml
@@ -66,7 +66,7 @@ authorizer: 'CassandraAuthorizer'
 # gc_grace_seconds: 20 minutes
 experimental_features:
   - alternator-ttl
-append_scylla_yaml: |
+append_scylla_yaml:
   alternator_ttl_period_in_seconds: 600
 
 post_prepare_cql_cmds: "ALTER TABLE alternator_usertable_no_lwt.usertable_no_lwt with gc_grace_seconds = 1200;"

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-lwt.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-lwt.yaml
@@ -47,5 +47,5 @@ authorizer: 'CassandraAuthorizer'
 # Set 'alternator_ttl_period_in_seconds' to 7 minutes for the TTL scan interval.
 experimental_features:
   - alternator-ttl
-append_scylla_yaml: |
+append_scylla_yaml:
   alternator_ttl_period_in_seconds: 420

--- a/test-cases/features/compaction-throughput-limit.yaml
+++ b/test-cases/features/compaction-throughput-limit.yaml
@@ -11,7 +11,7 @@ instance_type_loader: 'c7i.large'
 instance_type_monitor: 't3.small'
 
 user_prefix: 'compaction-limit'
-append_scylla_yaml: |
+append_scylla_yaml:
   auto_snapshot: false
 
 use_mgmt: false

--- a/test-cases/features/limit-streaming-io.yaml
+++ b/test-cases/features/limit-streaming-io.yaml
@@ -39,5 +39,5 @@ print_kernel_callstack: true
 store_perf_results: false
 email_recipients: ["qa@scylladb.com"]
 
-append_scylla_yaml: |
+append_scylla_yaml:
   stream_io_throughput_mb_per_sec: 300

--- a/test-cases/features/stop-compaction.yaml
+++ b/test-cases/features/stop-compaction.yaml
@@ -9,6 +9,6 @@ instance_type_db: 'i4i.large'
 backtrace_decoding: true
 
 user_prefix: 'stop-compaction'
-append_scylla_yaml: |
+append_scylla_yaml:
   enable_sstables_mc_format: true
   enable_sstables_md_format: true

--- a/test-cases/features/uda_udf.yaml
+++ b/test-cases/features/uda_udf.yaml
@@ -8,9 +8,9 @@ n_loaders: 1
 n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
-append_scylla_yaml: |
-  experimental_features:
-     - udf
+experimental_features:
+  - udf
+append_scylla_yaml:
   enable_user_defined_functions: true
   user_defined_function_time_limit_ms: 10000
   user_defined_function_allocation_limit_bytes: 1048576

--- a/test-cases/jepsen/jepsen_with_raft.yaml
+++ b/test-cases/jepsen/jepsen_with_raft.yaml
@@ -20,6 +20,5 @@ jepsen_test_count: 5
 jepsen_test_run_policy: any
 bare_loaders: true
 
-append_scylla_yaml: |
-  experimental_features:
-    - raft
+experimental_features:
+  - raft

--- a/test-cases/performance/perf-regression-throughput-cdc-mixed-poll-batching.yaml
+++ b/test-cases/performance/perf-regression-throughput-cdc-mixed-poll-batching.yaml
@@ -24,9 +24,8 @@ store_perf_results: true
 append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
 
 
-append_scylla_yaml: |
-  experimental_features:
-    - cdc
+experimental_features:
+  - cdc
 
 email_recipients: ['scylla-perf-results@scylladb.com', 'cdc@scylladb.com']
 backtrace_decoding: false

--- a/test-cases/performance/perf-regression-write-throughput-cdc.yaml
+++ b/test-cases/performance/perf-regression-write-throughput-cdc.yaml
@@ -17,9 +17,8 @@ store_perf_results: true
 append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
 
 
-append_scylla_yaml: |
-  experimental_features:
-    - cdc
+experimental_features:
+  - cdc
 
 email_recipients: ['scylla-perf-results@scylladb.com', 'cdc@scylladb.com ']
 backtrace_decoding: false

--- a/unit_tests/test_data/scylla_yaml_update.yaml
+++ b/unit_tests/test_data/scylla_yaml_update.yaml
@@ -9,7 +9,7 @@ instance_type_db: 'i4i.large'
 backtrace_decoding: true
 
 user_prefix: 'stop-compaction'
-append_scylla_yaml: |
+append_scylla_yaml:
   enable_sstables_mc_format: true
   enable_sstables_md_format: false
   force_schema_commit_log: false

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -437,7 +437,7 @@ class ScyllaYamlTest(unittest.TestCase):
         test_config_file = Path(__file__).parent / 'test_data' / 'scylla_yaml_update.yaml'
         with open(test_config_file, encoding="utf-8") as test_file:
             test_config_file_yaml = yaml.safe_load(test_file)
-            append_scylla_args_dict = yaml.safe_load(test_config_file_yaml["append_scylla_yaml"])
+            append_scylla_args_dict = test_config_file_yaml.get("append_scylla_yaml", {})
         yaml1.update(append_scylla_args_dict)
         assert yaml1.enable_sstables_mc_format == append_scylla_args_dict["enable_sstables_mc_format"]
         assert yaml1.enable_sstables_md_format == append_scylla_args_dict["enable_sstables_md_format"]


### PR DESCRIPTION
Currently the 'append_scylla_yaml' attribute is defined in test configurations as a multiline string representation of a dict. And is processed correspondingly in SCT.
The downside of it is if there are several test configurations for a test run that have 'append_scylla_yaml' attribute in them, SCTConfiguration overwrites the attribute value for each loaded config. As a result the last test configuration 'wins', in terms of that only its value is added to scylla.yaml.

The change converts value of all 'append_scylla_yaml' attribute occurrences in configs to a dict, so that it is natively merged by anyconfig. It also adjusts places where 'append_scylla_yaml' is used in the code, to process it
as a dict, not a string.

Related task: https://github.com/scylladb/scylla-cluster-tests/issues/7364

### Testing
- [["configurations/audit.yaml","test-cases/features/stop-compaction.yaml"] configs](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/sct-debug/51/) this is to ensure that 'append_scylla_yaml' values from different configs are merged
- [["test-cases/longevity/longevity-topology-changes-3h.yaml","configurations/raft/enable_raft_experimental.yaml"] configs](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/longevity-5gb-1h-AbortRepairMonkey-docker-test/37/) - experimental_features attribute is supported as a standalone attribute in test config, but we had a number of instances where it was a part of append_scylla_yaml. This build is to ensure that experimental_features attribute is correctly merged to scylla.yaml, after moving out of append_scylla_yaml.
- [["test-cases/artifacts/ubuntu2004-fips.yaml", "configurations/local-ear.yaml"] configs](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/artifacts-ubuntu2004-fips-test/) this is to ensure that when there were nested subattributes in string version of append_scylla_yaml, after conversion to dict they are correctly merged and added to the final scylla.yaml.
- [["test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml", "configurations/kms-ear.yaml"] configs](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/append_scylla_yaml_test/2/) - this is to ensure that KMS logic is not affected, as its attributes was changed in this commit.

### PR pre-checks (self review)
- [ ] I added the relevant `backport` labels
- [X] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
