### PR TITLE
fix(byoLongevityPipeline): fix defaultValue of extra_environment_variables

### DIFF
--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -106,7 +106,7 @@ def call() {
             string(defaultValue: "qa@scylladb.com",
                    description: 'email recipients of email report',
                    name: 'email_recipients')
-            text(defaultValue: "${pipelineParams.get('extra_environment_variables', '')}",
+            text(defaultValue: "",
                  description: (
                      'Extra environment variables to be set in the test environment, uses the java Properties File Format.\n' +
                      'Example:\n' +


### PR DESCRIPTION
	It used undefined parameter "pipelineParams".
	refs: d2236eacd78496bd200583132e5f0ee5d3f73acf
refs: https://github.com/scylladb/scylla-cluster-tests/pull/8268/commits/d2236eacd78496bd200583132e5f0ee5d3f73acf
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
