### PR TITLE
fix(sdcm/cluster): try to parse host ID from incomplete output

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -467,8 +467,8 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         return self.vm_region
 
     @property
-    def host_id(self):
-        return self.parent_cluster.get_nodetool_info(self, publish_event=False).get('ID')
+    def host_id(self) -> str | None:
+        return self.parent_cluster.get_nodetool_info(self, ignore_status=True, publish_event=False).get("ID")
 
     @property
     def db_node_instance_type(self) -> Optional[str]:


### PR DESCRIPTION
`nodetool info` can fail at any point but host ID is a very first info printed out. So, we can try to parse the stdout to extract it.

Health check failed right after a node upgrade because `nodetool info` failed due to an internal problem (see more details here: https://github.com/scylladb/scylladb/issues/19923 )

```
2024-07-17 13:13:09.654: (TestFrameworkEvent Severity.ERROR) period_type=one-time event_id=92f6d16e-eff5-46ec-80f6-5f96ae1bced5, source=UpgradeTest.test_generic_cluster_upgrade (upgrade_test.UpgradeTest)() message=Traceback (most recent call last):
File "/home/ubuntu/scylla-cluster-tests/upgrade_test.py", line 982, in test_generic_cluster_upgrade
self._start_and_wait_for_node_upgrade(node_to_upgrade, step=next(step))
File "/home/ubuntu/scylla-cluster-tests/upgrade_test.py", line 899, in _start_and_wait_for_node_upgrade
node.check_node_health()
File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 2687, in check_node_health
event = next(events, None)
File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/health_checker.py", line 275, in check_group0_tokenring_consistency
current_node.name, current_node.host_id)
File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 471, in host_id
return self.parent_cluster.get_nodetool_info(self, publish_event=False).get('ID')
File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 4326, in get_nodetool_info
res = node.run_nodetool('info', **kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 2625, in run_nodetool
runner(cmd, timeout=timeout, ignore_status=ignore_status, verbose=verbose, retry=retry)
File "/home/ubuntu/scylla-cluster-tests/sdcm/remote/remote_base.py", line 614, in run
result = _run()
File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/decorators.py", line 70, in inner
return func(*args, **kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/remote/remote_base.py", line 605, in _run
return self._run_execute(cmd, timeout, ignore_status, verbose, new_session, watchers)
File "/home/ubuntu/scylla-cluster-tests/sdcm/remote/remote_base.py", line 538, in _run_execute
result = connection.run(**command_kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/remote/libssh2_client/__init__.py", line 620, in run
return self._complete_run(channel, exception, timeout_reached, timeout, result, warn, stdout, stderr)
File "/home/ubuntu/scylla-cluster-tests/sdcm/remote/libssh2_client/__init__.py", line 655, in _complete_run
raise UnexpectedExit(result)
sdcm.remote.libssh2_client.exceptions.UnexpectedExit: Encountered a bad command exit code!
Command: "/usr/bin/nodetool -u cassandra -pw 'cassandra'  info "
Exit code: 4
Stdout:
ID                     : 9b1a71fe-9fe1-4713-85bf-fac922a6c792
Gossip active          : true
Stderr:
error executing GET request to http://localhost:10000/storage_service/rpc_server with parameters {}: remote replied with status code 404 Not Found:
Not found
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
