### PR TITLE
fix(docker-loaders): add `--security-opt seccomp=unconfined` to command

### DIFF
--- a/sdcm/cql_stress_cassandra_stress_thread.py
+++ b/sdcm/cql_stress_cassandra_stress_thread.py
@@ -134,6 +134,7 @@ class CqlStressCassandraStressThread(CassandraStressThread):
                                                     command_line="-c 'tail -f /dev/null'",
                                                     extra_docker_opts=f'{cpu_options} '
                                                     '--network=host '
+                                                    '--security-opt seccomp=unconfined '
                                                     f'--label shell_marker={self.shell_marker}'
                                                     f' --entrypoint /bin/bash')
         stress_cmd = self.create_stress_cmd(cmd_runner, keyspace_idx, loader)

--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -106,8 +106,10 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
             cpu_options = f'--cpuset-cpus="{cpu_idx}"'
 
         docker = cleanup_context = RemoteDocker(loader, self.docker_image_name,
-                                                extra_docker_opts=f'{cpu_options} --label shell_marker={self.shell_marker}'
-                                                                  f' --network=host --entrypoint=""')
+                                                extra_docker_opts=f'{cpu_options} --label shell_marker={self.shell_marker} '
+                                                                  '--network=host '
+                                                                  '--security-opt seccomp=unconfined '
+                                                                  '--entrypoint=""')
 
         if not os.path.exists(loader.logdir):
             os.makedirs(loader.logdir, exist_ok=True)

--- a/sdcm/ndbench_thread.py
+++ b/sdcm/ndbench_thread.py
@@ -140,7 +140,9 @@ class NdBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-many-
             node_cmd = self.stress_cmd
 
         docker = cleanup_context = RemoteDocker(loader, self.docker_image_name,
-                                                extra_docker_opts=f'--network=host --label shell_marker={self.shell_marker}')
+                                                extra_docker_opts='--network=host '
+                                                                  '--security-opt seccomp=unconfined '
+                                                                  f'--label shell_marker={self.shell_marker}')
 
         node_cmd = f'STRESS_TEST_MARKER={self.shell_marker}; {node_cmd}'
 

--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -186,7 +186,9 @@ class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-in
                 cpu_options = f'--cpuset-cpus="{cpu_idx}"'
             cmd_runner = cleanup_context = RemoteDocker(
                 loader, self.params.get('stress_image.scylla-bench'),
-                extra_docker_opts=f'{cpu_options} --label shell_marker={self.shell_marker} --network=host',
+                extra_docker_opts=f'{cpu_options} --label shell_marker={self.shell_marker} '
+                                  '--network=host '
+                                  '--security-opt seccomp=unconfined '
             )
             cmd_runner_name = loader.ip_address
 

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -277,13 +277,11 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
             cmd_runner_name = loader.ip_address
 
             cpu_options = ""
-            if self.stress_num > 1:
-                cpu_options = f'--cpuset-cpus="{cpu_idx}"'
-
             cmd_runner = cleanup_context = RemoteDocker(loader, self.docker_image_name,
                                                         command_line="-c 'tail -f /dev/null'",
                                                         extra_docker_opts=f'{cpu_options} '
                                                                           '--network=host '
+                                                                          '--security-opt seccomp=unconfined '
                                                                           f'--label shell_marker={self.shell_marker}'
                                                                           f' --entrypoint /bin/bash'
                                                                           f' -v $HOME/{remote_hdr_file_name}:/{remote_hdr_file_name}')


### PR DESCRIPTION
running with all those check enable hurt performence quite badly so far we enable `--network=host` in all docker loaders, but that not enough to make comparable with stress tool running ontop of VM

Ref: https://www.scylladb.com/2018/08/09/cost-containerization-scylla/

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] integration tests
- [x] one perf test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
