### PR TITLE
fix(reuse_cluster): cleanup leftover containers from previous run

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -376,6 +376,8 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             self.set_hostname()
             self.configure_remote_logging()
         self.start_task_threads()
+        if self.test_config.REUSE_CLUSTER:
+            ContainerManager.destroy_unregistered_containers(self)
         self._init_port_mapping()
 
         self.set_keep_alive()


### PR DESCRIPTION
If a cluster is kept running after the test is finished (for later reuse) the containerized autossh hooks associated with cluster DB nodes are not deleted. But
they are no longer associated with existing nodes - the association exists in runtime.
When a new test is started reusing the existing cluster, a new set of autossh containers would be created. But as the leftover autossh containers are still
holding local syslogng ports, which are mapped to remote syslogng ports on DB nodes instances, syslogng initialization for new test is blocked.

Eventually the test with reusing a cluster fails with the error:
```
< t:2024-08-12 21:12:03,798 f:wait.py         l:79   c:sdcm.wait            p:ERROR > Wait for: wait for db logs: timeout - 300 seconds - expired
< t:2024-08-12 21:12:03,799 f:wait.py         l:83   c:sdcm.wait            p:ERROR > last error: Exception('No db log from the following nodes:\nPR-provision-test-dmitriy-db-node-ef0e486d-1\nPR-provision-test-dmitriy-db-node-ef0e486d-2\nPR-provision-test-dmitriy-db-node-ef0e486d-3\nfiles expected to be find:\n/home/dmitriy/sct-results/20240812-210539-941537/hosts/PR-provision-test-dmitriy-db-node-ef0e486d-1/messages.log\n/home/dmitriy/sct-results/20240812-210539-941537/hosts/PR-provision-test-dmitriy-db-node-ef0e486d-2/messages.log\n/home/dmitriy/sct-results/20240812-210539-941537/hosts/PR-provision-test-dmitriy-db-node-ef0e486d-3/messages.log')
< t:2024-08-12 21:12:03,805 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > 2024-08-12 21:12:03.801: (TestFrameworkEvent Severity.ERROR) period_type=one-time event_id=a77114c9-5b19-42a0-b40a-d857815f9b61, source=LongevityTest.SetUp()
< t:2024-08-12 21:12:03,805 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > exception=No db log from the following nodes:
< t:2024-08-12 21:12:03,805 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > PR-provision-test-dmitriy-db-node-ef0e486d-1
< t:2024-08-12 21:12:03,805 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > PR-provision-test-dmitriy-db-node-ef0e486d-2
< t:2024-08-12 21:12:03,805 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > PR-provision-test-dmitriy-db-node-ef0e486d-3
< t:2024-08-12 21:12:03,805 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > files expected to be find:
< t:2024-08-12 21:12:03,805 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > /home/dmitriy/sct-results/20240812-210539-941537/hosts/PR-provision-test-dmitriy-db-node-ef0e486d-1/messages.log
< t:2024-08-12 21:12:03,805 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > /home/dmitriy/sct-results/20240812-210539-941537/hosts/PR-provision-test-dmitriy-db-node-ef0e486d-2/messages.log
< t:2024-08-12 21:12:03,805 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > /home/dmitriy/sct-results/20240812-210539-941537/hosts/PR-provision-test-dmitriy-db-node-ef0e486d-3/messages.log
< t:2024-08-12 21:12:03,802 f:tester.py       l:192  c:sdcm.tester          p:ERROR > Exception in setUp. Will call tearDown < t:2024-08-12 21:12:03,802 f:tester.py       l:192  c:sdcm.tester          p:ERROR > Exception in setUp. Will call tearDown

```

The change introduces a new method to the ContainerManager set of docker utils, to allow removing leftover containers from previous test run, when reusing a cluster.

### Testing
- [x] :green_circle: regression check for regular (no cluster reuse) test run - [pr-provision test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/sct-pr-provision-test/55/)
- [x] :green_circle: reuse of the existing cluster locally:

Initial test tun:
```
❯ SCT_CONFIG_FILES='["test-cases/PR-provision-test.yaml","configurations/network_config/test_communication_public.yaml"]' SCT_ENABLE_ARGUS=false SCT_SCYLLA_VERSION=6.0.1 SCT_POST_BEHAVIOR_DB_NODES=keep SCT_POST_BEHAVIOR_LOADER_NODES=keep SCT_POST_BEHAVIOR_MONITOR_NODES=keep ./docker/env/hydra.sh run-test longevity_test.LongevityTest.test_custom_time --backend aws
There is scylladb/hydra:v1.74-tcconfig-0.29.1 in local cache, using it.
Going to run './sct.py  run-test longevity_test.LongevityTest.test_custom_time --backend aws'...
...
< t:2024-08-12 20:58:16,062 f:tester.py       l:3019 c:LongevityTest        p:INFO  > ================================= TEST RESULTS =================================
< t:2024-08-12 20:58:16,062 f:tester.py       l:3019 c:LongevityTest        p:INFO  > ================================================================================
< t:2024-08-12 20:58:16,062 f:tester.py       l:3019 c:LongevityTest        p:INFO  > SUCCESS :)
< t:2024-08-12 20:58:16,065 f:tester.py       l:2970 c:LongevityTest        p:INFO  > Test ID: ef0e486d-f972-4f0a-adde-f253ec7e62da

❯ cat ~/sct-results/latest/test_id
ef0e486d-f972-4f0a-adde-f253ec7e62da% 
```

The leftover containers:
```
❯ docker ps | grep ef0e486d
e28e121cab41   jnovack/autossh:1.2.2          "/entrypoint.sh"   17 minutes ago   Up 17 minutes                                                                                 PR-provision-test-dmitriy-monitor-node-ef0e486d-1-3.253.19.10-autossh-syslog_ng---KEEPALIVE
a47a3e250fa2   jnovack/autossh:1.2.2          "/entrypoint.sh"   18 minutes ago   Up 18 minutes                                                                                 PR-provision-test-dmitriy-loader-node-ef0e486d-1-34.254.182.143-autossh-syslog_ng---KEEPALIVE
60f2a7680c70   jnovack/autossh:1.2.2          "/entrypoint.sh"   20 minutes ago   Up 20 minutes                                                                                 PR-provision-test-dmitriy-db-node-ef0e486d-3-54.154.175.215-autossh-syslog_ng---KEEPALIVE
d7c1c813bc64   jnovack/autossh:1.2.2          "/entrypoint.sh"   20 minutes ago   Up 20 minutes                                                                                 PR-provision-test-dmitriy-db-node-ef0e486d-2-34.245.27.65-autossh-syslog_ng---KEEPALIVE
d5a5aa7bf0ea   jnovack/autossh:1.2.2          "/entrypoint.sh"   20 minutes ago   Up 20 minutes                                                                                 PR-provision-test-dmitriy-db-node-ef0e486d-1-34.254.201.3-autossh-syslog_ng---KEEPALIVE
```

Attempt to reuse the cluster without cleaning up the leftover containers:
```
❯ SCT_REUSE_CLUSTER=ef0e486d-f972-4f0a-adde-f253ec7e62da SCT_CONFIG_FILES='["test-cases/PR-provision-test.yaml","configurations/network_config/test_communication_public.yaml"]' SCT_ENABLE_ARGUS=false SCT_SCYLLA_VERSION=6.0.1 ./docker/env/hydra.sh run-test longevity_test.LongevityTest.test_custom_time --backend aws
There is scylladb/hydra:v1.74-tcconfig-0.29.1 in local cache, using it.
Going to run './sct.py  run-test longevity_test.LongevityTest.test_custom_time --backend aws'...
...
< t:2024-08-12 21:12:03,798 f:wait.py         l:79   c:sdcm.wait            p:ERROR > Wait for: wait for db logs: timeout - 300 seconds - expired
< t:2024-08-12 21:12:03,799 f:wait.py         l:83   c:sdcm.wait            p:ERROR > last error: Exception('No db log from the following nodes:\nPR-provision-test-dmitriy-db-node-ef0e486d-1\nPR-provision-test-dmitriy-db-node-ef0e486d-2\nPR-provision-test-dmitriy-db-node-ef0e486d-3\nfiles expected to be find:\n/home/dmitriy/sct-results/20240812-210539-941537/hosts/PR-provision-test-dmitriy-db-node-ef0e486d-1/messages.log\n/home/dmitriy/sct-results/20240812-210539-941537/hosts/PR-provision-test-dmitriy-db-node-ef0e486d-2/messages.log\n/home/dmitriy/sct-results/20240812-210539-941537/hosts/PR-provision-test-dmitriy-db-node-ef0e486d-3/messages.log')
< t:2024-08-12 21:12:03,805 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > 2024-08-12 21:12:03.801: (TestFrameworkEvent Severity.ERROR) period_type=one-time event_id=a77114c9-5b19-42a0-b40a-d857815f9b61, source=LongevityTest.SetUp()
< t:2024-08-12 21:12:03,805 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > exception=No db log from the following nodes:
< t:2024-08-12 21:12:03,805 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > PR-provision-test-dmitriy-db-node-ef0e486d-1
< t:2024-08-12 21:12:03,805 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > PR-provision-test-dmitriy-db-node-ef0e486d-2
< t:2024-08-12 21:12:03,805 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > PR-provision-test-dmitriy-db-node-ef0e486d-3
< t:2024-08-12 21:12:03,805 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > files expected to be find:
< t:2024-08-12 21:12:03,805 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > /home/dmitriy/sct-results/20240812-210539-941537/hosts/PR-provision-test-dmitriy-db-node-ef0e486d-1/messages.log
< t:2024-08-12 21:12:03,805 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > /home/dmitriy/sct-results/20240812-210539-941537/hosts/PR-provision-test-dmitriy-db-node-ef0e486d-2/messages.log
< t:2024-08-12 21:12:03,805 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > /home/dmitriy/sct-results/20240812-210539-941537/hosts/PR-provision-test-dmitriy-db-node-ef0e486d-3/messages.log
< t:2024-08-12 21:12:03,802 f:tester.py       l:192  c:sdcm.tester          p:ERROR > Exception in setUp. Will call tearDown < t:2024-08-12 21:12:03,802 f:tester.py       l:192  c:sdcm.tester          p:ERROR > Exception in setUp. Will call tearDown

...

----------------------------------------------------------------------
Ran 1 test in 398.105s

FAILED (errors=2)
```

Reusing the cluster with enabled cleanup of leftover containers:
```
❯ SCT_REUSE_CLUSTER=ef0e486d-f972-4f0a-adde-f253ec7e62da SCT_CONFIG_FILES='["test-cases/PR-provision-test.yaml","configurations/network_config/test_communication_public.yaml"]' SCT_ENABLE_ARGUS=false SCT_SCYLLA_VERSION=6.0.1 ./docker/env/hydra.sh run-test longevity_test.LongevityTest.test_custom_time --backend aws
There is scylladb/hydra:v1.74-tcconfig-0.29.1 in local cache, using it.
Going to run './sct.py  run-test longevity_test.LongevityTest.test_custom_time --backend aws'...
...
< t:2024-08-12 21:23:52,807 f:tester.py       l:3019 c:LongevityTest        p:INFO  > ================================= TEST RESULTS =================================
< t:2024-08-12 21:23:52,807 f:tester.py       l:3019 c:LongevityTest        p:INFO  > ================================================================================
< t:2024-08-12 21:23:52,807 f:tester.py       l:3019 c:LongevityTest        p:INFO  > SUCCESS :)
< t:2024-08-12 21:23:52,809 f:tester.py       l:2970 c:LongevityTest        p:INFO  > Test ID: ef0e486d-f972-4f0a-adde-f253ec7e62da
...
```

### PR pre-checks (self review)
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
