### PR TITLE
fix(perf-simple-query): fix results table

### DIFF
--- a/sdcm/utils/microbenchmarking/perf_simple_query_reporter.py
+++ b/sdcm/utils/microbenchmarking/perf_simple_query_reporter.py
@@ -54,6 +54,7 @@ class PerfSimpleQueryAnalyzer(BaseResultsAnalyzer):
             return False
 
         test_stats = self._get_perf_simple_query_result(doc)
+        columns = test_stats['stats'].keys()
         test_details = self._get_test_details(doc)
         if not (test_stats and test_details):
             self.log.debug("Could not find test statistics, regression check is skipped")
@@ -109,8 +110,11 @@ class PerfSimpleQueryAnalyzer(BaseResultsAnalyzer):
             table_line['test_version'] = data['results']['perf_simple_query_result']['versions'][
                 'scylla-server']
             stats = data['results']['perf_simple_query_result']['stats']
-            for key, value in stats.items():
+            for key in columns:
+                value = stats.get(key, 'N/A')
                 table_line[key] = value
+                if value == 'N/A':
+                    continue
                 if value > 0 and key != "mad tps":
                     diff = test_stats['stats'][key] / value
                     table_line["is_" + key + "_within_limits"] = False


### PR DESCRIPTION
When new column to perf simple query test is added it breaks the result table.

Fix by getting available columns from current run and create table with all of them. In case there's no result for that column in the past, replace with `N/A`.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/7496

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
tested in staging:
![image](https://github.com/scylladb/scylla-cluster-tests/assets/18242288/27e6f892-5c21-4993-b13f-7bc714f16816)


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [X] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
