### PR TITLE
Revert "[Backport 2024.1] fix(hot_reloading): pass correct patterns to `follow_system_log`"

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4228,7 +4228,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         with context_manager:
             for node in self.cluster.nodes:
                 node_system_logs[node] = node.follow_system_log(
-                    patterns=[f'messaging_service - Reloaded {{"{ssl_files_location}"}}'])
+                    patterns=f'messaging_service - Reloaded {{{ssl_files_location}}}')
                 node.remoter.send_files(src='data_dir/ssl_conf/db.crt', dst='/tmp')
                 node.remoter.run(f"sudo cp -f /tmp/db.crt {ssl_files_location}")
                 new_crt = node.remoter.run(f"cat {ssl_files_location}").stdout

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4228,7 +4228,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         with context_manager:
             for node in self.cluster.nodes:
                 node_system_logs[node] = node.follow_system_log(
-                    patterns=f'messaging_service - Reloaded {{{ssl_files_location}}}')
+                    patterns=[f'messaging_service - Reloaded {{{ssl_files_location}}}'])
                 node.remoter.send_files(src='data_dir/ssl_conf/db.crt', dst='/tmp')
                 node.remoter.run(f"sudo cp -f /tmp/db.crt {ssl_files_location}")
                 new_crt = node.remoter.run(f"cat {ssl_files_location}").stdout


### PR DESCRIPTION
Reverts scylladb/scylla-cluster-tests#7803

The following error occurs during HotReloadingInternodeCertificate nemesis in longevity-100gb-4h-fips-test scenario, executed on 2024.1.7 release - https://argus.scylladb.com/test/6af3624b-cded-4040-a656-e9246811b687/runs?additionalRuns[]=382b48f4-5dc5-461d-a814-fd64c23fc847 shows:
```
2024-07-04 06:57:38.352: (DisruptionEvent Severity.ERROR) period_type=end event_id=3442750b-bc79-4d1a-9862-fae65ebbbd68 duration=10m11s: nemesis_name=HotReloadingInternodeCertificate target_node=Node longevity-fips-2024-1-db-node-382b48f4-2 [3.252.168.133 | 10.4.3.193] errors=Reload SSL message not found in node log
Traceback (most recent call last):
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 5093, in wrapper
result = method(*args[1:], **kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 4244, in disrupt_hot_reloading_internode_certificate
if not check_ssl_reload_log(node_system_logs[node]):
File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/decorators.py", line 70, in inner
return func(*args, **kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 4215, in check_ssl_reload_log
raise LogContentNotFound('Reload SSL message not found in node log')
sdcm.exceptions.LogContentNotFound: Reload SSL message not found in node log
```

Turns out that in contrast to master the 2024.1 release logs `...messaging_service - Reloaded...` kind of messages without quoted path to the certificate. E.g.:
```
db-cluster-382b48f4/longevity-fips-2024-1-db-node-382b48f4-1/messages.log:15865:2024-07-04T08:07:17.655+00:00 longevity-fips-2024-1-db-node-382b48f4-1     !INFO | scylla[30327]:  [shard  6:main] messaging_service - Reloaded {/etc/scylla/ssl_conf/db.crt}
```

This backport should be reverted to the state when no quotes are used in search pattern.