### PR TITLE
fix(alternator): create a role with "login" and "superuser" flags

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1111,7 +1111,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.log.info("Going to create alternator tables")
             if self.params.get('alternator_enforce_authorization'):
                 with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
-                    session.execute("CREATE ROLE %s WITH PASSWORD = %s",
+                    session.execute("CREATE ROLE %s WITH PASSWORD = %s AND login = true AND superuser = true",
                                     (self.params.get('alternator_access_key_id'),
                                      self.params.get('alternator_secret_access_key')))
 

--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -76,7 +76,7 @@ def fixture_cql_driver(docker_scylla):
 def create_table(docker_scylla, cql_driver, alternator_api, params):
 
     with cql_driver.connect() as session:
-        session.execute("CREATE ROLE %s WITH PASSWORD = %s",
+        session.execute("CREATE ROLE %s WITH PASSWORD = %s AND login = true AND superuser = true",
                         (params.get('alternator_access_key_id'),
                          params.get('alternator_secret_access_key')))
 


### PR DESCRIPTION
since scylladb/scylladb#19740 was recently merge, we need to put the `login=true` for using roles with alternator

and when scylladb/scylladb#19762 would be merged
we'll need the `superuesr=true`, or do fine grind permission for any action we need

Ref: scylladb/scylladb#19740
Ref: scylladb/scylladb#19762
Ref: https://github.com/scylladb/scylla-dtest/issues/4697

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/rolling-upgrade-alternator-test/6/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
