### PR TITLE
fix(hot_reloading): pass correct patterns to `follow_system_log`

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4316,7 +4316,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         with context_manager:
             for node in self.cluster.nodes:
                 node_system_logs[node] = node.follow_system_log(
-                    patterns=f'messaging_service - Reloaded {{{ssl_files_location}}}')
+                    patterns=[f'messaging_service - Reloaded {{"{ssl_files_location}"}}'])
                 node.remoter.send_files(src=f'data_dir/ssl_conf/{TLSAssets.DB_CERT}', dst='/tmp')
                 node.remoter.run(f"sudo cp -f /tmp/{TLSAssets.DB_CERT} {ssl_files_location}")
                 new_crt = node.remoter.run(f"cat {ssl_files_location}").stdout


### PR DESCRIPTION
since it didn't passed a list down to `follow_system_log` the validation wasn't really working as expected, and could finish on finding any of the letters from the validation phrase.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-5gb-1h-SslHotReloadingNemesis-aws-test/4/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
