### PR TITLE
ci(custom-d1): add missing `row_count` option in the `prepare write` step

### DIFF
--- a/test-cases/longevity/longevity-gce-custom-d1-workload1-hybrid-raid.yaml
+++ b/test-cases/longevity/longevity-gce-custom-d1-workload1-hybrid-raid.yaml
@@ -9,11 +9,13 @@ prepare_write_cmd:
   - >-
     latte run --tag latte --duration 82286400 --request-timeout 60 --retry-interval '2s,10s'
     --threads 30 --connections 3 --concurrency 180 --rate 17000 --sampling 5s -P offset=0
-    --function load scylla-qa-internal/custom_d1/workload1/latte/custom_d1_workload1.rn
+    --function load -P row_count=82286400
+    scylla-qa-internal/custom_d1/workload1/latte/custom_d1_workload1.rn
   - >-
     latte run --tag latte --duration 82286400 --request-timeout 60 --retry-interval '2s,10s'
     --threads 30 --connections 3 --concurrency 180 --rate 17000 --sampling 5s -P offset=82286400
-    --function load scylla-qa-internal/custom_d1/workload1/latte/custom_d1_workload1.rn
+    --function load -P row_count=82286400
+    scylla-qa-internal/custom_d1/workload1/latte/custom_d1_workload1.rn
 stress_cmd:
   # NOTE: 'latte' tag will be used by the log collector code.
   # 01) T4F10 -> -r 51.5k (~1/2 from 103k) - part1

--- a/test-cases/longevity/longevity-gce-custom-d1-workload2-hybrid-raid.yaml
+++ b/test-cases/longevity/longevity-gce-custom-d1-workload2-hybrid-raid.yaml
@@ -10,45 +10,45 @@ prepare_write_cmd:
   - >-
     latte run --tag latte --duration 75100100 --request-timeout 60 --retry-interval '2s,10s'
     --sampling 5s --threads 30 --connections 3 --concurrency 180 --rate 19000 -P offset=0
-    --function custom -P codes="\"T2F1,T14F1\""
+    --function custom -P codes="\"T2F1,T14F1\"" -P row_count=75100100
     scylla-qa-internal/custom_d1/workload2/latte/custom_d1_workload2.rn
   - >-
     latte run --tag latte --duration 75100100 --request-timeout 60 --retry-interval '2s,10s'
     --sampling 5s --threads 30 --connections 3 --concurrency 180 --rate 19000 -P offset=75100100
-    --function custom -P codes="\"T2F1,T14F1\""
+    --function custom -P codes="\"T2F1,T14F1\"" -P row_count=75100100
     scylla-qa-internal/custom_d1/workload2/latte/custom_d1_workload2.rn
 
   - >-
     latte run --tag latte --duration 35100100 --request-timeout 60 --retry-interval '2s,10s'
     --sampling 5s --threads 30 --connections 3 --concurrency 180 --rate 8900 -P offset=0
-    --function custom -P codes="\"T13F1\""
+    --function custom -P codes="\"T13F1\"" -P row_count=35100100
     scylla-qa-internal/custom_d1/workload2/latte/custom_d1_workload2.rn
   - >-
     latte run --tag latte --duration 35100100 --request-timeout 60 --retry-interval '2s,10s'
     --sampling 5s --threads 30 --connections 3 --concurrency 180 --rate 8900 -P offset=35100100
-    --function custom -P codes="\"T13F1\""
+    --function custom -P codes="\"T13F1\"" -P row_count=35100100
     scylla-qa-internal/custom_d1/workload2/latte/custom_d1_workload2.rn
 
   - >-
     latte run --tag latte --duration 25100100 --request-timeout 60 --retry-interval '2s,10s'
     --sampling 5s --threads 30 --connections 3 --concurrency 180 --rate 6350 -P offset=0
-    --function custom -P codes="\"T1F1,T3F1,T6F1,T9F1\""
+    --function custom -P codes="\"T1F1,T3F1,T6F1,T9F1\"" -P row_count=25100100
     scylla-qa-internal/custom_d1/workload2/latte/custom_d1_workload2.rn
   - >-
     latte run --tag latte --duration 25100100 --request-timeout 60 --retry-interval '2s,10s'
     --sampling 5s --threads 30 --connections 3 --concurrency 180 --rate 6350 -P offset=25100100
-    --function custom -P codes="\"T1F1,T3F1,T6F1,T9F1\""
+    --function custom -P codes="\"T1F1,T3F1,T6F1,T9F1\"" -P row_count=25100100
     scylla-qa-internal/custom_d1/workload2/latte/custom_d1_workload2.rn
 
   - >-
     latte run --tag latte --duration 5100100 --request-timeout 60 --retry-interval '2s,10s'
     --sampling 5s --threads 30 --connections 3 --concurrency 180 --rate 1280 -P offset=0
-    --function custom -P codes="\"T4F1,T5F1,T7F1\""
+    --function custom -P codes="\"T4F1,T5F1,T7F1\"" -P row_count=5100100
     scylla-qa-internal/custom_d1/workload2/latte/custom_d1_workload2.rn
   - >-
     latte run --tag latte --duration 5100100 --request-timeout 60 --retry-interval '2s,10s'
     --sampling 5s --threads 30 --connections 3 --concurrency 180 --rate 1280 -P offset=5100100
-    --function custom -P codes="\"T4F1,T5F1,T7F1\""
+    --function custom -P codes="\"T4F1,T5F1,T7F1\"" -P row_count=5100100
     scylla-qa-internal/custom_d1/workload2/latte/custom_d1_workload2.rn
 
 stress_cmd:


### PR DESCRIPTION
Without this option the default value `1000000` was used.
And this default value is much smaller than the desired value which was set only with the `-d` key.
    
So, explicitly defined `row_count` option in addition to the `-d` one
with the same values just to write expected amount of data once.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
