### PR TITLE
test(longevities): duplicate tablets-supported tests for 2024.2

### DIFF
--- a/configurations/tablets_enabled.yaml
+++ b/configurations/tablets_enabled.yaml
@@ -1,0 +1,2 @@
+append_scylla_yaml:
+  enable_tablets: true

--- a/jenkins-pipelines/oss/longevity/tablets/longevity-100gb-4h-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/tablets/longevity-100gb-4h-arm.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/arm_instance_types/im4gn_4xlarge.yaml", "configurations/tablets_enabled.yaml"]''',
+    availability_zone: 'c'
+)

--- a/jenkins-pipelines/oss/longevity/tablets/longevity-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/tablets/longevity-100gb-4h.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    availability_zone: 'c',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/tablets_enabled.yaml"]''',
+    instance_provision_fallback_on_demand: true
+)


### PR DESCRIPTION
	The tablets feature is switched to be disabled by default in 2024.2.
	The relevant longevity tests that are supported by tablets should be
	duplicated with a tablets-enabled configuration.

The 2024.1 dashboard, can be the basis for duplicated jobs for 2024.2-tablets-enabled.
There are 21 jobs under "Clster -Longevity tests":
![image](https://github.com/user-attachments/assets/49b9bb1d-c9a9-4777-a453-24b668d046cd)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
