### PR TITLE
fix(artifacts-offline): ubuntu 2404 to point to correct configuration

### DIFF
--- a/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2404-nonroot.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts-offline-install/artifacts-ubuntu2404-nonroot.jenkinsfile
@@ -4,7 +4,7 @@
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 artifactsPipeline(
-    test_config: 'test-cases/artifacts/ubuntu2204.yaml',
+    test_config: 'test-cases/artifacts/ubuntu2404.yaml',
     backend: 'gce',
     nonroot_offline_install: true,
     provision_type: 'spot',


### PR DESCRIPTION
by mistake it was pointing 2204 configuration

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2404-test/10/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
