### PR TITLE
fix(nemesis): `hot_reloading_internode_certificate` to update correct certs

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1729,9 +1729,9 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
     def config_client_encrypt(self):
         install_client_certificate(self.remoter, self.ip_address)
 
-    def create_node_certificate(self, cert_file, cert_key):
+    def create_node_certificate(self, cert_file, cert_key, csr_file=None):
         create_certificate(
-            cert_file, cert_key, self.name, ca_cert_file=CA_CERT_FILE, ca_key_file=CA_KEY_FILE,
+            cert_file, cert_key, self.name, ca_cert_file=CA_CERT_FILE, ca_key_file=CA_KEY_FILE, server_csr_file=csr_file,
             ip_addresses=[self.ip_address, self.public_ip_address],
             dns_names=[self.public_dns_name, self.private_dns_name])
 
@@ -4650,7 +4650,9 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             SnitchConfig(node=node, datacenters=datacenters).apply()
 
         # Create node certificate for internode communication
-        node.create_node_certificate(node.ssl_conf_dir / TLSAssets.DB_CERT, node.ssl_conf_dir / TLSAssets.DB_KEY)
+        node.create_node_certificate(cert_file=node.ssl_conf_dir / TLSAssets.DB_CERT,
+                                     cert_key=node.ssl_conf_dir / TLSAssets.DB_KEY,
+                                     csr_file=node.ssl_conf_dir / TLSAssets.DB_CSR)
         # Create client facing node certificate, for client-to-node communication
         node.create_node_certificate(
             node.ssl_conf_dir / TLSAssets.DB_CLIENT_FACING_CERT, node.ssl_conf_dir / TLSAssets.DB_CLIENT_FACING_KEY)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4302,7 +4302,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.target_node.get_scylla_config_param("server_encryption_options"))["certificate"]
         in_place_crt = self.target_node.remoter.run(f"cat {ssl_files_location}",
                                                     ignore_status=True).stdout
-        update_certificate()
         node_system_logs = {}
 
         if SkipPerIssues('https://github.com/scylladb/scylladb/issues/7909', params=self.tester.params):
@@ -4317,7 +4316,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             for node in self.cluster.nodes:
                 node_system_logs[node] = node.follow_system_log(
                     patterns=[f'messaging_service - Reloaded {{"{ssl_files_location}"}}'])
-                node.remoter.send_files(src=f'data_dir/ssl_conf/{TLSAssets.DB_CERT}', dst='/tmp')
+                update_certificate(node)
+                node.remoter.send_files(src=str(node.ssl_conf_dir / TLSAssets.DB_CERT), dst='/tmp')
                 node.remoter.run(f"sudo cp -f /tmp/{TLSAssets.DB_CERT} {ssl_files_location}")
                 new_crt = node.remoter.run(f"cat {ssl_files_location}").stdout
                 if in_place_crt == new_crt:

--- a/sdcm/provision/helpers/certificate.py
+++ b/sdcm/provision/helpers/certificate.py
@@ -10,6 +10,8 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2021 ScyllaDB
+from __future__ import annotations
+
 import io
 import ipaddress
 import shutil
@@ -18,7 +20,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 from textwrap import dedent
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -29,6 +31,9 @@ from cryptography.x509.oid import NameOID
 from sdcm.remote import shell_script_cmd
 from sdcm.utils.common import get_data_dir_path
 from sdcm.utils.docker_utils import ContainerManager, DockerException
+
+if TYPE_CHECKING:
+    from sdcm.cluster import BaseNode
 
 
 @dataclass(frozen=True)
@@ -46,6 +51,8 @@ class TLSAssets:
     PKCS12_KEYSTORE: str = 'keystore.p12'
 
 
+CA_DEFAULT_PASSWORD = 'scylladb'
+
 SCYLLA_SSL_CONF_DIR = Path('/etc/scylla/ssl_conf')
 CA_CERT_FILE = Path(get_data_dir_path('ssl_conf', TLSAssets.CA_CERT))
 CA_KEY_FILE = Path(get_data_dir_path('ssl_conf', TLSAssets.CA_KEY))
@@ -53,7 +60,6 @@ CA_KEY_FILE = Path(get_data_dir_path('ssl_conf', TLSAssets.CA_KEY))
 # Cluster artifacts
 SERVER_KEY_FILE = Path(get_data_dir_path('ssl_conf', TLSAssets.DB_KEY))
 SERVER_CERT_FILE = Path(get_data_dir_path('ssl_conf', TLSAssets.DB_CERT))
-SERVER_CSR_FILE = Path(get_data_dir_path('ssl_conf', TLSAssets.DB_CSR))
 CLIENT_FACING_KEYFILE = Path(get_data_dir_path('ssl_conf', TLSAssets.DB_CLIENT_FACING_KEY))
 CLIENT_FACING_CERTFILE = Path(get_data_dir_path('ssl_conf', TLSAssets.DB_CLIENT_FACING_CERT))
 
@@ -93,7 +99,7 @@ def install_encryption_at_rest_files(remoter):
     remoter.sudo("md5sum /etc/encrypt_conf/*.pem", ignore_status=True)
 
 
-def create_ca(cname: str = 'scylladb.com', password: str = 'scylladb', valid_days: int = 365) -> None:
+def create_ca(cname: str = 'scylladb.com', valid_days: int = 365) -> None:
     """Generate and save a key and certificate for CA."""
     private_key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
     subject = issuer = x509.Name(
@@ -125,7 +131,7 @@ def create_ca(cname: str = 'scylladb.com', password: str = 'scylladb', valid_day
             private_key.private_bytes(
                 encoding=serialization.Encoding.PEM,
                 format=serialization.PrivateFormat.PKCS8,
-                encryption_algorithm=serialization.BestAvailableEncryption(password.encode())
+                encryption_algorithm=serialization.BestAvailableEncryption(CA_DEFAULT_PASSWORD.encode())
             )
         )
 
@@ -133,7 +139,7 @@ def create_ca(cname: str = 'scylladb.com', password: str = 'scylladb', valid_day
 # pylint: disable=too-many-arguments,too-many-locals
 def create_certificate(
         cert_file: Path, key_file: Path, cname: str, ca_cert_file: Path = None, ca_key_file: Path = None,
-        password: str = 'scylladb', ip_addresses: list = None, dns_names: list = None, valid_days: int = 365) -> None:
+        server_csr_file: Path = None, ip_addresses: list = None, dns_names: list = None, valid_days: int = 365) -> None:
     """
     Generate/save CSR, certificate and key.
 
@@ -162,17 +168,18 @@ def create_certificate(
             ca_cert = x509.load_pem_x509_certificate(file.read())
             issuer = ca_cert.subject
         with open(ca_key_file, 'rb') as file:
-            sign_key = serialization.load_pem_private_key(file.read(), password=password.encode())
+            sign_key = serialization.load_pem_private_key(file.read(), password=CA_DEFAULT_PASSWORD.encode())
 
-    # Create and save CSR for the cert
-    server_csr = (
-        x509.CertificateSigningRequestBuilder()
-        .subject_name(subject)
-        .add_extension(x509.SubjectAlternativeName(alt_names), critical=False)
-        .sign(private_key, hashes.SHA256())
-    )
-    with open(SERVER_CSR_FILE, 'wb') as csr_file:
-        csr_file.write(server_csr.public_bytes(serialization.Encoding.PEM))
+    if server_csr_file:
+        # Create and save CSR for the cert
+        server_csr = (
+            x509.CertificateSigningRequestBuilder()
+            .subject_name(subject)
+            .add_extension(x509.SubjectAlternativeName(alt_names), critical=False)
+            .sign(private_key, hashes.SHA256())
+        )
+        with open(server_csr_file, 'wb') as csr_file:
+            csr_file.write(server_csr.public_bytes(serialization.Encoding.PEM))
 
     # Building the certificate
     cert = (
@@ -270,9 +277,12 @@ def cleanup_ssl_config():
             item.unlink()
 
 
-def update_certificate(
-        db_csr_file: Path = SERVER_CSR_FILE, db_crt_file: Path = SERVER_CERT_FILE,
-        ca_file: Path = CA_CERT_FILE, ca_key_file: Path = CA_KEY_FILE, password: str = 'scylladb') -> None:
+def update_certificate(node: BaseNode) -> None:
+    db_csr_file = node.ssl_conf_dir / TLSAssets.DB_CSR
+    db_crt_file = node.ssl_conf_dir / TLSAssets.DB_CERT
+    ca_file: Path = CA_CERT_FILE
+    ca_key_file: Path = CA_KEY_FILE
+
     """Update server certificate."""
     # Load CSR, CA certificate and key
     with open(db_csr_file, 'rb') as file:
@@ -280,7 +290,7 @@ def update_certificate(
     with open(ca_file, 'rb') as file:
         ca_cert = x509.load_pem_x509_certificate(file.read())
     with open(ca_key_file, 'rb') as file:
-        ca_key = serialization.load_pem_private_key(file.read(), password=password.encode())
+        ca_key = serialization.load_pem_private_key(file.read(), password=CA_DEFAULT_PASSWORD.encode())
 
     san_extension = csr.extensions.get_extension_for_oid(x509.ExtensionOID.SUBJECT_ALTERNATIVE_NAME).value
 


### PR DESCRIPTION
since the refactor of reloading certs we started
seeing those errors to start new nodes:
```
[shard  0:main] init - Startup failed: std::system_error
   (error GnuTLS:-60, The certificate and the given key do not match.)
```

those were happening after `hot_reloading_internode_certificate` was trying to reload the certificates, problem it had an assumption updating certificate once, and sending it to all of the nodes. but now we generate certs per node, and it wasn't copying it from the correct place, hence generated cert that doesn't match the key.

ontop of that seems like the validation in that nemesis was wrongly using `follow_system_log`, cause it to missed looking for the actual line that shows the certs are reloaded (it seems to be broken like that since d2a7910b98e823086c69b01bec6d6735444e8a53)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🔴  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-5gb-1h-SslHotReloadingNemesis-aws-test/3/
- [x] 🟢  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-5gb-1h-SslHotReloadingNemesis-aws-test/4/
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
