### PR TITLE
improvement(nemesis): ignore raft transport error

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -334,6 +334,19 @@ def ignore_raft_topology_cmd_failing():
         yield
 
 
+@contextmanager
+def ignore_raft_transport_failing():
+    # Example of scenario when we should ignore this error: https://github.com/scylladb/scylladb/issues/15713#issuecomment-2217376031
+    with ExitStack() as stack:
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*raft::transport_error \(.*rpc::closed_error \(connection is closed\)",
+            extra_time_to_expiration=30
+        ))
+        yield
+
+
 def decorate_with_context(context_list: list[Callable | ContextManager] | Callable | ContextManager):
     """
     helper to decorate a function to run with a list of callables that return context managers

--- a/sdcm/utils/raft/common.py
+++ b/sdcm/utils/raft/common.py
@@ -8,7 +8,7 @@ from sdcm.exceptions import BootstrapStreamErrorFailure
 from sdcm.cluster import BaseNode, BaseScyllaCluster, BaseMonitorSet
 from sdcm.wait import wait_for
 from sdcm.sct_events.group_common_events import decorate_with_context, \
-    ignore_stream_mutation_fragments_errors, ignore_ycsb_connection_refused, ignore_raft_topology_cmd_failing
+    ignore_stream_mutation_fragments_errors, ignore_ycsb_connection_refused, ignore_raft_topology_cmd_failing, ignore_raft_transport_failing
 from sdcm.utils.adaptive_timeouts import Operations, adaptive_timeout
 from sdcm.utils.common import ParallelObject
 
@@ -117,7 +117,8 @@ class NodeBootstrapAbortManager:
 
         wait_operations_timeout = (self.SUCCESS_BOOTSTRAP_TIMEOUT + self.INSTANCE_START_TIMEOUT
                                    + terminate_pattern.timeout + abort_action_timeout)
-        with ignore_stream_mutation_fragments_errors(), ignore_raft_topology_cmd_failing(), contextlib.ExitStack() as stack:
+        with ignore_stream_mutation_fragments_errors(), ignore_raft_topology_cmd_failing(), \
+                ignore_raft_transport_failing(), contextlib.ExitStack() as stack:
             for expected_start_failed_context in self.verification_node.raft.get_severity_change_filters_scylla_start_failed(
                     terminate_pattern.timeout):
                 stack.enter_context(expected_start_failed_context)
@@ -142,7 +143,7 @@ class NodeBootstrapAbortManager:
                 self.verification_node.raft.clean_group0_garbage(raise_exception=True)
                 LOGGER.debug("Clean old scylla data and restart scylla service")
                 self.bootstrap_node.clean_scylla_data()
-            with ignore_raft_topology_cmd_failing(), \
+            with ignore_raft_topology_cmd_failing(), ignore_raft_transport_failing(), \
                     adaptive_timeout(operation=Operations.NEW_NODE, node=self.verification_node, timeout=3600) as bootstrap_timeout:
 
                 self.bootstrap_node.start_scylla_server(verify_up_timeout=bootstrap_timeout, verify_down=True)


### PR DESCRIPTION
We should ignore RPC transport error when one node boot is interrupted and Scylla did not start. In this case RPC to a new node was interrupted. We can ignore this error in this specific scenario (https://github.com/scylladb/scylladb/issues/15713#issuecomment-2217376031).

We have this scenario in 'BootstrapStreamingError' nemesis. Example of an error:
```
Transferring snapshot to 5f2e78c failed with: raft::transport_error (Failed to execute virtual future<raft::snapshot_reply> service::raft_rpc::send_snapshot(raft::server_id, const raft::install_snapshot &, seastar::abort_source &) on leader 5f2e78c9-c1b2-47f3-87b4-048fd2589d0d: seastar::rpc::closed_error (connection is closed))
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] I ran the test twice, but this error was not reproduced. No failures

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
