### PR TITLE
fix(cqlshrc): safely update cqlshrc

### DIFF
--- a/sdcm/provision/scylla_yaml/certificate_builder.py
+++ b/sdcm/provision/scylla_yaml/certificate_builder.py
@@ -31,7 +31,12 @@ CQLSHRC_FILE = get_data_dir_path('ssl_conf', 'client', 'cqlshrc')
 def update_cqlshrc(cqlshrc_file: str = CQLSHRC_FILE, client_encrypt: bool = False) -> None:
     config = configparser.ConfigParser()
     config.read(cqlshrc_file)
-    config['ssl']['validate'] = 'true' if client_encrypt else 'false'
+    config['ssl'] = {
+        'validate': 'true' if client_encrypt else 'false',
+        'certfile': f'{SCYLLA_SSL_CONF_DIR / CA_CERT_FILE.name}',
+        'userkey': f'{SCYLLA_SSL_CONF_DIR / CLIENT_FACING_KEYFILE.name}',
+        'usercert': f'{SCYLLA_SSL_CONF_DIR / CLIENT_FACING_CERTFILE.name}'
+    }
     with open(cqlshrc_file, 'w', encoding='utf-8') as file:
         config.write(file)
 


### PR DESCRIPTION
Cqlshrc config can require update depending on whether client encryption is enabled/disabled in the configuration under test. Until now the update was not safe in terms that it was expected that 'ssl' section is present in the config by default.

The change updates how 'ssl' section is set in the cqlshrc.

Fixes https://github.com/scylladb/scylla-cluster-tests/issues/8113

### Testing
- [x] :green_circle:  [pr-provision-test + enabled client/server encryption](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/sct-pr-provision-test/24/)

### PR pre-checks (self review)
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
