### PR TITLE
fix(azure): remove the usage of `build-id` from filtering images

### DIFF
--- a/sdcm/provision/azure/utils.py
+++ b/sdcm/provision/azure/utils.py
@@ -64,11 +64,6 @@ def get_scylla_images(  # pylint: disable=too-many-branches,too-many-locals
         for image in gallery_image_versions:
             if image.location != region_name or image.name.startswith('debug-'):
                 continue
-            try:
-                int(image.tags.get("build_id"))
-            except (ValueError, TypeError):
-                # skip images with invalid build_id (e.g. created manually)
-                continue
             image.tags["scylla_version"] = image.tags.get('scylla_version', image.tags.get('ScyllaVersion'))
             # Filter by tags
             for tag_name, expected_value in tags_to_search.items():
@@ -85,7 +80,6 @@ def get_scylla_images(  # pylint: disable=too-many-branches,too-many-locals
                     unparsable_scylla_versions.append(f"{image.name}: {image.tags.get('scylla_version')}")
     if unparsable_scylla_versions:
         LOGGER.warning("Couldn't parse scylla version from images: %s", str(unparsable_scylla_versions))
-    output.sort(key=lambda img: int(img.tags.get('build_id', "0")))
     output.sort(key=lambda img: int(SCYLLA_VERSION_GROUPED_RE.match(
         img.tags.get('scylla_version')).group("date")))
 


### PR DESCRIPTION
scylla-machine-image changed/removed the `build-id` tag from images and the code here assumed it's a number, and if not skipped to the next

this cause us to pick the latest image that had a number in `build-id` for couple of months, and not to find images by branch on 2024.2

Fixes: #8022

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested manually for master/branch-2024.2

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
