### PR TITLE
feature(perf-test): add option for `perf_extra_jobs_to_compare`

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -928,15 +928,17 @@ def update_conf_docs():
 @cli.command("perf-regression-report", help="Generate and send performance regression report")
 @click.option("-i", "--es-id", required=True, type=str, help="Id of the run in Elastic Search")
 @click.option("-e", "--emails", required=True, type=str, help="Comma separated list of emails. Example a@b.com,c@d.com")
-def perf_regression_report(es_id, emails):
+@click.option("--es-index", default="performancestatsv2", help="Elastic Search index")
+@click.option("--extra-jobs-to-compare", default=None, type=str, multiple=True, help="Extra jobs to compare")
+def perf_regression_report(es_id, emails, es_index, extra_jobs_to_compare):
     add_file_logger()
     emails = emails.split(',')
     if not emails:
         LOGGER.warning("No email recipients. Email will not be sent")
         sys.exit(1)
-    results_analyzer = PerformanceResultsAnalyzer(es_index="performanceregressiontest", es_doc_type="test_stats",
+    results_analyzer = PerformanceResultsAnalyzer(es_index=es_index, es_doc_type="test_stats",
                                                   email_recipients=emails, logger=LOGGER)
-    results_analyzer.check_regression(es_id)
+    results_analyzer.check_regression(es_id, extra_jobs_to_compare=extra_jobs_to_compare)
 
     logdir = Path(get_test_config().logdir())
     email_results_file = logdir / "email_data.json"

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1153,6 +1153,10 @@ class SCTConfiguration(dict):
         dict(name="stress_cmd_no_mv_profile", env="SCT_STRESS_CMD_NO_MV_PROFILE", type=str,
              help=""),
 
+        dict(name="perf_extra_jobs_to_compare", env="SCT_PERF_EXTRA_JOBS_TO_COMPARE", type=str_or_list_or_eval,
+             help="jobs to compare performance results with, for example if running in staging, "
+                  "we still can compare with official jobs"),
+
         # PerformanceRegressionUserProfilesTest
         dict(name="cs_user_profiles", env="SCT_CS_USER_PROFILES", type=str_or_list,
              help="cassandra-stress user-profiles list. Executed in test step"),

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3216,7 +3216,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             results_analyzer.check_regression(self._test_id, is_gce,
                                               email_subject_postfix=self.params.get('email_subject_postfix'),
                                               use_wide_query=True,
-                                              node_benchmarks=benchmarks_results)
+                                              node_benchmarks=benchmarks_results,
+                                              extra_jobs_to_compare=self.params.get('perf_extra_jobs_to_compare'))
         except Exception as ex:  # pylint: disable=broad-except
             self.log.exception('Failed to check regression: %s', ex)
 
@@ -3233,7 +3234,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             results_analyzer.check_regression_with_subtest_baseline(self._test_id,
                                                                     base_test_id=self.test_config.test_id(),
                                                                     subtest_baseline=subtest_baseline,
-                                                                    is_gce=is_gce)
+                                                                    is_gce=is_gce,
+                                                                    extra_jobs_to_compare=self.params.get('perf_extra_jobs_to_compare'))
         except Exception as ex:  # pylint: disable=broad-except
             self.log.exception('Failed to check regression: %s', ex)
 

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -106,6 +106,10 @@ def call(Map pipelineParams) {
             string(defaultValue: '',
                    description: 'Actual user requesting job start, for automated job builds (e.g. through Argus)',
                    name: 'requested_by_user')
+            string(defaultValue: "${pipelineParams.get('perf_extra_jobs_to_compare', '')}",
+                   description: 'jobs to compare performance results with, for example if running in staging, '
+                                + 'we still can compare with official jobs',
+                   name: 'perf_extra_jobs_to_compare')
         }
         options {
             timestamps()
@@ -327,6 +331,9 @@ def call(Map pipelineParams) {
                                                         fi
                                                         if [[ -n "${params.test_email_title ? params.test_email_title : ''}" ]] ; then
                                                             export SCT_EMAIL_SUBJECT_POSTFIX="${params.test_email_title}"
+                                                        fi
+                                                        if [[ -n "${params.perf_extra_jobs_to_compare ? params.perf_extra_jobs_to_compare : ''}" ]] ; then
+                                                            export SCT_PERF_EXTRA_JOBS_TO_COMPARE="${params.perf_extra_jobs_to_compare}"
                                                         fi
 
                                                         echo "start test ......."


### PR DESCRIPTION
before we have all kind of logic that prevented us from getting results from staging jobs, and from nested folders

as part of refactoring the perf jobs, we do want to be able to have nested folder, and also the ability to run staging job compare to offical jobs, without naming them exactly the same.

so in this change we introduce a new sct configuration `perf_extra_jobs_to_compare`, offical jobs would set it with thier actual location, so every time it would run in staging it would be comapre with the offical run.

this was introduced also to the `hydra perf-regression-report` so we can manually create reports and needed.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
