### PR TITLE
fix(test_list_all_available_nemesis): fix number of disrupt methods

### DIFF
--- a/unit_tests/test_nemesis_sisyphus.py
+++ b/unit_tests/test_nemesis_sisyphus.py
@@ -71,7 +71,7 @@ def test_list_all_available_nemesis(generate_file=True):
     disruption_list, disruptions_dict, disruption_classes = sisyphus.get_list_of_disrupt_methods(
         subclasses_list=subclasses, export_properties=True)
 
-    assert len(disruption_list) == 83
+    assert len(disruption_list) == 82
 
     if generate_file:
         with open('data_dir/nemesis.yml', 'w', encoding="utf-8") as outfile1:


### PR DESCRIPTION
Fix expected number of disrupt methods in test_list_all_available_nemesis test.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/sct-github-PRs-scan/job/scylla-cluster-tests/job/PR-7753/workflow-stage/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)