### PR TITLE
Manager release 3.3 adjustments

### DIFF
--- a/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.1',
+    manager_version: '3.2',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: 'test-cases/upgrades/manager-upgrade.yaml',

--- a/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.1',
+    manager_version: '3.2',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/debian10.yaml"]''',

--- a/jenkins-pipelines/manager/debian11-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian11-manager-upgrade.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.1',
+    manager_version: '3.2',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/debian11.yaml"]''',

--- a/jenkins-pipelines/manager/older-enterprise-ami-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/older-enterprise-ami-manager-upgrade.jenkinsfile
@@ -11,7 +11,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.1',
+    manager_version: '3.2',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: 'test-cases/upgrades/manager-upgrade.yaml',

--- a/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.1',
+    manager_version: '3.2',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu20.yaml"]''',

--- a/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.1',
+    manager_version: '3.2',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: 'test-cases/upgrades/manager-upgrade.yaml',


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-manager/issues/3904

The PR contains the following changes:
- adjust upgrade jobs to run upgrade from version 3.2;
- expect passing restore for enospc node for latest Scylla.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Scylla 2024.1](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/test_enospc_before_restore/7/)
- [ ] [Scylla 6.0.1](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/test_enospc_before_restore/11/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
