### PR TITLE
fix(syslogng-install): fix retries in installation script

### DIFF
--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -141,10 +141,10 @@ def install_syslogng_service():
             else
                 cat /etc/apt/sources.list
                 for n in 1 2 3 4 5 6 7 8 9; do # cloud-init is running it with set +o braceexpand
-                    if apt-get -y update 2>&1 | tee /tmp/syslog_ng_install.output || grep NO_PUBKEY \
-        /tmp/syslog_ng_install.output; then
+                    if apt-get -y update ; then
                         break
                     fi
+                    sleep 0.5
                 done
 
                 for n in 1 2 3; do # cloud-init is running it with set +o braceexpand

--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -135,8 +135,8 @@ def install_syslogng_service():
         elif apt-get --help 2>/dev/null 1>&2 ; then
             if dpkg-query --show syslog-ng ; then
                 rm /etc/syslog-ng/syslog-ng.conf  # Make sure we have default syslog-ng.conf
-                apt-get purge -y syslog-ng*
-                DPKG_FORCE=confmiss apt-get --reinstall -y install syslog-ng
+                apt-get purge -o DPkg::Lock::Timeout=300 -y syslog-ng*
+                DPKG_FORCE=confmiss apt-get --reinstall -o DPkg::Lock::Timeout=300 -y install syslog-ng
                 SYSLOG_NG_INSTALLED=1
             else
                 cat /etc/apt/sources.list


### PR DESCRIPTION
Now the the ssh "lock" we have if out, there are few reentrancy issue we need to solve in the syslog-ng installation
script
 
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] provision tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
