### PR TITLE
improvement(sdcm/tester.py): Add TEST_ERROR Argus status support

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -558,14 +558,34 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             severity=Severity.ERROR,
         )
 
+    def _is_test_error(self, events: dict[str, list[str]]) -> bool:
+        """
+            Test whether or not the result of the test can be considered as a TEST_ERROR
+            status for Argus. TEST_ERROR status is used for times when the SCT failure is caused by
+            either infrastructure or problems within SCT itself.
+
+        """
+        def check_error(event: str):
+            errors = [
+                re.compile(r"SpotTerminationEvent", re.IGNORECASE),
+                re.compile(r"source=[\w]+.SetUp\(\).+exception=403 FORBIDDEN QUOTA_EXCEEDED",
+                           re.IGNORECASE | re.DOTALL),
+                re.compile(r"source=[\w]+.SetUp\(\).+InsufficientInstanceCapacity", re.IGNORECASE | re.DOTALL),
+            ]
+            for error in errors:
+                if error.search(event):
+                    return True
+            return False
+
+        return any(check_error(e) for e in [*events.get("CRITICAL"), *events.get("ERROR")])
+
     def argus_finalize_test_run(self):
         try:
             stat_map = {
                 "SUCCESS": TestStatus.PASSED,
                 "FAILED": TestStatus.FAILED
             }
-            self.test_config.argus_client().finalize_sct_run()
-            self.argus_update_status(stat_map.get(self.get_test_status(), TestStatus.FAILED))
+
             last_events_limit = 100
             last_events = get_events_grouped_by_category(
                 limit=last_events_limit, _registry=self.events_processes_registry)
@@ -576,6 +596,13 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                     severity=severity, total_events=events_summary.get(severity, 0), messages=messages)
                 events_sorted.append(event_category)
             self.test_config.argus_client().submit_events(events_sorted)
+
+            test_status = stat_map.get(self.get_test_status(), TestStatus.FAILED)
+            if test_status == TestStatus.FAILED and self._is_test_error(last_events):
+                test_status = TestStatus.TEST_ERROR
+            self.argus_update_status(test_status)
+
+            self.test_config.argus_client().finalize_sct_run()
         except Exception:  # pylint: disable=broad-except
             self.log.error("Error committing test events to Argus", exc_info=True)
 


### PR DESCRIPTION
This commit adds additional logic into argus_finalize_test_run that
checks whether a failed run failed due to test error - e.g.
SpotTerminationEvent, where the framework encountered an environment
issue (not enough capacity) and cannot continue.

Task: scylladb/qa-tasks#1596

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Argus](https://argus.scylladb.com/test/b0b22734-758e-47b4-b6ec-29e64d212d52/runs?additionalRuns[]=b923c361-6ea6-4d6c-83b0-ff652723e8a3)
- [x] [Jenkins](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/alexey-argus-testing/95/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
