### PR TITLE
Use streaming instead of RBNO for a few longevity tests

### DIFF
--- a/configurations/disable_rbno.yaml
+++ b/configurations/disable_rbno.yaml
@@ -1,0 +1,4 @@
+# configuration to disable RBNO (https://opensource.docs.scylladb.com/stable/operating-scylla/procedures/cluster-management/repair-based-node-operation.html)
+# and use good old streaming method
+append_scylla_yaml:
+  enable_repair_based_node_ops: false

--- a/jenkins-pipelines/master-triggers/sct_triggers/tier1-custom-time-trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/tier1-custom-time-trigger.xml
@@ -29,7 +29,7 @@ stress_duration=1440</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>../tier1/longevity-1tb-5days-azure-test,../tier1/longevity-large-partition-200k-pks-4days-gce-test,../tier1/longevity-mv-si-4days-test,../tier1/longevity-schema-topology-changes-12h-test,../tier1/longevity-twcs-48h-test,../tier1/longevity-multidc-schema-topology-changes-12h-test,../tier1/longevity-50gb-3days-test,../tier1/longevity-150gb-asymmetric-cluster-12h-test</projects>
+          <projects>../tier1/longevity-1tb-5days-azure-test,../tier1/longevity-large-partition-200k-pks-4days-gce-test,../tier1/longevity-mv-si-4days-streaming-test,../tier1/longevity-schema-topology-changes-12h-test,../tier1/longevity-twcs-48h-test,../tier1/longevity-multidc-schema-topology-changes-12h-test,../tier1/longevity-50gb-3days-test,../tier1/longevity-150gb-asymmetric-cluster-12h-test</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>

--- a/jenkins-pipelines/master-triggers/sct_triggers/tier2-custom-time-trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/tier2-custom-time-trigger.xml
@@ -26,7 +26,7 @@ stress_duration=360</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>../tier2/longevity-200gb-48h-network-monkey-test,../tier2/longevity-cdc-8h-multi-dc-topology-changes-test,../tier2/longevity-counters-multidc-test,../tier2/longevity-double-cluster-with-schema-changes-test,../tier2/longevity-large-collections-12h-test,../tier2/longevity-large-partition-2days-reversed-queries-test,../tier2/longevity-lwt-24h-gce-test,../tier2/longevity-multi-keyspaces-60h-test,../tier2/longevity-mv-synchronous-updates-12h-test,../tier2/scale-5000-tables-test</projects>
+          <projects>../tier2/longevity-200gb-48h-network-monkey-test,../tier2/longevity-cdc-8h-multi-dc-topology-changes-streaming-test,../tier2/longevity-counters-multidc-test,../tier2/longevity-double-cluster-with-schema-changes-test,../tier2/longevity-large-collections-12h-test,../tier2/longevity-large-partition-2days-reversed-queries-test,../tier2/longevity-lwt-24h-gce-test,../tier2/longevity-multi-keyspaces-60h-test,../tier2/longevity-mv-synchronous-updates-12h-test,../tier2/scale-5000-tables-test</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>

--- a/jenkins-pipelines/oss/longevity/longevity-cdc-8h-multi-dc-topology-changes.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-cdc-8h-multi-dc-topology-changes.jenkinsfile
@@ -3,10 +3,10 @@
 // trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
+// Runs LongevityTest for topology changes with streaming instead of RBNO
 longevityPipeline(
     backend: 'aws',
     region: '''["eu-west-1", "us-east-1"]''',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml'
-
+    test_config: '''["test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml", "configurations/disable_rbno.yaml"]''',
 )

--- a/jenkins-pipelines/oss/longevity/longevity-mv-si-4days.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-mv-si-4days.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-mv-si-4days.yaml'
+    test_config: '''["test-cases/longevity/longevity-mv-si-4days.yaml", "configurations/disable_rbno.yaml"]'''
 
 )

--- a/jenkins-pipelines/oss/sct_triggers/tier1-aws-custom-time-trigger.xml
+++ b/jenkins-pipelines/oss/sct_triggers/tier1-aws-custom-time-trigger.xml
@@ -59,7 +59,7 @@ stress_duration=$stress_duration</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>../tier1/longevity-mv-si-4days-test,../tier1/longevity-schema-topology-changes-12h-test,../tier1/longevity-twcs-48h-test,../tier1/longevity-multidc-schema-topology-changes-12h-test,../tier1/longevity-50gb-3days-test,../tier1/longevity-150gb-asymmetric-cluster-12h-test</projects>
+          <projects>../tier1/longevity-mv-si-4days-streaming-test,../tier1/longevity-schema-topology-changes-12h-test,../tier1/longevity-twcs-48h-test,../tier1/longevity-multidc-schema-topology-changes-12h-test,../tier1/longevity-50gb-3days-test,../tier1/longevity-150gb-asymmetric-cluster-12h-test</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>

--- a/jenkins-pipelines/oss/tier1/longevity-mv-si-4days-streaming.jenkinsfile
+++ b/jenkins-pipelines/oss/tier1/longevity-mv-si-4days-streaming.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-mv-si-4days.yaml", "configurations/disable_rbno.yaml"]'''
+
+)

--- a/jenkins-pipelines/oss/tier2/longevity-cdc-8h-multi-dc-topology-changes-streaming.jenkinsfile
+++ b/jenkins-pipelines/oss/tier2/longevity-cdc-8h-multi-dc-topology-changes-streaming.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+// Runs LongevityTest for topology changes with streaming instead of RBNO
+longevityPipeline(
+    backend: 'aws',
+    region: '''["eu-west-1", "us-east-1"]''',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml", "configurations/disable_rbno.yaml"]''',
+)


### PR DESCRIPTION
### Overview
* Use streaming for one tier1 (`longevity-mv-si-4days`) and one tier2 (`longevity-cdc-8h-multi-dc-topology-changes`) longevity tests
    
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Run `longevity-mv-si-4days` in jenkins
- [ ] Run `longevity-cdc-8h-multi-dc-topology-changes` in jenkins

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Questions
* Are those two tests enough? Should I add more tests from different categories?
    * Are those even right tests? 
* How can I verify that it uses streaming?
* For how long do I need to run tests to verify correctness of this PR?


Fixes https://github.com/scylladb/scylla-cluster-tests/issues/8289