### PR TITLE
fix(artifacts): skip configuring syslog-ng for artifacts test

### DIFF
--- a/sdcm/provision/common/configuration_script.py
+++ b/sdcm/provision/common/configuration_script.py
@@ -86,10 +86,11 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
         # 5. Make sure that whenever you use "cat <<EOF >>/file", make sure that EOF has no spaces in front of it
         script = ''
 
-        script += configure_syslogng_destination_conf(
-            host=self.syslog_host_port[0],
-            port=self.syslog_host_port[1],
-            throttle_per_second=SYSLOGNG_LOG_THROTTLE_PER_SECOND)
+        if self.logs_transport == 'syslog-ng':
+            script += configure_syslogng_destination_conf(
+                host=self.syslog_host_port[0],
+                port=self.syslog_host_port[1],
+                throttle_per_second=SYSLOGNG_LOG_THROTTLE_PER_SECOND)
         script += self._skip_if_already_run()
         script += disable_daily_apt_triggers()
         if self.logs_transport == 'syslog-ng':


### PR DESCRIPTION
ConfigurationScriptBuilder should skip syslog-ng setup steps for artifacts tests, which do not use syslog-ng logs transport.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/8527

### Testing
- [x] :green_circle: [artifacts-ubuntu2204-test](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/artifacts-ubuntu2204-test/2/)
- [x] :green_circle: regular PR provision test + cluster reuse flow were executed (and pass) as part PR CI


### PR pre-checks (self review)
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
