### PR TITLE
fix(tls-certs): fix usage of certs in mgmt_cli test and improve naming of tls artifacts 

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -16,6 +16,7 @@ import json
 import time
 import logging
 import datetime
+from pathlib import Path
 from re import findall
 from textwrap import dedent
 from statistics import mean
@@ -24,11 +25,12 @@ from distutils.version import LooseVersion
 
 import requests
 from invoke.exceptions import Failure as InvokeFailure
-from sdcm.remote.libssh2_client.exceptions import Failure as Libssh2Failure
 
+from sdcm.remote.libssh2_client.exceptions import Failure as Libssh2Failure
 from sdcm import wait
 from sdcm.mgmt.common import \
     TaskStatus, ScyllaManagerError, HostStatus, HostSsl, HostRestStatus, duration_to_timedelta, DEFAULT_TASK_TIMEOUT
+from sdcm.provision.helpers.certificate import TLSAssets
 from sdcm.utils.distro import Distro
 from sdcm.wait import WaitForTimeoutError
 
@@ -36,9 +38,9 @@ LOGGER = logging.getLogger(__name__)
 
 STATUS_DONE = 'done'
 STATUS_ERROR = 'error'
-SSL_CONF_DIR = '/tmp/ssl_conf'
-SSL_USER_CERT_FILE = SSL_CONF_DIR + '/db.crt'
-SSL_USER_KEY_FILE = SSL_CONF_DIR + '/db.key'
+SSL_CONF_DIR = Path('/tmp/ssl_conf')
+SSL_USER_CERT_FILE = SSL_CONF_DIR / TLSAssets.CLIENT_CERT
+SSL_USER_KEY_FILE = SSL_CONF_DIR / TLSAssets.CLIENT_KEY
 REPAIR_TIMEOUT_SEC = 7200  # 2 hours
 
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -71,7 +71,7 @@ from sdcm.nemesis_publisher import NemesisElasticSearchPublisher
 from sdcm.paths import SCYLLA_YAML_PATH
 from sdcm.prometheus import nemesis_metrics_obj
 from sdcm.provision.scylla_yaml import SeedProvider
-from sdcm.provision.helpers.certificate import update_certificate
+from sdcm.provision.helpers.certificate import update_certificate, TLSAssets
 from sdcm.remote.libssh2_client.exceptions import UnexpectedExit as Libssh2UnexpectedExit
 from sdcm.sct_events import Severity
 from sdcm.sct_events.database import DatabaseLogEvent
@@ -4256,8 +4256,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             for node in self.cluster.nodes:
                 node_system_logs[node] = node.follow_system_log(
                     patterns=f'messaging_service - Reloaded {{{ssl_files_location}}}')
-                node.remoter.send_files(src='data_dir/ssl_conf/db.crt', dst='/tmp')
-                node.remoter.run(f"sudo cp -f /tmp/db.crt {ssl_files_location}")
+                node.remoter.send_files(src=f'data_dir/ssl_conf/{TLSAssets.DB_CERT}', dst='/tmp')
+                node.remoter.run(f"sudo cp -f /tmp/{TLSAssets.DB_CERT} {ssl_files_location}")
                 new_crt = node.remoter.run(f"cat {ssl_files_location}").stdout
                 if in_place_crt == new_crt:
                     raise Exception('The CRT file was not replaced')

--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -21,7 +21,7 @@ from enum import Enum
 
 from sdcm.loader import ScyllaBenchStressExporter
 from sdcm.prometheus import nemesis_metrics_obj
-from sdcm.provision.helpers.certificate import SCYLLA_SSL_CONF_DIR
+from sdcm.provision.helpers.certificate import SCYLLA_SSL_CONF_DIR, TLSAssets
 from sdcm.sct_events.loaders import ScyllaBenchEvent, SCYLLA_BENCH_ERROR_EVENTS_PATTERNS
 from sdcm.utils.common import FileFollowerThread, convert_metric_to_ms
 from sdcm.stress_thread import DockerBasedStressThread
@@ -160,11 +160,12 @@ class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-in
                         cmd_runner.send_files(str(ssl_file),
                                               str(SCYLLA_SSL_CONF_DIR / ssl_file.name),
                                               verbose=True)
-                stress_cmd = f'{stress_cmd.strip()} -tls -tls-ca-cert-file {SCYLLA_SSL_CONF_DIR}/ca.pem'
+                stress_cmd = f'{stress_cmd.strip()} -tls -tls-ca-cert-file {SCYLLA_SSL_CONF_DIR}/{TLSAssets.CA_CERT}'
 
                 if self.params.get("client_encrypt_mtls"):
-                    stress_cmd = (f'{stress_cmd.strip()} -tls-client-key-file {SCYLLA_SSL_CONF_DIR}/test.key '
-                                  f'-tls-client-cert-file {SCYLLA_SSL_CONF_DIR}/test.crt')
+                    stress_cmd = (
+                        f'{stress_cmd.strip()} -tls-client-key-file {SCYLLA_SSL_CONF_DIR}/{TLSAssets.CLIENT_KEY} '
+                        f'-tls-client-cert-file {SCYLLA_SSL_CONF_DIR}/{TLSAssets.CLIENT_CERT}')
 
                     # TBD: update after https://github.com/scylladb/scylla-bench/issues/140 is resolved
                     # server_names = ' '.join(f'-tls-server-name {ip}' for ip in ips.split(","))

--- a/sdcm/stress/latte_thread.py
+++ b/sdcm/stress/latte_thread.py
@@ -19,7 +19,7 @@ import logging
 from pathlib import Path
 
 from sdcm.prometheus import nemesis_metrics_obj
-from sdcm.provision.helpers.certificate import SCYLLA_SSL_CONF_DIR
+from sdcm.provision.helpers.certificate import SCYLLA_SSL_CONF_DIR, TLSAssets
 from sdcm.sct_events.loaders import LatteStressEvent
 from sdcm.utils.common import (
     FileFollowerThread,
@@ -116,9 +116,9 @@ class LatteStressThread(DockerBasedStressThread):  # pylint: disable=too-many-in
                                           str(SCYLLA_SSL_CONF_DIR / ssl_file.name),
                                           verbose=True)
 
-            ssl_config += (f' --ssl --ssl-ca {SCYLLA_SSL_CONF_DIR}/ca.pem '
-                           f'--ssl-cert {SCYLLA_SSL_CONF_DIR}/test.crt '
-                           f'--ssl-key {SCYLLA_SSL_CONF_DIR}/test.key')
+            ssl_config += (f' --ssl --ssl-ca {SCYLLA_SSL_CONF_DIR}/{TLSAssets.CA_CERT} '
+                           f'--ssl-cert {SCYLLA_SSL_CONF_DIR}/{TLSAssets.CLIENT_CERT} '
+                           f'--ssl-key {SCYLLA_SSL_CONF_DIR}/{TLSAssets.CLIENT_KEY}')
         datacenter = ""
         if self.loader_set.test_config.MULTI_REGION:
             # The datacenter name can be received from "nodetool status" output. It's possible for DB nodes only,


### PR DESCRIPTION
After TLS certificates preparation was reworked in SCT, individual TLS certificates are created and distributed for loader and cluster nodes.

The change adds the same logic for creating and distributing certificate/key to a manager node (which is usually a monitor node in the mgmt_cli tests).
Also certificate/key naming in SCT is changed to avoid redefining them in different modules - the names are defined as constants in one place now and re-used where necessary.

### Testing
- [x] :green_circle: [ubuntu22-sanity-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/ubuntu22-sanity-test/1/)
- [x] :green_circle: [regression longevity test with server+client encryptions enabled](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/certs-rework-tests/26/)


### PR pre-checks (self review)
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
