### PR TITLE
feature(docker): run docker artifact test ontop of FIPS

### DIFF
--- a/jenkins-pipelines/enterprise/artifacts/artifacts-docker-fips.jenkinsfile
+++ b/jenkins-pipelines/enterprise/artifacts/artifacts-docker-fips.jenkinsfile
@@ -1,0 +1,13 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/docker.yaml',
+    backend: 'docker',
+    region: 'fips',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -49,7 +49,7 @@ from sdcm.utils.common import (
     gce_meta_to_dict,
     list_instances_aws,
     list_instances_gce,
-    str_to_bool,
+    str_to_bool, convert_name_to_ami_if_needed,
 )
 from sdcm.utils.aws_utils import ec2_instance_wait_public_ip, ec2_ami_get_root_device_name, tags_as_ec2_tags, EC2NetworkConfiguration
 from sdcm.utils.aws_region import AwsRegion
@@ -548,6 +548,9 @@ class AwsSctRunner(SctRunner):
                 interfaces[-1]["AssociatePublicIpAddress"] = not address_pool
 
         LOGGER.info("Creating instance...")
+        base_image = convert_name_to_ami_if_needed(
+            ami_id_param=base_image, region_names=tuple([aws_region.region_name]))
+
         result = aws_region.resource.create_instances(
             ImageId=base_image,
             InstanceType=instance_type,
@@ -1349,3 +1352,8 @@ def clean_sct_runners(test_status: str,
             end_message = "No runners have been terminated"
 
     LOGGER.info(end_message)
+
+
+class AwsFipsSctRunner(AwsSctRunner):
+    VERSION = f"{SctRunner.VERSION}-fips"
+    BASE_IMAGE = 'resolve:ssm:/aws/service/marketplace/prod-k6fgbnayirmrc/latest'

--- a/vars/getCloudProviderFromBackend.groovy
+++ b/vars/getCloudProviderFromBackend.groovy
@@ -9,7 +9,8 @@ def call(String backend) {
         'gce-siren': 'gce',
         'azure': 'azure',
         'docker': 'aws',
-        'baremetal': 'aws'
+        'baremetal': 'aws',
+        'docker-fips': 'aws-fips',
         ]
     if (!backend) {
         return backend

--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -29,11 +29,13 @@ def call(String backend, String region=null, String datacenter=null, String loca
                           'gce-us-central1': "${gcp_project}-builders-us-central1-template-v2",
                           'gce': "${gcp_project}-builders-us-east1-template-v2",
                           'aws': 'aws-sct-builders-eu-west-1-v3-asg',
-                          'azure-eastus': 'aws-sct-builders-us-east-1-v3-asg']
+                          'azure-eastus': 'aws-sct-builders-us-east-1-v3-asg',
+                          'aws-fips': 'aws-sct-builders-us-east-1-v3-fibs-CI-FIPS',
+                          ]
 
     def cloud_provider = getCloudProviderFromBackend(backend)
 
-    if ((cloud_provider == 'aws' && region) || (cloud_provider == 'gce' && datacenter) || (cloud_provider == 'azure' && location)) {
+    if ((cloud_provider == 'aws' && region) || (cloud_provider == 'gce' && datacenter) || (cloud_provider == 'azure' && location) || (cloud_provider == 'aws-fibs' && region)) {
         def supported_regions = []
 
         if (cloud_provider == 'aws') {
@@ -62,6 +64,8 @@ def call(String backend, String region=null, String datacenter=null, String loca
         } else {
             throw new Exception("=================== ${cloud_provider} region ${region} not supported ! ===================")
         }
+    } else if (region == 'fips') {
+        return [ "label": jenkins_labels['aws-fips'], "region": '' ]
     } else {
         return [ "label": jenkins_labels[cloud_provider], "region": region ]
     }


### PR DESCRIPTION
in this change we introduce a new AWS ASG for testing
docker artifacts on top of FIPS machines,
it has a separated SCT runner, and ASG and labels in jenkins.

so it would be completely separate from the regular SCT runner images,
and can be updated separately

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢  docker with fips - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-docker-fips-test/12/
- [x] 🔴 docker with fips 2024.1, crashing (what this case is for): https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-docker-fips-test/16/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
