### PR TITLE
improvement(upgrade): make upgrade CI jobs fail fast if BYO fails

### DIFF
--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -150,6 +150,38 @@ def call(Map pipelineParams) {
                     }
                 }
             }
+            stage('BYO Scylladb [optional]') {
+                agent {
+                    label {
+                        label builder.label
+                    }
+                }
+                steps {
+                    catchError(stageResult: 'FAILURE') {
+                        script {
+                            wrap([$class: 'BuildUser']) {
+                                dir('scylla-cluster-tests') {
+                                    timeout(time: 240, unit: 'MINUTES') {
+                                        byoScylladb(params, false)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                post{
+                    failure {
+                        script{
+                            sh "exit 1"
+                        }
+                    }
+                    unstable {
+                        script{
+                            sh "exit 1"
+                        }
+                    }
+                }
+            }
             stage('Run SCT stages') {
                 steps {
                     script {
@@ -184,19 +216,6 @@ def call(Map pipelineParams) {
                                                         dir('scylla-cluster-tests') {
                                                             timeout(time: 5, unit: 'MINUTES') {
                                                                 createArgusTestRun(params)
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        stage('BYO Scylladb [optional]') {
-                                            catchError(stageResult: 'FAILURE') {
-                                                script {
-                                                    wrap([$class: 'BuildUser']) {
-                                                        dir('scylla-cluster-tests') {
-                                                            timeout(time: 240, unit: 'MINUTES') {
-                                                                byoScylladb(params, false)
                                                             }
                                                         }
                                                     }


### PR DESCRIPTION
Fixes: #7884

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/valerii/job/vp-rolling-upgrade-ubuntu22.04-test/13 (controlled failure of BYO)
- https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/valerii/job/vp-rolling-upgrade-ubuntu22.04-test/14 (BYO succeeded)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
