### PR TITLE
test(manager): introduce Manager installation test on Rocky8 distribution

### DIFF
--- a/configurations/manager/debian10.yaml
+++ b/configurations/manager/debian10.yaml
@@ -1,5 +1,5 @@
 ami_id_monitor: 'resolve:ssm:/aws/service/debian/release/10/latest/amd64'  # Debian Buster latest image
 ami_monitor_user: 'admin'
-monitor_branch: 'branch-4.6'  # Pass it as debian image is not the formal monitor image
+monitor_branch: 'branch-4.7'  # Pass it as debian image is not the formal monitor image
 
 manager_scylla_backend_version: '2023'  # Notice: Uses 2023.1, while other (newer deb) use 2024, since we support both

--- a/configurations/manager/debian11.yaml
+++ b/configurations/manager/debian11.yaml
@@ -1,3 +1,3 @@
 ami_id_monitor: 'resolve:ssm:/aws/service/debian/release/11/latest/amd64'  # Debian Bullseye latest image
 ami_monitor_user: 'admin'
-monitor_branch: 'branch-4.6'  # Pass it as debian image is not the formal monitor image
+monitor_branch: 'branch-4.7'  # Pass it as debian image is not the formal monitor image

--- a/configurations/manager/rocky8.yaml
+++ b/configurations/manager/rocky8.yaml
@@ -1,3 +1,3 @@
 ami_id_monitor: 'ami-011ef2017d41cb239'  # Rocky Linux 8 (Official) image, region - us-east-1
 ami_monitor_user: 'rocky'
-monitor_branch: 'branch-4.6'  # Pass it as debian image is not the formal monitor image
+monitor_branch: 'branch-4.7'  # Pass it as debian image is not the formal monitor image

--- a/configurations/manager/rocky8.yaml
+++ b/configurations/manager/rocky8.yaml
@@ -1,0 +1,3 @@
+ami_id_monitor: 'ami-011ef2017d41cb239'  # Rocky Linux 8 (Official) image, region - us-east-1
+ami_monitor_user: 'rocky'
+monitor_branch: 'branch-4.6'  # Pass it as debian image is not the formal monitor image

--- a/configurations/manager/ubuntu20.yaml
+++ b/configurations/manager/ubuntu20.yaml
@@ -1,3 +1,3 @@
 ami_id_monitor: 'resolve:ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id'  # Canonical, Ubuntu, 20.04 LTS, amd64 focal latest image
 ami_monitor_user: 'ubuntu'
-monitor_branch: 'branch-4.6'  # Pass it as debian image is not the formal monitor image
+monitor_branch: 'branch-4.7'  # Pass it as debian image is not the formal monitor image

--- a/jenkins-pipelines/manager/rocky8-manager-install.jenkinsfile
+++ b/jenkins-pipelines/manager/rocky8-manager-install.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    region: 'us-east-1',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_installed_and_functional',
+    test_config: '''["test-cases/manager/manager-installation-set-distro.yaml", "configurations/manager/rocky8.yaml"]''',
+
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2253,7 +2253,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
 
         if self.distro.is_rhel_like:
             self.install_epel()
-            self.remoter.sudo("yum install python36-PyYAML -y", retry=3)
+            self.install_package("python3-PyYAML")
         elif self.distro.is_sles:
             self.remoter.sudo("zypper install python36-PyYAML -y", retry=3)
         elif not self.distro.is_debian_like:
@@ -5469,12 +5469,22 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
 
         if node.distro.is_rhel_like:
             node.install_epel()
-            node.install_package(package_name="unzip wget python36 python36-pip")
-            prereqs_script = dedent("""
+            node.install_package(package_name="unzip wget python3 python3-pip")
+            # get-docker.sh doesn't support Rocky, thus docker should be installed from repo via dnf install
+            if node.distro.is_rocky:
+                install_docker_cmd = dedent("""
+                    dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+                    dnf install -y docker-ce docker-ce-cli containerd.io
+                """)
+            else:
+                install_docker_cmd = dedent("""
+                    curl -fsSL get.docker.com --retry 5 --retry-max-time 300 -o get-docker.sh
+                    sh get-docker.sh
+                """)
+            prereqs_script = dedent(f"""
                 python3 -m pip install --upgrade pip
                 python3 -m pip install pyyaml
-                curl -fsSL get.docker.com --retry 5 --retry-max-time 300 -o get-docker.sh
-                sh get-docker.sh
+                {install_docker_cmd}
                 systemctl start docker
             """)
         elif node.distro.is_ubuntu:

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -916,7 +916,7 @@ class ScyllaManagerTool(ScyllaManagerBase):
         ScyllaManagerBase.__init__(self, id="MANAGER", manager_node=manager_node)
         self._initial_wait(20)
         LOGGER.info("Initiating Scylla-Manager, version: {}".format(self.sctool.version))
-        list_supported_distros = [Distro.CENTOS7,
+        list_supported_distros = [Distro.ROCKY8, Distro.ROCKY9,
                                   Distro.DEBIAN10, Distro.DEBIAN11,
                                   Distro.UBUNTU20, Distro.UBUNTU22]
         self.default_user = "centos"


### PR DESCRIPTION
This PR introduces the Manager installation test on Rocky8 distro (https://github.com/scylladb/scylla-manager/issues/3854).

Contains:
- Configuration file for Rocky8 distro;
- jenkinsfile for Rocky installation test;
- some adjustments to monitoring node configuration methods to make installation on Rocky finctuonal.

Test triggers were adjusted as well:
https://github.com/scylladb/scylla-pkg/pull/4137

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master/job/rocky8-installation-test/3/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
