### PR TITLE
fix(k8s): use bigger minio storage for GKE backup CI job

### DIFF
--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-backup.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-backup.yaml
@@ -7,6 +7,8 @@ k8s_n_scylla_pods_per_cluster: 3
 n_loaders: 2
 n_monitor_nodes: 1
 
+k8s_minio_storage_size: 300Gi
+
 nemesis_class_name: 'MgmtBackup'
 nemesis_interval: 5
 


### PR DESCRIPTION
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
