### PR TITLE
improvement(scylla.yaml): support `reader_concurrency_semaphore_cpu_concurrency` option

### DIFF
--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -351,6 +351,8 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods,too-many-
     enable_tablets: bool = None  # False, but default scylla.yaml for some versions (e.g. 6.0) override it to True
     force_gossip_topology_changes: bool = None  # False
 
+    reader_concurrency_semaphore_cpu_concurrency: int = None
+
     def dict(  # pylint: disable=arguments-differ
         self,
         *,

--- a/test-cases/longevity/longevity-gce-custom-d1-workload1-hybrid-raid.yaml
+++ b/test-cases/longevity/longevity-gce-custom-d1-workload1-hybrid-raid.yaml
@@ -140,3 +140,6 @@ scylla_d_overrides_files: [
   'scylla-qa-internal/custom_d1/workload1/scylla.d/io.conf',
   'scylla-qa-internal/custom_d1/workload1/scylla.d/io_properties.yaml',
 ]
+
+append_scylla_yaml:
+  reader_concurrency_semaphore_cpu_concurrency: 10

--- a/test-cases/longevity/longevity-gce-custom-d1-workload2-hybrid-raid.yaml
+++ b/test-cases/longevity/longevity-gce-custom-d1-workload2-hybrid-raid.yaml
@@ -260,3 +260,6 @@ scylla_d_overrides_files: [
   'scylla-qa-internal/custom_d1/workload1/scylla.d/io.conf',
   'scylla-qa-internal/custom_d1/workload1/scylla.d/io_properties.yaml',
 ]
+
+append_scylla_yaml:
+  reader_concurrency_semaphore_cpu_concurrency: 10

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -406,6 +406,7 @@ class ScyllaYamlTest(unittest.TestCase):
                 'write_request_timeout_in_ms': None,
                 'enable_tablets': None,
                 'force_gossip_topology_changes': None,
+                'reader_concurrency_semaphore_cpu_concurrency': None,
             }
         )
 


### PR DESCRIPTION
The `reader_concurrency_semaphore_cpu_concurrency` scylla config option was added recently to mitigate one of the Scylla issues - https://github.com/scylladb/scylla-enterprise/issues/4206

So, add it's support to SCT and start using it in the `custom_d1` ones.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
