### PR TITLE
fix(aws): `ec2_ami_get_root_device_name` to look into multiple accounts

### DIFF
--- a/sdcm/sct_provision/aws/instance_parameters_builder.py
+++ b/sdcm/sct_provision/aws/instance_parameters_builder.py
@@ -101,7 +101,7 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
 
     @cached_property
     def _root_device_name(self):
-        return ec2_ami_get_root_device_name(image_id=self.ImageId, region=self._region_name)
+        return ec2_ami_get_root_device_name(image_id=self.ImageId, region_name=self._region_name)
 
     @property
     def _root_device_size(self):

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -560,7 +560,7 @@ class AwsSctRunner(SctRunner):
                         [{"Key": "Name", "Value": instance_name}],
             }],
             BlockDeviceMappings=[{
-                "DeviceName": ec2_ami_get_root_device_name(image_id=base_image, region=aws_region.region_name),
+                "DeviceName": ec2_ami_get_root_device_name(image_id=base_image, region_name=aws_region.region_name),
                 "Ebs": {
                     "VolumeSize": root_disk_size_gb or self.instance_root_disk_size(test_duration),
                     "VolumeType": "gp3"

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1379,7 +1379,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             if loader_info['disk_size']:
                 loader_info['device_mappings'] = [{
                     "DeviceName": ec2_ami_get_root_device_name(image_id=self.params.get('ami_id_loader').split()[0],
-                                                               region=regions[0]),
+                                                               region_name=regions[0]),
                     "Ebs": {
                         "VolumeSize": loader_info['disk_size'],
                         "VolumeType": "gp3"

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -240,7 +240,7 @@ def init_monitoring_info_from_params(monitor_info: dict, params: dict, regions: 
         if monitor_info['disk_size']:
             monitor_info['device_mappings'] = [{
                 "DeviceName": ec2_ami_get_root_device_name(image_id=params.get('ami_id_monitor').split()[0],
-                                                           region=regions[0]),
+                                                           region_name=regions[0]),
                 "Ebs": {
                     "VolumeSize": monitor_info['disk_size'],
                     "VolumeType": "gp3"
@@ -268,7 +268,7 @@ def init_db_info_from_params(db_info: dict, params: dict, regions: List, root_de
         if db_info['disk_size']:
             root_device = root_device if root_device else ec2_ami_get_root_device_name(
                 image_id=params.get('ami_id_db_scylla').split()[0],
-                region=regions[0])
+                region_name=regions[0])
             db_info['device_mappings'] = [{
                 "DeviceName": root_device,
                 "Ebs": {
@@ -430,15 +430,17 @@ def ec2_instance_wait_public_ip(instance):
     LOGGER.debug("[%s] Got public ip: %s", instance, instance.public_ip_address)
 
 
-def ec2_ami_get_root_device_name(image_id, region):
-    ec2 = boto3.resource('ec2', region)
-    image = ec2.Image(image_id)
-    try:
-        if image.root_device_name:
-            return image.root_device_name
-    except (TypeError, ClientError) as exc:
-        raise AssertionError(f"Image '{image_id}' details not found in '{region}'") from exc
-    return None
+def ec2_ami_get_root_device_name(image_id, region_name):
+    ec2_resource = boto3.resource('ec2', region_name)
+
+    for client in (ec2_resource, get_scylla_images_ec2_resource(region_name=region_name)):
+        try:
+            image = client.Image(image_id)
+            if image.root_device_name:
+                return image.root_device_name
+        except (TypeError, AttributeError, ClientError):
+            pass
+    raise AssertionError(f"Image '{image_id}' details not found in '{region_name}'")
 
 
 @functools.cache


### PR DESCRIPTION
since we have images available in more then one account, and images are not always set as public, and we can see their metadata we should look them up in all of the account possible

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] aws provision test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
