### PR TITLE
fix(sdcm/reporting/tooling_reporting): Add exception handler for Argus

### DIFF
--- a/sdcm/reporting/tooling_reporter.py
+++ b/sdcm/reporting/tooling_reporter.py
@@ -38,7 +38,10 @@ class ToolReporterBase():
         if not self.argus_client:
             LOGGER.warning("%s: Skipping reporting to argus, client not initialized.", self)
             return
-        report_package_to_argus(self.argus_client, self.TOOL_NAME, self.version, self.additional_data)
+        try:
+            report_package_to_argus(self.argus_client, self.TOOL_NAME, self.version, self.additional_data)
+        except Exception: # pylint: disable=broad-except
+            LOGGER.warning("Failed reporting tool version to Argus", exc_info=True)
 
     def _collect_version_info(self) -> None:
         raise NotImplementedError()


### PR DESCRIPTION
This fixes an issue where a test might stop if we can't report a tooling
version to argus.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
