### PR TITLE
fix(offline-installer): stop hard coding the username

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2358,7 +2358,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         return self._service_cmd(service_name=service_name, cmd='status', timeout=timeout, ignore_status=ignore_status)
 
     def is_service_exists(self,  service_name: str, timeout: int = 500) -> bool:
-        return self.remoter.run(f"systemctl list-unit-files | grep {service_name}.service",
+        return self.remoter.run(f"{self.systemctl} list-unit-files | grep {service_name}.service",
                                 timeout=timeout, ignore_status=True).return_code == 0
 
     def start_service(self, service_name: str, timeout: int = 500, ignore_status=False):

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -156,8 +156,6 @@ from sdcm.exceptions import (
 # Test duration (min). Parameter used to keep instances produced by tests that
 # are supposed to run longer than 24 hours from being killed
 SCYLLA_DIR = "/var/lib/scylla"
-TEST_USER = 'scylla-test'
-INSTALL_DIR = f"/home/{TEST_USER}/scylladb"
 
 DB_LOG_PATTERN_RESHARDING_START = "(?i)database - Resharding"
 DB_LOG_PATTERN_RESHARDING_FINISH = "(?i)storage_service - Restarting a node in NORMAL"
@@ -573,6 +571,11 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         return _distro
 
     @cached_property
+    def offline_install_dir(self) -> Path:
+        home = Path(self.remoter.run("echo $HOME").stdout.strip())
+        return home / 'scylladb'
+
+    @cached_property
     def is_nonroot_install(self):
         return self.parent_cluster.params.get("unified_package") \
             and self.parent_cluster.params.get("nonroot_offline_install")
@@ -702,7 +705,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
     def extract_seeds_from_scylla_yaml(self):
         yaml_dst_path = os.path.join(tempfile.mkdtemp(prefix='sct'), 'scylla.yaml')
         wait.wait_for(func=self.remoter.receive_files, step=10, text='Waiting for copying scylla.yaml', timeout=300,
-                      throw_exc=True, src=self.add_install_prefix(SCYLLA_YAML_PATH), dst=yaml_dst_path)
+                      throw_exc=True, src=str(self.add_install_prefix(SCYLLA_YAML_PATH)), dst=yaml_dst_path)
         with open(yaml_dst_path, encoding="utf-8") as yaml_stream:
             try:
                 conf_dict = yaml.safe_load(yaml_stream)
@@ -2325,7 +2328,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
     def journalctl(self):
         return self.wrap_cmd_with_permission('journalctl')
 
-    def add_install_prefix(self, abs_path):
+    def add_install_prefix(self, abs_path) -> Path:
         """
         nonroot install included all files inside a install root directory,
         it's different with root install.
@@ -2334,15 +2337,15 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         if not self.is_nonroot_install:
             return abs_path
         checklist = {
-            SCYLLA_YAML_PATH: f'{INSTALL_DIR}{SCYLLA_YAML_PATH}',
-            SCYLLA_PROPERTIES_PATH: f'{INSTALL_DIR}{SCYLLA_PROPERTIES_PATH}',
-            '/etc/scylla.d/io.conf': f'{INSTALL_DIR}/etc/scylla.d/io.conf',
-            '/usr/bin/scylla': f'{INSTALL_DIR}/bin/scylla',
-            '/usr/bin/nodetool': f'{INSTALL_DIR}/share/cassandra/bin/nodetool',
-            '/usr/bin/cqlsh': f'{INSTALL_DIR}/share/cassandra/bin/cqlsh',
-            '/usr/bin/cassandra-stress': f'{INSTALL_DIR}/share/cassandra/bin/cassandra-stress',
+            SCYLLA_YAML_PATH: self.offline_install_dir / SCYLLA_YAML_PATH[1:],
+            SCYLLA_PROPERTIES_PATH: self.offline_install_dir / SCYLLA_PROPERTIES_PATH[1:],
+            '/etc/scylla.d/io.conf': self.offline_install_dir / 'etc/scylla.d/io.conf',
+            '/usr/bin/scylla': self.offline_install_dir / 'bin/scylla',
+            '/usr/bin/nodetool': self.offline_install_dir / 'share/cassandra/bin/nodetool',
+            '/usr/bin/cqlsh': self.offline_install_dir / 'share/cassandra/bin/cqlsh',
+            '/usr/bin/cassandra-stress': self.offline_install_dir / 'share/cassandra/bin/cassandra-stress',
         }
-        return checklist.get(abs_path, INSTALL_DIR + abs_path)
+        return checklist.get(abs_path, self.offline_install_dir / abs_path)
 
     def _service_cmd(self, service_name: str, cmd: str, timeout: int = 500, ignore_status=False):
         cmd = f'{self.systemctl} {cmd} {service_name}.service'
@@ -4506,17 +4509,17 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
     def scylla_configure_non_root_installation(self, node, devname):
         node.stop_scylla_server(verify_down=False)
-        node.remoter.run(f'{INSTALL_DIR}/sbin/scylla_setup --nic {devname} --no-raid-setup',
+        node.remoter.run(f'{node.offline_install_dir}/sbin/scylla_setup --nic {devname} --no-raid-setup',
                          verbose=True, ignore_status=True)
         # simple config
         node.remoter.run(
-            f"echo 'cluster_name: \"{self.name}\"' >> {INSTALL_DIR}/etc/scylla/scylla.yaml")  # pylint: disable=no-member
+            f"echo 'cluster_name: \"{self.name}\"' >> {node.offline_install_dir}/etc/scylla/scylla.yaml")  # pylint: disable=no-member
         node.remoter.run(
-            f"sed -ie 's/- seeds: .*/- seeds: {node.ip_address}/g' {INSTALL_DIR}/etc/scylla/scylla.yaml")
+            f"sed -ie 's/- seeds: .*/- seeds: {node.ip_address}/g' {node.offline_install_dir}/etc/scylla/scylla.yaml")
         node.remoter.run(
-            f"sed -ie 's/^listen_address: .*/listen_address: {node.ip_address}/g' {INSTALL_DIR}/etc/scylla/scylla.yaml")
+            f"sed -ie 's/^listen_address: .*/listen_address: {node.ip_address}/g' {node.offline_install_dir}/etc/scylla/scylla.yaml")
         node.remoter.run(
-            f"sed -ie 's/^rpc_address: .*/rpc_address: {node.ip_address}/g' {INSTALL_DIR}/etc/scylla/scylla.yaml")
+            f"sed -ie 's/^rpc_address: .*/rpc_address: {node.ip_address}/g' {node.offline_install_dir}/etc/scylla/scylla.yaml")
 
     def node_setup(self, node: BaseNode, verbose: bool = False, timeout: int = 3600):  # pylint: disable=too-many-branches,too-many-statements,too-many-locals
         node.wait_ssh_up(verbose=verbose, timeout=timeout)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2003,6 +2003,9 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
                 # Reload the env variables by ssh reconnect
                 self.remoter.run('env', verbose=True, change_context=True)
                 assert 'XDG_RUNTIME_DIR' in self.remoter.run('env', verbose=True).stdout
+
+            self.remoter.run('mkdir -p $HOME/.config/systemd/user', verbose=True)
+
             if package_version < packaging.version.parse('3'):
                 install_cmds = dedent("""
                     tar xvfz ./unified_package.tar.gz

--- a/sdcm/remote/remote_file.py
+++ b/sdcm/remote/remote_file.py
@@ -15,6 +15,7 @@ import os
 import logging
 import tempfile
 import contextlib
+from pathlib import Path
 from io import StringIO
 
 import yaml
@@ -32,21 +33,21 @@ def read_to_stringio(fobj):
 
 # pylint: disable=too-many-locals,too-many-arguments
 @contextlib.contextmanager
-def remote_file(remoter, remote_path, serializer=StringIO.getvalue, deserializer=read_to_stringio, sudo=False,
+def remote_file(remoter, remote_path: str | Path, serializer=StringIO.getvalue, deserializer=read_to_stringio, sudo=False,
                 preserve_ownership=True, preserve_permissions=True, log_change=True):
     filename = os.path.basename(remote_path)
     local_tempfile = os.path.join(tempfile.mkdtemp(prefix='sct'), filename)
     if preserve_ownership and sudo:
-        ownership = remoter.sudo(cmd='stat -c "%U:%G" ' + remote_path).stdout.strip()
+        ownership = remoter.sudo(cmd=f'stat -c "%U:%G" {remote_path}').stdout.strip()
     if preserve_permissions and sudo:
-        permissions = remoter.sudo(cmd='stat -c "%a" ' + remote_path).stdout.strip()
+        permissions = remoter.sudo(cmd=f'stat -c "%a" {remote_path}').stdout.strip()
 
     wait.wait_for(remoter.receive_files,
                   step=10,
                   text=f"Waiting for copying `{remote_path}' from {remoter.hostname}",
                   timeout=300,
                   throw_exc=True,
-                  src=remote_path,
+                  src=str(remote_path),
                   dst=local_tempfile)
     with open(local_tempfile, encoding="utf-8") as fobj:
         parsed_data = deserializer(fobj)


### PR DESCRIPTION
for some reason the path where to install the offline-installer was hard-coded to `/home/scylla-test/scylladb`, which can lead to case where the image has a different default user, which is not name like that.

this commit change it, to dynamically lookup the home directory and build the path on that.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2204-test/53/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-rocky9-test/37/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2404-test/9/
- [x] 🟢  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-amazon2023-offline_install-nonroot-test/18/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
