### PR TITLE
fix(k8s): make K8S deployments not fail on mgmt version gatherings

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -504,7 +504,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.log.error("Unable to collect package versions for Argus - skipping...", exc_info=True)
 
     def argus_collect_manager_version(self):
-        if self.monitors.nodes and self.params.get('use_mgmt'):
+        # NOTE: K8S runs manager server in a pod on a non-monitor node.
+        #       Moreover, manager version is known in this case by the docker image tags.
+        if self.monitors.nodes and self.params.get('use_mgmt') and not self.k8s_clusters:
             manager_tool = get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
             self.log.info("Saving manager version in Argus...")
             # sctool.version output:


### PR DESCRIPTION
After merge of the [1] PR the K8S deployments started failing with the following error:

```
  Command: 'sudo sctool version'
  Exit code: 1
  Stdout:
  Stderr:
  sudo: sctool: command not found
```

It is caused by the fact of using monitoring node which, in case of K8S, doesn't have scylla-manager.

So, make that code be run only in non-k8s cases.

[1] https://github.com/scylladb/scylla-cluster-tests/pull/7538

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/job/scylla-operator/job/operator-1.13/job/gke/job/longevity-scylla-operator-3h-gke-test/3
- https://jenkins.scylladb.com/job/scylla-operator/job/operator-1.13/job/gke/job/longevity-scylla-operator-3h-gke-repair-test/3

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
