### PR TITLE
Manager restore benchmark improvements

### DIFF
--- a/configurations/manager/1GB_dataset.yaml
+++ b/configurations/manager/1GB_dataset.yaml
@@ -1,0 +1,7 @@
+test_duration: 720
+
+prepare_write_cmd: ["cassandra-stress write cl=ONE n=1048576 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=50 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1048576"]
+stress_read_cmd: ["cassandra-stress read cl=ONE n=1048576 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=50 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1048576"]
+
+instance_type_db: 'i4i.xlarge'
+instance_type_loader: 'c6i.xlarge'

--- a/configurations/manager/1TB_500GB_dataset.yaml
+++ b/configurations/manager/1TB_500GB_dataset.yaml
@@ -1,0 +1,19 @@
+test_duration: 4320
+
+prepare_write_cmd: ["cassandra-stress write cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..131072000",
+                    "cassandra-stress write cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=131072001..262144000",
+                    "cassandra-stress write cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=262144001..393216000",
+                    "cassandra-stress write cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=393216001..524288000"]
+
+stress_read_cmd: ["cassandra-stress read cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..131072000",
+                  "cassandra-stress read cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=131072001..262144000",
+                  "cassandra-stress read cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=262144001..393216000",
+                  "cassandra-stress read cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=393216001..524288000"]
+
+prepare_write_cmd_1: ["cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..268435456",
+                    "cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=268435457..536870912",
+                    "cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..805306368",
+                    "cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1073741824"]
+
+instance_type_db: 'i3en.3xlarge'
+instance_type_loader: 'c6i.2xlarge'

--- a/configurations/manager/1TB_dataset.yaml
+++ b/configurations/manager/1TB_dataset.yaml
@@ -1,14 +1,14 @@
-test_duration: 1440
+test_duration: 2880
 
-prepare_write_cmd: ["cassandra-stress write cl=ALL n=268440000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..268440000",
-                    "cassandra-stress write cl=ALL n=268440000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=268440001..536880000",
-                    "cassandra-stress write cl=ALL n=268440000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=536880001..805320000",
-                    "cassandra-stress write cl=ALL n=268440000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=805320001..1073760000"]
+prepare_write_cmd: ["cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..268435456",
+                    "cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=268435457..536870912",
+                    "cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..805306368",
+                    "cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1073741824"]
 
-stress_read_cmd: ["cassandra-stress read cl=ONE n=268440000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..268440000",
-                  "cassandra-stress read cl=ONE n=268440000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=268440001..536880000",
-                  "cassandra-stress read cl=ONE n=268440000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=536880001..805320000",
-                  "cassandra-stress read cl=ONE n=268440000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=805320001..1073760000"]
+stress_read_cmd: ["cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..268435456",
+                  "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=268435457..536870912",
+                  "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..805306368",
+                  "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1073741824"]
 
 instance_type_db: 'i4i.2xlarge'
 instance_type_loader: 'c6i.2xlarge'

--- a/configurations/manager/1TB_dataset.yaml
+++ b/configurations/manager/1TB_dataset.yaml
@@ -10,5 +10,5 @@ stress_read_cmd: ["cassandra-stress read cl=ONE n=268435456 -schema 'replication
                   "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..805306368",
                   "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1073741824"]
 
-instance_type_db: 'i4i.2xlarge'
+instance_type_db: 'i3en.2xlarge'
 instance_type_loader: 'c6i.2xlarge'

--- a/configurations/manager/1TB_twcs_dataset.yaml
+++ b/configurations/manager/1TB_twcs_dataset.yaml
@@ -1,0 +1,24 @@
+test_duration: 2880
+
+prepare_write_cmd_1: ["cassandra-stress write cl=ONE n=157286400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..157286400",
+                      "cassandra-stress write cl=ONE n=157286400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=157286401..314572800",
+                      "cassandra-stress write cl=ONE n=157286400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=314572801..471859200",
+                      "cassandra-stress write cl=ONE n=157286400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=471859201..629145600"]
+
+prepare_write_cmd_2: ["cassandra-stress write cl=ONE n=78643200 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..78643200",
+                      "cassandra-stress write cl=ONE n=78643200 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=78643201..157286400",
+                      "cassandra-stress write cl=ONE n=78643200 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=157286401..235929600",
+                      "cassandra-stress write cl=ONE n=78643200 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=235929601..314572800"]
+
+prepare_write_cmd_3: ["cassandra-stress write cl=ONE n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..26214400",
+                      "cassandra-stress write cl=ONE n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=26214401..52428800",
+                      "cassandra-stress write cl=ONE n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=52428801..78643200",
+                      "cassandra-stress write cl=ONE n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=78643201..104857600"]
+
+stress_read_cmd: ["cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..268435456",
+                  "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=268435457..536870912",
+                  "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..805306368",
+                  "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1073741824"]
+
+instance_type_db: 'i3en.2xlarge'
+instance_type_loader: 'c6i.2xlarge'

--- a/configurations/manager/2TB_dataset.yaml
+++ b/configurations/manager/2TB_dataset.yaml
@@ -1,14 +1,14 @@
-test_duration: 2880
+test_duration: 4320
 
-prepare_write_cmd: ["cassandra-stress write cl=ALL n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..536880000",
-                    "cassandra-stress write cl=ALL n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=536880001..1073760000",
-                    "cassandra-stress write cl=ALL n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1073760001..1610640000",
-                    "cassandra-stress write cl=ALL n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1610640001..2147520000"]
+prepare_write_cmd: ["cassandra-stress write cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..536870912",
+                    "cassandra-stress write cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..1073741824",
+                    "cassandra-stress write cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1073741825..1610612736",
+                    "cassandra-stress write cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1610612737..2147483648"]
 
-stress_read_cmd: ["cassandra-stress read cl=ONE n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..536880000",
-                  "cassandra-stress read cl=ONE n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=536880001..1073760000",
-                  "cassandra-stress read cl=ONE n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1073760001..1610640000",
-                  "cassandra-stress read cl=ONE n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1610640001..2147520000"]
+stress_read_cmd: ["cassandra-stress read cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..536870912",
+                  "cassandra-stress read cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..1073741824",
+                  "cassandra-stress read cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1073741825..1610612736",
+                  "cassandra-stress read cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1610612737..2147483648"]
 
 instance_type_db: 'i3en.3xlarge'
 instance_type_loader: 'c6i.2xlarge'

--- a/configurations/manager/500GB_dataset.yaml
+++ b/configurations/manager/500GB_dataset.yaml
@@ -1,14 +1,14 @@
-test_duration: 720
+test_duration: 1440
 
-prepare_write_cmd: ["cassandra-stress write cl=ALL n=134220000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..134220000",
-                    "cassandra-stress write cl=ALL n=134220000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=134220001..268440000",
-                    "cassandra-stress write cl=ALL n=134220000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=268440001..402660000",
-                    "cassandra-stress write cl=ALL n=134220000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=402660001..536880000"]
+prepare_write_cmd: ["cassandra-stress write cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..131072000",
+                    "cassandra-stress write cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=131072001..262144000",
+                    "cassandra-stress write cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=262144001..393216000",
+                    "cassandra-stress write cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=393216001..524288000"]
 
-stress_read_cmd: ["cassandra-stress read cl=ONE n=134220000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..134220000",
-                  "cassandra-stress read cl=ONE n=134220000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=134220001..268440000",
-                  "cassandra-stress read cl=ONE n=134220000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=268440001..402660000",
-                  "cassandra-stress read cl=ONE n=134220000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=402660001..536880000"]
+stress_read_cmd: ["cassandra-stress read cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..131072000",
+                  "cassandra-stress read cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=131072001..262144000",
+                  "cassandra-stress read cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=262144001..393216000",
+                  "cassandra-stress read cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=393216001..524288000"]
 
 instance_type_db: 'i4i.2xlarge'
 instance_type_loader: 'c6i.xlarge'

--- a/configurations/manager/500GB_dataset_two_ks.yaml
+++ b/configurations/manager/500GB_dataset_two_ks.yaml
@@ -1,0 +1,14 @@
+test_duration: 1440
+
+prepare_write_cmd: ["cassandra-stress write cl=ONE n=65536000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..65536000",
+                    "cassandra-stress write cl=ONE n=65536000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=65536001..131072000",
+                    "cassandra-stress write cl=ONE n=65536000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=131072001..196608000",
+                    "cassandra-stress write cl=ONE n=65536000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=196608001..262144000"]
+
+stress_read_cmd: ["cassandra-stress read cl=ONE n=65536000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..65536000",
+                  "cassandra-stress read cl=ONE n=65536000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=65536001..131072000",
+                  "cassandra-stress read cl=ONE n=65536000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=131072001..196608000",
+                  "cassandra-stress read cl=ONE n=65536000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=196608001..262144000"]
+
+instance_type_db: 'i4i.2xlarge'
+instance_type_loader: 'c6i.xlarge'

--- a/configurations/manager/5TB_dataset.yaml
+++ b/configurations/manager/5TB_dataset.yaml
@@ -1,14 +1,14 @@
 test_duration: 7200
 
-prepare_write_cmd: ["cassandra-stress write cl=ALL n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..1342200000",
-                    "cassandra-stress write cl=ALL n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1342200001..2684400000",
-                    "cassandra-stress write cl=ALL n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=2684400001..4026600000",
-                    "cassandra-stress write cl=ALL n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=4026600001..5368800000"]
+prepare_write_cmd: ["cassandra-stress write cl=ALL n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1342177280",
+                    "cassandra-stress write cl=ALL n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1342177281..2684354560",
+                    "cassandra-stress write cl=ALL n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=2684354561..4026531840",
+                    "cassandra-stress write cl=ALL n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=4026531841..5368709120"]
 
-stress_read_cmd: ["cassandra-stress read cl=ONE n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..1342200000",
-                  "cassandra-stress read cl=ONE n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1342200001..2684400000",
-                  "cassandra-stress read cl=ONE n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=2684400001..4026600000",
-                  "cassandra-stress read cl=ONE n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=4026600001..5368800000"]
+stress_read_cmd: ["cassandra-stress read cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1342177280",
+                  "cassandra-stress read cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1342177281..2684354560",
+                  "cassandra-stress read cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=2684354561..4026531840",
+                  "cassandra-stress read cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=4026531841..5368709120"]
 
 instance_type_db: 'i4i.4xlarge'
-instance_type_loader: 'c6i.4xlarge'
+instance_type_loader: 'c6i.2xlarge'

--- a/defaults/manager_restore_benchmark_snapshots.yaml
+++ b/defaults/manager_restore_benchmark_snapshots.yaml
@@ -34,7 +34,7 @@ sizes:  # size of backed up dataset in GB
     scylla_version: "2024.2.0-rc0"
     number_of_nodes: 3
     compaction_strategy: "IncrementalCompactionStrategy"
-  2000:
+  2tb_1t_ics:
     tag: "sm_20240816185129UTC"
     number_of_rows: 2147483648
     exp_timeout: 57600  # 16 hours

--- a/defaults/manager_restore_benchmark_snapshots.yaml
+++ b/defaults/manager_restore_benchmark_snapshots.yaml
@@ -1,0 +1,52 @@
+bucket: "manager-backup-tests-permanent-snapshots-us-east-1"
+cs_read_cmd_template: "cassandra-stress read cl=ONE n={num_of_rows} -schema 'keyspace={keyspace_name} replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=50 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq={sequence_start}..{sequence_end}"
+sizes:  # size of backed up dataset in GB
+  1:
+    tag: "sm_20240812100424UTC"
+    number_of_rows: 1073760
+    exp_timeout: 1200  # 20 minutes (timeout for restore data operation)
+    ks_name: "keyspace1"
+    scylla_version: "2024.2.0-rc0"
+    number_of_nodes: 3
+    compaction_strategy: "IncrementalCompactionStrategy"
+#    enabled_tablets: false
+  500:
+    tag: "sm_20240813112034UTC"
+    number_of_rows: 524288000
+    exp_timeout: 14400  # 4 hours
+    ks_name: "keyspace1"
+    scylla_version: "2024.2.0-rc0"
+    number_of_nodes: 3
+    compaction_strategy: "IncrementalCompactionStrategy"
+  500_2tables:
+    tag: "sm_20240819203428UTC"
+    number_of_rows: 524288000
+    exp_timeout: 14400  # 4 hours
+    ks_name: ["keyspace1", "keyspace2"]
+    scylla_version: "2024.2.0-rc0"
+    number_of_nodes: 3
+    compaction_strategy: "IncrementalCompactionStrategy"
+  1000:
+    tag: "sm_20240814180009UTC"
+    number_of_rows: 1073741824
+    exp_timeout: 28800  # 8 hours
+    ks_name: "keyspace1"
+    scylla_version: "2024.2.0-rc0"
+    number_of_nodes: 3
+    compaction_strategy: "IncrementalCompactionStrategy"
+  2000:
+    tag: "sm_20240816185129UTC"
+    number_of_rows: 2147483648
+    exp_timeout: 57600  # 16 hours
+    ks_name: "keyspace1"
+    scylla_version: "2024.2.0-rc0"
+    number_of_nodes: 3
+    compaction_strategy: "IncrementalCompactionStrategy"
+#    enabled_tablets: false
+#    - tag: "sm_20240813114617UTC"
+#      number_of_rows: 524288000
+#      exp_timeout: 18000  # 5 hours
+#      ks_name: "keyspace1"
+#      scylla_version: "2024.2.0-rc0"
+#      number_of_nodes: 3
+#      enabled_tablets: true

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -364,3 +364,4 @@
 | **<a href="#user-content-bisect_end_date" name="bisect_end_date">bisect_end_date</a>**  | Scylla build date until which bisecting should run. Format: YYYY-MM-DD | N/A | SCT_BISECT_END_DATE
 | **<a href="#user-content-mgmt_restore_params" name="mgmt_restore_params">mgmt_restore_params</a>**  | Manager restore operation specific parameters: batch_size, parallel | N/A | SCT_MGMT_RESTORE_PARAMS
 | **<a href="#user-content-mgmt_agent_backup_config" name="mgmt_agent_backup_config">mgmt_agent_backup_config</a>**  | Manager agent backup general configuration: checkers, transfers, low_level_retries | N/A | SCT_MGMT_AGENT_BACKUP_CONFIG
+| **<a href="#user-content-mgmt_reuse_backup_size" name="mgmt_reuse_backup_size">mgmt_reuse_backup_size</a>**  | The size of pre-created backup in GB to reuse in Manager restore benchmarking test | N/A | SCT_MGMT_REUSE_BACKUP_SIZE

--- a/jenkins-pipelines/manager/ubuntu22-manager-backup-restore-custom-dataset.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-backup-restore-custom-dataset.jenkinsfile
@@ -6,10 +6,10 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
-    test_name: 'mgmt_cli_test.MgmtCliTest.test_backup_and_restore_only_data',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_restore_benchmark',
     test_config: 'test-cases/manager/manager-backup-restore-set-dataset.yaml',
     mgmt_restore_params: "{'batch_size': 2, 'parallel': 1}",
-    agent_backup_params: "{'checkers': 100, 'transfers': 2, 'low_level_retries': 20}",
+    mgmt_agent_backup_config: "{'checkers': 100, 'transfers': 2, 'low_level_retries': 20}",
 
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -76,8 +76,12 @@ class BackupFunctionsMixIn(LoaderUtilsMixin):
     def locations(self) -> list[str]:
         backend = self.params.get("backup_bucket_backend")
 
+        buckets = self.params.get("backup_bucket_location")
+        if not isinstance(buckets, list):
+            buckets = buckets.split()
+
         # FIXME: Make it works with multiple locations or file a bug for scylla-manager.
-        return [f"{backend}:{location}" for location in self.params.get("backup_bucket_location").split()[:1]]
+        return [f"{backend}:{location}" for location in buckets[:1]]
 
     def _run_cmd_with_retry(self, executor, cmd, retries=10):
         for _ in range(retries):

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -1275,7 +1275,7 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
         mgr_cluster = self._ensure_and_get_cluster(manager_tool)
 
-        backup_task = mgr_cluster.create_backup_task(location_list=self.locations)
+        backup_task = mgr_cluster.create_backup_task(location_list=self.locations, rate_limit_list=["0"])
         backup_task_status = backup_task.wait_and_get_final_status(timeout=110000)
         assert backup_task_status == TaskStatus.DONE, \
             f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -25,6 +25,7 @@ from datetime import datetime
 from dataclasses import dataclass
 
 import boto3
+import yaml
 
 from invoke import exceptions
 
@@ -52,6 +53,16 @@ from sdcm.exceptions import FilesNotCorrupted
 class ManagerTestMetrics:
     backup_time = "N/A"
     restore_time = "N/A"
+
+
+@dataclass
+class SnapshotData:
+    bucket: str
+    tag: str
+    ks_name: str | list[str]
+    exp_timeout: int
+    cs_read_cmd_template: str
+    number_of_rows: int
 
 
 class BackupFunctionsMixIn(LoaderUtilsMixin):
@@ -493,35 +504,6 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
             }
         )
         return email_data
-
-    def test_backup_and_restore_only_data(self):
-        self.run_prepare_write_cmd()
-        manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
-        mgr_cluster = self._ensure_and_get_cluster(manager_tool)
-        backup_task = mgr_cluster.create_backup_task(location_list=self.locations)
-        backup_task_status = backup_task.wait_and_get_final_status(timeout=110000)
-        assert backup_task_status == TaskStatus.DONE, \
-            f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"
-        InfoEvent(message=f'The backup task has ended successfully. Backup run time: {backup_task.duration}').publish()
-        self.manager_test_metrics.backup_time = backup_task.duration
-
-        ks_number = self.params.get('keyspace_num') or 1
-        ks_names = self.get_keyspace_name(ks_number=ks_number)
-        for ks_name in ks_names:
-            self.db_cluster.nodes[0].run_cqlsh(f'TRUNCATE {ks_name}.standard1')
-
-        if restore_params := self.params.get('mgmt_restore_params'):
-            batch_size = restore_params.batch_size
-            parallel = restore_params.parallel
-        else:
-            batch_size, parallel = None, None
-
-        task = self.restore_backup_with_task(mgr_cluster=mgr_cluster, snapshot_tag=backup_task.get_snapshot_tag(),
-                                             timeout=110000, restore_data=True, batch_size=batch_size,
-                                             parallel=parallel)
-        self.manager_test_metrics.restore_time = task.duration
-
-        self.run_verification_read_stress()
 
     def test_restore_multiple_backup_snapshots(self):  # pylint: disable=too-many-locals  # noqa: PLR0914
         manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
@@ -1234,3 +1216,131 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
             assert host_health.rest_status == HostRestStatus.UP, "Host REST status is not 'UP'"
 
         self.log.info('finishing test_manager_installed_and_functional')
+
+    # ----- RESTORE -----
+
+    @staticmethod
+    def get_snapshot_data(size: int):
+        snapshots_config = "defaults/manager_restore_benchmark_snapshots.yaml"
+        with open(snapshots_config, encoding="utf-8") as snapshots_yaml:
+            all_snapshots_dict = yaml.safe_load(snapshots_yaml)
+
+        try:
+            snapshot_dict = all_snapshots_dict["sizes"][size]
+        except KeyError:
+            raise ValueError(f"Snapshot data for size '{size}'GB was not found in the {snapshots_config} file")
+
+        snapshot_data = SnapshotData(
+            bucket=all_snapshots_dict["bucket"],
+            tag=snapshot_dict["tag"],
+            ks_name=snapshot_dict["ks_name"],
+            exp_timeout=snapshot_dict["exp_timeout"],
+            cs_read_cmd_template=all_snapshots_dict["cs_read_cmd_template"],
+            number_of_rows=snapshot_dict["number_of_rows"],
+        )
+        return snapshot_data
+
+    def prepare_stress_read_cmd(self, command_template, keyspace_name, number_of_rows):
+        stress_queue = []
+        number_of_loaders = self.params.get("n_loaders")
+        rows_per_loader = int(number_of_rows / number_of_loaders)
+        for loader_index in range(number_of_loaders):
+            stress_command = command_template.format(num_of_rows=rows_per_loader,
+                                                     keyspace_name=keyspace_name,
+                                                     sequence_start=rows_per_loader * loader_index + 1,
+                                                     sequence_end=rows_per_loader * (loader_index + 1))
+            read_thread = self.run_stress_thread(stress_cmd=stress_command, round_robin=True,
+                                                 stop_test_on_failure=False)
+            stress_queue.append(read_thread)
+        return stress_queue
+
+    def get_restore_custom_parameters(self):
+        if restore_params := self.params.get('mgmt_restore_params'):
+            batch_size = restore_params.batch_size
+            parallel = restore_params.parallel
+        else:
+            batch_size, parallel = None, None
+        return batch_size, parallel
+
+    def test_backup_and_restore_only_data(self):
+        """The test is extensively used for restore benchmarking purposes and consists of the following steps:
+        1. Populate the cluster with data (currently operates with datasets of 500GB, 1TB, 2TB, 5TB);
+        2. Run the backup task and wait for its completion;
+        3. Truncate the tables in the cluster;
+        4. Run the restore task (custom batch_size and parallel params can be set in the pipeline)
+           and wait for its completion;
+        5. Run the verification read stress to ensure the data is restored correctly.
+        """
+        self.run_prepare_write_cmd()
+        manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
+        mgr_cluster = self._ensure_and_get_cluster(manager_tool)
+
+        backup_task = mgr_cluster.create_backup_task(location_list=self.locations)
+        backup_task_status = backup_task.wait_and_get_final_status(timeout=110000)
+        assert backup_task_status == TaskStatus.DONE, \
+            f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"
+        InfoEvent(message=f'The backup task has ended successfully. Backup run time: {backup_task.duration}').publish()
+        self.manager_test_metrics.backup_time = backup_task.duration
+
+        ks_number = self.params.get('keyspace_num') or 1
+        ks_names = self.get_keyspace_name(ks_number=ks_number)
+        for ks_name in ks_names:
+            self.db_cluster.nodes[0].run_cqlsh(f'TRUNCATE {ks_name}.standard1')
+
+        batch_size, parallel = self.get_restore_custom_parameters()
+        task = self.restore_backup_with_task(mgr_cluster=mgr_cluster, snapshot_tag=backup_task.get_snapshot_tag(),
+                                             timeout=110000, restore_data=True, batch_size=batch_size,
+                                             parallel=parallel)
+        self.manager_test_metrics.restore_time = task.duration
+
+        self.run_verification_read_stress()
+
+    def test_restore_from_precreated_backup(self, backup_size: int = 1):
+        """The test restores the schema and data from a pre-created backup and runs the verification read stress.
+        1. Define the backup to restore from
+        2. Run restore schema to empty cluster
+        3. Run restore data
+        4. Run verification read stress
+
+        Args:
+            backup_size (int): size of backup in GB
+        """
+        manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
+        mgr_cluster = self._ensure_and_get_cluster(manager_tool)
+
+        snapshot_data = self.get_snapshot_data(backup_size)
+
+        self.log.info("Restoring the schema")
+        location = [f"s3:{snapshot_data.bucket}"]
+        self.restore_backup_with_task(mgr_cluster=mgr_cluster, snapshot_tag=snapshot_data.tag, timeout=600,
+                                      restore_schema=True, location_list=location)
+        ks_names = snapshot_data.ks_name if isinstance(snapshot_data.ks_name, list) else [snapshot_data.ks_name]
+        for ks_name in ks_names:
+            self.set_ks_strategy_to_network_and_rf_according_to_cluster(keyspace=ks_name, repair_after_alter=False)
+
+        self.log.info("Restoring the data")
+        batch_size, parallel = self.get_restore_custom_parameters()
+        task = self.restore_backup_with_task(mgr_cluster=mgr_cluster, snapshot_tag=snapshot_data.tag,
+                                             timeout=snapshot_data.exp_timeout, restore_data=True,
+                                             location_list=location, batch_size=batch_size, parallel=parallel)
+        self.manager_test_metrics.restore_time = task.duration
+
+        self.log.info("Running verification read stress")
+        stress_queue = self.prepare_stress_read_cmd(command_template=snapshot_data.cs_read_cmd_template,
+                                                    keyspace_name=snapshot_data.ks_name,
+                                                    number_of_rows=snapshot_data.number_of_rows)
+        for stress in stress_queue:
+            assert self.verify_stress_thread(cs_thread_pool=stress), "Data verification stress command"
+
+    def test_restore_benchmark(self):
+        """Benchmark restore operation.
+
+        The test suggests two flows - populate the cluster with data, create the backup, and then restore it or
+        restore from a pre-created backup.
+        """
+        if backup_size := self.params.get('mgmt_reuse_backup_size'):
+            self.log.info("Executing test_restore_from_precreated_backup...")
+            self.test_restore_from_precreated_backup(backup_size)
+        else:
+            self.log.info("Executing test_backup_and_restore_only_data...")
+            self.test_backup_and_restore_only_data()

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -195,9 +195,9 @@ class RestoreParameters(BaseModel):
 
 
 class AgentBackupParameters(BaseModel):
-    checkers: Optional[int]
-    transfers: Optional[int]
-    low_level_retries: Optional[int]
+    checkers: Optional[int] = 100
+    transfers: Optional[int] = 2
+    low_level_retries: Optional[int] = 20
 
     class Config:
         extra = Extra.forbid

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1127,6 +1127,10 @@ class SCTConfiguration(dict):
              help="Manager agent backup general configuration: checkers, transfers, low_level_retries. "
                   "For example, {'checkers': 100, 'transfers': 2, 'low_level_retries': 20}"),
 
+        dict(name="mgmt_reuse_backup_size", env="SCT_MGMT_REUSE_BACKUP_SIZE", type=int,
+             help="Size of the backup (in GB) to reuse in the Manager restore test. "
+                  "The following sizes are supported: 1, 500, 1000, 2000, 5000"),
+
         # PerformanceRegressionTest
 
         dict(name="stress_cmd_w", env="SCT_STRESS_CMD_W",
@@ -2024,6 +2028,11 @@ class SCTConfiguration(dict):
         # 21 Validate Manager agent backup general parameters
         if backup_params := self.get("mgmt_agent_backup_config"):
             self["mgmt_agent_backup_config"] = AgentBackupParameters(**backup_params)
+
+        # 22 Validate backup size for Manager restore operation is valid
+        backup_size = self.get('mgmt_reuse_backup_size')
+        if backup_size and backup_size not in {1, 500, 1000, 2000, 5000}:
+            raise ValueError(f"There is no pre-created backup for size {backup_size}GB. Please, choose another one")
 
     def log_config(self):
         self.log.info(self.dump_config())

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1168,6 +1168,20 @@ class SCTConfiguration(dict):
                 be provided by the test suite infrastructure.
                 multiple commands can passed as a list"""),
 
+        dict(name="prepare_write_cmd_2", env="SCT_PREPARE_WRITE_CMD_2",
+             type=str_or_list, k8s_multitenancy_supported=True,
+             help="""cassandra-stress commands.
+            You can specify everything but the -node parameter, which is going to
+            be provided by the test suite infrastructure.
+            multiple commands can passed as a list"""),
+
+        dict(name="prepare_write_cmd_3", env="SCT_PREPARE_WRITE_CMD_3",
+             type=str_or_list, k8s_multitenancy_supported=True,
+             help="""cassandra-stress commands.
+            You can specify everything but the -node parameter, which is going to
+            be provided by the test suite infrastructure.
+            multiple commands can passed as a list"""),
+
         dict(name="stress_cmd_no_mv", env="SCT_STRESS_CMD_NO_MV", type=str_or_list,
              help="""cassandra-stress commands.
                 You can specify everything but the -node parameter, which is going to

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1127,7 +1127,7 @@ class SCTConfiguration(dict):
              help="Manager agent backup general configuration: checkers, transfers, low_level_retries. "
                   "For example, {'checkers': 100, 'transfers': 2, 'low_level_retries': 20}"),
 
-        dict(name="mgmt_reuse_backup_size", env="SCT_MGMT_REUSE_BACKUP_SIZE", type=int,
+        dict(name="mgmt_reuse_backup_size", env="SCT_MGMT_REUSE_BACKUP_SIZE", type=str,
              help="Size of the backup (in GB) to reuse in the Manager restore test. "
                   "The following sizes are supported: 1, 500, 1000, 2000, 5000"),
 
@@ -1160,6 +1160,13 @@ class SCTConfiguration(dict):
                     You can specify everything but the -node parameter, which is going to
                     be provided by the test suite infrastructure.
                     multiple commands can passed as a list"""),
+
+        dict(name="prepare_write_cmd_1", env="SCT_PREPARE_WRITE_CMD_1",
+             type=str_or_list, k8s_multitenancy_supported=True,
+             help="""cassandra-stress commands.
+                You can specify everything but the -node parameter, which is going to
+                be provided by the test suite infrastructure.
+                multiple commands can passed as a list"""),
 
         dict(name="stress_cmd_no_mv", env="SCT_STRESS_CMD_NO_MV", type=str_or_list,
              help="""cassandra-stress commands.
@@ -2030,9 +2037,9 @@ class SCTConfiguration(dict):
             self["mgmt_agent_backup_config"] = AgentBackupParameters(**backup_params)
 
         # 22 Validate backup size for Manager restore operation is valid
-        backup_size = self.get('mgmt_reuse_backup_size')
-        if backup_size and backup_size not in {1, 500, 1000, 2000, 5000}:
-            raise ValueError(f"There is no pre-created backup for size {backup_size}GB. Please, choose another one")
+        # backup_size = self.get('mgmt_reuse_backup_size')
+        # if backup_size and backup_size not in {1, 500, 1000, 2000, 5000}:
+        #     raise ValueError(f"There is no pre-created backup for size {backup_size}GB. Please, choose another one")
 
     def log_config(self):
         self.log.info(self.dump_config())

--- a/sdcm/utils/loader_utils.py
+++ b/sdcm/utils/loader_utils.py
@@ -240,6 +240,8 @@ class LoaderUtilsMixin:
                 self.log.debug("Using round_robin for multiple Keyspaces...")
                 for i in range(1, keyspace_num + 1):
                     keyspace_name = self._get_keyspace_name(i)
+                    if i == 2:
+                        prepare_write_cmd = self.params.get('prepare_write_cmd_1')
                     self._run_all_stress_cmds(write_queue, params={'stress_cmd': prepare_write_cmd,
                                                                    'keyspace_name': keyspace_name,
                                                                    'round_robin': True})

--- a/sdcm/utils/loader_utils.py
+++ b/sdcm/utils/loader_utils.py
@@ -224,7 +224,7 @@ class LoaderUtilsMixin:
     def run_prepare_write_cmd(self):
         # In some cases (like many keyspaces), we want to create the schema (all keyspaces & tables) before the load
         # starts - due to the heavy load, the schema propogation can take long time and c-s fails.
-        prepare_write_cmd = self.params.get('prepare_write_cmd')
+        prepare_write_cmd = self.params.get('prepare_write_cmd_1')
         prepare_cs_user_profiles = self.params.get('prepare_cs_user_profiles')
         keyspace_num = self.params.get('keyspace_num')
         write_queue = []
@@ -240,8 +240,7 @@ class LoaderUtilsMixin:
                 self.log.debug("Using round_robin for multiple Keyspaces...")
                 for i in range(1, keyspace_num + 1):
                     keyspace_name = self._get_keyspace_name(i)
-                    if i == 2:
-                        prepare_write_cmd = self.params.get('prepare_write_cmd_1')
+                    prepare_write_cmd = self.params.get(f'prepare_write_cmd_{i}')
                     self._run_all_stress_cmds(write_queue, params={'stress_cmd': prepare_write_cmd,
                                                                    'keyspace_name': keyspace_name,
                                                                    'round_robin': True})

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -150,6 +150,12 @@ def call(Map pipelineParams) {
                                    For example, {'batch_size': 2, 'parallel': 1}""",
                    name: 'mgmt_restore_params')
 
+            string(defaultValue: "${pipelineParams.get('mgmt_reuse_backup_size', '')}",
+                   description: """The size of the backup in GB to reuse in restore benchmark test.
+                                   Leave empty to NOT reuse the pre-created backup.
+                                   Supported values are 1, 500, 1000, 2000 and 5000""",
+                   name: 'mgmt_reuse_backup_size')
+
             string(defaultValue: "${pipelineParams.get('mgmt_agent_backup_config', '')}",
                    description: """Backup general configuration for the agent (scylla-manager-agent.yaml):
                                    checkers, transfers, low_level_retries.
@@ -351,6 +357,10 @@ def call(Map pipelineParams) {
 
                                         if [[ ! -z "${params.mgmt_restore_params}" ]] ; then
                                             export SCT_MGMT_RESTORE_PARAMS="${params.mgmt_restore_params}"
+                                        fi
+
+                                        if [[ ! -z "${params.mgmt_reuse_backup_size}" ]] ; then
+                                            export SCT_MGMT_REUSE_BACKUP_SIZE="${params.mgmt_reuse_backup_size}"
                                         fi
 
                                         if [[ ! -z "${params.mgmt_agent_backup_config}" ]] ; then

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -54,6 +54,10 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('backup_bucket_backend', '')}",
                description: 's3|gcs|azure or empty',
                name: 'backup_bucket_backend')
+            string(defaultValue: "${pipelineParams.get('backup_bucket_location', '')}",
+               description: """Backup bucket name, if empty - the default 'manager-backup-tests-us-east-1' bucket is used.
+                               'manager-backup-tests-permanent-snapshots-us-east-1' bucket can be used to store backups permanently.""",
+               name: 'backup_bucket_location')
             string(defaultValue: "${pipelineParams.get('backend', 'aws')}",
                description: 'aws|gce',
                name: 'backend')
@@ -299,6 +303,10 @@ def call(Map pipelineParams) {
 
                                         if [[ -n "${params.backup_bucket_backend}" ]] ; then
                                             export SCT_BACKUP_BUCKET_BACKEND="${params.backup_bucket_backend}"
+                                        fi
+
+                                        if [[ -n "${params.backup_bucket_location}" ]] ; then
+                                            export SCT_BACKUP_BUCKET_LOCATION="${params.backup_bucket_location}"
                                         fi
 
                                         if [[ ! -z "${params.scylla_ami_id}" ]] ; then


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-manager/issues/3950

So, the PR introduces the new flow for Manager restore benchmark test - adds the option to run restore from pre-created backups - as well as improves the current approach.

The short summary of changes:
- Introduced the test that restores from pre-created backup. At the same time, the existing approach with populating the data,
creating the backup from scratch and consecutive restore is kept in place;
- Some fixes to c-s stress cmds to speed up large datasets population process;
- Set rate limit to 0 to speed up backup operation in restore benchmark test;
- Added 1GB dataset for test/pipeline debug purposes;
- Added backup_bucket_location to list of Manager job parameters.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Restore from pre-created backup [test](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master/job/backup-restore-precreated-snapshot/7/);
- [ ] The full flow [test](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master/job/backup-restore-custom-dataset-test/26/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
