### PR TITLE
feature(disk-to-ram ratio): add a minimal test case

### DIFF
--- a/jenkins-pipelines/oss/features/disk-to-ram-ratio/minimal-memory-size.jenkinsfile
+++ b/jenkins-pipelines/oss/features/disk-to-ram-ratio/minimal-memory-size.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    availability_zone: 'c',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/features/disk-to-ram-ratio/minimal-memory-size.yaml',
+    instance_provision_fallback_on_demand: true
+)

--- a/test-cases/features/disk-to-ram-ratio/minimal-memory-size.yaml
+++ b/test-cases/features/disk-to-ram-ratio/minimal-memory-size.yaml
@@ -1,0 +1,21 @@
+test_duration: 240
+
+prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=209715200 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..209715200 -col 'n=FIXED(1) size=FIXED(512)' -log interval=5",
+                     "cassandra-stress write cl=QUORUM n=209715200 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=209715201..419430400 -col 'n=FIXED(1) size=FIXED(512)' -log interval=5"
+                    ]
+stress_cmd: ["cassandra-stress read cl=QUORUM duration=90m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=50 -pop seq=1..209715200 -log interval=5",
+             "cassandra-stress write cl=QUORUM duration=90m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=50 -pop seq=209715201..419430400 -col 'n=FIXED(1) size=FIXED(512)' -log interval=5"
+            ]
+
+round_robin: true
+n_db_nodes: 3
+n_loaders: 2
+n_monitor_nodes: 1
+
+instance_type_db: 'i4i.large'
+
+nemesis_class_name: 'NoOpMonkey'
+nemesis_interval: 99
+
+user_prefix: 'disk-to-ram-minimal-memory-test'
+append_scylla_args: '--memory 2200M --blocked-reactor-notify-ms 25 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'


### PR DESCRIPTION
	Adding a test that contains 1GB memory size
	and writes 100 GB c-s key-value.
	After prepare step finishes with a 1:100 ratio,
	starting a read/write stress.
[Test plan doc](https://docs.google.com/document/d/1_SJz1j8I6DZLCdVtdmDh9MCLBjCa1Tvsq1T8LiUaMfQ/edit?usp=sharing)
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
