### PR TITLE
improvement(investigation): add test_method to config

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1156,6 +1156,7 @@ def run_test(argv, backend, config, logdir):
     if logdir:
         os.environ['_SCT_LOGDIR'] = logdir
 
+    os.environ['SCT_TEST_METHOD'] = argv
     logfile = os.path.join(get_test_config().logdir(), 'output.log')
     sys.stdout = OutputLogger(logfile, sys.stdout)
     sys.stderr = OutputLogger(logfile, sys.stderr)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -200,6 +200,9 @@ class SCTConfiguration(dict):
         dict(name="cluster_backend", env="SCT_CLUSTER_BACKEND", type=str,
              help="backend that will be used, aws/gce/docker"),
 
+        dict(name="test_method", env="SCT_TEST_METHOD", type=str,
+             help="class.method used to run the test. Filled automatically with run-test sct command."),
+
         dict(name="test_duration", env="SCT_TEST_DURATION", type=int,
              help="""
                   Test duration (min). Parameter used to keep instances produced by tests


### PR DESCRIPTION
When looking at the test run in Argus (and in general) it's hard to get the idea what test method was used - which is sometimes hard to get for jobs that run tests in parallel (e.g. perf tests with different test methods for each workload: write, read, mixed).

Added new config param `test_method` so it will be visible in sct.log and can be consumed and properly displayed in Argus.

refs: https://github.com/scylladb/argus/issues/375

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - provision test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
