### PR TITLE
fix(cdc_stressor): raise UnsupportedNemesis when no CDC enabled

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4474,8 +4474,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         ks_tables_with_cdc = self.cluster.get_all_tables_with_cdc(self.target_node)
         if not ks_tables_with_cdc:
             self.log.warning("CDC is not enabled on any table. Skipping")
-            UnsupportedNemesis("CDC is not enabled on any table. Skipping")
-            return
+            raise UnsupportedNemesis("CDC is not enabled on any table. Skipping")
 
         ks, table = random.choice(ks_tables_with_cdc).split(".")
         self._run_cdc_stressor_tool(ks, table)


### PR DESCRIPTION
When CDC is not enabled in any table, `disrupt_run_cdcstressor_tool` should raise `UnsupportedNemesis`. Otherwise it looks like it was executed, but wasn't.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - doesn't seem to be needed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
