### PR TITLE
improvement(pylint): disable f-string-interpolation error

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -147,6 +147,7 @@ disable=print-statement,
         bad-continuation,
         cyclic-import,
         duplicate-code,
+        logging-fstring-interpolation,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
In SCT we always run with debug log thus we don't care about having f-strings in log messages. There's no improvement from having this check turned on and f-string based messages are more readable and more natural to python programmers.
This check is disabled in our `ruff` linter but still we often backport commits to different branches where we still use it.

Disabling this check in .pylintrc.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
