### PR TITLE
fix(artifacts): add rocky9-selinux

### DIFF
--- a/jenkins-pipelines/oss/artifacts/artifacts-rocky9-selinux.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-rocky9-selinux.jenkinsfile
@@ -1,0 +1,13 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/rocky9-selinux.yaml',
+    backend: 'gce',
+    provision_type: 'spot',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/test-cases/artifacts/rocky9-selinux.yaml
+++ b/test-cases/artifacts/rocky9-selinux.yaml
@@ -1,0 +1,21 @@
+backtrace_decoding: false
+cluster_backend: 'gce'
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/rocky-linux-cloud/global/images/family/rocky-linux-9'
+gce_instance_type_db: 'n1-standard-2'
+gce_root_disk_type_db: 'pd-ssd'
+root_disk_size_db: 50
+gce_n_local_ssd_disk_db: 1
+instance_provision: "spot"
+instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
+n_db_nodes: 1
+n_loaders: 0
+n_monitor_nodes: 0
+nemesis_class_name: 'NoOpMonkey'
+scylla_linux_distro: 'centos'
+test_duration: 60
+user_prefix: 'artifacts-rocky9-selinux'
+append_scylla_setup_args: '--no-selinux-setup'
+
+user_credentials_path: '~/.ssh/scylla_test_id_ed25519'
+use_preinstalled_scylla: false


### PR DESCRIPTION
since there are bugs related centos9 stream that we might not gonna attend to.
adding the test case to work also with rocky9

Ref: https://github.com/scylladb/scylladb/issues/19325

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🔴 rocky9-selinux - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-rocky9-selinux-test/2/
- [x] run with a fix from @syuu1228 -

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
