### PR TITLE
fix(manager): return centos7 back to the list of supported OS

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -916,7 +916,8 @@ class ScyllaManagerTool(ScyllaManagerBase):
         ScyllaManagerBase.__init__(self, id="MANAGER", manager_node=manager_node)
         self._initial_wait(20)
         LOGGER.info("Initiating Scylla-Manager, version: {}".format(self.sctool.version))
-        list_supported_distros = [Distro.ROCKY8, Distro.ROCKY9,
+        list_supported_distros = [Distro.CENTOS7,
+                                  Distro.ROCKY8, Distro.ROCKY9,
                                   Distro.DEBIAN10, Distro.DEBIAN11,
                                   Distro.UBUNTU20, Distro.UBUNTU22]
         self.default_user = "centos"


### PR DESCRIPTION
Since we stuck with CentOS image on Azure, centos7 should returned back to the list of manager supported distros.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/scylla-manager/job/manager-3.3/job/sct-feature-test-backup-azure/8/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)