### PR TITLE
fix(kms): disable enterprise file stream

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -88,6 +88,7 @@ from sdcm.utils.git import get_git_commit_id, get_git_status_info
 from sdcm.utils.ldap import LDAP_USERS, LDAP_PASSWORD, LDAP_ROLE, LDAP_BASE_OBJECT, \
     LdapConfigurationError, LdapServerType
 from sdcm.utils.log import configure_logging, handle_exception
+from sdcm.utils.issues import SkipPerIssues
 from sdcm.db_stats import PrometheusDBStats
 from sdcm.results_analyze import PerformanceResultsAnalyzer, SpecifiedStatsPerformanceAnalyzer, \
     LatencyDuringOperationsPerformanceAnalyzer
@@ -906,6 +907,12 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             'key_provider': 'KmsKeyProviderFactory',
             'kms_host': kms_host,
         }
+
+        if SkipPerIssues("scylladb/scylla-enterprise#4246", self.params):
+            # until https://github.com/scylladb/scylla-enterprise/issues/4246 would be solved
+            # we should disable the enterprise file streaming feature
+            append_scylla_yaml['enable_file_stream'] = False
+
         self.log.warning("`user_info_encryption` and `system_info_encryption` are configured to use KMS by default")
         self.params["append_scylla_yaml"] = append_scylla_yaml
         return None


### PR DESCRIPTION
since we have a problem for now to enable both features we disable file based stream, when ever we enable KMS

all other EaR cases, would need to handle it on their own assuming they would want to enable tablets

Ref: scylladb/scylla-enterprise#4246

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
