### PR TITLE
fix(raft exceptions): filter a missing stream_ranges exception on scylla shutdown

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -304,7 +304,7 @@ def ignore_raft_topology_cmd_failing():
         stack.enter_context(EventsSeverityChangerFilter(
             new_severity=Severity.WARNING,
             event_class=DatabaseLogEvent,
-            regex=r".*raft_topology - raft_topology_cmd failed with: seastar::abort_requested_exception \(abort requested\)",
+            regex=r".*raft_topology - raft_topology_cmd.* failed with: seastar::abort_requested_exception \(abort requested\)",
             extra_time_to_expiration=30
         ))
         stack.enter_context(EventsSeverityChangerFilter(


### PR DESCRIPTION

	The exception of: "stream_ranges failed with: seastar::abort_requested_exception"
	might also be expected on scylla shutdown, therefore should be filtered.
	Fixes: #8371
Fixes: #8371
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- The regex finds the error string like:
```
regex = r".*raft_topology - raft_topology_cmd.* failed with: seastar::abort_requested_exception \(abort requested\)"
test_string = "2024-08-11T16:16:12.017+00:00 longevity-large-partitions-3h-6-0-db-node-ffb10b13-5      !ERR | scylla[10306]:  [shard 0: gms] raft_topology - raft_topology_cmd stream_ranges failed with: seastar::abort_requested_exception (abort requested)"
match = re.search(regex, test_string)
if match:
    print("Match found!")
else:
    print("No match found.")
Match found!
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
