### PR TITLE
fix(c-s): update the docker image we use for c-s

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -208,7 +208,7 @@ stress_image:
   ndbench: 'scylladb/hydra-loaders:ndbench-jdk8-20210720'
   ycsb: 'scylladb/hydra-loaders:ycsb-jdk8-20220918'
   nosqlbench: 'scylladb/hydra-loaders:nosqlbench-4.15.49'
-  cassandra-stress: 'scylladb/scylla:5.4.6' # empty default would be same version as scylla under test
+  cassandra-stress: 'docker.io/scylladb/hydra-loaders:cassandra-stress-6.0-20240701'
   scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.21'
   gemini: 'scylladb/hydra-loaders:gemini-v1.8.6'
   alternator-dns: 'scylladb/hydra-loaders:alternator-dns-0.1'

--- a/docker/cassandra-stress/Dockerfile-deb
+++ b/docker/cassandra-stress/Dockerfile-deb
@@ -6,6 +6,11 @@ ARG DEB_KEY
 ENV DEB_LIST_URL=${DEB_LIST_URL:-https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla/branch-5.1/deb/unified/2022-08-18T12%3A17%3A46Z/scylladb-5.1/scylla.list}
 ENV DEB_KEY=${DEB_KEY:-D0A112E067426AB2}
 
+
+RUN echo \
+  "deb http://deb.debian.org/debian unstable main non-free contrib" | \
+  tee /etc/apt/sources.list.d/non-free.list > /dev/null
+
 RUN apt-get update && apt-get -y install wget gnupg2 \
     && wget ${DEB_LIST_URL} \
     && mv scylla.list /etc/apt/sources.list.d/ \

--- a/docker/cassandra-stress/README.md
+++ b/docker/cassandra-stress/README.md
@@ -2,9 +2,9 @@
 ### Building from DEB files (quicker)
 
 ```
-export DEB_LIST_URL=https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla/branch-5.1/deb/unified/2022-08-18T12%3A17%3A46Z/scylladb-5.1/scylla.list
-export CS_DOCKER_IMAGE=scylladb/hydra-loaders:cassandra-stress-$(date +'%Y%m%d')
-docker build . -t ${CS_DOCKER_IMAGE} -f Dockerfile-deb --build-arg DEB_LIST_URL=$DEB_LIST_URL
+export DEB_LIST_URL=https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla/branch-6.0/deb/unified/latest/scylladb-6.0/scylla.list
+export CS_DOCKER_IMAGE=scylladb/hydra-loaders:cassandra-stress-6.0-$(date +'%Y%m%d')
+docker build . -t ${CS_DOCKER_IMAGE} -f Dockerfile-deb --build-arg DEB_LIST_URL=$DEB_LIST_URL --build-arg DEB_KEY=87722433EBB454AE
 docker push ${CS_DOCKER_IMAGE}
 ```
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -3098,10 +3098,7 @@ class LoaderPodCluster(cluster.BaseLoaderSet, PodCluster):
     def _get_docker_image(self):
         if loader_image := self.params.get('stress_image.cassandra-stress'):
             return loader_image
-        else:
-            docker_image = self.params.get('docker_image')
-            scylla_version = self.params.get('scylla_version')
-            return f"{docker_image}:{scylla_version}"
+        raise ValueError("No 'stress_image.cassandra-stress' option found in the test configuration")
 
     def add_nodes(self,
                   count: int,

--- a/sdcm/remote/kubernetes_cmd_runner.py
+++ b/sdcm/remote/kubernetes_cmd_runner.py
@@ -396,7 +396,7 @@ class KubernetesPodWatcher(KubernetesRunner):
             return params.get("stress_image.ycsb")
         if loader_image := params.get('stress_image.cassandra-stress'):
             return loader_image
-        return f"{params.get('docker_image')}:{params.get('scylla_version')}"
+        raise ValueError("No loader image found in the params")
 
     def _get_pod_status(self) -> dict:
         result_raw = self.context.config.k8s_kluster.kubectl(

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -33,7 +33,6 @@ from sdcm.utils.user_profile import get_profile_content, replace_scylla_qa_inter
 from sdcm.sct_events.loaders import CassandraStressEvent, CS_ERROR_EVENTS_PATTERNS, CS_NORMAL_EVENTS_PATTERNS
 from sdcm.stress.base import DockerBasedStressThread
 from sdcm.utils.docker_remote import RemoteDocker
-from sdcm.utils.version_utils import get_docker_image_by_version
 from sdcm.utils.remote_logger import SSHLoggerBase
 
 
@@ -249,13 +248,6 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
 
     def _run_stress(self, loader, loader_idx, cpu_idx):
         pass
-
-    @cached_property
-    def docker_image_name(self):
-        if cassandra_stress_image := super().docker_image_name:
-            return cassandra_stress_image
-        else:
-            return get_docker_image_by_version(self.node_list[0].get_scylla_binary_version())
 
     def _run_cs_stress(self, loader, loader_idx, cpu_idx, keyspace_idx):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         cleanup_context = contextlib.nullcontext()

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -20,7 +20,6 @@ from typing import List, Optional, Literal
 from collections import namedtuple, defaultdict
 from urllib.parse import urlparse
 from functools import lru_cache, wraps
-from itertools import count
 
 import yaml
 import boto3
@@ -484,41 +483,6 @@ def get_scylla_docker_repo_from_version(scylla_version: str):
     if is_enterprise(scylla_version):
         return 'scylladb/scylla-enterprise'
     return 'scylladb/scylla'
-
-
-def get_docker_image_by_version(scylla_version: str):
-    # get shorter version, for getting releases, and check if it's enterprise.
-    short_scylla_version = SCYLLA_VERSION_RE.match(scylla_version)
-    assert short_scylla_version, f"'{scylla_version}' isn't acceptable version string"
-    short_scylla_version = short_scylla_version.group().replace('~', '-')
-
-    # select the repo to use, and the scylla_versio to match
-    docker_repo = 'scylladb/scylla'
-    if is_enterprise(short_scylla_version):
-        docker_repo += '-enterprise'
-
-    default_image = f"{docker_repo}:latest"
-
-    if 'dev' in scylla_version:
-        docker_repo += '-nightly'
-        scylla_version = scylla_version.replace('~', '-')
-    else:
-        scylla_version = short_scylla_version
-
-    for page_number in count(start=1):
-        try:
-            all_tags = requests.get(url=f'https://hub.docker.com/v2/repositories/{docker_repo}/'
-                                        f'tags?page_size=50&page={page_number}').json()
-        except requests.RequestException:
-            break
-        for image in all_tags.get('results', []):
-            image_name = image.get('name')
-            if image_name and scylla_version == image_name:
-                return f"{docker_repo}:{image_name}"
-        if not all_tags.get('next'):
-            break
-    # if image wasn't found, default to the latest releases
-    return default_image
 
 
 def _list_repo_file_etag(s3_client: S3Client, prefix: str) -> Optional[dict]:

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -13,7 +13,6 @@ from sdcm.utils.version_utils import (
     get_all_versions,
     get_branch_version,
     get_branch_version_for_multiple_repositories,
-    get_docker_image_by_version,
     get_git_tag_from_helm_chart_version,
     get_scylla_urls_from_repository,
     get_specific_tag_of_docker_image,
@@ -413,50 +412,6 @@ def test_scylla_version_for_argus_regexp(full_version, short, date, commit_id):
     assert parsed_version.group("short") == short
     assert parsed_version.group("date") == date
     assert parsed_version.group("commit") == commit_id
-
-
-@pytest.mark.integration
-@pytest.mark.need_network
-@pytest.mark.parametrize("version, expected", (
-    ("4.6.rc2-20220102.e8a1cfb6f", "scylladb/scylla:4.6.rc2"),
-    ("5.0.1-0.20220719.b177dacd3", "scylladb/scylla:5.0.1"),
-    ("5.1", "scylladb/scylla:5.1"),
-    ("5.1.0~rc1", "scylladb/scylla:5.1.0-rc1"),
-    ("5.0.1", "scylladb/scylla:5.0.1"),
-    ("5.2.0~dev-0.20220824.6ce5e9079c1e", "scylladb/scylla-nightly:5.2.0-dev-0.20220824.6ce5e9079c1e"),
-    ("5.1.0~dev-0.20220726.29c28dcb0c33", "scylladb/scylla-nightly:5.1.0-dev-0.20220726.29c28dcb0c33"),
-    ("2022.2.dev-20220515.no_such_sha", "scylladb/scylla-enterprise:latest"),
-    ("5.2.0~dev-20220515.no_such_sha", "scylladb/scylla:latest"),
-))
-def test_get_docker_image_by_version(version, expected):
-    assert get_docker_image_by_version(scylla_version=version) == expected
-
-
-def test_get_docker_image_by_version_broken_string_version():
-    with pytest.raises(AssertionError):
-        get_docker_image_by_version(scylla_version="broken_version")
-
-
-def test_get_docker_image_by_version_fallback_on_errors():
-    def mock_requests_factory(response_stub):
-        return mock.Mock(**{
-            'json.return_value': response_stub,
-        })
-
-    def raise_request_error(**kwargs):
-        raise requests.HTTPError()
-
-    non_existing_version = '5.2.0~dev-0.20221124.999b7f5d9b77'
-    expected_fallback = 'scylladb/scylla:latest'
-    with unittest.mock.patch("requests.get") as get_mock:
-        get_mock.side_effect = lambda **_: mock_requests_factory({})
-        assert get_docker_image_by_version(scylla_version=non_existing_version) == expected_fallback
-
-        get_mock.side_effect = lambda **_: mock_requests_factory({"results": [{'name': ''}, {}]})
-        assert get_docker_image_by_version(scylla_version=non_existing_version) == expected_fallback
-
-        get_mock.side_effect = raise_request_error
-        assert get_docker_image_by_version(scylla_version=non_existing_version) == expected_fallback
 
 
 @pytest.mark.parametrize("version_string, expected", (


### PR DESCRIPTION
until we'll have an offical release of c-s seperate from scylla core we built this image, base on the version from scylla 6.0 this version should have tablets support (which 5.4.6 didn't had)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
