### PR TITLE
fix(scylla-manager): get version if monitor node exists

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -504,7 +504,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.log.error("Unable to collect package versions for Argus - skipping...", exc_info=True)
 
     def argus_collect_manager_version(self):
-        if self.params.get('use_mgmt'):
+        if self.monitors.nodes and self.params.get('use_mgmt'):
             manager_tool = get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
             self.log.info("Saving manager version in Argus...")
             # sctool.version output:

--- a/unit_tests/test_tester.py
+++ b/unit_tests/test_tester.py
@@ -97,6 +97,9 @@ class ClusterTesterForTests(ClusterTester):
     def save_email_data(self):
         pass
 
+    def argus_collect_manager_version(self):
+        pass
+
     def tearDown(self):
         super().tearDown()
         self._validate_results()


### PR DESCRIPTION
This issue was caused by https://github.com/scylladb/scylla-cluster-tests/pull/7538. 
The monitor node is not created in artifact tests that causes to failure:
```
File sdcm/tester.py, line 508, in argus_collect_manager_version
  manager_tool = get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
  IndexError: list index out of range
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [artifact test](https://argus.scylladb.com/test/f810956d-24b5-4321-93b0-f7e62bb211d5/runs?additionalRuns[]=80b473e6-d160-4c03-b181-f6e496c28722)
- [x] [longevity](https://argus.scylladb.com/test/e6ef2a1c-7267-4566-9954-f49caa755c50/runs?additionalRuns[]=af5355de-d873-4a3d-ac86-898fa1fb7f3c)
- [x] [longevity, use_mgmt is false](https://argus.scylladb.com/test/077623f5-2bff-4b2b-9186-2b7e5c093519/runs?additionalRuns[]=4ad4d75a-169f-437d-8549-cfe1d33b6653)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
