### PR TITLE
improvement(parallel-operations): grow-shrink cluster

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3976,6 +3976,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             LOGGER.info("Starting nodes in parallel")
         else:
             LOGGER.info("Starting nodes sequentially")
+            self.parallel_node_operations = False  # disable parallel operations regardless of test config
 
         return parallel_startup
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -73,6 +73,7 @@ from sdcm.prometheus import nemesis_metrics_obj
 from sdcm.provision.scylla_yaml import SeedProvider
 from sdcm.provision.helpers.certificate import update_certificate, TLSAssets
 from sdcm.remote.libssh2_client.exceptions import UnexpectedExit as Libssh2UnexpectedExit
+from sdcm.rest.remote_curl_client import RemoteCurlClient
 from sdcm.sct_events import Severity
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.decorators import raise_event_on_failure
@@ -1224,8 +1225,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if not ContainerManager.is_running(self.tester.localhost, 'ldap'):
             raise LdapNotRunning("LDAP server was supposed to be running, but it is not")
 
-    def _add_and_init_new_cluster_node(self, old_node_ip=None, host_id=None,
-                                       timeout=MAX_TIME_WAIT_FOR_NEW_NODE_UP, rack=0):
+    def _replace_cluster_node(self, old_node_ip=None, host_id=None,
+                              timeout=MAX_TIME_WAIT_FOR_NEW_NODE_UP, rack=0):
         """When old_node_ip or host_id are not None then replacement node procedure is initiated"""
         # TODO: make it work on K8S when we have decommissioned (by nodetool) nodes.
         #       Now it will fail because pod which hosts decommissioned Scylla member is reported
@@ -1264,6 +1265,35 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         InfoEvent(message="FinishEvent - New Node is up and normal").publish()
         return new_node
 
+    def _add_and_init_new_cluster_nodes(self, count, timeout=MAX_TIME_WAIT_FOR_NEW_NODE_UP, rack=None):
+        if rack is None and self._is_it_on_kubernetes():
+            rack = 0
+        self.log.info("Adding %s new nodes to cluster...", count)
+        InfoEvent(message=f'StartEvent - Adding {count} new nodes to cluster').publish()
+        new_nodes = self.cluster.add_nodes(
+            count=count, dc_idx=self.target_node.dc_idx, enable_auto_bootstrap=True, rack=rack)
+        self.monitoring_set.reconfigure_scylla_monitoring()
+        for new_node in new_nodes:
+            self.set_current_running_nemesis(node=new_node)
+        try:
+            with adaptive_timeout(Operations.NEW_NODE, node=self.cluster.nodes[0], timeout=timeout):
+                self.cluster.wait_for_init(node_list=new_nodes, timeout=timeout, check_node_health=False)
+            self.cluster.set_seeds()
+            self.cluster.update_seed_provider()
+        except (NodeSetupFailed, NodeSetupTimeout):
+            self.log.warning("TestConfig of the '%s' failed, removing them from list of nodes" % new_nodes)
+            for node in new_nodes:
+                self.cluster.nodes.remove(node)
+            self.log.warning("Nodes will not be terminated. Please terminate manually!!!")
+            raise
+        for new_node in new_nodes:
+            new_node.wait_native_transport()
+        self.cluster.wait_for_nodes_up_and_normal(nodes=new_nodes)
+        for new_node in new_nodes:
+            self.unset_current_running_nemesis(node=new_node)
+        InfoEvent(message="FinishEvent - New Nodes are up and normal").publish()
+        return new_nodes
+
     @decorate_with_context(ignore_ycsb_connection_refused)
     def _terminate_cluster_node(self, node):
         self.cluster.terminate_node(node)
@@ -1278,7 +1308,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if add_node:
             # When adding node after decommission the node is declared as up only after it completed bootstrapping,
             # increasing the timeout for now
-            new_node = self._add_and_init_new_cluster_node(rack=self.target_node.rack)
+            new_node = self._add_and_init_new_cluster_nodes(count=1, rack=self.target_node.rack)
             # after decomission and add_node, the left nodes have data that isn't part of their tokens anymore.
             # In order to eliminate cases that we miss a "data loss" bug because of it, we cleanup this data.
             # This fix important when just user profile is run in the test and "keyspace1" doesn't exist.
@@ -1319,7 +1349,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     @latency_calculator_decorator(legend="Replace a node in cluster with new one")
     def replace_node(self, old_node_ip, host_id, rack=0):
-        return self._add_and_init_new_cluster_node(old_node_ip, host_id, rack=rack)
+        return self._replace_cluster_node(old_node_ip, host_id, rack=rack)
 
     def _verify_resharding_on_k8s(self, cpus, dc_idx):
         nodes_data = []
@@ -1496,7 +1526,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.log.info('Decommission %s', node)
         self.cluster.decommission(node, timeout=MAX_TIME_WAIT_FOR_DECOMMISSION)
 
-        new_node = self.add_new_node(rack=node.rack)
+        new_node = self.add_new_nodes(count=1, rack=node.rack)
         self.unset_current_running_nemesis(new_node)
 
         # NOTE: wait for all other neighbour pods become ready
@@ -3546,7 +3576,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 "Node was not removed properly (Node status:{})".format(removed_node_status)
 
             # add new node
-            new_node = self._add_and_init_new_cluster_node(rack=self.target_node.rack)
+            new_node = self._add_and_init_new_cluster_nodes(count=1, rack=self.target_node.rack)
             # in case the removed node was not last seed.
             if node_to_remove.is_seed and num_of_seed_nodes > 1:
                 new_node.set_seed_flag(True)
@@ -3830,7 +3860,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 self.log.error('Unexpected exception raised in checking decommission status: %s', exc)
 
             self.log.info('Decommission might complete before stopping it. Re-add a new node')
-            new_node = self._add_and_init_new_cluster_node(rack=self.target_node.rack)
+            new_node = self._add_and_init_new_cluster_nodes(count=1, rack=self.target_node.rack)
             if new_node.is_seed != target_is_seed:
                 new_node.set_seed_flag(target_is_seed)
                 self.cluster.update_seed_provider()
@@ -3985,17 +4015,36 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         self.clear_snapshots()
 
-    @latency_calculator_decorator(legend="Adding new node")
-    def add_new_node(self, rack=0):
-        return self._add_and_init_new_cluster_node(rack=rack)
+    @latency_calculator_decorator(legend="Adding new nodes")
+    def add_new_nodes(self, count, rack=None):
+        nodes = self._add_and_init_new_cluster_nodes(count, rack=rack)
+        self._wait_for_tablets_balanced(nodes[0])
+        return nodes
 
-    @latency_calculator_decorator(legend="Decommission node: remove node from cluster")
-    def decommission_node(self, node):
-        self.cluster.decommission(node)
+    @latency_calculator_decorator(legend="Decommission nodes: remove nodes from cluster")
+    def decommission_nodes(self, nodes):
 
-    def decommission_nodes(self, add_nodes_number, rack, is_seed: Optional[Union[bool, DefaultValue]] = DefaultValue,
-                           dc_idx: Optional[int] = None):
-        for idx in range(add_nodes_number):
+        def _decommission(node):
+            try:
+                InfoEvent(f'StartEvent - ShrinkCluster started decommissioning a node {node}').publish()
+                self.cluster.decommission(node)
+                InfoEvent(f'FinishEvent - ShrinkCluster has done decommissioning a node {node}').publish()
+            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+                InfoEvent(f'FinishEvent - ShrinkCluster failed decommissioning a node {self.target_node} with error '
+                          f'{str(exc)}').publish()
+                raise
+
+        num_workers = None if (self.cluster.parallel_node_operations and nodes[0].raft.is_enabled) else 1
+        parallel_obj = ParallelObject(objects=nodes, timeout=7200, num_workers=num_workers)
+        InfoEvent(f'StartEvent - ShrinkCluster started decommissioning {len(nodes)} nodes').publish()
+        parallel_obj.run(_decommission, ignore_exceptions=False, unpack_objects=True)
+        self.monitoring_set.reconfigure_scylla_monitoring()
+        InfoEvent(f'FinishEvent - ShrinkCluster has done decommissioning {len(nodes)} nodes').publish()
+
+    def _decommission_nodes(self, nodes_number, rack, is_seed: Optional[Union[bool, DefaultValue]] = DefaultValue,
+                            dc_idx: Optional[int] = None):
+        nodes_to_decommission = []
+        for idx in range(nodes_number):
             if self._is_it_on_kubernetes():
                 if rack is None and self._is_it_on_kubernetes():
                     rack = 0
@@ -4004,15 +4053,17 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 rack_idx = rack if rack is not None else idx % self.cluster.racks_count
                 # if rack is not specified, round-robin racks
                 self.set_target_node(is_seed=is_seed, dc_idx=dc_idx, rack=rack_idx)
-            self.log.info("Next node will be removed %s", self.target_node)
-
-            try:
-                InfoEvent(f'StartEvent - ShrinkCluster started decommissioning a node {self.target_node}').publish()
-                self.decommission_node(self.target_node)
-                InfoEvent(f'FinishEvent - ShrinkCluster has done decommissioning a node {self.target_node}').publish()
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
-                InfoEvent(f'FinishEvent - ShrinkCluster failed decommissioning a node {self.target_node} with error '
-                          f'{str(exc)}').publish()
+            nodes_to_decommission.append(self.target_node)
+            self.target_node = None  # otherwise node.running_nemesis will be taken off the node by self.set_target_node
+        try:
+            if self.cluster.parallel_node_operations:
+                self.decommission_nodes(nodes_to_decommission)
+            else:
+                for node in nodes_to_decommission:
+                    self.decommission_nodes([node])
+        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            InfoEvent(f'FinishEvent - ShrinkCluster failed decommissioning a node {self.target_node} with error '
+                      f'{str(exc)}').publish()
 
     def disrupt_grow_shrink_cluster(self):
         sleep_time_between_ops = self.cluster.params.get('nemesis_sequence_sleep_between_ops')
@@ -4037,21 +4088,19 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if rack is None and self._is_it_on_kubernetes():
             rack = 0
         add_nodes_number = self.tester.params.get('nemesis_add_node_cnt')
-        self.log.info("Start grow cluster on %s nodes", add_nodes_number)
-        InfoEvent(message=f"Start grow cluster on {add_nodes_number} nodes").publish()
-        for idx in range(add_nodes_number):
-            # if rack is not specified, round-robin racks to spread nodes evenly
-            rack_idx = rack if rack is not None else idx % self.cluster.racks_count
-            InfoEvent(message=f'GrowCluster - Add New node to {rack_idx} rack').publish()
-            added_node = self.add_new_node(rack=rack_idx)
-            self.unset_current_running_nemesis(added_node)
-            InfoEvent(message=f'GrowCluster - Done adding New node {added_node.name}').publish()
+        InfoEvent(message=f"Start grow cluster by {add_nodes_number} nodes").publish()
+        if self.cluster.parallel_node_operations:
+            self.add_new_nodes(count=add_nodes_number, rack=rack)
+        else:
+            for idx in range(add_nodes_number):
+                # if rack is not specified, round-robin racks to spread nodes evenly
+                rack_idx = rack if rack is not None else idx % self.cluster.racks_count
+                self.add_new_nodes(count=1, rack=rack_idx)
         self.log.info("Finish cluster grow")
         time.sleep(self.interval)
 
     def _shrink_cluster(self, rack=None):
         add_nodes_number = self.tester.params.get('nemesis_add_node_cnt')
-        self.log.info("Start shrink cluster by %s nodes", add_nodes_number)
         InfoEvent(message=f'Start shrink cluster by {add_nodes_number} nodes').publish()
         # Check that number of nodes is enough for decommission:
         cur_num_nodes_in_dc = len([n for n in self.cluster.nodes if n.dc_idx == self.target_node.dc_idx])
@@ -4074,7 +4123,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         # Currently on kubernetes first two nodes of each rack are getting seed status
         # Because of such behavior only way to get them decommission is to enable decommissioning
         # TBD: After https://github.com/scylladb/scylla-operator/issues/292 is fixed remove is_seed parameter
-        self.decommission_nodes(
+        self._decommission_nodes(
             decommission_nodes_number,
             rack,
             is_seed=None if self._is_it_on_kubernetes() else DefaultValue,
@@ -5018,6 +5067,30 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.log.warning("'%s' node will be restarted to make the CQL work again", self.target_node)
             self.target_node.restart_scylla_server()
             raise
+
+    def _wait_for_tablets_balanced(self, node):
+        """
+        Waiting for tablets to be balanced using REST API.
+
+        doing it several times as there's a risk of:
+        "currently a small time window after adding nodes and before load balancing starts during which
+        topology may appear as quiesced because the state machine goes through an idle state before it enters load balancing state"
+        """
+        if not node.raft.is_enabled:
+            self.log.info("Raft is disabled, skipping wait for balance")
+            return
+        with self.cluster.cql_connection_patient(node=node) as session:
+            if not is_tablets_feature_enabled(session):
+                self.log.info("Tablets are disabled, skipping wait for balance")
+                return
+        time.sleep(60)  # one minute gap before checking, just to give some time to the state machine
+        client = RemoteCurlClient(host="127.0.0.1:10000", endpoint="", node=node)
+        self.log.info("Waiting for tablets to be balanced")
+        for _ in range(3):
+            client.run_remoter_curl(method="POST", path="storage_service/quiesce_topology",
+                                    params={}, timeout=3600, retry=3)
+            time.sleep(5)
+        self.log.info("Tablets are balanced")
 
 
 def disrupt_method_wrapper(method, is_exclusive=False):  # pylint: disable=too-many-statements  # noqa: PLR0915


### PR DESCRIPTION
Adding and decommissioning nodes should be run in parallel as this is currently Scylla's default behavior.

Refactored code to support it. Can be disabled if
`parallel_node_operations` param is set to false.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - provision tests
- [x] - [add 3 nodes in parallel, single AZ](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/longevity-5gb-1h-GrowShrinkClusterNemesis-aws-test/23/)
- [x] - [add 3 nodes sequentially, single az](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/longevity-5gb-1h-GrowShrinkClusterNemesis-aws-test/22/)
- [x] - [add 3 nodes in parallel, 3 az's](https://argus.scylladb.com/test/a2af091e-3cbd-4068-b825-35d511f15d17/runs?additionalRuns[]=3c8be89c-3ca1-4065-958c-c4ef0cf3ae05) - works
- [x] - [grow-shrink on gce](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/nemesis/job/longevity-5gb-1h-GrowShrinkClusterNemesis-gce-test/2/)
- [x] - [terminate and replace node](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/nemesis/job/longevity-5gb-1h-NodeTerminateAndReplace-aws-test/2/)
- [x] - [grow-shrink perf test - parallel](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/scylla-master-perf-regression-latency-650gb-grow-shrink/38/)
- [x] - [grow-shrink perf test - sequential](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/scylla-master-perf-regression-latency-650gb-grow-shrink/40/) - failed due reasons fixed by https://github.com/scylladb/scylla-cluster-tests/pull/7761 I consider it working

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
