### PR TITLE
fix(get_all_versions_from_centos_repository): limit only to scylla packages

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -92,6 +92,8 @@ SCYLLA_REPO_BUCKET = "downloads.scylladb.com"
 LATEST_SYMLINK_NAME = "latest"
 NO_TIMESTAMP = dateutil.parser.parse("1961-04-12T06:07:00Z", ignoretz=True)  # Poyekhali!
 
+SUPPORTED_PACKAGES = ("scylla", "scylla-enterprise", "scylla-manager")
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -359,7 +361,8 @@ def get_all_versions_from_centos_repository(urls: set[str]) -> set[str]:
         xml_url = url.replace(REPOMD_XML_PATH, primary_path)
 
         parser = Parser(url=xml_url)
-        major_versions = [package['version'][1]['ver'] for package in parser.getList()]
+        major_versions = [package['version'][1]['ver']
+                          for package in parser.getList() if package['name'][0] in SUPPORTED_PACKAGES]
         return set(major_versions)
 
     threads = ParallelObject(objects=urls, timeout=SCYLLA_URL_RESPONSE_TIMEOUT).run(func=get_version)

--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -128,6 +128,12 @@ class TestBaseVersion(unittest.TestCase):
         version_list = general_test(scylla_repo, linux_distro)
         assert set(version_list) == {'6.0', '2024.1'}
 
+    def test_2024_2_ubuntu(self):
+        scylla_repo = self.url_base + '-enterprise/enterprise-2024.2/deb/unified/latest/scylladb-2024.2/scylla.list'
+        linux_distro = 'ubuntu-focal'
+        version_list = general_test(scylla_repo, linux_distro)
+        assert set(version_list) == {'6.0', '2024.1'}
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
since now scylla-doctor was introduced into scylla repositories we don't want to retrieve it's version, only the scylla versions

if and when we'll need to get it's version, we'll need to refactor this code to supply list of package we'll want to look at.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] test with unittests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
