### PR TITLE
fix(cql-stress): update cql-stress to latest version

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -216,7 +216,7 @@ stress_image:
   kcl: 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC'
   harry: 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816'
   latte: 'scylladb/hydra-loaders:latte-0.26.1-scylladb'
-  cql-stress-cassandra-stress: 'docker.io/scylladb/hydra-loaders:cql-stress-cassandra-stress-20240606'
+  cql-stress-cassandra-stress: 'docker.io/scylladb/hydra-loaders:cql-stress-cassandra-stress-20240718'
 
 service_level_shares: [1000]
 

--- a/docker/cql-stress-cassandra-stress/image
+++ b/docker/cql-stress-cassandra-stress/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/hydra-loaders:cql-stress-cassandra-stress-20240606
+scylladb/hydra-loaders:cql-stress-cassandra-stress-20240718

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -655,21 +655,11 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
-        self.assertEqual(conf.get('stress_image'),
-                         {'alternator-dns': 'scylladb/hydra-loaders:alternator-dns-0.1',
-                          'cassandra-stress': 'scylla-bench',
-                          'cdc-stresser': 'scylladb/hydra-loaders:cdc-stresser-A',
-                          'gemini': 'scylladb/hydra-loaders:gemini-v1.8.6',
-                          'ndbench': 'scylladb/hydra-loaders:ndbench-jdk8-A',
-                          'nosqlbench': 'scylladb/hydra-loaders:nosqlbench-A',
-                          'scylla-bench': 'scylladb/something',
-                          'ycsb': 'scylladb/something_else',
-                          'kcl': 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC',
-                          'harry': 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816',
-                          'latte': 'scylladb/hydra-loaders:latte-0.26.1-scylladb',
-                          'cql-stress-cassandra-stress': 'docker.io/scylladb/hydra-loaders:cql-stress-cassandra-stress-20240606'})
+        stress_image = conf.get('stress_image')
+        self.assertEqual(stress_image['ndbench'], 'scylladb/hydra-loaders:ndbench-jdk8-A')
+        self.assertEqual(stress_image['nosqlbench'], 'scylladb/hydra-loaders:nosqlbench-A')
 
-        self.assertEqual(conf.get('stress_image.gemini'), 'scylladb/hydra-loaders:gemini-v1.8.6')
+        self.assertEqual(conf.get('stress_image.scylla-bench'), 'scylladb/something')
         self.assertEqual(conf.get('stress_image.non-exist'), None)
 
         self.assertEqual(conf.get('stress_read_cmd'), ['cassandra_stress', 'cassandra_stress'])


### PR DESCRIPTION
Updating cql-stress to latest version.
This version contains the fix for https://github.com/scylladb/cql-stress/pull/86

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - integration tests, I'll take it for a ride also in different test where I need it

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
