### PR TITLE
fix(hydra): don't running any python code outside hydra image

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -14,7 +14,6 @@ SCT_DIR=$(dirname "${DOCKER_ENV_DIR}")
 SCT_DIR=$(dirname "${SCT_DIR}")
 VERSION=v$(cat "${DOCKER_ENV_DIR}/version")
 HOST_NAME=SCT-CONTAINER
-RUN_BY_USER=$(python3 "${SCT_DIR}/sdcm/utils/get_username.py")
 USER_ID=$(id -u "${USER}"):$(id -g "${USER}")
 HOME_DIR=${HOME}
 
@@ -245,8 +244,6 @@ function run_in_docker () {
     $([[ -n "$HYDRA_DRY_RUN" ]] && echo echo) \
     $tool ${REMOTE_DOCKER_HOST} run --rm ${TTY_STDIN} --privileged \
         -h ${HOST_NAME} \
-        -l "TestId=${SCT_TEST_ID}" \
-        -l "RunByUser=${RUN_BY_USER}" \
         -v "${SCT_DIR}:${SCT_DIR}" \
         -v /tmp:/tmp \
         -v /var/tmp:/var/tmp \

--- a/unit_tests/test_hydra_sh.py
+++ b/unit_tests/test_hydra_sh.py
@@ -109,7 +109,6 @@ class LongevityPipelineTest:
         docker_run_prefix = self.docker_run_prefix(runner)
         sct_dir = self.sct_path(runner)
         expected = (
-            re.compile(f"{docker_run_prefix} -l TestId=11111111-1111-1111-1111-111111111111"),
             re.compile(f"{docker_run_prefix} -v {sct_dir}:{sct_dir} .* -v /var/run:/run"),
             re.compile(f"{docker_run_prefix} --group-add 1 --group-add 2 --group-add 3"),
         )


### PR DESCRIPTION
when doing so we can easily break users depends on which python version they are using, we shouldn't assume anything about user env.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
