### PR TITLE
test(perf): hinted handoff perf test

### DIFF
--- a/data_dir/nemesis_classes.yml
+++ b/data_dir/nemesis_classes.yml
@@ -89,3 +89,4 @@
 - TruncateLargeParititionMonkey
 - TruncateMonkey
 - ValidateHintedHandoffShortDowntime
+- WaitStopWaitStartWaitMonkey

--- a/jenkins-pipelines/performance_staging/perf-regression-latency-250gb-hinted-handoff.jenkinsfile
+++ b/jenkins-pipelines/performance_staging/perf-regression-latency-250gb-hinted-handoff.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: """["test-cases/performance/perf-regression-latency-250gb-hinted-handoff.yaml"]""",
+    sub_tests: ["test_latency_write_with_nemesis"],
+    email_recipients: 'artsiom.mishuta@scylladb.com'
+)

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -26,7 +26,7 @@ from upgrade_test import UpgradeTest
 from sdcm.tester import ClusterTester, teardown_on_exception
 from sdcm.sct_events import Severity
 from sdcm.sct_events.filters import EventsSeverityChangerFilter
-from sdcm.sct_events.loaders import CassandraStressEvent
+from sdcm.sct_events.loaders import CassandraStressEvent, CqlStressCassandraStressEvent
 from sdcm.sct_events.system import HWPerforanceEvent, InfoEvent
 from sdcm.utils.decorators import log_run_info, latency_calculator_decorator
 from sdcm.utils.csrangehistogram import CSHistogramTagTypes
@@ -215,7 +215,10 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         with EventsSeverityChangerFilter(new_severity=Severity.NORMAL,  # killing stress creates Critical error
                                          event_class=CassandraStressEvent,
                                          extra_time_to_expiration=60):
-            self.loaders.kill_stress_thread()
+            with EventsSeverityChangerFilter(new_severity=Severity.NORMAL,  # killing CqlStress creates Critical error
+                                         event_class=CqlStressCassandraStressEvent,
+                                         extra_time_to_expiration=60):
+                self.loaders.kill_stress_thread()
 
     def preload_data(self, compaction_strategy=None):
         # if test require a pre-population of data

--- a/test-cases/performance/perf-regression-latency-250gb-hinted-handoff.yaml
+++ b/test-cases/performance/perf-regression-latency-250gb-hinted-handoff.yaml
@@ -1,0 +1,35 @@
+test_duration: 680
+prepare_write_cmd: ["cql-stress-cassandra-stress write no-warmup cl=ALL n=62500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..62500000",
+                    "cql-stress-cassandra-stress write no-warmup cl=ALL n=62500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=62500001..125000000",
+                    "cql-stress-cassandra-stress write no-warmup cl=ALL n=62500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=125000001..187500000",
+                    "cql-stress-cassandra-stress write no-warmup cl=ALL n=62500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=187500001..250000000"]
+
+stress_cmd_w: "cql-stress-cassandra-stress write no-warmup cl=QUORUM duration=600m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=200' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
+stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=600m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=50 throttle=4000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=600m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=50 throttle=3500/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
+
+n_db_nodes: 3
+nemesis_add_node_cnt: 3
+n_loaders: 4
+n_monitor_nodes: 1
+
+instance_type_loader: 'c5.2xlarge'
+instance_type_monitor: 't3.large'
+instance_type_db: 'i3.2xlarge'
+
+nemesis_class_name: 'WaitStopWaitStartWaitMonkey'
+nemesis_interval: 1
+nemesis_sequence_sleep_between_ops: 30
+
+user_prefix: 'perf-latency-hinted-handoff'
+space_node_threshold: 644245094
+ami_id_db_scylla_desc: 'VERSION_DESC'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --hinted-handoff-enabled true'
+backtrace_decoding: false
+print_kernel_callstack: true
+
+store_perf_results: false
+use_prepared_loaders: true
+use_hdr_cs_histogram: false


### PR DESCRIPTION
the idea of the test is to measure how hinted handoff applying is affect performance (latency, throughput)

ideally 20% resources of the cluster for background work

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
