### PR TITLE
feature(sct-runner): update image to use java-21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,7 @@ def runRestoreMonitoringStack(){
 pipeline {
     agent {
         label {
-            label "aws-sct-builders-eu-west-1-v2-CI"
+            label "aws-sct-builders-eu-west-1-v3-CI"
         }
     }
     parameters {

--- a/docs/sct-runners.md
+++ b/docs/sct-runners.md
@@ -22,3 +22,27 @@ hydra --execute-on-runner `cat sct_runner_ip` [Any hydra commands]
 hydra is syncing the whole SCT directory with rsync,
 try to make sure there's no huge files in SCT directory,
 because that would slow it down
+
+
+### process of updating sct runner images
+
+1. update code in sct_runner.py, give it a new version number
+2. Build all images
+    ```bash
+
+     ./sct.py create-runner-image -c aws -r eu-west-2 -z a
+
+    ./sct.py create-runner-image -c gce -r us-east1 -z a
+    SCT_GCE_PROJECT=gcp ./sct.py create-runner-image -c gce -r us-east1 -z a
+    SCT_GCE_PROJECT=gcp-local-ssd-latency ./sct.py create-runner-image -c gce -r us-east1 -z a
+
+    ./sct.py create-runner-image -c azure -r eastus -z a
+    ```
+3. update version on `aws_builder.py` and `gce_builder.py`
+4. build jenkins configuration with new sct runner image
+    ```bash
+    ./sct.py configure-jenkins-builders -c gce
+    ./sct.py configure-jenkins-builders -c aws
+    ```
+
+5. update `vars/getJenkinsLabels.groovy` with the new labels created in step 1

--- a/jenkins-pipelines/qa/hydra-clean-runner-instances.jenkinsfile
+++ b/jenkins-pipelines/qa/hydra-clean-runner-instances.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 pipeline {
     agent {
         label {
-            label "aws-sct-builders-eu-west-1-v2-CI"
+            label "aws-sct-builders-eu-west-1-v3-CI"
         }
     }
     environment {

--- a/jenkins-pipelines/qa/hydra-clean-test-resources.jenkinsfile
+++ b/jenkins-pipelines/qa/hydra-clean-test-resources.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 pipeline {
     agent {
         label {
-            label "aws-sct-builders-eu-west-1-v2-CI"
+            label "aws-sct-builders-eu-west-1-v3-CI"
         }
     }
     environment {

--- a/jenkins-pipelines/qa/hydra-cleanup-cloud.jenkinsfile
+++ b/jenkins-pipelines/qa/hydra-cleanup-cloud.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 pipeline {
     agent {
         label {
-            label "aws-sct-builders-eu-west-1-v2-CI"
+            label "aws-sct-builders-eu-west-1-v3-CI"
         }
     }
     environment {

--- a/jenkins-pipelines/qa/hydra-show-jepsen-results.jenkinsfile
+++ b/jenkins-pipelines/qa/hydra-show-jepsen-results.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 pipeline {
     agent {
         label {
-            label "aws-sct-builders-eu-west-1-v2-CI"
+            label "aws-sct-builders-eu-west-1-v3-CI"
         }
     }
     environment {

--- a/jenkins-pipelines/qa/hydra-show-monitor.jenkinsfile
+++ b/jenkins-pipelines/qa/hydra-show-monitor.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 pipeline {
     agent {
         label {
-            label "aws-sct-builders-eu-west-1-v2-CI"
+            label "aws-sct-builders-eu-west-1-v3-CI"
         }
     }
     environment {

--- a/sct.py
+++ b/sct.py
@@ -1583,8 +1583,8 @@ def create_runner_instance(cloud_provider, region, availability_zone, instance_t
 
     LOGGER.info("Verifying SSH connectivity...")
     runner_public_ip = sct_runner.get_instance_public_ip(instance=instance)
-    remoter = sct_runner.get_remoter(host=runner_public_ip, connect_timeout=120)
-    if remoter.run("true", timeout=100, verbose=False, ignore_status=True).ok:
+    remoter = sct_runner.get_remoter(host=runner_public_ip, connect_timeout=240)
+    if remoter.run("true", timeout=200, verbose=False, ignore_status=True).ok:
         LOGGER.info("Successfully connected the SCT Runner. Public IP: %s", runner_public_ip)
         with sct_runner_ip_path.open(mode="w", encoding="utf-8") as sct_runner_ip_file:
             sct_runner_ip_file.write(runner_public_ip)

--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -84,8 +84,7 @@ class KeyStore:  # pylint: disable=too-many-public-methods
         return self.get_ssh_key_pair(name="scylla_test_id_ed25519")
 
     def get_azure_ssh_key_pair(self):
-        # TODO: still needed to use old key, until we can create new runners with updated key
-        return self.get_ssh_key_pair(name="scylla-test")
+        return self.get_ssh_key_pair(name="scylla_test_id_ed25519")
 
     def get_qa_ssh_keys(self):
         return [

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -138,7 +138,7 @@ class SctRunnerInfo:  # pylint: disable=too-many-instance-attributes
 
 class SctRunner(ABC):
     """Provision and configure the SCT runner."""
-    VERSION = "1.7"  # Version of the Image
+    VERSION = "1.8"  # Version of the Image
     NODE_TYPE = "sct-runner"
     RUNNER_NAME = "SCT-Runner"
     LOGIN_USER = "ubuntu"
@@ -221,6 +221,7 @@ class SctRunner(ABC):
              # Disable apt-key warnings and set non-interactive frontend.
             export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
             export DEBIAN_FRONTEND=noninteractive
+            export PIP_BREAK_SYSTEM_PACKAGES=true
 
             apt-get -qq clean
             apt-get -qq update
@@ -240,7 +241,7 @@ class SctRunner(ABC):
             install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
             # Configure Jenkins user.
-            apt-get -qq install --no-install-recommends openjdk-11-jre-headless  # https://www.jenkins.io/doc/administration/requirements/java/
+            apt-get -qq install --no-install-recommends openjdk-21-jre-headless  # https://www.jenkins.io/doc/administration/requirements/java/
             adduser --disabled-password --gecos "" jenkins || true
             usermod -aG docker jenkins
             mkdir -p /home/jenkins/.ssh
@@ -452,7 +453,7 @@ class SctRunner(ABC):
 class AwsSctRunner(SctRunner):
     """Provision and configure the SCT Runner on AWS."""
     CLOUD_PROVIDER = "aws"
-    BASE_IMAGE = "ami-07c2ae35d31367b3e"  # Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-01
+    BASE_IMAGE = "ami-02f921fd5f09a1812"  # Canonical, Ubuntu, 24.04 LTS, amd64 numbat image build on 2024-08-06
     SOURCE_IMAGE_REGION = "eu-west-2"  # where the source Runner image will be created and copied to other regions
     IMAGE_BUILDER_INSTANCE_TYPE = "t3.small"
     REGULAR_TEST_INSTANCE_TYPE = "m7i-flex.large"  # 2 vcpus, 8G
@@ -774,7 +775,7 @@ class GceSctRunner(SctRunner):  # pylint: disable=too-many-instance-attributes
     """Provision and configure the SCT runner on GCE."""
 
     CLOUD_PROVIDER = "gce"
-    BASE_IMAGE = "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts"
+    BASE_IMAGE = "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64"
     SOURCE_IMAGE_REGION = "us-east1"  # where the source Runner image will be created and copied to other regions
     IMAGE_BUILDER_INSTANCE_TYPE = "e2-standard-2"
     REGULAR_TEST_INSTANCE_TYPE = "e2-standard-2"  # 2 vcpus, 8G
@@ -991,8 +992,8 @@ class AzureSctRunner(SctRunner):
     GALLERY_IMAGE_VERSION = f"{SctRunner.VERSION}.0"  # Azure requires to have it in `X.Y.Z' format
     BASE_IMAGE = {
         "publisher": "canonical",
-        "offer": "0001-com-ubuntu-server-jammy",
-        "sku": "22_04-lts-gen2",
+        "offer": "ubuntu-24_04-lts",
+        "sku": "server",
         "version": "latest",
     }
     SOURCE_IMAGE_REGION = AzureRegion.SCT_GALLERY_REGION

--- a/sdcm/utils/aws_builder.py
+++ b/sdcm/utils/aws_builder.py
@@ -58,7 +58,7 @@ EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
   config.labels,  // labels
   "/tmp/jenkins/", // fs root
   new SSHConnector(22,
-                   "user-jenkins_scylla-qa-ec2.pem", "", "", "", "", null, 0, 0,
+                   "user-jenkins_scylla_test_id_ed25519.pem", "", "", "", "", null, 0, 0,
                    new NonVerifyingKeyVerificationStrategy()),
   false, // privateIpUsed
   true, // alwaysReconnect
@@ -96,6 +96,7 @@ jenkins.save()
 class AwsBuilder:
     NUM_CPUS = 2
     NUM_EXECUTORS = 4
+    VERSION = 'v3'
 
     def __init__(self, region: AwsRegion, params=None, number=1):
         self.region = region
@@ -107,15 +108,15 @@ class AwsBuilder:
     @cached_property
     def name(self):
         # example: aws-eu-central-1-qa-builder-v2-1
-        return f"aws-{self.region.region_name}-qa-builder-v2-{self.number}"
+        return f"aws-{self.region.region_name}-qa-builder-{self.VERSION}-{self.number}"
 
     @cached_property
     def jenkins_labels(self):
-        return f"aws-sct-builders-{self.region.region_name}-v2-asg"
+        return f"aws-sct-builders-{self.region.region_name}-{self.VERSION}-asg"
 
     @property
     def launch_template_name(self):
-        return "aws-sct-builders"
+        return f"aws-sct-builders-{self.VERSION}"
 
     def get_root_ebs_info_from_ami(self, ami_id: str) -> str:
         res = self.region.resource.Image(ami_id)
@@ -146,7 +147,7 @@ class AwsBuilder:
         launch_template_data = self.get_launch_template_data(runner)
 
         res = self.region.client.describe_launch_template_versions(
-            LaunchTemplateName="aws-sct-builders",
+            LaunchTemplateName=self.launch_template_name,
         )
         default_version = [ver for ver in res['LaunchTemplateVersions'] if ver.get('DefaultVersion')][0]
         curr_launch_template_data = default_version.get('LaunchTemplateData')
@@ -294,8 +295,8 @@ class AwsCiBuilder(AwsBuilder):
     @cached_property
     def name(self):
         # example: aws-eu-central-1-qa-builder-v2-1
-        return f"aws-{self.region.region_name}-qa-builder-v2-{self.number}-CI"
+        return f"aws-{self.region.region_name}-qa-builder-{self.VERSION}-{self.number}-CI"
 
     @cached_property
     def jenkins_labels(self):
-        return f"aws-sct-builders-{self.region.region_name}-v2-CI"
+        return f"aws-sct-builders-{self.region.region_name}-{self.VERSION}-CI"

--- a/sdcm/utils/gce_builder.py
+++ b/sdcm/utils/gce_builder.py
@@ -65,7 +65,7 @@ instanceConfiguration.setTemplate("https://www.googleapis.com/compute/v1/project
 instanceConfiguration.setRetentionTimeMinutesStr("6")
 instanceConfiguration.setLaunchTimeoutSecondsStr("300")
 instanceConfiguration.setRunAsUser("jenkins")
-instanceConfiguration.setSshConfiguration(SshConfiguration.builder().customPrivateKeyCredentialsId("6e17c350-0a47-4a59-b0b9-7e64f1c35a65").build())
+instanceConfiguration.setSshConfiguration(SshConfiguration.builder().customPrivateKeyCredentialsId("user-jenkins_scylla_test_id_ed25519.pem").build())
 
 gcpCloud.addConfiguration(instanceConfiguration)
 
@@ -88,10 +88,10 @@ class GceBuilder:
 
     It creates a launch template based on sct-runner image, and adds configuration needed in Jenkins to use it
     """
+    VERSION = 'v2'
 
-    def __init__(self, region: GceRegion, number=1):
+    def __init__(self, region: GceRegion):
         self.region = region
-        self.number = number
         self.jenkins_info = KeyStore().get_json("jenkins.json")
         self.runner = GceSctRunner(region_name=self.region.region_name,
                                    availability_zone="a")
@@ -102,11 +102,11 @@ class GceBuilder:
     @cached_property
     def name(self):
         # example: gce-sct-project-1-us-east1-qa-builder
-        return f"gce-{self.region.project}-{self.region.region_name}-qa-builder"
+        return f"gce-{self.region.project}-{self.region.region_name}-qa-builder-{self.VERSION}"
 
     @cached_property
     def jenkins_labels(self):
-        return f"gcp-{self.region.project}-builders-{self.region.region_name}-template"
+        return f"gcp-{self.region.project}-builders-{self.region.region_name}-template-{self.VERSION}"
 
     def _add_cloud_configuration_to_jenkins(self):
         click.echo(f"{self.region.project}: {self.region.region_name}: add_cloud_configuration_to_jenkins")

--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -18,18 +18,18 @@ def call(String backend, String region=null, String datacenter=null, String loca
     def gcp_project = params.gce_project?.trim() ?: 'gcp-sct-project-1'
     gcp_project = gcp_project == 'gcp' ? 'gcp-skilled-adapter-452' : gcp_project
 
-    def jenkins_labels = ['aws-eu-west-1': 'aws-sct-builders-eu-west-1-v2-asg',
-                          'aws-eu-west-2': 'aws-sct-builders-eu-west-2-v2-asg',
-                          'aws-eu-north-1': 'aws-sct-builders-eu-north-1-v2-asg',
-                          'aws-eu-central-1': 'aws-sct-builders-eu-central-1-v2-asg',
-                          'aws-us-east-1' : 'aws-sct-builders-us-east-1-v2-asg',
-                          'aws-us-west-2' : 'aws-sct-builders-us-west-2-v2-asg',
+    def jenkins_labels = ['aws-eu-west-1': 'aws-sct-builders-eu-west-1-v3-asg',
+                          'aws-eu-west-2': 'aws-sct-builders-eu-west-2-v3-asg',
+                          'aws-eu-north-1': 'aws-sct-builders-eu-north-1-v3-asg',
+                          'aws-eu-central-1': 'aws-sct-builders-eu-central-1-v3-asg',
+                          'aws-us-east-1' : 'aws-sct-builders-us-east-1-v3-asg',
+                          'aws-us-west-2' : 'aws-sct-builders-us-west-2-v3-asg',
                           'gce-us-east1': "${gcp_project}-builders-us-east1-template",
                           'gce-us-west1': "${gcp_project}-builders-us-west1-template",
                           'gce-us-central1': "${gcp_project}-builders-us-central1-template",
                           'gce': "${gcp_project}-builders-us-east1-template",
-                          'aws': 'aws-sct-builders-eu-west-1-v2-asg',
-                          'azure-eastus': 'aws-sct-builders-us-east-1-v2-asg']
+                          'aws': 'aws-sct-builders-eu-west-1-v3-asg',
+                          'azure-eastus': 'aws-sct-builders-us-east-1-v3-asg']
 
     def cloud_provider = getCloudProviderFromBackend(backend)
 

--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -24,10 +24,10 @@ def call(String backend, String region=null, String datacenter=null, String loca
                           'aws-eu-central-1': 'aws-sct-builders-eu-central-1-v3-asg',
                           'aws-us-east-1' : 'aws-sct-builders-us-east-1-v3-asg',
                           'aws-us-west-2' : 'aws-sct-builders-us-west-2-v3-asg',
-                          'gce-us-east1': "${gcp_project}-builders-us-east1-template",
-                          'gce-us-west1': "${gcp_project}-builders-us-west1-template",
-                          'gce-us-central1': "${gcp_project}-builders-us-central1-template",
-                          'gce': "${gcp_project}-builders-us-east1-template",
+                          'gce-us-east1': "${gcp_project}-builders-us-east1-template-v2",
+                          'gce-us-west1': "${gcp_project}-builders-us-west1-template-v2",
+                          'gce-us-central1': "${gcp_project}-builders-us-central1-template-v2",
+                          'gce': "${gcp_project}-builders-us-east1-template-v2",
                           'aws': 'aws-sct-builders-eu-west-1-v3-asg',
                           'azure-eastus': 'aws-sct-builders-us-east-1-v3-asg']
 


### PR DESCRIPTION
we are switching all jenkins workers to start using java-21 while we are at it, we are updates the sct-runners images to be based on ubuntu 2404 images

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] build image aws
- [x] build image gce
- [x] build image azure
- [x] provision tests
- [x] test on aws (worker + runner): 🟢 : https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-10gb-3h-ipv6-test/18/
- [x] test on gce (worker + runner): 🟢 : https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-10gb-3h-gce-test/45/
- [x] test on azure (AWS worker + runner): 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-10gb-3h-azure-test/33/
- [x] 🟢  https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-azure-image-test/49/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
