### PR TITLE
fix(wait_cloud_init_completes): check return code and not stderr

### DIFF
--- a/sdcm/provision/helpers/cloud_init.py
+++ b/sdcm/provision/helpers/cloud_init.py
@@ -44,10 +44,9 @@ def wait_cloud_init_completes(remoter: RemoteCmdRunnerBase, instance: VmInstance
 
 def log_user_data_scripts_errors(remoter: RemoteCmdRunnerBase) -> bool:
     errors_found = False
-    result = remoter.run(f"ls {CLOUD_INIT_SCRIPTS_PATH}")
-    ls_errors = result.stderr
-    if ls_errors:
-        LOGGER.error("Error listing generated scripts: %s", ls_errors)
+    result = remoter.run(f"ls {CLOUD_INIT_SCRIPTS_PATH}", ignore_status=True)
+    if result.failed:
+        LOGGER.error("Error listing generated scripts: return_code: %s, stderr: %s", result.return_code, result.stderr)
         errors_found = True
     files_list = result.stdout
     if not files_list:


### PR DESCRIPTION
in some distros (OEL8) we might have those printed into stderr:
```
/etc/bashrc: line 100: TMOUT: readonly variable
```

the code was checking the stderr of `ls` command, the command succeeded but there was still something in stderr.

changing the code to check first the return code, and if that failed to print out the content of the stdout.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-oel81-test/5/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
