### PR TITLE
fix(jenkins): mark send-email step as failed when no results

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1341,6 +1341,7 @@ def send_email(test_id=None, test_status=None, start_time=None, started_by=None,
         reporter = build_reporter('TestAborted', email_recipients, testrun_dir)
         if reporter:
             reporter.send_report(test_results)
+            sys.exit(1)
         else:
             LOGGER.error('failed to get a reporter')
             sys.exit(1)


### PR DESCRIPTION
In case perf test results are missing we send email to have other test related info anyway. But this confuses the user as it looks in jenkins as everything is fine.

Fix by failing send-email step in such a case.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
