### PR TITLE
fix(manager-sanity-test): sync tls files to manager node

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2284,10 +2284,10 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         self.install_package(package_names)
 
         self.log.debug("Create and send client TLS certificate/key to the node")
-        self.create_node_certificate(self.ssl_conf_dir / TLSAssets.CLIENT_CERT,
-                                     self.ssl_conf_dir / TLSAssets.CLIENT_KEY)
-        self.remoter.send_files(
-            str(self.ssl_conf_dir), dst='/tmp/ssl_conf')
+        self.create_node_certificate(cert_file=self.ssl_conf_dir / TLSAssets.CLIENT_CERT,
+                                     cert_key=self.ssl_conf_dir / TLSAssets.CLIENT_KEY)
+        self.remoter.run(f'mkdir -p {mgmt.cli.SSL_CONF_DIR}')
+        self.remoter.send_files(src=str(self.ssl_conf_dir) + '/', dst=str(mgmt.cli.SSL_CONF_DIR))
 
         if self.is_docker():
             try:


### PR DESCRIPTION
After rework of how TLS certificates and keys are created for each node in SCT we cannot just copy the whole directory with TLS items from SCT runner instance to a manager node. There are now dedicated subdirectories with certs/keys, one for each node. These directories names are dynamically defined at runtime.

The change makes proper syncing of TLS files to manager node, instead of sending the whole directory.

### Testing
- [x] :green_circle: [ubuntu22 manager sanity test](https://argus.scylladb.com/test/e3a17708-918e-4fd8-871b-2444315ab860/runs?additionalRuns[]=a0ed3784-d05e-47f0-8382-d30e59b92670)
- [x] :green_circle: [ubuntu20 manager sanity test](https://argus.scylladb.com/test/e3a17708-918e-4fd8-871b-2444315ab860/runs?additionalRuns[]=8b763a3f-48b0-4070-bb57-778da4aac1b3)

### PR pre-checks (self review)
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
