### PR TITLE
test(tablets): disable tablets for unsupported features on 6.1

### DIFF
--- a/jenkins-pipelines/oss/longevity/longevity-cdc-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-cdc-100gb-4h.jenkinsfile
@@ -8,6 +8,6 @@ longevityPipeline(
     region: 'eu-west-1',
     availability_zone: 'a,b,c',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-cdc-100gb-4h.yaml'
+    test_config: '''["test-cases/longevity/longevity-cdc-100gb-4h.yaml", "configurations/tablets_disabled.yaml"]'''
 
 )

--- a/jenkins-pipelines/oss/longevity/longevity-lwt-3h.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-lwt-3h.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
-    test_config: 'test-cases/longevity/longevity-lwt-basic-3h.yaml'
+    test_config: '''["test-cases/longevity/longevity-lwt-basic-3h.yaml", "configurations/tablets_disabled.yaml"]'''
 
 )


### PR DESCRIPTION
	Configure LWT/CDC pipelines with tablets-disabled,
	so it can be tested in 6.1, where tablets are enabled by default.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
