### PR TITLE
test(manager): Introduce the sanity test on mixed cluster (vnodes+tablets)

### DIFF
--- a/jenkins-pipelines/manager/ubuntu22-manager-vnodes-tablets.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-vnodes-tablets.jenkinsfile
@@ -1,0 +1,17 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    region: 'us-east-1',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity_vnodes_tablets_cluster',
+    test_config: 'test-cases/manager/manager-regression-singleDC-set-distro.yaml',
+
+    scylla_version: '6.0',
+
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+)

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -841,8 +841,10 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         self.log.info('Task: {} is done.'.format(repair_task.id))
         self.log.debug("sctool version is : {}".format(manager_tool.sctool.version))
 
-        expected_keyspaces_to_be_repaired = ["system_auth", "system_distributed",  # pylint: disable=invalid-name
-                                             self.NETWORKSTRATEGY_KEYSPACE_NAME]
+        expected_keyspaces_to_be_repaired = ["system_distributed", self.NETWORKSTRATEGY_KEYSPACE_NAME]
+        if not self.db_cluster.nodes[0].raft.is_consistent_topology_changes_enabled:
+            expected_keyspaces_to_be_repaired.append("system_auth")
+        self.log.debug("Keyspaces expected to be repaired: {}".format(expected_keyspaces_to_be_repaired))
         per_keyspace_progress = repair_task.per_keyspace_progress
         self.log.info("Looking in the repair output for all of the required keyspaces")
         for keyspace_name in expected_keyspaces_to_be_repaired:

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -42,6 +42,7 @@ from sdcm.sct_events.system import InfoEvent
 from sdcm.sct_events.group_common_events import ignore_no_space_errors, ignore_stream_mutation_fragments_errors
 from sdcm.utils.gce_utils import get_gce_storage_client
 from sdcm.utils.azure_utils import AzureService
+from sdcm.utils.tablets.common import TabletsConfiguration
 from sdcm.exceptions import FilesNotCorrupted
 
 
@@ -172,21 +173,24 @@ class BackupFunctionsMixIn(LoaderUtilsMixin):
                             keyspace_and_table_list=keyspace_and_table_list)
 
     # pylint: disable=too-many-arguments
-    def verify_backup_success(self, mgr_cluster, backup_task, keyspace_name='keyspace1', tables_names=None,
+    def verify_backup_success(self, mgr_cluster, backup_task, ks_names: list = None, tables_names: list = None,
                               truncate=True, restore_data_with_task=False, timeout=None):
+        if ks_names is None:
+            ks_names = ['keyspace1']
         if tables_names is None:
             tables_names = ['standard1']
-        per_keyspace_tables_dict = {keyspace_name: tables_names}
+        ks_tables_map = {keyspace: tables_names for keyspace in ks_names}
         if truncate:
-            for table_name in tables_names:
-                self.log.info(f'running truncate on {keyspace_name}.{table_name}')
-                self.db_cluster.nodes[0].run_cqlsh(f'TRUNCATE {keyspace_name}.{table_name}')
+            for ks, tables in ks_tables_map.items():
+                for table_name in tables:
+                    self.log.info(f'running truncate on {ks}.{table_name}')
+                    self.db_cluster.nodes[0].run_cqlsh(f'TRUNCATE {ks}.{table_name}')
         if restore_data_with_task:
             self.restore_backup_with_task(mgr_cluster=mgr_cluster, snapshot_tag=backup_task.get_snapshot_tag(),
                                           timeout=timeout, restore_data=True)
         else:
             self.restore_backup_from_backup_task(mgr_cluster=mgr_cluster, backup_task=backup_task,
-                                                 keyspace_and_table_list=per_keyspace_tables_dict)
+                                                 keyspace_and_table_list=ks_tables_map)
 
     def restore_backup_with_task(self, mgr_cluster, snapshot_tag, timeout, restore_schema=False, restore_data=False,
                                  location_list=None):
@@ -335,7 +339,7 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         self.log.info("creating the table {} in the keyspace {}".format(table_name, keyspace_name))
         self.create_table(table_name, keyspace_name=keyspace_name)
 
-    def test_manager_sanity(self):
+    def test_manager_sanity(self, prepared_ks: bool = False, ks_names: list = None):
         """
         Test steps:
         1) Run the repair test.
@@ -343,11 +347,12 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         3) test_mgmt_cluster_healthcheck
         4) test_client_encryption
         """
-        self.generate_load_and_wait_for_results()
+        if not prepared_ks:
+            self.generate_load_and_wait_for_results()
         with self.subTest('Basic Backup Test'):
-            self.test_basic_backup()
+            self.test_basic_backup(ks_names=ks_names)
         with self.subTest('Restore Backup Test'):
-            self.test_restore_backup_with_task()
+            self.test_restore_backup_with_task(ks_names=ks_names)
         with self.subTest('Repair Multiple Keyspace Types'):
             self.test_repair_multiple_keyspace_types()
         with self.subTest('Mgmt Cluster CRUD'):
@@ -363,6 +368,26 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         with self.subTest('Client Encryption'):
             # Since this test activates encryption, it has to be the last test in the sanity
             self.test_client_encryption()
+
+    def test_manager_sanity_vnodes_tablets_cluster(self):
+        """
+        Test steps:
+        1) Create tablets keyspace and propagate some data.
+        2) Create vnodes keyspace and propagate some data.
+        3) Run sanity test (test_manager_sanity).
+        """
+        self.log.info('starting test_manager_sanity_vnodes_tablets_cluster')
+
+        ks_config = [("tablets_keyspace", True), ("vnodes_keyspace", False)]
+        ks_names = [i[0] for i in ks_config]
+        for ks_name, tablets_enabled in ks_config:
+            tablets_config = TabletsConfiguration(enabled=tablets_enabled)
+            self.create_keyspace(ks_name, replication_factor=3, tablets_config=tablets_config)
+            self.generate_load_and_wait_for_results(keyspace_name=ks_name)
+
+        self.test_manager_sanity(prepared_ks=True, ks_names=ks_names)
+
+        self.log.info('finishing test_manager_sanity_vnodes_tablets_cluster')
 
     def test_repair_intensity_feature_on_multiple_node(self):
         self._repair_intensity_feature(fault_multiple_nodes=True)
@@ -522,7 +547,7 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
                     # self.populate_data_parallel()
         return table_name
 
-    def test_basic_backup(self):
+    def test_basic_backup(self, ks_names: list = None):
         self.log.info('starting test_basic_backup')
         manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
         mgr_cluster = self._ensure_and_get_cluster(manager_tool)
@@ -530,25 +555,27 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         backup_task_status = backup_task.wait_and_get_final_status(timeout=1500)
         assert backup_task_status == TaskStatus.DONE, \
             f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"
-        self.verify_backup_success(mgr_cluster=mgr_cluster, backup_task=backup_task)
-        self.run_verification_read_stress()
+        self.verify_backup_success(mgr_cluster=mgr_cluster, backup_task=backup_task, ks_names=ks_names)
+        self.run_verification_read_stress(ks_names)
         mgr_cluster.delete()  # remove cluster at the end of the test
         self.log.info('finishing test_basic_backup')
 
-    def test_restore_backup_with_task(self):
+    def test_restore_backup_with_task(self, ks_names: list = None):
         self.log.info('starting test_restore_backup_with_task')
         manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
         mgr_cluster = self._ensure_and_get_cluster(manager_tool)
-        backup_task = mgr_cluster.create_backup_task(location_list=self.locations, keyspace_list=["keyspace1"])
+        if not ks_names:
+            ks_names = ['keyspace1']
+        backup_task = mgr_cluster.create_backup_task(location_list=self.locations, keyspace_list=ks_names)
         backup_task_status = backup_task.wait_and_get_final_status(timeout=1500)
         assert backup_task_status == TaskStatus.DONE, \
             f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"
         soft_timeout = 36 * 60
         hard_timeout = 50 * 60
         with adaptive_timeout(Operations.MGMT_REPAIR, self.db_cluster.nodes[0], timeout=soft_timeout):
-            self.verify_backup_success(mgr_cluster=mgr_cluster, backup_task=backup_task, restore_data_with_task=True,
-                                       timeout=hard_timeout)
-        self.run_verification_read_stress()
+            self.verify_backup_success(mgr_cluster=mgr_cluster, backup_task=backup_task, ks_names=ks_names,
+                                       restore_data_with_task=True, timeout=hard_timeout)
+        self.run_verification_read_stress(ks_names)
         mgr_cluster.delete()  # remove cluster at the end of the test
         self.log.info('finishing test_restore_backup_with_task')
 

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -106,7 +106,7 @@ class ManagerUpgradeTest(BackupFunctionsMixIn, ClusterTester):
                 f"Unknown failure in task {rerunning_backup_task.id}"
 
         with self.subTest("Creating a backup task and stopping it"):
-            self.generate_load_and_wait_for_results(keyspace_name_to_replace="keyspace2")
+            self.generate_load_and_wait_for_results(keyspace_name="keyspace2")
             legacy_args = "--force" if manager_tool.sctool.client_version.startswith("2.1") else None
             pausable_backup_task = mgr_cluster.create_backup_task(
                 cron=create_cron_list_from_timedelta(minutes=1),

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -105,6 +105,7 @@ from sdcm.utils.log_time_consistency import DbLogTimeConsistencyAnalyzer
 from sdcm.utils.net import get_my_ip, get_sct_runner_ip
 from sdcm.utils.operations_thread import ThreadParams
 from sdcm.utils.replication_strategy_utils import LocalReplicationStrategy, NetworkTopologyReplicationStrategy
+from sdcm.utils.tablets.common import TabletsConfiguration
 from sdcm.utils.threads_and_processes_alive import gather_live_processes_and_dump_to_file, \
     gather_live_threads_and_dump_to_file
 from sdcm.utils.version_utils import (
@@ -2334,7 +2335,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                             session=session, keyspace_name=keyspace_name, throw_exc=False)
         return does_keyspace_exist
 
-    def create_keyspace(self, keyspace_name, replication_factor):
+    def create_keyspace(self, keyspace_name, replication_factor, tablets_config: Optional[TabletsConfiguration] = None):
         """
         If replication_factor is int, the all DC's will have the same replication factor, if 0, use LocalReplicationStrategy
         If replication_factor is dict, the keys are the DC's names and the values are the replication factor for each DC
@@ -2352,8 +2353,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             else:
                 replication_strategy = NetworkTopologyReplicationStrategy(**replication_factor)
 
-            execution_result = session.execute('CREATE KEYSPACE IF NOT EXISTS %s WITH replication=%s'
-                                               % (keyspace_name, str(replication_strategy)))
+            cmd = 'CREATE KEYSPACE IF NOT EXISTS %s WITH replication=%s' % (keyspace_name, str(replication_strategy))
+            if tablets_config:
+                cmd += ' AND TABLETS = %s' % tablets_config
+            execution_result = session.execute(cmd)
+
         if execution_result:
             self.log.debug("keyspace creation result: {}".format(execution_result.response_future))
         with self.db_cluster.cql_connection_patient(validation_node) as session:

--- a/sdcm/utils/loader_utils.py
+++ b/sdcm/utils/loader_utils.py
@@ -65,20 +65,28 @@ class LoaderUtilsMixin:
 
     def assemble_and_run_all_stress_cmd(self, stress_queue, stress_cmd, keyspace_num):
         if stress_cmd:
+            round_robin = self.params.get('round_robin')
             # Stress: Same as in prepare_write - allow the load to be spread across all loaders when using multi ks
-            if keyspace_num > 1 and self.params.get('round_robin'):
+            if keyspace_num > 1 and round_robin:
                 self.log.debug("Using round_robin for multiple Keyspaces...")
                 for i in range(1, keyspace_num + 1):
                     keyspace_name = self._get_keyspace_name(i)
-                    params = {'keyspace_name': keyspace_name, 'round_robin': True, 'stress_cmd': stress_cmd}
-
+                    params = {'keyspace_name': keyspace_name, 'stress_cmd': stress_cmd, 'round_robin': round_robin}
                     self._run_all_stress_cmds(stress_queue, params)
 
             # The old method when we run all stress_cmds for all keyspace on the same loader, or in round-robin if defined in test yaml
             else:
-                params = {'keyspace_num': keyspace_num, 'stress_cmd': stress_cmd,
-                          'round_robin': self.params.get('round_robin')}
+                params = {'keyspace_num': keyspace_num, 'stress_cmd': stress_cmd, 'round_robin': round_robin}
                 self._run_all_stress_cmds(stress_queue, params)
+
+    def assemble_and_run_all_stress_cmd_by_ks_names(self, stress_queue, stress_cmd, ks_names=None):
+        for ks_name in ks_names:
+            params = {
+                'keyspace_name': ks_name,
+                'stress_cmd': stress_cmd,
+                'round_robin': self.params.get('round_robin')
+            }
+            self._run_all_stress_cmds(stress_queue, params)
 
     def _run_all_stress_cmds(self, stress_queue, params):
         stress_cmds = params['stress_cmd']

--- a/sdcm/utils/tablets/common.py
+++ b/sdcm/utils/tablets/common.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class TabletsConfiguration:
+    enabled: Optional[bool] = None
+    initial: Optional[int] = None
+
+    def __str__(self):
+        items = []
+        for k, v in self.__dict__.items():
+            if v is not None:
+                value = str(v).lower() if isinstance(v, bool) else v
+                items.append(f"'{k}': {value}")
+        return '{' + ', '.join(items) + '}'

--- a/test-cases/upgrades/manager-upgrade.yaml
+++ b/test-cases/upgrades/manager-upgrade.yaml
@@ -1,7 +1,7 @@
 test_duration: 360
 
-stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) keyspace=keyspace1' -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
-stress_read_cmd: "cassandra-stress read cl=QUORUM n=1200300 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) keyspace=keyspace1' -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
+stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
+stress_read_cmd: "cassandra-stress read cl=QUORUM n=1200300 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
 
 instance_type_db: 'i4i.large'
 instance_type_loader: 'c6i.large'


### PR DESCRIPTION
The PR partially addresses https://github.com/scylladb/scylla-manager/issues/3853.

The PR consists of:
- New test that performs sanity checks on cluster with mixed keyspaces - 1 vnodes keyspace + 1 tablets keyspace;
- .jenkinsfile that handles test execution in CI;
- A few fixes/extensions for some load/stress methods to handle non-default or several keyspace names;
- Fix for system_auth keyspace repair test.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] New test: 
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-sanity-test/16/
- [x] Jenkins job:
https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-vnodes-tablets-cluster-test/
- [x] Regression sanity test: 
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/debian11-sanity-test/2/
- [x] Regression upgrade test: 
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-upgrade-test/1/
- [x] Ubuntu sanity (Scylla 6.0) to verify repair test fixes:
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-sanity-test/17/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)