### PR TITLE
fix(manager): add links to .list/.repo files for release 3.3

### DIFF
--- a/defaults/manager_versions.yaml
+++ b/defaults/manager_versions.yaml
@@ -7,6 +7,14 @@ manager_repos_by_version:
     ubuntu20: 'https://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
     ubuntu22: 'https://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
     ubuntu24: 'https://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
+  "3.3":
+    centos7: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.3.repo'
+    centos8: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.3.repo'
+    debian10: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/debian/scylladb-manager-3.3.list'
+    debian11: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/debian/scylladb-manager-3.3.list'
+    ubuntu20: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.3.list'
+    ubuntu22: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.3.list'
+    ubuntu24: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.3.list'
   "3.2":
     centos7: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.2.repo'
     centos8: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.2.repo'
@@ -23,14 +31,6 @@ manager_repos_by_version:
     ubuntu20: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.1.list'
     ubuntu22: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.1.list'
     ubuntu24: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.1.list'
-  "3.0":
-    centos7: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.0.repo'
-    centos8: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.0.repo'
-    debian10: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/debian/scylladb-manager-3.0-buster.list'
-    debian11: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/debian/scylladb-manager-3.0.list'
-    ubuntu20: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.0-focal.list'
-    ubuntu22: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.0-focal.list'
-    ubuntu24: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.0-focal.list'
 
 scylla_backend_repo_by_version:
   "2022":


### PR DESCRIPTION
Since the Manager 3.3 has been released, the manager_versions.yaml is updated to have the links to .repo and .list files for this release.

Together with that, the links for old release 3.0 have been removed.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
