### PR TITLE
fix(artifacts-test): make creation of CA and Java truststore idempotent

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -69,7 +69,7 @@ from sdcm.provision.scylla_yaml.certificate_builder import ScyllaYamlCertificate
 from sdcm.provision.scylla_yaml.cluster_builder import ScyllaYamlClusterAttrBuilder
 from sdcm.provision.scylla_yaml.scylla_yaml import ScyllaYaml
 from sdcm.provision.helpers.certificate import (
-    install_client_certificate, install_encryption_at_rest_files, create_certificate,
+    create_ca, install_client_certificate, install_encryption_at_rest_files, create_certificate,
     export_pem_cert_to_pkcs12_keystore, CA_CERT_FILE, CA_KEY_FILE, JKS_TRUSTSTORE_FILE, TLSAssets)
 from sdcm.remote import RemoteCmdRunnerBase, LOCALRUNNER, NETWORK_EXCEPTIONS, shell_script_cmd, RetryableNetworkException
 from sdcm.remote.libssh2_client import UnexpectedExit as Libssh2_UnexpectedExit
@@ -2283,12 +2283,6 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             self.download_scylla_manager_repo(manager_repo_url)
         self.install_package(package_names)
 
-        self.log.debug("Create and send client TLS certificate/key to the node")
-        self.create_node_certificate(cert_file=self.ssl_conf_dir / TLSAssets.CLIENT_CERT,
-                                     cert_key=self.ssl_conf_dir / TLSAssets.CLIENT_KEY)
-        self.remoter.run(f'mkdir -p {mgmt.cli.SSL_CONF_DIR}')
-        self.remoter.send_files(src=str(self.ssl_conf_dir) + '/', dst=str(mgmt.cli.SSL_CONF_DIR))
-
         if self.is_docker():
             try:
                 self.remoter.run("echo no | sudo scyllamgr_setup")
@@ -4085,6 +4079,16 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 node.restart_scylla()
 
     def enable_client_encrypt(self):
+        create_ca(self.test_config.tester_obj().localhost)
+        for node in self.nodes:
+            node.create_node_certificate(cert_file=node.ssl_conf_dir / TLSAssets.DB_CERT,
+                                         cert_key=node.ssl_conf_dir / TLSAssets.DB_KEY,
+                                         csr_file=node.ssl_conf_dir / TLSAssets.DB_CSR)
+            # Create client facing node certificate, for client-to-node communication
+            node.create_node_certificate(
+                node.ssl_conf_dir / TLSAssets.DB_CLIENT_FACING_CERT, node.ssl_conf_dir / TLSAssets.DB_CLIENT_FACING_KEY)
+            for src in (CA_CERT_FILE, JKS_TRUSTSTORE_FILE):
+                shutil.copy(src, node.ssl_conf_dir)
         self.log.debug("Enabling client encryption on nodes")
         with self.patch_params() as params:
             params['client_encrypt'] = True
@@ -4650,15 +4654,16 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 datacenters = self.datacenter  # pylint: disable=no-member
             SnitchConfig(node=node, datacenters=datacenters).apply()
 
-        # Create node certificate for internode communication
-        node.create_node_certificate(cert_file=node.ssl_conf_dir / TLSAssets.DB_CERT,
-                                     cert_key=node.ssl_conf_dir / TLSAssets.DB_KEY,
-                                     csr_file=node.ssl_conf_dir / TLSAssets.DB_CSR)
-        # Create client facing node certificate, for client-to-node communication
-        node.create_node_certificate(
-            node.ssl_conf_dir / TLSAssets.DB_CLIENT_FACING_CERT, node.ssl_conf_dir / TLSAssets.DB_CLIENT_FACING_KEY)
-        for src in (CA_CERT_FILE, JKS_TRUSTSTORE_FILE):
-            shutil.copy(src, node.ssl_conf_dir)
+        if self.params.get('server_encrypt'):
+            # Create node certificate for internode communication
+            node.create_node_certificate(cert_file=node.ssl_conf_dir / TLSAssets.DB_CERT,
+                                         cert_key=node.ssl_conf_dir / TLSAssets.DB_KEY,
+                                         csr_file=node.ssl_conf_dir / TLSAssets.DB_CSR)
+            # Create client facing node certificate, for client-to-node communication
+            node.create_node_certificate(
+                node.ssl_conf_dir / TLSAssets.DB_CLIENT_FACING_CERT, node.ssl_conf_dir / TLSAssets.DB_CLIENT_FACING_KEY)
+            for src in (CA_CERT_FILE, JKS_TRUSTSTORE_FILE):
+                shutil.copy(src, node.ssl_conf_dir)
         node.config_setup(append_scylla_args=self.get_scylla_args())
 
         self._scylla_post_install(node, install_scylla, nic_devname)
@@ -5098,14 +5103,15 @@ class BaseLoaderSet():
             self.log.info("Don't install anything because bare loaders requested")
             return
 
-        node.create_node_certificate(node.ssl_conf_dir / TLSAssets.CLIENT_CERT,
-                                     node.ssl_conf_dir / TLSAssets.CLIENT_KEY)
-        for src in (CA_CERT_FILE, JKS_TRUSTSTORE_FILE):
-            shutil.copy(src, node.ssl_conf_dir)
         if self.params.get('client_encrypt'):
+            node.create_node_certificate(node.ssl_conf_dir / TLSAssets.CLIENT_CERT,
+                                         node.ssl_conf_dir / TLSAssets.CLIENT_KEY)
+            for src in (CA_CERT_FILE, JKS_TRUSTSTORE_FILE):
+                shutil.copy(src, node.ssl_conf_dir)
             export_pem_cert_to_pkcs12_keystore(
                 node.ssl_conf_dir / TLSAssets.CLIENT_CERT, node.ssl_conf_dir / TLSAssets.CLIENT_KEY,
                 node.ssl_conf_dir / TLSAssets.PKCS12_KEYSTORE)
+
             if self.params.get('use_prepared_loaders'):
                 node.config_client_encrypt()
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -63,8 +63,7 @@ from sdcm.kafka.kafka_cluster import LocalKafkaCluster
 from sdcm.provision.azure.provisioner import AzureProvisioner
 from sdcm.provision.network_configuration import ssh_connection_ip_type
 from sdcm.provision.provisioner import provisioner_factory
-from sdcm.provision.helpers.certificate import (
-    create_ca, import_ca_to_jks_truststore, update_certificate, cleanup_ssl_config)
+from sdcm.provision.helpers.certificate import create_ca, update_certificate, cleanup_ssl_config
 from sdcm.reporting.tooling_reporter import PythonDriverReporter
 from sdcm.scan_operation_thread import ScanOperationThread
 from sdcm.nosql_thread import NoSQLBenchStressThread
@@ -903,7 +902,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.connections = []
         make_threads_be_daemonic_by_default()
 
-        self.create_ca()
+        if (not self.params.get("cluster_backend").startswith("k8s") and
+                any([self.params.get('client_encrypt'), self.params.get('server_encrypt')])):
+            create_ca(self.localhost)
 
         # download rpms for update_db_packages
         if self.params.get('update_db_packages'):
@@ -3713,8 +3714,3 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             workload=CSWorkloadTypes(stress_operation),
             path=self.loaders.logdir, start_time=start_time, end_time=end_time,
             interval=time_interval, tag_type=tag_type)
-
-    def create_ca(self):
-        """Create Certificate Authority and Java truststore"""
-        create_ca()
-        import_ca_to_jks_truststore(self.localhost)

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -24,7 +24,7 @@ from sdcm.cluster import BaseNode
 from sdcm.prometheus import start_metrics_server
 from sdcm.provision import provisioner_factory
 from sdcm.provision.helpers.certificate import (
-    create_ca, create_certificate, import_ca_to_jks_truststore, SCYLLA_SSL_CONF_DIR, CLIENT_FACING_CERTFILE,
+    create_ca, create_certificate, SCYLLA_SSL_CONF_DIR, CLIENT_FACING_CERTFILE,
     CLIENT_FACING_KEYFILE, CA_CERT_FILE, CA_KEY_FILE, CLIENT_CERT_FILE, CLIENT_KEY_FILE)
 from sdcm.remote import RemoteCmdRunnerBase
 from sdcm.sct_events.continuous_event import ContinuousEventsRegistry
@@ -77,9 +77,8 @@ def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # pylint: di
         curr_dir = os.getcwd()
         try:
             os.chdir(Path(__file__).parent.parent)
-            create_ca()
             localhost = LocalHost(user_prefix='unit_test_fake_user', test_id='unit_test_fake_test_id')
-            import_ca_to_jks_truststore(localhost)
+            create_ca(localhost)
             create_certificate(CLIENT_FACING_CERTFILE, CLIENT_FACING_KEYFILE, cname="scylladb",
                                ca_cert_file=CA_CERT_FILE, ca_key_file=CA_KEY_FILE)
             create_certificate(CLIENT_CERT_FILE, CLIENT_KEY_FILE, cname="scylladb",

--- a/unit_tests/test_tester.py
+++ b/unit_tests/test_tester.py
@@ -176,9 +176,6 @@ class ClusterTesterForTests(ClusterTester):
         time.sleep(0.5)
         super().stop_event_device()
 
-    def create_ca(self):
-        pass
-
 
 class SubtestAndTeardownFailsTest(ClusterTesterForTests):
     def test(self):


### PR DESCRIPTION
There are a couple of error-prone situations when CA cert/key pair is created:
- the CA is created for every test run, even if the configuration under test
doesn't have encryption enabled (hence don't need CA to sign nodes certs)
- in case of artifacts tests there are situations when a Jenkins builder node
hosts several artifacts tests in a row, i.e. the test environment is not cleaned up
between tests. In this case SCT will try to import CA pem certificate to existing
Java truststore and will fail

The change addresses both problems:
- creation of CA is made optional, depending on whether client and/or server encryption
are enabled in the test configuration
- creation of CA is made idempotent between different executions of a test on the
same node - a check is added to CA creation procedure to ensure that CA is not already
present on the node

### Testing
- [x] :green_circle: [artifacts-ubuntu2004-arm-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-ubuntu2004-arm-test/4/)
- [x] :green_circle: [manager node test (which enables client encryption on the fly)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/ubuntu22-sanity-test/15/)
- [x] :green_circle: [ssl_hot_reloading nemesis test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/certs-rework-tests/28/)
- [x] :green_circle: [pr-provision test with client+server encryption](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/sct-pr-provision-test/9/)

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
