### PR TITLE
fix(provision-tests): add `requested_by_user` pipeline parameter

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,6 +73,9 @@ pipeline {
         string(defaultValue: "5.2.11",
                description: 'the scylla version to use for the provision tests',
                name: 'scylla_version')
+        string(defaultValue: '',
+               description: 'Actual user requesting job start, for automated job builds (e.g. through Argus)',
+               name: 'requested_by_user')
     }
     environment {
         AWS_ACCESS_KEY_ID         = credentials('qa-aws-secret-key-id')

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -149,7 +149,7 @@ def call(Map pipelineParams) {
                                                     # clean the old sct_runner_ip file
                                                     rm -fv ./sct_runner_ip
 
-                                                    if [[ -n "${params.requested_by_user}" ]] ; then
+                                                    if [[ -n "${params.requested_by_user ? params.requested_by_user : ''}" ]] ; then
                                                         export BUILD_USER_REQUESTED_BY=${params.requested_by_user}
                                                     fi
                                                     export SCT_COLLECT_LOGS=false

--- a/vars/createArgusTestRun.groovy
+++ b/vars/createArgusTestRun.groovy
@@ -6,7 +6,7 @@ def call(Map params) {
         set -xe
 
         echo "Creating Argus test run ..."
-        if [[ -n "${params.requested_by_user}" ]] ; then
+        if [[ -n "${params.requested_by_user ? params.requested_by_user : ''}" ]] ; then
             export BUILD_USER_REQUESTED_BY=${params.requested_by_user}
         fi
         export SCT_CLUSTER_BACKEND="${params.backend}"

--- a/vars/createSctRunner.groovy
+++ b/vars/createSctRunner.groovy
@@ -36,7 +36,7 @@ def call(Map params, Integer test_duration, String region) {
         export SCT_CLUSTER_BACKEND="${params.backend}"
         export SCT_CONFIG_FILES=${test_config}
 
-        if [[ -n "${params.requested_by_user}" ]] ; then
+        if [[ -n "${params.requested_by_user ? params.requested_by_user : ''}" ]] ; then
             export BUILD_USER_REQUESTED_BY=${params.requested_by_user}
         fi
 

--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -160,7 +160,7 @@ def call(Map pipelineParams) {
                                 export SCT_CONFIG_FILES=${params.test_config}
                                 export SCT_COLLECT_LOGS=false
 
-                                if [[ -n "${params.requested_by_user}" ]] ; then
+                                if [[ -n "${params.requested_by_user ? params.requested_by_user : ''}" ]] ; then
                                     export BUILD_USER_REQUESTED_BY=${params.requested_by_user}
                                 fi
                                 if [[ ! -z "${params.scylla_version}" ]]; then

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -305,7 +305,7 @@ def call(Map pipelineParams) {
 
                                                         rm -fv ./latest
 
-                                                        if [[ -n "${params.requested_by_user}" ]] ; then
+                                                        if [[ -n "${params.requested_by_user ? params.requested_by_user : ''}" ]] ; then
                                                             export BUILD_USER_REQUESTED_BY=${params.requested_by_user}
                                                         fi
                                                         export SCT_CLUSTER_BACKEND=${params.backend}

--- a/vars/provisionResources.groovy
+++ b/vars/provisionResources.groovy
@@ -14,7 +14,7 @@ def call(Map params, String region){
     export SCT_CONFIG_FILES=${test_config}
     export SCT_COLLECT_LOGS=false
 
-    if [[ -n "${params.requested_by_user}" ]] ; then
+    if [[ -n "${params.requested_by_user ? params.requested_by_user : ''}" ]] ; then
         export BUILD_USER_REQUESTED_BY=${params.requested_by_user}
     fi
 

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -244,7 +244,7 @@ def call(Map pipelineParams) {
 
                                                             rm -fv ./latest
 
-                                                            if [[ -n "${params.requested_by_user}" ]] ; then
+                                                            if [[ -n "${params.requested_by_user ? params.requested_by_user : ''}" ]] ; then
                                                                 export BUILD_USER_REQUESTED_BY=${params.requested_by_user}
                                                             fi
 

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -31,7 +31,7 @@ def call(Map params, String region, functional_test = false, Map pipelineParams 
     export SCT_CONFIG_FILES=${test_config}
     export SCT_COLLECT_LOGS=false
 
-    if [[ -n "${params.requested_by_user}" ]] ; then
+    if [[ -n "${params.requested_by_user ? params.requested_by_user : ''}" ]] ; then
         export BUILD_USER_REQUESTED_BY=${params.requested_by_user}
     fi
 


### PR DESCRIPTION
since `requested_by_user` was missing, we ended up with provision tests resources tagged by `null` user

azure test shows it like:
```
Tag 'RunByUser' has value 'null' which is not allowed by Azure API. Replacing with empty string.
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] provision test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
