### PR TITLE
improvement(Alternator): support creating tablets-enabled tables

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -82,6 +82,7 @@ from sdcm.utils.common import format_timestamp, wait_ami_available, \
     make_threads_be_daemonic_by_default, ParallelObject, clear_out_all_exit_hooks, change_default_password
 from sdcm.utils.cql_utils import cql_quote_if_needed
 from sdcm.utils.database_query_utils import PartitionsValidationAttributes, fetch_all_rows
+from sdcm.utils.features import is_tablets_feature_enabled
 from sdcm.utils.get_username import get_username
 from sdcm.utils.decorators import log_run_info, retrying
 from sdcm.utils.git import get_git_commit_id, get_git_status_info
@@ -1115,13 +1116,28 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                     (self.params.get('alternator_access_key_id'),
                                      self.params.get('alternator_secret_access_key')))
 
-            schema = self.params.get("dynamodb_primarykey_type")
-            self.alternator.create_table(node=node, schema=schema)
-            self.alternator.create_table(node=node, schema=schema, isolation=alternator.enums.WriteIsolation.FORBID_RMW,
-                                         table_name=NO_LWT_TABLE_NAME)
+            with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
+                # is tablets feature enabled in Scylla configuration.
+                tablets_enabled = is_tablets_feature_enabled(session)
             prepare_cmd = self.params.get('prepare_write_cmd')
             stress_cmd = self.params.get('stress_cmd')
-            if any('dynamodb.ttlKey' in str(cmd) for cmd in [prepare_cmd, stress_cmd]):
+            is_ttl_in_workload = any('dynamodb.ttlKey' in str(cmd) for cmd in [prepare_cmd, stress_cmd])
+
+            # Enable tablets with Alternator TTL requires (#16567).
+            tablets_support_ttl = not SkipPerIssues(issues="scylladb/scylladb#16567", params=self.params)
+
+            # Enable tablets for Alternator with LWT requires issue: "[Epic] tablets: support LWT #18068"
+            tablets_support_lwt = not SkipPerIssues(issues="scylladb/scylladb#18068", params=self.params)
+
+            tablets_supported_alternator_workload = not is_ttl_in_workload or tablets_support_ttl
+            schema = self.params.get("dynamodb_primarykey_type")
+            self.alternator.create_table(node=node, schema=schema,
+                                         tablets_enabled=tablets_enabled and tablets_support_lwt and tablets_supported_alternator_workload)
+            self.alternator.create_table(node=node, schema=schema, isolation=alternator.enums.WriteIsolation.FORBID_RMW,
+                                         table_name=NO_LWT_TABLE_NAME,
+                                         tablets_enabled=tablets_enabled and tablets_supported_alternator_workload)
+
+            if is_ttl_in_workload:
                 self.alternator.update_table_ttl(node=node, table_name=alternator.consts.TABLE_NAME)
                 self.alternator.update_table_ttl(node=node, table_name=alternator.consts.NO_LWT_TABLE_NAME)
 


### PR DESCRIPTION
	Tablets feature is currently supported by Alternator, but disabled by default (since LWT is not supported).
	It should be explicitly requested by the specified tag.
	fixes: #8197
	refs: scylladb/scylladb#18068
fixes: #8197
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- Test Alternator without LWT and TTL runs with tablets:
- - https://jenkins.scylladb.com/job/scylla-staging/job/yarongilor/job/reproductions/13/
- - - [test](https://argus.scylladb.com/test/dfa0a7dd-68a5-4a6c-8d9c-a1131811fdbe/runs?additionalRuns[]=b18b5cd1-2346-4ab0-8b20-b2fe7382b16b) passed ok
- - - 
![image](https://github.com/user-attachments/assets/fbdc064b-f9ad-4b63-9da4-23849370fe14)

```
Aug 07 16:14:34.708495 alternator-no-ttl-1-loaders-no-lwt--db-node-b18b5cd1-1 scylla[6397]:  [shard 0:stmt] migration_manager - Create new Keyspace: KSMetaData{name=alternator_usertable_no_lwt, strategyClass=org.apache.cassandra.locator.NetworkTopologyStrategy, strategyOptions={"eu-west": "3"}, cfMetaData={}, durable_writes=true, tablets={"initial":0}, userTypes=org.apache.cassandra.config.UTMetaData@0x600008f8f1a8}

2024-08-07T16:14:35.158+00:00 alternator-no-ttl-1-loaders-no-lwt--db-node-b18b5cd1-1     !INFO | scylla[6397]:  [shard 0: gms] load_balancer - Node 15f609a5-151d-4f94-9a24-1fe6525aa8a3: rack=1a avg_load=1, tablets=4, shards=4, state=normal

```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
