### PR TITLE
fix(nemesis): refer to correct scylladb repo

### DIFF
--- a/sct_scan_issues.py
+++ b/sct_scan_issues.py
@@ -15,6 +15,7 @@
 
 import sys
 import ast
+import tempfile
 import logging
 from pathlib import Path
 
@@ -24,7 +25,7 @@ from sdcm.utils.issues import SkipPerIssues
 from sdcm.sct_config import SCTConfiguration
 from sdcm.utils.common import get_sct_root_path
 from sdcm.utils.sct_cmd_helpers import add_file_logger
-
+from sdcm.sct_events.setup import start_events_device, stop_events_device
 LOGGER = logging.getLogger(__name__)
 
 
@@ -47,6 +48,8 @@ def get_value(node):
 def scan_issue_skips():
     add_file_logger()
     unneeded_skips = False
+    temp_dir = tempfile.mkdtemp()
+    start_events_device(temp_dir)
 
     params = SCTConfiguration()
     for file_path in Path(get_sct_root_path()).glob("**/*.py"):
@@ -69,9 +72,10 @@ def scan_issue_skips():
                         "sct-") and label.name.endswith("-skip"))
 
                     if not (issues_opened or issues_labeled):
-                        click.secho(f"{args[:1]} should be consider to be remove from code", fg="red")
+                        click.secho(f"{args[:1]} is closed, should be consider to be remove from code", fg="red")
                         unneeded_skips = True
 
+    stop_events_device()
     if unneeded_skips:
         return sys.exit(1)
     return 0

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3115,9 +3115,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             Validates that hinted handoff mechanism works: there were no drops and errors
             during short stop of one of the nodes in cluster
         """
-        # NOTE: enable back when 'https://github.com/scylladb/scylla/issues/8136' issue is fixed
-        if SkipPerIssues('https://github.com/scylladb/scylla/issues/8136', params=self.tester.params):
-            raise UnsupportedNemesis('https://github.com/scylladb/scylla/issues/8136')
+        # NOTE: enable back when 'https://github.com/scylladb/scylladb/issues/8136' issue is fixed
+        if SkipPerIssues('https://github.com/scylladb/scylladb/issues/8136', params=self.tester.params):
+            raise UnsupportedNemesis('https://github.com/scylladb/scylladb/issues/8136')
 
         if self.cluster.params.get('hinted_handoff') == 'disabled':
             raise UnsupportedNemesis('For this nemesis to work, `hinted_handoff` needs to be set to `enabled`')
@@ -3599,8 +3599,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         """
 
         # Temporary disable due to  https://github.com/scylladb/scylla/issues/6522
-        if SkipPerIssues('https://github.com/scylladb/scylla/issues/6522', self.tester.params):
-            raise UnsupportedNemesis('https://github.com/scylladb/scylla/issues/6522')
+        if SkipPerIssues('https://github.com/scylladb/scylladb/issues/6522', self.tester.params):
+            raise UnsupportedNemesis('https://github.com/scylladb/scylladb/issues/6522')
 
         name = 'RejectInterNodeNetwork'
 

--- a/sdcm/utils/issues.py
+++ b/sdcm/utils/issues.py
@@ -119,10 +119,15 @@ class SkipPerIssues:
                                                           labels=issue_details['labels']),
                                           completed=True)
         except ClientError as exc:
-            logging.warning("failed to get issue: %s from s3 cache", issue)
+            severity = Severity.ERROR
+            # some repos are not cached so we just warns about, and fallback
+            if issue_parsed.repo_id in ['field-engineering']:
+                severity = Severity.WARNING
+            else:
+                logging.warning("failed to get issue: %s from s3 cache", issue)
             TestFrameworkEvent(source=self.__class__.__name__,
                                message=f"failed to get issue {issue} from s3 cache",
-                               severity=Severity.ERROR,
+                               severity=severity,
                                exception=exc).publish()
         try:
             return self.github.get_repo(f'{issue_parsed.user_id}/{issue_parsed.repo_id}', lazy=True).get_issue(issue_parsed.issue_id)


### PR DESCRIPTION
some SkipPerIssue instances were referring to old scylla repo name issue caches is per the new names, hence we need to align those

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested local with `hydra scan-skip-issues`

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
