### PR TITLE
fix(restart_with_reshard): wait log messages for 10 minutes

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -121,6 +121,7 @@ from sdcm.utils.version_utils import (
 )
 from sdcm.utils.net import get_my_ip
 from sdcm.utils.node import build_node_api_command
+from sdcm.wait import wait_for_log_lines
 from sdcm.sct_events import Severity
 from sdcm.sct_events.base import LogEvent, add_severity_limit_rules, max_severity
 from sdcm.sct_events.health import ClusterHealthValidatorEvent
@@ -2568,28 +2569,15 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         with self.remote_scylla_yaml() as scylla_yml:
             scylla_yml.murmur3_partitioner_ignore_msb_bits = murmur3_partitioner_ignore_msb_bits
 
-        search_reshard_start = self.follow_system_log(patterns=[DB_LOG_PATTERN_RESHARDING_START])
-        search_reshard_finish = self.follow_system_log(patterns=[DB_LOG_PATTERN_RESHARDING_FINISH])
-        start_scylla_timeout = 7200
-        self.start_scylla(timeout=start_scylla_timeout)
-        resharding_started = list(search_reshard_start)
-        resharding_finished = list(search_reshard_finish)
+        resharding_details = f"Resharding: (murmur3_partitioner_ignore_msb_bits={murmur3_partitioner_ignore_msb_bits})"
 
-        if resharding_started:
-            self.log.debug(f'Resharding has been started successfully '
-                           f'(murmur3_partitioner_ignore_msb_bits={murmur3_partitioner_ignore_msb_bits})')
-        else:
-            raise Exception(f'Resharding has not been started '
-                            f'(murmur3_partitioner_ignore_msb_bits={murmur3_partitioner_ignore_msb_bits}) '
-                            'Check the log for the details')
-
-        if resharding_finished:
-            self.log.debug(f'Resharding has been finished successfully '
-                           f'(murmur3_partitioner_ignore_msb_bits={murmur3_partitioner_ignore_msb_bits})')
-        else:
-            raise Exception(f'Resharding has not been finished within {start_scylla_timeout}'
-                            f'(murmur3_partitioner_ignore_msb_bits={murmur3_partitioner_ignore_msb_bits}) '
-                            'Check the log for the details')
+        with wait_for_log_lines(node=self,
+                                start_line_patterns=[DB_LOG_PATTERN_RESHARDING_START],
+                                end_line_patterns=[DB_LOG_PATTERN_RESHARDING_FINISH],
+                                start_timeout=600, end_timeout=900,
+                                error_msg_ctx=resharding_details):
+            start_scylla_timeout = 7200
+            self.start_scylla(timeout=start_scylla_timeout)
 
     def _gen_nodetool_cmd(self, sub_cmd, args, options):
         credentials = self.parent_cluster.get_db_auth()

--- a/sdcm/wait.py
+++ b/sdcm/wait.py
@@ -138,8 +138,15 @@ def exponential_retry(func: Callable[[], R],
 
 
 @contextmanager
-def wait_for_log_lines(node, start_line_patterns, end_line_patterns, start_timeout=60, end_timeout=120):
+def wait_for_log_lines(node, start_line_patterns, end_line_patterns, start_timeout=60, end_timeout=120,
+                       error_msg_ctx=""):
     """Waits for given lines patterns to appear in node logs despite exception raised"""
+    start_ctx = f"Timeout occurred while waiting for start log line {start_line_patterns} on node: {node.name}."
+    if error_msg_ctx:
+        start_ctx += f" Context: {error_msg_ctx}"
+    end_ctx = f"Timeout occurred while waiting for end log line {end_line_patterns} on node: {node.name}"
+    if error_msg_ctx:
+        end_ctx += f". Context: {error_msg_ctx}"
     start_follower = node.follow_system_log(patterns=start_line_patterns)
     end_follower = node.follow_system_log(patterns=end_line_patterns)
     start_time = time.time()
@@ -150,11 +157,11 @@ def wait_for_log_lines(node, start_line_patterns, end_line_patterns, start_timeo
         while not started and (time.time() - start_time < start_timeout):
             started = any(start_follower)
         if not started:
-            raise TimeoutError(
-                f"timeout occurred while waiting for start log line ({start_line_patterns} on node: {node.name}")
+            raise TimeoutError(start_ctx)
+        LOGGER.debug("Start line patterns %s were found.%s", start_line_patterns, error_msg_ctx)
         ended = any(end_follower)
         while not ended and (time.time() - start_time < end_timeout):
             ended = any(end_follower)
         if not ended:
-            raise TimeoutError(
-                f"timeout occurred while waiting for end log line ({end_line_patterns} on node: {node.name}")
+            raise TimeoutError(end_ctx)
+        LOGGER.debug("End line patterns %s were found.%s", end_line_patterns, error_msg_ctx)


### PR DESCRIPTION
Some times log messages are written to log file with delay, this could cause that scylla already started, but log_follower couldn't find appropriate log messages, because they will be written later. This happened with RestartWIthReshardNemesis.
Scylla was stopped, scylla yaml was updated with new `murmur3_partitioner_ignore_msb_bits` value. Then scylla started and resharding is expected. Resharding is checked by log messages, but if for some reason log messages will be written with delay to log (log_follower will fail the nemesis)

Fixes: scylladb/scylla-cluster-tests#7427

### Testing
- [Job with master passed](https://argus.scylladb.com/test/dc8131ca-2823-443a-9816-9eae668d6b6d/runs?additionalRuns[]=62cca91b-dc27-47aa-ae6b-ffdc8aa0cd2d)
- [Job with branch-2024.1](https://argus.scylladb.com/test/dc8131ca-2823-443a-9816-9eae668d6b6d/runs?additionalRuns[]=ae6cdd01-884d-4ff2-ac65-ffbfda7d9051)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
