### PR TITLE
fix(decommission): increase timeout

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4036,7 +4036,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 raise
 
         num_workers = None if (self.cluster.parallel_node_operations and nodes[0].raft.is_enabled) else 1
-        parallel_obj = ParallelObject(objects=nodes, timeout=7200, num_workers=num_workers)
+        parallel_obj = ParallelObject(objects=nodes, timeout=MAX_TIME_WAIT_FOR_DECOMMISSION, num_workers=num_workers)
         InfoEvent(f'StartEvent - ShrinkCluster started decommissioning {len(nodes)} nodes').publish()
         parallel_obj.run(_decommission, ignore_exceptions=False, unpack_objects=True)
         self.monitoring_set.reconfigure_scylla_monitoring()


### PR DESCRIPTION
Timeout for decommission is too low and some tests fail due to that.

Increase timeout for decommission to `MAX_TIME_WAIT_FOR_DECOMMISSION`

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
