### PR TITLE
fix(wait_cloud_init_completes): ignore warnings

### DIFF
--- a/sdcm/provision/helpers/cloud_init.py
+++ b/sdcm/provision/helpers/cloud_init.py
@@ -10,8 +10,11 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2022 ScyllaDB
+import json
 import logging
 from pathlib import Path
+
+from packaging.version import Version
 
 from sdcm import sct_abs_path
 from sdcm.provision.provisioner import VmInstance
@@ -31,12 +34,24 @@ def wait_cloud_init_completes(remoter: RemoteCmdRunnerBase, instance: VmInstance
     LOGGER.info("Waiting for cloud-init to complete on node %s...", instance.name)
     errors_found = False
     remoter.is_up(60 * 5)
-    result = remoter.sudo("cloud-init status --wait")
-    status = result.stdout
-    LOGGER.debug("cloud-init status: %s", status)
-    if "done" not in status:
-        LOGGER.error("Some error during cloud-init %s", status)
-        errors_found = True
+    # examples: 24.1.3-0ubuntu3.3, 19.3-46.amzn2.0.2
+    cloud_init_version = Version(remoter.sudo("cloud-init --version 2>&1").stdout.split()[1].split('-')[0])
+    # cloud-init supports json output from version 23.4, see:
+    # https://cloudinit.readthedocs.io/en/latest/explanation/return_codes.html#id1
+    if cloud_init_version >= Version("23.4"):
+        result = remoter.sudo("cloud-init status --format=json --wait", ignore_status=True)
+        status = json.loads(result.stdout)
+
+        LOGGER.debug("cloud-init status: %s", status)
+        if status['status'] != "done" or status['errors'] or result.return_code == 1:
+            LOGGER.error("Some errors during cloud-init %s", status)
+            errors_found = True
+    else:
+        result = remoter.sudo("cloud-init status --wait", ignore_status=True)
+        status = result.stdout
+        if "done" not in status or result.return_code == 1:
+            LOGGER.error("Some errors during cloud-init %s", status)
+            errors_found = True
     scripts_errors_found = log_user_data_scripts_errors(remoter=remoter)
     if errors_found or scripts_errors_found:
         raise CloudInitError("Errors during cloud-init provisioning phase. See logs for errors.")

--- a/unit_tests/provisioner/test_provision_sct_resources.py
+++ b/unit_tests/provisioner/test_provision_sct_resources.py
@@ -20,6 +20,7 @@ from sdcm.test_config import TestConfig
 def test_can_provision_instances_according_to_sct_configuration(params, test_config, azure_service, fake_remoter):
     """Integration test for provisioning sct resources according to SCT configuration."""
     fake_remoter.result_map = {r"sudo cloud-init status --wait": Result(stdout="..... \n status: done", stderr="nic", exited=0),
+                               r"sudo cloud-init --version": Result(stdout="/bin/ 19.2-amzn", stderr="", exited=0),
                                r"ls /var/lib/sct/cloud-init": Result(stdout="done", exited=0)}
     tags = TestConfig.common_tags()
     provision_sct_resources(params=params, test_config=test_config, azure_service=azure_service)
@@ -57,6 +58,7 @@ def test_can_provision_instances_according_to_sct_configuration(params, test_con
 def test_fallback_on_demand_when_spot_fails(fallback_on_demand, params, test_config, azure_service, fake_remoter):
     # pylint: disable=unused-argument
     fake_remoter.result_map = {r"sudo cloud-init status --wait": Result(stdout="..... \n status: done", stderr="nic", exited=0),
+                               r"sudo cloud-init --version": Result(stdout="/bin/ 19.2-amzn", stderr="", exited=0),
                                r"ls /var/lib/sct/cloud-init": Result(stdout="done", exited=0)}
     provision_sct_resources(params=params, test_config=test_config, azure_service=azure_service)
     provisioner_eastus = provisioner_factory.create_provisioner(


### PR DESCRIPTION
newer versions of cloud-init, report status code 2, if there are warnings, and we should have failures like the:
```
2024-06-15 22:14:22.954: (TestFrameworkEvent Severity.ERROR)
   period_type=one-time event_id=..., source=ArtifactsTest.SetUp()
exception=Failed to create node: Encountered a bad command exit code!
Command: 'sudo cloud-init status --wait'
Exit code: 2
Stdout:
status: done
Stderr:
```

in this chaneg we detect the cloud-init version, and adapt the logic we do for identifing if cloud-init failed or not, while showing the extended information json newer version can supply

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-rocky9-test/39/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-amazon2-test/8/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-amazon2023-test/6/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-debian10-arm-test/15/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2204-test/57/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
