### PR TITLE
fix(nemesis-tests-trigger): disable trigger

### DIFF
--- a/jenkins-pipelines/master-triggers/sct_triggers/nightly-%(sct_branch)s-nemesis-tests-trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/nightly-%(sct_branch)s-nemesis-tests-trigger.xml
@@ -3,7 +3,7 @@
   <description>Triggers Master Tests on Nightly basis at 23:45 PM
 </description>
   <scm class="hudson.scm.NullSCM"/>
-  <disabled>false</disabled>
+  <disabled>true</disabled>
   <triggers>
     <hudson.triggers.TimerTrigger>
       <spec>00 2 * * *</spec>


### PR DESCRIPTION
we disable the trigger long time ago,
but recently fix the job that update all sct jenkins jobs and that enabled it back, we don't need those runs for now.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
