### PR TITLE
feature(c-s): start using c-s docker image from dockerhub

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -55,9 +55,3 @@ k8s_instance_type_auxiliary: 't3.large'
 #       '--blocked-reactor-notify-ms 100' cannot be set, because it gets set by operator itself
 append_scylla_args: '--abort-on-lsa-bad-alloc 1 --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'
 docker_image: ''
-
-# NOTE: Define a separate image for the 'cassandra stress' that supports 'serverless' feature.
-#       It will allow to test 'serverless' feature against any stable Scylla release
-#       with old 'cassandra-stress' binary.
-stress_image:
-  cassandra-stress: 'scylladb/scylla:5.2.11'

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -67,9 +67,3 @@ append_scylla_args: '--abort-on-lsa-bad-alloc 1 --abort-on-internal-error 1 --ab
 docker_image: ''
 backup_bucket_backend: 's3'
 backup_bucket_location: 'minio-bucket'
-
-# NOTE: Define a separate image for the 'cassandra stress' that supports 'serverless' feature.
-#       It will allow to test 'serverless' feature against any stable Scylla release
-#       with old 'cassandra-stress' binary.
-stress_image:
-  cassandra-stress: 'scylladb/scylla:5.2.11'

--- a/defaults/k8s_local_kind_config.yaml
+++ b/defaults/k8s_local_kind_config.yaml
@@ -42,9 +42,3 @@ backtrace_decoding: false
 append_scylla_args: '--abort-on-lsa-bad-alloc 1 --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'
 docker_image: ''
 backup_bucket_location: 'minio-bucket'
-
-# NOTE: Define a separate image for the 'cassandra stress' that supports 'serverless' feature.
-#       It will allow to test 'serverless' feature against any stable Scylla release
-#       with old 'cassandra-stress' binary.
-stress_image:
-  cassandra-stress: 'scylladb/scylla:5.2.11'

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -209,7 +209,7 @@ stress_image:
   ndbench: 'scylladb/hydra-loaders:ndbench-jdk8-20210720'
   ycsb: 'scylladb/hydra-loaders:ycsb-jdk8-20220918'
   nosqlbench: 'scylladb/hydra-loaders:nosqlbench-5.21.2'
-  cassandra-stress: 'docker.io/scylladb/hydra-loaders:cassandra-stress-6.0-20240701'
+  cassandra-stress: 'scylladb/cassandra-stress:3.12.2'
   scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.22'
   gemini: 'scylladb/hydra-loaders:gemini-v1.8.6'
   alternator-dns: 'scylladb/hydra-loaders:alternator-dns-0.1'

--- a/unit_tests/test_cassandra_stress_thread.py
+++ b/unit_tests/test_cassandra_stress_thread.py
@@ -23,6 +23,7 @@ pytestmark = [
 
 def test_01_cassandra_stress(request, docker_scylla, params):
     params['cs_debug'] = True
+    params['use_hdr_cs_histogram'] = True
 
     loader_set = LocalLoaderSetDummy(params=params)
 


### PR DESCRIPTION
we are migrating c-s from scylla-tools-java into a new repository, and now it's has it's own docker image and releases in dockerhub, we don't need to pull in scylla old docker images for c-s anymore.

Ref: https://hub.docker.com/r/scylladb/cassandra-stress

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
