### PR TITLE
fix(issue_cache): add pull-requests to cache

### DIFF
--- a/.github/dump_issues.py
+++ b/.github/dump_issues.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import csv
+import json
+import argparse
+import subprocess
+from pathlib import Path
+
+
+def dump_issue_status_to_csv(repository: str, target_dir: Path = Path('issues')) -> None:
+    q = """
+    gh api graphql --paginate -f query='
+    query Search($endCursor: String){
+      search(query: "repo:$$repository", type: ISSUE, first: 100,  after: $endCursor) {
+        issueCount
+        pageInfo {
+          startCursor
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          ... on PullRequest {
+            number
+            title
+            state
+            labels(first: 50, orderBy: {direction: DESC, field: CREATED_AT}) {
+              nodes {
+                name
+              }
+            }
+          }
+          ... on Issue {
+            number
+            title
+            state
+            labels(first: 50, orderBy: {direction: DESC, field: CREATED_AT}) {
+              nodes {
+                name
+              }
+            }
+          }
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+      }
+    }' | jq -s .
+    """
+
+    q = q.replace('$$repository', repository)
+    ret = subprocess.run(q, shell=True, text=True, capture_output=True, check=True)
+    pages = json.loads(ret.stdout)
+
+    all_issues = sum([p['data']['search']['nodes'] for p in pages], [])
+
+    assert all_issues, f'No issues found for repository {repository}'
+
+    target_dir.mkdir(exist_ok=True, parents=True)
+
+    with (target_dir / f'{repository.replace("/", "_")}.csv').open(mode='w') as csvfile:
+        issue_writer = csv.writer(csvfile, delimiter=',', quotechar=' ',  quoting=csv.QUOTE_MINIMAL)
+        for issue in all_issues:
+            labels = '|'.join([l['name'] for l in issue['labels']['nodes']])
+            issue_writer.writerow([
+                issue['number'],
+                issue['state'],
+                labels,
+                issue['title']])
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Dump a github repository issues/PRs status to csv file')
+    parser.add_argument('--repository', type=str, required=True,
+                        help='Github repository full name i.e. scylladb/scylla-pkg')
+    parser.add_argument('--target-dir', type=lambda p: Path(p).absolute(),
+                        default='./issues', help='path to save the issues csv file')
+
+    args = parser.parse_args()
+
+    dump_issue_status_to_csv(args.repository, args.target_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/cache-issues.yaml
+++ b/.github/workflows/cache-issues.yaml
@@ -8,10 +8,15 @@ jobs:
   collect_n_upload:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/dump_issues.py
+          sparse-checkout-cone-mode: false
       - run: |
           mkdir -p issues
           for repo in scylladb scylla-enterprise scylla-manager scylla-operator scylla-cluster-tests scylla-dtest qa-tasks scylla-tools-java ; do
-            gh issue list --state all --json number,state,labels --limit 30000 --template '{{range .}}{{.number}},{{.state}},{{range .labels}}{{.name}}|{{end}}{{println ""}}{{end}}' --repo scylladb/$repo > issues/scylladb_$repo.csv
+            .github/dump_issues.py --repository scylladb/$repo
           done
         env:
           GH_TOKEN: ${{ secrets.ISSUE_ASSIGNMENT_TO_PROJECT_TOKEN }}

--- a/.github/workflows/cache-issues.yaml
+++ b/.github/workflows/cache-issues.yaml
@@ -4,6 +4,10 @@ on:
     - cron: '0 */6 * * *'
   workflow_dispatch:
 
+  # TODO: added for testing, need to be removed
+  pull_request:
+  push:
+
 jobs:
   collect_n_upload:
     runs-on: ubuntu-latest
@@ -29,5 +33,5 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'us-east-1'
           S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          S3_KEY: 'issues'
+          S3_KEY: 'testing-issues/'
           FILE: ./issues


### PR DESCRIPTION
in some places we are using PRs and not issue to identify if we should be skipping something in the test code

for that we are now scannning diffrently the issue, with the usage of graphql and github search

Ref: scylladb/qa-tasks#1735

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
