### PR TITLE
fix(setup): fix verifying cloud-init command

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -507,7 +507,7 @@ class AWSNode(cluster.BaseNode):
         super().init()
 
     def wait_for_cloud_init(self):
-        if self.remoter.sudo('command -v cloud-init', ignore_status=True).ok:
+        if self.remoter.sudo("bash -c 'command -v cloud-init'", ignore_status=True).ok:
             wait_cloud_init_completes(self.remoter, self)
 
     @property

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -113,7 +113,7 @@ class GCENode(cluster.BaseNode):
         super().init()
 
     def wait_for_cloud_init(self):
-        if self.remoter.sudo('command -v cloud-init', ignore_status=True).ok:
+        if self.remoter.sudo("bash -c 'command -v cloud-init'", ignore_status=True).ok:
             wait_cloud_init_completes(self.remoter, self)
 
     @cached_property


### PR DESCRIPTION
`command` command in the context of `sudo` does not work (raising `sudo: command: command not found` error).

Fix by wrapping over `bash -c` .

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - aws provision test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
