### PR TITLE
Move disable auto upgrades to cloud init

### DIFF
--- a/sdcm/provision/common/configuration_script.py
+++ b/sdcm/provision/common/configuration_script.py
@@ -22,6 +22,7 @@ from sdcm.provision.common.utils import (
     restart_syslogng_service,
     configure_ssh_accept_rsa,
     install_syslogng_exporter,
+    disable_daily_apt_triggers,
 )
 from sdcm.provision.user_data import CLOUD_INIT_SCRIPTS_PATH
 
@@ -74,6 +75,7 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
         # 4. There is race condition between sct and boot script, disable ssh to mitigate it
         # 5. Make sure that whenever you use "cat <<EOF >>/file", make sure that EOF has no spaces in front of it
         script = ''
+        script += disable_daily_apt_triggers()
         if self.logs_transport == 'syslog-ng':
             script += install_syslogng_service()
             script += configure_syslogng_target_script(

--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -192,3 +192,18 @@ def install_syslogng_exporter():
     systemctl enable syslog_ng_exporter.service
     systemctl start syslog_ng_exporter.service
 """)
+
+
+def disable_daily_apt_triggers():
+    return dedent("""\
+    if apt-get --help >/dev/null 2>&1 ; then
+        if [ ! -f /tmp/disable_daily_apt_triggers_done ]; then
+            rm -f /etc/apt/apt.conf.d/*unattended-upgrades /etc/apt/apt.conf.d/*auto-upgrades || true
+            rm -f /etc/apt/apt.conf.d/*periodic /etc/apt/apt.conf.d/*update-notifier || true
+            systemctl stop apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service || true
+            systemctl disable apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service || true
+            apt-get remove -o DPkg::Lock::Timeout=300 -y unattended-upgrades update-manager || true
+            touch /tmp/disable_daily_apt_triggers_done
+        fi
+    fi
+    """)

--- a/sdcm/sct_provision/region_definition_builder.py
+++ b/sdcm/sct_provision/region_definition_builder.py
@@ -21,6 +21,7 @@ from sdcm.sct_config import SCTConfiguration
 from sdcm.sct_provision.common.types import NodeTypeType
 
 from sdcm.sct_provision.user_data_objects import SctUserDataObject
+from sdcm.sct_provision.user_data_objects.apt_daily_triggers import DisableAptTriggersUserDataObject
 from sdcm.sct_provision.user_data_objects.scylla import ScyllaUserDataObject
 from sdcm.sct_provision.user_data_objects.sshd import SshdUserDataObject
 from sdcm.sct_provision.user_data_objects.syslog_ng import SyslogNgUserDataObject, SyslogNgExporterUserDataObject
@@ -138,6 +139,7 @@ class DefinitionBuilder(abc.ABC):
 
     def _get_user_data_objects(self, instance_name: str, node_type: NodeTypeType) -> List[SctUserDataObject]:
         user_data_object_classes: List[Type[SctUserDataObject]] = [
+            DisableAptTriggersUserDataObject,
             SyslogNgUserDataObject,
             SyslogNgExporterUserDataObject,
             SshdUserDataObject,

--- a/sdcm/sct_provision/user_data_objects/apt_daily_triggers.py
+++ b/sdcm/sct_provision/user_data_objects/apt_daily_triggers.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+
+from sdcm.provision.common.utils import disable_daily_apt_triggers
+from sdcm.sct_provision.user_data_objects import SctUserDataObject
+
+
+@dataclass
+class DisableAptTriggersUserDataObject(SctUserDataObject):
+
+    @property
+    def is_applicable(self) -> bool:
+        return True
+
+    @property
+    def script_to_run(self) -> str:
+        return disable_daily_apt_triggers()

--- a/sdcm/sct_provision/user_data_objects/sshd.py
+++ b/sdcm/sct_provision/user_data_objects/sshd.py
@@ -26,6 +26,6 @@ class SshdUserDataObject(SctUserDataObject):
     @property
     def script_to_run(self) -> str:
         script = configure_sshd_script()
-        script = configure_ssh_accept_rsa()
+        script += configure_ssh_accept_rsa()
         script += restart_sshd_service()
         return script


### PR DESCRIPTION
Apt daily triggers disabling takes time and is quite late in the
proces. This prolongs setup due chance that triggers are fired before
installation of syslog-ng and other packages and makes apt lock to be
awaited. Also doing it with `remoter` class in multiple commands is not
most efficient way of doing it.

Moved disabling apt daily triggers to cloud-init step as the first in
the process.

closes: https://github.com/scylladb/qa-tasks/issues/1695

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - all provision tests
- [x] - [rocky9 based artifact test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/artifacts-rocky9-test/3/)
- [x] - [debian11 based artifact test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/artifacts-debian11-test/2/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
