### PR TITLE
fix(loader): update loader ami with tablet aware driver

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -7,7 +7,7 @@ user_credentials_path: '~/.ssh/scylla_test_id_ed25519'
 instance_type_loader: 'c6i.xlarge'
 instance_type_monitor: 't3.large'
 # manual on creating loader AMI's: see docs/new_loader_ami.md
-ami_id_loader: 'scylla-qa-loader-ami-v20-ubuntu22'
+ami_id_loader: 'scylla-qa-loader-ami-v21-ubuntu22'  # versions: c-s 2024.2.0-rc0, s-b 0.1.21
 # manual on updating monitor images see: docs/monitoring-images.md
 ami_id_monitor: 'scylladb-monitor-4-7-2-2024-05-13t08-38-47z'
 


### PR DESCRIPTION
Loader ami used old c-s which didn't have java driver with tablets support.

Created new image with c-s from 2024.2.0-rc0 and updated scylla-bench to 0.1.21.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/longevity-5gb-1h-MajorCompactionMonkey-aws-test/15/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
