### PR TITLE
fix(manager): update manager backporting label to manager-3.3

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -158,3 +158,22 @@ pull_request_rules:
           - manager-3.2
         assignees:
           - "{{ author }}"
+  - name: Automate backport pull request manager-3.3
+    conditions:
+      - base=master # Ensure this rule only applies to PRs merged into the master branch
+      - label=backport/manager-3.3 # The PR must have this label to trigger the backport
+    actions:
+      backport:
+        title: "[Backport manager-3.3] {{ title }}"
+        body: |
+          {{ body }}
+
+          {% for c in commits %}
+          (cherry picked from commit {{ c.sha }})
+          {% endfor %}
+
+          Parent PR: #{{number}}
+        branches:
+          - manager-3.3
+        assignees:
+          - "{{ author }}"


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-cluster-tests/issues/7686.

Since the new manager release branch has been created (manager-3.3), the backport label should be updated in mergify.yml.

The new `backport/manager-3.3` label was created as well:
https://github.com/scylladb/scylla-cluster-tests/labels/backport%2Fmanager-3.3

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
