### PR TITLE
fix(offline-installer): amazon linux 2023 doesn't have python2

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1959,7 +1959,8 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         if not nonroot:
             self.install_package(package_name='xfsprogs mdadm')
 
-        if not self.distro.is_rocky9 and not self.distro.is_ubuntu24:  # centos/rocky9/ubuntu24.04 and above don't have python2 anymore
+        if not any((self.distro.is_rocky9, self.distro.is_ubuntu24, self.distro.is_amazon2023)):
+            # centos/rocky9/ubuntu24.04/amazon2023 and above don't have python2 anymore
             self.install_package(package_name='python2')
         # Offline install does't provide openjdk-11, it has to be installed in advance
         # https://github.com/scylladb/scylla-jmx/issues/127

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1966,6 +1966,8 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         # https://github.com/scylladb/scylla-jmx/issues/127
         if self.distro.is_amazon2:
             self.remoter.sudo('amazon-linux-extras install java-openjdk11')
+        elif self.distro.is_amazon2023:
+            self.install_package(package_name="java-11-amazon-corretto-headless")
         elif self.distro.is_rhel_like:
             self.install_package(package_name='java-11-openjdk-headless')
         elif self.distro.is_sles:


### PR DESCRIPTION
we shouldn't try install python on this distro, it doesn't have it.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-amazon2023-offline_install-test/5/
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-amazon2023-offline_install-nonroot-test/5/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
