### PR TITLE
fix(fill_db_data): remove cache form properties

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -23,7 +23,6 @@ import time
 import re
 
 from collections import OrderedDict
-from functools import cached_property
 from uuid import UUID
 
 from cassandra import InvalidRequest
@@ -3106,7 +3105,7 @@ class FillDatabaseData(ClusterTester):
         for test_num, item in enumerate(self.all_verification_items):
             test_name = item.get('name', 'Test #' + str(test_num))
             # Check if current cluster version supports non-frozed UDT
-            if 'skip_condition' in item and 'non_frozen_udt' in item['skip_condition'] \
+            if 'skip_condition' in item \
                     and not eval(item['skip_condition']):
                 item['skip'] = 'skip'
                 self.all_verification_items[test_num]['skip'] = 'skip'
@@ -3178,19 +3177,19 @@ class FillDatabaseData(ClusterTester):
             version_with_support = self.NON_FROZEN_SUPPORT_OS_MIN_VERSION
         return self.parsed_scylla_version >= version_with_support
 
-    @cached_property
+    @property
     def enable_cdc_for_tables(self) -> bool:
         if self.tablets_enabled and SkipPerIssues(issues="https://github.com/scylladb/scylladb/issues/16317", params=self.params):
             return False
         return True
 
-    @cached_property
+    @property
     def is_counter_supported(self) -> bool:
         if self.tablets_enabled and SkipPerIssues(issues="scylladb/scylladb#18180", params=self.params):
             return False
         return True
 
-    @cached_property
+    @property
     def tablets_enabled(self) -> bool:
         """Check is tablets enabled on cluster"""
         with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:


### PR DESCRIPTION
since the status can change after the upgrade itself we should be caching those, and we should calculate them every single time.

also remove udt specific logic form the loop doing the skip condition, it's not needed anythmore, now that we have function calls for doing the logic for each case.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-ubuntu20.04-test/19/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
