### PR TITLE
fix(perf-jobs): correct `perf_extra_jobs_to_compare` for ops jobs

### DIFF
--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-grow-shrink.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-grow-shrink.jenkinsfile
@@ -9,5 +9,5 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: """["test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml", "configurations/tablets_disabled.yaml", "configurations/disable_kms.yaml"]""",
     sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
-    perf_extra_jobs_to_compare: """["scylla-enterprise/scylla-enterprise-perf-latency-650gb-grow-shrink","scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-grow-shrink"]""",
+    perf_extra_jobs_to_compare: """["scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-grow-shrink","scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-grow-shrink"]""",
 )

--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis.jenkinsfile
@@ -8,5 +8,5 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: """["test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml", "configurations/tablets_disabled.yaml", "configurations/disable_kms.yaml"]""",
     sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
-    perf_extra_jobs_to_compare: """["scylla-enterprise/scylla-enterprise-perf-latency-650gb-with-nemesis","scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis"]""",
+    perf_extra_jobs_to_compare: """["scylla-enterprise/scylla-enterprise-perf-regression-latency-650gb-with-nemesis","scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis"]""",
 )

--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/perf-regression/scylla-master-perf-regression-latency-650gb-grow-shrink.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/perf-regression/scylla-master-perf-regression-latency-650gb-grow-shrink.jenkinsfile
@@ -9,5 +9,5 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: """["test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml", "configurations/tablets_disabled.yaml"]""",
     sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
-    perf_extra_jobs_to_compare: """["scylla-master/scylla-master-perf-latency-650gb-grow-shrink","scylla-master/perf-regression/scylla-master-perf-regression-latency-650gb-grow-shrink"]""",
+    perf_extra_jobs_to_compare: """["scylla-master/scylla-master-perf-regression-latency-650gb-grow-shrink","scylla-master/perf-regression/scylla-master-perf-regression-latency-650gb-grow-shrink"]""",
 )

--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/perf-regression/scylla-master-perf-regression-latency-650gb-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/perf-regression/scylla-master-perf-regression-latency-650gb-with-nemesis.jenkinsfile
@@ -8,5 +8,5 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: """["test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml", "configurations/tablets_disabled.yaml"]""",
     sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
-    perf_extra_jobs_to_compare: """["scylla-master/scylla-master-perf-latency-650gb-with-nemesis","scylla-master/perf-regression/scylla-master-perf-regression-latency-650gb-with-nemesis"]""",
+    perf_extra_jobs_to_compare: """["scylla-master/scylla-master-perf-regression-latency-650gb-with-nemesis","scylla-master/perf-regression/scylla-master-perf-regression-latency-650gb-with-nemesis"]""",
 )


### PR DESCRIPTION
some jos was pointing to wrong old job names, which casue the regression check, not to show older versions.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
