### PR TITLE
fix(ipv6): don't limit certificates creation to ipv4

### DIFF
--- a/sdcm/provision/helpers/certificate.py
+++ b/sdcm/provision/helpers/certificate.py
@@ -153,7 +153,7 @@ def create_certificate(
 
     alt_names = [x509.DNSName(cname)]
     if ip_addresses:
-        alt_names.extend([x509.IPAddress(ipaddress.IPv4Address(ip)) for ip in ip_addresses])
+        alt_names.extend([x509.IPAddress(ipaddress.ip_address(ip)) for ip in ip_addresses])
     if dns_names:
         alt_names.extend([x509.DNSName(dns) for dns in dns_names])
 


### PR DESCRIPTION
recent changes from #7436, seems to have casuing ipv6 cases to break like following:
```
2024-06-22 03:17:22.741: (TestFrameworkEvent Severity.ERROR) period_type=one-time
event_id=47cf9ea7-ecb7-40ba-8a9e-bbb85b289ead, source=LongevityTest.SetUp()
exception=[Node parallel-topology-schema-changes-mu-loader-node-3546ab88-2
[34.253.230.142 | 10.4.11.221 | 2a05:d018:12e3:f002:b483:d673:04af:5c0b] (dc name: eu-west-1)]
NodeSetupFailed: Expected 4 octets in '2a05:d018:12e3:f002:b483:d673:04af:5c0b'
```

this commit change to `ipaddress.ip_address()` that can automaticly return the correct type of ip address

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-10gb-3h-ipv6-test/10/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
