### PR TITLE
improvement(ruff): enable unused variable check

### DIFF
--- a/multiple_dc_test.py
+++ b/multiple_dc_test.py
@@ -55,7 +55,7 @@ class MultipleDcTest(ClusterTester):
         old_node.start_scylla(verify_up=True, verify_down=True)
         new_node.start_scylla(verify_up=True, verify_down=True)
 
-        results = self.get_stress_results(queue=stress_queue)
+        self.get_stress_results(queue=stress_queue)
 
     def test_series_stop(self):
 
@@ -70,13 +70,13 @@ class MultipleDcTest(ClusterTester):
         for node in nodes_2nd_dc:
             node.start_scylla(verify_up=True, verify_down=True)
 
-        results = self.get_stress_results(queue=stress_queue)
+        self.get_stress_results(queue=stress_queue)
 
     def test_parallel_stop(self):
         # run a background workload
-        stress_queue = self.run_stress_thread(stress_cmd=self.params.get('stress_cmd'),
-                                              stress_num=2,
-                                              keyspace_num=1)
+        self.run_stress_thread(stress_cmd=self.params.get('stress_cmd'),
+                               stress_num=2,
+                               keyspace_num=1)
         nodes_2nd_dc = [n for n in node_list if n.dc_idx == 1]
 
         # stop the services of 2nd dc in parallel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-lint.select = ["PL", "YTT", "BLE"]
+lint.select = ["PL", "YTT", "BLE", "F841"]
 
 lint.ignore = ["E501", "PLR2004"]
 

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -390,14 +390,14 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         # if simulated_racks, create all instances in the same az
         instance_az = 0 if self.params.get("simulated_racks") else rack
         instances = []
-        if rack is None:
+        if instance_az is None:
             # define how many nodes should be created on each rack, e.g. for 3 nodes and 2 racks it will be [2, 1]
             base = count // self.racks_count
             extra = count % self.racks_count
             rack_distribution = [base + 1 if i < extra else base for i in range(self.racks_count)]
         else:
             # otherwise create all nodes on the specified rack
-            rack_distribution = [count if i == rack else 0 for i in range(self.racks_count)]
+            rack_distribution = [count if i == instance_az else 0 for i in range(self.racks_count)]
         self.log.info('rack distribution: %s', rack_distribution)
         for rack_idx, rack_count in enumerate(rack_distribution):
             if rack_count == 0:

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -394,7 +394,7 @@ class ManagerTask:
         # * check that progress command works on various task statuses (that was how manager bug #856 found).
         # * print the progress to log in cases needed for failures/performance analysis.
         ###
-        progress = self.progress  # pylint: disable=unused-variable
+        progress = self.progress  # pylint: disable=unused-variable  # noqa: F841
         return self.status in list_status
 
     def wait_for_status(self, list_status, check_task_progress=True, timeout=3600, step=120):

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1819,7 +1819,7 @@ class SCTConfiguration(dict):
                         else:
                             azure_image = azure_utils.get_released_scylla_images(
                                 scylla_version=scylla_version, region_name=region)[0]
-                    except Exception as ex:
+                    except Exception as ex:  # noqa: BLE001
                         raise ValueError(
                             f"Azure Image for scylla_version='{scylla_version}' not found in {region}") from ex
                     self.log.debug("Found Azure Image %s for scylla_version='%s' in %s",


### PR DESCRIPTION
Recently a bug was introduced to parallel nodes bootstrap where simulated_racks was ignored. This could have been prevented if ruff verified unused variables.

Introduced this check (verified whole repo locally) and fixed all the issues (including ignore of simulated racks).

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
