### PR TITLE
fix(nemesis): parallel cleanups in all nemesis using cleanups

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1316,11 +1316,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 new_node.set_seed_flag(target_is_seed)
                 self.cluster.update_seed_provider()
             try:
-                test_keyspaces = self.cluster.get_test_keyspaces()
-                for node in self.cluster.nodes:
-                    with adaptive_timeout(Operations.CLEANUP, node=node, timeout=HOUR_IN_SEC * 48):
-                        for keyspace in test_keyspaces:
-                            node.run_nodetool(sub_cmd='cleanup', args=keyspace, retry=0)
+                self.nodetool_cleanup_on_all_nodes_parallel()
             finally:
                 self.unset_current_running_nemesis(new_node)
         return new_node
@@ -1966,7 +1962,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         with adaptive_timeout(Operations.REBUILD, self.target_node, timeout=HOUR_IN_SEC * 48):
             self.target_node.run_nodetool('rebuild', retry=0)
 
-    def disrupt_nodetool_cleanup(self):
+    def nodetool_cleanup_on_all_nodes_parallel(self):
         # Inner disrupt function for ParallelObject
         def _nodetool_cleanup(node):
             InfoEvent('NodetoolCleanupMonkey %s' % node).publish()
@@ -1976,6 +1972,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         parallel_objects = ParallelObject(self.cluster.nodes, num_workers=min(
             32, len(self.cluster.nodes)), timeout=HOUR_IN_SEC * 48)
         parallel_objects.run(_nodetool_cleanup)
+
+    def disrupt_nodetool_cleanup(self):
+        self.nodetool_cleanup_on_all_nodes_parallel()
 
     def _prepare_test_table(self, ks='keyspace1', table=None):
         ks_cfs = self.cluster.get_non_system_ks_cf_list(db_node=self.target_node)
@@ -3585,11 +3584,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             # In order to eliminate cases that we miss a "data loss" bug because of it, we cleanup this data.
             # This fix important when just user profile is run in the test and "keyspace1" doesn't exist.
             try:
-                test_keyspaces = self.cluster.get_test_keyspaces()
-                for node in self.cluster.nodes:
-                    with adaptive_timeout(Operations.CLEANUP, node, timeout=HOUR_IN_SEC * 48):
-                        for keyspace in test_keyspaces:
-                            node.run_nodetool(sub_cmd='cleanup', args=keyspace, retry=0)
+                self.nodetool_cleanup_on_all_nodes_parallel()
             finally:
                 self.unset_current_running_nemesis(new_node)
 


### PR DESCRIPTION
quite some time ago the `disrupt_nodetool_cleanup` change to work in parallel, but other nemesis that do the same sequence of running cleanup on all nodes (after topology changes) we still doing that in a sequence

this change align it for all of the places cleanup is used.

Note: for tablet cleanup should be no-op, and it's not really matter, but this change is for backporting into older branches

Closes: scylladb/qa-tasks#1690

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢   run decommission - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-5gb-1h-DecommissionMonkey-aws-test/10
- [x] 🟢  run add remove node - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-5gb-1h-TerminateAndRemoveNodeMonkey-aws-test/2

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
