### PR TITLE
feature(teardown-validators): parallel nemeses error events validator

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -250,6 +250,13 @@ teardown_validators:
     timeout: 1200
     keyspace: ''
     table: ''
+  test_error_events:
+    enabled: false
+    failing_events:
+      - event_class: DatabaseLogEvent
+        event_type: RUNTIME_ERROR
+        regex: '.*runtime_error.*'
+      - event_class: CoreDumpEvent
 
 kafka_backend: null
 kafka_connectors: []

--- a/sdcm/teardown_validators/__init__.py
+++ b/sdcm/teardown_validators/__init__.py
@@ -1,3 +1,4 @@
+from sdcm.teardown_validators.events import ErrorEventsValidator
 from sdcm.teardown_validators.sstables import SstablesValidator
 
-teardown_validators_list = [SstablesValidator]
+teardown_validators_list = [SstablesValidator, ErrorEventsValidator]

--- a/sdcm/teardown_validators/base.py
+++ b/sdcm/teardown_validators/base.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
 import logging
+from typing import TYPE_CHECKING
 
-from sdcm.cluster import BaseCluster
 from sdcm.sct_config import SCTConfiguration
+
+if TYPE_CHECKING:
+    from sdcm.tester import ClusterTester
 
 LOGGER = logging.getLogger(__name__)
 
@@ -9,9 +13,9 @@ LOGGER = logging.getLogger(__name__)
 class TeardownValidator:  # pylint: disable=too-few-public-methods
     validator_name = None  # must be defined by child classes
 
-    def __init__(self, params: SCTConfiguration, cluster: BaseCluster):
+    def __init__(self, params: SCTConfiguration, tester: ClusterTester):
         self.params = params
-        self.cluster = cluster
+        self.tester = tester
         self.configuration = params.get(f"teardown_validators.{self.validator_name}")
         self.is_enabled = self.configuration.get("enabled", False)
         if not self.is_enabled:

--- a/sdcm/teardown_validators/events.py
+++ b/sdcm/teardown_validators/events.py
@@ -1,0 +1,66 @@
+import json
+import logging
+import re
+from functools import reduce
+from typing import Optional, Union
+
+from sdcm.sct_events.events_device import get_events_main_device
+from sdcm.sct_events import Severity
+from sdcm.teardown_validators.base import TeardownValidator
+
+LOGGER = logging.getLogger(__name__)
+
+
+class FailingEventsFilter:
+    def __init__(
+            self,
+            event_class: str,
+            event_type: Optional[str] = None,
+            regex: Optional[Union[str, re.Pattern]] = None):
+        """Filter to match only events that qualify as valid reason to fail a test."""
+        self.event_class = event_class
+        self.event_type = event_type
+        self.regex = re.compile(regex) if isinstance(regex, str) else regex
+
+    def filter_events(self, events: list[dict]) -> list[dict]:
+        filtered_events = []
+        for event in events:
+            if self._matches(event):
+                filtered_events.append(event)
+        return filtered_events
+
+    def _matches(self, event: dict) -> bool:
+        match = (
+            (event['severity'] == Severity.ERROR.name) and
+            (event['base'] == self.event_class) and
+            (self.event_type is None or event['type'] == self.event_type) and
+            (self.regex is None or self.regex.search(event['line']))
+        )
+        return match
+
+
+class ErrorEventsValidator(TeardownValidator):  # pylint: disable=too-few-public-methods
+    """
+    A teardown validator that checks test events log for presence of specific error events and critical-level events.
+    If the test doesn't have any of the defined failing error events or critical events, its status
+    defaults to 'SUCCESS'.
+
+    Usage:
+        An instance of ErrorEventsValidator can be used during teardown of a test, where specific error events
+        should not be considered as test failures.
+        This is particularly useful in complex testing environments where multiple parallel operations may lead to
+        non-critical errors that should not directly influence the overall test outcome.
+    """
+    validator_name = 'test_error_events'
+
+    def validate(self):
+        LOGGER.info("Running validation of failing events for parallel nemeses")
+        filters = [FailingEventsFilter(**event) for event in self.configuration.get("failing_events")]
+        raw_events_log = get_events_main_device(_registry=self.tester.events_processes_registry).raw_events_log
+
+        with open(raw_events_log, encoding='utf-8') as events_file:
+            initial_events = (json.loads(line) for line in events_file)
+            failing_events = reduce(lambda events, f: f.filter_events(events), filters, initial_events)
+
+        critical_events = self.tester.get_event_summary().get(Severity.CRITICAL.name, 0)
+        self.tester.get_test_status = lambda: 'FAILED' if (failing_events or critical_events) else 'SUCCESS'

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2886,8 +2886,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             InfoEvent(message="TEST_END").publish()
         self.log.info("Post test validators are starting...")
         for validator_class in teardown_validators_list:
-            for db_cluster in self.db_clusters_multitenant:
-                validator_class(self.params, db_cluster).validate()
+            validator_class(self.params, self).validate()
         self.log.info('TearDown is starting...')
         self.stop_timeout_thread()
         self.stop_event_analyzer()

--- a/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -45,3 +45,9 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
+
+teardown_validators:
+  test_error_events:
+    enabled: true
+    failing_events:
+      - event_class: CoreDumpEvent

--- a/unit_tests/test_teardown_validator.py
+++ b/unit_tests/test_teardown_validator.py
@@ -1,0 +1,116 @@
+import logging
+import unittest
+from unittest.mock import Mock, patch, mock_open
+
+from sdcm.teardown_validators.events import ErrorEventsValidator, Severity
+from sdcm.sct_config import SCTConfiguration
+
+LOGGER = logging.getLogger(__name__)
+
+
+FAILING_EVENTS = {
+    'only_class': {
+        'event_class': 'Event1',
+    },
+    'class_and_type': {
+        'event_class': 'Event2',
+        'event_type': 'Type2',
+    },
+    'class_and_type_and_regex': {
+        'event_class': 'Event3',
+        'event_type': 'Type3',
+        'regex': '.*failing event.*',
+
+    }
+}
+
+
+class FakeSCTConfiguration(SCTConfiguration):
+    def __init__(self, failing_events: list):
+        self.failing_events = failing_events
+        super().__init__()
+
+    def _load_environment_variables(self):
+        return {
+            'teardown_validators': {
+                'test_error_events': {
+                    'enabled': True,
+                    'failing_events': self.failing_events
+                }
+            }
+        }
+
+
+class TestErrorEventsValidator(unittest.TestCase):
+    def setUp(self):
+        self.tester_mock = Mock()
+
+    def setup_validator(self, failing_events):
+        self.params = FakeSCTConfiguration(failing_events)
+        self.validator = ErrorEventsValidator(self.params, self.tester_mock)
+
+    def setup_mocks(self, get_events_main_device_mock, event_data, critical_events=None):
+        get_events_main_device_mock.return_value.raw_events_log = 'raw_events.log'
+        self.tester_mock.get_event_summary.return_value = {Severity.CRITICAL.name: critical_events}
+        open_mock = mock_open(read_data=event_data)
+        return open_mock
+
+    @patch('sdcm.teardown_validators.events.get_events_main_device')
+    def test_validate_no_failing_events_no_critical_events(self, get_events_main_device_mock):
+        self.setup_validator(FAILING_EVENTS.values())
+        event_data = (
+            '{"severity": "WARNING", "base": "Event1", "type": "Type1", "line": "failing event line"}\n'
+            '{"severity": "ERROR", "base": "Event4", "type": "Type1", "line": "failing event line"}\n')
+        open_mock = self.setup_mocks(get_events_main_device_mock, event_data, critical_events=0)
+
+        with patch('builtins.open', open_mock):
+            self.validator.validate()
+        self.assertEqual(self.tester_mock.get_test_status(), 'SUCCESS')
+
+    @patch('sdcm.teardown_validators.events.get_events_main_device')
+    def test_validate_with_failing_event_class(self, get_events_main_device_mock):
+        self.setup_validator([FAILING_EVENTS['only_class']])
+        event_data = (
+            '{"severity": "WARNING", "base": "Event1", "type": "Type1", "line": "failing event line"}\n'
+            '{"severity": "ERROR", "base": "Event1", "type": "null", "line": "null"}\n')
+        open_mock = self.setup_mocks(get_events_main_device_mock, event_data, critical_events=0)
+
+        with patch('builtins.open', open_mock):
+            self.validator.validate()
+        self.assertEqual(self.tester_mock.get_test_status(), 'FAILED')
+
+    @patch('sdcm.teardown_validators.events.get_events_main_device')
+    def test_validate_with_failing_event_class_and_type(self, get_events_main_device_mock):
+        self.setup_validator([FAILING_EVENTS['class_and_type']])
+        event_data = (
+            '{"severity": "WARNING", "base": "Event1", "type": "Type1", "line": "failing event line"}\n'
+            '{"severity": "ERROR", "base": "Event2", "type": "Type2", "line": "null"}\n')
+        open_mock = self.setup_mocks(get_events_main_device_mock, event_data, critical_events=0)
+
+        with patch('builtins.open', open_mock):
+            self.validator.validate()
+        self.assertEqual(self.tester_mock.get_test_status(), 'FAILED')
+
+    @patch('sdcm.teardown_validators.events.get_events_main_device')
+    def test_validate_with_failing_event_class_and_type_and_regex(self, get_events_main_device_mock):
+        self.setup_validator([FAILING_EVENTS['class_and_type_and_regex']])
+        event_data = (
+            '{"severity": "WARNING", "base": "Event1", "type": "Type1", "line": "failing event line"}\n'
+            '{"severity": "ERROR", "base": "Event3", "type": "Type3", "line": "This is failing event line"}\n')
+        open_mock = self.setup_mocks(get_events_main_device_mock, event_data, critical_events=0)
+
+        with patch('builtins.open', open_mock):
+            self.validator.validate()
+        self.assertEqual(self.tester_mock.get_test_status(), 'FAILED')
+
+    @patch('sdcm.teardown_validators.events.get_events_main_device')
+    def test_validate_with_failing_events_with_critical_events(self, get_events_main_device_mock):
+        self.setup_validator([FAILING_EVENTS['class_and_type_and_regex']])
+        event_data = (
+            '{"severity": "WARNING", "base": "Event1", "type": "Type1", "line": "failing event line"}\n'
+            '{"severity": "ERROR", "base": "Event3", "type": "Type3", "line": "This is failing event line"}\n')
+        open_mock = self.setup_mocks(get_events_main_device_mock, event_data, critical_events=1)
+
+        with patch('builtins.open', open_mock):
+            self.validator.validate()
+        self.assertEqual(self.tester_mock.get_test_status(), 'FAILED')


### PR DESCRIPTION
In some cases (e.g. parallel nemeses) we don't want to fail the test based on an error event, but rather look for coredumps or critical level events.

The change introduces a teardown validator, which takes into account only pre-defined error events to make a decision if the test is failed.

The related task: https://github.com/scylladb/qa-tasks/issues/1671

### Testing
- [x] :green_circle: [longevity-5gb-1h-CorruptThenScrubMonkey + scrub + error events validators](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/sct-debug/53/)

### PR pre-checks (self review)
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
