### PR TITLE
improvement(open_system_log): added debug line

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1467,6 +1467,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
                 # ignore microseconds because log lines don't have them
                 on_datetime = on_datetime.replace(microsecond=0)
             left, right = 0, log_file.seek(0, 2)
+            log_size = right
             while left <= right:
                 mid = (left + right) // 2
                 log_file.seek(mid)
@@ -1489,6 +1490,8 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
                     left = mid + 1
                 elif log_time >= on_datetime:
                     right = mid - 1
+            self.log.debug("Asked to open log at %s, the closest log line is %s. log size: %s, line: <%s>...",
+                           on_datetime, log_time, log_size, line[100])
             yield log_file
 
     def start_decode_on_monitor_node_thread(self):


### PR DESCRIPTION
We see problems with audit logs missing. Possibly it's due miss in `open_system_log` method but we can't be sure.

Added log message that will help us investigation in case of issues. refs: https://github.com/scylladb/scylla-cluster-tests/issues/7102

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
