### PR TITLE
fix(nemesis): make argus correctly save end nemesis info after DB shrink

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -94,6 +94,7 @@ from sdcm.sct_events.loaders import CassandraStressLogEvent, ScyllaBenchEvent
 from sdcm.sct_events.nemesis import DisruptionEvent
 from sdcm.sct_events.system import InfoEvent
 from sdcm.sla.sla_tests import SlaTests
+from sdcm.utils.argus import get_argus_client
 from sdcm.utils.aws_kms import AwsKms
 from sdcm.utils import cdc
 from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations
@@ -5147,7 +5148,7 @@ def disrupt_method_wrapper(method, is_exclusive=False):  # pylint: disable=too-m
         if not isinstance(start_time, int):
             start_time = int(start_time)
         try:
-            argus_client = nemesis.target_node.test_config.argus_client()
+            argus_client = get_argus_client(run_id=nemesis.cluster.test_config.test_id())
             if nemesis_event.severity == Severity.ERROR:
                 argus_client.finalize_nemesis(name=method_name, start_time=start_time,
                                               status=NemesisStatus.FAILED, message=nemesis_event.full_traceback)


### PR DESCRIPTION
The decommission operation in nemesis code assigns the `nemesis.target_node` attr with the `None` value.
It leads to the following argus error when nemesis succeeds:
```
    > Traceback (most recent call last):
    >   File "%path%/sdcm/nemesis.py", line 5151, in argus_finalize_nemesis_info
    >     argus_client = nemesis.target_node.test_config.argus_client()
    > AttributeError: 'NoneType' object has no attribute 'test_config'
```
So, avoid this problem by getting argus client without target node.

Closes: https://github.com/scylladb/scylla-cluster-tests/issues/8341

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-longevity-10gb-3h-test#120](https://argus.scylladb.com/test/631c0991-5548-434e-b7a3-f47eb2db8777/runs?additionalRuns[]=af7fcd20-9ce1-4f12-85f7-8e4a61c7b84f)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
