### PR TITLE
fix(hydra): use python3.11 `Don’t prepend a potentially unsafe path to sys.path`

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -2,6 +2,9 @@
 
 set -eo pipefail
 
+# make sure the call to get_username.py doesn't import any local modules
+export PYTHONSAFEPATH=true
+
 CMD=$@
 DOCKER_ENV_DIR=$(readlink -f "$0")
 DOCKER_ENV_DIR=$(dirname "${DOCKER_ENV_DIR}")


### PR DESCRIPTION
cause if we don't, we have some modules in utils which are identical in their names to some builtins, and it would fail like that:
```
Traceback (most recent call last):
  File "..././sdcm/utils/get_username.py", line 15, in <module>
    import getpass
  File ".../3.11.3/lib/python3.11/getpass.py", line 17, in <module>
    import contextlib
  File ".../3.11.3/lib/python3.11/contextlib.py", line 6, in <module>
    from collections import deque
  File ".../3.11.3/lib/python3.11/collections/__init__.py", line 36, in <module>
    from operator import eq as _eq
ImportError: cannot import name 'eq' from 'operator'
(.../sdcm/utils/operator/__init__.py)
```

this snippet of python code is run before we get into the hydra image hence we don't control the python version being used...

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
