### PR TITLE
fix(keystore): stop reusing boto3 clients in multiple threads

### DIFF
--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -29,9 +29,13 @@ SSHKey = namedtuple("SSHKey", ["name", "public_key", "private_key"])
 
 
 class KeyStore:  # pylint: disable=too-many-public-methods
-    def __init__(self):
-        self.s3: S3ServiceResource = boto3.resource("s3")
-        self.s3_client: S3Client = boto3.client("s3")
+    @property
+    def s3(self) -> S3ServiceResource:
+        return boto3.resource("s3")
+
+    @property
+    def s3_client(self) -> S3Client:
+        return boto3.client("s3")
 
     def get_file_contents(self, file_name):
         obj = self.s3.Object(KEYSTORE_S3_BUCKET, file_name)


### PR DESCRIPTION
It seems like it's not safe to share clients between threads and we started seeing cases of SCT segfaulting
right at the start, during the `Keystore.sync()`
which run multiple threads to make the process faster but it doesn't help if it also make things unstable

looking at botocore issues, seem like it's documented that botocore isn't threadsafe

Ref: https://github.com/boto/botocore/issues/3164

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] provision test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
