### PR TITLE
fix(k8s): make monitoring setup not fail when loaders have no IP addrs

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5520,8 +5520,10 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
             for loader in self.targets["loaders"].nodes:
                 if loader.region not in loader_targets_per_dc:
                     loader_targets_per_dc[loader.region] = {"targets": [], "labels": {"dc": loader.region}}
-                loader_targets_per_dc[loader.region]["targets"].append(
-                    f"{normalize_ipv6_url(getattr(loader, self.DB_NODES_IP_ADDRESS))}:9100")
+                loader_ip_addr = getattr(loader, self.DB_NODES_IP_ADDRESS) or ""
+                if loader_ip_addr:
+                    loader_targets_per_dc[loader.region]["targets"].append(
+                        f"{normalize_ipv6_url(loader_ip_addr)}:9100")
 
             def update_scrape_configs(base_scrape_configs, static_config_list, job_name="node_exporter"):
                 for i, scrape_config in enumerate(base_scrape_configs):


### PR DESCRIPTION
In K8S we widely use dynamic loader pods and when we setup monitoring node we don't have IP addresses for loaders.
So, skip such cases instead of failing when we setup monitoring.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
