### PR TITLE
fix(screenshots): report screenshots to argus from all tests

### DIFF
--- a/cdc_replication_test.py
+++ b/cdc_replication_test.py
@@ -417,18 +417,16 @@ class CDCReplicationTest(ClusterTester):
         self.log.info("Prepare data for email")
 
         email_data = self._get_common_email_data()
-        grafana_dataset = self.monitors.get_grafana_screenshot_and_snapshot(self.start_time) if self.monitors else {}
-        email_data.update({"grafana_screenshots": grafana_dataset.get("screenshots", []),
-                           "grafana_snapshots": grafana_dataset.get("snapshots", []),
-                           "nemesis_details": self.get_nemesises_stats(),
-                           "nemesis_name": self.params.get("nemesis_class_name"),
-                           "scylla_ami_id": self.params.get("ami_id_db_scylla") or "-",
-                           "number_of_oracle_nodes": self.params.get("n_test_oracle_db_nodes"),
-                           "oracle_ami_id": self.params.get("ami_id_db_oracle"),
-                           "oracle_db_version":
-                               self.cs_db_cluster.nodes[0].scylla_version if self.cs_db_cluster else "N/A",
-                           "oracle_instance_type": self.params.get("instance_type_db_oracle"),
-                           "consistency_status": self.consistency_ok
-                           })
+        email_data.update({
+            "nemesis_details": self.get_nemesises_stats(),
+            "nemesis_name": self.params.get("nemesis_class_name"),
+            "scylla_ami_id": self.params.get("ami_id_db_scylla") or "-",
+            "number_of_oracle_nodes": self.params.get("n_test_oracle_db_nodes"),
+            "oracle_ami_id": self.params.get("ami_id_db_oracle"),
+            "oracle_db_version":
+            self.cs_db_cluster.nodes[0].scylla_version if self.cs_db_cluster else "N/A",
+            "oracle_instance_type": self.params.get("instance_type_db_oracle"),
+            "consistency_status": self.consistency_ok
+        })
 
         return email_data

--- a/gemini_test.py
+++ b/gemini_test.py
@@ -130,7 +130,6 @@ class GeminiTest(ClusterTester):
         self.log.info('Prepare data for email')
 
         email_data = self._get_common_email_data()
-        grafana_dataset = self.monitors.get_grafana_screenshot_and_snapshot(self.start_time) if self.monitors else {}
 
         if self.loaders:
             gemini_version = self.loaders.gemini_version
@@ -138,19 +137,19 @@ class GeminiTest(ClusterTester):
             self.log.warning("Failed to get gemini version as loader instance is not created")
             gemini_version = ""
 
-        email_data.update({"gemini_cmd": self.gemini_results["cmd"],
-                           "gemini_version": gemini_version,
-                           "nemesis_details": self.get_nemesises_stats(),
-                           "nemesis_name": self.params.get("nemesis_class_name"),
-                           "number_of_oracle_nodes": self.params.get("n_test_oracle_db_nodes"),
-                           "oracle_ami_id": self.params.get("ami_id_db_oracle"),
-                           "oracle_db_version":
-                               self.cs_db_cluster.nodes[0].scylla_version if self.cs_db_cluster else "N/A",
-                           "oracle_instance_type": self.params.get("instance_type_db_oracle"),
-                           "results": self.gemini_results["results"],
-                           "scylla_ami_id": self.params.get("ami_id_db_scylla"),
-                           "status": self.gemini_results["status"],
-                           "grafana_screenshots": grafana_dataset.get("screenshots", []),
-                           "grafana_snapshots": grafana_dataset.get("snapshots", [])})
+        email_data.update({
+            "gemini_cmd": self.gemini_results["cmd"],
+            "gemini_version": gemini_version,
+            "nemesis_details": self.get_nemesises_stats(),
+            "nemesis_name": self.params.get("nemesis_class_name"),
+            "number_of_oracle_nodes": self.params.get("n_test_oracle_db_nodes"),
+            "oracle_ami_id": self.params.get("ami_id_db_oracle"),
+            "oracle_db_version":
+            self.cs_db_cluster.nodes[0].scylla_version if self.cs_db_cluster else "N/A",
+            "oracle_instance_type": self.params.get("instance_type_db_oracle"),
+            "results": self.gemini_results["results"],
+            "scylla_ami_id": self.params.get("ami_id_db_scylla"),
+            "status": self.gemini_results["status"],
+        })
 
         return email_data

--- a/jepsen_test.py
+++ b/jepsen_test.py
@@ -104,10 +104,7 @@ class JepsenTest(ClusterTester):
     def get_email_data(self):
         self.log.info("Prepare data for email")
         email_data = self._get_common_email_data()
-        grafana_dataset = self.monitors.get_grafana_screenshot_and_snapshot(self.start_time) if self.monitors else {}
         email_data.update({
-            "grafana_screenshots": grafana_dataset.get("screenshots", []),
-            "grafana_snapshots": grafana_dataset.get("snapshots", []),
             "jepsen_report": self.save_jepsen_report(),
             "jepsen_scylla_repo": self.params.get("jepsen_scylla_repo"),
             "jepsen_test_cmd": self.params.get("jepsen_test_cmd"),

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -464,27 +464,19 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
 
     def get_email_data(self):
         self.log.info("Prepare data for email")
-        grafana_dataset = {}
 
         email_data = self._get_common_email_data()
-
-        try:
-            grafana_dataset = self.monitors.get_grafana_screenshot_and_snapshot(
-                self.start_time) if self.monitors else {}
-        except Exception as error:  # pylint: disable=broad-except
-            self.log.exception("Error in gathering Grafana screenshots and snapshots. Error:\n%s",
-                               error, exc_info=error)
 
         benchmarks_results = self.db_cluster.get_node_benchmarks_results() if self.db_cluster else {}
         # If cluster was not created, not need to collect nemesis stats - they do not exist
         nemeses_stats = self.get_nemesises_stats() if self.db_cluster else {}
 
-        email_data.update({"grafana_screenshots": grafana_dataset.get("screenshots", []),
-                           "grafana_snapshots": grafana_dataset.get("snapshots", []),
-                           "node_benchmarks": benchmarks_results,
-                           "nemesis_details": nemeses_stats,
-                           "nemesis_name": self.params.get("nemesis_class_name"),
-                           "scylla_ami_id": self.params.get("ami_id_db_scylla") or "-", })
+        email_data.update({
+            "node_benchmarks": benchmarks_results,
+            "nemesis_details": nemeses_stats,
+            "nemesis_name": self.params.get("nemesis_class_name"),
+            "scylla_ami_id": self.params.get("ami_id_db_scylla") or "-",
+        })
         return email_data
 
     def create_templated_user_stress_params(self, idx, cs_profile):  # pylint: disable=invalid-name

--- a/performance_scale_up_test.py
+++ b/performance_scale_up_test.py
@@ -54,25 +54,15 @@ class ScaleUpTest(ClusterTester):
     def get_email_data(self):
         self.log.info("Prepare data for email")
         email_data = {}
-        grafana_dataset = {}
 
         try:
             email_data = self._get_common_email_data()
         except Exception as error:  # pylint: disable=broad-except
             self.log.exception("Error in gathering common email data: Error:\n%s", error, exc_info=error)
 
-        try:
-            grafana_dataset = self.monitors.get_grafana_screenshot_and_snapshot(
-                self.start_time) if self.monitors else {}
-        except Exception as error:  # pylint: disable=broad-except
-            self.log.exception("Error in gathering Grafana screenshots and snapshots. Error:\n%s",
-                               error, exc_info=error)
-
-        email_data.update({"grafana_screenshots": grafana_dataset.get("screenshots", []),
-                           "grafana_snapshots": grafana_dataset.get("snapshots", []),
-                           "ingest_time": self.ingest_time,
-                           "rebuild_duration": self.rebuild_duration,
-                           "subject": f"Scale up test results - {email_data['scylla_instance_type']}",
-                           }
-                          )
+        email_data.update({
+            "ingest_time": self.ingest_time,
+            "rebuild_duration": self.rebuild_duration,
+            "subject": f"Scale up test results - {email_data['scylla_instance_type']}",
+        })
         return email_data

--- a/sct.py
+++ b/sct.py
@@ -1278,7 +1278,6 @@ def get_test_results_for_failed_test(test_status, start_time):
         "start_time": start_time,
         "end_time": format_timestamp(time.time()),
         "grafana_screenshots": "",
-        "grafana_snapshots": "",
         "nodes": "",
         "test_id": "",
         "username": ""

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5850,7 +5850,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
         """)
         node.remoter.run("bash -ce '%s'" % kill_script)
 
-    def get_grafana_screenshot_and_snapshot(self, test_start_time: Optional[int] = None) -> dict[str, list[str]]:
+    def get_grafana_screenshots_from_all_monitors(self, test_start_time: Optional[float] = None) -> list[str]:
         """
             Take screenshot of the Grafana per-server-metrics dashboard and upload to S3
         """
@@ -5862,7 +5862,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
         for node in self.nodes:
             screenshot_links.extend(self.get_grafana_screenshots(node, test_start_time))
 
-        return {'screenshots': screenshot_links}
+        return screenshot_links
 
     def get_grafana_screenshots(self, node: BaseNode, test_start_time: float) -> list[str]:
         screenshot_links = []
@@ -5943,8 +5943,8 @@ class NoMonitorSet():
     def collect_logs(self, storage_dir):
         pass
 
-    def get_grafana_screenshot_and_snapshot(self, test_start_time=None):  # pylint: disable=unused-argument,no-self-use,invalid-name
-        return {}
+    def get_grafana_screenshots_from_all_monitors(self, test_start_time=None):  # pylint: disable=unused-argument,no-self-use,invalid-name
+        return []
 
 
 class LocalNode(BaseNode):

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -649,7 +649,6 @@ class TestStatsMixin(Stats):
         test_details['start_host'] = platform.node()
         test_details['test_duration'] = self.params.get(key='test_duration')
         test_details['start_time'] = int(time.time())
-        test_details['grafana_snapshots'] = []
         test_details['grafana_screenshots'] = []
         test_details['grafana_annotations'] = []
         test_details['prometheus_data'] = ""
@@ -841,9 +840,8 @@ class TestStatsMixin(Stats):
             if self.params.get("store_perf_results"):
                 update_data["results"] = self.get_prometheus_stats(alternator=alternator,
                                                                    scrap_metrics_step=scrap_metrics_step)
-            grafana_dataset = self.monitors.get_grafana_screenshot_and_snapshot(test_details["start_time"])
-            test_details.update({"grafana_screenshots": grafana_dataset.get("screenshots", []),
-                                 "grafana_snapshots": grafana_dataset.get("snapshots", []),
+            grafana_screenshots = self.monitors.get_grafana_screenshots_from_all_monitors(test_details["start_time"])
+            test_details.update({"grafana_screenshots": grafana_screenshots,
                                  "grafana_annotations": self.monitors.upload_annotations_to_s3(),
                                  "prometheus_data": self.monitors.download_monitor_data(), })
 

--- a/sdcm/report_templates/results_base.html
+++ b/sdcm/report_templates/results_base.html
@@ -307,7 +307,7 @@
 {% endblock %}
 
 {% block links %}
-    {% if kibana_url or job_url or grafana_screenshots or grafana_snapshots or parallel_timelines_report or relocatable_pkg %}
+    {% if kibana_url or job_url or grafana_screenshots or parallel_timelines_report or relocatable_pkg %}
     <h3>Links:</h3>
     <ul>
         {% if kibana_url %}
@@ -325,17 +325,6 @@
             {% endif %}
             {% if grafana_screenshots[2] %}
                 <li><a href={{ grafana_screenshots[2] }}>Download "Alternator metrics" Grafana Screenshot</a></li>
-            {% endif %}
-        {% endif %}
-        {% if grafana_snapshots %}
-            {% if grafana_snapshots[0] %}
-                <li><a href={{ grafana_snapshots[0] }}>Shared "Overview metrics" Grafana Snapshot</a></li>
-            {% endif %}
-            {% if grafana_snapshots[1] %}
-                <li><a href={{ grafana_snapshots[1] }}>Shared "Per server metrics nemesis" Grafana Snapshot</a></li>
-            {% endif %}
-            {% if grafana_snapshots[2] %}
-                <li><a href={{  grafana_snapshots[2] }}>Shared "Alternator metrics" Grafana Snapshot</a></li>
             {% endif %}
         {% endif %}
         {% if parallel_timelines_report %}

--- a/sdcm/report_templates/results_base_custom.html
+++ b/sdcm/report_templates/results_base_custom.html
@@ -160,7 +160,7 @@
 {%- endblock -%}
 
 {%- block links -%}
-    {% if kibana_url or job_url or grafana_screenshots or grafana_snapshots or relocatable_pkg %}
+    {% if kibana_url or job_url or grafana_screenshots or relocatable_pkg %}
     <h3>Links:</h3>
     <ul>
         {% if kibana_url %}
@@ -180,19 +180,8 @@
                 <li><a href={{ grafana_screenshots[2] }}>Download "Alternator metrics" Grafana Screenshot</a></li>
             {% endif %}
         {% endif %}
-        {% if grafana_snapshots %}
-            {% if grafana_snapshots[0] %}
-                <li><a href={{ grafana_snapshots[0] }}>Shared "Per server metrics nemesis" Grafana Snapshot</a></li>
-            {% endif %}
-            {% if grafana_snapshots[1] %}
-                <li><a href={{ grafana_snapshots[1] }}>Shared "Overview metrics" Grafana Snapshot</a></li>
-            {% endif %}
-            {% if grafana_snapshots[2] %}
-                <li><a href={{  grafana_snapshots[2] }}>Shared "Alternator metrics" Grafana Snapshot</a></li>
-            {% endif %}
         {% if relocatable_pkg %}
             <li><a href={{ relocatable_pkg }}>Relocatable package url</a></li>
-        {% endif %}
         {% endif %}
     </ul>
     {% if logs_links %}

--- a/sdcm/report_templates/results_base_new.html
+++ b/sdcm/report_templates/results_base_new.html
@@ -253,7 +253,7 @@
 {%- endblock -%}
 
 {%- block links -%}
-    {%- if current_main_test.gen_kibana_dashboard_url() or current_main_test.kibana_url or current_main_test.job_url or current_main_test.grafana_screenshots or current_main_test.grafana_snapshots -%}
+    {%- if current_main_test.gen_kibana_dashboard_url() or current_main_test.kibana_url or current_main_test.job_url or current_main_test.grafana_screenshots -%}
     <h3>Links:</h3>
     <ul>
         <li><a href={{ current_main_test.gen_kibana_dashboard_url() }}>Kibana</a></li>
@@ -262,16 +262,8 @@
             {%- if current_main_test.grafana_screenshots[0] -%}
                 <li><a href={{ current_main_test.grafana_screenshots[0] }}>Download "Per server metrics nemesis" Grafana Screenshot</a></li>
             {%- endif -%}
-            {%- if current_main_test.grafana_snapshots[1] -%}
+            {%- if current_main_test.grafana_screenshots[1] -%}
                 <li><a href={{ current_main_test.grafana_screenshots[1] }}>Download "Overview metrics" Grafana Screenshot</a></li>
-            {%- endif -%}
-        {%- endif -%}
-        {%- if current_main_test.grafana_snapshots -%}
-            {%- if current_main_test.grafana_snapshots[0] -%}
-                <li><a href={{ current_main_test.grafana_snapshots[0] }}>Shared "Per server metrics nemesis" Grafana Snapshot</a></li>
-            {%- endif -%}
-            {%- if current_main_test.grafana_snapshots[1] -%}
-                <li><a href={{ current_main_test.grafana_snapshots[1] }}>Shared "Overview metrics" Grafana Snapshot</a></li>
             {%- endif -%}
         {%- endif -%}
     {%- endif -%}

--- a/sdcm/report_templates/results_performance_multi_baseline.html
+++ b/sdcm/report_templates/results_performance_multi_baseline.html
@@ -131,7 +131,7 @@
                 {%- if subtest.grafana_screenshots[0] -%}
                     <li><a href={{ subtest.grafana_screenshots[0] }}>Download "Per server metrics nemesis" Grafana Screenshot</a></li>
                 {%- endif -%}
-                {%- if subtest.grafana_snapshots[1] -%}
+                {%- if subtest.grafana_screenshots[1] -%}
                     <li><a href={{ subtest.grafana_screenshots[1] }}>Download "Overview metrics" Grafana Screenshot</a></li>
                 {%- endif -%}
             {%- endif -%}

--- a/sdcm/report_templates/results_performance_multi_baseline_single_metric.html
+++ b/sdcm/report_templates/results_performance_multi_baseline_single_metric.html
@@ -129,7 +129,7 @@
                 {%- if subtest.grafana_screenshots[0] -%}
                     <li><a href={{ subtest.grafana_screenshots[0] }}>Download "Per server metrics nemesis" Grafana Screenshot</a></li>
                 {%- endif -%}
-                {%- if subtest.grafana_snapshots[1] -%}
+                {%- if subtest.grafana_screenshots[1] -%}
                     <li><a href={{ subtest.grafana_screenshots[1] }}>Download "Overview metrics" Grafana Screenshot</a></li>
                 {%- endif -%}
             {%- endif -%}

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -74,16 +74,6 @@ class BaseResultsAnalyzer:  # pylint: disable=too-many-instance-attributes
         return self._es.get(index=self._es_index, doc_type=self._es_doc_type, id=test_id)
 
     @staticmethod
-    def _get_grafana_snapshot(test_doc):
-        grafana_snapshots = test_doc['_source']['test_details'].get('grafana_snapshots')
-        if grafana_snapshots and isinstance(grafana_snapshots, list):
-            return grafana_snapshots
-        elif grafana_snapshots and isinstance(grafana_snapshots, str):
-            return [grafana_snapshots]
-        else:
-            return []
-
-    @staticmethod
     def _get_grafana_screenshot(test_doc):
         grafana_screenshots = test_doc['_source']['test_details'].get('grafana_screenshot')
         if not grafana_screenshots:
@@ -469,7 +459,6 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
             test_version=test_version,
             build_id=build_id,
             setup_details=self._get_setup_details(doc, is_gce),
-            grafana_snapshots=self._get_grafana_snapshot(doc),
             grafana_screenshots=self._get_grafana_screenshot(doc),
             job_url=doc['_source']['test_details'].get('job_url', ""),
             node_benchmarks=node_benchmarks,
@@ -854,7 +843,6 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
             "prometheus_stats": {stat: doc["_source"]["results"].get(stat, {})
                                  for stat in TestStatsMixin.PROMETHEUS_STATS},
             "prometheus_stats_units": TestStatsMixin.PROMETHEUS_STATS_UNITS,
-            "grafana_snapshots": self._get_grafana_snapshot(doc),
             "grafana_screenshots": self._get_grafana_screenshot(doc),
             "cs_raw_cmd": cassandra_stress.get('raw_cmd', "") if cassandra_stress else "",
             "ycsb_raw_cmd": ycsb.get('raw_cmd', "") if ycsb else "",
@@ -994,7 +982,6 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
                 current_tests[sub_type]['best_test_id'] = {
                     k: f"#{version_info['commit_id']}, {version_info['date']}" for k in self.PARAMS}
                 current_tests[sub_type]['results'] = row['_source']['results']
-                grafana_snapshots[sub_type] = self._get_grafana_snapshot(row)
                 grafana_screenshots[sub_type] = self._get_grafana_screenshot(row)
 
                 self.log.info('Added current test results %s. Check next', row['_id'])

--- a/sdcm/results_analyze/test.py
+++ b/sdcm/results_analyze/test.py
@@ -366,7 +366,6 @@ class TestResultClass(ClassBase):
         'subtest_name': '_source.test_details.sub_type',
         'test_id': '_id',
         'software': '_source.versions',
-        'grafana_snapshots': '_source.test_details.grafana_snapshots',
         'grafana_screenshots': '_source.test_details.grafana_screenshots',
         'es_index': '_index',
         'main_test_id': '_source.test_details.test_id',
@@ -399,7 +398,6 @@ class TestResultClass(ClassBase):
     metrics: ScyllaTestMetrics = None
     subtest_name: str = None
     software: SoftwareVersions = None
-    grafana_snapshots: list = []
     grafana_screenshots: list = []
     test_name: str = None
     es_index: str = None

--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -361,7 +361,6 @@ class MgmtEmailReporter(BaseEmailReporter):
 class LongevityEmailReporter(BaseEmailReporter):
     _fields = (
         "grafana_screenshots",
-        "grafana_snapshots",
         "nemesis_details",
         "nemesis_name",
         "scylla_ami_id",
@@ -469,7 +468,6 @@ class GeminiEmailReporter(LongevityEmailReporter):
         "scylla_ami_id",
         "status",
         "grafana_screenshots",
-        "grafana_snapshots",
     )
     email_template_file = "results_gemini.html"
 
@@ -486,7 +484,6 @@ class FunctionalEmailReporter(LongevityEmailReporter):
 class ScaleUpEmailReporter(LongevityEmailReporter):
     _fields = (
         "grafana_screenshots",
-        "grafana_snapshots",
         "ingest_time",
         "rebuild_duration",
     )
@@ -496,7 +493,6 @@ class ScaleUpEmailReporter(LongevityEmailReporter):
 class UpgradeEmailReporter(BaseEmailReporter):
     _fields = (
         "grafana_screenshots",
-        "grafana_snapshots",
         "new_scylla_repo",
         "new_version",
         "scylla_ami_id",
@@ -520,7 +516,6 @@ class TestAbortedEmailReporter(LongevityEmailReporter):
 class CDCReplicationReporter(LongevityEmailReporter):
     _fields = (
         "grafana_screenshots",
-        "grafana_snapshots",
         "nemesis_details",
         "nemesis_name",
         "scylla_ami_id",
@@ -536,7 +531,6 @@ class CDCReplicationReporter(LongevityEmailReporter):
 class JepsenEmailReporter(BaseEmailReporter):
     _fields = (
         "grafana_screenshots",
-        "grafana_snapshots",
         "jepsen_report",
         "jepsen_scylla_repo",
         "jepsen_test_cmd",
@@ -552,7 +546,6 @@ class JepsenEmailReporter(BaseEmailReporter):
 class SlaPerUserEmailReporter(LongevityEmailReporter):
     _fields = (
         "grafana_screenshots",
-        "grafana_snapshots",
         "scylla_ami_id",
         "parallel_timelines_report",
         "workload_comparison"

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3606,21 +3606,29 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         try:
             email_data = self.get_email_data()
             self._argus_add_relocatable_pkg(email_data)
-            self.argus_collect_screenshots(email_data)
         except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
             self.log.error("Error while saving email data. Error: %s\nTraceback: %s", exc, traceback.format_exc())
+
+        grafana_screenshots = []
+        try:
+            grafana_screenshots = self.monitors.get_grafana_screenshots_from_all_monitors(
+                self.start_time) if self.monitors else {}
+            self.argus_collect_screenshots(grafana_screenshots)
+        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            self.log.exception("Error while collecting screenshots:", exc_info=exc)
 
         json_file_path = os.path.join(self.logdir, "email_data.json")
 
         if email_data:
+            email_data['grafana_screenshots'] = grafana_screenshots
             email_data["reporter"] = self.email_reporter.__class__.__name__
             self.log.debug('Save email data to file %s', json_file_path)
             self.log.debug('Email data: %s', email_data)
             save_email_data_to_file(email_data, json_file_path)
 
-    def argus_collect_screenshots(self, email_data: dict) -> None:
-        screenshot_links = email_data.get("grafana_screenshots", [])
-        self.test_config.argus_client().submit_screenshots(screenshot_links)
+    def argus_collect_screenshots(self, grafana_screenshots: list) -> None:
+        if grafana_screenshots:
+            self.test_config.argus_client().submit_screenshots(grafana_screenshots)
 
     def _argus_add_relocatable_pkg(self, email_data):
         """Adds Package with url to relocatable package in Argus.

--- a/sla_per_user_system_test.py
+++ b/sla_per_user_system_test.py
@@ -879,7 +879,6 @@ class SlaPerUserTest(LongevityTest):
 
     def get_email_data(self):
         self.log.info("Prepare data for email for SLA test")
-        grafana_dataset = {}
         email_data = {}
 
         try:
@@ -887,18 +886,11 @@ class SlaPerUserTest(LongevityTest):
         except Exception as error:  # pylint: disable=broad-except  # noqa: BLE001
             self.log.error("Error in gathering common email data: Error:\n%s", error)
 
-        try:
-            grafana_dataset = self.monitors.get_grafana_screenshot_and_snapshot(
-                self.start_time) if self.monitors else {}
-        except Exception as error:  # pylint: disable=broad-except  # noqa: BLE001
-            self.log.error("Error in gathering Grafana screenshots and snapshots. Error:\n%s", error)
-
-        email_data.update({"grafana_screenshots": grafana_dataset.get("screenshots", []),
-                           "grafana_snapshots": grafana_dataset.get("snapshots", []),
-                           "scylla_ami_id": self.params.get("ami_id_db_scylla") or "-",
-                           "region": self.params.get("region_name") or "-",
-                           "workload_comparison": self._comparison_results if self._comparison_results else {}
-                           })
+        email_data.update({
+            "scylla_ami_id": self.params.get("ami_id_db_scylla") or "-",
+            "region": self.params.get("region_name") or "-",
+            "workload_comparison": self._comparison_results if self._comparison_results else {}
+        })
 
         return email_data
 
@@ -942,13 +934,8 @@ class SlaPerUserTest(LongevityTest):
 
         self.assertTrue(latency_99_for_mixed_workload, msg='Not received cassandra-stress for mixed workload')
 
-        grafana_dataset = self.monitors.get_grafana_screenshot_and_snapshot(test_start_time=test_start_time)
-
-        grafana_screenshots = grafana_dataset.get('screenshots', [])
-        grafana_snapshots = grafana_dataset.get('snapshots', [])
-
+        grafana_screenshots = self.monitors.get_grafana_screenshots_from_all_monitors(test_start_time=test_start_time)
         self.log.debug('GRAFANA SCREENSHOTS: {}'.format(grafana_screenshots))
-        self.log.debug('GRAFANA SNAPSHOTS: {}'.format(grafana_snapshots))
 
         # Compare latency of two runs
         self.log.debug('Test results:\n---------------------\n')

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -1315,10 +1315,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         self.log.info('Prepare data for email')
 
         email_data = self._get_common_email_data()
-        grafana_dataset = self.monitors.get_grafana_screenshot_and_snapshot(self.start_time) if self.monitors else {}
         email_data.update({
-            "grafana_screenshots": grafana_dataset.get("screenshots", []),
-            "grafana_snapshots": grafana_dataset.get("snapshots", []),
             "new_scylla_repo": self.params.get("new_scylla_repo"),
             "new_version": self.new_ver,
             "scylla_ami_id": self.params.get("ami_id_db_scylla") or "-",


### PR DESCRIPTION
the reporting to argus was depended on specific logic in each test to take the screenshots, some tests didn't had them.

this change consolidate taking the screenshots, and take them and report to argus for all of the tests, regardless if they have email report or not.

this change also remove the references to grafana_snapshot since we don't generate them anymore.

Fixes: scylladb/scylla-cluster-tests#8032

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] provision tests
- [x] 🟢 [one perf test (to validate problem solved)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/scylla-enterprise-perf-regression-throughput-shard-aware-i4i/2/)
- [x] 🟢 [one simple longevity ](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/54/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
