### PR TITLE
test(cql-stress): new test to cover how mixed mode is working

### DIFF
--- a/docker/cql-stress-cassandra-stress/Dockerfile
+++ b/docker/cql-stress-cassandra-stress/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.78 as builder
+FROM rust:1.78 AS builder
 
 ARG BRANCH
 ARG REPO
@@ -11,6 +11,6 @@ RUN git clone ${REPO} -b ${BRANCH}
 RUN cd cql-stress && cargo build --release --bin cql-stress-cassandra-stress
 
 
-FROM rust:1.73-slim as app
+FROM rust:1.73-slim AS app
 
 COPY --from=builder /cql-stress/target/release/cql-stress-cassandra-stress /usr/local/bin/

--- a/docker/cql-stress-cassandra-stress/README.md
+++ b/docker/cql-stress-cassandra-stress/README.md
@@ -5,3 +5,14 @@ docker build . -t ${CQL_STRESS_CS_DOCKER_IMAGE}
 docker push ${CQL_STRESS_CS_DOCKER_IMAGE}
 echo "${CQL_STRESS_CS_DOCKER_IMAGE}" > image
 ```
+
+### build from a fork/branch
+```
+BRANCH=fix_mixed_stmt_preparation
+GIT_FORK=https://github.com/muzarski/cql-stress.git
+
+export CQL_STRESS_CS_DOCKER_IMAGE=scylladb/hydra-loaders:cql-stress-cassandra-stress-$(date +'%Y%m%d')-${BRANCH}
+docker build . -t ${CQL_STRESS_CS_DOCKER_IMAGE} --build-arg BRANCH=${BRANCH} --build-arg REPO=${GIT_FORK}
+docker push ${CQL_STRESS_CS_DOCKER_IMAGE}
+
+```


### PR DESCRIPTION
we have few issue with the mixed mode, regarding counter related
schema and operations, we need this cover to make sure we don't
waste time on such issues.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢  integration test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
