### PR TITLE
fix(wait-port-down): case for abrupt scylla kill

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -95,7 +95,7 @@ from sdcm.utils.common import (
     generate_random_string,
     prepare_and_start_saslauthd_service,
     raise_exception_in_thread,
-    get_sct_root_path,
+    get_sct_root_path, wait_port_down,
 )
 from sdcm.utils.ci_tools import get_test_name
 from sdcm.utils.distro import Distro
@@ -1413,10 +1413,9 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             self.remoter.run('sudo systemctl restart node-exporter.service')
 
     def wait_db_down(self, verbose=True, timeout=3600, check_interval=60):
-        text = None
         if verbose:
-            text = '%s: Waiting for DB services to be down' % self.name
-        wait.wait_for(func=lambda: not self.db_up(), step=check_interval, text=text, timeout=timeout, throw_exc=True)
+            LOGGER.debug('%s: Waiting for DB services to be down' % self.name)
+        wait_port_down(self.cql_address, self.CQL_PORT, timeout=timeout, check_interval=check_interval)
 
     def wait_cs_installed(self, verbose=True):
         text = None

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1868,6 +1868,17 @@ def wait_for_port(host, port):
     socket.create_connection((host, port)).close()
 
 
+def wait_port_down(host, port, timeout=60, check_interval=1) -> None:
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            socket.create_connection((host, port)).close()
+            time.sleep(check_interval)
+        except OSError:
+            return
+    raise TimeoutError(f"Port {port} on {host} is still up after {timeout} seconds")
+
+
 def can_connect_to(ip: str, port: int, timeout: int = 1) -> bool:
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)


### PR DESCRIPTION
When killing Scylla abruptly, kernel might not to acknowledge port has been released before Scylla get's back to normal operating state. This causes 'wait_db_down` to fail.

Fix by trying to establish dummy connection (without sending data) to scylla cql port - when this is done, kernel updates port state and this method should work properly.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/7480

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [kill scylla nemesis](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/longevity-5gb-1h-ScyllaKillMonkey-aws-test/16/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
