### PR TITLE
fix(longevity): get table for 'add_drop_column'

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2040,7 +2040,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if tables_to_skip is None:
             tables_to_skip = {}
         to_be_skipped_default = tables_to_skip.get('*', '').split(',')
-        with self.cluster.cql_connection_patient(self.tester.db_cluster.nodes[0]) as session:
+        with self.cluster.cql_connection_patient(self.target_node) as session:
             query_result = session.execute('SELECT keyspace_name FROM system_schema.keyspaces;')
             for result_rows in query_result:
                 keyspaces.extend([row.lower()
@@ -2055,7 +2055,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     to_be_skipped = []
                 else:
                     to_be_skipped = to_be_skipped.split(',') + to_be_skipped_default
-                tables = get_db_tables(session, ks, with_compact_storage=False)
+                tables = get_db_tables(session=session,
+                                       keyspace_name=ks,
+                                       node=self.target_node,
+                                       with_compact_storage=False)
                 if to_be_skipped:
                     tables = [table for table in tables if table not in to_be_skipped]
                 if not tables:


### PR DESCRIPTION
If run disrupt_add_remove_dc nemesis in parallel to the disrupt_add_drop_column one then we can get following error:
```
  KeyError: 'keyspace_new_dc'
```

It is caused by the concurrency of a new keyspace addition (disrupt_add_remove_dc nemesis) and driver session update in addition to the unsafe coding assuming driver's session (disrupt_add_drop_column nemesis) knows about that newly added keyspace. Another possible problem: new added keyspace was dropped in exacly time when we run describe of the table.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/7240

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-schema-topology-changes-12h](https://argus.scylladb.com/test/ed048b23-03ef-4486-a005-3cbac0163c87/runs?additionalRuns[]=e64dc80b-8b56-4652-83f4-06764c5e6a3a)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
