### PR TITLE
fix(FullScan): rename forward_service to mapreduce_service

### DIFF
--- a/sdcm/scan_operation_thread.py
+++ b/sdcm/scan_operation_thread.py
@@ -459,7 +459,7 @@ class FullScanAggregatesOperation(FullscanOperationBase):
                       event: Type[FullScanEvent | FullPartitionScanEvent
                                   | FullPartitionScanReversedOrderEvent]) -> None:
         self.log.debug('Will run command %s', cmd)
-        validate_forward_service_requests_start_time = time.time()
+        validate_mapreduce_service_requests_start_time = time.time()
         try:
             cmd_result = session.execute(
                 query=cmd, trace=False, timeout=self._session_execution_timeout)
@@ -482,7 +482,7 @@ class FullScanAggregatesOperation(FullscanOperationBase):
             event.severity = Severity.ERROR
             return
 
-        message, severity = self._validate_fullscan_result(cmd_result, validate_forward_service_requests_start_time)
+        message, severity = self._validate_fullscan_result(cmd_result, validate_mapreduce_service_requests_start_time)
         if not severity:
             event.message = f"{type(self).__name__} operation ended successfully: {message}"
         else:
@@ -490,7 +490,7 @@ class FullScanAggregatesOperation(FullscanOperationBase):
             event.message = f"{type(self).__name__} operation failed: {message}"
 
     def _validate_fullscan_result(
-            self, cmd_result: ResultSet, validate_forward_service_requests_start_time):
+            self, cmd_result: ResultSet, validate_mapreduce_service_requests_start_time):
         result = cmd_result.all()
 
         if not result:
@@ -503,36 +503,36 @@ class FullScanAggregatesOperation(FullscanOperationBase):
         self.log.debug("Fullscan aggregation result: %s", output)
 
         try:
-            self.validate_forward_service_requests_dispatched_to_other_nodes(
-                validate_forward_service_requests_start_time)
+            self.validate_mapreduce_service_requests_dispatched_to_other_nodes(
+                validate_mapreduce_service_requests_start_time)
         except Retry as retry_exception:
-            self.log.debug("prometheus_forward_service_requests metrics:\n %s",
+            self.log.debug("prometheus_mapreduce_service_requests metrics:\n %s",
                            str(retry_exception))
             self.log.debug("Fullscan aggregation result: %s", output)
-            return "Fullscan failed - 'forward_service_requests_dispatched_to_other_nodes' was not triggered", \
+            return "Fullscan failed - 'mapreduce_service_requests_dispatched_to_other_nodes' was not triggered", \
                 Severity.ERROR
 
         return f'result {result[0]}', None
 
     @retrying(n=6, sleep_time=10, allowed_exceptions=(Retry, ))
-    def validate_forward_service_requests_dispatched_to_other_nodes(self, start_time):
+    def validate_mapreduce_service_requests_dispatched_to_other_nodes(self, start_time):
         prometheus = PrometheusDBStats(
             TestConfig().tester_obj().monitors.nodes[0].external_address)
-        prometheus_forward_service_requests = prometheus.query(
-            'scylla_forward_service_requests_dispatched_to_other_nodes',
+        prometheus_mapreduce_service_requests = prometheus.query(
+            'scylla_mapreduce_service_requests_dispatched_to_other_nodes',
             start_time, time.time())
 
         # expected format is :
-        # [{'metric': {'__name__': 'scylla_forward_service_requests_dispatched_to_other_nodes',
+        # [{'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes',
         # 'instance': '10.4.0.181', 'job': 'scylla', 'shard': '0'}, 'values': [[1690287334.763, '0']]}, ...]
-        for metric in prometheus_forward_service_requests:
-            forward_service_requests_dispatched_before_query = int(metric["values"][0][1])
-            forward_service_requests_dispatched_after_query = int(metric["values"][-1][1])
-            if forward_service_requests_dispatched_before_query < forward_service_requests_dispatched_after_query:
-                self.log.info('forward_service_requests_dispatched_to_other_nodes was triggered')
+        for metric in prometheus_mapreduce_service_requests:
+            mapreduce_service_requests_dispatched_before_query = int(metric["values"][0][1])
+            mapreduce_service_requests_dispatched_after_query = int(metric["values"][-1][1])
+            if mapreduce_service_requests_dispatched_before_query < mapreduce_service_requests_dispatched_after_query:
+                self.log.info('mapreduce_service_requests_dispatched_to_other_nodes was triggered')
                 return
 
-        raise Retry(prometheus_forward_service_requests)
+        raise Retry(prometheus_mapreduce_service_requests)
 
 
 class PagedResultHandler:

--- a/unit_tests/test_scan_operation_thread.py
+++ b/unit_tests/test_scan_operation_thread.py
@@ -152,7 +152,7 @@ def test_negative_prometheus_validation_error(events, cluster):
             all_events = get_event_log_file(events)
             assert "Severity.NORMAL" in all_events[0] and "period_type=begin" in all_events[0]
             assert "Severity.ERROR" in all_events[1] and "period_type=end" in all_events[
-                1] and "Fullscan failed - 'forward_service_requests_dispatched_to_other_nodes' was not triggered" in all_events[1]
+                1] and "Fullscan failed - 'mapreduce_service_requests_dispatched_to_other_nodes' was not triggered" in all_events[1]
 
 
 class ExecuteOperationTimedOutMockCqlConnectionPatient(MockCqlConnectionPatient):


### PR DESCRIPTION
rename forward_service to mapreduce_service
according to
https://github.com/scylladb/scylladb/commit/3fc4e23a36aad7a418805797b08370a3f3ddae2b

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/artsiom_mishuta/job/scylla_mapreduce_service_requests_dispatched_to_other_nodes/2/
```
< t:2024-07-29 10:05:48,274 f:db_stats.py     l:229  c:sdcm.db_stats        p:DEBUG > Response from Prometheus server: {'status': 'success', 'data': {'resultType': 'matrix', 'result': [{'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'in
< t:2024-07-29 10:05:48,274 f:decorators.py   l:72   c:sdcm.utils.decorators p:DEBUG > 'validate_mapreduce_service_requests_dispatched_to_other_nodes': failed with 'Retry([{'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.1.90', 'job': 'scylla', 'shard': '0'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.1.90', 'job': 'scylla', 'shard': '1'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.1.90', 'job': 'scylla', 'shard': '2'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.1.90', 'job': 'scylla', 'shard': '3'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.1.90', 'job': 'scylla', 'shard': '4'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.1.90', 'job': 'scylla', 'shard': '5'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.1.90', 'job': 'scylla', 'shard': '6'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.201', 'job': 'scylla', 'shard': '0'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.201', 'job': 'scylla', 'shard': '1'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.201', 'job': 'scylla', 'shard': '2'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.201', 'job': 'scylla', 'shard': '3'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.201', 'job': 'scylla', 'shard': '4'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.201', 'job': 'scylla', 'shard': '5'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.201', 'job': 'scylla', 'shard': '6'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.217', 'job': 'scylla', 'shard': '0'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.217', 'job': 'scylla', 'shard': '1'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.217', 'job': 'scylla', 'shard': '2'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.217', 'job': 'scylla', 'shard': '3'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.217', 'job': 'scylla', 'shard': '4'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.217', 'job': 'scylla', 'shard': '5'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.217', 'job': 'scylla', 'shard': '6'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.66', 'job': 'scylla', 'shard': '0'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.66', 'job': 'scylla', 'shard': '1'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.66', 'job': 'scylla', 'shard': '2'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.66', 'job': 'scylla', 'shard': '3'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.66', 'job': 'scylla', 'shard': '4'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.66', 'job': 'scylla', 'shard': '5'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.2.66', 'job': 'scylla', 'shard': '6'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.3.109', 'job': 'scylla', 'shard': '0'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.3.109', 'job': 'scylla', 'shard': '1'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.3.109', 'job': 'scylla', 'shard': '2'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.3.109', 'job': 'scylla', 'shard': '3'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.3.109', 'job': 'scylla', 'shard': '4'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.3.109', 'job': 'scylla', 'shard': '5'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.3.109', 'job': 'scylla', 'shard': '6'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.3.139', 'job': 'scylla', 'shard': '0'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.3.139', 'job': 'scylla', 'shard': '1'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.3.139', 'job': 'scylla', 'shard': '2'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.3.139', 'job': 'scylla', 'shard': '3'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.3.139', 'job': 'scylla', 'shard': '4'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.3.139', 'job': 'scylla', 'shard': '5'}, 'values': [[1722247543.458, '0']]}, {'metric': {'__name__': 'scylla_mapreduce_service_requests_dispatched_to_other_nodes', 'cluster': 'my-cluster', 'dc': 'eu-west-1', 'instance': '10.4.3.139', 'job': 'scylla', 'shard': '6'}, 'values': [[1722247543.458, '0']]}])', retrying [#0]
< t:2024-07-29 10:05:49,143 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <10.4.1.107>: total,       9344802,  102484,  102484,  102484,     9.7,     5.9,    32.3,    55.9,    90.0,   171.3,   95.0,  0.03257,      0,      0,       0,       0,       0,       0
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

fixes https://github.com/scylladb/scylla-cluster-tests/issues/8184
