### PR TITLE
fix(jepsen): revert of old RSA keys

### DIFF
--- a/test-cases/jepsen/jepsen.yaml
+++ b/test-cases/jepsen/jepsen.yaml
@@ -20,3 +20,8 @@ jepsen_scylla_repo: 'https://github.com/scylladb/jepsen.git'
 jepsen_test_count: 5
 jepsen_test_run_policy: any
 bare_loaders: true
+
+# since jepsen is using very old ssh library (jsch), we can only use RSA keys
+# and our new keys are ECDSA, so we need to revert using the old key we have
+# TODO: raise it with jepsen
+user_credentials_path: '~/.ssh/scylla-test'


### PR DESCRIPTION
since jepsen is using very old ssh library (jsch), we can only use RSA keys and our new keys are ECDSA, so we need to revert using the old key we have

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] 🕦 https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/jepsen-test-all/14/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
