### PR TITLE
fix(local run): check if manager agent is up

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1360,8 +1360,12 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         # When the agent is IP, it should answer an https request of https://NODE_IP:10001/ping with status code 204
         # Scylla Manager Agent uses Scylla listen/broadcast address - https://manager.docs.scylladb.com/stable/config/
         # scylla-manager-agent-config.html#:~:text=value.%0A%23auth_token%3A-,%23%20Bind%20REST%20API%20to,-the%20specified%20TCP
-        response = requests.get(f"https://{normalize_ipv6_url(self.scylla_listen_address)}:{port}/ping", verify=False)
-        return response.status_code == 204
+        http_address = f"https://{normalize_ipv6_url(self.scylla_listen_address)}:{port}/ping"
+        curl_output = self.remoter.run(cmd=f'''curl -k --write-out "%{{http_code}}\n" --silent --output /dev/null "{http_address}"''',
+                                       verbose=True, ignore_status=True)
+        LOGGER.debug("curl with scylla_listen_address stdout: %s", curl_output.stdout)
+        http_status_code = int(curl_output.stdout.strip())
+        return http_status_code == 204
 
     def wait_manager_agent_up(self, verbose=True, timeout=180):
         text = None


### PR DESCRIPTION
The changes in commit https://github.com/scylladb/scylla-cluster-tests/commit/ aea611d6142a6fb80cca4d7663a419407879ae90 breaks the opportunity to run tests from local developer PC.

The setup fails on wait_manager_agent_up function as tries to access nodes via private ip address. Use curl from DB node when check if manager agent is up instead of send request from runner (local machine).

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/7636

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] local run
- [x] [AWS](https://argus.scylladb.com/test/22d76ec7-28e1-4f13-8c9a-9f6357bb3d8a/runs?additionalRuns[]=b63e5cbb-a697-410b-9482-1cd57f6ccce8)
- [x] [GCE](https://argus.scylladb.com/test/ec686f46-d7da-40a2-9677-2d946e07f709/runs?additionalRuns[]=6f558f7f-5001-4ba4-96cf-71053824427e)
- [x] [Azure](https://argus.scylladb.com/test/99e3d2d1-6472-44d2-84e9-2cdcceb090cc/runs?additionalRuns[]=69f3182a-421a-4b3d-b954-2f2730686377)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
