### PR TITLE
fix(artifacts_test): assert row isn't empty

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -74,6 +74,8 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
                                                              f"WHERE uuid = %s", args=(self.node.uuid,))
         self.log.debug("Last row in %s for uuid '%s': %s", self.CHECK_VERSION_TABLE, self.node.uuid, row)
 
+        assert row, f"No rows found in {self.CHECK_VERSION_TABLE} for uuid '{self.node.uuid}'"
+
         public_ip_address = self.node.host_public_ip_address if backend == 'docker' else self.node.public_ip_address
         self.log.debug("public_ip_address = %s", public_ip_address)
 


### PR DESCRIPTION
retry on the housekeeping check is expecting `AssertionError` but wasn't expecting `TypeError`

so in this change we are asserting the row isn't empty before moving on and trying to read specific things out of it

Fixes: scylladb/scylladb#19875

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle:  [docker artifact test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-docker-test/26/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
