### PR TITLE
improvement(stress): Report two lines of the error, instead of only 100 characters

### DIFF
--- a/sdcm/stress/base.py
+++ b/sdcm/stress/base.py
@@ -151,5 +151,7 @@ def format_stress_cmd_error(exc: Exception) -> str:
     """Format nicely the exception from a stress command failure."""
 
     if hasattr(exc, "result") and exc.result.failed:
-        return f"Stress command completed with bad status {exc.result.exited}: {exc.result.stderr:.100}"
+        # Report only first two lines
+        message = "\n".join(exc.result.stderr.splitlines()[:2])
+        return f"Stress command completed with bad status {exc.result.exited}: {message}"
     return f"Stress command execution failed with: {exc}"


### PR DESCRIPTION
Fixes #8291

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Locally, using wrong stress command

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

