### PR TITLE
feature(sct.py): Add upload hydra command

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -132,3 +132,13 @@ ssh -i ~/.ssh/scylla-qa-ec2 ubuntu@44.192.58.53
 # this would clear all of the dockers used by monitoring stack that are currently running
 docker rm -f -v $(docker ps --filter name=agraf\|aprom\|aalert -a -q)
 ```
+
+## How can I upload a relevant log file that was missed by SCT and report it to Argus?
+
+The command `upload` provides such functionality:
+
+```bash
+hydra upload --test-id <uuid> path/to/file
+```
+
+In case you don't want to report to Argus / Argus is missing the test run for this id you can use `--no-use-argus` to skip that part.


### PR DESCRIPTION
This commit adds a new `upload` command to the hydra, allowing user to
specify a test id and a file path to upload an arbitrary file to s3 and
link it in Argus. Files ending in .png or .jpg are also added to the
test run screenshot collection inside argus.

Fixes scylladb/qa-tasks#330

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Argus](https://argus.scylladb.com/test/b0b22734-758e-47b4-b6ec-29e64d212d52/runs?additionalRuns[]=be1c5535-5596-4da4-b3de-7a414548371e)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
