### PR TITLE
test(elasticity): grow-shrink cluster perf test with doubling load

### DIFF
--- a/configurations/performance/cassandra-stress-650gb-8-col-i4i-80-percent-throughput-ent.yaml
+++ b/configurations/performance/cassandra-stress-650gb-8-col-i4i-80-percent-throughput-ent.yaml
@@ -1,0 +1,10 @@
+prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=300 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..162500000",
+                    "cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=300 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=162500000..325000000",
+                    "cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=300 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=325000000..487500000",
+                    "cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=300 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=487500000..650000000"]
+
+instance_type_db: 'i4i.2xlarge'
+# throttling to reach 80% throughput is not verified
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=2850m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=27000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=24000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=22000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,6500000)' "

--- a/configurations/performance/cassandra-stress-650gb-8-col-i4i-80-percent-throughput-oss.yaml
+++ b/configurations/performance/cassandra-stress-650gb-8-col-i4i-80-percent-throughput-oss.yaml
@@ -1,0 +1,10 @@
+prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=300 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..162500000",
+                    "cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=300 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=162500000..325000000",
+                    "cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=300 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=325000000..487500000",
+                    "cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=300 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=487500000..650000000"]
+
+instance_type_db: 'i4i.2xlarge'
+# throttling to reach 80% throughput is not verified
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=2850m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=24000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=20000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=17000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,6500000)' "

--- a/configurations/performance/cql-stress-650gb-8-col-i4i-80-percent-throughput-ent.yaml
+++ b/configurations/performance/cql-stress-650gb-8-col-i4i-80-percent-throughput-ent.yaml
@@ -1,0 +1,12 @@
+prepare_write_cmd: ["cql-stress-cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..162500000",
+                    "cql-stress-cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=162500000..325000000",
+                    "cql-stress-cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=325000000..487500000",
+                    "cql-stress-cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=487500000..650000000"]
+
+instance_type_db: 'i4i.2xlarge'
+# throttling to reach 80% throughput is not verified
+stress_cmd_w: "cql-stress-cassandra-stress write no-warmup cl=QUORUM duration=2850m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=27000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_r: "cql-stress-cassandra-stress read no-warmup  cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=24000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_m: "cql-stress-cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=22000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,6500000)' "
+use_hdr_cs_histogram: false  # https://github.com/scylladb/cql-stress/issues/95
+use_prepared_loaders: false  # no need for that - using docker anyway

--- a/configurations/performance/cql-stress-650gb-8-col-i4i-80-percent-throughput-oss.yaml
+++ b/configurations/performance/cql-stress-650gb-8-col-i4i-80-percent-throughput-oss.yaml
@@ -1,0 +1,12 @@
+prepare_write_cmd: ["cql-stress-cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..162500000",
+                    "cql-stress-cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=162500000..325000000",
+                    "cql-stress-cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=325000000..487500000",
+                    "cql-stress-cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=487500000..650000000"]
+
+instance_type_db: 'i4i.2xlarge'
+# throttling to reach 80% throughput is not verified
+stress_cmd_w: "cql-stress-cassandra-stress write no-warmup cl=QUORUM duration=2850m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=24000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_r: "cql-stress-cassandra-stress read no-warmup  cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=20000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_m: "cql-stress-cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=17000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,6500000)' "
+use_hdr_cs_histogram: false  # https://github.com/scylladb/cql-stress/issues/95
+use_prepared_loaders: false  # no need for that - using docker anyway

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -262,5 +262,6 @@ kafka_backend: null
 kafka_connectors: []
 
 run_scylla_doctor: false
+nemesis_double_load_during_grow_shrink_duration: 0
 
 enterprise_disable_kms: false

--- a/jenkins-pipelines/performance_staging/scylla-master-perf-regression-latency-650gb-elasticity.jenkinsfile
+++ b/jenkins-pipelines/performance_staging/scylla-master-perf-regression-latency-650gb-elasticity.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    availability_zone: 'a',
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: """["test-cases/performance/perf-regression-latency-650gb-elasticity.yaml", "configurations/performance/cql-stress-650gb-8-col-i4i-80-percent-throughput-oss.yaml"]""",
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"]
+)

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -323,6 +323,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
     def run_workload(self, stress_cmd, nemesis=False, sub_type=None):
         # create new document in ES with doc_id = test_id
         # allow to correctly save results for future compare
+        self.stress_cmd = stress_cmd
         if sub_type is None:
             sub_type = 'read' if ' read ' in stress_cmd else 'write' if ' write ' in stress_cmd else 'mixed'
         test_index = f'latency-during-ops-{sub_type}'

--- a/sdcm/cql_stress_cassandra_stress_thread.py
+++ b/sdcm/cql_stress_cassandra_stress_thread.py
@@ -134,6 +134,7 @@ class CqlStressCassandraStressThread(CassandraStressThread):
                                                     command_line="-c 'tail -f /dev/null'",
                                                     extra_docker_opts=f'{cpu_options} '
                                                     '--network=host '
+                                                    '--security-opt seccomp=unconfined '
                                                     f'--label shell_marker={self.shell_marker}'
                                                     f' --entrypoint /bin/bash')
         stress_cmd = self.create_stress_cmd(cmd_runner, keyspace_idx, loader)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4066,12 +4066,23 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             InfoEvent(f'FinishEvent - ShrinkCluster failed decommissioning a node {self.target_node} with error '
                       f'{str(exc)}').publish()
 
+    @latency_calculator_decorator(legend="Doubling cluster load")
+    def _double_cluster_load(self, duration: int) -> None:
+        duration = 30
+        self.log.info("Doubling the load on the cluster for %s minutes", duration)
+        stress_queue = self.tester.run_stress_thread(
+            stress_cmd=self.tester.stress_cmd, stress_num=1, stats_aggregate_cmds=False, duration=duration)
+        results = self.tester.get_stress_results(queue=stress_queue, store_results=False)
+        self.log.info(f"Double load results: {results}")
+
     def disrupt_grow_shrink_cluster(self):
         sleep_time_between_ops = self.cluster.params.get('nemesis_sequence_sleep_between_ops')
         if not self.has_steady_run and sleep_time_between_ops:
             self.steady_state_latency()
             self.has_steady_run = True
         self._grow_cluster(rack=None)
+        if duration := self.tester.params.get('nemesis_double_load_during_grow_shrink_duration'):
+            self._double_cluster_load(duration)
         self._shrink_cluster(rack=None)
 
     # NOTE: version limitation is caused by the following:

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1495,6 +1495,9 @@ class SCTConfiguration(dict):
              type=int, k8s_multitenancy_supported=True,
              help="Multiply the list of nemesis to execute by the specified factor"),
 
+        dict(name="nemesis_double_load_during_grow_shrink_duration", env="SCT_NEMESIS_DOUBLE_LOAD_DURING_GROW_SHRINK_DURATION", type=int,
+             help="After growing (and before shrink) in GrowShrinkCluster nemesis it will double the load for provided duration."),
+
         dict(name="raid_level", env="SCT_RAID_LEVEL",
              type=int,
              help="Number of of raid level: 0 - RAID0, 5 - RAID5"),

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -397,6 +397,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         InfoEvent(message=f"TEST_START test_id={self.test_config.test_id()}").publish()
         self.bisect_ref_value = None
         self.bisect_result_value = None
+        self.stress_cmd = self.params.get('stress_cmd')
 
     def _init_test_duration(self):
         self._stress_duration: int = self.params.get('stress_duration')
@@ -1982,6 +1983,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         # stress_cmd = self._cs_add_node_flag(stress_cmd)
         if duration:
             timeout = self.get_duration(duration)
+            if ' duration' in stress_cmd:
+                stress_cmd = re.sub(r'\sduration=\d+[mhd]\s', f' duration={duration}m ', stress_cmd)
         elif self._stress_duration and ' duration=' in stress_cmd:
             timeout = self.get_duration(self._stress_duration)
             stress_cmd = re.sub(r'\sduration=\d+[mhd]\s', f' duration={self._stress_duration}m ', stress_cmd)
@@ -2015,6 +2018,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         # pylint: disable=too-many-locals
         if duration:
             timeout = self.get_duration(duration)
+            if ' duration' in stress_cmd:
+                stress_cmd = re.sub(r'\sduration=\d+[mhd]\s', f' duration={duration}m ', stress_cmd)
         elif self._stress_duration and ' duration=' in stress_cmd:
             timeout = self.get_duration(self._stress_duration)
             stress_cmd = re.sub(r'\sduration=\d+[mhd]\s', f' duration={self._stress_duration}m ', stress_cmd)

--- a/test-cases/performance/perf-regression-latency-650gb-elasticity.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-elasticity.yaml
@@ -1,0 +1,39 @@
+test_duration: 3000
+prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..162500000",
+                    "cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=162500000..325000000",
+                    "cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=325000000..487500000",
+                    "cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=487500000..650000000"]
+
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=2850m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=250 fixed=20332/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=250 fixed=10310/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=250 fixed=8750/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,6500000)' "
+
+n_db_nodes: 3
+nemesis_add_node_cnt: 3
+n_loaders: 4
+n_monitor_nodes: 1
+
+instance_type_loader: 'c6i.2xlarge'
+instance_type_monitor: 't3.large'
+instance_type_db: 'i4i.2xlarge'
+
+nemesis_class_name: 'GrowShrinkClusterNemesis'
+nemesis_interval: 30
+nemesis_sequence_sleep_between_ops: 10
+
+user_prefix: 'elasticity-test'
+space_node_threshold: 644245094
+ami_id_db_scylla_desc: 'VERSION_DESC'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
+backtrace_decoding: false
+print_kernel_callstack: true
+
+store_perf_results: true
+email_recipients: ["scylla-perf-results@scylladb.com"]
+use_prepared_loaders: true
+use_hdr_cs_histogram: true
+email_subject_postfix: 'elasticity test'
+nemesis_double_load_during_grow_shrink_duration: 30
+parallel_node_operations: true


### PR DESCRIPTION
After releasing Scylla 6.0 we performed elasticity test which was basically grow-shrink cluster test in single AZ where after grow we double cluster load. It was tested also with cql-stress. We want to keep this test for future reference/rerun.

Adjusted grow-shrink nemesis to double the load for specified duration (in minutes). Configured by new param
`nemesis_double_load_during_grow_shrink_duration`. Also generated bunch of configurations to easily switch between cql-stress and c-s tools and OSS/Enterprise stress configurations.

closes: https://github.com/scylladb/qa-tasks/issues/1699

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [mixed with cql-stress on OSS](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/elasticity-test/3/) -failed due https://github.com/scylladb/scylla-cluster-tests/issues/7880 (should be tackled in differen PR)
- [X] - [write with c-s](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/perf-regression-elasticity-test/9/)
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
