### PR TITLE
fix(nemesis): skip nemesis if there is capacity errors

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -110,6 +110,7 @@ from sdcm.utils.compaction_ops import CompactionOps, StartStopCompactionArgs
 from sdcm.utils.context_managers import nodetool_context
 from sdcm.utils.decorators import retrying, latency_calculator_decorator
 from sdcm.utils.decorators import timeout as timeout_decor
+from sdcm.utils.decorators import skip_on_capacity_issues
 from sdcm.utils.docker_utils import ContainerManager
 from sdcm.utils.k8s import (
     convert_cpu_units_to_k8s_value,
@@ -1239,7 +1240,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         #       as 'NotReady' and will fail the pod waiter function.
         self.log.info("Adding new node to cluster...")
         InfoEvent(message='StartEvent - Adding new node to cluster').publish()
-        new_node = self.cluster.add_nodes(
+        new_node = skip_on_capacity_issues(self.cluster.add_nodes)(
             count=1, dc_idx=self.target_node.dc_idx, enable_auto_bootstrap=True, rack=rack)[0]
         self.monitoring_set.reconfigure_scylla_monitoring()
         self.set_current_running_nemesis(node=new_node)  # prevent to run nemesis on new node when running in parallel
@@ -1276,7 +1277,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             rack = 0
         self.log.info("Adding %s new nodes to cluster...", count)
         InfoEvent(message=f'StartEvent - Adding {count} new nodes to cluster').publish()
-        new_nodes = self.cluster.add_nodes(
+        new_nodes = skip_on_capacity_issues(self.cluster.add_nodes)(
             count=count, dc_idx=self.target_node.dc_idx, enable_auto_bootstrap=True, rack=rack,
             instance_type=instance_type)
         self.monitoring_set.reconfigure_scylla_monitoring()
@@ -4540,7 +4541,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 f"CDC extension settings are differs. Current: {actual_cdc_settings} expected: {cdc_settings}"
 
     def _add_new_node_in_new_dc(self) -> BaseNode:
-        new_node = self.cluster.add_nodes(1, dc_idx=0, enable_auto_bootstrap=True)[0]  # add node
+        new_node = skip_on_capacity_issues(self.cluster.add_nodes)(
+            1, dc_idx=0, enable_auto_bootstrap=True)[0]  # add node
         with new_node.remote_scylla_yaml() as scylla_yml:
             scylla_yml.rpc_address = new_node.ip_address
             scylla_yml.seed_provider = [SeedProvider(class_name='org.apache.cassandra.locator.SimpleSeedProvider',
@@ -5052,7 +5054,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         If node was not added anyway, clean it from cluster
         and return the cluster to initial state(by num of nodes)
         """
-        new_node: BaseNode = self.cluster.add_nodes(
+        new_node: BaseNode = skip_on_capacity_issues(self.cluster.add_nodes)(
             count=1, dc_idx=self.target_node.dc_idx, enable_auto_bootstrap=True, rack=self.target_node.rack)[0]
         self.monitoring_set.reconfigure_scylla_monitoring()
         self.set_current_running_nemesis(node=new_node)  # prevent to run nemesis on new node when running in parallel


### PR DESCRIPTION
if there's capacity error during a nemesis, we don't have much we can do about it, so we are gonna skip the nemesis insted just failing the nemesis

this change introduces a new decorator to help doing it on multiple calls in nemesis.py, later it can be extended to handle also other backend capacity issues (GCE/Azure), for now it handles only AWS capacity errors

Fixes: #7531

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
