### PR TITLE
test(latency): enable hinted handoff(650gb with nemesis)

### DIFF
--- a/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
@@ -39,3 +39,4 @@ use_capacity_reservation: true
 email_subject_postfix: 'latency during operations'
 stress_image:
   cassandra-stress: 'scylladb/cassandra-stress:3.17.3'
+hinted_handoff: 'enabled'


### PR DESCRIPTION
enable hinted handoff for perf-regression-latency-650gb-with-nemesis

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/job/scylla-staging/job/artsiom_mishuta/job/hints/job/scylla-master-perf-regression-latency-650gb-with-nemesis/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
