### PR TITLE
fix(is_port_used): make it more robust

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -19,6 +19,7 @@ import queue
 import logging
 import os
 import shutil
+import socket
 import ssl
 import sys
 import random
@@ -1217,16 +1218,10 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
     def is_port_used(self, port: int, service_name: str) -> bool:
         """Wait for the port to be used for the specified timeout. Returns True if used and False otherwise."""
         try:
-            cmd = f"grep -m1 :{port:04X} /proc/net/tcp /proc/net/tcp6"
-            result = self.remoter.run(cmd, verbose=False, ignore_status=True)
-            if result.ok:
-                return True
-            if result.return_code == 1:
-                # this is the case output is empty
-                return False
-            else:
-                self.log.error("Error checking for '%s' on port %s: rc: %s", service_name, port, result)
-                return False
+            socket.create_connection((self.cql_address, port)).close()
+            return True
+        except OSError:
+            return False
         except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
             self.log.error("Error checking for '%s' on port %s: %s", service_name, port, details)
             return False

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -96,7 +96,7 @@ from sdcm.utils.common import (
     generate_random_string,
     prepare_and_start_saslauthd_service,
     raise_exception_in_thread,
-    get_sct_root_path, wait_port_down,
+    get_sct_root_path,
 )
 from sdcm.utils.ci_tools import get_test_name
 from sdcm.utils.distro import Distro
@@ -1414,9 +1414,10 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             self.remoter.run('sudo systemctl restart node-exporter.service')
 
     def wait_db_down(self, verbose=True, timeout=3600, check_interval=60):
+        text = None
         if verbose:
-            LOGGER.debug('%s: Waiting for DB services to be down' % self.name)
-        wait_port_down(self.cql_address, self.CQL_PORT, timeout=timeout, check_interval=check_interval)
+            text = '%s: Waiting for DB services to be down' % self.name
+        wait.wait_for(func=lambda: not self.db_up(), step=check_interval, text=text, timeout=timeout, throw_exc=True)
 
     def wait_cs_installed(self, verbose=True):
         text = None

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1344,17 +1344,6 @@ def wait_for_port(host, port):
     socket.create_connection((host, port)).close()
 
 
-def wait_port_down(host, port, timeout=60, check_interval=1) -> None:
-    start_time = time.time()
-    while time.time() - start_time < timeout:
-        try:
-            socket.create_connection((host, port)).close()
-            time.sleep(check_interval)
-        except OSError:
-            return
-    raise TimeoutError(f"Port {port} on {host} is still up after {timeout} seconds")
-
-
 def can_connect_to(ip: str, port: int, timeout: int = 1) -> bool:
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)


### PR DESCRIPTION
Reverted previous fix for wait_db_down - it was working for checking db down properly, but still `is_port_used` was not working right for docker backend.

So used this new working approach in `is_port_used` instead.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/8031

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] - [kill scylla nemesis](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/longevity-5gb-1h-ScyllaKillMonkey-aws-test/17/)
- [x] - [artifact test with public ipv6](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/artifacts-ami-test/11/)
- [X] - [docker artifact test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/artifacts-docker-test/6/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
