### PR TITLE
fix(validate_rows_per_partitions): use a new validation event

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -142,3 +142,4 @@ HWPerforanceEvent: CRITICAL
 CommitLogCheckErrorEvent: ERROR
 ValidatorEvent: ERROR
 ScrubValidationErrorEvent: ERROR
+PartitionRowsValidationEvent: CRITICAL

--- a/sdcm/sct_events/health.py
+++ b/sdcm/sct_events/health.py
@@ -104,10 +104,20 @@ class DataValidatorEvent(InformationalEvent, abstract=True):
         return super().msgfmt
 
 
+class PartitionRowsValidationEvent(InformationalEvent):
+    def __init__(self, message: str, severity: Severity = Severity.NORMAL):
+        super().__init__(severity)
+        self.message = message
+
+    @property
+    def msgfmt(self) -> str:
+        return super().msgfmt + ": message={0.message}"
+
+
 DataValidatorEvent.add_subevent_type("DataValidator")
 DataValidatorEvent.add_subevent_type("ImmutableRowsValidator")
 DataValidatorEvent.add_subevent_type("UpdatedRowsValidator")
 DataValidatorEvent.add_subevent_type("DeletedRowsValidator")
 
 
-__all__ = ("ClusterHealthValidatorEvent", "DataValidatorEvent", )
+__all__ = ("ClusterHealthValidatorEvent", "DataValidatorEvent", "PartitionRowsValidationEvent")


### PR DESCRIPTION
	validate_rows_per_partitions has assertions for the expected number of rows.
	These assertions are now caught and generates a corresponding new event:
	"PartitionRowsValidationEvent". This prevents failing the nemesis thread.
	fixes: #8292
fixes: #8292
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/job/scylla-staging/job/yarongilor/job/byo-longevity-test-yg/3/

Testing a simulated validation failure passed ok, looking like this:
![image](https://github.com/user-attachments/assets/170f1631-29c5-4e00-935b-1cd6d5118825)
```
2024-08-11 09:31:34.220: (PartitionRowsValidationEvent Severity.CRITICAL) period_type=one-time event_id=13c498e5-1bbb-4814-b5c8-a5dde28e7206: message=Found missing rows for partitions: {0: 55, 1: 55, 2: 55, 3: 55, 4: 55, 5: 55, 6: 55, 7: 55, 8: 55, 9: 55, 10: 55, 11: 55, 12: 55, 13: 55, 14: 55, 15: 55, 16: 55, 17: 55, 18: 55, 19: 55, 20: 55, 21: 55, 22: 55, 23: 55, 24: 55}
```
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
