### PR TITLE
feature(perf-tests): change histogram max bar for P90/P99

### DIFF
--- a/sdcm/report_templates/results_latency_during_ops_short.html
+++ b/sdcm/report_templates/results_latency_during_ops_short.html
@@ -100,7 +100,7 @@
                                 {% endfor %}
                             {% endfor %}
                         </tr>
-                        <tr><td  colspan="12" style="text-align: center">Acceptance criteria per cycle: P99 < 15 ms </td></tr>
+                        <tr><td  colspan="12" style="text-align: center">Acceptance criteria per cycle: P99 < 10 ms </td></tr>
                         {% for cycle in results["cycles"] %}
                             {% set cycle_index = loop.index %}
                              <tr>

--- a/sdcm/utils/latency.py
+++ b/sdcm/utils/latency.py
@@ -138,12 +138,12 @@ def calculate_latency(latency_results):
 def analyze_hdr_percentiles(result_stats: dict[str, Any]) -> dict[str, Any]:
     top_limit_perc_values = {
         "replace_node": {
-            "percentile_90": 15,
-            "percentile_99": 20
+            "percentile_90": 5,
+            "percentile_99": 10
         },
         "default": {
-            "percentile_90": 10,
-            "percentile_99": 15
+            "percentile_90": 5,
+            "percentile_99": 10
         }
     }
     for operation, stats_data in result_stats.items():


### PR DESCRIPTION
for quite some time or latency during ops are below 5ms in both P90/P99, and it was decided to lower the bar (before it was 15ms for P99)

also seems like the results for `replace_node` are not that off and would be using the same bar for it as well

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
