### PR TITLE
Manager add stress read cmd into ipv6 config file

### DIFF
--- a/test-cases/manager/manager-regression-ipv6.yaml
+++ b/test-cases/manager/manager-regression-ipv6.yaml
@@ -1,6 +1,7 @@
 test_duration: 120
 
 stress_cmd: "cassandra-stress write cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
+stress_read_cmd: "cassandra-stress read cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
 
 instance_type_db: 'i4i.large'
 instance_type_loader: 'c6i.large'


### PR DESCRIPTION
The PR addresses the following issues:
- Configuration yaml for manager ipv6 test is missing stress_read_cmd parameter. Without it, read verification check is skipped in test.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [backup-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/sct-feature-test-backup/4/)
- [x] [sanity-ipv6](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-sanity-ipv6-test/4/)
- [x] [ubuntu22-sanity](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-sanity-test/26/)
- [x] [vnodes-tablets-sanity](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-vnodes-tablets-cluster-test/15/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
