### PR TITLE
fix(restore-backup): Fix incorrect suffix on recover_conf()

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -117,7 +117,7 @@ def recover_conf(node):
         node.remoter.run(
             r'for conf in $( rpm -qc $(rpm -qa | grep scylla) | grep -v contains ) '
             r'/etc/systemd/system/{var-lib-scylla,var-lib-systemd-coredump}.mount; '
-            r'do if test -e $conf.backup; then sudo cp -v $conf.backup $conf; fi; done')
+            r'do if test -e $conf.autobackup; then sudo cp -v $conf.autobackup $conf; fi; done')
     else:
         node.remoter.run(
             r'for conf in $(cat /var/lib/dpkg/info/scylla-*server.conffiles '


### PR DESCRIPTION
The commit e3bdc70 mistakenly renamed suffix of backup config file, it become inconsistent between backup_conf() and recover_conf(). It should use .autobackup since backup_conf() uses it.

Fixes #8392
Fixes scylladb/scylladb#19777