### PR TITLE
ci(manager): adjust upgrade jobs to run upgrade from version 3.2

### DIFF
--- a/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.1',
+    manager_version: '3.2',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: 'test-cases/upgrades/manager-upgrade.yaml',

--- a/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.1',
+    manager_version: '3.2',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/debian10.yaml"]''',

--- a/jenkins-pipelines/manager/debian11-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian11-manager-upgrade.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.1',
+    manager_version: '3.2',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/debian11.yaml"]''',

--- a/jenkins-pipelines/manager/older-enterprise-ami-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/older-enterprise-ami-manager-upgrade.jenkinsfile
@@ -11,7 +11,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.1',
+    manager_version: '3.2',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: 'test-cases/upgrades/manager-upgrade.yaml',

--- a/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.1',
+    manager_version: '3.2',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu20.yaml"]''',

--- a/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.1',
+    manager_version: '3.2',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: 'test-cases/upgrades/manager-upgrade.yaml',

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -31,7 +31,7 @@ def call(Map pipelineParams) {
                    description: 'manager agent repo',
                    name: 'scylla_mgmt_agent_address')
             string(defaultValue: "${pipelineParams.get('manager_version', '')}",
-                   description: 'master_latest|3.1|3.0',
+                   description: 'master_latest|3.2|3.1',
                    name: 'manager_version')
             string(defaultValue: '',
                    description: 'a Scylla AMI to run against (for AMI test, should be blank otherwise)',

--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -70,7 +70,7 @@ def call() {
                    name: 'scylla_mgmt_address')
 
             string(defaultValue: '',
-                   description: 'master_latest|3.1|3.0',
+                   description: 'master_latest|3.2|3.1',
                    name: 'manager_version')
 
             string(defaultValue: "spot",

--- a/vars/cdcReplicationPipeline.groovy
+++ b/vars/cdcReplicationPipeline.groovy
@@ -126,7 +126,7 @@ def call(Map pipelineParams) {
                    name: 'scylla_mgmt_address')
 
             string(defaultValue: '',
-                   description: 'master_latest|3.1|3.0',
+                   description: 'master_latest|3.2|3.1',
                    name: 'manager_version')
 
             string(defaultValue: "${pipelineParams.get('email_recipients', 'qa@scylladb.com')}",

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -85,7 +85,7 @@ def call(Map pipelineParams) {
                    name: 'ip_ssh_connections')
 
             string(defaultValue: "${pipelineParams.get('manager_version', '')}",
-                   description: 'master_latest|3.1|3.0',
+                   description: 'master_latest|3.2|3.1',
                    name: 'manager_version')
 
             string(defaultValue: '',

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -107,11 +107,11 @@ def call(Map pipelineParams) {
                    name: 'scylla_mgmt_address')
 
             string(defaultValue: "${pipelineParams.get('manager_version', 'master_latest')}",
-                   description: 'master_latest|3.1|3.0',
+                   description: 'master_latest|3.2|3.1',
                    name: 'manager_version')
 
             string(defaultValue: "${pipelineParams.get('target_manager_version', '')}",
-                   description: 'master_latest|3.1|3.0',
+                   description: 'master_latest|3.2|3.1',
                    name: 'target_manager_version')
 
             string(defaultValue: "${pipelineParams.get('scylla_mgmt_agent_address', '')}",


### PR DESCRIPTION
Since Manager 3.3 is about to be released, the upgrade jobs should use Manager version 3.2 as initial.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/view/Upgrade/job/ubuntu22-upgrade-test/2/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)