### PR TITLE
fix(is_enterprise): don't cache if no scylla is installed

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -782,21 +782,29 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             startup_interface_command = "ip link set {} up"
         self.remoter.sudo(startup_interface_command.format(interface_name))
 
-    @cached_property
+    @optional_cached_property
     def is_enterprise(self) -> bool | None:
         _is_enterprise = None
+
         if self.distro.is_rhel_like:
-            result = self.remoter.sudo("yum search scylla-enterprise 2>&1", ignore_status=True)
-            if result.ok:
-                _is_enterprise = "scylla-enterprise.x86_64" in result.stdout or "No matches found" not in result.stdout
+            oss_command = "yum info scylla"
+            enterprise_command = "yum info scylla-enterprise"
         elif self.distro.is_sles:
-            result = self.remoter.sudo("zypper search scylla-enterprise 2>&1", ignore_status=True)
-            if result.ok:
-                _is_enterprise = "scylla-enterprise" in result.stdout or "No matching items found" not in result.stdout
+            oss_command = "zypper info scylla"
+            enterprise_command = "zypper info scylla-enterprise"
         elif self.distro.is_debian_like:
-            result = self.remoter.sudo("apt-cache search scylla-enterprise", ignore_status=True)
-            if result.ok:
-                _is_enterprise = "scylla-enterprise" in result.stdout
+            oss_command = "apt-cache show scylla"
+            enterprise_command = "apt-cache show scylla-enterprise"
+        else:
+            raise ValueError(f"Unsupported OS [{self.distro}]")
+
+        oss_installed = self.remoter.sudo(oss_command, ignore_status=True).ok
+        enterprise_installed = self.remoter.sudo(enterprise_command, ignore_status=True).ok
+        if oss_installed or enterprise_installed:
+            _is_enterprise = enterprise_installed
+        else:
+            raise NoValue
+
         return _is_enterprise
 
     @property


### PR DESCRIPTION
cause of recent improvement to speeding up test setup, now we can reach to situation monitor stack might spin before first db node is installed (i.e. when not using scylla images).

that in turn might cache the outcome of `is_enterprise` with a None value since no version is yet installed which later would cause the installation to try install scylla oss version.

this change is moving to a logic that check for the existence of both OSS and enterprise version, and if both doesn't exists it don't cache any value, so when eventually we do have a version available it would return the correct answer.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-fips-test/5
- [x] 🟢  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-fips-test/8/
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
