### PR TITLE
feature(scylla-features): get available and enabled scylla features

### DIFF
--- a/sdcm/utils/features.py
+++ b/sdcm/utils/features.py
@@ -1,0 +1,78 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+#
+import logging
+
+from cassandra.cluster import Session  # pylint: disable=no-name-in-module
+
+CONSISTENT_TOPOLOGY_CHANGES_FEATURE = "SUPPORTS_CONSISTENT_TOPOLOGY_CHANGES"
+CONSISTENT_CLUSTER_MANAGEMENT_FEATURE = "SUPPORTS_RAFT_CLUSTER_MANAGEMENT"
+TABLETS_FEATURE = "TABLETS"
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_supported_features(session: Session) -> list[str]:
+    """
+    helper function to get supported_features from a running cluster,
+    if you need from a specific node use `patient_exclusive_cql_connection` session
+    """
+    result = session.execute("SELECT supported_features FROM system.local WHERE key='local'").one()
+    # NOTE: since row_factory can be different on different tests, we need to support multiple options
+    if isinstance(result, dict):
+        result = result["supported_features"].split(",")
+    elif isinstance(result, tuple):
+        result = result[0].split(",")
+    else:
+        raise NotImplementedError(f"unsupported row_factory={session.row_factory}")
+    LOGGER.debug("Supported features %s", result)
+    return result
+
+
+def get_enabled_features(session: Session) -> list[str]:
+    """
+    helper function to get supported_features from a running cluster,
+    if you need from a specific node use `patient_exclusive_cql_connection` session
+    """
+    result = session.execute("SELECT value FROM system.scylla_local WHERE key='enabled_features'").one()
+    # NOTE: since row_factory can be different on different tests, we need to support multiple options
+    if isinstance(result, dict):
+        result = result["value"].split(",")
+    elif isinstance(result, tuple):
+        result = result[0].split(",")
+    else:
+        raise NotImplementedError(f"unsupported row_factory={session.row_factory}")
+    LOGGER.debug("Enabled features %s", result)
+    return result
+
+
+def is_consistent_cluster_management_feature_enabled(session: Session) -> bool:
+    """ Check whether raft consistent cluster management feature enabled
+    if you need from a specific node use `patient_exclusive_cql_connection` session
+    """
+
+    return CONSISTENT_CLUSTER_MANAGEMENT_FEATURE in get_enabled_features(session)
+
+
+def is_consistent_topology_changes_feature_enabled(session: Session) -> bool:
+    """ Check whether raft topology feature enabled
+    if you need from a specific node use `patient_exclusive_cql_connection` session
+    """
+
+    return CONSISTENT_TOPOLOGY_CHANGES_FEATURE in get_enabled_features(session)
+
+
+def is_tablets_feature_enabled(session: Session) -> bool:
+    """ Check whether tablets enabled
+    if you need from a specific node use `patient_exclusive_cql_connection` session
+    """
+    return TABLETS_FEATURE in get_enabled_features(session)


### PR DESCRIPTION
New utils scylla features functions which allow to get supported and enabled scylla features on cluster and check if feature is enabled

These functions is better choice to check new features like tablets and raft consistent topology changes

### Testing
- [Job with patch](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/longevity-100gb-4h/111) Job failed due to error https://github.com/scylladb/scylladb/issues/18843, which was fixed on later build

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
