### PR TITLE
improvement(ruff): add f-string logs check

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -191,7 +191,7 @@ class BackupFunctionsMixIn(LoaderUtilsMixin):
         if truncate:
             for ks, tables in ks_tables_map.items():
                 for table_name in tables:
-                    self.log.info(f'running truncate on {ks}.{table_name}')
+                    self.log.info('running truncate on %s.%s', ks, table_name)
                     self.db_cluster.nodes[0].run_cqlsh(f'TRUNCATE {ks}.{table_name}')
         if restore_data_with_task:
             self.restore_backup_with_task(mgr_cluster=mgr_cluster, snapshot_tag=backup_task.get_snapshot_tag(),
@@ -240,7 +240,7 @@ class BackupFunctionsMixIn(LoaderUtilsMixin):
     def generate_load_and_wait_for_results(self, keyspace_name: str = None):
         load_thread = self._generate_load(keyspace_name=keyspace_name)
         load_results = load_thread.get_results()
-        self.log.info(f'load={load_results}')
+        self.log.info('load=%s', load_results)
 
     def _parse_stress_cmd(self, stress_cmd, params):
         # Due to an issue with scylla & cassandra-stress - we need to create the counter table manually

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-lint.select = ["PL", "YTT", "BLE", "F841", "F401"]
+lint.select = ["PL", "YTT", "BLE", "F841", "F401", "G004"]
 
 lint.ignore = ["E501", "PLR2004"]
 

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -135,7 +135,7 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
 
     def _create_on_demand_instances(self, count, interfaces, ec2_user_data, dc_idx=0, instance_type=None):  # pylint: disable=too-many-arguments
         ami_id = self._ec2_ami_id[dc_idx]
-        self.log.debug(f"Creating {count} on-demand instances using AMI id '{ami_id}'... ")
+        self.log.debug("Creating %s on-demand instances using AMI id '%s'... ", count, ami_id)
         params = dict(ImageId=ami_id,
                       UserData=ec2_user_data,
                       MinCount=count,
@@ -226,7 +226,7 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         if interfaces_amount == 1:
             interfaces[0].update({'AssociatePublicIpAddress': True})
 
-        self.log.info(f"Create {self.instance_provision} instance(s)")
+        self.log.info("Create %s instance(s)", self.instance_provision)
         if self.instance_provision == 'mixed':
             instances = self._create_mixed_instances(count, interfaces, ec2_user_data, dc_idx,
                                                      instance_type=instance_type)
@@ -254,11 +254,11 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         if self.params.get('instance_provision_fallback_on_demand'):
             instances_provision_fallbacks.append(INSTANCE_PROVISION_ON_DEMAND)
 
-        self.log.debug(f"Instances provision fallbacks : {instances_provision_fallbacks}")
+        self.log.debug("Instances provision fallbacks : %s", instances_provision_fallbacks)
 
         for instances_provision_type in instances_provision_fallbacks:
             try:
-                self.log.info(f"Create {instances_provision_type} instance(s)")
+                self.log.info("Create %s instance(s)", instances_provision_type)
                 if instances_provision_type == INSTANCE_PROVISION_ON_DEMAND:
                     instances = self._create_on_demand_instances(
                         count, interfaces, ec2_user_data, dc_idx, instance_type=instance_type)
@@ -280,7 +280,7 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                 ec2_client.SPOT_CAPACITY_NOT_AVAILABLE_ERROR in cl_ex or \
                 ec2_client.SPOT_PRICE_TOO_LOW in cl_ex or \
                 ec2_client.SPOT_STATUS_UNEXPECTED_ERROR in cl_ex:
-            self.log.error(f"Cannot create {instance_provision} instance(s): {cl_ex}")
+            self.log.error("Cannot create %s instance(s): %s", instance_provision, cl_ex)
             return True
         return False
 
@@ -498,7 +498,7 @@ class AWSNode(cluster.BaseNode):
         return interfaces
 
     def init(self):
-        LOGGER.debug("Waiting until instance {0._instance} starts running...".format(self))
+        LOGGER.debug("Waiting until instance %s starts running...", self._instance)
         self._instance_wait_safe(self._instance.wait_until_running)
 
         if not self.test_config.REUSE_CLUSTER:
@@ -695,7 +695,7 @@ class AWSNode(cluster.BaseNode):
                 f"sudo sh -c  \"echo 'sudo ip route add {ipv6_cidr} dev eth0' >> /etc/sysconfig/network-scripts/init.ipv6-global\"")
 
             res = self.remoter.run(f"grep '{ipv6_cidr}' /etc/sysconfig/network-scripts/init.ipv6-global")
-            LOGGER.debug('init.ipv6-global was {}updated'.format('' if res.stdout.strip else 'NOT '))
+            LOGGER.debug('init.ipv6-global was %s updated', '' if res.stdout.strip else 'NOT ')
 
     def restart(self):
         # We differentiate between "Restart" and "Reboot".

--- a/sdcm/cluster_azure.py
+++ b/sdcm/cluster_azure.py
@@ -124,7 +124,7 @@ class AzureNode(cluster.BaseNode):
                     SpotTerminationEvent(node=self, message=message).publish()
                 else:
                     # other EventType's that can be triggered by Azure's maintenance: "Reboot" | "Redeploy" | "Freeze" | "Terminate"
-                    self.log.warning(f"Unhandled Azure scheduled event: {event}")
+                    self.log.warning("Unhandled Azure scheduled event: %s", event)
         except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
             self.log.warning('Error during getting Azure scheduled events: %s', details)
             return 0

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -495,10 +495,10 @@ class MonitorSetDocker(cluster.BaseMonitorSet, DockerCluster):  # pylint: disabl
                 self.stop_scylla_monitoring(node)
                 self.log.error("Stopping scylla monitoring succeeded")
             except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
-                self.log.error(f"Stopping scylla monitoring failed with {str(exc)}")
+                self.log.error("Stopping scylla monitoring failed with %s", str(exc))
             try:
                 node.remoter.sudo(f"rm -rf '{self.monitor_install_path_base}'")
                 self.log.error("Cleaning up scylla monitoring succeeded")
             except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
-                self.log.error(f"Cleaning up scylla monitoring failed with {str(exc)}")
+                self.log.error("Cleaning up scylla monitoring failed with %s", str(exc))
             node.destroy()

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -347,7 +347,7 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         # pylint: disable=too-many-locals
 
         def set_tags_as_labels(_instance: compute_v1.Instance):
-            self.log.debug(f"Expected tags are {self.tags}")
+            self.log.debug("Expected tags are %s", self.tags)
             # https://cloud.google.com/resource-manager/docs/tags/tags-creating-and-managing#adding_tag_values
             regex_key = re.compile(r'[^a-z0-9-_]')
 
@@ -355,7 +355,7 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                 return regex_key.sub('_', value.lower())[:60]
 
             normalized_tags = {to_short_name(k): to_short_name(v) for k, v in self.tags.items()}
-            self.log.debug(f"normalized tags are {normalized_tags}")
+            self.log.debug("normalized tags are %s", normalized_tags)
 
             gce_set_labels(instances_client=self._gce_service,
                            instance=_instance,
@@ -411,7 +411,7 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         try:
             set_tags_as_labels(instance)
         except google.api_core.exceptions.InvalidArgument as exc:
-            self.log.warning(f"Unable to set tags as labels due to {exc}")
+            self.log.warning("Unable to set tags as labels due to %s", exc)
 
         return instance
 

--- a/sdcm/coredump.py
+++ b/sdcm/coredump.py
@@ -163,7 +163,7 @@ class CoredumpThreadBase(Thread):  # pylint: disable=too-many-instance-attribute
             try:
                 core_info.process_retry += 1
                 if self.upload_retry_limit < core_info.process_retry:
-                    self.log.error(f"Maximum retry uploading is reached for core {str(core_info)}")
+                    self.log.error("Maximum retry uploading is reached for core %s", str(core_info))
                     in_progress.remove(core_info)
                     completed.append(core_info)
                     continue
@@ -185,7 +185,7 @@ class CoredumpThreadBase(Thread):  # pylint: disable=too-many-instance-attribute
         try:
             core_info.publish_event()
         except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
-            self.log.error(f"Failed to publish coredump event due to the: {str(exc)}")
+            self.log.error("Failed to publish coredump event due to the: %s", str(exc))
 
     def extract_info_from_core_pids(
             self, new_cores: Optional[List[CoreDumpInfo]], exclude_cores: List[CoreDumpInfo]) -> List[CoreDumpInfo]:
@@ -232,10 +232,10 @@ class CoredumpThreadBase(Thread):  # pylint: disable=too-many-instance-attribute
         if core_info.download_url:
             return False
         if not core_info.corefile:
-            self.log.error(f"{str(core_info)} has inaccessible corefile, can't upload it")
+            self.log.error("%s has inaccessible corefile, can't upload it", str(core_info))
             return False
         try:
-            self.log.debug(f'Start uploading file: {core_info.corefile}')
+            self.log.debug('Start uploading file: %s', core_info.corefile)
             core_info.download_instructions = 'Coredump upload in progress'
             with self.hard_link_corefile(core_info.corefile) as hard_link:
                 if hard_link:
@@ -244,7 +244,7 @@ class CoredumpThreadBase(Thread):  # pylint: disable=too-many-instance-attribute
             return True
         except Exception as exc:  # pylint: disable=broad-except
             core_info.download_instructions = 'failed to upload core'
-            self.log.error(f"Following error occurred during uploading coredump {core_info.corefile}: {str(exc)}")
+            self.log.error("Following error occurred during uploading coredump %s: %s", core_info.corefile, str(exc))
             raise
 
     @cached_property
@@ -321,7 +321,7 @@ class CoredumpExportSystemdThread(CoredumpThreadBase):
         hard_links_path = Path(corefile).parent / 'hardlinks'
         link_path = hard_links_path / Path(corefile).name
         self.node.remoter.sudo(f'mkdir -p {hard_links_path}', ignore_status=True)
-        self.log.debug(f'doing: ln {corefile} {link_path}')
+        self.log.debug('doing: ln %s %s', corefile, link_path)
         self.node.remoter.sudo(f'ln {corefile} {link_path}', ignore_status=True)
         yield link_path
         self.node.remoter.sudo(f'rm -f {link_path}', ignore_status=True)
@@ -458,7 +458,7 @@ class CoredumpExportSystemdThread(CoredumpThreadBase):
                         raise ValueError(f'Date has unknown format: {timestring}')
                     event_timestamp = datetime.strptime(timestring, fmt).timestamp()
                 except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
-                    self.log.error(f"Failed to convert date '{line}' ({timestring}), due to error: {str(exc)}")
+                    self.log.error("Failed to convert date '%s' (%s), due to error: %s", line, timestring, str(exc))
         core_info.update(executable=executable, command_line=command_line, corefile=corefile,
                          source_timestamp=event_timestamp, coredump_info="\n".join(coredump_info)+"\n")
 
@@ -532,7 +532,7 @@ class CoredumpExportFileThread(CoredumpThreadBase):
         output = []
         for directory in self.coredumps_directories:
             for corefile in self.node.remoter.sudo(f'ls {directory}', verbose=False, ignore_status=True).stdout.split():
-                self.log.debug(f'Found core file at {corefile}')
+                self.log.debug('Found core file at %s', corefile)
                 core_data = self._extract_core_info_from_file_name(os.path.basename(corefile))
                 output.append(
                     CoreDumpInfo(

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -384,7 +384,7 @@ class PrometheusDBStats:
     def create_snapshot(self):
         url = "http://{}:{}/api/v1/admin/tsdb/snapshot".format(normalize_ipv6_url(self.host), self.port)
         result = self.request(url, True)
-        LOGGER.debug('Request result: {}'.format(result))
+        LOGGER.debug('Request result: %s', result)
         return result
 
     @staticmethod
@@ -682,7 +682,7 @@ class TestStatsMixin(Stats):
             self._stats['results'][stat] = {}
         if specific_tested_stats:
             self._stats['results'].update(specific_tested_stats)
-            self.log.info("Creating specific tested stats of: {}".format(specific_tested_stats))
+            self.log.info("Creating specific tested stats of: %s", specific_tested_stats)
         self.create()
 
     def update_stress_cmd_details(self, cmd, prefix='', stresser="cassandra-stress", aggregate=True):

--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -173,7 +173,7 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
                 stats['results'].append(res)
                 for err_type in ['write_errors', 'read_errors', 'errors']:
                     if res.get(err_type, None):
-                        LOGGER.error("Gemini {} errors: {}".format(err_type, res[err_type]))
+                        LOGGER.error("Gemini %s errors: %s", err_type, res[err_type])
                         stats['status'] = 'FAILED'
                         stats['errors'][err_type] = res[err_type]
         if not stats.get('status'):
@@ -188,7 +188,7 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
             results = json.loads(json_str)
 
         except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
-            LOGGER.error("Invalid json document {}".format(details))
+            LOGGER.error("Invalid json document %s", details)
 
         return results.get('result')
 

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -561,7 +561,7 @@ class LogCollector:
             os.makedirs(local_dir, exist_ok=True)
         except OSError as details:
             if not os.path.exists(local_dir):
-                LOGGER.error("Folder is not created. {}".format(details))
+                LOGGER.error("Folder is not created. %s", details)
                 raise
         return local_dir
 

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -438,7 +438,7 @@ class ManagerTask:
         else:
             list_final_status = [
                 TaskStatus.ERROR, TaskStatus.ERROR_FINAL, TaskStatus.STOPPED, TaskStatus.DONE, TaskStatus.ABORTED]
-        LOGGER.debug("Waiting for task: {} getting to a final status ({})..".format(self.id, str(list_final_status)))
+        LOGGER.debug("Waiting for task: %s getting to a final status (%s)..", self.id, str(list_final_status))
         res = self.wait_for_status(list_status=list_final_status, timeout=timeout, step=step)
         if not res:
             raise ScyllaManagerError("Unexpected result on waiting for task {} status".format(self.id))
@@ -527,7 +527,7 @@ class ManagerCluster(ScyllaManagerBase):
             return self.sctool.get_table_value(
                 parsed_table=cluster_list, column_name=column_to_search, identifier=cluster_name)
         except ScyllaManagerError as ex:
-            LOGGER.warning("Cluster name not found in Scylla-Manager: {}".format(ex))
+            LOGGER.warning("Cluster name not found in Scylla-Manager: %s", ex)
             return None
 
     def set_cluster_id(self, value: str):
@@ -552,7 +552,7 @@ class ManagerCluster(ScyllaManagerBase):
 
         res = self.sctool.run(cmd=cmd, parse_table_res=False)
         task_id = res.stdout.strip()
-        LOGGER.debug("Created task id is: {}".format(task_id))
+        LOGGER.debug("Created task id is: %s", task_id)
         return RestoreTask(task_id=task_id, cluster_id=self.id, manager_node=self.manager_node)
 
     def create_backup_task(self, dc_list=None,  # pylint: disable=too-many-arguments,too-many-locals,too-many-branches  # noqa: PLR0913
@@ -601,7 +601,7 @@ class ManagerCluster(ScyllaManagerBase):
         res = self.sctool.run(cmd=cmd, parse_table_res=False)
 
         task_id = res.stdout.strip()
-        LOGGER.debug("Created task id is: {}".format(task_id))
+        LOGGER.debug("Created task id is: %s", task_id)
         return BackupTask(task_id=task_id, cluster_id=self.id, manager_node=self.manager_node)
 
     def create_repair_task(self, dc_list=None,  # pylint: disable=too-many-arguments
@@ -647,11 +647,11 @@ class ManagerCluster(ScyllaManagerBase):
 
         # expected result output is to have a format of: "repair/2a4125d6-5d5a-45b9-9d8d-dec038b3732d"
         if 'repair' not in res.stdout:
-            LOGGER.error("Encountered an error on '{}' command response".format(cmd))
+            LOGGER.error("Encountered an error on '%s' command response", cmd)
             raise ScyllaManagerError(res.stderr)
 
         task_id = res.stdout.split('\n')[0]
-        LOGGER.debug("Created task id is: {}".format(task_id))
+        LOGGER.debug("Created task id is: %s", task_id)
 
         return RepairTask(task_id=task_id, cluster_id=self.id,
                           manager_node=self.manager_node)  # return the manager's object with new repair-task-id
@@ -731,7 +731,7 @@ class ManagerCluster(ScyllaManagerBase):
             cmd = "stop --delete {} -c {}".format(task_id, self.id)
         else:
             cmd = "-c {} task delete {}".format(self.id, task_id)
-        LOGGER.debug("Task Delete command to execute is: {}".format(cmd))
+        LOGGER.debug("Task Delete command to execute is: %s", cmd)
         self.sctool.run(cmd=cmd, parse_table_res=False)
         LOGGER.debug("Deleted the task '{}' successfully!". format(task_id))
 
@@ -830,7 +830,7 @@ class ManagerCluster(ScyllaManagerBase):
         dict_hosts_health = {}
         for dc_name, hosts_table in dict_status_tables.items():
             if len(hosts_table) < 2:
-                LOGGER.debug("Cluster: {} - {} has no hosts health report".format(self.id, dc_name))
+                LOGGER.debug("Cluster: %s - %s has no hosts health report", self.id, dc_name)
             else:
                 list_titles_row = hosts_table[0]
                 host_col_idx = list_titles_row.index("Address")
@@ -857,7 +857,7 @@ class ManagerCluster(ScyllaManagerBase):
                                                                rest_status=HostRestStatus.from_str(rest_status),
                                                                rest_rtt=rest_rtt, ssl=HostSsl.from_str(ssl),
                                                                rest_http_status_code=rest_http_status_code)
-            LOGGER.debug("Cluster {} Hosts Health is:".format(self.id))
+            LOGGER.debug("Cluster %s Hosts Health is:", self.id)
             for ip, health in dict_hosts_health.items():
                 LOGGER.debug("{}: {},{},{},{},{}".format(ip, health.status, health.rtt,
                                                          health.rest_status, health.rest_rtt, health.ssl))
@@ -907,7 +907,7 @@ def verify_errorless_result(cmd, res):
         raise ScyllaManagerError("Encountered an error on '{}' command response {}\ncommand exit code:{}\nstderr:{}".format(
             cmd, res, res.exited, res.stderr))
     if res.stderr:
-        LOGGER.error("Encountered an error on '{}' stderr: {}".format(cmd, str(res.stderr)))  # TODO: just for checking
+        LOGGER.error("Encountered an error on '%s' stderr: %s", cmd, str(res.stderr))  # TODO: just for checking
 
 
 class ScyllaManagerTool(ScyllaManagerBase):
@@ -920,7 +920,7 @@ class ScyllaManagerTool(ScyllaManagerBase):
     def __init__(self, manager_node):
         ScyllaManagerBase.__init__(self, id="MANAGER", manager_node=manager_node)
         self._initial_wait(20)
-        LOGGER.info("Initiating Scylla-Manager, version: {}".format(self.sctool.version))
+        LOGGER.info("Initiating Scylla-Manager, version: %s", self.sctool.version)
         list_supported_distros = [Distro.CENTOS7,
                                   Distro.ROCKY8, Distro.ROCKY9,
                                   Distro.DEBIAN10, Distro.DEBIAN11,
@@ -1042,7 +1042,7 @@ class ScyllaManagerTool(ScyllaManagerBase):
             manager_from_version, scylla_mgmt_upgrade_to_repo))
         self.manager_node.upgrade_mgmt(scylla_mgmt_address=scylla_mgmt_upgrade_to_repo)
         new_manager_version = self.sctool.version
-        LOGGER.debug('The Manager version after upgrade is: {}'.format(new_manager_version))
+        LOGGER.debug('The Manager version after upgrade is: %s', new_manager_version)
         return new_manager_version
 
     def rollback_upgrade(self, scylla_mgmt_address):
@@ -1106,7 +1106,7 @@ class ScyllaManagerToolNonRedhat(ScyllaManagerTool):
         res = self.manager_node.remoter.run('sudo apt-get update', ignore_status=True)
         res = self.manager_node.remoter.run('apt-cache  show scylla-manager-client | grep Version:')
         rollback_to_version = res.stdout.split()[1]
-        LOGGER.debug("Rolling back manager version from: {} to: {}".format(manager_from_version, rollback_to_version))
+        LOGGER.debug("Rolling back manager version from: %s to: %s", manager_from_version, rollback_to_version)
         # self.manager_node.install_mgmt(scylla_mgmt_address=scylla_mgmt_address)
         downgrade_to_pre_upgrade_repo = dedent("""
 
@@ -1266,7 +1266,7 @@ class SCTool:
             elif identifier in row:
                 ret_val = row[column_name_index]
                 break
-        LOGGER.debug("{} {} value is:{}".format(identifier, column_name, ret_val))
+        LOGGER.debug("%s %s value is:%s", identifier, column_name, ret_val)
         return ret_val
 
     @staticmethod

--- a/sdcm/microbenchmarking.py
+++ b/sdcm/microbenchmarking.py
@@ -339,9 +339,9 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
 
                 if not subdirs:
                     dataset_name = os.path.basename(fullpath)
-                    self.log.info('Dataset name: {}'.format(dataset_name))
+                    self.log.info('Dataset name: %s', dataset_name)
                     dirname = os.path.basename(os.path.dirname(fullpath))
-                    self.log.info("Test set: {}".format(dirname))
+                    self.log.info("Test set: %s", dirname)
                     for filename in files:
                         if filename.startswith('.'):
                             continue
@@ -381,7 +381,7 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
             self.log.info("Nothing to exclude")
             return
 
-        self.log.info('Exclude testrun {} from results'.format(testrun_id))
+        self.log.info('Exclude testrun %s from results', testrun_id)
         filter_path = (
             "hits.hits._id",  # '2018-04-02_18:36:47_large-partition-skips_[64-32.1)'
             "hits.hits._source.hostname",  # 'godzilla.cloudius-systems.com'
@@ -414,7 +414,7 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
             self.log.info("Nothing to exclude")
             return
 
-        self.log.info('Exclude test id {} from results'.format(test_id))
+        self.log.info('Exclude test id %s from results', test_id)
         doc = self._es.get_doc(index=self._es_index, doc_id=test_id)
         if doc:
             self._es.update_doc(index=self._es_index,
@@ -455,7 +455,7 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
             "hits.hits._source.hostname",
             "hits.hits._source.versions.scylla-server.run_date_time"
         )
-        self.log.info('Exclude tests before date {}'.format(date))
+        self.log.info('Exclude tests before date %s', date)
         results = self._es.search(index=self._es_index, filter_path=filter_path, size=self._limit,  # pylint: disable=unexpected-keyword-arg
                                   q="hostname:'%s' AND versions.scylla-server.version:%s*" %
                                   (self.hostname, self.db_version[:3]))
@@ -488,14 +488,14 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
             "hits.hits._source.test_run_date"
         )
 
-        self.log.info('Exclude tests by commit id #{}'.format(commit_id))
+        self.log.info('Exclude tests by commit id #%s', commit_id)
 
         results = self._es.search(index=self._es_index, filter_path=filter_path, size=self._limit,  # pylint: disable=unexpected-keyword-arg
                                   q="hostname:'{}' \
                                   AND versions.scylla-server.version:{}*\
                                   AND versions.scylla-server.commit_id:'{}'".format(self.hostname, self.db_version[:3], commit_id))
         if not results:
-            self.log.info('There is no testrun results for commit id #{}'.format(commit_id))
+            self.log.info('There is no testrun results for commit id #%s', commit_id)
             return
 
         for doc in results['hits']['hits']:

--- a/sdcm/monitorstack/__init__.py
+++ b/sdcm/monitorstack/__init__.py
@@ -54,7 +54,7 @@ def restore_monitoring_stack(test_id, date_time=None):  # pylint: disable=too-ma
 
     LOGGER.info('Restoring monitoring stack from archive %s', arch['file_path'])
     monitoring_stack_base_dir = tempfile.mkdtemp()
-    LOGGER.info('Download file {} to directory {}'.format(arch['link'], monitoring_stack_base_dir))
+    LOGGER.info('Download file %s to directory %s', arch['link'], monitoring_stack_base_dir)
     downloaded_monitoring_archive = S3Storage().download_file(arch['link'],
                                                               dst_dir=monitoring_stack_base_dir)
     monitoring_data_arch = extract_monitoring_data_archive(downloaded_monitoring_archive,
@@ -503,7 +503,7 @@ def verify_grafana_is_available(grafana_docker_port=GRAFANA_DOCKER_PORT):
                                                             port=grafana_docker_port,
                                                             title=dashboard.title)
             grafana_statuses.append(result)
-            LOGGER.info("Dashboard {} is available".format(dashboard.title))
+            LOGGER.info("Dashboard %s is available", dashboard.title)
         except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
             LOGGER.error("Dashboard %s is not available. Error: %s", dashboard.title, details)
             grafana_statuses.append(False)

--- a/sdcm/ndbench_thread.py
+++ b/sdcm/ndbench_thread.py
@@ -107,7 +107,7 @@ class NdBenchStatsPublisher(FileFollowerThread):
                             self.set_metric(operation, name, float(value))
 
                 except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
-                    LOGGER.warning("Failed to send metric. Failed with exception {exc}".format(exc=exc))
+                    LOGGER.warning("Failed to send metric. Failed with exception %s", exc)
 
 
 class NdBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -69,7 +69,7 @@ class BaseResultsAnalyzer:  # pylint: disable=too-many-instance-attributes
         :return: test results in json format
         """
         if not self._es.exists(index=self._es_index, doc_type=self._es_doc_type, id=test_id):
-            self.log.error('Test results not found: {}'.format(test_id))
+            self.log.error('Test results not found: %s', test_id)
             return None
         return self._es.get(index=self._es_index, doc_type=self._es_doc_type, id=test_id)
 
@@ -179,7 +179,7 @@ class BaseResultsAnalyzer:  # pylint: disable=too-many-instance-attributes
 
     def send_email(self, subject, content, html=True, files=()):
         if self._email_recipients:
-            self.log.debug('Send email to {}'.format(self._email_recipients))
+            self.log.debug('Send email to %s', self._email_recipients)
             email = Email()
             email.send(subject, content, html=html, recipients=self._email_recipients, files=files)
         else:
@@ -506,7 +506,7 @@ class SpecifiedStatsPerformanceAnalyzer(BaseResultsAnalyzer):
     def _test_stats(self, test_doc):
         # check if stats exists
         if 'results' not in test_doc['_source']:
-            self.log.error('Cannot find the field: results for test id: {}!'.format(test_doc['_id']))
+            self.log.error('Cannot find the field: results for test id: %s!', test_doc['_id'])
             return None
         return test_doc['_source']['results']
 
@@ -521,7 +521,7 @@ class SpecifiedStatsPerformanceAnalyzer(BaseResultsAnalyzer):
         # get test res
         doc = self.get_test_by_id(test_id)
         if not doc:
-            self.log.error('Cannot find test by id: {}!'.format(test_id))
+            self.log.error('Cannot find test by id: %s!', test_id)
             return False
 
         test_stats = self._test_stats(doc)
@@ -543,10 +543,10 @@ class SpecifiedStatsPerformanceAnalyzer(BaseResultsAnalyzer):
             size=self._limit,
             filter_path=filter_path,
         )
-        self.log.debug("Filtered tests found are: {}".format(tests_filtered))
+        self.log.debug("Filtered tests found are: %s", tests_filtered)
 
         if not tests_filtered:
-            self.log.info('Cannot find tests with the same parameters as {}'.format(test_id))
+            self.log.info('Cannot find tests with the same parameters as %s', test_id)
             return False
         cur_test_version = None
         tested_params = stats.keys()
@@ -572,7 +572,7 @@ class SpecifiedStatsPerformanceAnalyzer(BaseResultsAnalyzer):
                 continue
             version_info = tag_row['_source']['versions']['scylla-server']
             version = version_info['version']
-            self.log.debug("version_info={} version={}".format(version_info, version))
+            self.log.debug("version_info=%s version=%s", version_info, version)
 
             if tag_row['_id'] == test_id:  # save the current test values
                 cur_test_version = version
@@ -599,7 +599,7 @@ class SpecifiedStatsPerformanceAnalyzer(BaseResultsAnalyzer):
                         else:
                             group_by_version[version][param].append(tag_row['_source'][param])
 
-            self.log.debug("group_by_version={}".format(group_by_version))
+            self.log.debug("group_by_version=%s", group_by_version)
 
         if not cur_test_version:
             raise ValueError("Could not retrieve current test details from database")
@@ -653,7 +653,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
         stats_average = self._remove_non_stat_keys(test_doc['_source']['results']['stats_average'])
         stats_total = test_doc['_source']['results']['stats_total']
         if not stats_average or not stats_total or any(stats_average[k] == '' for k in self.PARAMS):
-            self.log.error('Cannot find average/total results for test: {}!'.format(test_doc['_id']))
+            self.log.error('Cannot find average/total results for test: %s!', test_doc['_id'])
             return None
         # replace average by total value for op rate
         stats_average['op rate'] = stats_total['op rate']
@@ -729,7 +729,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
         # get test res
         doc = self.get_test_by_id(test_id)
         if not doc:
-            self.log.error('Cannot find test by id: {}!'.format(test_id))
+            self.log.error('Cannot find test by id: %s!', test_id)
             return False
         self.log.debug(PP.pformat(doc))
 
@@ -751,7 +751,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
                                          size=self._limit, request_timeout=30)
 
         if not tests_filtered:
-            self.log.info('Cannot find tests with the same parameters as {}'.format(test_id))
+            self.log.info('Cannot find tests with the same parameters as %s', test_id)
             return False
         # get the best res for all versions of this job
         group_by_version = {}
@@ -820,7 +820,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
 
         for version, group in group_by_version.items():
             if version == test_version and not group_by_version[test_version]['tests']:
-                self.log.info('No previous tests in the current version {} to compare'.format(test_version))
+                self.log.info('No previous tests in the current version %s to compare', test_version)
                 continue
             cmp_res = self.cmp(test_stats, group['stats_best'], version, group['best_test_id'])
             latest_version_test = group["tests"].peekitem(index=-1)[1]
@@ -909,7 +909,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
 
         doc = self.get_test_by_id(test_id)
         if not doc:
-            self.log.error('Cannot find test by id: {}!'.format(test_id))
+            self.log.error('Cannot find test by id: %s!', test_id)
             return False
         self.log.debug(PP.pformat(doc))
 
@@ -938,7 +938,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
         )
 
         if not tests_filtered:
-            self.log.info('Cannot find tests with the same parameters as {}'.format(test_id))
+            self.log.info('Cannot find tests with the same parameters as %s', test_id)
             return False
         # get the best res for all versions of this job
         group_by_version_sub_type = SortedDict()
@@ -1052,7 +1052,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
             cmp_res = {}
             for sub_type, tests in group.items():
                 if not tests['tests']:
-                    self.log.info('No previous tests in the current version {} to compare'.format(test_version))
+                    self.log.info('No previous tests in the current version %s to compare', test_version)
                     continue
                 if sub_type not in current_tests:
                     continue
@@ -1113,7 +1113,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
         if rp_main_test:
             rp_main_test = rp_main_test[0]
         if not rp_main_test or not rp_main_test.is_valid():
-            self.log.error('Cannot find main_test by id: {}!'.format(test_id))
+            self.log.error('Cannot find main_test by id: %s!', test_id)
             return None
         return rp_main_test
 
@@ -1281,7 +1281,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
         rp_main_test = self.get_test_instance_by_id(test_id)
 
         if not rp_main_test:
-            self.log.error('Cannot find test with id: {}!'.format(test_id))
+            self.log.error('Cannot find test with id: %s!', test_id)
             return False
 
         if subject is None:
@@ -1304,7 +1304,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
         ])
 
         if not prior_main_tests:
-            self.log.error('Cannot find prior runs for test with id: {}!'.format(test_id))
+            self.log.error('Cannot find prior runs for test with id: %s!', test_id)
             return False
 
         # Get all subtests of the current main test and sort them by subtest name
@@ -1314,7 +1314,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
         ]).sort_by('subtest_name')
 
         if not rp_subtests_of_current_test:
-            self.log.error('Cannot find subtests for test id: {}!'.format(test_id))
+            self.log.error('Cannot find subtests for test id: %s!', test_id)
             return False
 
         if not subtests_info:

--- a/sdcm/sla/libs/sla_utils.py
+++ b/sdcm/sla/libs/sla_utils.py
@@ -179,7 +179,7 @@ class SlaUtils:
             # Example of scheduler_runtime_per_sla:
             #   {'10.0.2.177': {'sl:default': [410.5785714285715, 400.36428571428576],
             #   'sl:sl500_596ca81a': [177.11428571428573, 182.02857142857144]}
-            LOGGER.debug('SERVICE LEVEL GROUP - RUNTIMES: {}'.format(scheduler_runtime_per_sla))
+            LOGGER.debug('SERVICE LEVEL GROUP - RUNTIMES: %s', scheduler_runtime_per_sla)
             if not scheduler_runtime_per_sla:
                 # Set this message as WARNING because I found that prometheus return empty answer despite the data
                 # exists (I run this request manually and got data). Prometheus request doesn't fail, it succeeded but
@@ -203,7 +203,7 @@ class SlaUtils:
                 if role_sl_attribute['sl_group_runtime'] == 0.0:
                     sl_group_runtime_zero = True
 
-            LOGGER.debug('RUN TIME PER ROLE: {}'.format(roles_full_info))
+            LOGGER.debug('RUN TIME PER ROLE: %s', roles_full_info)
 
             # We know and validate expected_ratio in the feature test. In the longevity we can not perform such kind
             # of validation because WP load runs in parallel with disruptive and non-disruptive nemeses, so we can not

--- a/sdcm/sla/sla_tests.py
+++ b/sdcm/sla/sla_tests.py
@@ -143,7 +143,7 @@ class Steps(SlaUtils):
                         )
 
                         connections_map = result.stdout.strip()
-                        LOGGER.debug("[NODE {}] {}".format(node.private_ip_address, connections_map))
+                        LOGGER.debug("[NODE %s] %s", node.private_ip_address, connections_map)
                 # End fix
 
                 start_time = time.time() + 60

--- a/sdcm/stress/base.py
+++ b/sdcm/stress/base.py
@@ -65,7 +65,7 @@ class DockerBasedStressThread:  # pylint: disable=too-many-instance-attributes
         if self.round_robin:
             self.stress_num = 1
             loaders = [self.loader_set.get_loader()]
-            LOGGER.debug("Round-Robin through loaders, Selected loader is {} ".format(loaders))
+            LOGGER.debug("Round-Robin through loaders, Selected loader is %s ", loaders)
         else:
             loaders = self.loader_set.nodes
         self.loaders = loaders

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2359,7 +2359,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             execution_result = session.execute(cmd)
 
         if execution_result:
-            self.log.debug("keyspace creation result: {}".format(execution_result.response_future))
+            self.log.debug("keyspace creation result: %s", execution_result.response_future)
         with self.db_cluster.cql_connection_patient(validation_node) as session:
             does_keyspace_exist = self.wait_validate_keyspace_existence(session, keyspace_name)
         return does_keyspace_exist
@@ -2413,7 +2413,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             query = '%s AND scylla_encryption_options=%s' % (query, scylla_encryption_options)
         if compact_storage:
             query += ' AND COMPACT STORAGE'
-        self.log.debug('CQL query to execute: {}'.format(query))
+        self.log.debug('CQL query to execute: %s', query)
         with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0], keyspace=keyspace_name) as session:
             session.execute(query)
         time.sleep(0.2)
@@ -2423,7 +2423,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             timeout = f" USING TIMEOUT {truncate_timeout_sec}s" if truncate_timeout_sec else ""
             session.execute('TRUNCATE TABLE {0}.{1}{2}'.format(ks_name, table_name, timeout))
         except Exception as ex:  # pylint: disable=broad-except  # noqa: BLE001
-            self.log.debug('Failed to truncate base table {0}.{1}. Error: {2}'.format(ks_name, table_name, str(ex)))
+            self.log.debug('Failed to truncate base table %s.%s. Error: %s', ks_name, table_name, str(ex))
 
     def create_materialized_view(self, ks_name, base_table_name, mv_name, mv_partition_key, mv_clustering_key, session,  # noqa: PLR0913
                                  # pylint: disable=too-many-arguments
@@ -2470,17 +2470,17 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if compact_storage:
             query += ' AND COMPACT STORAGE'
 
-        self.log.debug('MV create statement: {}'.format(query))
+        self.log.debug('MV create statement: %s', query)
         session.execute(query, timeout=600)
 
     def _wait_for_view(self, scylla_cluster, session, key_space, view):
-        self.log.debug("Waiting for view {}.{} to finish building...".format(key_space, view))
+        self.log.debug("Waiting for view %s.%s to finish building...", key_space, view)
 
         def _view_build_finished(live_nodes_amount):
             result = self.rows_to_list(session.execute("SELECT status FROM system_distributed.view_build_status WHERE "
                                                        "keyspace_name='{0}' "
                                                        "AND view_name='{1}'".format(key_space, view)))
-            self.log.debug('View build status result: {}'.format(result))
+            self.log.debug('View build status result: %s', result)
             return len([status for status in result if status[0] == 'SUCCESS']) >= live_nodes_amount
 
         attempts = 20
@@ -2505,7 +2505,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             result = self.rows_to_list(session.execute("SELECT last_token FROM system.views_builds_in_progress "
                                                        "WHERE keyspace_name='{0}' AND view_name='{1}'".format(key_space,
                                                                                                               view)))
-            self.log.debug('View build in progress: {}'.format(result))
+            self.log.debug('View build in progress: %s', result)
             return result != []
 
         self.log.debug("Ensure view building started.")
@@ -2553,7 +2553,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         result = True
         create_statement = "SELECT * FROM system_schema.views where view_name = '%s' " \
                            "and keyspace_name = '%s'" % (src_view, src_keyspace)
-        self.log.debug('Start create table with statement: {}'.format(create_statement))
+        self.log.debug('Start create table with statement: %s', create_statement)
         if not self.create_table_as(node, src_keyspace, src_view, dest_keyspace,
                                     dest_table, create_statement, columns_list):
             return False
@@ -2617,7 +2617,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                             name=dest_table,
                             columns=', '.join(['%s %s' % (c[0], c[1]) for c in columns]),
                             pk=', '.join(primary_keys))
-                self.log.debug('Create new table with cql: {}'.format(create_cql))
+                self.log.debug('Create new table with cql: %s', create_cql)
                 session.execute(create_cql)
                 return True
             return False
@@ -2646,7 +2646,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 return False
 
             # TODO: Temporary function. Will be removed
-            self.log.debug('Rows in the {} MV before saving: {}'.format(src_table, len(source_table_rows)))
+            self.log.debug('Rows in the %s MV before saving: %s', src_table, len(source_table_rows))
 
             insert_statement = session.prepare(
                 'insert into {keyspace}.{name} ({columns}) '
@@ -2922,7 +2922,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.argus_finalize_test_run()
         self.argus_heartbeat_stop_signal.set()
 
-        self.log.info('Test ID: {}'.format(self.test_config.test_id()))
+        self.log.info('Test ID: %s', self.test_config.test_id())
         self._check_alive_routines_and_report_them()
         self._check_if_db_log_time_consistency_looks_good()
         self.remove_python_exit_hooks()
@@ -3422,10 +3422,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 ).publish_or_dump(default_logger=self.log)
 
     def stop_all_nodes_except_for(self, node):
-        self.log.debug("Stopping all nodes except for: {}".format(node.name))
+        self.log.debug("Stopping all nodes except for: %s", node.name)
 
         for c_node in [n for n in self.db_cluster.nodes if n != node]:
-            self.log.debug("Stopping node: {}".format(c_node.name))
+            self.log.debug("Stopping node: %s", c_node.name)
             c_node.stop_scylla_server()
 
     def start_all_nodes(self):
@@ -3433,7 +3433,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.log.debug("Starting all nodes")
         # restarting all nodes twice in order to pervent no-seed node issues
         for c_node in self.db_cluster.nodes * 2:
-            self.log.debug("Starting node: {} ({})".format(c_node.name, c_node.public_ip_address))
+            self.log.debug("Starting node: %s (%s)", c_node.name, c_node.public_ip_address)
             c_node.start_scylla_server(verify_up=False)
             time.sleep(10)
         self.log.debug("Wait DB is up after all nodes were started")
@@ -3441,16 +3441,16 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             c_node.wait_db_up()
 
     def start_all_nodes_except_for(self, node):
-        self.log.debug("Starting all nodes except for: {}".format(node.name))
+        self.log.debug("Starting all nodes except for: %s", node.name)
         node_list = [n for n in self.db_cluster.nodes if n != node]
 
         # Start down seed nodes first, if exists
         for c_node in [n for n in node_list if n.is_seed]:
-            self.log.debug("Starting seed node: {}".format(c_node.name))
+            self.log.debug("Starting seed node: %s", c_node.name)
             c_node.start_scylla_server()
 
         for c_node in [n for n in node_list if not n.is_seed]:
-            self.log.debug("Starting non-seed node: {}".format(c_node.name))
+            self.log.debug("Starting non-seed node: %s", c_node.name)
             c_node.start_scylla_server()
 
         node.wait_db_up()
@@ -3486,12 +3486,12 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         assert fs_size_res[0], "Could not resolve capacity query result."
         kb_size = 2 ** 10
         mb_size = kb_size * 1024
-        self.log.debug("fs_size_res: {}".format(fs_size_res))
-        self.log.debug("used_capacity_query: {}".format(used_capacity_query))
+        self.log.debug("fs_size_res: %s", fs_size_res)
+        self.log.debug("used_capacity_query: %s", used_capacity_query)
 
         used_cap_res = self.prometheus_db.query(
             query=used_capacity_query, start=int(time.time()) - 5, end=int(time.time()))
-        self.log.debug("used_cap_res: {}".format(used_cap_res))
+        self.log.debug("used_cap_res: %s", used_cap_res)
 
         assert used_cap_res, "No results from Prometheus"
         used_size_mb = float(used_cap_res[0]["values"][0][1]) / float(mb_size)

--- a/sdcm/utils/alternator/api.py
+++ b/sdcm/utils/alternator/api.py
@@ -101,19 +101,19 @@ class Alternator:
             schema = schema.value
         schema = schemas.ALTERNATOR_SCHEMAS[schema]
         dynamodb_api = self.get_dynamodb_api(node=node)
-        LOGGER.debug("Creating a new table '{}' using node '{}'".format(table_name, node.name))
+        LOGGER.debug("Creating a new table '%s' using node '%s'", table_name, node.name)
         table = dynamodb_api.resource.create_table(
             TableName=table_name, BillingMode="PAY_PER_REQUEST", **schema, **kwargs)
         if wait_until_table_exists:
             waiter = dynamodb_api.client.get_waiter('table_exists')
             waiter.wait(TableName=table_name, WaiterConfig=dict(Delay=1, MaxAttempts=100))
 
-        LOGGER.info("The table '{}' successfully created..".format(table_name))
+        LOGGER.info("The table '%s' successfully created..", table_name)
         response = dynamodb_api.client.describe_table(TableName=table_name)
 
         if isolation:
             self.set_write_isolation(node=node, isolation=isolation, table_name=table_name)
-        LOGGER.debug("Table's schema and configuration are: {}".format(response))
+        LOGGER.debug("Table's schema and configuration are: %s", response)
         return table
 
     def update_table_ttl(self, node, table_name, enabled: bool = True):
@@ -134,15 +134,15 @@ class Alternator:
             parallel_params, result, still_running_while = {}, [], True
             if is_parallel_scan:
                 parallel_params = {"TotalSegments": threads_num, "Segment": part_scan_idx}
-                LOGGER.debug("Starting parallel scan part '{}' on table '{}'".format(part_scan_idx + 1, table_name))
+                LOGGER.debug("Starting parallel scan part '%s' on table '%s'", part_scan_idx + 1, table_name)
             else:
-                LOGGER.debug("Starting full scan on table '{}'".format(table_name))
+                LOGGER.debug("Starting full scan on table '%s'", table_name)
             while still_running_while:
                 response = table.scan(**parallel_params, **kwargs)
                 result.extend(response["Items"])
                 still_running_while = 'LastEvaluatedKey' in response
 
-            LOGGER.debug("Founding the following items:\n{}".format(pformat(result)))
+            LOGGER.debug("Founding the following items:\n%s", pformat(result))
             return result
 
         if is_parallel_scan:
@@ -194,6 +194,6 @@ class Alternator:
         if wait_until_table_removed:
             waiter = dynamodb_api.client.get_waiter('table_not_exists')
             waiter.wait(TableName=table_name)
-            LOGGER.info("The '{}' table successfully removed".format(table_name))
+            LOGGER.info("The '%s' table successfully removed", table_name)
         else:
-            LOGGER.info("Send request to removed '{}' table".format(table_name))
+            LOGGER.info("Send request to removed '%s' table", table_name)

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -279,11 +279,11 @@ class S3Storage():
         s3_url = self.generate_url(file_path, dest_dir)
         s3_obj = "{}/{}".format(dest_dir, os.path.basename(file_path))
         try:
-            LOGGER.info("Uploading '{file_path}' to {s3_url}".format(file_path=file_path, s3_url=s3_url))
+            LOGGER.info("Uploading '%s' to %", file_path, s3_url)
             self._bucket.upload_file(Filename=file_path,
                                      Key=s3_obj,
                                      Config=self.transfer_config)
-            LOGGER.info("Uploaded to {0}".format(s3_url))
+            LOGGER.info("Uploaded to %s", s3_url)
             LOGGER.info("Set public read access")
             self.set_public_access(key=s3_obj)
             return s3_url
@@ -309,7 +309,7 @@ class S3Storage():
         key_name = link.replace("https://{0.bucket_name}.s3.amazonaws.com/".format(self), "")
         file_name = os.path.basename(key_name)
         try:
-            LOGGER.info("Downloading {0} from {1}".format(key_name, self.bucket_name))
+            LOGGER.info("Downloading %s from %s", key_name, self.bucket_name)
             self._bucket.download_file(Key=key_name,
                                        Filename=os.path.join(dst_dir, file_name),
                                        Config=self.transfer_config)
@@ -317,7 +317,7 @@ class S3Storage():
             return os.path.join(os.path.abspath(dst_dir), file_name)
 
         except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
-            LOGGER.warning("File {} is not downloaded by reason: {}".format(key_name, details))
+            LOGGER.warning("File %s is not downloaded by reason: %s", key_name, details)
             return ""
 
 
@@ -457,7 +457,7 @@ class ParallelObject:
                                                                                            fun_args=fun_args,
                                                                                            fun_kwargs=fun_kwargs))
                 return_val = fun(*args, **kwargs)
-                LOGGER.debug("[{thread_name}] Done.".format(thread_name=thread_name))
+                LOGGER.debug("[%s] Done.", thread_name)
                 return return_val
 
             return inner
@@ -465,7 +465,7 @@ class ParallelObject:
         results = []
 
         if not self.disable_logging:
-            LOGGER.debug("Executing in parallel: '{}' on {}".format(func.__name__, self.objects))
+            LOGGER.debug("Executing in parallel: '%s' on %s", func.__name__, self.objects)
             func = func_wrap(func)
 
         futures = []
@@ -855,7 +855,7 @@ def list_instances_aws(tags_dict=None, region_name=None, running=False, group_as
         total_items = sum([len(value) for _, value in instances.items()])
 
     if verbose:
-        LOGGER.info("Found total of {} instances.".format(total_items))
+        LOGGER.info("Found total of %s instances.", total_items)
 
     return instances
 
@@ -890,7 +890,7 @@ def clean_instances_aws(tags_dict: dict, regions=None, dry_run=False):
             if node_type and node_type == "sct-runner":
                 LOGGER.info("Skipping Sct Runner instance '%s'", instance_id)
                 continue
-            LOGGER.info("Going to delete '{instance_id}' [name={name}] ".format(instance_id=instance_id, name=name))
+            LOGGER.info("Going to delete '%s' [name=%s] ", instance_id, name)
             if not dry_run:
                 response = client.terminate_instances(InstanceIds=[instance_id])
                 terminate_resource_in_argus(client=argus_client, resource_name=name)
@@ -2287,7 +2287,7 @@ def download_dir_from_cloud(url):
     parsed = urlparse(url)
     LOGGER.info("Downloading [%s] to [%s]", url, tmp_dir)
     if os.path.isdir(tmp_dir) and os.listdir(tmp_dir):
-        LOGGER.warning("[{}] already exists, skipping download".format(tmp_dir))
+        LOGGER.warning("[%s] already exists, skipping download", tmp_dir)
     elif url.startswith('s3://'):
         s3_download_dir(parsed.hostname, parsed.path, tmp_dir)
     elif url.startswith('gs://'):
@@ -2509,8 +2509,8 @@ def search_test_id_in_latest(logdir):
     result = LocalCmdRunner().run('cat {0}/latest/test_id'.format(logdir), ignore_status=True)
     if not result.exited and result.stdout:
         test_id = result.stdout.strip()
-        LOGGER.info("Found latest test_id: {}".format(test_id))
-        LOGGER.info("Collect logs for test-run with test-id: {}".format(test_id))
+        LOGGER.info("Found latest test_id: %s", test_id)
+        LOGGER.info("Collect logs for test-run with test-id: %s", test_id)
     else:
         LOGGER.error('test_id not found. Exit code: %s; Error details %s', result.exited, result.stderr)
     return test_id
@@ -2751,7 +2751,7 @@ def reach_enospc_on_node(target_node):
         free_space_size = int(result.stdout.split()[3])
         occupy_space_size = int(free_space_size * 90 / 100)
         occupy_space_cmd = f'fallocate -l {occupy_space_size}K /var/lib/scylla/occupy_90percent.{time.time()}'
-        LOGGER.debug('Cost 90% free space on /var/lib/scylla/ by {}'.format(occupy_space_cmd))
+        LOGGER.debug('Cost 90%% free space on /var/lib/scylla/ by %s', occupy_space_cmd)
         try:
             target_node.remoter.sudo(occupy_space_cmd, verbose=True)
         except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
@@ -2767,7 +2767,7 @@ def reach_enospc_on_node(target_node):
 
 
 def clean_enospc_on_node(target_node, sleep_time):
-    LOGGER.debug('Sleep {} seconds before releasing space to scylla'.format(sleep_time))
+    LOGGER.debug('Sleep %s seconds before releasing space to scylla', sleep_time)
     time.sleep(sleep_time)
 
     LOGGER.debug('Delete occupy_90percent file to release space to scylla-server')
@@ -3196,7 +3196,7 @@ def list_placement_groups_aws(tags_dict=None, region_name=None, available=False,
         total_items = sum([len(value) for _, value in placement_groups.items()])
 
     if verbose:
-        LOGGER.info("Found total of {} instances.".format(total_items))
+        LOGGER.info("Found total of %s instances.", total_items)
 
     return placement_groups
 
@@ -3222,7 +3222,7 @@ def clean_placement_groups_aws(tags_dict: dict, regions=None, dry_run=False):
         client: EC2Client = boto3.client('ec2', region_name=region)
         for instance in instance_list:
             name = instance.get("GroupName")
-            LOGGER.info("Going to delete placement group '{name} ".format(name=name))
+            LOGGER.info("Going to delete placement group '%sname ", name=name)
             if not dry_run:
                 try:
                     response = client.delete_placement_group(GroupName=name)

--- a/sdcm/utils/database_query_utils.py
+++ b/sdcm/utils/database_query_utils.py
@@ -127,7 +127,7 @@ class PartitionsValidationAttributes:  # pylint: disable=too-few-public-methods,
 
                 partitions[i] = pk_rows_num_result
                 stats_file.write('{i}:{rows}, '.format(i=i, rows=partitions[i]))
-        LOGGER.info('File with partitions row data: {}'.format(partitions_stats_file))
+        LOGGER.info('File with partitions row data: %s', partitions_stats_file)
         if save_into_file_name == self.PARTITIONS_ROWS_BEFORE:
             self.partitions_rows_collected = True
         return partitions

--- a/sdcm/utils/loader_utils.py
+++ b/sdcm/utils/loader_utils.py
@@ -112,7 +112,7 @@ class LoaderUtilsMixin:
                     stress_params.update({'keyspace_name': keyspace_name})
 
             # Run all stress commands
-            self.log.debug('stress cmd: {}'.format(stress_cmd))
+            self.log.debug('stress cmd: %s', stress_cmd)
             if stress_cmd.startswith('scylla-bench'):
                 stress_queue.append(self.run_stress_thread(stress_cmd=stress_cmd,
                                                            stats_aggregate_cmds=False,
@@ -182,7 +182,7 @@ class LoaderUtilsMixin:
                     params = {'stress_cmd': stress_cmd, 'profile': cs_profile, 'round_robin': round_robin}
                     stress_params = dict(params)
 
-                    self.log.debug('stress cmd: {}'.format(stress_cmd))
+                    self.log.debug('stress cmd: %s', stress_cmd)
                     stress_queue.append(self.run_stress_thread(**stress_params))
 
         return stress_queue

--- a/sdcm/utils/microbenchmarking/perf_simple_query_reporter.py
+++ b/sdcm/utils/microbenchmarking/perf_simple_query_reporter.py
@@ -31,13 +31,13 @@ class PerfSimpleQueryAnalyzer(BaseResultsAnalyzer):
 
     def _get_perf_simple_query_result(self, test_doc):
         if not keys_exists(test_doc, "_source", "results", "perf_simple_query_result"):
-            self.log.error('Cannot find the field: perf_simple_query_result for test id: {}!'.format(test_doc['_id']))
+            self.log.error('Cannot find the field: perf_simple_query_result for test id: %s!', test_doc['_id'])
             return None
         return test_doc['_source']['results']['perf_simple_query_result']
 
     def _get_test_details(self, test_doc):
         if not keys_exists(test_doc, "_source", "test_details"):
-            self.log.error('Cannot find the field: test_details for test id: {}!'.format(test_doc['_id']))
+            self.log.error('Cannot find the field: test_details for test id: %s!', test_doc['_id'])
             return None
         return test_doc["_source"]["test_details"]
 
@@ -50,7 +50,7 @@ class PerfSimpleQueryAnalyzer(BaseResultsAnalyzer):
     def check_regression(self, test_id, mad_deviation_limit=0.02, regression_limit=0.05, is_gce=False):  # pylint: disable=too-many-locals,too-many-statements
         doc = self.get_test_by_id(test_id)
         if not doc:
-            self.log.error('Cannot find test by id: {}!'.format(test_id))
+            self.log.error('Cannot find test by id: %s!', test_id)
             return False
 
         test_stats = self._get_perf_simple_query_result(doc)


### PR DESCRIPTION
We miss f-string log checks in ruff and cause issues with backporting (and anyway we want to keep it).

Fixed along issues with it in most of cases.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
