### PR TITLE
fix(reuse_cluster): fix reuse_cluster flow for Azure backend

### DIFF
--- a/sdcm/cluster_azure.py
+++ b/sdcm/cluster_azure.py
@@ -292,6 +292,9 @@ class ScyllaAzureCluster(cluster.BaseScyllaCluster, AzureCluster):
     def _wait_for_preinstalled_scylla(node):
         node.wait_for_machine_image_configured()
 
+    def _reuse_cluster_setup(self, node: AzureNode) -> None:
+        node.run_startup_script()
+
 
 class LoaderSetAzure(cluster.BaseLoaderSet, AzureCluster):
 


### PR DESCRIPTION
The change adds a method to sdcm.cluster_azure.ScyllaAzureCluster class to call syslog-ng (re)configuration script during reuse_cluster flow.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/8520

### Testing
- [x] :green_circle: as part of PR provision build in CI

### PR pre-checks (self review)
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
