### PR TITLE
improvement(byo): make CI jobs fail fast if BYO fails

### DIFF
--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -249,6 +249,18 @@ def call(Map pipelineParams) {
                         }
                     }
                 }
+                post{
+                    failure {
+                        script{
+                            sh "exit 1"
+                        }
+                    }
+                    unstable {
+                        script{
+                            sh "exit 1"
+                        }
+                    }
+                }
             }
             stage('Create SCT Runner') {
                 steps {


### PR DESCRIPTION
Fixes: #7884

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/job/scylla-staging/job/valerii/job/vp-longevity-10gb-3h-test/110

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
