### PR TITLE
ci(custom_d1): start using deletion functions

### DIFF
--- a/test-cases/longevity/longevity-gce-custom-d1-workload1-hybrid-raid.yaml
+++ b/test-cases/longevity/longevity-gce-custom-d1-workload1-hybrid-raid.yaml
@@ -114,6 +114,20 @@ stress_cmd:
     --function custom -P row_count=164572800 -P print_applied_func_names=2
     -P codes="\"T1F1-5 , T2F1-4 , T3F2-3,T3F5 , T4F3-5,T4F8 , T5F2\""
     scylla-qa-internal/custom_d1/workload1/latte/custom_d1_workload1.rn
+  # 15) T4F12 -> -r 1k (2x500), deletion scenario 1 - by 1
+  - >-
+    latte run --tag latte --duration 720m --request-timeout 30 --retry-interval '2s,10s'
+    --sampling 5s --threads 30 --connections 3 --concurrency 90 --rate 500
+    --function custom -P row_count=1000000 -P offset=164572800 -P print_applied_func_names=2
+    -P codes="\"T4F12\""
+    scylla-qa-internal/custom_d1/workload1/latte/custom_d1_workload1.rn
+  # 16) T4F13 -> -r 1k, deletion scenario 2 - by many
+  - >-
+    latte run --tag latte --duration 720m --request-timeout 30 --retry-interval '2s,10s'
+    --sampling 5s --threads 30 --connections 3 --concurrency 90 --rate 1000
+    --function custom -P row_count=1000000 -P offset=165572800 -P print_applied_func_names=2
+    -P codes="\"T4F13\""
+    scylla-qa-internal/custom_d1/workload1/latte/custom_d1_workload1.rn
 round_robin: true
 
 gce_instance_type_db: 'n2-highmem-32'

--- a/test-cases/longevity/longevity-gce-custom-d1-workload2-hybrid-raid.yaml
+++ b/test-cases/longevity/longevity-gce-custom-d1-workload2-hybrid-raid.yaml
@@ -234,6 +234,20 @@ stress_cmd:
     --function custom -P row_count=5100100
     -P print_applied_func_names=2 -P codes="\"T4F2\""
     scylla-qa-internal/custom_d1/workload2/latte/custom_d1_workload2.rn
+  # 27) T14F8  -> deletion scenario 1 - by 1
+  - >-
+    latte run --tag latte --duration 720m --request-timeout 30 --retry-interval '2s,10s'
+    --sampling 5s --threads 10 --connections 3 --concurrency 90 --rate 500
+    --function custom -P row_count=1000000 -P offset=150100100 -P print_applied_func_names=2
+    -P codes="\"T14F8\""
+    scylla-qa-internal/custom_d1/workload2/latte/custom_d1_workload2.rn
+  # 28) T14F9  -> deletion scenario 2 - by many
+  - >-
+    latte run --tag latte --duration 720m --request-timeout 30 --retry-interval '2s,10s'
+    --sampling 5s --threads 10 --connections 3 --concurrency 90 --rate 1000
+    --function custom -P row_count=1000000 -P offset=150100100 -P print_applied_func_names=2
+    -P codes="\"T14F9\""
+    scylla-qa-internal/custom_d1/workload2/latte/custom_d1_workload2.rn
 round_robin: true
 
 gce_instance_type_db: 'n2-highmem-32'


### PR DESCRIPTION
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-longevity-gce-custom-d1-workload2-hybrid-raid#32](https://argus.scylladb.com/test/7a8a0e29-e8e2-45c4-9271-ec040095e4a7/runs?additionalRuns[]=e3092f3b-4a0f-4699-91c2-64a35bf5b0c8)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
