### PR TITLE
fix(reuse_cluster): fix reuse_cluster flow for k8s-local-kind backend

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -532,7 +532,8 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
     @cached_property
     def tags(self) -> Dict[str, str]:
         return {**self.parent_cluster.tags,
-                "Name": str(self.name), "UserName": str(self.ssh_login_info.get('user'))}
+                "Name": str(self.name),
+                "UserName": str(self.ssh_login_info.get('user')) if self.ssh_login_info else ''}
 
     def _set_keep_alive(self):
         ContainerManager.set_all_containers_keep_alive(self)


### PR DESCRIPTION
sdcm.cluster.BaseNode.tags property attribute gets one of tag values from sdcm.cluster.BaseNode.ssh_login_info dict attribute, without checking if the latter has a value (by default ssh_login_info is None).

The commit addresses the problem by adding the corresponding check, to ensure that ssh_login_info has a value.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/8404

### Testing
- [x] tested locally as the CI does not have yet reuse cluster option in pipelines

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
