### PR TITLE
fix(.github/search_commit.py): backport pattern for perf branches

### DIFF
--- a/.github/search_commits.py
+++ b/.github/search_commits.py
@@ -51,7 +51,7 @@ def main():  # pylint: disable=too-many-locals  # noqa: PLR0914
                 pr_number = int(match[0])
                 if pr_number in processed_prs:
                     continue
-                ref = re.search(r'-(\d+\.\d+)', args.ref)
+                ref = re.search(r'-(\d+\.\d+|perf-v(\d+))', args.ref)
                 label_to_add = f'backport/{ref.group(1)}-done'
                 label_to_remove = f'backport/{ref.group(1)}'
                 remove_label_url = f'https://api.github.com/repos/{args.repository}/issues/{pr_number}/labels/{label_to_remove}'


### PR DESCRIPTION
The current pattern we search for when doign the backport label change matches the `*-x.y`. Updating the pattern to include also `perf-v`

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/8118

