### PR TITLE
Manager restore benchmark improvements

### DIFF
--- a/configurations/manager/1TB_dataset.yaml
+++ b/configurations/manager/1TB_dataset.yaml
@@ -1,14 +1,14 @@
-test_duration: 1440
+test_duration: 2880
 
-prepare_write_cmd: ["cassandra-stress write cl=ALL n=268440000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..268440000",
-                    "cassandra-stress write cl=ALL n=268440000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=268440001..536880000",
-                    "cassandra-stress write cl=ALL n=268440000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=536880001..805320000",
-                    "cassandra-stress write cl=ALL n=268440000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=805320001..1073760000"]
+prepare_write_cmd: ["cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..268435456",
+                    "cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=268435457..536870912",
+                    "cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..805306368",
+                    "cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1073741824"]
 
-stress_read_cmd: ["cassandra-stress read cl=ONE n=268440000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..268440000",
-                  "cassandra-stress read cl=ONE n=268440000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=268440001..536880000",
-                  "cassandra-stress read cl=ONE n=268440000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=536880001..805320000",
-                  "cassandra-stress read cl=ONE n=268440000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=805320001..1073760000"]
+stress_read_cmd: ["cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..268435456",
+                  "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=268435457..536870912",
+                  "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..805306368",
+                  "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1073741824"]
 
 instance_type_db: 'i4i.2xlarge'
 instance_type_loader: 'c6i.2xlarge'

--- a/configurations/manager/1TB_dataset.yaml
+++ b/configurations/manager/1TB_dataset.yaml
@@ -10,5 +10,5 @@ stress_read_cmd: ["cassandra-stress read cl=ONE n=268435456 -schema 'replication
                   "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..805306368",
                   "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1073741824"]
 
-instance_type_db: 'i4i.2xlarge'
+instance_type_db: 'i3en.2xlarge'
 instance_type_loader: 'c6i.2xlarge'

--- a/configurations/manager/2TB_dataset.yaml
+++ b/configurations/manager/2TB_dataset.yaml
@@ -1,14 +1,14 @@
-test_duration: 2880
+test_duration: 4320
 
-prepare_write_cmd: ["cassandra-stress write cl=ALL n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..536880000",
-                    "cassandra-stress write cl=ALL n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=536880001..1073760000",
-                    "cassandra-stress write cl=ALL n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1073760001..1610640000",
-                    "cassandra-stress write cl=ALL n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1610640001..2147520000"]
+prepare_write_cmd: ["cassandra-stress write cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..536870912",
+                    "cassandra-stress write cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..1073741824",
+                    "cassandra-stress write cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1073741825..1610612736",
+                    "cassandra-stress write cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1610612737..2147483648"]
 
-stress_read_cmd: ["cassandra-stress read cl=ONE n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..536880000",
-                  "cassandra-stress read cl=ONE n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=536880001..1073760000",
-                  "cassandra-stress read cl=ONE n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1073760001..1610640000",
-                  "cassandra-stress read cl=ONE n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1610640001..2147520000"]
+stress_read_cmd: ["cassandra-stress read cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..536870912",
+                  "cassandra-stress read cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..1073741824",
+                  "cassandra-stress read cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1073741825..1610612736",
+                  "cassandra-stress read cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1610612737..2147483648"]
 
 instance_type_db: 'i3en.3xlarge'
 instance_type_loader: 'c6i.2xlarge'

--- a/configurations/manager/500GB_dataset.yaml
+++ b/configurations/manager/500GB_dataset.yaml
@@ -1,14 +1,14 @@
-test_duration: 720
+test_duration: 1440
 
-prepare_write_cmd: ["cassandra-stress write cl=ALL n=134220000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..134220000",
-                    "cassandra-stress write cl=ALL n=134220000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=134220001..268440000",
-                    "cassandra-stress write cl=ALL n=134220000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=268440001..402660000",
-                    "cassandra-stress write cl=ALL n=134220000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=402660001..536880000"]
+prepare_write_cmd: ["cassandra-stress write cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..131072000",
+                    "cassandra-stress write cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=131072001..262144000",
+                    "cassandra-stress write cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=262144001..393216000",
+                    "cassandra-stress write cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=393216001..524288000"]
 
-stress_read_cmd: ["cassandra-stress read cl=ONE n=134220000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..134220000",
-                  "cassandra-stress read cl=ONE n=134220000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=134220001..268440000",
-                  "cassandra-stress read cl=ONE n=134220000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=268440001..402660000",
-                  "cassandra-stress read cl=ONE n=134220000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=402660001..536880000"]
+stress_read_cmd: ["cassandra-stress read cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..131072000",
+                  "cassandra-stress read cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=131072001..262144000",
+                  "cassandra-stress read cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=262144001..393216000",
+                  "cassandra-stress read cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=393216001..524288000"]
 
 instance_type_db: 'i4i.2xlarge'
 instance_type_loader: 'c6i.xlarge'

--- a/configurations/manager/5TB_dataset.yaml
+++ b/configurations/manager/5TB_dataset.yaml
@@ -1,14 +1,14 @@
 test_duration: 7200
 
-prepare_write_cmd: ["cassandra-stress write cl=ALL n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..1342200000",
-                    "cassandra-stress write cl=ALL n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1342200001..2684400000",
-                    "cassandra-stress write cl=ALL n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=2684400001..4026600000",
-                    "cassandra-stress write cl=ALL n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=4026600001..5368800000"]
+prepare_write_cmd: ["cassandra-stress write cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1342177280",
+                    "cassandra-stress write cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1342177281..2684354560",
+                    "cassandra-stress write cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=2684354561..4026531840",
+                    "cassandra-stress write cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=4026531841..5368709120"]
 
-stress_read_cmd: ["cassandra-stress read cl=ONE n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..1342200000",
-                  "cassandra-stress read cl=ONE n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1342200001..2684400000",
-                  "cassandra-stress read cl=ONE n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=2684400001..4026600000",
-                  "cassandra-stress read cl=ONE n=1342200000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=4026600001..5368800000"]
+stress_read_cmd: ["cassandra-stress read cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1342177280",
+                  "cassandra-stress read cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1342177281..2684354560",
+                  "cassandra-stress read cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=2684354561..4026531840",
+                  "cassandra-stress read cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=4026531841..5368709120"]
 
 instance_type_db: 'i4i.4xlarge'
-instance_type_loader: 'c6i.4xlarge'
+instance_type_loader: 'c6i.2xlarge'

--- a/defaults/manager_restore_benchmark_snapshots.yaml
+++ b/defaults/manager_restore_benchmark_snapshots.yaml
@@ -1,0 +1,110 @@
+bucket: "manager-backup-tests-permanent-snapshots-us-east-1"
+cs_read_cmd_template: "cassandra-stress read cl=ONE n={num_of_rows} -schema 'keyspace={keyspace_name} replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq={sequence_start}..{sequence_end}"
+sizes:  # size of backed up dataset in GB
+  1gb_1t_ics:
+    tag: "sm_20240812100424UTC"
+    schema:
+      keyspace1:
+        - standard1: 1
+    number_of_rows: 1073760
+    exp_timeout: 1200  # 20 minutes (timeout for restore data operation)
+    scylla_version: "2024.2.0-rc0"
+    number_of_nodes: 3
+    compaction_strategy: "IncrementalCompactionStrategy"
+    prohibit_verification_read: false
+  500gb_1t_ics:
+    tag: "sm_20240813112034UTC"
+    schema:
+      keyspace1:
+        - standard1: 500
+    number_of_rows: 524288000
+    exp_timeout: 14400  # 4 hours
+    scylla_version: "2024.2.0-rc0"
+    number_of_nodes: 3
+    compaction_strategy: "IncrementalCompactionStrategy"
+    prohibit_verification_read: false
+  500gb_1t_ics_tablets:
+    tag: "sm_20240813114617UTC"
+    schema:
+      keyspace1:
+        - standard1: 500
+    number_of_rows: 524288000
+    exp_timeout: 14400  # 4 hours
+    scylla_version: "2024.2.0-rc0"
+    number_of_nodes: 3
+    compaction_strategy: "IncrementalCompactionStrategy"
+    prohibit_verification_read: false
+  500gb_2t_ics:
+    tag: "sm_20240819203428UTC"
+    schema:
+      keyspace1:
+        - standard1: 250
+      keyspace2:
+        - standard1: 250
+    number_of_rows: 524288000
+    exp_timeout: 14400  # 4 hours
+    scylla_version: "2024.2.0-rc0"
+    number_of_nodes: 3
+    compaction_strategy: "IncrementalCompactionStrategy"
+    prohibit_verification_read: true
+  1tb_1t_ics:
+    tag: "sm_20240814180009UTC"
+    schema:
+      keyspace1:
+        - standard1: 1024
+    number_of_rows: 1073741824
+    exp_timeout: 28800  # 8 hours
+    scylla_version: "2024.2.0-rc0"
+    number_of_nodes: 3
+    compaction_strategy: "IncrementalCompactionStrategy"
+    prohibit_verification_read: false
+  1tb_4t_twcs:
+    tag: "sm_20240821145503UTC"
+    schema:
+      keyspace1:
+        - t_10gb: 10
+        - t_90gb: 90
+        - t_300gb: 300
+        - t_600gb: 600
+    number_of_rows: 428571429
+    exp_timeout: 28800  # 8 hours
+    scylla_version: "2024.2.0-rc0"
+    number_of_nodes: 3
+    compaction_strategy: "TimeWindowCompactionStrategy"
+    prohibit_verification_read: true
+  1tb_2t_twcs:
+    tag: "sm_20240827191125UTC"
+    schema:
+      keyspace1:
+        - t_300gb: 300
+        - t_700gb: 700
+    number_of_rows: 428571429
+    exp_timeout: 28800  # 8 hours
+    scylla_version: "2024.2.0-rc0"
+    number_of_nodes: 9
+    compaction_strategy: "TimeWindowCompactionStrategy"
+    prohibit_verification_read: true
+  1.5tb_2t_ics:
+    tag: "sm_20240820180152UTC"
+    schema:
+      keyspace1:
+        - standard1: 500
+      keyspace2:
+        - standard1: 1024
+    number_of_rows: 1598029824
+    exp_timeout: 43200  # 12 hours
+    scylla_version: "2024.2.0-rc0"
+    number_of_nodes: 3
+    compaction_strategy: "IncrementalCompactionStrategy"
+    prohibit_verification_read: true
+  2tb_1t_ics:
+    tag: "sm_20240816185129UTC"
+    schema:
+      keyspace1:
+        - standard1: 2048
+    number_of_rows: 2147483648
+    exp_timeout: 57600  # 16 hours
+    scylla_version: "2024.2.0-rc0"
+    number_of_nodes: 3
+    compaction_strategy: "IncrementalCompactionStrategy"
+    prohibit_verification_read: false

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -364,3 +364,5 @@
 | **<a href="#user-content-bisect_end_date" name="bisect_end_date">bisect_end_date</a>**  | Scylla build date until which bisecting should run. Format: YYYY-MM-DD | N/A | SCT_BISECT_END_DATE
 | **<a href="#user-content-mgmt_restore_params" name="mgmt_restore_params">mgmt_restore_params</a>**  | Manager restore operation specific parameters: batch_size, parallel | N/A | SCT_MGMT_RESTORE_PARAMS
 | **<a href="#user-content-mgmt_agent_backup_config" name="mgmt_agent_backup_config">mgmt_agent_backup_config</a>**  | Manager agent backup general configuration: checkers, transfers, low_level_retries | N/A | SCT_MGMT_AGENT_BACKUP_CONFIG
+| **<a href="#user-content-mgmt_reuse_backup_snapshot_name" name="mgmt_reuse_backup_snapshot_name">mgmt_reuse_backup_snapshot_name</a>**  | Name of backup snapshot to use in Manager restore benchmark test | N/A | SCT_MGMT_REUSE_BACKUP_SNAPSHOT_NAME
+| **<a href="#user-content-mgmt_skip_post_restore_stress_read" name="mgmt_skip_post_restore_stress_read">mgmt_skip_post_restore_stress_read</a>**  | Skip post-restore c-s verification read in the Manager restore benchmark tests | N/A | SCT_MGMT_SKIP_POST_RESTORE_STRESS_READ

--- a/jenkins-pipelines/manager/ubuntu22-manager-backup-restore-custom-dataset.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-backup-restore-custom-dataset.jenkinsfile
@@ -6,10 +6,10 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
-    test_name: 'mgmt_cli_test.MgmtCliTest.test_backup_and_restore_only_data',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_restore_benchmark',
     test_config: 'test-cases/manager/manager-backup-restore-set-dataset.yaml',
     mgmt_restore_params: "{'batch_size': 2, 'parallel': 1}",
-    agent_backup_params: "{'checkers': 100, 'transfers': 2, 'low_level_retries': 20}",
+    mgmt_agent_backup_config: "{'checkers': 100, 'transfers': 2, 'low_level_retries': 20}",
 
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -89,8 +89,12 @@ class BackupFunctionsMixIn(LoaderUtilsMixin):
     def locations(self) -> list[str]:
         backend = self.params.get("backup_bucket_backend")
 
+        buckets = self.params.get("backup_bucket_location")
+        if not isinstance(buckets, list):
+            buckets = buckets.split()
+
         # FIXME: Make it works with multiple locations or file a bug for scylla-manager.
-        return [f"{backend}:{location}" for location in self.params.get("backup_bucket_location").split()[:1]]
+        return [f"{backend}:{location}" for location in buckets[:1]]
 
     def _run_cmd_with_retry(self, executor, cmd, retries=10):
         for _ in range(retries):

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -1336,8 +1336,8 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
         mgr_cluster = self._ensure_and_get_cluster(manager_tool)
 
-        backup_task = mgr_cluster.create_backup_task(location_list=self.locations)
-        backup_task_status = backup_task.wait_and_get_final_status(timeout=110000)
+        backup_task = mgr_cluster.create_backup_task(location_list=self.locations, rate_limit_list=["0"])
+        backup_task_status = backup_task.wait_and_get_final_status(timeout=200000)
         assert backup_task_status == TaskStatus.DONE, \
             f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"
         InfoEvent(message=f'The backup task has ended successfully. Backup run time: {backup_task.duration}').publish()

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -243,22 +243,22 @@ class BackupFunctionsMixIn(LoaderUtilsMixin):
         load_results = load_thread.get_results()
         self.log.info(f'load={load_results}')
 
-    def _parse_stress_cmd(self, stress_cmd, params):
-        # Due to an issue with scylla & cassandra-stress - we need to create the counter table manually
-        if 'counter_' in stress_cmd:
-            self._create_counter_table()
-
-        if 'compression' in stress_cmd:
-            if 'keyspace_name' not in params:
-                compression_prefix = re.search('compression=(.*)Compressor', stress_cmd).group(1)
-                keyspace_name = "keyspace_{}".format(compression_prefix.lower())
-                params.update({'keyspace_name': keyspace_name})
-
-        return params
-
-    @staticmethod
-    def _get_keyspace_name(ks_number, keyspace_pref='keyspace'):
-        return '{}{}'.format(keyspace_pref, ks_number)
+    def get_keyspace_name(self, ks_prefix: str = 'keyspace', ks_number: int = 1) -> list:
+        """Get keyspace name based on the following logic:
+            - if keyspaces number > 1, numeric indexes are used in the ks name;
+            - if keyspaces number == 1, ks name depends on whether compression is applied to keyspace. If applied,
+            the compression postfix will be used in the name, otherwise numeric index (keyspace1)
+        """
+        if ks_number > 1:
+            return ['{}{}'.format(ks_prefix, i) for i in range(1, ks_number + 1)]
+        else:
+            stress_cmd = self.params.get('stress_read_cmd')
+            if 'compression' in stress_cmd:
+                compression_postfix = re.search('compression=(.*)Compressor', stress_cmd).group(1)
+                keyspace_name = '{}_{}'.format(ks_prefix, compression_postfix.lower())
+            else:
+                keyspace_name = '{}{}'.format(ks_prefix, ks_number)
+            return [keyspace_name]
 
     def generate_background_read_load(self):
         self.log.info('Starting c-s read')
@@ -506,9 +506,10 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         InfoEvent(message=f'The backup task has ended successfully. Backup run time: {backup_task.duration}').publish()
         self.manager_test_metrics.backup_time = backup_task.duration
 
-        keyspace_num = self.params.get('keyspace_num') or 1
-        for i in range(1, keyspace_num + 1):
-            self.db_cluster.nodes[0].run_cqlsh(f'TRUNCATE keyspace{i}.standard1')
+        ks_number = self.params.get('keyspace_num') or 1
+        ks_names = self.get_keyspace_name(ks_number=ks_number)
+        for ks_name in ks_names:
+            self.db_cluster.nodes[0].run_cqlsh(f'TRUNCATE {ks_name}.standard1')
 
         if restore_params := self.params.get('mgmt_restore_params'):
             batch_size = restore_params.batch_size

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -179,9 +179,9 @@ class RestoreParameters(BaseModel):
 
 
 class AgentBackupParameters(BaseModel):
-    checkers: Optional[int]
-    transfers: Optional[int]
-    low_level_retries: Optional[int]
+    checkers: Optional[int] = 100
+    transfers: Optional[int] = 2
+    low_level_retries: Optional[int] = 20
 
     class Config:
         extra = Extra.forbid

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1130,6 +1130,13 @@ class SCTConfiguration(dict):
              help="Manager agent backup general configuration: checkers, transfers, low_level_retries. "
                   "For example, {'checkers': 100, 'transfers': 2, 'low_level_retries': 20}"),
 
+        dict(name="mgmt_reuse_backup_snapshot_name", env="SCT_MGMT_REUSE_BACKUP_SNAPSHOT_NAME", type=str,
+             help="Name of backup snapshot to use in Manager restore benchmark test, for example, 500gb_2t_ics. "
+                  "The name provides the info about dataset size (500gb), tables number (2) and compaction (ICS)"),
+
+        dict(name="mgmt_skip_post_restore_stress_read", env="SCT_MGMT_SKIP_POST_RESTORE_STRESS_READ", type=boolean,
+             help="Skip post-restore c-s verification read in the Manager restore benchmark tests"),
+
         # PerformanceRegressionTest
 
         dict(name="stress_cmd_w", env="SCT_STRESS_CMD_W",

--- a/test-cases/manager/manager-backup-restore-set-dataset.yaml
+++ b/test-cases/manager/manager-backup-restore-set-dataset.yaml
@@ -1,6 +1,13 @@
+test_duration: 720
+
 round_robin: true
 
-instance_type_db: 'i4i.2xlarge'
+# 1GB dataset
+prepare_write_cmd: ["cassandra-stress write cl=ONE n=1048576 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=50 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1048576"]
+stress_read_cmd: ["cassandra-stress read cl=ONE n=1048576 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=50 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1048576"]
+
+instance_type_db: 'i4i.xlarge'
+instance_type_loader: 'c6i.xlarge'
 
 region_name: us-east-1
 n_db_nodes: 3
@@ -11,5 +18,4 @@ post_behavior_db_nodes: "destroy"
 post_behavior_loader_nodes: "destroy"
 post_behavior_monitor_nodes: "destroy"
 
-user_prefix: manager-restore
-space_node_threshold: 6442
+user_prefix: 'manager-restore-benchmark'

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -147,6 +147,12 @@ def call(Map pipelineParams) {
                                    For example, {'batch_size': 2, 'parallel': 1}""",
                    name: 'mgmt_restore_params')
 
+            string(defaultValue: "${pipelineParams.get('mgmt_reuse_backup_snapshot_name', '')}",
+                   description: """Name of backup snapshot to use in Manager restore benchmark test, for example, 500gb_2t_ics.
+                                   The name provides the info about dataset size (500gb), number of tables (2) and compaction (ICS).
+                                   All snapshots are defined in the 'https://github.com/scylladb/scylla-cluster-tests/blob/master/defaults/manager_restore_benchmark_snapshots.yaml'""",
+                   name: 'mgmt_reuse_backup_snapshot_name')
+
             string(defaultValue: "${pipelineParams.get('mgmt_agent_backup_config', '')}",
                    description: """Backup general configuration for the agent (scylla-manager-agent.yaml):
                                    checkers, transfers, low_level_retries.
@@ -168,7 +174,8 @@ def call(Map pipelineParams) {
                      'Extra environment variables to be set in the test environment, uses the java Properties File Format.\n' +
                      'Example:\n' +
                      '\tSCT_STRESS_IMAGE.cassandra-stress=scylladb/cassandra-stress:3.13.0\n' +
-                     '\tSCT_N_DB_NODES=6'
+                     '\tSCT_N_DB_NODES=6\n' +
+                     '\tSCT_MGMT_SKIP_POST_RESTORE_STRESS_READ=true\n'
                      ),
                  name: 'extra_environment_variables')
         }
@@ -352,6 +359,10 @@ def call(Map pipelineParams) {
 
                                         if [[ ! -z "${params.mgmt_restore_params}" ]] ; then
                                             export SCT_MGMT_RESTORE_PARAMS="${params.mgmt_restore_params}"
+                                        fi
+
+                                        if [[ ! -z "${params.mgmt_reuse_backup_snapshot_name}" ]] ; then
+                                            export SCT_MGMT_REUSE_BACKUP_SNAPSHOT_NAME="${params.mgmt_reuse_backup_snapshot_name}"
                                         fi
 
                                         if [[ ! -z "${params.mgmt_agent_backup_config}" ]] ; then

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -54,6 +54,10 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('backup_bucket_backend', '')}",
                description: 's3|gcs|azure or empty',
                name: 'backup_bucket_backend')
+            string(defaultValue: "${pipelineParams.get('backup_bucket_location', '')}",
+               description: """Backup bucket name, if empty - the default 'manager-backup-tests-us-east-1' bucket is used.
+                               'manager-backup-tests-permanent-snapshots-us-east-1' bucket can be used to store backups permanently.""",
+               name: 'backup_bucket_location')
             string(defaultValue: "${pipelineParams.get('backend', 'aws')}",
                description: 'aws|gce',
                name: 'backend')
@@ -301,6 +305,10 @@ def call(Map pipelineParams) {
 
                                         if [[ -n "${params.backup_bucket_backend}" ]] ; then
                                             export SCT_BACKUP_BUCKET_BACKEND="${params.backup_bucket_backend}"
+                                        fi
+
+                                        if [[ -n "${params.backup_bucket_location}" ]] ; then
+                                            export SCT_BACKUP_BUCKET_LOCATION="${params.backup_bucket_location}"
                                         fi
 
                                         if [[ ! -z "${params.scylla_ami_id}" ]] ; then


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-manager/issues/3950

So, the PR introduces the new flow for Manager restore benchmark test - adds the option to run restore from pre-created backups - as well as improves the current approach.

The short summary of changes:
- Introduced the test that restores from pre-created backup. At the same time, the existing approach with populating the data, creating the backup from scratch and consecutive restore is kept in place;
- Some fixes to c-s stress cmds to speed up large datasets population process;
- Set rate limit to 0 to speed up backup operation in restore benchmark test;
- Added backup_bucket_location to list of Manager job parameters.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Restore from pre-created backup [test](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master/job/backup-restore-custom-dataset-test-PR/4/);
- [x] The full flow [test](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master/job/backup-restore-custom-dataset-test-PR/3/);
- [x] Don't ignore verification read [run](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master/job/backup-restore-custom-dataset-test-PR/9/).

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)