### PR TITLE
improvement(c-s): use latest cassandra-stress docker image

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -209,7 +209,7 @@ stress_image:
   ndbench: 'scylladb/hydra-loaders:ndbench-jdk8-20210720'
   ycsb: 'scylladb/hydra-loaders:ycsb-jdk8-20220918'
   nosqlbench: 'scylladb/hydra-loaders:nosqlbench-5.21.2'
-  cassandra-stress: 'scylladb/cassandra-stress:3.12.2'
+  cassandra-stress: 'scylladb/cassandra-stress:3.13.0'
   scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.22'
   gemini: 'scylladb/hydra-loaders:gemini-v1.8.6'
   alternator-dns: 'scylladb/hydra-loaders:alternator-dns-0.1'

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -88,7 +88,7 @@ def call(Map pipelineParams) {
                     description: (
                         'Extra environment variables to be set in the test environment, uses the java Properties File Format.\n' +
                         'Example:\n' +
-                        '\tSCT_STRESS_IMAGE.cassandra-stress=scylladb/cassandra-stress:3.12.1\n' +
+                        '\tSCT_STRESS_IMAGE.cassandra-stress=scylladb/cassandra-stress:3.13.0\n' +
                         '\tSCT_USE_MGMT=false'
                         ),
                     name: 'extra_environment_variables')

--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -110,7 +110,7 @@ def call() {
                  description: (
                      'Extra environment variables to be set in the test environment, uses the java Properties File Format.\n' +
                      'Example:\n' +
-                     '\tSCT_STRESS_IMAGE.cassandra-stress=scylladb/cassandra-stress:3.12.1\n' +
+                     '\tSCT_STRESS_IMAGE.cassandra-stress=scylladb/cassandra-stress:3.13.0\n' +
                      '\tSCT_USE_MGMT=false'
                      ),
                  name: 'extra_environment_variables')

--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -75,7 +75,7 @@ def call(Map pipelineParams) {
                  description: (
                      'Extra environment variables to be set in the test environment, uses the java Properties File Format.\n' +
                      'Example:\n' +
-                     '\tSCT_STRESS_IMAGE.cassandra-stress=scylladb/cassandra-stress:3.12.1\n' +
+                     '\tSCT_STRESS_IMAGE.cassandra-stress=scylladb/cassandra-stress:3.13.0\n' +
                      '\tSCT_USE_MGMT=false'
                      ),
                  name: 'extra_environment_variables')

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -158,7 +158,7 @@ def call(Map pipelineParams) {
                     description: (
                         'Extra environment variables to be set in the test environment, uses the java Properties File Format.\n' +
                         'Example:\n' +
-                        '\tSCT_STRESS_IMAGE.cassandra-stress=scylladb/cassandra-stress:3.12.1\n' +
+                        '\tSCT_STRESS_IMAGE.cassandra-stress=scylladb/cassandra-stress:3.13.0\n' +
                         '\tSCT_USE_MGMT=false'
                         ),
                     name: 'extra_environment_variables')

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -167,7 +167,7 @@ def call(Map pipelineParams) {
                  description: (
                      'Extra environment variables to be set in the test environment, uses the java Properties File Format.\n' +
                      'Example:\n' +
-                     '\tSCT_STRESS_IMAGE.cassandra-stress=scylladb/cassandra-stress:3.12.1\n' +
+                     '\tSCT_STRESS_IMAGE.cassandra-stress=scylladb/cassandra-stress:3.13.0\n' +
                      '\tSCT_N_DB_NODES=6'
                      ),
                  name: 'extra_environment_variables')

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -110,7 +110,7 @@ def call(Map pipelineParams) {
                  description: (
                      'Extra environment variables to be set in the test environment, uses the java Properties File Format.\n' +
                      'Example:\n' +
-                     '\tSCT_STRESS_IMAGE.cassandra-stress=scylladb/cassandra-stress:3.12.1\n' +
+                     '\tSCT_STRESS_IMAGE.cassandra-stress=scylladb/cassandra-stress:3.13.0\n' +
                      '\tSCT_USE_MGMT=false'
                      ),
                  name: 'extra_environment_variables')

--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -113,7 +113,7 @@ def call(Map pipelineParams) {
                  description: (
                      'Extra environment variables to be set in the test environment, uses the java Properties File Format.\n' +
                      'Example:\n' +
-                     '\tSCT_STRESS_IMAGE.cassandra-stress=scylladb/cassandra-stress:3.12.1\n' +
+                     '\tSCT_STRESS_IMAGE.cassandra-stress=scylladb/cassandra-stress:3.13.0\n' +
                      '\tSCT_USE_MGMT=false'
                      ),
                  name: 'extra_environment_variables')

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -83,7 +83,7 @@ def call(Map pipelineParams) {
                  description: (
                      'Extra environment variables to be set in the test environment, uses the java Properties File Format.\n' +
                      'Example:\n' +
-                     '\tSCT_STRESS_IMAGE.cassandra-stress=scylladb/cassandra-stress:3.12.1\n' +
+                     '\tSCT_STRESS_IMAGE.cassandra-stress=scylladb/cassandra-stress:3.13.0\n' +
                      '\tSCT_USE_MGMT=false'
                      ),
                  name: 'extra_environment_variables')


### PR DESCRIPTION
Latest version of cassandra-stress (3.13.0) fixes the issue with snappy compression and changes the base image for Java. (now using JRE instead of JDK for running)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

