### PR TITLE
improvement(cleanup): job for cleanup test resources

### DIFF
--- a/jenkins-pipelines/qa/hydra-clean-test-resources.jenkinsfile
+++ b/jenkins-pipelines/qa/hydra-clean-test-resources.jenkinsfile
@@ -1,0 +1,52 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+pipeline {
+    agent {
+        label {
+            label "aws-sct-builders-eu-west-1-v2-CI"
+        }
+    }
+    environment {
+        AWS_ACCESS_KEY_ID     = credentials('qa-aws-secret-key-id')
+        AWS_SECRET_ACCESS_KEY = credentials('qa-aws-secret-access-key')
+    }
+    parameters {
+        string(defaultValue: '',
+               description: 'ID of a SCT test to clean resources',
+               name: 'test_id')
+        string(defaultValue: 'aws',
+               description: 'resources backend',
+               name: 'backend')
+    }
+    options {
+        timestamps()
+        buildDiscarder(logRotator(numToKeepStr: '50'))
+    }
+    stages {
+        stage('Checkout') {
+            steps {
+                dir('scylla-cluster-tests') {
+                    checkout scm
+                }
+            }
+        }
+        stage('Clean Test Resources') {
+            steps {
+                catchError(stageResult: 'FAILURE') {
+                    timeout(time: 15, unit: 'MINUTES') {
+                        sctScript """
+                            export SCT_REGION_NAME=
+                            export SCT_GCE_DATACENTER=
+                            export SCT_AZURE_REGION_NAME=
+                            ./docker/env/hydra.sh clean-resources --backend ${params.backend} --test-id ${params.test_id}
+                        """
+                   }
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
We want enable easy resources cleanup for Argus users without installing hydra.

Added a job that does the job.

refs: https://github.com/scylladb/qa-tasks/issues/323

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - https://jenkins.scylladb.com/view/QA/job/QA-tools/job/hydra-clean-test-resources/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
