### PR TITLE
fix(logcollector): do not fail the whole log collection phase on a failure of one collector 

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1584,11 +1584,16 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
                                                   storage_dir=self.storage_dir,
                                                   params=self.params)
             LOGGER.info("Start collect logs for cluster %s", log_collector.cluster_log_type)
-            if result := log_collector.collect_logs(local_search_path=local_dir_with_logs):
-                results[log_collector.cluster_log_type] = result
-                LOGGER.info("collected data for %s\n%s\n", log_collector.cluster_log_type, result)
-            else:
-                LOGGER.warning("There are no logs collected for %s", log_collector.cluster_log_type)
+            try:
+                if result := log_collector.collect_logs(local_search_path=local_dir_with_logs):
+                    results[log_collector.cluster_log_type] = result
+                    LOGGER.info("collected data for %s\n%s\n", log_collector.cluster_log_type, result)
+                else:
+                    LOGGER.warning("There are no logs collected for %s", log_collector.cluster_log_type)
+            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+                LOGGER.warning(
+                    "%s is not able to collect logs. Moving to the next log collector",
+                    log_collector.__class__.__name__, exc_info=True)
         return results
 
     def create_base_storage_dir(self, test_dir=None):


### PR DESCRIPTION
Log collection phase of a test run can fail if a failure occurs when collecting logs of a specific type.

Handling of unexpected exceptions is added, when iterating over log collectors, so that it continues with the next collector, instead of failing the whole 
log collection sequence.
Additionally the change adds skipping of jepsen logs collection sequence if no jepsen test was executed during SCT run.

Fixes https://github.com/scylladb/scylla-cluster-tests/issues/7470.

### Testing

- [x] :green_circle: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/sct-pr-provision-test/23/

### PR pre-checks (self review)
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
