### PR TITLE
improvement(azure): skip providing public ip when not needed

### DIFF
--- a/sdcm/provision/azure/network_interface_provider.py
+++ b/sdcm/provision/azure/network_interface_provider.py
@@ -44,7 +44,7 @@ class NetworkInterfaceProvider:
     def get(self, name: str) -> NetworkInterface:
         return self._cache[self.get_nic_name(name)]
 
-    def get_or_create(self, subnet_id: str, ip_addresses_ids: List[str], names: List[str]) -> List[NetworkInterface]:
+    def get_or_create(self, subnet_id: str, ip_addresses_ids: List[str | None], names: List[str]) -> List[NetworkInterface]:
         """Creates or gets (if already exists) network interface"""
         nics = []
         pollers = []
@@ -63,10 +63,11 @@ class NetworkInterfaceProvider:
                 }],
                 "enable_accelerated_networking": True,
             }
-            parameters["ip_configurations"][0]["public_ip_address"] = {
-                "id": address,
-                "properties": {"deleteOption": "Delete"}
-            }
+            if address is not None:
+                parameters["ip_configurations"][0]["public_ip_address"] = {
+                    "id": address,
+                    "properties": {"deleteOption": "Delete"}
+                }
             LOGGER.info("Creating nic in resource group %s...", self._resource_group_name)
             poller = self._azure_service.network.network_interfaces.begin_create_or_update(
                 resource_group_name=self._resource_group_name,

--- a/sdcm/provision/azure/provisioner.py
+++ b/sdcm/provision/azure/provisioner.py
@@ -134,9 +134,9 @@ class AzureProvisioner(Provisioner):  # pylint: disable=too-many-instance-attrib
         sec_group_id = self._network_sec_group_provider.get_or_create(security_rules=ScyllaOpenPorts).id
         vnet_name = self._vnet_provider.get_or_create().name
         subnet_id = self._subnet_provider.get_or_create(vnet_name, sec_group_id).id
-        ip_addresses = self._ip_provider.get_or_create(names=[d.name for d in definitions_to_provision], version="IPV4")
-        nics = self._nic_provider.get_or_create(subnet_id, ip_addresses_ids=[address.id for address in ip_addresses], names=[
-                                                definition.name for definition in definitions_to_provision])
+        ip_addresses = self._ip_provider.get_or_create(instance_definitions=definitions_to_provision, version="IPV4")
+        nics = self._nic_provider.get_or_create(subnet_id, ip_addresses_ids=[address.id for address in ip_addresses],
+                                                names=[definition.name for definition in definitions_to_provision])
         v_ms = self._vm_provider.get_or_create(definitions=definitions_to_provision, nics_ids=[
                                                nic.id for nic in nics], pricing_model=pricing_model)
         for definition, v_m in zip(definitions, v_ms):

--- a/sdcm/provision/provisioner.py
+++ b/sdcm/provision/provisioner.py
@@ -48,6 +48,7 @@ class InstanceDefinition:  # pylint: disable=too-many-instance-attributes
     data_disks: List[DataDisk] | None = None
     user_data: List[UserDataObject] | None = field(
         default_factory=list, repr=False)  # None when no cloud-init use at all
+    use_public_ip: bool = False
 
 
 class ProvisionError(Exception):
@@ -74,7 +75,7 @@ class VmInstance:  # pylint: disable=too-many-instance-attributes
     region: str
     user_name: str
     ssh_key_name: str
-    public_ip_address: str
+    public_ip_address: str | None
     private_ip_address: str
     tags: Dict[str, str]
     pricing_model: PricingModel

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1925,10 +1925,16 @@ class SCTConfiguration(dict):
         # 9) append username or ami_id_db_scylla_desc to the user_prefix
         version_tag = self.get('ami_id_db_scylla_desc') or getpass.getuser()
         user_prefix = self.get('user_prefix') or getpass.getuser()
+        prefix_max_len = 35
         if version_tag != user_prefix:
-            self['user_prefix'] = "{}-{}".format(user_prefix, version_tag)[:35]
-        else:
-            self['user_prefix'] = user_prefix[:35]
+            user_prefix = "{}-{}".format(user_prefix, version_tag)
+        if self.get('cluster_backend') == 'azure':
+            # for Azure need to shorten it more due longer region names
+            prefix_max_len -= 2
+        if (self.get("simulated_regions") or 0) > 1:
+            # another shortening for simulated regions due added simulated dc suffix
+            prefix_max_len -= 3
+        self['user_prefix'] = user_prefix[:prefix_max_len]
 
         # 11) validate that supported instance_provision selected
         if self.get('instance_provision') not in ['spot', 'on_demand', 'spot_fleet', 'spot_low_price']:

--- a/sdcm/sct_provision/instances_provider.py
+++ b/sdcm/sct_provision/instances_provider.py
@@ -46,7 +46,7 @@ def provision_instances_with_fallback(provisioner: Provisioner, definitions: Lis
 
     provisioned_instances = provisioner.get_or_create_instances(definitions=definitions)
     for v_m in provisioned_instances:
-        ssh_login_info = {'hostname': v_m.public_ip_address,
+        ssh_login_info = {'hostname': v_m.public_ip_address if v_m.public_ip_address else v_m.private_ip_address,
                           'user': v_m.user_name,
                           'key_file': f"~/.ssh/{v_m.ssh_key_name}"}
         remoter = RemoteCmdRunnerBase.create_remoter(**ssh_login_info)

--- a/sdcm/sct_provision/region_definition_builder.py
+++ b/sdcm/sct_provision/region_definition_builder.py
@@ -17,6 +17,7 @@ from typing import List, Dict, Type
 from pathlib import Path
 
 from sdcm.keystore import KeyStore, SSHKey
+from sdcm.provision.network_configuration import ssh_connection_ip_type
 from sdcm.provision.provisioner import InstanceDefinition
 from sdcm.sct_config import SCTConfiguration
 from sdcm.sct_provision.common.types import NodeTypeType
@@ -81,6 +82,7 @@ class DefinitionBuilder(abc.ABC):
                               "NodeIndex": str(index)}
         user_data = self._get_user_data_objects(node_type=node_type, instance_name=name)
         mapper = self.SCT_PARAM_MAPPER[node_type]
+        use_public_ip = ssh_connection_ip_type(self.params) == "public" or node_type == "monitor"
         return InstanceDefinition(name=name,
                                   image_id=self.params.get(mapper.image_id),
                                   type=instance_type or self.params.get(mapper.type),
@@ -88,7 +90,8 @@ class DefinitionBuilder(abc.ABC):
                                   root_disk_size=self.params.get(mapper.root_disk_size),
                                   tags=tags,
                                   ssh_key=self._get_ssh_key(),
-                                  user_data=user_data
+                                  user_data=user_data,
+                                  use_public_ip=use_public_ip,
                                   )
 
     def build_region_definition(self, region: str, availability_zone: str, n_db_nodes: int,  # pylint: disable=too-many-arguments

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -1087,7 +1087,9 @@ class AzureSctRunner(SctRunner):
                                            tags=tags | {"launch_time": get_current_datetime_formatted()},
                                            root_disk_size=root_disk_size_gb or self.instance_root_disk_size(
                                                test_duration=test_duration),
-                                           user_data=None)
+                                           user_data=None,
+                                           use_public_ip=True,
+                                           )
             self.instance = provisioner.get_or_create_instance(definition=vm_params,
                                                                pricing_model=PricingModel.ON_DEMAND)
             return self.instance

--- a/unit_tests/provisioner/conftest.py
+++ b/unit_tests/provisioner/conftest.py
@@ -48,18 +48,20 @@ def params():
     EnvConfig = namedtuple('EnvConfig',
                            ["SCT_CLUSTER_BACKEND", "SCT_TEST_ID", "SCT_CONFIG_FILES", "SCT_AZURE_REGION_NAME",
                             "SCT_N_DB_NODES",
-                            "SCT_AZURE_IMAGE_DB", "SCT_N_LOADERS", "SCT_N_MONITORS_NODES", "SCT_AVAILABILITY_ZONE"])
+                            "SCT_AZURE_IMAGE_DB", "SCT_N_LOADERS", "SCT_N_MONITORS_NODES", "SCT_AVAILABILITY_ZONE",
+                            "SCT_IP_SSH_CONNECTIONS"])
     env_config = EnvConfig(
         SCT_CLUSTER_BACKEND="azure",
         SCT_TEST_ID=f"{str(uuid.uuid4())}",
         SCT_CONFIG_FILES=f'["{Path(__file__).parent.absolute()}/azure_default_config.yaml"]',
         SCT_AZURE_REGION_NAME="['eastus', 'easteu']",
         SCT_N_DB_NODES="3 1",
-        SCT_AZURE_IMAGE_DB="/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/scylla-images/providers/"
-                           "Microsoft.Compute/images/scylla-5.2.0-dev-x86_64-2022-08-22T04-18-36Z",
+        SCT_AZURE_IMAGE_DB="/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/"
+                           "scylla-images/providers/Microsoft.Compute/images/scylla-2024.1.9-x86_64-2024-08-30T04-49-46",
         SCT_N_LOADERS="2 0",
         SCT_N_MONITORS_NODES="1",
-        SCT_AVAILABILITY_ZONE="a"
+        SCT_AVAILABILITY_ZONE="a",
+        SCT_IP_SSH_CONNECTIONS="public",
     )
     os.environ.update(env_config._asdict())
     return SCTConfiguration()

--- a/unit_tests/provisioner/test_provisioner.py
+++ b/unit_tests/provisioner/test_provisioner.py
@@ -74,7 +74,8 @@ def definition(image_id, image_type):
         user_name="tester",
         ssh_key=KeyStore().get_ec2_ssh_key_pair(),
         tags={'test-tag': 'test_value'},
-        user_data=[PrintingTestUserDataObject()]
+        user_data=[PrintingTestUserDataObject()],
+        use_public_ip=True,
     )
 
 


### PR DESCRIPTION
Usually tests don't need public ips as we basically work with private ones only.

Stop provisioning public ips in Azure when not needed.

closes: https://github.com/scylladb/qa-tasks/issues/1572

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [artifact test (public ip)](https://argus.scylladb.com/test/b09f644c-6671-4d78-86f7-a66483f40d6c/runs?additionalRuns[]=652bcf41-8d2b-472c-857c-e07d647c4db8)
- [ ] - [longevity test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/longevity-5gb-1h-StartStopValidationCompaction-azure-test/2/)
- [x] - azure provision test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
