### PR TITLE
fix(provision): shorten node name when Azure and simulated dc

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1925,10 +1925,16 @@ class SCTConfiguration(dict):
         # 9) append username or ami_id_db_scylla_desc to the user_prefix
         version_tag = self.get('ami_id_db_scylla_desc') or getpass.getuser()
         user_prefix = self.get('user_prefix') or getpass.getuser()
+        prefix_max_len = 35
         if version_tag != user_prefix:
-            self['user_prefix'] = "{}-{}".format(user_prefix, version_tag)[:35]
-        else:
-            self['user_prefix'] = user_prefix[:35]
+            user_prefix = "{}-{}".format(user_prefix, version_tag)
+        if self.get('cluster_backend') == 'azure':
+            # for Azure need to shorten it more due longer region names
+            prefix_max_len -= 2
+        if (self.get("simulated_regions") or 0) > 1:
+            # another shortening for simulated regions due added simulated dc suffix
+            prefix_max_len -= 3
+        self['user_prefix'] = user_prefix[:prefix_max_len]
 
         # 11) validate that supported instance_provision selected
         if self.get('instance_provision') not in ['spot', 'on_demand', 'spot_fleet', 'spot_low_price']:


### PR DESCRIPTION
In case we use Azure or simulated regions node name might get too long and fail to create certificates.

Shorten node names accordingly.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/8523

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [testing as part of other PR on Azure](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/longevity-5gb-1h-StartStopValidationCompaction-azure-test/6/)
- [x] - provision aws test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
