### PR TITLE
fix(upgrade): enable default_filters after node upgrade

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -34,6 +34,7 @@ from sdcm import wait
 from sdcm.cluster import BaseNode
 from sdcm.fill_db_data import FillDatabaseData
 from sdcm.sct_events import Severity
+from sdcm.sct_events.setup import enable_default_filters
 from sdcm.stress_thread import CassandraStressThread
 from sdcm.utils.decorators import retrying
 from sdcm.utils.user_profile import get_profile_content
@@ -362,6 +363,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         InfoEvent(message='upgrade_node - starting to "_update_argus_upgraded_version"').publish()
         self._update_argus_upgraded_version(node, new_ver)
         InfoEvent(message='upgrade_node - ended to "_update_argus_upgraded_version"').publish()
+        enable_default_filters(sct_config=self.params)
         if upgrade_sstables:
             InfoEvent(message='upgrade_node - starting to "upgradesstables_if_command_available"').publish()
             self.upgradesstables_if_command_available(node)
@@ -463,6 +465,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             self.upgradesstables_if_command_available(node)
 
         self.db_cluster.wait_all_nodes_un()
+        enable_default_filters(sct_config=self.params)
 
     @staticmethod
     def upgradesstables_if_command_available(node, queue=None):  # pylint: disable=invalid-name


### PR DESCRIPTION
Audit was disabled by scylladb/scylla-enterprise#3148. But it was not disabled in 2022.2
So every time after upgrade from this version the test suffers from 'Authentication error on host /10.142.0.200:9042: Cannot achieve consistency level for cl ONE. Requires 1, alive 0 error.'
This commit enables the default event filters again after node upgrade/rollback

Task: https://github.com/scylladb/scylla-cluster-tests/issues/7907

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] [rolling-upgrade-with-sla](https://argus.scylladb.com/test/c715037b-caed-479f-b550-944f46ea7576/runs?additionalRuns[]=b6aab9aa-c5cd-4ecd-89f8-b0f791587c95)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
