### PR TITLE
fix(rolling-upgrade): remove branch filter

### DIFF
--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -65,6 +65,7 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods,too-many-
     rpc_interface_prefer_ipv6: bool = None  # False
     # [SeedProvider(class_name='org.apache.cassandra.locator.SimpleSeedProvider')]
     seed_provider: List[SeedProvider] = None
+    force_schema_commit_log: bool = None  # False
     consistent_cluster_management: bool = None  # False
     compaction_throughput_mb_per_sec: int = None  # 0
     compaction_large_partition_warning_threshold_mb: int = None  # 1000

--- a/sdcm/utils/features.py
+++ b/sdcm/utils/features.py
@@ -32,6 +32,8 @@ def get_supported_features(session: Session) -> list[str]:
         result = result["supported_features"].split(",")
     elif isinstance(result, tuple):
         result = result[0].split(",")
+    elif result is None:
+        result = []
     else:
         raise NotImplementedError(f"unsupported row_factory={session.row_factory}")
     LOGGER.debug("Supported features %s", result)
@@ -49,6 +51,8 @@ def get_enabled_features(session: Session) -> list[str]:
         result = result["value"].split(",")
     elif isinstance(result, tuple):
         result = result[0].split(",")
+    elif result is None:
+        result = []
     else:
         raise NotImplementedError(f"unsupported row_factory={session.row_factory}")
     LOGGER.debug("Enabled features %s", result)

--- a/test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml
+++ b/test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml
@@ -25,7 +25,7 @@ use_preinstalled_scylla: false
 scylla_d_overrides_files: [
   'scylla-qa-internal/custom_d1/workload1/scylla.d/n2-highmem-8/cpuset.conf',
   'scylla-qa-internal/custom_d1/workload1/scylla.d/memory.conf',
-  'scylla-qa-internal/custom_d1/workload1/scylla.d/io.conf',
+  'scylla-qa-internal/custom_d1/workload1/scylla.d/2021.1/io.conf',
 ]
 
 user_prefix: 'rolling-upgrade-custom-d1'

--- a/test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml
+++ b/test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml
@@ -41,3 +41,7 @@ append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 
 use_mgmt: false
 
 use_prepared_loaders: true
+
+append_scylla_yaml:
+  consistent_cluster_management: true
+  force_schema_commit_log: true

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -207,6 +207,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         scylla_yaml_updates = {}
         if not self.params.get('disable_raft'):
             scylla_yaml_updates.update({"consistent_cluster_management": True})
+            scylla_yaml_updates.update({"force_schema_commit_log": True})
 
         if self.params.get("enable_tablets_on_upgrade"):
             scylla_yaml_updates.update({"experimental_features": ["tablets", "consistent-topology-changes"]})

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -326,6 +326,11 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
                         f' -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"'
                     )
                     InfoEvent(message='upgrade_node - ended to "apt-get update"').publish()
+
+        InfoEvent(message='upgrade_node - fix /etc/scylla.d/io.conf arguments compatibility').publish()
+        node.remoter.sudo(
+            f"sed -i 's/--num-io-queues/--num-io-groups/' {node.add_install_prefix('/etc/scylla.d/io.conf')}")
+
         InfoEvent(message='upgrade_node - starting to "check_reload_systemd_config"').publish()
         check_reload_systemd_config(node)
         InfoEvent(message='upgrade_node - ended to "check_reload_systemd_config"').publish()

--- a/vars/supportedUpgradeFromVersions.groovy
+++ b/vars/supportedUpgradeFromVersions.groovy
@@ -14,21 +14,6 @@ def call(List base_versions_list, String linux_distro, String new_scylla_repo, S
         println("Did not find a valid base versions string!")
             throw new Exception("Didn't get valid base versions automatically!")
         }
-
     }
-    if (new_scylla_repo.contains('enterprise')) {
-        return base_versions_list
-    } else {
-        return base_versions_list.findAll{ ! is_enterprise_version(it) }
-    }
-}
-
-def is_enterprise_version(String version) {
-    def first_version = 0
-    try {
-        first_version = version.tokenize('.')[0] as Integer
-    } catch (java.lang.NumberFormatException ex) {
-        println "WARN: non formal/versioned branch '$version', assuming opensource version"
-    }
-    return first_version > 2000
+    return base_versions_list
 }


### PR DESCRIPTION
this filter was assuming enterprise repo url, would have `enterprise` in them, that is not completly correct, the offical releases urls don't have `enterprise` in them.

regardless the code nowdays return the exact list of version needed for upgrade, and there no need for this filtering. (that was introduce in 2019, by fruch)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [upgrade from 2021.1 -> 2023.1](https://argus.scylladb.com/test/e8d634c2-3042-49de-b8cb-1efa43609f85/runs?additionalRuns[]=812b35e7-c296-4068-8807-4147d85b1e65)
- [x] upgrade from 2021.1 -> 2024.1

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
