### PR TITLE
improvement(reuse-cluster): make reuse_cluster feature testable in CI

### DIFF
--- a/sdcm/sct_provision/user_data_objects/syslog_ng.py
+++ b/sdcm/sct_provision/user_data_objects/syslog_ng.py
@@ -13,7 +13,11 @@
 from dataclasses import dataclass
 
 from sdcm.provision.common.configuration_script import SYSLOGNG_LOG_THROTTLE_PER_SECOND
-from sdcm.provision.common.utils import configure_syslogng_target_script, restart_syslogng_service, install_syslogng_exporter
+from sdcm.provision.common.utils import (
+    configure_syslogng_target_script,
+    restart_syslogng_service,
+    install_syslogng_exporter,
+    configure_syslogng_destination_conf)
 from sdcm.sct_provision.user_data_objects import SctUserDataObject
 
 
@@ -31,10 +35,9 @@ class SyslogNgUserDataObject(SctUserDataObject):
     @property
     def script_to_run(self) -> str:
         host, port = self.test_config.get_logging_service_host_port()
-        script = configure_syslogng_target_script(host=host,
-                                                  port=port,
-                                                  throttle_per_second=SYSLOGNG_LOG_THROTTLE_PER_SECOND,
-                                                  hostname=self.instance_name)
+        script = configure_syslogng_destination_conf(
+            host=host, port=port, throttle_per_second=SYSLOGNG_LOG_THROTTLE_PER_SECOND)
+        script += configure_syslogng_target_script(hostname=self.instance_name)
         script += restart_syslogng_service()
         return script
 


### PR DESCRIPTION
The change makes the reuse-cluster feature testable/guarded, so we can ensure that it works when it is offered to a wider audience for use in their dev work.

Changes made are:
- add an additional checkbox/boolean option and a step to Jenkins longevity pipeline. If option is selected, the pipeline re-executes the test using the reuse_cluster functionality.
- fix syslog-ng startup script, so that it updates the existing service configuration with correct logging destination host/port on existing instances, when a cluster is reused.
- fix cluster initialization for GCE backend when reusing a cluster, so that it properly searches for existing instances.

### Testing
- [x] :green_circle: GCE backend: [provision-test](https://jenkins.scylladb.com/job/sct-github-PRs-scan/job/scylla-cluster-tests/job/PR-8405/15/)
- [x] :green_circle: AWS backend: [provision-test](https://jenkins.scylladb.com/job/sct-github-PRs-scan/job/scylla-cluster-tests/job/PR-8405/14/)
- [x] :green_circle: [provision-test - regression check when reuse_cluster is not selected](https://jenkins.scylladb.com/job/sct-github-PRs-scan/job/scylla-cluster-tests/job/PR-8405/16/)

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
