### PR TITLE
feature(hydra.sh): add a command to update scylla db packages

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1856,6 +1856,7 @@ cli.add_command(sct_ssh.copy_cmd)
 cli.add_command(sct_ssh.attach_test_sg_cmd)
 cli.add_command(sct_ssh.ssh_cmd)
 cli.add_command(sct_ssh.gcp_allow_public)
+cli.add_command(sct_ssh.update_scylla_packages)
 cli.add_command(sct_scan_issues.scan_issue_skips)
 
 if __name__ == '__main__':

--- a/sct_ssh.py
+++ b/sct_ssh.py
@@ -304,7 +304,7 @@ def ssh(user, test_id, region, force_use_public_ip, node_name):
         pty.spawn(shlex.split(cmd))
 
 
-@click.command("ssh-cmd")
+@click.command("ssh-cmd", context_settings={"ignore_unknown_options": True})
 @click.option("-u", "--user", default=None,
               help="User to search for (RunByUser tag)")
 @click.option("-t", "--test-id", default=None, help="test id to search for")
@@ -312,8 +312,9 @@ def ssh(user, test_id, region, force_use_public_ip, node_name):
 @click.option("-P", "--force-use-public-ip", is_flag=True, show_default=True, default=False,
               help="Force usage of public address")
 @click.argument("node_name", required=False)
-@click.argument("command", required=True)
+@click.argument("command", required=True, nargs=-1)
 def ssh_cmd(user, test_id, region, force_use_public_ip, node_name, command):
+    command = ' '.join(command)
     output = ssh_run_cmd(node_name, command, user, test_id, region, force_use_public_ip)
     if output.stderr:
         click.echo(click.style(output.stderr, fg='red'))

--- a/sdcm/remote/base.py
+++ b/sdcm/remote/base.py
@@ -194,7 +194,7 @@ class CommandRunner(metaclass=ABCMeta):
     def _make_ssh_command(user: str = "root",  # pylint: disable=too-many-arguments
                           port: int = 22, opts: str = '', hosts_file: str = '/dev/null',
                           key_file: str = None, connect_timeout: float = 300, alive_interval: float = 300,
-                          extra_ssh_options: str = '') -> str:
+                          extra_ssh_options: str = '', proxy_cmd: str = None) -> str:
         assert isinstance(connect_timeout, int)
         ssh_full_path = subprocess.check_output(['which', 'ssh']).decode().strip()
         base_command = ssh_full_path
@@ -202,12 +202,12 @@ class CommandRunner(metaclass=ABCMeta):
         base_command += (" -a -x %s -o StrictHostKeyChecking=no "
                          "-o UserKnownHostsFile=%s -o BatchMode=yes "
                          "-o ConnectTimeout=%d -o ServerAliveInterval=%d "
-                         "-l %s -p %d")
+                         "-l %s -p %d %s")
         if key_file is not None:
             base_command += ' -i %s' % os.path.expanduser(key_file)
         assert connect_timeout > 0  # can't disable the timeout
         return base_command % (opts, hosts_file, connect_timeout,
-                               alive_interval, user, port)
+                               alive_interval, user, port, proxy_cmd)
 
 
 class OutputWatcher(StreamWatcher):  # pylint: disable=too-few-public-methods

--- a/sdcm/remote/remote_cmd_runner.py
+++ b/sdcm/remote/remote_cmd_runner.py
@@ -114,6 +114,19 @@ class RemoteCmdRunner(RemoteCmdRunnerBase, ssh_transport='fabric', default=True)
         return True
 
     def _create_connection(self) -> Connection:
+        gateway_connection = None
+        if self.proxy_host:
+            gateway_connection = Connection(
+                host=self.proxy_host,
+                user=self.proxy_user,
+                port=self.proxy_port,
+                config=self.ssh_config,
+                connect_timeout=self.connect_timeout,
+                connect_kwargs={
+                    "key_filename": os.path.expanduser(self.proxy_key) if self.proxy_key else None
+                }
+            )
+
         return Connection(
             host=self.hostname,
             user=self.user,
@@ -123,4 +136,5 @@ class RemoteCmdRunner(RemoteCmdRunnerBase, ssh_transport='fabric', default=True)
             connect_kwargs={
                 "key_filename": os.path.expanduser(self.key_file),
             } if self.key_file else None,
+            gateway=gateway_connection
         )


### PR DESCRIPTION
The change adds a new hydra command that allows to update DB binaries of the whole cluster or of selected nodes.
This functionality allows for a developer to update scylla version from their developing machine and re-run a test / run another test without the need to re-create a cluster (i.e. using reuse-cluster capability).

### Testing
[x] :green_circle: (repeated for aws and gce)
- provisioned a cluster: [pr-provision-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/sct-pr-provision-test/48/)
- executed the new `update-scylla-packages` command for the test-id in question, selecting 2 DB nodes out of 3 for update and providing local folder as a location of new packages versions:
```
❯ ./sct.py update-scylla-packages --test-id bf149edb-c7b9-42f7-96c2-40c74df3c13b --backend aws -p /home/dmitriy/Work/Scylla/test_upd_pkg_dir
logged in as arn:aws:sts::797456418907:assumed-role/DeveloperAccessRole/dmytro.kruglov@scylladb.com
? Select machine:  (Use arrow keys to move, <space> to select, <a> to toggle, <i> to invert)
   ● aws - PR-provision-test-master-db-node-bf149edb-2 - 34.240.123.60 10.4.3.4 - eu-west-1
 » ● aws - PR-provision-test-master-db-node-bf149edb-1 - 3.250.188.111 10.4.0.224 - eu-west-1
   ○ aws - PR-provision-test-master-db-node-bf149edb-3 - 54.171.105.51 10.4.0.88 - eu-west-1

? Select machine:  done (2 selections)
Updating DB packages
Updating DB packages
<10.4.3.4>: Command rsync not available -- disabled
<10.4.0.224>: Command rsync not available -- disabled
unzipping any tar.gz rpms
Detected Linux distribution: UBUNTU22
Installed .deb packages before replacing with new .DEB files
['scylla\t6.0.1-0.20240612.bc89aac9d017-1', 'scylla-conf\t6.0.1-0.20240612.bc89aac9d017-1', 'scylla-cqlsh\t6.0.1-0.20240612.bc89aac9d017-1', 'scylla-kernel-conf\t6.0.1-0.20240612.bc89aac9d017-1', 'scylla-machine-image\t6.0.1-20240613.5b94160-1', 'scylla-manager-agent\t3.3.0~0.20240627.772cc4df8', 'scylla-node-exporter\t6.0.1-0.20240612.bc89aac9d017-1', 'scylla-python3\t6.0.1-0.20240612.bc89aac9d017-1', 'scylla-server\t6.0.1-0.20240612.bc89aac9d017-1', 'scylla-server-dbg\t6.0.1-0.20240612.bc89aac9d017-1', 'scylla-tools\t']
unzipping any tar.gz rpms
Detected Linux distribution: UBUNTU22
Installed .deb packages before replacing with new .DEB files
['scylla\t6.0.1-0.20240612.bc89aac9d017-1', 'scylla-conf\t6.0.1-0.20240612.bc89aac9d017-1', 'scylla-cqlsh\t6.0.1-0.20240612.bc89aac9d017-1', 'scylla-kernel-conf\t6.0.1-0.20240612.bc89aac9d017-1', 'scylla-machine-image\t6.0.1-20240613.5b94160-1', 'scylla-manager-agent\t3.3.0~0.20240627.772cc4df8', 'scylla-node-exporter\t6.0.1-0.20240612.bc89aac9d017-1', 'scylla-python3\t6.0.1-0.20240612.bc89aac9d017-1', 'scylla-server\t6.0.1-0.20240612.bc89aac9d017-1', 'scylla-server-dbg\t6.0.1-0.20240612.bc89aac9d017-1', 'scylla-tools\t']
Installed .deb packages after replacing with new .DEB files
['scylla\t6.1.0~rc0-0.20240718.14222ad20520-1', 'scylla-conf\t6.0.1-0.20240612.bc89aac9d017-1', 'scylla-cqlsh\t6.1.0~rc0-0.20240718.14222ad20520-1', 'scylla-jmx\t6.1.0~rc0-0.20240718.14222ad20520-1', 'scylla-kernel-conf\t6.1.0~rc0-0.20240718.14222ad20520-1', 'scylla-machine-image\t6.0.1-20240613.5b94160-1', 'scylla-manager-agent\t3.3.0~0.20240627.772cc4df8', 'scylla-node-exporter\t6.1.0~rc0-0.20240718.14222ad20520-1', 'scylla-python3\t6.1.0~rc0-0.20240718.14222ad20520-1', 'scylla-server\t6.1.0~rc0-0.20240718.14222ad20520-1', 'scylla-server-dbg\t6.1.0~rc0-0.20240718.14222ad20520-1', 'scylla-tools\t6.1.0~rc0-0.20240718.14222ad20520-1', 'scylla-tools-core\t6.1.0~rc0-0.20240718.14222ad20520-1']
Installed .deb packages after replacing with new .DEB files
['scylla\t6.1.0~rc0-0.20240718.14222ad20520-1', 'scylla-conf\t6.0.1-0.20240612.bc89aac9d017-1', 'scylla-cqlsh\t6.1.0~rc0-0.20240718.14222ad20520-1', 'scylla-jmx\t6.1.0~rc0-0.20240718.14222ad20520-1', 'scylla-kernel-conf\t6.1.0~rc0-0.20240718.14222ad20520-1', 'scylla-machine-image\t6.0.1-20240613.5b94160-1', 'scylla-manager-agent\t3.3.0~0.20240627.772cc4df8', 'scylla-node-exporter\t6.1.0~rc0-0.20240718.14222ad20520-1', 'scylla-python3\t6.1.0~rc0-0.20240718.14222ad20520-1', 'scylla-server\t6.1.0~rc0-0.20240718.14222ad20520-1', 'scylla-server-dbg\t6.1.0~rc0-0.20240718.14222ad20520-1', 'scylla-tools\t6.1.0~rc0-0.20240718.14222ad20520-1', 'scylla-tools-core\t6.1.0~rc0-0.20240718.14222ad20520-1']
Update DB packages duration -> 351 s
```
[x] :green_circle: [regular longevity config (i.e. (not a CLI command) execution) to regression test the BaseScyllaCluster.update_db_packages procedure](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/longevity-5gb-1h-test/48/)
Excerpt from logs that indicates successful update of DB packages on a node:
```
18:02:39  < t:2024-08-06 16:02:39,160 f:cluster.py      l:4198 c:sdcm.cluster_aws     p:INFO  > Node ubuntu-hydra-up-db-node-c93f07a3-1 [3.250.123.153 | 10.4.1.133]: Installed .deb packages before replacing with new .DEB files
18:02:39  < t:2024-08-06 16:02:39,207 f:cluster.py      l:4199 c:sdcm.cluster_aws     p:INFO  > Node ubuntu-hydra-up-db-node-c93f07a3-1 [3.250.123.153 | 10.4.1.133]: ['scylla\t5.4.8-0.20240620.43f77c71c723-1', 'scylla-conf\t5.4.8-0.20240620.43f77c71c723-1', 'scylla-cqlsh\t5.4.8-0.20240620.43f77c71c723-1', 'scylla-jmx\t5.4.8-0.20240620.43f77c71c723-1', 'scylla-kernel-conf\t5.4.8-0.20240620.43f77c71c723-1', 'scylla-machine-image\t5.4.8-20240620.f5695e0-1', 'scylla-node-exporter\t5.4.8-0.20240620.43f77c71c723-1', 'scylla-python3\t5.4.8-0.20240620.43f77c71c723-1', 'scylla-server\t5.4.8-0.20240620.43f77c71c723-1', 'scylla-server-dbg\t5.4.8-0.20240620.43f77c71c723-1', 'scylla-tools\t5.4.8-0.20240620.43f77c71c723-1', 'scylla-tools-core\t5.4.8-0.20240620.43f77c71c723-1']
...
18:03:17  < t:2024-08-06 16:03:17,687 f:cluster.py      l:4201 c:sdcm.cluster_aws     p:INFO  > Node ubuntu-hydra-up-db-node-c93f07a3-1 [3.250.123.153 | 10.4.1.133]: Installed .deb packages after replacing with new .DEB files
18:03:17  < t:2024-08-06 16:03:17,738 f:cluster.py      l:4202 c:sdcm.cluster_aws     p:INFO  > Node ubuntu-hydra-up-db-node-c93f07a3-1 [3.250.123.153 | 10.4.1.133]: ['scylla\t5.4.9-0.20240711.0e02128d2895-1', 'scylla-conf\t5.4.9-0.20240711.0e02128d2895-1', 'scylla-cqlsh\t5.4.9-0.20240711.0e02128d2895-1', 'scylla-jmx\t5.4.9-0.20240711.0e02128d2895-1', 'scylla-kernel-conf\t5.4.9-0.20240711.0e02128d2895-1', 'scylla-machine-image\t5.4.8-20240620.f5695e0-1', 'scylla-node-exporter\t5.4.9-0.20240711.0e02128d2895-1', 'scylla-python3\t5.4.9-0.20240711.0e02128d2895-1', 'scylla-server\t5.4.9-0.20240711.0e02128d2895-1', 'scylla-server-dbg\t5.4.9-0.20240711.0e02128d2895-1', 'scylla-tools\t5.4.9-0.20240711.0e02128d2895-1', 'scylla-tools-core\t5.4.9-0.20240711.0e02128d2895-1']
```

### PR pre-checks (self review)
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
