### PR TITLE
fix(createTestJobPipeline): when build v15 branch, need to skip others

### DIFF
--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-enterprise-performance-trigger.xml
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-enterprise-performance-trigger.xml
@@ -30,7 +30,7 @@ provision_type=on_demand</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-shard-aware-1TB,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-throughput-shard-aware-i4i,perf-regression/scylla-enterprise-perf-regression-latency-650gb-elasticity</projects>
+          <projects>../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-shard-aware-1TB,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-throughput-shard-aware-i4i,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-elasticity</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>
@@ -45,7 +45,7 @@ provision_type=on_demand</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>../scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64,..../scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64</projects>
+          <projects>../scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64,../scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>

--- a/vars/createTestJobPipeline.groovy
+++ b/vars/createTestJobPipeline.groovy
@@ -39,7 +39,7 @@ def call() {
                     H 01 * * 0 %jenkins_path="scylla-master/releng-testing"
                     H 01 * * 0 %jenkins_path="scylla-enterprise" ; is_enterprise=true
                     H 01 * * 0 %jenkins_path="scylla-master"
-                    H 01 * * 0 %sct_branch="branch-perf-v15"
+                    H 01 * * 0 %sct_branch=branch-perf-v15
                 '''
             )
         }
@@ -69,11 +69,11 @@ def call() {
                                             sh """#!/bin/bash
                                                 set -xe
                                                 env
-
-                                                echo "start create test jobs for branch ${params.jenkins_path} ......."
-                                                ./docker/env/hydra.sh create-test-release-jobs ${params.jenkins_path} --sct_branch ${params.sct_branch} --sct_repo ${params.sct_repo}
-                                                echo "all jobs have been created"
-
+                                                if [[ -n "${params.jenkins_path}" ]]; then
+                                                    echo "start create test jobs for branch ${params.jenkins_path} ......."
+                                                    ./docker/env/hydra.sh create-test-release-jobs ${params.jenkins_path} --sct_branch ${params.sct_branch} --sct_repo ${params.sct_repo}
+                                                    echo "all jobs have been created"
+                                                fi
                                                 if ${params.is_enterprise}; then
                                                     echo "start create test jobs for branch ${params.jenkins_path} ......."
                                                     ./docker/env/hydra.sh create-test-release-jobs-enterprise ${params.jenkins_path} --sct_branch ${params.sct_branch} --sct_repo ${params.sct_repo}


### PR DESCRIPTION
the building of the jobs for v15 wasn't working since we introduced it the pipeline was trying to create regular master jobs and was failing

now it should skip, and and should create the jobs needed

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/QA/job/QA-tools/job/create-sct-test-jobs-for-branch/451/
- [x] https://jenkins.scylladb.com/view/QA/job/QA-tools/job/create-sct-test-jobs-for-branch/452/
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
