### PR TITLE
fix(benchmarks): ignore errors in benchmarks

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3761,10 +3761,12 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
             return
         if "db-cluster" not in self.name:
             return
-
-        self.node_benchmark_manager.add_nodes(self.nodes)
-        self.node_benchmark_manager.install_benchmark_tools()
-        self.node_benchmark_manager.run_benchmarks()
+        try:
+            self.node_benchmark_manager.add_nodes(self.nodes)
+            self.node_benchmark_manager.install_benchmark_tools()
+            self.node_benchmark_manager.run_benchmarks()
+        except Exception as ex:  # pylint: disable=broad-except  # noqa: BLE001
+            self.log.error("Failed to run node benchmarks: %s", ex)
 
     def get_node_benchmarks_results(self):
         if not self.params.get("run_db_node_benchmarks") or not self.nodes:


### PR DESCRIPTION
Node benchmarks are not mandatory and shouldn't affect the test.

Ignoring any error that happen during benchmarks - just logging error message if anyone wanted to investigate.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/7451

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
