### PR TITLE
[branch-2024.2] fix(byo): use proper default values for BYO scylla params

### DIFF
--- a/vars/byoScylladb.groovy
+++ b/vars/byoScylladb.groovy
@@ -23,7 +23,7 @@ def call(Map params, boolean build_image){
     if (params.byo_job_path) {
         jobToTrigger = params.byo_job_path
     } else {
-        jobToTrigger = "/scylla-master/byo/byo_build_tests_dtest"
+        jobToTrigger = "/enterprise-2024.2/byo/byo_build_tests_dtest"
     }
     if (jobToTrigger.startsWith("./")) {
         currentJobDirectoryPath = JOB_NAME.substring(0, JOB_NAME.lastIndexOf('/'))

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -158,14 +158,14 @@ def call(Map pipelineParams) {
             string(defaultValue: '',
                    description: 'Branch of the custom "scylladb" repo. Leave empty if byo is not needed.',
                    name: 'byo_scylla_branch')
-            string(defaultValue: '/scylla-master/byo/byo_build_tests_dtest',
-                   description: 'Used when byo scylladb repo+branch is provided. Default "/scylla-master/byo/byo_build_tests_dtest"',
+            string(defaultValue: '/enterprise-2024.2/byo/byo_build_tests_dtest',
+                   description: 'Used when byo scylladb repo+branch is provided. Default "/enterprise-2024.2/byo/byo_build_tests_dtest"',
                    name: 'byo_job_path')
-            string(defaultValue: 'scylla',
-                   description: '"scylla" or "scylla-enterprise". Default is "scylla".',
+            string(defaultValue: 'scylla-enterprise',
+                   description: '"scylla" or "scylla-enterprise". Default is "scylla-enterprise".',
                    name: 'byo_default_product')
-            string(defaultValue: 'next',
-                   description: 'Default branch to be used for scylla and other repositories. Default is "next".',
+            string(defaultValue: 'next-2024.2',
+                   description: 'Default branch to be used for scylla and other repositories. Default is "next-2024.2".',
                    name: 'byo_default_branch')
         }
         options {

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -81,14 +81,14 @@ def call(Map pipelineParams) {
             string(defaultValue: '',
                    description: 'Branch of the custom "scylladb" repo. Leave empty if byo is not needed.',
                    name: 'byo_scylla_branch')
-            string(defaultValue: '/scylla-master/byo/byo_build_tests_dtest',
-                   description: 'Used when byo scylladb repo+branch is provided. Default "/scylla-master/byo/byo_build_tests_dtest"',
+            string(defaultValue: '/enterprise-2024.2/byo/byo_build_tests_dtest',
+                   description: 'Used when byo scylladb repo+branch is provided. Default "/enterprise-2024.2/byo/byo_build_tests_dtest"',
                    name: 'byo_job_path')
-            string(defaultValue: 'scylla',
-                   description: '"scylla" or "scylla-enterprise". Default is "scylla".',
+            string(defaultValue: 'scylla-enterprise',
+                   description: '"scylla" or "scylla-enterprise". Default is "scylla-enterprise".',
                    name: 'byo_default_product')
-            string(defaultValue: 'next',
-                   description: 'Default branch to be used for scylla and other repositories. Default is "next".',
+            string(defaultValue: 'next-2024.2',
+                   description: 'Default branch to be used for scylla and other repositories. Default is "next-2024.2".',
                    name: 'byo_default_branch')
         }
         options {


### PR DESCRIPTION
After branching to the `branch-2024.2` we should update the BYO params default values to make it be proper ones.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
