### PR TITLE
fix(et_supported_scylla_base_versions): make upgrade work for minor version

### DIFF
--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -52,31 +52,31 @@ class TestBaseVersion(unittest.TestCase):
         linux_distro = 'ubuntu-jammy'
         cloud_provider = 'azure'
         version_list = general_test(scylla_repo, linux_distro, cloud_provider)
-        self.assertEqual(version_list, ['5.2', '2023.1'])
+        assert set(version_list) == {'5.2', '2023.1'}
 
     def test_4_5_with_centos8(self):
         scylla_repo = self.url_base + '/branch-4.5/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
         linux_distro = 'centos-8'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(version_list, ['4.4', '4.5'])
+        assert set(version_list) == {'4.4', '4.5'}
 
     def test_4_5(self):
         scylla_repo = self.url_base + '/4.5/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
         linux_distro = 'centos'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(version_list, ['4.4', '4.5'])
+        assert set(version_list) == {'4.4', '4.5'}
 
     def test_5_0(self):
         scylla_repo = self.url_base + '/branch-5.0/rpm/centos/2023-01-21T02:51:18Z/scylla.repo'
         linux_distro = 'centos-8'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(version_list, ['4.6', '5.0'])
+        assert set(version_list) == {'4.6', '5.0'}
 
     def test_5_1(self):
         scylla_repo = self.url_base + '/branch-5.1/deb/unified/2023-01-21T02:35:18Z/scylladb-5.1/scylla.list'
         linux_distro = 'ubuntu-focal'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(version_list, ['5.0', '5.1'])
+        assert set(version_list) == {'5.0', '5.1'}
 
     def test_enterprise(self):
         scylla_repo = self.url_base + '-enterprise/enterprise/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
@@ -89,38 +89,44 @@ class TestBaseVersion(unittest.TestCase):
         scylla_repo = self.url_base + '-enterprise/branch-2021.1/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
         linux_distro = 'centos'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(version_list, ['4.3', '2020.1', '2021.1'])
+        assert set(version_list) == {'4.3', '2020.1', '2021.1'}
 
     def test_2021_1_with_centos8(self):
         scylla_repo = self.url_base + '-enterprise/branch-2021.1/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
         linux_distro = 'centos-8'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(version_list, ['4.3', '2021.1'])
+        assert set(version_list) == {'4.3', '2021.1'}
 
     def test_2022_1_with_centos8(self):
         scylla_repo = self.url_base + \
             '-enterprise/enterprise-2022.1/deb/unified/2022-06-03T00:22:55Z/scylladb-2022.1/scylla.list'
         linux_distro = 'centos-8'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(['5.0', '2021.1', '2022.1'], version_list)
+        assert set(version_list) == {'5.0', '2021.1', '2022.1'}
 
     def test_2024_1_with_centos9(self):
         scylla_repo = self.url_base + '-enterprise/enterprise-2024.1/rpm/centos/latest/scylla.repo'
         linux_distro = 'centos-9'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(['5.4', '2024.1'], version_list)
+        assert set(version_list) == {'5.4', '2024.1'}
 
     def test_2022_2(self):
         scylla_repo = self.url_base + '-enterprise/enterprise-2022.2/rpm/centos/2022-10-09T10:39:11Z/scylla.repo'
         linux_distro = 'centos'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(version_list, ['5.1', '2022.1', '2022.2'])
+        assert set(version_list) == {'5.1', '2022.1', '2022.2'}
 
     def test_2024_1(self):
         scylla_repo = self.url_base + '-enterprise/enterprise-2024.1/rpm/centos/latest/scylla.repo'
         linux_distro = 'centos'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(version_list, ['5.4', '2022.2', '2023.1'])
+        assert set(version_list) == {'5.4', '2022.2', '2023.1', '2024.1'}
+
+    def test_2024_2(self):
+        scylla_repo = self.url_base + '-enterprise/enterprise-2024.2/rpm/centos/latest/scylla.repo'
+        linux_distro = 'centos-9'
+        version_list = general_test(scylla_repo, linux_distro)
+        assert set(version_list) == {'6.0', '2024.1'}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
seems like the upgrade from minor to minor wasn't working as expected and we need to add the minor version anyhow, and count on the RC filter to work as expected

also added the OSS base version for 2024.2

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
