### PR TITLE
fix(operator.py): Increased timeout for get_mgr_backup_task method

### DIFF
--- a/sdcm/mgmt/operator.py
+++ b/sdcm/mgmt/operator.py
@@ -343,7 +343,7 @@ class OperatorManagerCluster(ManagerCluster):
             func=self.get_operator_backup_task_status,
             text=f"Waiting until operator backup task '{so_backup_task.name}' get it's status",
             step=2,
-            timeout=300,
+            timeout=600,
             task_name=so_backup_task.name,
             throw_exc=True)
         for mgr_task in self.backup_task_list:


### PR DESCRIPTION
Some of the longevity tests for the Operator (e.g., [longevity-scylla-operator-3h-eks-backup-test](https://jenkins.scylladb.com/job/scylla-operator/job/operator-master/job/gke/job/longevity-scylla-operator-3h-gke-backup-test/)) are failing because they exceed the 300 second timeout set in the get_mgr_backup_task method. After investigation, I noticed that this operation can take up to approximately 8 minutes, so I increased the timeout to 10 minutes. Link to successful run after increasing timeout [here](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/kamil-grzywinski/job/longevity-scylla-operator-3h-eks-backup-test/3/)