### PR TITLE
fix(upgrade_test): add DEBIAN_FRONTEND=noninteractive to apt-get commands

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -301,11 +301,11 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
                     InfoEvent(message='upgrade_node - ended to remove and install scylla on RHEL').publish()
                 else:
                     InfoEvent(message='upgrade_node - starting to remove and install scylla on debian').publish()
-                    node.remoter.run(r'sudo apt-get remove scylla\* -y')
-                    # fixme: add publick key
-                    node.remoter.run(
-                        r'sudo apt-get install {} -y '
-                        r'-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" '.format(scylla_pkg_ver))
+                    node.remoter.sudo(r'apt-get remove scylla\* -y')
+                    node.remoter.sudo(
+                        f'DEBIAN_FRONTEND=noninteractive apt-get install {scylla_pkg_ver} -y'
+                        f' -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"'
+                    )
                     InfoEvent(message='upgrade_node - ended to remove and install scylla on debian').publish()
                 InfoEvent(message='upgrade_node - starting to "recover_conf"').publish()
                 recover_conf(node)
@@ -320,10 +320,11 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
                     InfoEvent(message='upgrade_node - ended to "yum update"').publish()
                 else:
                     InfoEvent(message='upgrade_node - starting to "apt-get update"').publish()
-                    node.remoter.run('sudo apt-get update')
-                    node.remoter.run(
-                        r'sudo apt-get dist-upgrade {} -y '
-                        r'-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" '.format(scylla_pkg))
+                    node.remoter.sudo('apt-get update')
+                    node.remoter.sudo(
+                        f'DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade {scylla_pkg} -y'
+                        f' -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"'
+                    )
                     InfoEvent(message='upgrade_node - ended to "apt-get update"').publish()
         InfoEvent(message='upgrade_node - starting to "check_reload_systemd_config"').publish()
         check_reload_systemd_config(node)
@@ -403,10 +404,11 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
                 node.remoter.run(r'sudo yum remove scylla\* -y')
                 node.remoter.run(r'sudo yum install %s -y' % node.scylla_pkg())
             else:
-                node.remoter.run(r'sudo apt-get remove scylla\* -y')
-                node.remoter.run(
-                    r'sudo apt-get install %s\* -y '
-                    r'-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" ' % node.scylla_pkg())
+                node.remoter.sudo(r'apt-get remove scylla\* -y')
+                node.remoter.sudo(
+                    rf'DEBIAN_FRONTEND=noninteractive apt-get install {node.scylla_pkg()}\* -y'
+                    rf' -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"'
+                )
             recover_conf(node)
             node.remoter.run('sudo systemctl daemon-reload')
 


### PR DESCRIPTION
Some of the upgrades from 2024.1 to 2024.2 try different frontends
instead of using noninteractive by default:

```
Stderr:
debconf: unable to initialize frontend: Dialog
debconf: (Dialog frontend will not work on a dumb terminal, an emacs
shell buffer, or without a controlling terminal.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
dpkg-preconfigure: unable to re-open stdin:
```

The Debian Handbook recommends to add `DEBIAN_FRONTEND=noninteractive` env variable to non-interactive upgrade scripts (as we already do in `sdcm/cluster.py`)

E.g.: https://argus.scylladb.com/test/51d72851-b8d3-4818-a986-404f742f9b03/runs?additionalRuns[]=f3fe515c-3408-4a92-850c-40d2d32c5af8

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/evgeniy/job/rolling-upgrade-debian11-test/2/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
