### PR TITLE
Mixed shard repair reproducer

### DIFF
--- a/configurations/custom-smp-per-node-for-repair.yaml
+++ b/configurations/custom-smp-per-node-for-repair.yaml
@@ -1,0 +1,6 @@
+smp_per_db_node_mapping: [16, 16, 16, 12]
+
+hinted_handoff: 'disabled'
+
+append_scylla_yaml:
+  enable_tablets: false

--- a/jenkins-pipelines/oss/features/features-fixed-shard-repair.jenkinsfile
+++ b/jenkins-pipelines/oss/features/features-fixed-shard-repair.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'mixed_shard_repair_test.MixedShardRepair.test_mix_shard_ops',
+    test_config: 'test-cases/features/fixed-shard-repair.yaml',
+)

--- a/jenkins-pipelines/oss/features/features-mixed-shard-repair.jenkinsfile
+++ b/jenkins-pipelines/oss/features/features-mixed-shard-repair.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'mixed_shard_repair_test.MixedShardRepair.test_mix_shard_ops',
+    test_config: 'test-cases/features/mixed-shard-repair.yaml',
+)

--- a/jenkins-pipelines/oss/longevity/longevity-150gb-asymmetric-custom-shards-cluster-12h-gce.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-150gb-asymmetric-custom-shards-cluster-12h-gce.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'gce',
+    region: 'us-east1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml", "configurations/custom-smp-per-node-for-repair.yaml"]'''
+)

--- a/jenkins-pipelines/oss/longevity/longevity-200gb-48h-asymmetric-custom-shards.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-200gb-48h-asymmetric-custom-shards.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: """["test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml", "configurations/custom-smp-per-node-for-repair.yaml"]""",
+
+)

--- a/mixed_shard_repair_test.py
+++ b/mixed_shard_repair_test.py
@@ -1,0 +1,54 @@
+from sdcm.tester import ClusterTester
+from sdcm.utils.decorators import measure_time
+
+
+class MixedShardRepair(ClusterTester):
+
+    @measure_time
+    def _run_repair(self, node):
+        node.run_nodetool(sub_cmd='repair')
+
+    @measure_time
+    def _run_bootstrap(self):
+        new_node = self.db_cluster.add_nodes(count=1)[0]
+        self.db_cluster.wait_for_init(node_list=[new_node])
+        return new_node
+
+    @measure_time
+    def _run_rebuild(self, node):
+        node.run_nodetool(sub_cmd='rebuild')
+
+    @measure_time
+    def _run_decommission(self, node):
+        node.run_nodetool(sub_cmd='decommission')
+
+    def _repair(self, node):
+        self.log.info('Running nodetool repair on {}'.format(node.name))
+        repair_time = self._run_repair(node=node)[0]  # pylint: disable=unsubscriptable-object
+        self.log.info('Repair time on node: {} is: {}'.format(node.name, repair_time))
+
+    def _bootstrap(self):
+        self.log.info('Bootstrapping a new node...')
+        bootstrap_time, new_node = self._run_bootstrap()
+        self.monitors.reconfigure_scylla_monitoring()
+        self.log.info('Bootstrap time of node: {} is: {}'.format(new_node.name, bootstrap_time))
+        return new_node
+
+    def _rebuild(self, node):
+        self.log.info('Rebuilding a node: {}...'.format(node.name))
+        rebuild_time = self._run_rebuild(node=node)[0]  # pylint: disable=unsubscriptable-object
+        self.log.info('Rebuild time of node: {} is: {}'.format(node.name, rebuild_time))
+
+    def _decommission(self, node):
+        self.log.info('Decommission of a node: {}...'.format(node.name))
+        decommission_time = self._run_decommission(node=node)[0]  # pylint: disable=unsubscriptable-object
+        self.log.info('Decommission time of node: {} is: {}'.format(node.name, decommission_time))
+
+    def test_mix_shard_ops(self):
+        self.populate_data_parallel(size_in_gb=1024, replication_factor=3, blocking=True)
+        node1 = self.db_cluster.nodes[0]
+        node2 = self.db_cluster.nodes[1]
+        node3 = self._bootstrap()
+        self._repair(node1)
+        self._rebuild(node2)
+        self._decommission(node3)

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -15,7 +15,7 @@ import os
 import re
 import time
 import logging
-from typing import Dict, Any, ParamSpec, TypeVar
+from typing import Dict, Any, Optional, ParamSpec, TypeVar
 from textwrap import dedent
 from functools import cached_property, cache
 from collections.abc import Callable
@@ -70,7 +70,7 @@ class GCENode(cluster.BaseNode):
 
     log = LOGGER
 
-    def __init__(self, gce_instance: compute_v1.Instance,
+    def __init__(self, gce_instance: compute_v1.Instance,     # noqa: PLR0913
                  gce_service: compute_v1.InstancesClient,
                  credentials,
                  parent_cluster,
@@ -79,7 +79,8 @@ class GCENode(cluster.BaseNode):
                  base_logdir: str = None,
                  dc_idx: int = 0,
                  rack: int = 0,
-                 gce_project: str = None):
+                 gce_project: str = None,
+                 shard_num: Optional[int] = None):
         name = f"{node_prefix}-{dc_idx}-{node_index}".lower()
         self.node_index = node_index
         self.project = gce_project
@@ -97,7 +98,8 @@ class GCENode(cluster.BaseNode):
                          base_logdir=base_logdir,
                          node_prefix=node_prefix,
                          dc_idx=dc_idx,
-                         rack=rack)
+                         rack=rack,
+                         shard_num=shard_num)
 
     def refresh_network_interfaces_info(self):
         pass
@@ -274,7 +276,7 @@ class GCECluster(cluster.BaseCluster):
                  cluster_uuid=None, gce_instance_type='n2-standard-1', gce_region_names=None,
                  gce_n_local_ssd=1, gce_image_username='root', cluster_prefix='cluster',
                  node_prefix='node', n_nodes=3, add_disks=None, params=None, node_type=None,
-                 service_accounts=None, add_nodes=True):
+                 service_accounts=None, add_nodes=True, nodes_smp=None):
 
         self._gce_image = gce_image
         self._gce_image_type = gce_image_type
@@ -298,7 +300,8 @@ class GCECluster(cluster.BaseCluster):
                          params=params,
                          region_names=gce_region_names,
                          node_type=node_type,
-                         add_nodes=add_nodes)
+                         add_nodes=add_nodes,
+                         nodes_smp=nodes_smp or [])
         self.log.debug("GCECluster constructor")
 
     def __str__(self):
@@ -517,7 +520,8 @@ class GCECluster(cluster.BaseCluster):
                            node_index=node_index,
                            base_logdir=self.logdir,
                            dc_idx=dc_idx,
-                           rack=rack)
+                           rack=rack,
+                           shard_num=self.get_node_shard_num(node_index))
             node.init()
             return node
         except Exception as ex:  # noqa: BLE001
@@ -559,7 +563,7 @@ class ScyllaGCECluster(cluster.BaseScyllaCluster, GCECluster):
     def __init__(self, gce_image, gce_image_type, gce_image_size, gce_network, gce_service, credentials,  # noqa: PLR0913
                  gce_instance_type='n2-standard-1', gce_n_local_ssd=1,
                  gce_image_username='centos',
-                 user_prefix=None, n_nodes=3, add_disks=None, params=None, gce_datacenter=None, service_accounts=None):
+                 user_prefix=None, n_nodes=3, add_disks=None, params=None, gce_datacenter=None, service_accounts=None, nodes_smp=None):
         # We have to pass the cluster name in advance in user_data
         cluster_prefix = cluster.prepend_user_prefix(user_prefix, 'db-cluster')
         node_prefix = cluster.prepend_user_prefix(user_prefix, 'db-node')
@@ -581,6 +585,7 @@ class ScyllaGCECluster(cluster.BaseScyllaCluster, GCECluster):
             gce_region_names=gce_datacenter,
             node_type='scylla-db',
             service_accounts=service_accounts,
+            nodes_smp=nodes_smp or [],
         )
         self.version = '2.1'
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1743,7 +1743,7 @@ class BasePodContainer(cluster.BaseNode):
     pod_terminate_timeout = 5  # minutes
 
     def __init__(self, name: str, parent_cluster: PodCluster, node_prefix: str = "node", node_index: int = 1,
-                 base_logdir: Optional[str] = None, dc_idx: int = 0, rack=0):
+                 base_logdir: Optional[str] = None, dc_idx: int = 0, rack=0, shard_num=None):
         self.node_index = node_index
         cluster.BaseNode.__init__(
             self, name=name,
@@ -1751,7 +1751,8 @@ class BasePodContainer(cluster.BaseNode):
             base_logdir=base_logdir,
             node_prefix=node_prefix,
             dc_idx=dc_idx,
-            rack=rack)
+            rack=rack,
+            shard_num=shard_num)
         self.k8s_cluster = self.parent_cluster.k8s_clusters[self.dc_idx]
         self._rack_name = None
 
@@ -2324,7 +2325,7 @@ class LoaderStsContainer(BasePodContainer):
 class PodCluster(cluster.BaseCluster):
     PodContainerClass: Type[BasePodContainer] = BasePodContainer
 
-    def __init__(self,
+    def __init__(self,  # pylint: disable=too-many-arguments  # noqa: PLR0913
                  k8s_clusters: List[KubernetesCluster],
                  namespace: str = "default",
                  container: Optional[str] = None,
@@ -2336,6 +2337,7 @@ class PodCluster(cluster.BaseCluster):
                  params: Optional[dict] = None,
                  node_pool_name: Optional[str] = '',
                  add_nodes: Optional[bool] = True,
+                 nodes_smp: Optional[list[int]] = None
                  ) -> None:
         self.k8s_clusters = k8s_clusters
         self.namespace = namespace
@@ -2349,7 +2351,8 @@ class PodCluster(cluster.BaseCluster):
                          params=params,
                          region_names=[],
                          node_type=node_type,
-                         add_nodes=add_nodes)
+                         add_nodes=add_nodes,
+                         nodes_smp=nodes_smp or [])
 
     def __str__(self):
         return f"{type(self).__name__} {self.name} | Namespace: {self.namespace}"
@@ -2365,7 +2368,8 @@ class PodCluster(cluster.BaseCluster):
                                       node_prefix=self.node_prefix,
                                       node_index=node_index,
                                       dc_idx=dc_idx,
-                                      rack=rack)
+                                      rack=rack,
+                                      shard_num=self.get_node_shard_num(node_index))
         # NOTE: use lock to avoid hanging running in a multitenant setup
         with NODE_INIT_LOCK:
             node.init()
@@ -2500,6 +2504,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):
                  params: Optional[dict] = None,
                  node_pool_name: str = '',
                  add_nodes: bool = True,
+                 nodes_smp: Optional[list[int]] = None
                  ) -> None:
         self.k8s_clusters = k8s_clusters
         self.namespace = self.generate_namespace(namespace_template=SCYLLA_NAMESPACE)
@@ -2523,7 +2528,8 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):
                          n_nodes=n_nodes,
                          params=params,
                          node_pool_name=node_pool_name,
-                         add_nodes=add_nodes)
+                         add_nodes=add_nodes,
+                         nodes_smp=nodes_smp or [])
         # NOTE: register callbacks for the Scylla pods IP change events
         for k8s_cluster in k8s_clusters:
             if k8s_cluster.scylla_pods_ip_change_tracker_thread:

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -548,6 +548,9 @@ class SCTConfiguration(dict):
              In case of random option - Scylla will start with different (random) shards on every node of the cluster
              """),
 
+        dict(name="smp_per_db_node_mapping", env="SCT_SMP_PER_DB_NODE_MAPPING", type=str_or_list_or_eval,
+             help="List of shard number to set per node in Scylla cluster; list of int, like [4, 5, 3]"),
+
         dict(name="seeds_selector", env="SCT_SEEDS_SELECTOR", type=str,
              choices=['random', 'first', 'all'],
              help="""How to select the seeds. Expected values: random/first/all"""),

--- a/test-cases/features/fixed-shard-repair.yaml
+++ b/test-cases/features/fixed-shard-repair.yaml
@@ -1,0 +1,18 @@
+test_duration: 6000
+
+n_db_nodes: 3
+n_loaders: 4
+n_monitor_nodes: 1
+
+smp_per_db_node_mapping: [16, 16, 16, 16]
+
+instance_type_db: 'i3en.6xlarge'
+instance_type_loader: 'c6i.2xlarge'
+
+collect_logs: true
+backtrace_decoding: true
+
+hinted_handoff: 'disabled'
+
+append_scylla_yaml:
+  enable_tablets: false

--- a/test-cases/features/mixed-shard-repair.yaml
+++ b/test-cases/features/mixed-shard-repair.yaml
@@ -1,0 +1,18 @@
+test_duration: 6000
+
+n_db_nodes: 3
+n_loaders: 4
+n_monitor_nodes: 1
+
+smp_per_db_node_mapping: [16, 16, 16, 12]
+
+instance_type_db: 'i3en.6xlarge'
+instance_type_loader: 'c6i.2xlarge'
+
+collect_logs: true
+backtrace_decoding: true
+
+hinted_handoff: 'disabled'
+
+append_scylla_yaml:
+  enable_tablets: false


### PR DESCRIPTION
Reproducer for mixed shard repair to choose the best solution for https://github.com/scylladb/scylladb/issues/18269.

Sets up a 3-node cluster on AWS with 1TB of data and runs repair.

It will be run with jenkins with the following configurations:
- on master; each node has the same number of shards (60)
- on master; nodes will have 60, 59, 58 shards
- POC1 (https://github.com/scylladb/scylladb/pull/20295); 60, 59, 58
- POC2 (https://github.com/scylladb/scylladb/pull/20296); 60, 59, 58
