### PR TITLE
fix(integration-tests): make latte tests work correctly

### DIFF
--- a/unit_tests/test_latte_thread.py
+++ b/unit_tests/test_latte_thread.py
@@ -70,7 +70,7 @@ def test_03_latte_run(request, docker_scylla, prom_address, params):
     loader_set = LocalLoaderSetDummy()
     loader_set.params = params
 
-    cmd = ("latte run --function run -d 10s docker/latte/workloads/workload.rn")
+    cmd = ("latte run --function run -d 10s docker/latte/workloads/workload.rn --generate-report")
 
     latte_thread = LatteStressThread(
         loader_set, cmd, node_list=[docker_scylla], timeout=5, params=params
@@ -109,7 +109,7 @@ def test_04_latte_run_client_encrypt(request, docker_scylla, params):
     loader_set = LocalLoaderSetDummy()
     loader_set.params = params
 
-    cmd = ("latte run -d 10s docker/latte/workloads/workload.rn")
+    cmd = ("latte run -d 10s docker/latte/workloads/workload.rn --generate-report")
 
     latte_thread = LatteStressThread(
         loader_set, cmd, node_list=[docker_scylla], timeout=5,


### PR DESCRIPTION
The `--generate-report` was added to the recent latte version and is needed to get latency mean output.
So, add it to make latte integration tests work again.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
