### PR TITLE
improvement(cleanup): update Argus on cloud cleanup

### DIFF
--- a/sdcm/sct_provision/region_definition_builder.py
+++ b/sdcm/sct_provision/region_definition_builder.py
@@ -75,7 +75,8 @@ class DefinitionBuilder(abc.ABC):
         user_prefix = self.params.get('user_prefix')
         common_tags = TestConfig.common_tags()
         node_type_short = "db" if "db" in node_type else node_type
-        name = f"{user_prefix}-{node_type_short}-node-{region}-{index}".lower()
+        short_test_id = TestConfig.test_id().split("-")[0]
+        name = f"{user_prefix}-{node_type_short}-node-{short_test_id}-{region}-{index}".lower()
         action = self.params.get(f"post_behavior_{node_type_short}_nodes")
         tags = common_tags | {"NodeType": node_type,
                               "keep_action": "terminate" if action == "destroy" else "",

--- a/unit_tests/lib/fake_resources.py
+++ b/unit_tests/lib/fake_resources.py
@@ -25,7 +25,9 @@ def prepare_fake_region(test_id: str, region: str, n_db_nodes: int = 3, n_loader
               "fake_image_monitor": "test:image:monitor:2", "fake_instance_type_monitor": "test-inst-type", "ami_monitor_user": "centos",
               "root_disk_size_monitor": 15,
               "fake_region_name": ["eastus"], "cluster_backend": "fake"}
-    builder = region_definition_builder.get_builder(params=params, test_config=TestConfig())
+    test_config = TestConfig()
+    test_config.set_test_id_only(test_id)
+    builder = region_definition_builder.get_builder(params=params, test_config=test_config)
     region_definition = builder.build_region_definition(region, "a", n_db_nodes, n_loaders, n_monitor_nodes)
     provisioner = provisioner_factory.create_provisioner(backend=region_definition.backend,
                                                          test_id=region_definition.test_id,

--- a/unit_tests/provisioner/test_azure_region_definition_builder.py
+++ b/unit_tests/provisioner/test_azure_region_definition_builder.py
@@ -28,13 +28,17 @@ def test_can_create_basic_scylla_instance_definition_from_sct_config():
                            ["SCT_CLUSTER_BACKEND", "SCT_TEST_ID", "SCT_CONFIG_FILES", "SCT_AZURE_REGION_NAME",
                             "SCT_N_DB_NODES", "SCT_USER_PREFIX",
                             "SCT_AZURE_IMAGE_DB", "SCT_N_LOADERS", "SCT_N_MONITORS_NODES"])
+
+    test_id = "3923f974-bf0e-4c3c-9f52-3f6473b8a0b6"
+    test_config = TestConfig()
+    test_config.set_test_id_only(test_id)
     env_config = EnvConfig(
         SCT_CLUSTER_BACKEND="azure",
-        SCT_TEST_ID="3923f974-bf0e-4c3c-9f52-3f6473b8a0b6",
+        SCT_TEST_ID=test_config.test_id(),
         SCT_CONFIG_FILES=f'["{Path(__file__).parent.absolute()}/azure_default_config.yaml"]',
         SCT_AZURE_REGION_NAME="['eastus', 'easteu']",
         SCT_N_DB_NODES="3 1",
-        SCT_USER_PREFIX="unit-test",
+        SCT_USER_PREFIX="unit",
         SCT_AZURE_IMAGE_DB="/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/scylla-images/providers/"
                            "Microsoft.Compute/images/scylla-5.2.0-dev-x86_64-2022-08-22T04-18-36Z",
         SCT_N_LOADERS="2 0",
@@ -48,12 +52,11 @@ def test_can_create_basic_scylla_instance_definition_from_sct_config():
     #  temporary using gce keypair, until replacing keys in jenkins, and all backend would be using same key (including runners)
     ssh_key = KeyStore().get_gce_ssh_key_pair()
     prefix = config.get('user_prefix')
-    test_config = TestConfig()
-    test_config.set_test_id_only(env_config.SCT_TEST_ID)
     builder = region_definition_builder.get_builder(params=config, test_config=test_config)
     region_definitions = builder.build_all_region_definitions()
 
-    instance_definition = InstanceDefinition(name=f"{prefix}-db-node-3923f974-eastus-1", image_id=env_config.SCT_AZURE_IMAGE_DB,
+    instance_definition = InstanceDefinition(name=f"{prefix}-db-node-{test_config.test_id()[:8]}-eastus-1",
+                                             image_id=env_config.SCT_AZURE_IMAGE_DB,
                                              type="Standard_L8s_v3", user_name="scyllaadm", root_disk_size=30,
                                              tags=tags | {"NodeType": "scylla-db", "keep_action": "",
                                                           'NodeIndex': '1', "TestId": test_config.test_id()},

--- a/unit_tests/provisioner/test_azure_region_definition_builder.py
+++ b/unit_tests/provisioner/test_azure_region_definition_builder.py
@@ -30,7 +30,7 @@ def test_can_create_basic_scylla_instance_definition_from_sct_config():
                             "SCT_AZURE_IMAGE_DB", "SCT_N_LOADERS", "SCT_N_MONITORS_NODES"])
     env_config = EnvConfig(
         SCT_CLUSTER_BACKEND="azure",
-        SCT_TEST_ID="example_test_id",
+        SCT_TEST_ID="3923f974-bf0e-4c3c-9f52-3f6473b8a0b6",
         SCT_CONFIG_FILES=f'["{Path(__file__).parent.absolute()}/azure_default_config.yaml"]',
         SCT_AZURE_REGION_NAME="['eastus', 'easteu']",
         SCT_N_DB_NODES="3 1",
@@ -49,17 +49,19 @@ def test_can_create_basic_scylla_instance_definition_from_sct_config():
     ssh_key = KeyStore().get_gce_ssh_key_pair()
     prefix = config.get('user_prefix')
     test_config = TestConfig()
+    test_config.set_test_id_only(env_config.SCT_TEST_ID)
     builder = region_definition_builder.get_builder(params=config, test_config=test_config)
     region_definitions = builder.build_all_region_definitions()
 
-    instance_definition = InstanceDefinition(name=f"{prefix}-db-node-eastus-1", image_id=env_config.SCT_AZURE_IMAGE_DB,
+    instance_definition = InstanceDefinition(name=f"{prefix}-db-node-3923f974-eastus-1", image_id=env_config.SCT_AZURE_IMAGE_DB,
                                              type="Standard_L8s_v3", user_name="scyllaadm", root_disk_size=30,
-                                             tags=tags | {"NodeType": "scylla-db", "keep_action": "", 'NodeIndex': '1'},
+                                             tags=tags | {"NodeType": "scylla-db", "keep_action": "",
+                                                          'NodeIndex': '1', "TestId": test_config.test_id()},
                                              ssh_key=ssh_key)
     assert len(region_definitions) == 2
     actual_region_definition = region_definitions[0]
 
-    assert actual_region_definition.test_id == env_config.SCT_TEST_ID
+    assert actual_region_definition.test_id == test_config.test_id()
     assert actual_region_definition.backend == "azure"
     assert actual_region_definition.region == "eastus"
     # ignoring user_data in this validation

--- a/unit_tests/provisioner/test_provisioner.py
+++ b/unit_tests/provisioner/test_provisioner.py
@@ -55,7 +55,7 @@ def image_type(backend):
 
 @pytest.fixture(scope='module')
 def test_id():
-    return f"unit-test-{str(uuid.uuid4())}"
+    return f"{str(uuid.uuid4())}"
 
 
 @pytest.fixture(scope='module')

--- a/unit_tests/test_log_collector.py
+++ b/unit_tests/test_log_collector.py
@@ -22,7 +22,7 @@ from unit_tests.lib.fake_resources import prepare_fake_region
 
 @pytest.fixture(scope='session')
 def test_id():
-    return f"unit-test-{str(uuid.uuid4())}"
+    return f"{str(uuid.uuid4())}"
 
 
 def test_create_collecting_nodes(test_id, tmp_path_factory):

--- a/unit_tests/test_utils__operator__multitenant_common.py
+++ b/unit_tests/test_utils__operator__multitenant_common.py
@@ -57,7 +57,7 @@ class FakeDbCluster:  # pylint: disable=too-few-public-methods
 class FakeMultitenantTestBase:  # pylint: disable=too-few-public-methods
     def __init__(self):
         self.test_config = TestConfig()
-        self.test_config.test_id = lambda: "fake-test-id"
+        self.test_config.set_test_id_only("fake-test-id")
         self.params = sct_config.SCTConfiguration()
         self.params.verify_configuration()
         self.db_clusters_multitenant = [FakeDbCluster(1), FakeDbCluster(2)]

--- a/utils/cloud_cleanup/__init__.py
+++ b/utils/cloud_cleanup/__init__.py
@@ -1,4 +1,33 @@
 import os
 import sys
+from functools import partial
+from typing import Literal, Callable
+
+from argus.client.sct.client import ArgusSCTClient
+
+from sdcm.keystore import KeyStore
+from sdcm.utils.log import setup_stdout_logger
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+LOGGER = setup_stdout_logger()
+
+
+def argus_client_factory() -> Callable[[str], ArgusSCTClient]:
+    """Factory function to create ArgusSCTClient instances with pre-configured credentials."""
+    creds = KeyStore().get_argus_rest_credentials()
+    return partial(ArgusSCTClient, auth_token=creds["token"], base_url=creds["baseUrl"])
+
+
+argus_client = argus_client_factory()
+
+
+def update_argus_resource_status(test_id: str, resource_name: str, action: Literal['terminate', 'stop']):
+    if not test_id and not resource_name:
+        LOGGER.error("Skip update Argus due missing test_id and resource_name")
+        return
+    try:
+        client = argus_client(test_id)
+        client.terminate_resource(name=resource_name, reason=f'cloud-cleanup: {action} resource due to expiration')
+    except Exception as exc:  # noqa: BLE001 catching all to make sure it does not break the main process
+        LOGGER.error("Failed to update Argus resource status: %s", exc)
+        return

--- a/utils/cloud_cleanup/gce/clean_gce.py
+++ b/utils/cloud_cleanup/gce/clean_gce.py
@@ -7,6 +7,7 @@ from pytz import utc
 from sdcm.utils.context_managers import environment
 from sdcm.utils.gce_utils import get_gce_compute_instances_client, SUPPORTED_PROJECTS
 from sdcm.utils.log import setup_stdout_logger
+from utils.cloud_cleanup import update_argus_resource_status
 
 DEFAULT_KEEP_HOURS = 14
 LOGGER = setup_stdout_logger()
@@ -57,6 +58,7 @@ def clean_gce_instances(instances_client, project_id, dry_run):
                                                       zone=instance.zone.split('/')[-1])
                         res.done()
                         LOGGER.info("%s terminated", instance.name)
+                        update_argus_resource_status(instance_metadata.get('TestId', ''), instance.name, 'terminate')
                     except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
                         LOGGER.error("error while terminating instance %s: %s", instance.name, exc)
                 else:
@@ -72,6 +74,7 @@ def clean_gce_instances(instances_client, project_id, dry_run):
                                                     zone=instance.zone.split('/')[-1])
                         res.done()
                         LOGGER.info("%s stopped", instance.name)
+                        update_argus_resource_status(instance_metadata.get('TestId', ''), instance.name, 'stop')
                     except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
                         LOGGER.error("error while stopping instance %s: %s", instance.name, exc)
                 else:


### PR DESCRIPTION
improvement(cleanup): update Argus on cloud cleanup

When cleaning instances with cloud cleanup scripts, Argus is not
updated. This makes `Resources` tab in Argus outdated and may mislead
users.

Update Argus when periodical cleanup script is triggering machine
termination/stop.

Closes: https://github.com/scylladb/scylla-cluster-tests/issues/8299


fix(azure): fix resources names

Azure instances names differ from `node.name` values. This causes
discrepancy between resources names between Argus-Azure. While in
testing it does not cause problems, updating resources status in Argus
raises error about missing resource name (because cleanup scripts base
on Azure names).

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - tested manually (although currently only managed to verify GCE, Azure failed due bug - fixed below, AWS waiting for opportunity)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
