### PR TITLE
feature(reuse-cluster): add a test for reuse-cluster option of SCT

### DIFF
--- a/reuse_cluster_test.py
+++ b/reuse_cluster_test.py
@@ -1,0 +1,75 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2024 ScyllaDB
+import logging
+import unittest
+
+from sdcm.cluster import TestConfig
+from sdcm.sct_events.events_processes import create_default_events_process_registry
+from sdcm.tester import ClusterTester
+from sdcm.utils.loader_utils import LoaderUtilsMixin
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ReuseClusterTest(unittest.TestCase):
+    """Test ability to reuse existing cluster in tests"""
+
+    # Define reusable equivalent to ClusterTester that can be instantiated multiple times during the test
+    ReusableCluster = type('ReusableCluster', (ClusterTester, LoaderUtilsMixin), {})
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.cluster = None
+        self.ReusableCluster.events_processes_registry = (
+            create_default_events_process_registry(log_dir=TestConfig().logdir()))
+
+    def provision_cluster(self, reuse_cluster_id: str = None) -> None:
+        """Provision a cluster from scratch or re-provision an existing one"""
+        if reuse_cluster_id:
+            TestConfig().reuse_cluster(True)
+            TestConfig().set_test_id(reuse_cluster_id)
+        self.cluster = self.ReusableCluster()
+        self.cluster.setUp()
+
+    def check_scylla(self) -> None:
+        stress_cmd = 'cassandra-stress {mode} no-warmup cl=QUORUM -mode cql3 native -pop seq=1..10000 -rate threads=10'
+        self.cluster.run_stress(stress_cmd.format(mode="write"), duration=1)
+        self.cluster.run_stress(stress_cmd.format(mode="mixed 'ratio(write=1,read=2)'"), duration=1)
+
+    def test_reuse_cluster(self):
+        LOGGER.info("Initial cluster provisioning")
+        self.provision_cluster()
+        self.cluster.db_cluster.check_nodes_up_and_normal()
+        self.cluster.db_cluster.check_cluster_health()
+
+        test_id = self.cluster.test_config.test_id()
+        initial_db_nodes = [i._instance for i in self.cluster.db_cluster.nodes]
+
+        LOGGER.info("Pre-populate DB with data")
+        self.cluster.run_prepare_write_cmd()
+
+        LOGGER.info("Reuse the previously provisioned cluster")
+        self.provision_cluster(reuse_cluster_id=test_id)
+        self.cluster.db_cluster.check_nodes_up_and_normal()
+        self.cluster.db_cluster.check_cluster_health()
+        self.check_scylla()
+
+        LOGGER.info("Verify that re-provisioned cluster consists of the initial DB nodes")
+        self.assertEquals(set([i._instance for i in self.cluster.db_cluster.nodes]), set(initial_db_nodes),
+                          "The re-provisioned cluster nodes do not match the initial DB nodes")
+
+    def tearDown(self):
+        if self.cluster:
+            self.cluster.tearDown()
+        super().tearDown()

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -376,6 +376,8 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             self.set_hostname()
             self.configure_remote_logging()
         self.start_task_threads()
+        if self.test_config.REUSE_CLUSTER:
+            ContainerManager.destroy_unregistered_containers(self)
         self._init_port_mapping()
 
         self.set_keep_alive()

--- a/sdcm/utils/docker_utils.py
+++ b/sdcm/utils/docker_utils.py
@@ -369,6 +369,22 @@ class ContainerManager:  # pylint: disable=too-many-public-methods)
         LOGGER.debug("%s: container `%s' unregistered", instance, name)
 
     @classmethod
+    def destroy_unregistered_containers(
+            cls, instance: INodeWithContainerManager, docker_client: DockerClient = None) -> None:
+        """Destroy, if any, containers that were created for the instance during previous test run(s)"""
+        docker_client = docker_client or cls.default_docker_client
+        filters = {
+            "label": [
+                f"TestId={instance.tags['TestId']}",
+                f"Name={instance.name}",
+            ]
+        }
+        containers = docker_client.containers.list(all=True, filters=filters)
+        for container in containers:
+            if container not in instance._containers.values():
+                container.remove(v=True, force=True)
+
+    @classmethod
     def build_with_progress_prints(cls, docker_client, image_tag, **kwargs):
         """
         build image while printing the progress to log


### PR DESCRIPTION
The change makes the reuse-cluster feature testable/guarded, so we can ensure that it works when it is offered to a wider audience for use in their dev work.

Closes: https://github.com/scylladb/qa-tasks/issues/1749

### Testing
- [ ]

### PR pre-checks (self review)
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
