### PR TITLE
feature(remoter): execuation of long running command

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4994,7 +4994,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
     def decommission(self, node: BaseNode, timeout: int | float = None):
         with adaptive_timeout(operation=Operations.DECOMMISSION, node=node):
-            node.run_nodetool("decommission", timeout=timeout, retry=0)
+            node.run_nodetool("decommission", timeout=timeout, long_running=True, retry=0)
         self.verify_decommission(node)
 
     @property

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -34,7 +34,7 @@ from importlib import import_module
 from typing import List, Optional, Dict, Union, Set, Iterable, ContextManager, Any, IO, AnyStr, Callable
 from datetime import datetime
 from textwrap import dedent
-from functools import cached_property, wraps, lru_cache
+from functools import cached_property, wraps, lru_cache, partial
 from collections import defaultdict
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -73,6 +73,7 @@ from sdcm.provision.helpers.certificate import (
     export_pem_cert_to_pkcs12_keystore, CA_CERT_FILE, CA_KEY_FILE, JKS_TRUSTSTORE_FILE, TLSAssets)
 from sdcm.remote import RemoteCmdRunnerBase, LOCALRUNNER, NETWORK_EXCEPTIONS, shell_script_cmd, RetryableNetworkException
 from sdcm.remote.libssh2_client import UnexpectedExit as Libssh2_UnexpectedExit
+from sdcm.remote.remote_long_running import run_long_running_cmd
 from sdcm.remote.remote_file import remote_file, yaml_file_to_dict, dict_to_yaml_file
 from sdcm import wait, mgmt
 from sdcm.sct_config import SCTConfiguration
@@ -2589,9 +2590,10 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         return f"{self.add_install_prefix('/usr/bin/nodetool')} {options} {sub_cmd} {args}"
 
     # pylint: disable=inconsistent-return-statements
-    def run_nodetool(self, sub_cmd: str, args: str = "", options: str = "", timeout: int = None,
+    def run_nodetool(self, sub_cmd: str, args: str = "", options: str = "", timeout: int = None,  # noqa: PLR0913
                      ignore_status: bool = False, verbose: bool = True, coredump_on_timeout: bool = False,
-                     warning_event_on_exception: Exception = None, error_message: str = "", publish_event: bool = True, retry: int = 1
+                     warning_event_on_exception: Exception = None, error_message: str = "", publish_event: bool = True, retry: int = 1,
+                     long_running: bool = False
                      ) -> Result:
         """
             Wrapper for nodetool command.
@@ -2612,6 +2614,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
                                            in the list
         :param error_message: additional error message to exception message
         :param publish_event: publish event or not
+        :param long_running: command would be executed on host, and polled for results
         :return: Remoter result object
         """
         cmd = self._gen_nodetool_cmd(sub_cmd, args, options)
@@ -2621,8 +2624,13 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
                            options=options,
                            publish_event=publish_event) as nodetool_event:
             try:
+                if long_running:
+                    runner = partial(run_long_running_cmd, self.remoter)
+                else:
+                    runner = self.remoter.run
                 result = \
-                    self.remoter.run(cmd, timeout=timeout, ignore_status=ignore_status, verbose=verbose, retry=retry)
+                    runner(cmd, timeout=timeout, ignore_status=ignore_status, verbose=verbose, retry=retry)
+
                 self.log.debug("Command '%s' duration -> %s s" % (result.command, result.duration))
 
                 nodetool_event.duration = result.duration

--- a/sdcm/cluster_baremetal.py
+++ b/sdcm/cluster_baremetal.py
@@ -166,7 +166,7 @@ class LoaderSetPhysical(cluster.BaseLoaderSet, PhysicalMachineCluster):  # pylin
         cluster.BaseLoaderSet.__init__(self, kwargs["params"])
         PhysicalMachineCluster.__init__(self, **kwargs)
 
-    @ classmethod
+    @classmethod
     def _get_node_ips_param(cls, ip_type='public'):
         return cluster.BaseLoaderSet.get_node_ips_param(ip_type)
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1960,14 +1960,14 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def repair_nodetool_rebuild(self):
         with adaptive_timeout(Operations.REBUILD, self.target_node, timeout=HOUR_IN_SEC * 48):
-            self.target_node.run_nodetool('rebuild', retry=0)
+            self.target_node.run_nodetool('rebuild', long_running=True, retry=0)
 
     def nodetool_cleanup_on_all_nodes_parallel(self):
         # Inner disrupt function for ParallelObject
         def _nodetool_cleanup(node):
             InfoEvent('NodetoolCleanupMonkey %s' % node).publish()
             with adaptive_timeout(Operations.CLEANUP, node, timeout=HOUR_IN_SEC * 48):
-                node.run_nodetool(sub_cmd="cleanup", retry=0)
+                node.run_nodetool(sub_cmd="cleanup", long_running=True, retry=0)
 
         parallel_objects = ParallelObject(self.cluster.nodes, num_workers=min(
             32, len(self.cluster.nodes)), timeout=HOUR_IN_SEC * 48)
@@ -3060,7 +3060,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                                               warning_event_on_exception=(UnexpectedExit, Libssh2UnexpectedExit),
                                               error_message="Repair failed as expected. ",
                                               publish_event=False,
-                                              retry=0)
+                                              long_running=True, retry=0)
             except (UnexpectedExit, Libssh2UnexpectedExit):
                 self.log.info('Repair failed as expected')
             except Exception:
@@ -3874,7 +3874,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                           sub_cmd="decommission",
                           timeout=nodetool_decommission_timeout,
                           warning_event_on_exception=(Exception,),
-                          retry=0)
+                          long_running=True, retry=0)
 
         watcher = partial(
             self._call_disrupt_func_after_expression_logged,
@@ -3892,10 +3892,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 ParallelObject(objects=[trigger, watcher], timeout=full_operations_timeout).call_objects()
             if new_node := decommission_post_action():
                 new_node.wait_node_fully_start()
-                new_node.run_nodetool("rebuild", retry=0)
+                new_node.run_nodetool("rebuild", long_running=True, retry=0)
             else:
                 self.target_node.wait_node_fully_start()
-                self.target_node.run_nodetool(sub_cmd="rebuild", retry=0)
+                self.target_node.run_nodetool(sub_cmd="rebuild", long_running=True, retry=0)
 
     def start_and_interrupt_repair_streaming(self):
         """
@@ -3906,7 +3906,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         """
         self._destroy_data_and_restart_scylla()
         trigger = partial(
-            self.target_node.run_nodetool, sub_cmd="repair", warning_event_on_exception=(Exception,), retry=0, timeout=600,
+            self.target_node.run_nodetool, sub_cmd="repair", warning_event_on_exception=(Exception,), long_running=True, retry=0, timeout=600,
         )
         log_follower = self.target_node.follow_system_log(patterns=["Repair 1 out of"])
         timeout = 1200
@@ -3924,7 +3924,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.target_node.wait_node_fully_start()
 
         with adaptive_timeout(Operations.REBUILD, self.target_node, timeout=HOUR_IN_SEC * 48):
-            self.target_node.run_nodetool("rebuild", retry=0)
+            self.target_node.run_nodetool("rebuild", long_running=True, retry=0)
 
     def start_and_interrupt_rebuild_streaming(self):
         """
@@ -3940,7 +3940,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             timeout += 1200  # Azure reboot can take up to 20min to initiate
 
         trigger = partial(
-            self.target_node.run_nodetool, sub_cmd="rebuild", warning_event_on_exception=(Exception,), retry=0, timeout=timeout//2
+            self.target_node.run_nodetool, sub_cmd="rebuild", warning_event_on_exception=(Exception,), long_running=True, retry=0, timeout=timeout//2
         )
         log_follower = self.target_node.follow_system_log(patterns=["rebuild from dc:"])
 
@@ -3955,7 +3955,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         ParallelObject(objects=[trigger, watcher], timeout=timeout + 60).call_objects()
         self.target_node.wait_node_fully_start(timeout=300)
         with adaptive_timeout(Operations.REBUILD, self.target_node, timeout=HOUR_IN_SEC * 48):
-            self.target_node.run_nodetool("rebuild", retry=0)
+            self.target_node.run_nodetool("rebuild", long_running=True, retry=0)
 
     def disrupt_decommission_streaming_err(self):
         """
@@ -4598,7 +4598,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 with wait_for_log_lines(node=new_node, start_line_patterns=["rebuild.*started with keyspaces=", "Rebuild starts"],
                                         end_line_patterns=["rebuild.*finished with keyspaces=", "Rebuild succeeded"],
                                         start_timeout=60, end_timeout=600):
-                    new_node.run_nodetool(sub_cmd=f"rebuild -- {datacenters[0]}", retry=0)
+                    new_node.run_nodetool(sub_cmd=f"rebuild -- {datacenters[0]}", long_running=True, retry=0)
                 InfoEvent(message='Running full cluster repair on each node').publish()
                 for cluster_node in self.cluster.nodes:
                     cluster_node.run_nodetool(sub_cmd="repair -pr", publish_event=True)

--- a/sdcm/remote/remote_long_running.py
+++ b/sdcm/remote/remote_long_running.py
@@ -1,0 +1,69 @@
+import time
+import logging
+from uuid import uuid4
+from pathlib import Path
+from contextlib import ExitStack
+
+from sdcm.remote.remote_cmd_runner import RemoteCmdRunnerBase
+from sdcm.remote.libssh2_client.result import Result
+from sdcm.remote.libssh2_client.exceptions import UnexpectedExit
+
+logger = logging.getLogger(__name__)
+
+
+def run_long_running_cmd(remoter: RemoteCmdRunnerBase,
+                         cmd: str,
+                         timeout: float | None = None,
+                         ignore_status: bool = False,
+                         verbose: bool = True,
+                         retry: int = 0):
+    """
+    Run a long-running command on the remote host. The command is executed in the background and the function waits
+    for the process of the command to finish.
+
+    this function is useful for running commands that take a long time to finish, and we might get ssh disconnects during
+    the command, this is designed to be able to keep on check on the remote process after the ssh reconnects.
+    hence this function doesn't support retrying of the commands, and aiming at command that can be executed only once.
+    i.e. nodetool decommission or nodetool darin
+
+    The function returns the result of the command, same as remote.run() or remote.sudo() functions.
+    """
+    assert retry == 0, "retry is not supported for long running commands, always use it with retry=0"
+
+    cmd_uuid = uuid4()
+    cmd_stdout_log = Path('/tmp') / f'remoter_stdout_{cmd_uuid}.log'
+    cmd_stderr_log = Path('/tmp') / f'remoter_stderr_{cmd_uuid}.log'
+    cmd_exit_log = Path('/tmp') / f'remoter_exit_{cmd_uuid}.log'
+    cmd_bash = Path('/tmp') / f'remoter_cmd_{cmd_uuid}.sh'
+
+    with ExitStack() as stack:
+        def clear_tmp_files():
+            for log_file in (cmd_stdout_log, cmd_stderr_log, cmd_exit_log, cmd_bash):
+                remoter.run(f'rm {log_file}', verbose=False, ignore_status=True)
+
+        stack.callback(clear_tmp_files)
+        remoter.run(f'echo "{cmd}" > {cmd_bash}')
+
+        start_time = time.perf_counter()
+
+        remote_command = f'(bash -o pipefail {cmd_bash} ; echo $? > {cmd_exit_log}) >& {cmd_stdout_log} 2> {cmd_stderr_log} </dev/null  &  echo $!'
+        if verbose:
+            logger.debug("<%s> execute run_long_running_cmd: %s", remoter.hostname, remote_command)
+        pid = remoter.run(remote_command, retry=0, verbose=verbose).stdout
+
+        remoter.run(f'while [ -e /proc/{pid.strip()} ]; do sleep 0.1; done', timeout=timeout, retry=10, verbose=False)
+
+        stdout = str(remoter.run(f'cat {cmd_stdout_log}', verbose=False).stdout)
+        stderr = str(remoter.run(f'cat {cmd_stderr_log}', verbose=False).stdout)
+        exit_code = int(remoter.run(f'cat {cmd_exit_log}', verbose=False).stdout)
+        result = Result(command=cmd, stdout=stdout,
+                        stderr=stderr, exited=exit_code,
+                        hide=('stderr', 'stdout'), pty=False)
+
+        result.duration = time.perf_counter() - start_time
+        result.exit_status = exit_code  # for compatibility with subprocess.run
+
+        if not ignore_status and exit_code != 0:
+            raise UnexpectedExit(result=result)
+
+        return result

--- a/unit_tests/test_remote_long_running.py
+++ b/unit_tests/test_remote_long_running.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import pytest
+
+from sdcm.remote import LOCALRUNNER
+from sdcm.remote.remote_long_running import run_long_running_cmd
+from sdcm.remote.libssh2_client import UnexpectedExit
+
+
+@pytest.fixture(scope='function', autouse=True)
+def fixture_check_tmp_files_cleared():
+    yield
+    assert list(Path('/tmp').glob('remoter_*')) == []
+
+
+def test_long_command_failing():
+    with pytest.raises(UnexpectedExit,  match=r'.*Exit code: 127.*') as exc_info:
+        run_long_running_cmd(LOCALRUNNER, cmd='sleep 1 && bbb', timeout=100)
+
+    assert exc_info.value.result.command == 'sleep 1 && bbb'
+    assert "line 1: bbb: command not found" in exc_info.value.result.stderr
+    assert exc_info.value.result.stdout == ""
+    assert exc_info.value.result.exited == 127
+    assert exc_info.value.result.return_code == 127
+    assert exc_info.value.result.duration > 1
+
+
+def test_long_command_success():
+    result = run_long_running_cmd(LOCALRUNNER, cmd="sleep 1 && echo 'cmd is done'", timeout=100)
+    assert result.ok
+    assert result.stdout == "cmd is done\n"
+    assert result.stderr == ""
+    assert result.exited == 0
+    assert result.return_code == 0
+    assert result.duration > 1

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -240,7 +240,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             # replace the packages
             node.remoter.run(r'rpm -qa scylla\*')
             # flush all memtables to SSTables
-            node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True, retry=0)
+            node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True, long_running=True, retry=0)
             node.run_nodetool("snapshot")
             node.stop_scylla_server()
             # update *development* packages
@@ -267,7 +267,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             InfoEvent(message='upgrade_node - ended to "download_scylla_repo"').publish()
             # flush all memtables to SSTables
             InfoEvent(message='upgrade_node - started to "drain"').publish()
-            node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True, retry=0)
+            node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True, long_running=True, retry=0)
             InfoEvent(message='upgrade_node - ended to "drain"').publish()
             InfoEvent(message='upgrade_node - started to "nodetool snapshot"').publish()
             node.run_nodetool("snapshot")
@@ -371,7 +371,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         result = node.remoter.run('scylla --version')
         orig_ver = result.stdout.strip()
         # flush all memtables to SSTables
-        node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True, retry=0)
+        node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True, long_running=True, retry=0)
         # backup the data
         node.run_nodetool("snapshot")
         node.stop_scylla_server(verify_down=False)


### PR DESCRIPTION
cause we have issues with long running ssh commands that we can retry, if node is a bit load at the time of the operation we might get disconnected, and fail the command complectly from SCT end.

in this change we introduce a way to run the command in the background while logging stdout, stderr, and exit code.

and poll for the finish of the process by its pid

in the end we'll collect all the logs, and retry results as if it with a regular remoter execution

Fixes: #7781

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-5gb-1h-DecommissionMonkey-aws-test/11/ [Argus](https://argus.scylladb.com/test/ad50c9cd-7808-49cc-94dc-71d8a39f4ea0/runs)
- [x] 🟢   tier1 case where it happend last week: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-schema-topology-changes-12h-test/3 [Argus](https://argus.scylladb.com/test/9d982f7d-6c51-4359-9aff-1a1ce6263c0c/runs?additionalRuns[]=d26dc22f-fda9-4b6e-b677-1d9fc1b5a263)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
