### PR TITLE
feature(ruff): check for `unused-import (F401)`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-lint.select = ["PL", "YTT", "BLE", "F841"]
+lint.select = ["PL", "YTT", "BLE", "F841", "F401"]
 
 lint.ignore = ["E501", "PLR2004"]
 

--- a/sdcm/cluster_baremetal.py
+++ b/sdcm/cluster_baremetal.py
@@ -166,7 +166,7 @@ class LoaderSetPhysical(cluster.BaseLoaderSet, PhysicalMachineCluster):  # pylin
         cluster.BaseLoaderSet.__init__(self, kwargs["params"])
         PhysicalMachineCluster.__init__(self, **kwargs)
 
-    @ classmethod
+    @classmethod
     def _get_node_ips_param(cls, ip_type='public'):
         return cluster.BaseLoaderSet.get_node_ips_param(ip_type)
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -26,7 +26,6 @@ import tempfile
 import time
 import base64
 import random
-import socket
 import logging
 import traceback
 import contextlib
@@ -49,9 +48,9 @@ import invoke
 from invoke.exceptions import CommandTimedOut
 
 from sdcm import sct_abs_path, cluster
-from sdcm.cluster import DeadNode, ClusterNodesNotReady
+from sdcm.cluster import ClusterNodesNotReady
 from sdcm.provision.scylla_yaml.scylla_yaml import ScyllaYaml
-from sdcm.sct_config import SCTConfiguration, init_and_verify_sct_config
+from sdcm.sct_config import init_and_verify_sct_config
 from sdcm.test_config import TestConfig
 from sdcm.db_stats import PrometheusDBStats
 from sdcm.remote import LOCALRUNNER, NETWORK_EXCEPTIONS
@@ -62,11 +61,8 @@ from sdcm.remote.kubernetes_cmd_runner import (
 from sdcm.coredump import CoredumpExportFileThread
 from sdcm.log import SDCMAdapter
 from sdcm.mgmt import AnyManagerCluster
-from sdcm.sct_events.database import DatabaseLogEvent
-from sdcm.sct_events.filters import DbEventsFilter
 from sdcm.sct_events.health import ClusterHealthValidatorEvent
 from sdcm.sct_events.system import TestFrameworkEvent
-from sdcm.utils import properties
 import sdcm.utils.sstable.load_inventory as datasets
 from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations
 from sdcm.utils.ci_tools import get_test_name

--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -33,7 +33,7 @@ from cassandra.protocol import ProtocolException  # pylint: disable=no-name-in-m
 
 from sdcm.tester import ClusterTester
 from sdcm.utils.database_query_utils import fetch_all_rows
-from sdcm.utils.decorators import retrying, optional_cached_property
+from sdcm.utils.decorators import retrying
 from sdcm.utils.cdc.options import CDC_LOGTABLE_SUFFIX
 from sdcm.utils.version_utils import ComparableScyllaVersion
 from sdcm.utils.features import is_tablets_feature_enabled

--- a/sdcm/mgmt/__init__.py
+++ b/sdcm/mgmt/__init__.py
@@ -15,3 +15,7 @@ def get_scylla_manager_tool(manager_node, scylla_cluster=None) -> AnyManagerTool
     if manager_node.distro.is_rhel_like:
         return ScyllaManagerToolRedhatLike(manager_node=manager_node)
     return ScyllaManagerToolNonRedhat(manager_node=manager_node)
+
+
+__all__ = ['ScyllaManagerError', 'TaskStatus', 'HostStatus', 'HostSsl', 'HostRestStatus',
+           'AnyManagerTool', 'AnyManagerCluster', 'get_scylla_manager_tool']

--- a/sdcm/provision/scylla_yaml/__init__.py
+++ b/sdcm/provision/scylla_yaml/__init__.py
@@ -16,3 +16,6 @@ from .auxiliaries import ServerEncryptionOptions, ClientEncryptionOptions, SeedP
 from .certificate_builder import ScyllaYamlCertificateAttrBuilder
 from .cluster_builder import ScyllaYamlClusterAttrBuilder
 from .node_builder import ScyllaYamlNodeAttrBuilder
+
+__all__ = ["ScyllaYaml", "ServerEncryptionOptions", "ClientEncryptionOptions", "SeedProvider", "RequestSchedulerOptions",
+           "ScyllaYamlCertificateAttrBuilder", "ScyllaYamlClusterAttrBuilder", "ScyllaYamlNodeAttrBuilder"]

--- a/sdcm/sct_provision/__init__.py
+++ b/sdcm/sct_provision/__init__.py
@@ -10,7 +10,6 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2021 ScyllaDB
-from typing import Literal
 
 from sdcm.sct_provision.azure.azure_region_definition_builder import AzureDefinitionBuilder
 from sdcm.sct_provision.region_definition_builder import RegionDefinitionBuilder

--- a/sdcm/utils/alternator/__init__.py
+++ b/sdcm/utils/alternator/__init__.py
@@ -2,3 +2,5 @@ from sdcm.utils.alternator import api
 from sdcm.utils.alternator import consts
 from sdcm.utils.alternator import enums
 from sdcm.utils.alternator import schemas
+
+__all__ = ["api", "consts", "enums", "schemas"]

--- a/sdcm/utils/cdc/__init__.py
+++ b/sdcm/utils/cdc/__init__.py
@@ -1,1 +1,3 @@
 from sdcm.utils.cdc import options
+
+__all__ = ["options"]

--- a/sdcm/utils/cloud_monitor/__init__.py
+++ b/sdcm/utils/cloud_monitor/__init__.py
@@ -1,1 +1,3 @@
 from sdcm.utils.cloud_monitor.cloud_monitor import cloud_report, cloud_qa_report
+
+__all__ = ["cloud_report", "cloud_qa_report"]

--- a/sdcm/utils/k8s/__init__.py
+++ b/sdcm/utils/k8s/__init__.py
@@ -13,7 +13,6 @@
 
 # pylint: disable=too-many-arguments,too-many-lines
 import abc
-import getpass
 import json
 import os
 import time
@@ -43,7 +42,7 @@ from sdcm import sct_abs_path
 from sdcm.remote import LOCALRUNNER
 from sdcm.utils.common import walk_thru_data
 from sdcm.utils.decorators import timeout as timeout_decor, retrying
-from sdcm.utils.docker_utils import ContainerManager, DockerException, Container
+from sdcm.utils.docker_utils import ContainerManager, Container
 from sdcm.wait import wait_for
 
 

--- a/sdcm/utils/raft/__init__.py
+++ b/sdcm/utils/raft/__init__.py
@@ -4,12 +4,10 @@ import random
 
 from enum import Enum
 from typing import Protocol, NamedTuple, Mapping, Iterable
-from collections import namedtuple
 
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.filters import EventsSeverityChangerFilter
 from sdcm.sct_events import Severity
-from sdcm.utils.version_utils import ComparableScyllaVersion
 from sdcm.utils.features import is_consistent_topology_changes_feature_enabled, is_consistent_cluster_management_feature_enabled
 
 

--- a/unit_tests/lib/alternator_utils.py
+++ b/unit_tests/lib/alternator_utils.py
@@ -10,6 +10,5 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2020 ScyllaDB
-from sdcm.utils import alternator
 
 ALTERNATOR_PORT = 8000

--- a/unit_tests/test_nemesis.py
+++ b/unit_tests/test_nemesis.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field
 
 import pytest
 
-import sdcm.utils.cloud_monitor  # pylint: disable=unused-import # import only to avoid cyclic dependency
 from sdcm.nemesis import Nemesis, CategoricalMonkey, SisyphusMonkey, ToggleGcModeMonkey
 from sdcm.cluster import BaseScyllaCluster
 from sdcm.cluster_k8s.mini_k8s import LocalMinimalScyllaPodCluster

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -2,10 +2,8 @@ from __future__ import absolute_import
 
 import os
 import unittest
-from unittest import mock
 
 import pytest
-import requests
 
 import sdcm
 from sdcm.utils.version_utils import (


### PR DESCRIPTION
we had this check in pylint, and since we missing it on ruff it casue linting errors in backport PRs

this is something we want to keep checked anyhow

Ref: https://docs.astral.sh/ruff/rules/unused-import/

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] provision tests
- [x] integration tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
