### PR TITLE
fix(tester): reduce noise in the logs if there is no gemini_results attribute

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -593,7 +593,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def argus_collect_gemini_results(self):
         try:
             # pylint: disable=no-member
-            if not getattr(self, "gemini_results"):
+            if not hasattr(self, "gemini_results"):
                 return
 
             if self.loaders:


### PR DESCRIPTION
Example of the noise in SCT log:

```
03:15:21.196  < t:2024-06-30 21:42:02,263 f:tester.py       l:635  c:JepsenTest           p:WARNING > Error submitting gemini results to argus < t:2024-06-30 21:42:02,263 f:tester.py       l:635  c:JepsenTest           p:WARNING > Error submitting gemini results to argus
03:15:21.196  < t:2024-06-30 21:42:02,263 f:tester.py       l:635  c:JepsenTest           p:WARNING > Traceback (most recent call last):
03:15:21.196  < t:2024-06-30 21:42:02,263 f:tester.py       l:635  c:JepsenTest           p:WARNING >   File "/home/ubuntu/scylla-cluster-tests/sdcm/tester.py", line 596, in argus_collect_gemini_results
03:15:21.196  < t:2024-06-30 21:42:02,263 f:tester.py       l:635  c:JepsenTest           p:WARNING >     if not getattr(self, "gemini_results"):
03:15:21.196  < t:2024-06-30 21:42:02,263 f:tester.py       l:635  c:JepsenTest           p:WARNING > AttributeError: 'JepsenTest' object has no attribute 'gemini_results'. Did you mean: 'get_gemini_results'?
```