### PR TITLE
[Manager] Test to run restore with L&S outside of Manager

### DIFF
--- a/configurations/manager/nodetool_refresh_las_and_prim_replica.yaml
+++ b/configurations/manager/nodetool_refresh_las_and_prim_replica.yaml
@@ -1,0 +1,3 @@
+# Use only with test-cases/manager/manager-restore-outside.yaml
+
+mgmt_nodetool_refresh_flags: "--load-and-stream --primary-replica-only"

--- a/jenkins-pipelines/manager/ubuntu22-manager-restore-data-outside-of-manager.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-restore-data-outside-of-manager.jenkinsfile
@@ -1,0 +1,17 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    region: 'us-east-1',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_restore_data_without_manager',
+    test_config: 'test-cases/manager/manager-restore-outside.yaml',
+
+    backup_bucket_location: 'manager-backup-tests-permanent-snapshots-us-east-1',
+
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy'
+)

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -41,6 +41,7 @@ from sdcm.nemesis import MgmtRepair
 from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations
 from sdcm.utils.common import reach_enospc_on_node, clean_enospc_on_node
 from sdcm.utils.loader_utils import LoaderUtilsMixin
+from sdcm.utils.time_utils import ExecutionTimer
 from sdcm.sct_events.system import InfoEvent
 from sdcm.sct_events.group_common_events import ignore_no_space_errors, ignore_stream_mutation_fragments_errors
 from sdcm.utils.compaction_ops import CompactionOps
@@ -68,14 +69,17 @@ class SnapshotData:
     - prohibit_verification_read: if True, the verification read will be prohibited. Most likely, such a backup was
       created via c-s user profile.
     - number_of_rows: number of data rows written in the DB
+    - node_ids: list of node ids where backup was created
     """
     bucket: str
     tag: str
     exp_timeout: int
     keyspaces: list[str]
+    ks_tables_map: dict[str, list[str]]
     cs_read_cmd_template: str
     prohibit_verification_read: bool
     number_of_rows: int
+    node_ids: list[str]
 
 
 class BackupFunctionsMixIn(LoaderUtilsMixin):
@@ -174,7 +178,20 @@ class BackupFunctionsMixIn(LoaderUtilsMixin):
             return base_id.replace('-', '')
         return base_id
 
-    def restore_backup(self, mgr_cluster, snapshot_tag, keyspace_and_table_list):  # pylint: disable=too-many-locals
+    def restore_backup_without_manager(self, mgr_cluster, snapshot_tag, ks_tables_list, location=None,
+                                       precreated_backup=False):
+        """Restore backup without Scylla Manager but using the `nodetool refresh` operation
+        (https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/refresh.html).
+
+        The method downloads backup files from the backup bucket (aws s3 cp ...) and then loads them (nodetool refresh)
+        into the cluster node by node and table by table.
+
+        Two flows are supported:
+          - restore to a new cluster from pre-created backup.
+          - restore from backup created at the same cluster.
+        The difference between these two flows is in the way the node_id is retrieved - if the backup was created with
+        the cluster under test use node_ids of cluster under test, otherwise, get node_id from `sctool backup files...`
+        """
         backup_bucket_backend = self.params.get("backup_bucket_backend")
         if backup_bucket_backend == "s3":
             install_dependencies = self.install_awscli_dependencies
@@ -188,25 +205,39 @@ class BackupFunctionsMixIn(LoaderUtilsMixin):
         else:
             raise ValueError(f'{backup_bucket_backend=} is not supported')
 
-        per_node_backup_file_paths = mgr_cluster.get_backup_files_dict(snapshot_tag)
-        for node in self.db_cluster.nodes:
+        browse_all_clusters = True if precreated_backup else False
+        per_node_backup_file_paths = mgr_cluster.get_backup_files_dict(snapshot_tag, location, browse_all_clusters)
+        # One path is for schema, it should be filtrated as this method is supposed to be run on restored schema cluster
+        backed_up_node_ids = [i for i in per_node_backup_file_paths if 'schema' not in i]
+
+        nodetool_refresh_extra_flags = self.params.get('mgmt_nodetool_refresh_flags') or ""
+        for index, node in enumerate(self.db_cluster.nodes):
             install_dependencies(node=node)
             node_data_path = Path("/var/lib/scylla/data")
-            node_id = node.host_id
-            for keyspace, tables in keyspace_and_table_list.items():
+            # If the backup was not created with the cluster under test (precreated backup), get node_id from
+            # sctool backup files output, otherwise, use node_ids of cluster under test
+            backed_up_node_id = backed_up_node_ids[index] if precreated_backup else node.host_id
+            for keyspace, tables in ks_tables_list.items():
                 keyspace_path = node_data_path / keyspace
                 for table in tables:
                     table_id = self.get_table_id(node=node, table_name=table, keyspace_name=keyspace)
                     table_upload_path = keyspace_path / f"{table}-{table_id}" / "upload"
-                    for file_path in per_node_backup_file_paths[node_id][keyspace][table]:
-                        download(node=node, source=file_path, destination=table_upload_path)
+
+                    with ExecutionTimer() as timer:
+                        for file_path in per_node_backup_file_paths[backed_up_node_id][keyspace][table]:
+                            download(node=node, source=file_path, destination=table_upload_path)
+                    self.log.info(f"[Node {index}][{keyspace}.{table}] Download took {timer.duration}")
+
                     node.remoter.sudo(f"chown scylla:scylla -Rf {table_upload_path}")
-                    node.run_nodetool(f"refresh -- {keyspace} {table}")
+
+                    with ExecutionTimer() as timer:
+                        node.run_nodetool(f"refresh {keyspace} {table} {nodetool_refresh_extra_flags}")
+                    self.log.info(f"[Node {index}][{keyspace}.{table}] Nodetool refresh took {timer.duration}")
 
     def restore_backup_from_backup_task(self, mgr_cluster, backup_task, keyspace_and_table_list):
         snapshot_tag = backup_task.get_snapshot_tag()
-        self.restore_backup(mgr_cluster=mgr_cluster, snapshot_tag=snapshot_tag,
-                            keyspace_and_table_list=keyspace_and_table_list)
+        self.restore_backup_without_manager(mgr_cluster=mgr_cluster, snapshot_tag=snapshot_tag,
+                                            ks_tables_list=keyspace_and_table_list)
 
     # pylint: disable=too-many-arguments
     def verify_backup_success(self, mgr_cluster, backup_task, ks_names: list = None, tables_names: list = None,
@@ -1292,14 +1323,21 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         except KeyError:
             raise ValueError(f"Snapshot data for size '{snapshot_name}'GB was not found in the {snapshots_config} file")
 
+        ks_tables_map = {}
+        for ks, ts in snapshot_dict["schema"].items():
+            t_names = [list(t.keys())[0] for t in ts]
+            ks_tables_map[ks] = t_names
+
         snapshot_data = SnapshotData(
             bucket=all_snapshots_dict["bucket"],
             tag=snapshot_dict["tag"],
             exp_timeout=snapshot_dict["exp_timeout"],
             keyspaces=list(snapshot_dict["schema"].keys()),
+            ks_tables_map=ks_tables_map,
             cs_read_cmd_template=all_snapshots_dict["cs_read_cmd_template"],
             prohibit_verification_read=snapshot_dict["prohibit_verification_read"],
             number_of_rows=snapshot_dict["number_of_rows"],
+            node_ids=snapshot_dict.get("node_ids"),
         )
         return snapshot_data
 
@@ -1353,7 +1391,7 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
 
         self.run_verification_read_stress()
 
-    def test_restore_from_precreated_backup(self, snapshot_name: str):
+    def test_restore_from_precreated_backup(self, snapshot_name: str, restore_outside_manager: bool = False):
         """The test restores the schema and data from a pre-created backup and runs the verification read stress.
         1. Define the backup to restore from
         2. Run restore schema to empty cluster
@@ -1361,8 +1399,9 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         4. Run verification read stress
 
         Args:
-            snapshot_name (str): The name of the snapshot to restore from.
-                                 All snapshots are defined in the 'defaults/manager_restore_benchmark_snapshots.yaml'
+            snapshot_name: The name of the snapshot to restore from.
+                           All snapshots are defined in the 'defaults/manager_restore_benchmark_snapshots.yaml'
+            restore_outside_manager: set True to restore outside of Manager via nodetool refresh
         """
         manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
         mgr_cluster = self._ensure_and_get_cluster(manager_tool)
@@ -1376,12 +1415,25 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         for ks_name in snapshot_data.keyspaces:
             self.set_ks_strategy_to_network_and_rf_according_to_cluster(keyspace=ks_name, repair_after_alter=False)
 
-        self.log.info("Restoring the data")
-        extra_params = self.get_restore_extra_parameters()
-        task = self.restore_backup_with_task(mgr_cluster=mgr_cluster, snapshot_tag=snapshot_data.tag,
-                                             timeout=snapshot_data.exp_timeout, restore_data=True,
-                                             location_list=location, extra_params=extra_params)
-        self.manager_test_metrics.restore_time = task.duration
+        if restore_outside_manager:
+            self.log.info("Restoring the data outside the Manager")
+            with ExecutionTimer() as timer:
+                self.restore_backup_without_manager(
+                    mgr_cluster=mgr_cluster,
+                    snapshot_tag=snapshot_data.tag,
+                    ks_tables_list=snapshot_data.ks_tables_map,
+                    location=location[0],
+                    precreated_backup=True,
+                )
+            restore_time = timer.duration
+        else:
+            self.log.info("Restoring the data with Manager task")
+            extra_params = self.get_restore_extra_parameters()
+            task = self.restore_backup_with_task(mgr_cluster=mgr_cluster, snapshot_tag=snapshot_data.tag,
+                                                 timeout=snapshot_data.exp_timeout, restore_data=True,
+                                                 location_list=location, extra_params=extra_params)
+            restore_time = task.duration
+        self.manager_test_metrics.restore_time = restore_time
 
         if not (self.params.get('mgmt_skip_post_restore_stress_read') or snapshot_data.prohibit_verification_read):
             self.log.info("Running verification read stress")
@@ -1405,3 +1457,18 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         else:
             self.log.info("Executing test_backup_and_restore_only_data...")
             self.test_backup_and_restore_only_data()
+
+    def test_restore_data_without_manager(self):
+        """The test restores the schema and data from a pre-created backup.
+        The distinctive feature is that data restore is performed outside the Manager via nodetool refresh.
+        Nodetool refresh cmd can be run with extra flags: --load-and-stream and --primary-replica-only.
+        These extra flags can be set in `mgmt_nodetool_refresh_flags` variable.
+
+        The motivation of having such a test is to check L&S efficiency when doing the restore of the full cluster in
+        comparison with the same test but with restore executed via Manager.
+        """
+        snapshot_name = self.params.get('mgmt_reuse_backup_snapshot_name')
+        assert snapshot_name, ("The test requires a pre-created snapshot to restore from. "
+                               "Please provide the 'mgmt_reuse_backup_snapshot_name' parameter.")
+
+        self.test_restore_from_precreated_backup(snapshot_name, restore_outside_manager=True)

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -664,8 +664,10 @@ class ManagerCluster(ScyllaManagerBase):
         if not res:
             raise ScyllaManagerError("Unknown failure for sctool {} command".format(cmd))
 
-    def get_backup_files_dict(self, snapshot_tag):
-        command = f" -c {self.id} backup files --snapshot-tag {snapshot_tag}"
+    def get_backup_files_dict(self, snapshot_tag, location=None, all_clusters=None):
+        location_flag = f" --location {location}" if location else ""
+        all_clusters_flag = "--all-clusters" if all_clusters else ""
+        command = f" -c {self.id} backup files --snapshot-tag {snapshot_tag} {location_flag} {all_clusters_flag}"
         # The sctool backup files command prints the s3 paths of all of the files that are required to restore the
         # cluster from the backup
         snapshot_files = self.sctool.run(command)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1137,6 +1137,10 @@ class SCTConfiguration(dict):
         dict(name="mgmt_skip_post_restore_stress_read", env="SCT_MGMT_SKIP_POST_RESTORE_STRESS_READ", type=boolean,
              help="Skip post-restore c-s verification read in the Manager restore benchmark tests"),
 
+        dict(name="mgmt_nodetool_refresh_flags",
+             env="SCT_MGMT_NODETOOL_REFRESH_FLAGS", type=str,
+             help="Nodetool refresh extra options like --load-and-stream or --primary-replica-only"),
+
         # PerformanceRegressionTest
 
         dict(name="stress_cmd_w", env="SCT_STRESS_CMD_W",

--- a/sdcm/utils/time_utils.py
+++ b/sdcm/utils/time_utils.py
@@ -1,0 +1,27 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2024 ScyllaDB
+
+from datetime import datetime, timedelta
+
+
+class ExecutionTimer:
+    def __enter__(self):
+        self.start_time = datetime.now()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.end_time = datetime.now()
+
+    @property
+    def duration(self) -> timedelta:
+        return self.end_time - self.start_time

--- a/test-cases/manager/manager-restore-outside.yaml
+++ b/test-cases/manager/manager-restore-outside.yaml
@@ -1,0 +1,13 @@
+test_duration: 600
+
+instance_type_db: 'i4i.2xlarge'
+
+region_name: us-east-1
+n_db_nodes: 3
+n_monitor_nodes: 1
+n_loaders: 0
+
+mgmt_reuse_backup_snapshot_name: '500gb_1t_ics'
+mgmt_skip_post_restore_stress_read: true
+
+user_prefix: 'manager-restore-out-of-manager'


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-manager/issues/3993

The PR introduces the test that validate restore with L&S outside of Scylla Manager.
In addition to the test, contextmanager class that allows to measure execution time of wrapped function was added.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] no extra params [run](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master/job/backup-restore-outside-manager/37/);
- [x] with extra params [run](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master/job/backup-restore-outside-manager/38/) 
- [x] [regression](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-sanity-test/27/) 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code