### PR TITLE
fix(update_db_packages): fix issues with hanging threads during update

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -40,6 +40,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from contextlib import ExitStack, contextmanager
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import packaging.version
 
 import yaml
@@ -173,8 +174,6 @@ HOUR_IN_SEC: int = 60 * MINUTE_IN_SEC
 MAX_TIME_WAIT_FOR_NEW_NODE_UP: int = HOUR_IN_SEC * 8
 MAX_TIME_WAIT_FOR_ALL_NODES_UP: int = MAX_TIME_WAIT_FOR_NEW_NODE_UP + HOUR_IN_SEC
 MAX_TIME_WAIT_FOR_DECOMMISSION: int = HOUR_IN_SEC * 6
-
-NODE_CONFIG_SETUP_LOCK = threading.Lock()
 
 LOGGER = logging.getLogger(__name__)
 
@@ -3341,17 +3340,10 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         if node_list is None:
             node_list = self.nodes
 
-        _queue = queue.Queue()
-        for node in node_list:
-            setup_thread = threading.Thread(target=func, args=(node, _queue), daemon=True)
-            setup_thread.start()
+        with ThreadPoolExecutor() as executor:
+            futures = [executor.submit(func, node) for node in node_list]
+            results = [future.result() for future in as_completed(futures)]
 
-        results = []
-        while len(results) != len(node_list):
-            try:
-                results.append(_queue.get(block=True, timeout=5))
-            except queue.Empty:
-                pass
         return results
 
     def get_backtraces(self):
@@ -4112,7 +4104,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
     def _update_db_binary(self, new_scylla_bin, node_list, start_service=True):
         self.log.debug('User requested to update DB binary...')
 
-        def update_scylla_bin(node, _queue):
+        def update_scylla_bin(node):
             node.log.info('Updating DB binary')
             node.remoter.send_files(new_scylla_bin, '/tmp/scylla', verbose=True)
 
@@ -4132,18 +4124,12 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 chown root:root {binary_path}
                 chmod +x {binary_path}
             """))
-            _queue.put(node)
-            _queue.task_done()
 
-        def stop_scylla(node, _queue):
+        def stop_scylla(node):
             node.stop_scylla(verify_down=True, verify_up=False)
-            _queue.put(node)
-            _queue.task_done()
 
-        def start_scylla(node, _queue):
+        def start_scylla(node):
             node.start_scylla(verify_down=True, verify_up=True)
-            _queue.put(node)
-            _queue.task_done()
 
         start_time = time.time()
 
@@ -4175,7 +4161,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                     severity=Severity.CRITICAL
                 ).publish()
 
-        def update_scylla_packages(node, _queue):
+        def update_scylla_packages(node):
             node.log.info('Updating DB packages')
             node.remoter.run('mkdir /tmp/scylla')
             node.remoter.send_files(new_scylla_bin, '/tmp/scylla', verbose=True)
@@ -4207,18 +4193,12 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 dpkg_force_install()
                 node.log.info('Installed .deb packages after replacing with new .DEB files')
                 node.log.info(node.scylla_packages_installed)
-            _queue.put(node)
-            _queue.task_done()
 
-        def stop_scylla(node, _queue):
+        def stop_scylla(node):
             node.stop_scylla(verify_down=True, verify_up=False)
-            _queue.put(node)
-            _queue.task_done()
 
-        def start_scylla(node, _queue):
+        def start_scylla(node):
             node.start_scylla(verify_down=True, verify_up=True)
-            _queue.put(node)
-            _queue.task_done()
 
         start_time = time.time()
 


### PR DESCRIPTION
update_db_packages procedure executes updating of scylla packages in threads for each node and uses sdcm.utils.decorators.retrying mechanism for retries. Through this decorator it is allowed for UnexpectedExit exception to occur up to the specified number of times, when installing packages, then the UnexpectedExit exception should be reraised.

For some reason reraise doesn't return control back to the caller if update function is running in threading.Thread threads. So if for some reason a thread with packages update is continuously failing and all retries are exhausted, the thread hangs.

The change switches from threading.Thread to concurrent.futures.ThreadPoolExecutor for paralleling packages update on nodes. This approach doesn't have issues with reraising exceptions in threads.

Related tasks: https://github.com/scylladb/scylla-cluster-tests/issues/7162 and https://github.com/scylladb/scylla-cluster-tests/issues/7160

### Testing
- [x] :green_circle: [db packages installation scenario intended to fail on update_db_packages step](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/regression-latency-650gb-grow-shrink/10/)
- [x] :green_circle: [positive test run of updating db packages](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/longevity-5gb-1h-test/45/)

### PR pre-checks (self review)
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
