### PR TITLE
[Manager] Run tests on Ubuntu 24

### DIFF
--- a/configurations/manager/ubuntu24.yaml
+++ b/configurations/manager/ubuntu24.yaml
@@ -1,0 +1,3 @@
+ami_id_monitor: 'resolve:ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id'  # Canonical, Ubuntu, 24.04 LTS, amd64 focal latest image
+ami_monitor_user: 'ubuntu'
+monitor_branch: 'branch-4.7'  # Pass it as the image is not the formal monitor image

--- a/jenkins-pipelines/manager/ubuntu24-manager-install.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-install.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    region: 'us-east-1',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_installed_and_functional',
+    test_config: '''["test-cases/manager/manager-installation-set-distro.yaml", "configurations/manager/ubuntu24.yaml"]''',
+
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+)

--- a/jenkins-pipelines/manager/ubuntu24-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-sanity.jenkinsfile
@@ -1,0 +1,17 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    region: 'us-east-1',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
+    test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/manager/ubuntu24.yaml"]''',
+
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+
+    downstream_jobs_to_run: 'ubuntu24-upgrade-test'
+)

--- a/jenkins-pipelines/manager/ubuntu24-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-upgrade.jenkinsfile
@@ -1,0 +1,20 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    region: 'us-east-1',
+
+    target_manager_version: 'master_latest',
+
+    manager_version: '3.2',
+
+    test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
+    test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu24.yaml"]''',
+
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy'
+)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5534,14 +5534,15 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
             """)
         elif node.distro.is_ubuntu:
             node.install_package(
-                package_name="software-properties-common python3 python3-dev python-setuptools unzip wget python3-pip")
-            prereqs_script = dedent("""
+                package_name="software-properties-common python3 python3-dev python3-setuptools unzip wget python3-pip")
+            pip_break_system_packages = "--break-system-packages" if node.distro.is_ubuntu24 else ""
+            prereqs_script = dedent(f"""
                 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
                 sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
                 sudo apt-get update
-                sudo apt-get install -y docker docker.io
-                python3 -m pip install pyyaml
-                python3 -m pip install -I -U psutil
+                sudo apt-get install -y docker.io
+                python3 -m pip install pyyaml {pip_break_system_packages}
+                python3 -m pip install -I -U psutil {pip_break_system_packages}
                 systemctl start docker
             """)
         elif node.distro.is_debian:


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-manager/issues/4001

The PR expands Manager tests (sanity, installation, upgrade) with coverage for Ubuntu24 distribution.
CI triggers added in https://github.com/scylladb/scylla-pkg/pull/4298

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] ubuntu24 [installation](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu24-installation-test/1/)
- [x] ubuntu24 [sanity](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu24-sanity-test/2/)
- [x] ubuntu24 [upgrade](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu24-upgrade-test/5/)
- [x] ubuntu20 [regression](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu20-installation-test/7/)
- [x] ubuntu22 [regression](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-installation-test/10/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code