### PR TITLE
fix(disrupt_mgr): skip take_snapshot error per issue

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -87,6 +87,8 @@ from sdcm.sct_events.group_common_events import (
     decorate_with_context,
     ignore_reactor_stall_errors,
     ignore_disk_quota_exceeded_errors,
+    decorate_with_context_if_issues_open,
+    ignore_take_snapshot_failing,
 )
 from sdcm.sct_events.health import DataValidatorEvent
 from sdcm.sct_events.loaders import CassandraStressLogEvent, ScyllaBenchEvent
@@ -3004,6 +3006,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.log.warning("Deleted the following backup tasks before the nemesis starts: %s",
                              ", ".join(deleted_tasks))
 
+    @decorate_with_context_if_issues_open(
+        ignore_take_snapshot_failing,
+        issue_refs=['https://github.com/scylladb/scylla-manager/issues/3389'])
     def _mgmt_backup(self, backup_specific_tables):
         if not self.cluster.params.get('use_mgmt') and not self.cluster.params.get('use_cloud_manager'):
             raise UnsupportedNemesis('Scylla-manager configuration is not defined!')


### PR DESCRIPTION
The change adds a decorator helper that uses SkipPerIssues mechanism and applies (enters) provided contexts to a function if issue in question is open.

Also the new decorator is used to decorate mgmt_backup Nemesis disruption to skip take_snapshot related errors, until issue https://github.com/scylladb/scylla-manager/issues/3389
is resolved.

### Testing
- [x] :green_circle: PR provision for sanity check
- [x] :green_circle:  [MgmtBackup nemesis to regression check the changed disruption](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/longevity-5gb-1h-test/50/)

### PR pre-checks (self review)
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
