### PR TITLE
fix(hydra-ssh): tunnel shouldn't pick bastions with other keys

### DIFF
--- a/sct_ssh.py
+++ b/sct_ssh.py
@@ -76,6 +76,7 @@ def aws_find_bastion_for_instance(instance: dict) -> dict:
     region = get_region(instance)
     tags = {'bastion': 'true'}
     bastions = list_instances_aws(tags, running=True, region_name=region)
+    bastions = list(filter(lambda vm: vm['KeyName'] == instance['KeyName'], bastions))
     assert bastions, f"No bastion found for region: {region}"
     return bastions[0]
 
@@ -135,7 +136,6 @@ def gce_get_proxy_command(instance: compute_v1.Instance, strict_host_checking: b
 def aws_get_proxy_command(instance: dict, force_use_public_ip: bool, strict_host_checking: bool = False) -> [str, str, str]:
     aws_region = AwsRegion(get_region(instance))
     target_key = f'~/.ssh/{SSH_KEY_AWS_DEFAULT}'
-
     if aws_region.sct_vpc.vpc_id == instance["VpcId"] and not force_use_public_ip:
         # if we are the current VPC setup, proxy via bastion needed
         bastion = aws_find_bastion_for_instance(instance)

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1319,14 +1319,15 @@ def filter_gce_by_tags(tags_dict, instances: list[GceInstance]) -> list[GceInsta
     filtered_instances = []
 
     for instance in instances:
+        if 'Name' in tags_dict.keys() and tags_dict['Name'] == instance.name:
+            filtered_instances.append(instance)
+            continue
+
         tags = gce_meta_to_dict(instance.metadata)
         for tag_k, tag_v in tags_dict.items():
             if tag_k not in tags or (tags[tag_k] not in tag_v if isinstance(tag_v, list) else tags[tag_k] != tag_v):
                 break
         else:
-            filtered_instances.append(instance)
-
-        if 'Name' in tags_dict.keys() and tags_dict['Name'] == instance.name:
             filtered_instances.append(instance)
 
     return filtered_instances
@@ -1336,7 +1337,6 @@ def list_instances_gce(tags_dict: Optional[dict] = None,
                        running: bool = False,
                        verbose: bool = True) -> list[GceInstance]:
     """List all instances with specific tags GCE."""
-    print(tags_dict)
     instances_client, info = get_gce_compute_instances_client()
     if verbose:
         LOGGER.info("Going to get all instances from GCE")


### PR DESCRIPTION
since we switch diffrent keys, the tunneling can fail picking the a correct bastion, we now filter the the list of bastions to make sure we don't mix, and use diffrent keys from the one configured for an instance.

(those could be coming for older releases,
or people using older branches)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
