### PR TITLE
fix(artifact test): disable scylla-doctor

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -357,7 +357,10 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
             assert node_info_service.get_node_boot_time_seconds()
 
         with self.subTest("check scylla_doctor results"):
-            self.run_scylla_doctor()
+            if self.params.get("run_scylla_doctor"):
+                self.run_scylla_doctor()
+            else:
+                self.log.info("Running scylla-doctor is disabled")
 
         # We don't install any time sync service in docker, so the test is unnecessary:
         # https://github.com/scylladb/scylla/tree/master/dist/docker/etc/supervisord.conf.d

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -253,3 +253,5 @@ teardown_validators:
 
 kafka_backend: null
 kafka_connectors: []
+
+run_scylla_doctor: false

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1559,6 +1559,9 @@ class SCTConfiguration(dict):
 
         dict(name="kafka_connectors", env="SCT_KAFKA_CONNECTORS", type=str_or_list_or_eval,
              help="configuration for setup up kafka connectors"),
+
+        dict(name="run_scylla_doctor", env="SCT_RUN_SCYLLA_DOCTOR", type=boolean,
+             help="Run scylla-doctor in artifact tests"),
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',


### PR DESCRIPTION
Disable scylla-doctor because its files that we need to download, dissapeared from S3.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [artifacts-ami-test](https://argus.scylladb.com/test/c29b1204-20a2-4c4c-9864-b0c47e80efc6/runs?additionalRuns[]=a2e03184-92f5-4df7-8cb2-8bd1b18a38b0)


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
