### PR TITLE
feature(grow-shrink): option to set the instance type for grow-shrink

### DIFF
--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -522,3 +522,17 @@ def get_by_owner_ami(parameter: str, region_name) -> str:
     images = sorted(images, key=lambda x: x.creation_date, reverse=True)
     LOGGER.debug(f'found image "{images[0].name}" - {images[0].id}')
     return images[0].id
+
+
+def aws_check_instance_type_supported(instance_type: str, region_name: str) -> bool:
+    """
+    check if the instance type is supported in the region
+    """
+    client: EC2Client = boto3.client('ec2', region_name=region_name)
+    try:
+        client.describe_instance_types(InstanceTypes=[instance_type])
+    except ClientError as exc:
+        if exc.response['Error']['Code'] == 'InvalidInstanceType':
+            return False
+        raise
+    return True

--- a/sdcm/utils/azure_utils.py
+++ b/sdcm/utils/azure_utils.py
@@ -232,3 +232,11 @@ def list_instances_azure(tags_dict: Optional[dict[str, str]] = None,
         LOGGER.info("Done. Found total of %s instances.", len(instances))
 
     return instances
+
+
+def azure_check_instance_type_available(instance_type: str, location: str) -> bool:
+    """
+    Check if instance type is available in the given location.
+    """
+    azure_service = AzureService()
+    return any(instance_type in size.name for size in azure_service.compute.virtual_machine_sizes.list(location=location))

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -95,6 +95,12 @@ def get_gce_compute_disks_client() -> tuple[compute_v1.DisksClient, dict]:
     return compute_v1.DisksClient(credentials=credentials), info
 
 
+def get_gce_compute_machine_types_client() -> tuple[compute_v1.MachineTypesClient, dict]:
+    info = KeyStore().get_gcp_credentials()
+    credentials = service_account.Credentials.from_service_account_info(info)
+    return compute_v1.MachineTypesClient(credentials=credentials), info
+
+
 def gce_public_addresses(instance: compute_v1.Instance) -> list[str]:
     addresses = []
 
@@ -647,3 +653,18 @@ def gce_set_tags(instances_client: compute_v1.InstancesClient,
     operation = instances_client.set_tags(request=request)
 
     return wait_for_extended_operation(operation, f"setting tags on {instance.name}")
+
+
+def gce_check_if_machine_type_supported(
+        machine_types_client: compute_v1.MachineTypesClient,
+        machine_type: str,
+        project: str,
+        zone: str):
+    """
+    Check if the given machine type is supported in the given zone.
+    """
+    request = compute_v1.GetMachineTypeRequest()
+    request.project = project
+    request.zone = zone
+    request.machine_type = machine_type
+    return machine_types_client.get(request=request)

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -965,6 +965,39 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
         assert conf["ami_id_db_scylla"].startswith('ami-')
 
+    @pytest.mark.integration
+    def test_34_nemesis_grow_shrink_instance_type_aws(self):
+        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+        os.environ['SCT_REGION_NAME'] = '["eu-west-1", "us-east-1"]'
+        os.environ['SCT_N_DB_NODES'] = '2 2'
+        os.environ['SCT_SCYLLA_VERSION'] = "6.0.0"
+        os.environ['SCT_NEMESIS_GROW_SHRINK_INSTANCE_TYPE'] = 'i4i.xlarge'
+
+        conf = sct_config.SCTConfiguration()
+        conf.verify_configuration()
+
+    @pytest.mark.integration
+    def test_34_nemesis_grow_shrink_instance_type_gcp(self):
+        os.environ['SCT_CLUSTER_BACKEND'] = 'gce'
+        os.environ['SCT_GCE_DATACENTER'] = 'us-east1 us-west1'
+        os.environ['SCT_N_DB_NODES'] = '2 2'
+        os.environ['SCT_SCYLLA_VERSION'] = "6.0.0"
+        os.environ['SCT_NEMESIS_GROW_SHRINK_INSTANCE_TYPE'] = 'n2-highmem-32'
+
+        conf = sct_config.SCTConfiguration()
+        conf.verify_configuration()
+
+    @pytest.mark.integration
+    def test_34_nemesis_grow_shrink_instance_type_azure(self):
+        os.environ['SCT_CLUSTER_BACKEND'] = 'azure'
+        os.environ['SCT_AZURE_REGION_NAME'] = 'eastus'
+        os.environ['SCT_N_DB_NODES'] = '2 2'
+        os.environ['SCT_SCYLLA_VERSION'] = "6.0.0"
+        os.environ['SCT_NEMESIS_GROW_SHRINK_INSTANCE_TYPE'] = 'Standard_L8s_v3'
+
+        conf = sct_config.SCTConfiguration()
+        conf.verify_configuration()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
the commit introduces `nemesis_grow_shrink_instance_type` so one can select the instance type that would be use during the grow-shrink nemesis

when this option is used, the shrink phase is going to decomission exactly the node that was added, so we will leave the cluster in the same state (number of nodes, and their sizes)

Closes: scylladb/qa-tasks#1738

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-5gb-1h-GrowShrinkClusterNemesis-aws-test/7/ [Argus](https://argus.scylladb.com/test/bc471848-79b2-4321-b3b9-e78a5cb67563/runs?additionalRuns[]=b46f43bf-f007-489c-b4bf-7071b3257e4f)
  test with i4i.2xlarge grow with i4i.large, with 1 node, and with 3 nodes


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
