### PR TITLE
fix(recover_backup): use correct file ext to restore backupt on rhl

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -434,7 +434,7 @@ class FillDatabaseData(ClusterTester):
             ],
             'min_version': '1.7',
             'max_version': '',
-            'skip_condition': 'not self.is_counter_supported',
+            'skip_condition': 'self.is_counter_supported',
             'skip': ''},
         {
             'name': 'indexed_with_eq_test: Check that you can query for an indexed column even with a key EQ clause',

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -117,7 +117,7 @@ def recover_conf(node):
         node.remoter.run(
             r'for conf in $( rpm -qc $(rpm -qa | grep scylla) | grep -v contains ) '
             r'/etc/systemd/system/{var-lib-scylla,var-lib-systemd-coredump}.mount; '
-            r'do if test -e $conf.backup; then sudo cp -v $conf.backup $conf; fi; done')
+            r'do if test -e $conf.autobackup; then sudo cp -v $conf.autobackup $conf; fi; done')
     else:
         node.remoter.run(
             r'for conf in $(cat /var/lib/dpkg/info/scylla-*server.conffiles '


### PR DESCRIPTION
Wrong extention was used upon restore back files for rhl based systems.

Fixes: scylladb/scylladb#19777

Additional commit should fix the logic with skip condition. Because upon create tables, logic of skip condition is reversed, need to set false in skip contition field
related to https://github.com/scylladb/scylla-cluster-tests/commit/19577df303c2c3131029d8f936beab6bfd4e43d7



### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
