### PR TITLE
fix(manager): set throttle_per_node independent from Scylla version

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -26,7 +26,6 @@ from datetime import datetime
 import boto3
 
 from invoke import exceptions
-from pkg_resources import parse_version
 
 from sdcm import mgmt
 from sdcm.mgmt import ScyllaManagerError, TaskStatus, HostStatus, HostSsl, HostRestStatus
@@ -251,13 +250,7 @@ class BackupFunctionsMixIn(LoaderUtilsMixin):
         number_of_nodes = self.params.get("n_db_nodes")
         number_of_loaders = self.params.get("n_loaders")
 
-        scylla_version = self.db_cluster.nodes[0].scylla_version
-        if parse_version(scylla_version).release[0] == 2019:
-            # Making sure scylla version is 2019.1.x
-            throttle_per_node = 10666
-        else:
-            throttle_per_node = 14666
-
+        throttle_per_node = 14666
         throttle_per_loader = int(throttle_per_node * number_of_nodes / number_of_loaders)
         stress_cmd = stress_cmd.replace("<THROTTLE_PLACE_HOLDER>", str(throttle_per_loader))
         stress_thread = self.run_stress_thread(stress_cmd=stress_cmd)


### PR DESCRIPTION
No need to keep it since there are no tests executable with Scylla Enterprise version 2019. Moreover, it blocks tests execution on open-source versions because of version parsing issue.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/view/Repair/job/repair-control-test/1/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)