### PR TITLE
fix(certificates): don't include empty dns/ip into extensions

### DIFF
--- a/sdcm/provision/helpers/certificate.py
+++ b/sdcm/provision/helpers/certificate.py
@@ -168,9 +168,9 @@ def create_certificate(
 
     alt_names = [x509.DNSName(cname)]
     if ip_addresses:
-        alt_names.extend([x509.IPAddress(ipaddress.ip_address(ip)) for ip in ip_addresses])
+        alt_names.extend([x509.IPAddress(ipaddress.ip_address(ip)) for ip in ip_addresses if ip])
     if dns_names:
-        alt_names.extend([x509.DNSName(dns) for dns in dns_names])
+        alt_names.extend([x509.DNSName(dns) for dns in dns_names if dns])
 
     if ca_cert_file and ca_key_file:
         with open(ca_cert_file, 'rb') as file:


### PR DESCRIPTION
seems like from some point, if we include empty values into `Subject Alternative Name`, like this:
```
X509v3 extensions:
  X509v3 Subject Alternative Name:
     DNS:longevity-100gb-4h-master-db-node-f052ae6b-1,
     IP Address:10.12.8.241, IP Address:54.172.124.95,
     DNS:, DNS:ip-10-12-8-241.ec2.internal
```

we might end up with scylla not booting, when server encrpytion is used

```
scylla[6486]:  [shard  0:main] init - Startup failed: std::system_error
   (error GnuTLS:-62, Unknown Subject Alternative name in X.509 certificate.)
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/53/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
