### PR TITLE
fix(screenshot): revert to specific resolution

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -467,7 +467,6 @@ class GrafanaScreenShot(GrafanaEntity):
     Extends:
         GrafanaEntity
     """
-    DEFAULT_SNAPSHOT_WIDTH = 1920
 
     def get_grafana_screenshot(self, node, local_dst):
         """
@@ -501,7 +500,7 @@ class GrafanaScreenShot(GrafanaEntity):
                                                                         node.name))
                     LOGGER.debug("Get screenshot for url %s, save to %s", grafana_url, screenshot_path)
                     with requests.get(grafana_url, stream=True,
-                                      params=dict(width=self.DEFAULT_SNAPSHOT_WIDTH, height=-1)) as response:
+                                      params=dict(width=dashboard.resolution[0], height=dashboard.resolution[1])) as response:
                         response.raise_for_status()
                         with open(screenshot_path, 'wb') as output_file:
                             for chunk in response.iter_content(chunk_size=8192):

--- a/sdcm/monitorstack/ui.py
+++ b/sdcm/monitorstack/ui.py
@@ -7,12 +7,14 @@ class Dashboard:
     name: str
     path: str
     title: str
+    resolution: tuple[int]
 
 
 class OverviewDashboard(Dashboard):
     name = 'overview'
     path = 'd/overview-{version}/scylla-{dashboard_name}'
     title = 'Overview'
+    resolution = (1920, 4000)
 
 
 class ServerMetricsNemesisDashboard(Dashboard):
@@ -22,9 +24,11 @@ class ServerMetricsNemesisDashboard(Dashboard):
     name = f'{test_name}scylla-per-server-metrics-nemesis'
     title = 'Scylla Per Server Metrics Nemesis'
     path = 'dashboard/db/{dashboard_name}-{version}'
+    resolution = (1920, 15000)
 
 
 class AlternatorDashboard(Dashboard):
     name = 'alternator'
     title = 'Alternator'
     path = 'd/alternator-{version}/{dashboard_name}'
+    resolution = (1920, 4000)


### PR DESCRIPTION
we were using height=-1 for the renderer to automticlly capture all of the dashboard.

seems like with monitoring 4.7, this got broken cause of newer grafana version, and dashboard are coming out cut, and some ever completly broken and not readable.

couldn't pinpoint which exact version is causing it.

so meanwhile reverting to use exact resolution, that seems to be working as expected

Fixes: #7600

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] provision test - should check the snapshot

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
