### PR TITLE
improvement(known issue): change event severity if known issue closed

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1507,6 +1507,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
                 if obj is None:
                     break
                 event = obj["event"]
+                self.log.debug("Event origin severity: %s", event.severity)
                 if not scylla_debug_file:
                     scylla_debug_file = self.copy_scylla_debug_info(obj["node"], obj["debug_file"])
                 output = self.decode_raw_backtrace(scylla_debug_file, " ".join(event.raw_backtrace.split('\n')))
@@ -1514,6 +1515,18 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
                 the_map = FindIssuePerBacktrace()
                 if issue_url := the_map.find_issue(backtrace_type=event.type, decoded_backtrace=event.backtrace):
                     event.known_issue = issue_url
+                    skip_per_issue = SkipPerIssues(issue_url, self.parent_cluster.params)
+                    # If found issue is closed
+                    if not skip_per_issue.issues_opened():
+                        if skip_per_issue.issues_labeled():
+                            # If found issue has skip label, this issue was fixed but won't be backported to the tested branch.
+                            # So this reactor stall is expected and shouldn't fail the test
+                            # if this event severity is Error or Critical - decrease to warning.
+                            event.severity = Severity.WARNING if event.severity.value > Severity.WARNING.value else event.severity
+                        else:
+                            # If found issue has no skip label - increase severity to Error (if not).
+                            # A reason: the issue was fixed, and it is not expected to get this reactor stall
+                            event.severity = Severity.ERROR if event.severity.value < Severity.ERROR.value else event.severity
                     self.log.debug("Found issue for %s event: %s", event.event_id, event.known_issue)
             except queue.Empty:
                 pass


### PR DESCRIPTION
Posibility to find existing Scylla issue for reactor stall was presented by https://github.com/scylladb/scylla-cluster-tests/pull/7605. This commit takes into account issue status.

If found issue has skip label, this issue was fixed but won't be backported to the tested branch. So this reactor stall is expected and shouldn't fail the test. if this event severity is Error or Critical - decrease to warning.

If found issue has no skip label - increase severity to Error (if not). Because the issue was fixed, and it is not expected to get this reactor stall

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] [rolling_upgrade_with_sla](https://argus.scylladb.com/test/872fbe83-8dcc-4069-b010-f88efb64fc96/runs?additionalRuns[]=fb929fad-87eb-418e-847a-e3dc3536204c)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
