### PR TITLE
fix(cluster.py): make `cpu_cores` function be resilient to multiline printouts

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -598,7 +598,9 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
     def cpu_cores(self) -> Optional[int]:
         try:
             result = self.remoter.run("nproc", ignore_status=True)
-            return int(result.stdout)
+            # NOTE: there may be additional print outs before expected integer in the stdout.
+            #       One of such examples - K8S setups.
+            return int(([s for s in result.stdout.splitlines() if s.isdigit()] or [result.stdout])[0])
         except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
             self.log.error("Failed to get number of cores due to the %s", details)
         return None


### PR DESCRIPTION
Example of an error is here: https://jenkins.scylladb.com/job/scylla-operator/job/operator-master/job/functional/job/functional-k8s-local-kind-aws-test/65/consoleFull

```
13:18:52  < t:2024-08-23 10:18:51,784 f:decorators.py   l:71   c:sdcm.utils.decorators p:INFO  > \
    local-dc-1: Wait for the '3' pod(s) from the 'scylla' namespace with 'jsonpath='{.status.phase}'=Running' condition to be true... [try #1]
13:19:02  < t:2024-08-23 10:19:01,460 f:cluster.py      l:603  c:sdcm.cluster         p:ERROR > \
    Failed to get number of cores due to the invalid literal for int() with base 10: \
        "cp: can't stat '/etc/scylla/cassandra/logback-tools.xml': No such file or directory\n8\n"
13:19:42  < t:2024-08-23 10:19:36,265 f:decorators.py   l:71   c:sdcm.utils.decorators p:INFO  > \
    local-dc-1: Wait for the '3' pod(s) from the 'scylla' namespace with 'jsonpath='{.status.phase}'=Running' condition to be true... [try #2]
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
