### PR TITLE
fix(apt-keys): update the apt key for 2024

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -193,6 +193,7 @@ scylla_apt_keys:
   - '5E08FBD8B5D6EC9C'  # ScyllaDB Package Signing Key 2020 <security@scylladb.com>
   - 'D0A112E067426AB2'  # ScyllaDB Package Signing Key 2022 <security@scylladb.com>
   - '491C93B9DE7496A7'  # ScyllaDB Package Signing Key 2024 <security@scylladb.com>
+  - 'A43E06657BAC99E3'  # ScyllaDB Package Signing Key 2024 (RSA) <security@scylladb.com>
 
 raid_level: 0
 

--- a/test-cases/artifacts/debian11.yaml
+++ b/test-cases/artifacts/debian11.yaml
@@ -13,11 +13,6 @@ n_loaders: 0
 n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'debian-bullseye'
-scylla_apt_keys:
-  # When will use manager 2.6, need to remove this commit because it's a workaround to make artifacts works
-  - '5E08FBD8B5D6EC9C'  # ScyllaDB Package Signing Key 2020 <security@scylladb.com>
-  - 'D0A112E067426AB2'  # ScyllaDB Package Signing Key 2022 <security@scylladb.com>
-  - '491C93B9DE7496A7'  # ScyllaDB Package Signing Key 2024 <security@scylladb.com>
 test_duration: 60
 user_prefix: 'artifacts-debian11'
 use_preinstalled_scylla: false

--- a/test-cases/artifacts/ubuntu2004.yaml
+++ b/test-cases/artifacts/ubuntu2004.yaml
@@ -13,11 +13,6 @@ n_loaders: 0
 n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'ubuntu-focal'
-scylla_apt_keys:
-  # When will use manager 2.6, need to remove this commit because it's a workaround to make artifacts works
-  - '5E08FBD8B5D6EC9C'  # ScyllaDB Package Signing Key 2020 <security@scylladb.com>
-  - 'D0A112E067426AB2'  # ScyllaDB Package Signing Key 2022 <security@scylladb.com>
-  - '491C93B9DE7496A7'  # ScyllaDB Package Signing Key 2024 <security@scylladb.com>
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2004'
 use_preinstalled_scylla: false


### PR DESCRIPTION
update to the latest key

remove duplicate of definition of the apt keys

Ref: scylladb/scylla-enterprise#4222

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
