### PR TITLE
fix(cluster): multiple AZ configuration

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -213,8 +213,10 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         interfaces_amount = network_interfaces_count(self.params)
         interfaces = []
         for i in range(interfaces_amount):
+            LOGGER.debug("SubnetId: %s, dc_idx: %s, az index: %s, interface index: %s",
+                         self._ec2_subnet_id, dc_idx, az_idx, i)
             interfaces.append({'DeviceIndex': i,
-                               'SubnetId': self._ec2_subnet_id[dc_idx][az_idx + i],
+                               'SubnetId': self._ec2_subnet_id[dc_idx][az_idx][i],
                                'Groups': self._ec2_security_group_ids[dc_idx]})
         self.log.debug("interfaces: '%s' - to create_instances", interfaces)
 

--- a/sdcm/sct_provision/aws/instance_parameters_builder.py
+++ b/sdcm/sct_provision/aws/instance_parameters_builder.py
@@ -131,8 +131,10 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
         return self._ec2_network_configuration[0]
 
     def _network_interface_params(self, interface_index: int = 0):
+        LOGGER.debug("ec2_subnet_ids: %s; availability_zone: %s, interface_index: %s",
+                     self._ec2_subnet_ids, self.availability_zone, interface_index)
         return {
-            'SubnetId': self._ec2_subnet_ids[self.region_id][self.availability_zone + interface_index],  # pylint: disable=invalid-sequence-index
+            'SubnetId': self._ec2_subnet_ids[self.region_id][self.availability_zone][interface_index],  # pylint: disable=invalid-sequence-index
             'Groups': self._ec2_security_group_ids[self.region_id],  # pylint: disable=invalid-sequence-index
         }
 

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -300,15 +300,18 @@ class EC2NetworkConfiguration:
                 ec2_subnet_ids[region][availability_zone] = self.subnets_per_availability_zone(region=region,
                                                                                                aws_region=aws_region,
                                                                                                availability_zone=availability_zone)
+        LOGGER.debug("All ec2 subnet ids: %s", ec2_subnet_ids)
         return ec2_subnet_ids
 
     @property
     def subnets(self) -> List[list]:
-        ec2_subnet_ids = []
-        for region in self.subnets_per_region.values():
-            for az_subnets_id in region.values():
-                ec2_subnet_ids.append(az_subnets_id)
-        return ec2_subnet_ids
+        # Example:
+        # One region, 2 avalability zones, 2 network interfaces
+        # subnets_per_region = {'eu-central-1': {'a': ['subnet-085db77751694e2a6', 'subnet-03d8900174e00a73d'],
+        #                                        'b': ['subnet-084b1d12f9974e61f', 'subnet-094ed7c7c3bddd441']}}
+        # Will return:
+        #  [[['subnet-085db77751694e2a6', 'subnet-03d8900174e00a73d'], ['subnet-084b1d12f9974e61f', 'subnet-094ed7c7c3bddd441']]]
+        return [list(azs.values()) for azs in self.subnets_per_region.values()]
 
     def subnets_per_availability_zone(self, region: str, aws_region: AwsRegion, availability_zone: str) -> list:
         region_subnets = []

--- a/unit_tests/test_network_config.py
+++ b/unit_tests/test_network_config.py
@@ -1,0 +1,91 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2024 ScyllaDB
+import unittest
+from typing import NamedTuple
+
+from sdcm.utils.aws_utils import EC2NetworkConfiguration
+
+
+class RegionAZSubnets(NamedTuple):
+    region: str
+    availability_zone: str
+    subnets: list[str]
+
+
+# pylint: disable=too-few-public-methods
+class RegionsData:
+    UsEast1Region = [RegionAZSubnets(region="us-east-1", availability_zone="a", subnets=['subnet-0a09ba4421ec6aaa8',
+                                                                                         'subnet-03d8900174e00a73d']),
+                     RegionAZSubnets(region="us-east-1", availability_zone="b", subnets=['subnet-06604bf2840958461',
+                                                                                         'subnet-094ed7c7c3bddd441']),
+                     ]
+    EuCentral1Region = [RegionAZSubnets(region="eu-central-1", availability_zone="a", subnets=['subnet-085db77751694e2a6']),
+                        RegionAZSubnets(region="eu-central-1", availability_zone="b",
+                                        subnets=['subnet-084b1d12f9974e61f'])
+                        ]
+
+    def subnets_per_region(self, regions: list[str], availability_zones: list[str], network_interfaces_count: int):
+        subnets_per_region_dict = {}
+        for region in regions:
+            subnets_per_region_dict[region] = {}
+            current_region = [raz for r in [self.UsEast1Region, self.EuCentral1Region]
+                              for raz in r if raz.region == region]
+            for availability_zone in availability_zones:
+                current_az = [cr for cr in current_region if cr.availability_zone == availability_zone][0]
+                az_subnet = {availability_zone: [current_az.subnets[i] for i in range(network_interfaces_count)]}
+                subnets_per_region_dict[region].update(az_subnet)
+        return subnets_per_region_dict
+
+
+class FakeEC2NetworkConfiguration(EC2NetworkConfiguration):
+    # pylint: disable=super-init-not-called
+    def __init__(self, regions: list[str], availability_zones: list[str], network_interfaces_count: int,
+                 params: dict = None):
+        self.regions = regions
+        self.availability_zones = availability_zones
+        self.params = params
+        self.network_interfaces_count = network_interfaces_count
+
+    @property
+    def subnets_per_region(self):
+        return RegionsData().subnets_per_region(regions=self.regions,
+                                                availability_zones=self.availability_zones,
+                                                network_interfaces_count=self.network_interfaces_count)
+
+
+class AWSNetworkConfigurationTests(unittest.TestCase):
+    def test_subnets_property_one_region_one_az_one_interface(self):
+        net_config = FakeEC2NetworkConfiguration(
+            regions=["eu-central-1"], availability_zones=["a"], network_interfaces_count=1)
+        subnets = net_config.subnets
+        self.assertEqual(subnets, [[['subnet-085db77751694e2a6']]])
+
+    def test_subnets_property_one_region_two_az_one_interface(self):
+        net_config = FakeEC2NetworkConfiguration(
+            regions=["eu-central-1"], availability_zones=["a", "b"], network_interfaces_count=1)
+        subnets = net_config.subnets
+        self.assertEqual(subnets, [[['subnet-085db77751694e2a6'], ['subnet-084b1d12f9974e61f']]])
+
+    def test_subnets_property_one_region_two_az_two_interface(self):
+        net_config = FakeEC2NetworkConfiguration(
+            regions=["us-east-1"], availability_zones=["a", "b"], network_interfaces_count=2)
+        subnets = net_config.subnets
+        self.assertEqual(subnets, [[['subnet-0a09ba4421ec6aaa8', 'subnet-03d8900174e00a73d'],
+                                    ['subnet-06604bf2840958461', 'subnet-094ed7c7c3bddd441']]])
+
+    def test_subnets_property_two_region_two_az_one_interface(self):
+        net_config = FakeEC2NetworkConfiguration(regions=["us-east-1", 'eu-central-1'], availability_zones=["a", "b"],
+                                                 network_interfaces_count=1)
+        subnets = net_config.subnets
+        self.assertEqual(subnets, [[['subnet-0a09ba4421ec6aaa8'], ['subnet-06604bf2840958461']],
+                                   [['subnet-085db77751694e2a6'], ['subnet-084b1d12f9974e61f']]])


### PR DESCRIPTION
When trying to run test with multiple az's, provision step fails:
```
File "/home/ubuntu/scylla-cluster-tests/sdcm/sct_provision/aws/instance_parameters_builder.py", line 75, in NetworkInterfaces
  output.append({'DeviceIndex': index, **self._network_interface_params(interface_index=index)})
File "/home/ubuntu/scylla-cluster-tests/sdcm/sct_provision/aws/instance_parameters_builder.py", line 135, in _network_interface_params
  'SubnetId': self._ec2_subnet_ids[self.region_id][self.availability_zone + interface_index],
11:21:28  IndexError: list index out of range
```

To fix it collect info about subnet from relevant avalability zones and return it as list.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/7432
More issue that this commit will fix: https://github.com/scylladb/scylla-cluster-tests/issues/7384

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [1 region, 3 AZ, 1 interface](https://argus.scylladb.com/test/8d1f7b72-942b-419f-8856-074c0a3a8827/runs?additionalRuns[]=f740924a-61cd-4eb9-b82c-f544f98ec65c)
- [x] [1 region, 1 AZ, 1 interface](https://argus.scylladb.com/test/a023adb2-c07e-4509-9e35-2a61f9abe46c/runs?additionalRuns[]=6453c1f1-2f4c-4eb7-8221-327387e572db)
- [x] [2 regions, 1 AZ, 1 interface](https://argus.scylladb.com/test/a023adb2-c07e-4509-9e35-2a61f9abe46c/runs?additionalRuns[]=99f24d4f-6147-498b-aacd-8b0ebb9b88c1)
- [x] [3 regions, 3 AZ, 1 interface](https://argus.scylladb.com/test/50e0c80c-ad3b-4c9e-93c7-69b30dd821f2/runs?additionalRuns[]=5edb4a18-0366-4b0a-87b4-db37d1d85646) - nodes from `eu-west-1` were overloaded 
- [x] [1 region, 1 AZ, 2 interfaces](https://argus.scylladb.com/test/8d1f7b72-942b-419f-8856-074c0a3a8827/runs?additionalRuns[]=c6e84131-c9e6-4ecb-8391-3f0a20db138a)
- [ ] 2 regions, 2 AZ, 2 interface - Multiple network interfaces aren't supported for multi region use cases

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
