### PR TITLE
fix(integration-tests): enable auth by default

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -216,7 +216,7 @@ stress_image:
   kcl: 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC'
   harry: 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816'
   latte: 'scylladb/hydra-loaders:latte-0.25.2-scylladb'
-  cql-stress-cassandra-stress: 'scylladb/hydra-loaders:cql-stress-cassandra-stress-20240119'
+  cql-stress-cassandra-stress: 'docker.io/scylladb/hydra-loaders:cql-stress-cassandra-stress-20240606'
 
 service_level_shares: [1000]
 

--- a/docker/cql-stress-cassandra-stress/Dockerfile
+++ b/docker/cql-stress-cassandra-stress/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.73 as builder
+FROM rust:1.78 as builder
 
 ARG BRANCH
 ARG REPO

--- a/docker/cql-stress-cassandra-stress/image
+++ b/docker/cql-stress-cassandra-stress/image
@@ -1,1 +1,1 @@
-scylladb/hydra-loaders:cql-stress-cassandra-stress-20240119
+docker.io/scylladb/hydra-loaders:cql-stress-cassandra-stress-20240606

--- a/docker/scylla-sct/entry.sh
+++ b/docker/scylla-sct/entry.sh
@@ -9,8 +9,8 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
-
-enable_tablets: false
 EOM
+
+sed -e '/enable_tablets:.*/s/true/false/g' -i /etc/scylla/scylla.yaml
 
 /docker-entrypoint.py $*

--- a/docker/scylla-sct/entry.sh
+++ b/docker/scylla-sct/entry.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
 
 if [[ ! $(grep 'skip_wait_for_gossip_to_settle' /etc/scylla/scylla.yaml) ]]; then echo "skip_wait_for_gossip_to_settle: 0" >> /etc/scylla/scylla.yaml ; fi
+
+cat <<EOM >> /etc/scylla/scylla.yaml
+
+alternator_enforce_authorization: true
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
+enable_tablets: false
+EOM
+
 /docker-entrypoint.py $*

--- a/docker/scylla-sct/entry_ssl.sh
+++ b/docker/scylla-sct/entry_ssl.sh
@@ -4,11 +4,19 @@ if [[ ! $(grep 'skip_wait_for_gossip_to_settle' /etc/scylla/scylla.yaml) ]]; the
 
 cat <<EOM >> /etc/scylla/scylla.yaml
 
+alternator_enforce_authorization: true
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
 client_encryption_options:
   certificate: /etc/scylla/ssl_conf/client-facing.crt
   enabled: true
   keyfile: /etc/scylla/ssl_conf/client-facing.key
   truststore: /etc/scylla/ssl_conf/ca.pem
+
+enable_tablets: false
 EOM
 
 /docker-entrypoint.py $*

--- a/docker/scylla-sct/entry_ssl.sh
+++ b/docker/scylla-sct/entry_ssl.sh
@@ -16,7 +16,8 @@ client_encryption_options:
   keyfile: /etc/scylla/ssl_conf/client-facing.key
   truststore: /etc/scylla/ssl_conf/ca.pem
 
-enable_tablets: false
 EOM
+
+sed -e '/enable_tablets:.*/s/true/false/g' -i /etc/scylla/scylla.yaml
 
 /docker-entrypoint.py $*

--- a/internal_test_data/complex_test_case_with_version.yaml
+++ b/internal_test_data/complex_test_case_with_version.yaml
@@ -41,7 +41,7 @@ gce_n_local_ssd_disk_monitor: 0
 
 db_type: scylla
 instance_type_db: 'i4i.4xlarge'
-scylla_version: '5.1.3'
+scylla_version: '5.4.1'
 
 ami_id_loader: 'ami-07bcb57f57a485721'
 ami_id_monitor: 'ami-07bcb57f57a485721'

--- a/sdcm/cql_stress_cassandra_stress_thread.py
+++ b/sdcm/cql_stress_cassandra_stress_thread.py
@@ -97,6 +97,13 @@ class CqlStressCassandraStressThread(CassandraStressThread):
             stress_cmd = re.sub(r' seq=[\s]*([\d]+\.\.[\d]+)',
                                 r" 'dist=SEQ(\1)'", stress_cmd)
 
+        credentials = self.loader_set.get_db_auth()
+        if credentials and 'user=' not in stress_cmd:
+            if '-mode' in stress_cmd:
+                # put the credentials into the right place into -mode section
+                stress_cmd = re.sub(r'(-mode.*?)(-)?', r'\1 user={} password={} \2'.format(*credentials), stress_cmd)
+            else:
+                stress_cmd += ' -mode user={} password={} '.format(*credentials)
         stress_cmd = self.adjust_cmd_node_option(stress_cmd, loader, cmd_runner)
         return stress_cmd
 

--- a/sdcm/kafka/kafka_config.py
+++ b/sdcm/kafka/kafka_config.py
@@ -22,7 +22,7 @@ class ConnectorConfiguration(BaseModel):
     # see https://github.com/scylladb/kafka-connect-scylladb/blob/master/documentation/CONFIG.md
     scylladb_contact_points: Optional[str] = Field(alias="scylladb.contact.points")
     scylladb_keyspace: Optional[str] = Field(alias="scylladb.keyspace")
-    scylladb_user: Optional[str] = Field(alias="scylladb.user")
+    scylladb_username: Optional[str] = Field(alias="scylladb.username")
     scylladb_password: Optional[str] = Field(alias="scylladb.password")
 
     class Config:

--- a/sdcm/ndbench_thread.py
+++ b/sdcm/ndbench_thread.py
@@ -118,6 +118,9 @@ class NdBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-many-
         super().__init__(*args, **kwargs)
         # remove the ndbench command, and parse the rest of the ; separated values
         stress_cmd = re.sub(r'^ndbench', '', self.stress_cmd)
+        if credentials := self.loader_set.get_db_auth():
+            stress_cmd += f'; cass.username={credentials[0]} ; cass.password={credentials[1]}'
+
         self.stress_cmd = ' '.join([f'-Dndbench.config.{param.strip()}' for param in stress_cmd.split(';')])
         timeout = '' if 'cli.timeoutMillis' in self.stress_cmd else f'-Dndbench.config.cli.timeoutMillis={self.timeout * 1000}'
         self.stress_cmd = f'./gradlew {timeout}' \

--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -110,8 +110,9 @@ class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-in
         super().__init__(loader_set=loader_set, stress_cmd=stress_cmd, timeout=timeout, stress_num=stress_num,
                          node_list=node_list, round_robin=round_robin, params=params,
                          stop_test_on_failure=stop_test_on_failure)
-        if credentials and 'username=' not in self.stress_cmd:
-            self.stress_cmd += " -username {} -password {}".format(*credentials)
+        if credentials := self.loader_set.get_db_auth():
+            if 'username=' not in self.stress_cmd:
+                self.stress_cmd += " -username {} -password {}".format(*credentials)
 
         if not any(opt in self.stress_cmd for opt in ('-error-at-row-limit', '-error-limit')):
             result = re.search(r"-retry-number[= ]+(\d+) ", self.stress_cmd)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2032,7 +2032,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             node_list=self.db_cluster.nodes,
             round_robin=round_robin,
             stop_test_on_failure=stop_test_on_failure,
-            credentials=self.db_cluster.get_db_auth(),
             params=self.params,
         )
         bench_thread.run()

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1631,7 +1631,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def get_cluster_kafka(self):
         if kafka_backend := self.params.get('kafka_backend'):
             if kafka_backend == 'localstack':
-                self.kafka_cluster = LocalKafkaCluster()
+                self.kafka_cluster = LocalKafkaCluster(params=self.params)
                 self.kafka_cluster.start()
             else:
                 raise NotImplementedError(f"{kafka_backend=} not implemented")

--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -79,7 +79,8 @@ class RemoteDocker(BaseNode):
 
     def create_network(self, docker_network):
         try:
-            ret = self.node.remoter.run(f"docker network create {docker_network}").stdout.strip()
+            ret = self.node.remoter.run(
+                f"docker network create {docker_network} --label 'com.docker.compose.network=default'").stdout.strip()
             LOGGER.debug(ret)
         except (UnexpectedExit, Libssh2_UnexpectedExit) as ex:
             if 'already exists' in str(ex):

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -158,12 +158,12 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
                     dynamodb.primaryKeyType = {alternator.enums.YCSBSchemaTypes.HASH_SCHEMA.value}
                 ''')
             if self.params.get('alternator_enforce_authorization'):
-                aws_credentials_content = dedent(f""""
+                aws_credentials_content = dedent(f"""
                     accessKey = {self.params.get('alternator_access_key_id')}
                     secretKey = {alternator.api.Alternator.get_salted_hash(node=self.node_list[0], username=self.params.get('alternator_access_key_id'))}
                 """)
             else:
-                aws_credentials_content = dedent(f""""
+                aws_credentials_content = dedent(f"""
                     accessKey = {self.params.get('alternator_access_key_id')}
                     secretKey = {self.params.get('alternator_secret_access_key')}
                 """)

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -37,6 +37,7 @@ from unit_tests.lib.events_utils import EventsUtilsMixin
 from unit_tests.lib.fake_provisioner import FakeProvisioner
 from unit_tests.lib.fake_region_definition_builder import FakeDefinitionBuilder
 from unit_tests.lib.fake_remoter import FakeRemoter
+from unit_tests.lib.alternator_utils import ALTERNATOR_PORT
 
 
 @pytest.fixture(scope='module')
@@ -68,7 +69,7 @@ def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # pylint: di
     entryfile_path = Path(base_dir) if base_dir else Path(__file__).parent.parent
     entryfile_path = entryfile_path / 'docker' / 'scylla-sct' / ('entry_ssl.sh' if ssl else 'entry.sh')
 
-    alternator_flags = "--alternator-port 8000 --alternator-write-isolation=always"
+    alternator_flags = f"--alternator-port {ALTERNATOR_PORT} --alternator-write-isolation=always"
     docker_version = docker_scylla_args.get('image', "scylladb/scylla-nightly:6.1.0-dev-0.20240605.2c3f7c996f98")
     cluster = LocalScyllaClusterDummy(params=params)
 
@@ -86,7 +87,7 @@ def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # pylint: di
         finally:
             os.chdir(curr_dir)
     ssl_dir = (Path(__file__).parent.parent / 'data_dir' / 'ssl_conf').absolute()
-    extra_docker_opts = (f'-p 8000 -p {BaseNode.CQL_PORT} --cpus="1" -v {entryfile_path}:/entry.sh'
+    extra_docker_opts = (f'-p {ALTERNATOR_PORT} -p {BaseNode.CQL_PORT} --cpus="1" -v {entryfile_path}:/entry.sh'
                          f' -v {ssl_dir}:{SCYLLA_SSL_CONF_DIR}'
                          ' --entrypoint /entry.sh')
 
@@ -106,7 +107,7 @@ def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # pylint: di
 
     def db_alternator_up():
         try:
-            return scylla.is_port_used(port=8000, service_name="scylla-server")
+            return scylla.is_port_used(port=ALTERNATOR_PORT, service_name="scylla-server")
         except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
             logging.error("Error checking for scylla up normal: %s", details)
             return False

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -56,7 +56,7 @@ def prom_address():
 
 
 @pytest.fixture(name='docker_scylla', scope='function')
-def fixture_docker_scylla(request: pytest.FixtureRequest):  # pylint: disable=too-many-locals
+def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # pylint: disable=too-many-locals
     docker_scylla_args = {}
     if test_marker := request.node.get_closest_marker("docker_scylla_args"):
         docker_scylla_args = test_marker.kwargs
@@ -69,8 +69,8 @@ def fixture_docker_scylla(request: pytest.FixtureRequest):  # pylint: disable=to
     entryfile_path = entryfile_path / 'docker' / 'scylla-sct' / ('entry_ssl.sh' if ssl else 'entry.sh')
 
     alternator_flags = "--alternator-port 8000 --alternator-write-isolation=always"
-    docker_version = docker_scylla_args.get('image', "scylladb/scylla-nightly:5.5.0-dev-0.20240213.314fd9a11f23")
-    cluster = LocalScyllaClusterDummy()
+    docker_version = docker_scylla_args.get('image', "scylladb/scylla-nightly:6.1.0-dev-0.20240605.2c3f7c996f98")
+    cluster = LocalScyllaClusterDummy(params=params)
 
     if ssl:
         curr_dir = os.getcwd()
@@ -145,7 +145,12 @@ def fixture_params(request: pytest.FixtureRequest):
 
     os.environ['SCT_CLUSTER_BACKEND'] = 'docker'
     params = sct_config.SCTConfiguration()  # pylint: disable=attribute-defined-outside-init
-
+    params.update(dict(
+        authenticator='PasswordAuthenticator',
+        authenticator_user='cassandra',
+        authenticator_password='cassandra',
+        authorizer='CassandraAuthorizer',
+    ))
     yield params
 
     for k in os.environ:

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -111,7 +111,6 @@ def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # pylint: di
             logging.error("Error checking for scylla up normal: %s", details)
             return False
 
-    scylla.remoter.run('apt-get update')
     wait.wait_for(func=db_up, step=1, text='Waiting for DB services to be up', timeout=120, throw_exc=True)
     wait.wait_for(func=db_alternator_up, step=1, text='Waiting for DB services to be up alternator)',
                   timeout=120, throw_exc=True)

--- a/unit_tests/dummy_remote.py
+++ b/unit_tests/dummy_remote.py
@@ -90,14 +90,14 @@ class LocalNode(BaseNode):
 
 class LocalLoaderSetDummy(BaseCluster):
     # pylint: disable=super-init-not-called,abstract-method
-    def __init__(self, nodes=None):
+    def __init__(self, nodes=None, params=None):
         self.name = "LocalLoaderSetDummy"
-        self.params = {}
+        self.params = params or {}
+        self.added_password_suffix = False
         self.nodes = nodes if nodes is not None else [LocalNode("loader_node", parent_cluster=self)]
 
-    @staticmethod
-    def get_db_auth():
-        return None
+    def add_nodes(self, *args, **kwargs):
+        raise NotImplementedError
 
     @staticmethod
     def is_kubernetes():
@@ -107,15 +107,17 @@ class LocalLoaderSetDummy(BaseCluster):
         return self.nodes[0]
 
 
-class LocalScyllaClusterDummy(BaseScyllaCluster):
+class LocalScyllaClusterDummy(BaseScyllaCluster, BaseCluster):
     # pylint: disable=super-init-not-called
-    def __init__(self):
+    def __init__(self, params=None):
         self.name = "LocalScyllaClusterDummy"
-        self.params = {}
+        self.params = params or {}
+        self.added_password_suffix = False
+        self.log = logging.getLogger(self.name)
+        self._node_cycle = None
 
-    @staticmethod
-    def get_db_auth():
-        return None
+    def add_nodes(self, *args, **kwargs):
+        raise NotImplementedError
 
     def get_ip_to_node_map(self):
         """returns {ip: node} map for all nodes in cluster to get node by ip"""

--- a/unit_tests/lib/alternator_utils.py
+++ b/unit_tests/lib/alternator_utils.py
@@ -17,12 +17,15 @@ TEST_PARAMS = dict(
     dynamodb_primarykey_type="HASH_AND_RANGE",
     alternator_use_dns_routing=True,
     alternator_port=ALTERNATOR_PORT,
+    alternator_enforce_authorization=True,
+    alternator_access_key_id='alternator',
+    alternator_secret_access_key='password',
+    authenticator='PasswordAuthenticator',
+    authenticator_user='cassandra',
+    authenticator_password='cassandra',
+    authorizer='CassandraAuthorizer',
     docker_network='ycsb_net',
 )
 ALTERNATOR = alternator.api.Alternator(
-    sct_params={
-        "alternator_access_key_id": None,
-        "alternator_secret_access_key": None,
-        "alternator_port": ALTERNATOR_PORT,
-    }
+    sct_params=TEST_PARAMS
 )

--- a/unit_tests/lib/alternator_utils.py
+++ b/unit_tests/lib/alternator_utils.py
@@ -13,19 +13,3 @@
 from sdcm.utils import alternator
 
 ALTERNATOR_PORT = 8000
-TEST_PARAMS = dict(
-    dynamodb_primarykey_type="HASH_AND_RANGE",
-    alternator_use_dns_routing=True,
-    alternator_port=ALTERNATOR_PORT,
-    alternator_enforce_authorization=True,
-    alternator_access_key_id='alternator',
-    alternator_secret_access_key='password',
-    authenticator='PasswordAuthenticator',
-    authenticator_user='cassandra',
-    authenticator_password='cassandra',
-    authorizer='CassandraAuthorizer',
-    docker_network='ycsb_net',
-)
-ALTERNATOR = alternator.api.Alternator(
-    sct_params=TEST_PARAMS
-)

--- a/unit_tests/test_alternator_streams_kcl.py
+++ b/unit_tests/test_alternator_streams_kcl.py
@@ -18,7 +18,6 @@ import pytest
 from sdcm.ycsb_thread import YcsbStressThread
 from sdcm.kcl_thread import KclStressThread, CompareTablesSizesThread
 from unit_tests.dummy_remote import LocalLoaderSetDummy
-from unit_tests.lib.alternator_utils import TEST_PARAMS
 
 pytestmark = [
     pytest.mark.usefixtures("events"),
@@ -30,8 +29,16 @@ pytestmark = [
 def test_01_kcl_with_ycsb(
     request, docker_scylla, events, params
 ):  # pylint: disable=too-many-locals
-    params.update(TEST_PARAMS)
-    loader_set = LocalLoaderSetDummy()
+    params.update(dict(
+        dynamodb_primarykey_type="HASH_AND_RANGE",
+        alternator_use_dns_routing=True,
+        alternator_port=ALTERNATOR_PORT,
+        alternator_enforce_authorization=True,
+        alternator_access_key_id='alternator',
+        alternator_secret_access_key='password',
+        docker_network='ycsb_net',
+    ))
+    loader_set = LocalLoaderSetDummy(params=params)
     num_of_keys = 1000
     # 1. start kcl thread and ycsb at the same time
     ycsb_cmd = (

--- a/unit_tests/test_cassandra_stress_thread.py
+++ b/unit_tests/test_cassandra_stress_thread.py
@@ -24,7 +24,7 @@ pytestmark = [
 def test_01_cassandra_stress(request, docker_scylla, params):
     params['cs_debug'] = True
 
-    loader_set = LocalLoaderSetDummy()
+    loader_set = LocalLoaderSetDummy(params=params)
 
     cmd = (
         """cassandra-stress write cl=ONE duration=1m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) """
@@ -52,7 +52,7 @@ def test_01_cassandra_stress(request, docker_scylla, params):
 
 
 def test_02_cassandra_stress_user_profile(request, docker_scylla, params):
-    loader_set = LocalLoaderSetDummy()
+    loader_set = LocalLoaderSetDummy(params=params)
 
     cmd = (
         "cassandra-stress user profile=/tmp/cassandra-stress-custom.yaml ops'(insert=1,simple1=1)' "
@@ -81,7 +81,7 @@ def test_02_cassandra_stress_user_profile(request, docker_scylla, params):
 @pytest.mark.docker_scylla_args(ssl=True)
 def test_03_cassandra_stress_client_encrypt(request, docker_scylla, params):
 
-    loader_set = LocalLoaderSetDummy()
+    loader_set = LocalLoaderSetDummy(params=params)
 
     cmd = (
         "cassandra-stress write cl=ONE duration=1m -schema 'compaction(strategy=SizeTieredCompactionStrategy) "
@@ -113,8 +113,8 @@ def test_03_cassandra_stress_client_encrypt(request, docker_scylla, params):
     assert float(output[0]["latency 99th percentile"]) > 0
 
 
-def test_03_cassandra_stress_multi_region(request, docker_scylla, params):
-    loader_set = LocalLoaderSetDummy()
+def test_04_cassandra_stress_multi_region(request, docker_scylla, params):
+    loader_set = LocalLoaderSetDummy(params=params)
     loader_set.test_config.set_multi_region(True)
     request.addfinalizer(lambda: loader_set.test_config.set_multi_region(False))
     cmd = (

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -763,7 +763,6 @@ def test_get_any_ks_cf_list(docker_scylla, params, events):  # pylint: disable=u
                                 'system_traces.sessions', 'system_traces.sessions_time_idx',
                                 'system.role_attributes', 'system.role_members', 'system.role_permissions',
                                 'system.roles', 'system.service_levels_v2',
-                                'system.tablets',
                                 'system.topology', 'system.topology_requests',
                                 'system.cdc_generations_v3',
                                 '"123_keyspace"."120users"', '"123_keyspace".users'}

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -746,7 +746,7 @@ def test_get_any_ks_cf_list(docker_scylla, params, events):  # pylint: disable=u
                                 'system.cdc_local', 'system.versions', 'system_distributed_everywhere.cdc_generation_descriptions_v2',
                                 'system.scylla_local', 'system.cluster_status', 'system.protocol_servers',
                                 'system_distributed.cdc_streams_descriptions_v2', 'system_schema.keyspaces',
-                                'system.size_estimates', 'system_schema.scylla_tables', 'system_auth.roles',
+                                'system.size_estimates', 'system_schema.scylla_tables',
                                 'system.scylla_table_schema_history', 'system_schema.views',
                                 'system_distributed.view_build_status', 'system.built_views',
                                 'mview.users_by_first_name', 'mview.users_by_last_name', 'mview.users',
@@ -754,13 +754,18 @@ def test_get_any_ks_cf_list(docker_scylla, params, events):  # pylint: disable=u
                                 'system.hints', 'system.large_cells', 'system.large_partitions', 'system.large_rows',
                                 'system.paxos', 'system.peer_events', 'system.peers', 'system.range_xfers', 'system.repair_history',
                                 'system.scylla_views_builds_in_progress', 'system.snapshots', 'system.sstable_activity',
-                                'system.truncated', 'system.views_builds_in_progress', 'system_auth.role_attributes',
-                                'system_auth.role_members', 'system_distributed.service_levels', 'system_schema.aggregates',
+                                'system.truncated', 'system.views_builds_in_progress',
+                                'system_distributed.service_levels', 'system_schema.aggregates',
                                 'system_schema.computed_columns', 'system_schema.dropped_columns', 'system_schema.functions',
                                 'system_schema.indexes', 'system_schema.scylla_aggregates', 'system_schema.scylla_keyspaces',
                                 'system_schema.triggers', 'system_schema.types', 'system_schema.view_virtual_columns',
                                 'system_traces.events', 'system_traces.node_slow_log', 'system_traces.node_slow_log_time_idx',
                                 'system_traces.sessions', 'system_traces.sessions_time_idx',
+                                'system.role_attributes', 'system.role_members', 'system.role_permissions',
+                                'system.roles', 'system.service_levels_v2',
+                                'system.tablets',
+                                'system.topology', 'system.topology_requests',
+                                'system.cdc_generations_v3',
                                 '"123_keyspace"."120users"', '"123_keyspace".users'}
 
     table_names = cluster.get_non_system_ks_cf_list(docker_scylla, filter_empty_tables=False, filter_out_mv=True)
@@ -790,18 +795,10 @@ def test_filter_out_ks_with_rf_one(docker_scylla, params, events):  # pylint: di
         session.execute(
             "INSERT INTO mview.users (username, first_name, last_name, password) VALUES "
             "('fruch', 'Israel', 'Fruchter', '1111')")
-        session.execute(
-            "CREATE KEYSPACE mview2 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
-        session.execute(
-            "CREATE TABLE mview2.users (username text, first_name text, last_name text, password text, email text, "
-            "last_access timeuuid, PRIMARY KEY(username))")
-        session.execute(
-            "INSERT INTO mview2.users (username, first_name, last_name, password) VALUES "
-            "('fruch', 'Israel', 'Fruchter', '1111')")
         docker_scylla.run_nodetool('flush')
 
         table_names = cluster.get_non_system_ks_cf_list(docker_scylla, filter_func=cluster.is_ks_rf_one)
-        assert table_names == ['mview2.users']
+        assert table_names == []
 
 
 class TestNodetool(unittest.TestCase):

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -667,7 +667,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                           'kcl': 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC',
                           'harry': 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816',
                           'latte': 'scylladb/hydra-loaders:latte-0.25.2-scylladb',
-                          'cql-stress-cassandra-stress': 'scylladb/hydra-loaders:cql-stress-cassandra-stress-20240119'})
+                          'cql-stress-cassandra-stress': 'docker.io/scylladb/hydra-loaders:cql-stress-cassandra-stress-20240606'})
 
         self.assertEqual(conf.get('stress_image.gemini'), 'scylladb/hydra-loaders:gemini-v1.8.6')
         self.assertEqual(conf.get('stress_image.non-exist'), None)

--- a/unit_tests/test_cql_stress_cassandra_stress_thread.py
+++ b/unit_tests/test_cql_stress_cassandra_stress_thread.py
@@ -27,12 +27,12 @@ pytestmark = [
 
 
 def test_01_cql_stress_cassandra_stress(request, docker_scylla, prom_address, params):
-    loader_set = LocalLoaderSetDummy()
+    loader_set = LocalLoaderSetDummy(params=params)
 
     cmd = (
         """cql-stress-cassandra-stress write cl=ONE duration=1m """
         """-schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) """
-        """compaction(strategy=SizeTieredCompactionStrategy)' """
+        """compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 """
         """-rate threads=10 -pop seq=1..10000000"""
     )
 
@@ -68,7 +68,7 @@ def test_01_cql_stress_cassandra_stress(request, docker_scylla, prom_address, pa
 
 
 def test_02_cql_stress_cassandra_stress_multi_region(request, docker_scylla, params):
-    loader_set = LocalLoaderSetDummy()
+    loader_set = LocalLoaderSetDummy(params=params)
     loader_set.test_config.set_multi_region(True)
     request.addfinalizer(
         lambda: loader_set.test_config.set_multi_region(False))

--- a/unit_tests/test_kafka.py
+++ b/unit_tests/test_kafka.py
@@ -27,10 +27,10 @@ pytestmark = [
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.fixture(name="kafka_cluster", scope="session")
-def fixture_kafka_cluster(tmp_path_factory):
+@pytest.fixture(name="kafka_cluster", scope="function")
+def fixture_kafka_cluster(tmp_path_factory, params):
     os.environ["_SCT_TEST_LOGDIR"] = str(tmp_path_factory.mktemp("logs"))
-    kafka = LocalKafkaCluster()
+    kafka = LocalKafkaCluster(params=params)
 
     kafka.start()
 
@@ -68,10 +68,10 @@ def test_01_kafka_cdc_source_connector(request, docker_scylla, kafka_cluster, pa
         db_cluster=docker_scylla.parent_cluster, connector_config=connector_config
     )
 
-    loader_set = LocalLoaderSetDummy()
+    loader_set = LocalLoaderSetDummy(params=params)
 
     cmd = (
-        """cassandra-stress write cl=ONE n=500 -rate threads=10 """
+        """cassandra-stress write cl=ONE n=500 -mode cql3 native -rate threads=10 """
     )
 
     cs_thread = CassandraStressThread(

--- a/unit_tests/test_latte_thread.py
+++ b/unit_tests/test_latte_thread.py
@@ -27,8 +27,7 @@ pytestmark = [
 
 
 def test_01_latte_schema(request, docker_scylla, params):
-    loader_set = LocalLoaderSetDummy()
-    loader_set.params = params
+    loader_set = LocalLoaderSetDummy(params=params)
 
     cmd = ("latte schema docker/latte/workloads/workload.rn")
 
@@ -67,8 +66,7 @@ def test_02_latte_load(request, docker_scylla, params):
 
 
 def test_03_latte_run(request, docker_scylla, prom_address, params):
-    loader_set = LocalLoaderSetDummy()
-    loader_set.params = params
+    loader_set = LocalLoaderSetDummy(params=params)
 
     cmd = ("latte run --function run -d 10s docker/latte/workloads/workload.rn --generate-report")
 
@@ -106,8 +104,7 @@ def test_03_latte_run(request, docker_scylla, prom_address, params):
 def test_04_latte_run_client_encrypt(request, docker_scylla, params):
     params['client_encrypt'] = True
 
-    loader_set = LocalLoaderSetDummy()
-    loader_set.params = params
+    loader_set = LocalLoaderSetDummy(params=params)
 
     cmd = ("latte run -d 10s docker/latte/workloads/workload.rn --generate-report")
 

--- a/unit_tests/test_ndbench_thread.py
+++ b/unit_tests/test_ndbench_thread.py
@@ -12,7 +12,7 @@ pytestmark = [
 
 
 def test_01_cql_api(request, docker_scylla, params):
-    loader_set = LocalLoaderSetDummy()
+    loader_set = LocalLoaderSetDummy(params=params)
     cmd = (
         "ndbench cli.clientName=CassJavaDriverGeneric ; numKeys=20000000 ; "
         "numReaders=8; numWriters=8 ; cass.writeConsistencyLevel=QUORUM ; "
@@ -34,7 +34,7 @@ def test_02_cql_kill(request, docker_scylla, params):
     """
     verifies that kill command on the NdBenchStressThread is working
     """
-    loader_set = LocalLoaderSetDummy()
+    loader_set = LocalLoaderSetDummy(params=params)
     cmd = (
         "ndbench cli.clientName=CassJavaDriverGeneric ; numKeys=20000000 ; "
         "numReaders=8; numWriters=8 ; cass.writeConsistencyLevel=QUORUM ; "
@@ -60,7 +60,7 @@ def test_03_dynamodb_api(request, docker_scylla, events, params):
     """
 
     # start a command that would yield errors
-    loader_set = LocalLoaderSetDummy()
+    loader_set = LocalLoaderSetDummy(params=params)
     cmd = (
         f"ndbench cli.clientName=DynamoDBKeyValue ; numKeys=20000000 ; "
         f"numReaders=8; numWriters=8 ; readRateLimit=7200 ; writeRateLimit=1800; "
@@ -91,7 +91,7 @@ def test_03_dynamodb_api(request, docker_scylla, events, params):
 
 
 def test_04_verify_data(request, docker_scylla, events, params):
-    loader_set = LocalLoaderSetDummy()
+    loader_set = LocalLoaderSetDummy(params=params)
     cmd = (
         "ndbench cli.clientName=CassJavaDriverGeneric ; numKeys=30 ; "
         "readEnabled=false; numReaders=0; numWriters=1 ; cass.writeConsistencyLevel=QUORUM ; "

--- a/unit_tests/test_scylla_bench_thread.py
+++ b/unit_tests/test_scylla_bench_thread.py
@@ -31,7 +31,7 @@ pytestmark = [
     ],
 )
 def test_01_scylla_bench(request, docker_scylla, params, extra_cmd):
-    loader_set = LocalLoaderSetDummy()
+    loader_set = LocalLoaderSetDummy(params=params)
     if extra_cmd == "cloud-config":
         params["k8s_connection_bundle_file"] = "/home/fruch/Downloads/k8s_config.yaml"
         docker_scylla.parent_cluster.params = params

--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -23,12 +23,41 @@ from sdcm.utils.decorators import timeout
 from sdcm.utils.docker_utils import running_in_docker
 from sdcm.ycsb_thread import YcsbStressThread
 from unit_tests.dummy_remote import LocalLoaderSetDummy
-from unit_tests.lib.alternator_utils import ALTERNATOR_PORT, ALTERNATOR, TEST_PARAMS
+from unit_tests.lib.alternator_utils import ALTERNATOR_PORT
 
 pytestmark = [
     pytest.mark.usefixtures("events"),
     pytest.mark.integration,
 ]
+
+
+@pytest.fixture(scope="function", name="alternator_api")
+def fixture_alternator_api(params):
+    params.update(dict(
+        dynamodb_primarykey_type="HASH_AND_RANGE",
+        alternator_use_dns_routing=True,
+        alternator_port=ALTERNATOR_PORT,
+        alternator_enforce_authorization=True,
+        alternator_access_key_id='alternator',
+        alternator_secret_access_key='password',
+        docker_network='ycsb_net',
+    ))
+
+    def create_endpoint_url(node):
+        if running_in_docker():
+            endpoint_url = f"http://{node.internal_ip_address}:{ALTERNATOR_PORT}"
+        else:
+            address = node.get_port(f"{ALTERNATOR_PORT}")
+            endpoint_url = f"http://{address}"
+        return endpoint_url
+
+    alternator_api = alternator.api.Alternator(
+        sct_params=params
+    )
+
+    alternator_api.create_endpoint_url = create_endpoint_url
+
+    return alternator_api
 
 
 @pytest.fixture(scope="function", name="cql_driver")
@@ -44,25 +73,15 @@ def fixture_cql_driver(docker_scylla):
 
 
 @pytest.fixture(scope="function")
-def create_table(docker_scylla, cql_driver):
+def create_table(docker_scylla, cql_driver, alternator_api, params):
 
     with cql_driver.connect() as session:
         session.execute("CREATE ROLE %s WITH PASSWORD = %s",
-                        (TEST_PARAMS.get('alternator_access_key_id'),
-                         TEST_PARAMS.get('alternator_secret_access_key')))
-
-    def create_endpoint_url(node):
-        if running_in_docker():
-            endpoint_url = f"http://{node.internal_ip_address}:{ALTERNATOR_PORT}"
-        else:
-            address = node.get_port(f"{ALTERNATOR_PORT}")
-            endpoint_url = f"http://{address}"
-        return endpoint_url
+                        (params.get('alternator_access_key_id'),
+                         params.get('alternator_secret_access_key')))
 
     setattr(docker_scylla, "name", "mock-node")
-
-    ALTERNATOR.create_endpoint_url = create_endpoint_url
-    ALTERNATOR.create_table(node=docker_scylla, table_name=alternator.consts.TABLE_NAME)
+    alternator_api.create_table(node=docker_scylla, table_name=alternator.consts.TABLE_NAME)
 
 
 @pytest.fixture(scope="function")
@@ -91,7 +110,6 @@ def create_cql_ks_and_table(cql_driver):
 @pytest.mark.usefixtures("create_table")
 @pytest.mark.docker_scylla_args(docker_network='ycsb_net')
 def test_01_dynamodb_api(request, docker_scylla, prom_address, params):
-    params.update(TEST_PARAMS)
     loader_set = LocalLoaderSetDummy(params=params)
 
     cmd = (
@@ -134,7 +152,6 @@ def test_01_dynamodb_api(request, docker_scylla, prom_address, params):
 def test_02_dynamodb_api_dataintegrity(
     request, docker_scylla, prom_address, events, params
 ):
-    params.update(TEST_PARAMS)
     loader_set = LocalLoaderSetDummy(params=params)
 
     # 2. do write without dataintegrity=true
@@ -197,7 +214,6 @@ def test_02_dynamodb_api_dataintegrity(
 @pytest.mark.usefixtures("create_cql_ks_and_table")
 @pytest.mark.docker_scylla_args(docker_network='ycsb_net')
 def test_03_cql(request, docker_scylla, prom_address, params):
-    params.update(TEST_PARAMS)
     loader_set = LocalLoaderSetDummy(params=params)
 
     cmd = (
@@ -230,7 +246,7 @@ def test_03_cql(request, docker_scylla, prom_address, params):
 
 
 @pytest.mark.usefixtures("create_table")
-def test_04_insert_new_data(docker_scylla):
+def test_04_insert_new_data(docker_scylla, alternator_api):
     schema = alternator.schemas.HASH_AND_STR_RANGE_SCHEMA
     schema_keys = [key_details["AttributeName"] for key_details in schema["KeySchema"]]
     new_items = [
@@ -246,11 +262,11 @@ def test_04_insert_new_data(docker_scylla):
         {schema_keys[0]: "test_9", schema_keys[1]: "YrRvsqXAtppgCLiHhiQn"},
     ]
 
-    ALTERNATOR.batch_write_actions(
+    alternator_api.batch_write_actions(
         node=docker_scylla,
         new_items=new_items,
         schema=alternator.schemas.HASH_AND_STR_RANGE_SCHEMA,
     )
-    data = ALTERNATOR.scan_table(node=docker_scylla)
+    data = alternator_api.scan_table(node=docker_scylla)
     assert {row[schema_keys[0]]: row[schema_keys[1]]
             for row in new_items} == {row[schema_keys[0]]: row[schema_keys[1]] for row in data}

--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -16,6 +16,7 @@ import re
 import pytest
 import requests
 from cassandra.cluster import Cluster  # pylint: disable=no-name-in-module
+from cassandra.auth import PlainTextAuthProvider
 
 from sdcm.utils import alternator
 from sdcm.utils.decorators import timeout
@@ -25,13 +26,31 @@ from unit_tests.dummy_remote import LocalLoaderSetDummy
 from unit_tests.lib.alternator_utils import ALTERNATOR_PORT, ALTERNATOR, TEST_PARAMS
 
 pytestmark = [
-    pytest.mark.usefixtures("events", "create_table", "create_cql_ks_and_table"),
+    pytest.mark.usefixtures("events"),
     pytest.mark.integration,
 ]
 
 
+@pytest.fixture(scope="function", name="cql_driver")
+def fixture_cql_driver(docker_scylla):
+    if running_in_docker():
+        address = f"{docker_scylla.internal_ip_address}:9042"
+    else:
+        address = docker_scylla.get_port("9042")
+    node_ip, port = address.split(":")
+    port = int(port)
+    return Cluster([node_ip], port=port,
+                   auth_provider=PlainTextAuthProvider(username='cassandra', password='cassandra'))
+
+
 @pytest.fixture(scope="function")
-def create_table(docker_scylla):
+def create_table(docker_scylla, cql_driver):
+
+    with cql_driver.connect() as session:
+        session.execute("CREATE ROLE %s WITH PASSWORD = %s",
+                        (TEST_PARAMS.get('alternator_access_key_id'),
+                         TEST_PARAMS.get('alternator_secret_access_key')))
+
     def create_endpoint_url(node):
         if running_in_docker():
             endpoint_url = f"http://{node.internal_ip_address}:{ALTERNATOR_PORT}"
@@ -47,16 +66,9 @@ def create_table(docker_scylla):
 
 
 @pytest.fixture(scope="function")
-def create_cql_ks_and_table(docker_scylla):
-    if running_in_docker():
-        address = f"{docker_scylla.internal_ip_address}:9042"
-    else:
-        address = docker_scylla.get_port("9042")
-    node_ip, port = address.split(":")
-    port = int(port)
+def create_cql_ks_and_table(cql_driver):
 
-    cluster_driver = Cluster([node_ip], port=port)
-    session = cluster_driver.connect()
+    session = cql_driver.connect()
     session.execute(
         """create keyspace ycsb WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor': 1 };"""
     )
@@ -76,10 +88,11 @@ def create_cql_ks_and_table(docker_scylla):
     )
 
 
+@pytest.mark.usefixtures("create_table")
 @pytest.mark.docker_scylla_args(docker_network='ycsb_net')
 def test_01_dynamodb_api(request, docker_scylla, prom_address, params):
-    loader_set = LocalLoaderSetDummy()
     params.update(TEST_PARAMS)
+    loader_set = LocalLoaderSetDummy(params=params)
 
     cmd = (
         "bin/ycsb run dynamodb -P workloads/workloada -threads 5 -p recordcount=1000000 "
@@ -116,11 +129,13 @@ def test_01_dynamodb_api(request, docker_scylla, prom_address, params):
     assert float(output[0]["latency 99th percentile"]) > 0
 
 
+@pytest.mark.usefixtures("create_table")
+@pytest.mark.docker_scylla_args(docker_network='ycsb_net')
 def test_02_dynamodb_api_dataintegrity(
     request, docker_scylla, prom_address, events, params
 ):
-    loader_set = LocalLoaderSetDummy()
     params.update(TEST_PARAMS)
+    loader_set = LocalLoaderSetDummy(params=params)
 
     # 2. do write without dataintegrity=true
     cmd = (
@@ -179,9 +194,11 @@ def test_02_dynamodb_api_dataintegrity(
     assert "=ERROR" in cat["ERROR"][1]
 
 
+@pytest.mark.usefixtures("create_cql_ks_and_table")
+@pytest.mark.docker_scylla_args(docker_network='ycsb_net')
 def test_03_cql(request, docker_scylla, prom_address, params):
-    loader_set = LocalLoaderSetDummy()
     params.update(TEST_PARAMS)
+    loader_set = LocalLoaderSetDummy(params=params)
 
     cmd = (
         "bin/ycsb load scylla -P workloads/workloada -threads 5 -p recordcount=1000000 "
@@ -212,6 +229,7 @@ def test_03_cql(request, docker_scylla, prom_address, params):
     ycsb_thread.get_results()
 
 
+@pytest.mark.usefixtures("create_table")
 def test_04_insert_new_data(docker_scylla):
     schema = alternator.schemas.HASH_AND_STR_RANGE_SCHEMA
     schema_keys = [key_details["AttributeName"] for key_details in schema["KeySchema"]]


### PR DESCRIPTION
for covering related auth in alternator tests
we want to enable the integration tests to work
by default with auth enforced.

it flushed out, that we need to fix latte support
and that cql-stress version we have doesn't support auth

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
