### PR TITLE
fix(events): make S-B distribution failure event filter be more precise

### DIFF
--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -267,8 +267,11 @@ ScyllaBenchLogEvent.add_subevent_type("ConsistencyError", severity=Severity.ERRO
 ScyllaBenchLogEvent.add_subevent_type("DataValidationError", severity=Severity.CRITICAL,
                                       regex=r"doesn't match |failed to validate data|failed to verify checksum|corrupt checksum or data|"
                                             r"data corruption")
-ScyllaBenchLogEvent.add_subevent_type("ParseDistributionError", severity=Severity.CRITICAL,
-                                      regex=r"missing parameter|unexpected parameter|unsupported|invalid")
+ScyllaBenchLogEvent.add_subevent_type(
+    "ParseDistributionError",
+    severity=Severity.CRITICAL,
+    regex=r"missing parameter|unexpected parameter|unsupported"
+          r"|invalid input value|distribution is invalid|distribution has invalid format")
 
 
 SCYLLA_BENCH_ERROR_EVENTS = (


### PR DESCRIPTION
The `invalid` word may easily be printed out by `gocql` driver in some warning.
In this case it should not be taken by the `ParseDistributionError` SCT event.

So, fix it by using more precise templates.

Closes: #7705

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
