### PR TITLE
feature(monitoring): set the scylla monitoring image to 4.8.0

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -9,7 +9,7 @@ instance_type_monitor: 't3.large'
 # manual on creating loader AMI's: see docs/new_loader_ami.md
 ami_id_loader: 'scylla-qa-loader-ami-v21-ubuntu22'  # versions: c-s 2024.2.0-rc0, s-b 0.1.21
 # manual on updating monitor images see: docs/monitoring-images.md
-ami_id_monitor: 'scylladb-monitor-4-7-2-2024-05-13t08-38-47z'
+ami_id_monitor: 'scylladb-monitor-4-8-0-2024-08-06t03-34-43z'
 
 availability_zone: 'a'
 root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -6,7 +6,7 @@ gce_project: '' # empty mean default one, can be overwritten to use different on
 gce_image_db: '' # so we can use `scylla_version` as needed
 gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts'
 # manual on updating monitor images see: docs/monitoring-images.md
-gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-7-2-2024-05-15t06-30-55z'
+gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-8-0-2024-08-06t03-34-43z'
 gce_image_username: 'scylla-test'
 
 gce_instance_type_loader: 'e2-standard-2'

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -26,7 +26,7 @@ scylla_linux_distro: 'ubuntu-focal'
 scylla_linux_distro_loader: 'ubuntu-jammy'
 ssh_transport: 'libssh2'
 
-monitor_branch: 'branch-4.7'
+monitor_branch: 'branch-4.8'
 
 space_node_threshold: 0
 

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -499,8 +499,11 @@ class GrafanaScreenShot(GrafanaEntity):
                                                                         datetime.datetime.now().strftime("%Y%m%d_%H%M%S"),
                                                                         node.name))
                     LOGGER.debug("Get screenshot for url %s, save to %s", grafana_url, screenshot_path)
+                    # deliberately specifying params as string to be able to use kiosk mode
+                    # since requests can put a param without value, if using dict
+                    # https://github.com/psf/requests/issues/2651
                     with requests.get(grafana_url, stream=True,
-                                      params=dict(width=dashboard.resolution[0], height=dashboard.resolution[1])) as response:
+                                      params=f"width={dashboard.resolution[0]}&height=-1&kiosk") as response:
                         response.raise_for_status()
                         with open(screenshot_path, 'wb') as output_file:
                             for chunk in response.iter_content(chunk_size=8192):

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -374,7 +374,7 @@ class MonitoringStack(BaseMonitoringEntity):
 
         archive_name = os.path.join(monitor_base_dir,
                                     f"monitoring_data_stack_{monitor_branch}_{monitor_version}.tar.gz")
-        if not node.remoter.run(f"tar czvf '{archive_name}' -C '{monitor_base_dir}' '{monitor_install_dir_name}'",
+        if not node.remoter.run(f"tar czvf '{archive_name}' --exclude='gpx_scylladb_*' -C '{monitor_base_dir}' '{monitor_install_dir_name}'",
                                 ignore_status=True).ok:
             return ""
         if not check_archive(node.remoter, archive_name):


### PR DESCRIPTION
Set the monitoring image to version 4.8.0

#### Testing
- [x] aws provision test
- [x] gce provision test
- [x] check monitor can be retrieved 
- [x] check screenshots working
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-10gb-3h-ipv6-test/14/
