### PR TITLE
feature(sdcm/reporting): Add initial simple elasticsearch reporter

### DIFF
--- a/sdcm/reporting/elastic_reporter.py
+++ b/sdcm/reporting/elastic_reporter.py
@@ -1,0 +1,55 @@
+import datetime
+import logging
+
+
+from sdcm.es import ES
+from sdcm.utils.ci_tools import get_job_name, get_job_url
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ElasticRunReporter:
+
+    INDEX_NAME = "sct_test_runs"
+
+    def __init__(self) -> None:
+        self._es = ES()
+
+    @staticmethod
+    def get_build_number(build_job_url: str) -> int | None:
+        build_number = build_job_url.rstrip("/").split("/")[-1] if build_job_url else -1
+        if build_number:
+            try:
+                return int(build_number)
+            except ValueError:
+                LOGGER.error("Error parsing build number from %s: got %s as build_number", build_job_url, build_number)
+        return None
+
+    def report_run(self, run_id: str, status: str, index=None) -> bool:
+        job_name = get_job_name()
+        if job_name == "local_run":
+            LOGGER.warning("Will not report a local run to elastic, aborting.")
+            return False
+        build_url = get_job_url()
+        if not build_url:
+            LOGGER.warning("Build URL is missing, unable to report the run.")
+            return False
+        build_number = self.get_build_number(build_url)
+
+        index = self.INDEX_NAME if not index else index
+        if not self._check_index(index):
+            self._es.indices.create(index=self.INDEX_NAME)
+        document = {
+            "timestamp": datetime.datetime.utcnow(),
+            "run_id": run_id,
+            "status": status,
+            "build_id": job_name,
+            "build_url": build_url,
+            "build_number": build_number,
+        }
+
+        self._es.create(index=index, document=document, id=run_id, doc_type="sct_test_run_short_v1")
+        return True
+
+    def _check_index(self, index_name: str):
+        return self._es.indices.exists(index=index_name)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -64,6 +64,7 @@ from sdcm.provision.azure.provisioner import AzureProvisioner
 from sdcm.provision.network_configuration import ssh_connection_ip_type
 from sdcm.provision.provisioner import provisioner_factory
 from sdcm.provision.helpers.certificate import create_ca, update_certificate, cleanup_ssl_config
+from sdcm.reporting.elastic_reporter import ElasticRunReporter
 from sdcm.reporting.tooling_reporter import PythonDriverReporter
 from sdcm.scan_operation_thread import ScanOperationThread
 from sdcm.nosql_thread import NoSQLBenchStressThread
@@ -2969,6 +2970,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         self.finalize_teardown()
         self.argus_finalize_test_run()
+        try:
+            ElasticRunReporter().report_run(run_id=self.test_config.test_id(), status=self.get_test_status())
+        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            pass
         self.argus_heartbeat_stop_signal.set()
 
         self.log.info('Test ID: {}'.format(self.test_config.test_id()))


### PR DESCRIPTION
This commit adds a simple elastic reporter for the run status of a
particular job. This acts as a replacement to previously used
db_stats.py, notably being much simpler in both the usage and resulting
documents.

Task: scylladb/qa-tasks#1490

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Argus](https://argus.scylladb.com/test/b0b22734-758e-47b4-b6ec-29e64d212d52/runs?additionalRuns[]=25096c59-5d48-43fd-8059-4445fed79607)
- [x] [Jenkins](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/alexey-argus-testing/98/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
