### PR TITLE
fix(jepsen): hack tcpdump to work as jepsen needs

### DIFF
--- a/jepsen_test.py
+++ b/jepsen_test.py
@@ -46,7 +46,12 @@ class JepsenTest(ClusterTester):
                    destination_dir_name="jepsen-scylla",
                    clone_as_root=False)
         for db_node in self.db_cluster.nodes:
-            remoter.run(f"ssh-keyscan -t rsa {db_node.ip_address} >> ~/.ssh/known_hosts")
+            remoter.run(f"ssh-keyscan -t ed25519 {db_node.ip_address} >> ~/.ssh/known_hosts")
+
+            # newer jepsen test is using tcpdump, and expect it in /usr/bin
+            db_node.install_package("tcpdump")
+            db_node.remoter.sudo("ln -s /sbin/tcpdump /usr/bin/tcpdump", ignore_status=True)
+
         remoter.send_files(os.path.expanduser(self.db_cluster.nodes[0].ssh_login_info["key_file"]), DB_SSH_KEY)
 
     def setUp(self):


### PR DESCRIPTION
jepsen is picky about the location of tcpdump in some version so we'll symlink to where it's expecting

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/jepsen-test-all/14/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
