### PR TITLE
fix(jmx): fix wait for jmx up

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1231,7 +1231,9 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
     def jmx_up(self):
         if not self.is_service_exists(service_name='scylla-jmx'):
             return True
-        return self.is_port_used(port=7199, service_name="scylla-jmx")
+        return self.remoter.run(f"{self.systemctl} is-active scylla-jmx.service && "
+                                f"{self.systemctl} status scylla-jmx.service | grep 'JMX is enabled to receive remote connections on port'",
+                                timeout=10, ignore_status=True).return_code == 0
 
     def cs_installed(self, cassandra_stress_bin=None):
         if cassandra_stress_bin is None:


### PR DESCRIPTION
As we now verify ports being open from sct runner, we cannot use it for jmx as it listens on localhost.

Fix by verifying JMX being up by verification of log message in scylla-jmx service status.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/8183

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [non root artifact test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/artifacts-ubuntu2204-nonroot-test/9/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
