### PR TITLE
fix(benchmarks): disable node benchmarks

### DIFF
--- a/jenkins-pipelines/performance/Perf-Regression/scylla-release-perf-regression-latency-shard-aware-1TB.jenkinsfile
+++ b/jenkins-pipelines/performance/Perf-Regression/scylla-release-perf-regression-latency-shard-aware-1TB.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/perf-loaders-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/perf-loaders-shard-aware-config.yaml"]''',
     sub_tests: ["test_latency"],
     test_email_title: "shard-aware"
 )

--- a/jenkins-pipelines/performance/Perf-Regression/scylla-release-perf-regression-throughput-non-shard-aware.jenkinsfile
+++ b/jenkins-pipelines/performance/Perf-Regression/scylla-release-perf-regression-throughput-non-shard-aware.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: '''["test-cases/performance/perf-regression.100threads.30M-keys.yaml","configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml", "configurations/disable_speculative_retry.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression.100threads.30M-keys.yaml","configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/disable_speculative_retry.yaml"]''',
     sub_tests: ["test_write", "test_read", "test_mixed"],
     test_email_title: "throughput - non-shard-aware",
 

--- a/jenkins-pipelines/performance/Perf-Regression/scylla-release-perf-regression-throughput-shard-aware.jenkinsfile
+++ b/jenkins-pipelines/performance/Perf-Regression/scylla-release-perf-regression-throughput-shard-aware.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: '''["test-cases/performance/perf-regression.100threads.30M-keys.yaml","configurations/perf-loaders-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml", "configurations/disable_speculative_retry.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression.100threads.30M-keys.yaml","configurations/perf-loaders-shard-aware-config.yaml", "configurations/disable_speculative_retry.yaml"]''',
     sub_tests: ["test_write", "test_read", "test_mixed"],
     test_email_title: "throughput - shard-aware",
 

--- a/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-regression-latency-shard-aware-1TB.jenkinsfile
+++ b/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-regression-latency-shard-aware-1TB.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/perf-loaders-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/perf-loaders-shard-aware-config.yaml"]''',
     sub_tests: ["test_latency"],
     test_email_title: "shard-aware"
 )

--- a/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-regression-throughput-non-shard-aware-i4i.jenkinsfile
+++ b/jenkins-pipelines/performance/scylla-enterprise/scylla-enterprise-perf-regression-throughput-non-shard-aware-i4i.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: '''["test-cases/performance/perf-regression.100threads.30M-keys-i4i-enterprise.yaml","configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml", "configurations/disable_speculative_retry.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression.100threads.30M-keys-i4i-enterprise.yaml","configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/disable_speculative_retry.yaml"]''',
     sub_tests: ["test_write", "test_read", "test_mixed"],
     test_email_title: "throughput - non-shard-aware",
 

--- a/jenkins-pipelines/performance/scylla-master/scylla-master-perf-regression-latency-shard-aware-1TB.jenkinsfile
+++ b/jenkins-pipelines/performance/scylla-master/scylla-master-perf-regression-latency-shard-aware-1TB.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/perf-loaders-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/perf-loaders-shard-aware-config.yaml"]''',
     sub_tests: ["test_latency"],
     test_email_title: "shard-aware"
 )

--- a/jenkins-pipelines/performance/scylla-master/scylla-master-perf-regression-throughput-non-shard-aware-i4i.jenkinsfile
+++ b/jenkins-pipelines/performance/scylla-master/scylla-master-perf-regression-throughput-non-shard-aware-i4i.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: '''["test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml","configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml", "configurations/disable_speculative_retry.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml","configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/disable_speculative_retry.yaml"]''',
     sub_tests: ["test_write", "test_read", "test_mixed"],
     test_email_title: "throughput - non-shard-aware",
 

--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -20,4 +20,4 @@ user_prefix: 'longevity-10gb-3h'
 space_node_threshold: 64424
 
 gce_n_local_ssd_disk_db: 2
-run_db_node_benchmarks: true
+run_db_node_benchmarks: false


### PR DESCRIPTION
After examination of test runs, node benchmarks don't bring any valuable information: seems there's no correlation between its results and performance of nodes.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/7468

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
