### PR TITLE
improvement(perf-simple-query): send results to argus

### DIFF
--- a/microbenchmarking_test.py
+++ b/microbenchmarking_test.py
@@ -11,6 +11,8 @@
 #
 # Copyright (c) 2023 ScyllaDB
 import json
+
+from sdcm.argus_results import send_perf_simple_query_result_to_argus
 from sdcm.tester import ClusterTester, teardown_on_exception, log_run_info
 from sdcm.utils.microbenchmarking.perf_simple_query_reporter import PerfSimpleQueryAnalyzer
 
@@ -28,12 +30,18 @@ class PerfSimpleQueryTest(ClusterTester):
         result = self.db_cluster.nodes[0].remoter.run(
             "scylla perf-simple-query --json-result=perf-simple-query-result.txt --smp 1 -m 1G")
         if result.ok:
+            regression_report = {}
             output = self.db_cluster.nodes[0].remoter.run("cat perf-simple-query-result.txt").stdout
+            results = json.loads(output)
             self.create_test_stats(
-                specific_tested_stats={"perf_simple_query_result": json.loads(output)},
+                specific_tested_stats={"perf_simple_query_result": results},
                 doc_id_with_timestamp=True)
             if self.create_stats:
                 is_gce = self.params.get('cluster_backend') == 'gce'
-                PerfSimpleQueryAnalyzer(self._test_index, self._es_doc_type).check_regression(
+                regression_report = PerfSimpleQueryAnalyzer(self._test_index, self._es_doc_type).check_regression(
                     self._test_id, is_gce=is_gce,
                     extra_jobs_to_compare=self.params.get('perf_extra_jobs_to_compare'))
+            send_perf_simple_query_result_to_argus(self.test_config.argus_client(),
+                                                   results,
+                                                   regression_report.get("scylla_date_results_table", [])
+                                                   )

--- a/sdcm/utils/microbenchmarking/perf_simple_query_reporter.py
+++ b/sdcm/utils/microbenchmarking/perf_simple_query_reporter.py
@@ -47,7 +47,8 @@ class PerfSimpleQueryAnalyzer(BaseResultsAnalyzer):
         keys.sort(reverse=True)
         return [results[key] for key in keys]
 
-    def check_regression(self, test_id, mad_deviation_limit=0.02, regression_limit=0.05, is_gce=False, extra_jobs_to_compare=None):  # pylint: disable=too-many-locals,too-many-statements  # noqa: PLR0914
+    def check_regression(self, test_id, mad_deviation_limit=0.02, regression_limit=0.05, is_gce=False, extra_jobs_to_compare=None  # pylint: disable=too-many-locals,too-many-statements  # noqa: PLR0914
+                         ) -> dict:
         doc = self.get_test_by_id(test_id)
         if not doc:
             self.log.error('Cannot find test by id: {}!'.format(test_id))
@@ -150,3 +151,4 @@ class PerfSimpleQueryAnalyzer(BaseResultsAnalyzer):
         file_path = os.path.join(TestConfig.logdir(), 'email_data.json')
         with open(file_path, 'w', encoding="utf-8") as file:
             json.dump(for_render, file)
+        return for_render


### PR DESCRIPTION
Sending perf-simple-query results to Argus.

refs: https://github.com/scylladb/qa-tasks/issues/1244

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [perf-simple-query test - argus](https://argus.scylladb.com/test/20c7e63e-f5ba-4ca2-946a-efec89b57949/runs?additionalRuns[]=2ba20be4-3f86-49e1-9f47-f3431eea2a82)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
