### PR TITLE
feature(aws): introduce way to find images by owners

### DIFF
--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -15,7 +15,7 @@ import socket
 import time
 import logging
 from functools import cached_property
-from typing import List, Dict
+from typing import List, Dict, get_args
 
 import boto3
 from botocore.exceptions import ClientError
@@ -494,3 +494,31 @@ def is_using_aws_mock() -> bool:
         return True
     except socket.gaierror:
         return False
+
+
+def get_by_owner_ami(parameter: str, region_name) -> str:
+    """
+    get AMIs by owner/architecture/name filter
+
+    for case, we have only  the owner id, and it's not publish
+    in marketplace, hence we can't use the ssm parameter store.
+
+    example:
+    - '131827586825/x86_64/OL8.*' - it's oracle linux 8, and we want the latest one
+
+    """
+    ec2_resource: EC2ServiceResource = boto3.resource('ec2', region_name=region_name)
+
+    owner, arch, name_filter = parameter.split('/')
+    assert arch in get_args(AwsArchType)
+
+    images = ec2_resource.images.filter(
+        Owners=[owner],
+        Filters=[
+            {'Name': 'name', 'Values': [name_filter]},
+            {'Name': 'architecture', 'Values': [arch]},
+        ],
+    )
+    images = sorted(images, key=lambda x: x.creation_date, reverse=True)
+    LOGGER.debug(f'found image "{images[0].name}" - {images[0].id}')
+    return images[0].id

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -72,6 +72,7 @@ from sdcm.utils.aws_utils import (
     EksClusterForCleaner,
     get_scylla_images_ec2_resource,
     get_ssm_ami,
+    get_by_owner_ami,
 )
 from sdcm.utils.ssh_agent import SSHAgent
 from sdcm.utils.decorators import retrying
@@ -1459,6 +1460,13 @@ def convert_name_to_ami_if_needed(ami_id_param: str, region_names: list[str],) -
         ami_list: list[str] = []
         for region_name in region_names:
             ami_list.append(get_ssm_ami(ssm_name, region_name=region_name))
+        return " ".join(ami_list)
+
+    if len(param_values) == 1 and param_values[0].startswith("resolve:owner:"):
+        owner_details = param_values[0].replace("resolve:owner:", "")
+        ami_list: list[str] = []
+        for region_name in region_names:
+            ami_list.append(get_by_owner_ami(owner_details, region_name=region_name))
         return " ".join(ami_list)
 
     if len(param_values) == 1 and not param_values[0].startswith("ami-"):

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -965,6 +965,16 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
         assert conf["ami_id_db_scylla"].startswith('ami-')
 
+    @pytest.mark.integration
+    def test_33_resolve_aws_by_owner(self):
+        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'resolve:owner:131827586825/x86_64/OL8.*'
+
+        conf = sct_config.SCTConfiguration()
+        conf.verify_configuration()
+
+        assert conf["ami_id_db_scylla"].startswith('ami-')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
for case, we have only  the owner id, and it's not publish in marketplace, hence we can't use the ssm parameter store.

as an example oracle only supply the owner id, and the AMIs are not visiable in marketplace, and can be found via SSM (as we do for other distro, like ubuntu/debian/amazon)

so now we can specifiy in the configuration something like this:

```yaml
ami_id_db_scylla: 'resolve:owner:131827586825/x86_64/OL8.*'
```

Ref: https://forums.oracle.com/ords/apexds/post/launch-an-oracle-linux-instance-in-aws-9462

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
