### PR TITLE
ci(provisionResources): set SCT_N_DB_NODES variable on provision stage

### DIFF
--- a/vars/provisionResources.groovy
+++ b/vars/provisionResources.groovy
@@ -130,6 +130,10 @@ def call(Map params, String region){
         export SCT_MANAGER_VERSION="${params.manager_version}"
     fi
 
+    if [[ -n "${params.n_db_nodes ? params.n_db_nodes : ''}" ]] ; then
+        export SCT_N_DB_NODES=${params.n_db_nodes}
+    fi
+
     if [[ -n "${params.pytest_addopts ? params.pytest_addopts : ''}" ]] ; then
         export PYTEST_ADDOPTS="${params.pytest_addopts}"
     fi


### PR DESCRIPTION
Having this parameter SCT_N_DB_NODES set, allows to vary the number of nodes in Manager jobs where the input param (n_db_nodes) exists and is used from time to time.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Test](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-installation-test/6/) with set n_db_nodes value (3) in Jenkins job. Default value defined by test-case.yaml is 1. The test was started with 3 DB nodes.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)