### PR TITLE
fix(trigger): remove grow-shrink test from nightly run

### DIFF
--- a/jenkins-pipelines/master-triggers/sct_triggers/nightly-%(sct_branch)s-nemesis-tests-trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/nightly-%(sct_branch)s-nemesis-tests-trigger.xml
@@ -27,7 +27,7 @@ stress_duration=660</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>../nemesis/longevity-5gb-1h-MgmtRepair-aws-test,../nemesis/longevity-5gb-1h-CorruptThenRepairMonkey-aws-test,../nemesis/longevity-5gb-1h-GrowShrinkClusterNemesis-aws-test,../nemesis/longevity-5gb-1h-NodeTerminateAndReplace-aws-test,../nemesis/longevity-5gb-1h-MgmtBackupSpecificKeyspaces-aws-test,../nemesis/longevity-5gb-1h-MgmtBackup-aws-test</projects>
+          <projects>../nemesis/longevity-5gb-1h-MgmtRepair-aws-test,../nemesis/longevity-5gb-1h-CorruptThenRepairMonkey-aws-test,../nemesis/longevity-5gb-1h-NodeTerminateAndReplace-aws-test,../nemesis/longevity-5gb-1h-MgmtBackupSpecificKeyspaces-aws-test,../nemesis/longevity-5gb-1h-MgmtBackup-aws-test</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>


### PR DESCRIPTION
We don't want this test to stay in nighlty trigger - was left by mistake.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
