### PR TITLE
feature(kms): sct configuration to disable kms

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -255,3 +255,5 @@ kafka_backend: null
 kafka_connectors: []
 
 run_scylla_doctor: false
+
+enterprise_disable_kms: false

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1313,6 +1313,10 @@ class SCTConfiguration(dict):
              help="The time interval in minutes which gets waited before the KMS key rotation happens."
                   " Applied when the AWS KMS service is configured to be used."),
 
+        dict(name="enterprise_disable_kms", env="SCT_ENTERPRISE_DISABLE_KMS", type=boolean,
+             help="An escape hatch to disable KMS for enterprise run, when needed, "
+                  "we enable kms by default since if we use scylla 2023.1.3 and up"),
+
         dict(name="logs_transport", env="SCT_LOGS_TRANSPORT", type=str,
              help="How to transport logs: syslog-ng, ssh or docker", choices=("ssh", "docker", "syslog-ng")),
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -838,6 +838,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if (self.params.is_enterprise and ComparableScyllaVersion(self.params.scylla_version) >= '2023.1.3'
             and self.params.get('cluster_backend') == 'aws'
             and not self.params.get('scylla_encryption_options')
+            and not self.params.get('enterprise_disable_kms')
             and self.params.get("db_type") != "mixed_scylla"  # oracle probably doesn't support KMS
             ):
             self.params['scylla_encryption_options'] = "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'KmsKeyProviderFactory', 'kms_host': 'auto'}"  # pylint: disable=line-too-long


### PR DESCRIPTION
we enable kms by default since if we use scylla 2023.1.3 and up in some case this introduce machinary we don't really need for a specific test, or for example can affect our performence runs in a way we don't yet want.

in this commit we introduce an escape hatch to disable KMS for enterprise run

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
