### PR TITLE
improvement(scylla.yaml): support `allowed_repair_based_node_ops` option

### DIFF
--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -266,6 +266,9 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods,too-many-
     replace_node_first_boot: str = None  # ""
     override_decommission: bool = None  # False
     enable_repair_based_node_ops: bool = None  # True
+    # NOTE: example for disabling RBNO for 'bootstrap' and 'decommission' operations:
+    #       allowed_repair_based_node_ops: "replace,removenode,rebuild"
+    allowed_repair_based_node_ops: str = None
     ring_delay_ms: int = None  # 30 * 1000
     shadow_round_ms: int = None  # 300 * 1000
     fd_max_interval_ms: int = None  # 2 * 1000

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -241,6 +241,7 @@ class ScyllaYamlTest(unittest.TestCase):
                 'enable_ipv6_dns_lookup': None,
                 'enable_keyspace_column_family_metrics': None,
                 'enable_repair_based_node_ops': None,
+                'allowed_repair_based_node_ops': None,
                 'enable_shard_aware_drivers': None,
                 'enable_sstable_data_integrity_check': None,
                 'enable_sstable_key_validation': None,


### PR DESCRIPTION
Add support of the `allowed_repair_based_node_ops` scylla option to SCT.

It is useful for workarounding slow bootstraps in multi-dc setups with RBNO.
Example for disabling RBNO for `bootstrap` and `decommission` operations:
```
  enable_repair_based_node_ops: true
  allowed_repair_based_node_ops: "replace,removenode,rebuild"
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
