### PR TITLE
fix(upgrade-tests): skip counter test if tablets enabled

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -435,6 +435,7 @@ class FillDatabaseData(ClusterTester):
             ],
             'min_version': '1.7',
             'max_version': '',
+            'skip_condition': 'not self.is_counter_supported',
             'skip': ''},
         {
             'name': 'indexed_with_eq_test: Check that you can query for an indexed column even with a key EQ clause',
@@ -3180,6 +3181,12 @@ class FillDatabaseData(ClusterTester):
     @cached_property
     def enable_cdc_for_tables(self) -> bool:
         if self.tablets_enabled and SkipPerIssues(issues="https://github.com/scylladb/scylladb/issues/16317", params=self.params):
+            return False
+        return True
+
+    @cached_property
+    def is_counter_supported(self) -> bool:
+        if self.tablets_enabled and SkipPerIssues(issues="scylladb/scylladb#18180", params=self.params):
             return False
         return True
 


### PR DESCRIPTION
part of the rolling upgrade we create and test some tables after each step, one of those is `counters_test: Validate counter support` since counter isn't supported by tablets, we need to skip it once tablets is enabled.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-debian11-test/11/ [Argus](https://argus.scylladb.com/test/94307779-73d9-4e4b-8c69-de3431a72ccd/runs?additionalRuns[]=8766ab65-1074-48cc-bb24-ed9cb1fddf39)
- [x] 🟢  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-debian11-test/12/ [Argus](https://argus.scylladb.com/test/94307779-73d9-4e4b-8c69-de3431a72ccd/runs?additionalRuns[]=8766ab65-1074-48cc-bb24-ed9cb1fddf39)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
