### PR TITLE
fix(issue_cache): add pull-requests to cache

### DIFF
--- a/.github/workflows/cache-issues.yaml
+++ b/.github/workflows/cache-issues.yaml
@@ -7,11 +7,15 @@ on:
 jobs:
   collect_n_upload:
     runs-on: ubuntu-latest
+    # run only on main repository, won't work on forks
+    if: github.repository == 'scylladb/scylla-cluster-tests'
     steps:
       - run: |
           mkdir -p issues
+          mkdir -p issues/pull-requests
           for repo in scylladb scylla-enterprise scylla-manager scylla-operator scylla-cluster-tests scylla-dtest qa-tasks scylla-tools-java ; do
-            gh issue list --state all --json number,state,labels --limit 30000 --template '{{range .}}{{.number}},{{.state}},{{range .labels}}{{.name}}|{{end}}{{println ""}}{{end}}' --repo scylladb/$repo > issues/scylladb_$repo.csv
+            gh issue list --state all --json number,state,labels,title --limit 30000 --template '{{range .}}{{.number}},{{.state}},{{range .labels}}{{.name}}|{{end}},{{.title}}{{println ""}}{{end}}' --repo scylladb/$repo > issues/scylladb_$repo.csv
+            gh pr list --state all --json number,state,labels,title --limit 30000 --template '{{range .}}{{.number}},{{.state}},{{range .labels}}{{.name}}|{{end}},{{.title}}{{println ""}}{{end}}' --repo scylladb/$repo > issues/pull-requests/scylladb_$repo.csv
           done
         env:
           GH_TOKEN: ${{ secrets.ISSUE_ASSIGNMENT_TO_PROJECT_TOKEN }}

--- a/.github/workflows/cache-issues.yaml
+++ b/.github/workflows/cache-issues.yaml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: '0 */6 * * *'
   workflow_dispatch:
+  # TODO: Add for test, remove before merge
+  push:
+  pull_request:
 
 jobs:
   collect_n_upload:

--- a/unit_tests/test_utils_issues.py
+++ b/unit_tests/test_utils_issues.py
@@ -71,3 +71,10 @@ def test_opened_issue_tag_not_matching_version_tag(params):
 
     assert not SkipPerIssues(
         ["scylladb/qa-tasks#1615"], params)
+
+
+def test_closed_pull_request(params):
+    params.scylla_version = '2019.1.3'
+
+    assert not SkipPerIssues(
+        ["scylladb/scylla-cluster-tests#7832"], params)


### PR DESCRIPTION
in some places we are using PRs and not issue to identify
if we should be skipping something in the test code

we now generate two diffrent cache files on s3 for each repository
one for the issues and one for the pull requests

client code is merging it to once local cache, so it's mentioning
of either one should be working as expect, and read from cache,
not using affecting the hourly rate-limit

Ref: https://github.com/scylladb/qa-tasks/issues/1735

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] unit tests
- [x] integration tests
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
