### PR TITLE
fix(parallel-operations): disable when force gossip

### DIFF
--- a/configurations/force-gossip-topology-changes.yaml
+++ b/configurations/force-gossip-topology-changes.yaml
@@ -1,0 +1,3 @@
+append_scylla_yaml:
+  force_gossip_topology_changes: true
+  enable_tablets: false

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3956,7 +3956,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         self.test_config = TestConfig()
         self._node_cycle = None
         self.params = kwargs.get('params', {})
-        self.parallel_node_operations = self.params.get("parallel_node_operations") or False
+        force_gossip = (self.params.get('append_scylla_yaml') or {}).get('force_gossip_topology_changes', False)
+        self.parallel_node_operations = False if force_gossip else self.params.get("parallel_node_operations") or False
         super().__init__(*args, **kwargs)
 
     def get_node_ips_param(self, public_ip=True):

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -343,6 +343,7 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods,too-many-
     compaction_collection_items_count_warning_threshold: int = None  # None
 
     enable_tablets: bool = None  # False, but default scylla.yaml for some versions (e.g. 6.0) override it to True
+    force_gossip_topology_changes: bool = None  # False
 
     def dict(  # pylint: disable=arguments-differ
         self,

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -400,6 +400,7 @@ class ScyllaYamlTest(unittest.TestCase):
                 'workdir': None,
                 'write_request_timeout_in_ms': None,
                 'enable_tablets': None,
+                'force_gossip_topology_changes': None,
             }
         )
 


### PR DESCRIPTION
When scylla yaml has `force_gossip_topology_changes` set to `True` then parallel node operations should be disabled.

Added proper handling, configuration and updated `ScyllaYaml` model.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/nemesis/job/longevity-5gb-1h-GrowShrinkClusterNemesis-gce-test/4/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
