### PR TITLE
fix(disrupt_toggle_audit_syslog): tz=UTC in all datetime usage

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -32,7 +32,7 @@ import json
 import ipaddress
 from importlib import import_module
 from typing import List, Optional, Dict, Union, Set, Iterable, ContextManager, Any, IO, AnyStr, Callable
-from datetime import datetime
+from datetime import datetime, timezone
 from textwrap import dedent
 from functools import cached_property, wraps, lru_cache
 from collections import defaultdict
@@ -1478,7 +1478,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
                     continue
                 while True:
                     try:
-                        log_time = datetime.fromisoformat(line.split(' ')[0]).replace(tzinfo=None)
+                        log_time = datetime.fromisoformat(line.split(' ')[0]).replace(tzinfo=timezone.utc)
                     except ValueError:
                         # in case it gets to split line fragment
                         line = log_file.readline()

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4939,7 +4939,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             audit.configure(audit_config)
             keyspace_name = keyspaces_for_audit[0]
             errors = []
-            audit_start = datetime.datetime.now() - datetime.timedelta(seconds=5)
+            audit_start = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(seconds=5)
             InfoEvent(message='Writing/Reading data from audited keyspace').publish()
             write_cmd = f"cassandra-stress write no-warmup cl=ONE n=1000 -schema" \
                         f" 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)" \
@@ -4979,7 +4979,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         audit_config.categories = ["DCL", "DDL", "AUTH", "ADMIN"]
         audit.configure(audit_config)
         table_name = "audit_cf"
-        audit_start = datetime.datetime.now() - datetime.timedelta(seconds=5)
+        audit_start = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(seconds=5)
         with self.cluster.cql_connection_patient(node=self.target_node) as session:
             query = f"CREATE TABLE IF NOT EXISTS {keyspace_name}.{table_name} (id int PRIMARY KEY, value timestamp)"
             session.execute(query)
@@ -4988,7 +4988,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             if not audit_rows:
                 errors.append("Audit log is empty while should contain executed DDL (create table) operation")
 
-            audit_start = datetime.datetime.now() - datetime.timedelta(seconds=5)
+            audit_start = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(seconds=5)
             query = f"ALTER TABLE {keyspace_name}.{table_name} WITH read_repair_chance = 0.0"
             session.execute(query)
             self.cluster.wait_for_schema_agreement()
@@ -4996,7 +4996,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             if not audit_rows:
                 errors.append("Audit log is empty while should contain executed DDL (alter table) operation")
 
-            audit_start = datetime.datetime.now() - datetime.timedelta(seconds=5)
+            audit_start = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(seconds=5)
             query = f"DROP TABLE {keyspace_name}.{table_name}"
             session.execute(query, timeout=300)
             self.cluster.wait_for_schema_agreement()


### PR DESCRIPTION
seems like we are using naive datetime all of this nemesis, log output are in UTC time, we should align everything to work assuming it's UTC, to make sure times are aligned.

Ref: #7885

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
