### PR TITLE
feature(ruff): enable PLR0916 and preview mode

### DIFF
--- a/.github/search_commits.py
+++ b/.github/search_commits.py
@@ -27,7 +27,7 @@ def get_parser():
     return parser.parse_args()
 
 
-def main():  # pylint: disable=too-many-locals
+def main():  # pylint: disable=too-many-locals  # noqa: PLR0914
     args = get_parser()
     github = Github(github_token)
     repo = github.get_repo(args.repository, lazy=False)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
 
     -   id: ruff
         name: ruff
-        entry: ruff check --fix
+        entry: ruff check --fix --preview
         language: system
         types: [python]
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -5,7 +5,7 @@ module.exports = {
         // Subject
         'subject-empty': [2, 'never'],
         'subject-full-stop': [2, 'never', '.'],
-        'subject-max-length': [2, 'always', 100],
+        'subject-max-length': [2, 'always', 120],
         'subject-min-length': [2, 'always', 10],
         // Type
         'type-enum': [2,'always',['ci','docs','feature','fix','improvement','perf','refactor','revert','style','test', 'unit-test', 'build']],
@@ -15,7 +15,7 @@ module.exports = {
         'scope-min-length': [2, 'always', 3],
         // Body
         'body-min-length': [2, 'always', 30],
-        'body-max-line-length': [2, 'always', 100],
+        'body-max-line-length': [2, 'always', 120],
         'body-leading-blank': [2, 'always'],
     },
     parserPreset: {

--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -95,7 +95,7 @@ def test_single_operator_image_tag_is_everywhere(db_cluster):
 
 
 @pytest.mark.required_operator("v1.11.0")
-def test_deploy_quasi_multidc_db_cluster(db_cluster: ScyllaPodCluster):  # pylint: disable=too-many-locals,too-many-statements,too-many-branches
+def test_deploy_quasi_multidc_db_cluster(db_cluster: ScyllaPodCluster):  # pylint: disable=too-many-locals,too-many-statements,too-many-branches  # noqa: PLR0914
     """
     Deploy 2 'ScyllaCluster' K8S objects in 2 different namespaces in the single K8S cluster
     and combine them into a single DB cluster.

--- a/ics_space_amplification_goal_test.py
+++ b/ics_space_amplification_goal_test.py
@@ -135,7 +135,7 @@ class IcsSpaceAmplificationTest(LongevityTest):
             node.stop_scylla_server()
             node.start_scylla_server()
 
-    def test_ics_space_amplification_goal(self):  # pylint: disable=too-many-locals
+    def test_ics_space_amplification_goal(self):  # pylint: disable=too-many-locals  # noqa: PLR0914
         """
         (1) writing new data. wait for compactions to finish.
         (2) over-writing existing data.

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -522,7 +522,7 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
 
         self.run_verification_read_stress()
 
-    def test_restore_multiple_backup_snapshots(self):  # pylint: disable=too-many-locals
+    def test_restore_multiple_backup_snapshots(self):  # pylint: disable=too-many-locals  # noqa: PLR0914
         manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
         mgr_cluster = self._ensure_and_get_cluster(manager_tool)
         cluster_backend = self.params.get('cluster_backend')

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -52,7 +52,7 @@ class ManagerUpgradeTest(BackupFunctionsMixIn, ClusterTester):
                                                auth_token=self.monitors.mgmt_auth_token)
         return mgr_cluster, current_manager_version
 
-    def test_upgrade(self):  # pylint: disable=too-many-locals,too-many-statements
+    def test_upgrade(self):  # pylint: disable=too-many-locals,too-many-statements  # noqa: PLR0914
         manager_node = self.monitors.nodes[0]
 
         target_upgrade_server_version = self.params.get('target_scylla_mgmt_server_address')

--- a/performance_search_max_throughput_test.py
+++ b/performance_search_max_throughput_test.py
@@ -47,7 +47,7 @@ class MaximumPerformanceSearchTest(PerformanceRegressionTest):
 
         self.run_search_best_performance(**stress_params)
 
-    def run_search_best_performance(self, stress_cmd_tmpl: str,  # pylint: disable=too-many-arguments,too-many-locals,too-many-statements
+    def run_search_best_performance(self, stress_cmd_tmpl: str,  # pylint: disable=too-many-arguments,too-many-locals,too-many-statements  # noqa: PLR0914
                                     stress_num: int,
                                     stress_num_step: int,
                                     stress_step_duration: str,

--- a/pylintrc
+++ b/pylintrc
@@ -281,7 +281,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=140
+max-line-length=240
 
 # Maximum number of lines in a module.
 max-module-lines=1000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-lint.select = ["PL", "YTT", "BLE", "F841", "F401"]
+lint.select = ["PL", "PLR0916", "YTT", "BLE", "F841", "F401"]
 
 lint.ignore = ["E501", "PLR2004"]
 
@@ -9,6 +9,8 @@ force-exclude = true
 line-length = 240
 respect-gitignore = true
 
+lint.preview = true
+lint.explicit-preview-rules = true
 
 [tool.ruff.lint.pylint]
 max-args = 12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-lint.select = ["PL", "PLR0916", "YTT", "BLE", "F841", "F401"]
+lint.select = ["PL", "PLR0916", "PLR0913","PLR0914", "YTT", "BLE", "F841", "F401"]
 
 lint.ignore = ["E501", "PLR2004"]
 
@@ -16,3 +16,4 @@ lint.explicit-preview-rules = true
 max-args = 12
 max-statements = 100
 max-branches = 24
+max-locals = 15

--- a/sct.py
+++ b/sct.py
@@ -341,7 +341,7 @@ def clean_resources(ctx, post_behavior, user, test_id, logdir, dry_run, backend)
 @sct_option('--test-id', 'test_id', help='test id to filter by')
 @click.option('--verbose', is_flag=True, default=False, help='if enable, will log progress')
 @click.pass_context
-def list_resources(ctx, user, test_id, get_all, get_all_running, verbose):  # noqa: PLR0912, PLR0915
+def list_resources(ctx, user, test_id, get_all, get_all_running, verbose):  # noqa: PLR0912, PLR0914, PLR0915
     # pylint: disable=too-many-locals,too-many-arguments,too-many-branches,too-many-statements
 
     add_file_logger()

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5582,7 +5582,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
         if node.distro.is_ubuntu:
             node.remoter.run(f'sed -i "s/python3/python3.6/g" {self.monitor_install_path}/*.py')
 
-    def configure_scylla_monitoring(self, node, sct_metrics=True, alert_manager=True):  # pylint: disable=too-many-locals,too-many-branches
+    def configure_scylla_monitoring(self, node, sct_metrics=True, alert_manager=True):  # pylint: disable=too-many-locals,too-many-branches  # noqa: PLR0914
         cloud_prom_bearer_token = self.params.get('cloud_prom_bearer_token')
 
         if sct_metrics and not self.params.get("reuse_cluster"):

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -801,7 +801,7 @@ class ManagerCluster(ScyllaManagerBase):
         return HealthcheckTask(task_id=healthcheck_id, cluster_id=self.id,
                                manager_node=self.manager_node)  # return the manager's health-check-task object with the found id
 
-    def get_hosts_health(self):
+    def get_hosts_health(self):  # noqa: PLR0914
         """
         Gets the Manager's Cluster Nodes status
         """

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4148,7 +4148,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     @decorate_with_context(ignore_ycsb_connection_refused)
     @scylla_versions(("2023.1.1-dev", None))
-    def _enable_disable_table_encryption(self, enable_kms_key_rotation, additional_scylla_encryption_options=None):
+    def _enable_disable_table_encryption(self, enable_kms_key_rotation, additional_scylla_encryption_options=None):  # noqa: PLR0914
         if self.cluster.params.get("cluster_backend") != "aws":
             raise UnsupportedNemesis("This nemesis is supported only on the AWS cluster backend")
 

--- a/sdcm/remote/remote_long_running.py
+++ b/sdcm/remote/remote_long_running.py
@@ -11,7 +11,7 @@ from sdcm.remote.libssh2_client.exceptions import UnexpectedExit
 logger = logging.getLogger(__name__)
 
 
-def run_long_running_cmd(remoter: RemoteCmdRunnerBase,
+def run_long_running_cmd(remoter: RemoteCmdRunnerBase,  # pylint: disable=too-many-arguments
                          cmd: str,
                          timeout: float | None = None,
                          ignore_status: bool = False,

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -406,7 +406,7 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
         except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
             LOGGER.error("Compare results failed: %s", exc)
 
-    def check_regression(self, test_id, data, is_gce=False, node_benchmarks=None, email_subject_postfix=None):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements, too-many-arguments
+    def check_regression(self, test_id, data, is_gce=False, node_benchmarks=None, email_subject_postfix=None):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements, too-many-arguments  # noqa: PLR0914
         doc = self.get_test_by_id(test_id)
         full_test_name = doc["_source"]["test_details"]["test_name"]
         test_name = full_test_name.split('.')[-1]  # Example: longevity_test.LongevityTest.test_custom_time
@@ -510,7 +510,7 @@ class SpecifiedStatsPerformanceAnalyzer(BaseResultsAnalyzer):
             return None
         return test_doc['_source']['results']
 
-    def check_regression(self, test_id, stats):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
+    def check_regression(self, test_id, stats):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements  # noqa: PLR0914
         """
         Get test results by id, filter similar results and calculate DB values for each version,
         then compare with max-allowed in the tested version (and report all the found versions).
@@ -713,7 +713,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
         return cmp_res
 
     # pylint: disable=too-many-arguments
-    def check_regression(self, test_id, is_gce=False, email_subject_postfix=None,
+    def check_regression(self, test_id, is_gce=False, email_subject_postfix=None,  # noqa: PLR0914
                          use_wide_query=False, lastyear=False,
                          node_benchmarks=None, extra_jobs_to_compare=None) -> None:
         """
@@ -892,7 +892,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
                       'template': self._email_template_fp}
         self.save_email_data_file(subject, email_data, file_path='email_data.json')
 
-    def check_regression_with_subtest_baseline(self, test_id, base_test_id, subtest_baseline, is_gce=False, extra_jobs_to_compare=None) -> None:
+    def check_regression_with_subtest_baseline(self, test_id, base_test_id, subtest_baseline, is_gce=False, extra_jobs_to_compare=None) -> None:  # noqa: PLR0914
         """
         Get test results by id, filter similar results and calculate max values for each version,
         then compare with max in the test version and all the found versions.
@@ -1235,7 +1235,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
                 for num in sorted(to_delete, reverse=True):
                     prior_tests.pop(num)
 
-    def check_regression_multi_baseline(  # noqa: PLR0912, PLR0915
+    def check_regression_multi_baseline(  # noqa: PLR0912, PLR0914, PLR0915
             self,
             test_id,
             subtests_info: list = None,

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1703,7 +1703,7 @@ class SCTConfiguration(dict):
     ami_id_params = ['ami_id_db_scylla', 'ami_id_loader', 'ami_id_monitor', 'ami_id_db_cassandra', 'ami_id_db_oracle']
     aws_supported_regions = ['eu-west-1', 'eu-west-2', 'us-west-2', 'us-east-1', 'eu-north-1', 'eu-central-1']
 
-    def __init__(self):  # noqa: PLR0912, PLR0915
+    def __init__(self):  # noqa: PLR0912, PLR0914, PLR0915
         # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         super().__init__()
         self.scylla_version = None

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -249,7 +249,7 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
     def _run_stress(self, loader, loader_idx, cpu_idx):
         pass
 
-    def _run_cs_stress(self, loader, loader_idx, cpu_idx, keyspace_idx):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    def _run_cs_stress(self, loader, loader_idx, cpu_idx, keyspace_idx):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements  # noqa: PLR0914
         cleanup_context = contextlib.nullcontext()
         os.makedirs(loader.logdir, exist_ok=True)
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -862,12 +862,18 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         )
 
     def prepare_kms_host(self) -> None:
-        if (self.params.is_enterprise and ComparableScyllaVersion(self.params.scylla_version) >= '2023.1.3'
-            and self.params.get('cluster_backend') == 'aws'
-            and not self.params.get('scylla_encryption_options')
-            and not self.params.get('enterprise_disable_kms')
-            and self.params.get("db_type") != "mixed_scylla"  # oracle probably doesn't support KMS
-            ):
+        version_supports_kms = (self.params.is_enterprise and
+                                ComparableScyllaVersion(self.params.scylla_version) >= '2023.1.3')
+        backend_support_kms = self.params.get('cluster_backend') in ('aws',)
+        kms_configured_in_sct = self.params.get('scylla_encryption_options')
+        test_uses_oracle = self.params.get("db_type") == "mixed_scylla"
+        should_enable_kms = (version_supports_kms and
+                             backend_support_kms and
+                             not kms_configured_in_sct and
+                             not test_uses_oracle and
+                             not self.params.get('enterprise_disable_kms'))
+
+        if should_enable_kms:
             self.params['scylla_encryption_options'] = "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'KmsKeyProviderFactory', 'kms_host': 'auto'}"  # pylint: disable=line-too-long
         if not (scylla_encryption_options := self.params.get("scylla_encryption_options") or ''):
             return None

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1160,7 +1160,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.log.debug("Nemesis threads %s", nemesis_threads)
         return nemesis_threads
 
-    def get_cluster_gce(self, loader_info, db_info, monitor_info):  # noqa: PLR0912
+    def get_cluster_gce(self, loader_info, db_info, monitor_info):  # noqa: PLR0912, PLR0914
         # pylint: disable=too-many-locals,too-many-statements,too-many-branches
         if loader_info['n_nodes'] is None:
             n_loader_nodes = self.params.get('n_loaders')

--- a/sdcm/utils/bisect_test.py
+++ b/sdcm/utils/bisect_test.py
@@ -57,7 +57,7 @@ def bisect_test(test_func):  # pylint: disable=too-many-statements
     """
 
     @wraps(test_func)
-    def wrapper(*args, **kwargs):  # pylint: disable=too-many-locals, too-many-statements
+    def wrapper(*args, **kwargs):  # pylint: disable=too-many-locals, too-many-statements  # noqa: PLR0914
         tester_obj = args[0]
         start_date = tester_obj.params.get('bisect_start_date')
         test_func(*args, **kwargs)

--- a/sdcm/utils/latency.py
+++ b/sdcm/utils/latency.py
@@ -21,7 +21,7 @@ def avg(values):
 
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-nested-blocks,too-many-branches
-def collect_latency(monitor_node, start, end, load_type, cluster, nodes_list):
+def collect_latency(monitor_node, start, end, load_type, cluster, nodes_list):  # noqa: PLR0914
     res = {}
     prometheus = PrometheusDBStats(host=monitor_node.external_address)
     duration = int(end - start)

--- a/sdcm/utils/microbenchmarking/perf_simple_query_reporter.py
+++ b/sdcm/utils/microbenchmarking/perf_simple_query_reporter.py
@@ -47,7 +47,7 @@ class PerfSimpleQueryAnalyzer(BaseResultsAnalyzer):
         keys.sort(reverse=True)
         return [results[key] for key in keys]
 
-    def check_regression(self, test_id, mad_deviation_limit=0.02, regression_limit=0.05, is_gce=False):  # pylint: disable=too-many-locals,too-many-statements
+    def check_regression(self, test_id, mad_deviation_limit=0.02, regression_limit=0.05, is_gce=False):  # pylint: disable=too-many-locals,too-many-statements  # noqa: PLR0914
         doc = self.get_test_by_id(test_id)
         if not doc:
             self.log.error('Cannot find test by id: {}!'.format(test_id))

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -618,7 +618,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         with node_to_update.remote_scylla_yaml() as scylla_yaml:
             scylla_yaml.update(updates)
 
-    def test_rolling_upgrade(self):  # pylint: disable=too-many-locals,too-many-statements  # noqa: PLR0915
+    def test_rolling_upgrade(self):  # pylint: disable=too-many-locals,too-many-statements  # noqa: PLR0914, PLR0915
         """
         Upgrade half of nodes in the cluster, and start special read workload
         during the stage. Checksum method is changed to xxhash from Scylla 2.2,


### PR DESCRIPTION
PLR016 is needed, since we had similar check in pylint, and we hit it in backport to older branches

also the preview enable this feature for this visual feature for the CLI:

```
sdcm/tester.py:838:13: PLR0916 Too many Boolean expressions (6 > 5)
    |
837 |       def prepare_kms_host(self) -> None:
838 |           if (self.params.is_enterprise and ComparableScyllaVersion(self.params.scylla_version) >= '2023.1.3'
    |  _____________^
839 | |             and self.params.get('cluster_backend') == 'aws'
840 | |             and not self.params.get('scylla_encryption_options')
841 | |             and not self.params.get('enterprise_disable_kms')
842 | |             and self.params.get("db_type") != "mixed_scylla"  # oracle probably doesn't support KMS
    | |____________________________________________________________^ PLR0916
```

[skip-lint]

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
