### PR TITLE
fix(scylla-sstable): switch from `--scylla-yaml-file` to `SCYLLA_CONF` env variable

### DIFF
--- a/sdcm/utils/sstable/sstable_utils.py
+++ b/sdcm/utils/sstable/sstable_utils.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import logging
 import random
+from pathlib import Path
 
 from sdcm.paths import SCYLLA_YAML_PATH
 from sdcm.utils.version_utils import ComparableScyllaVersion
@@ -69,8 +70,8 @@ class SstableUtils:
 
         if ComparableScyllaVersion(self.db_node.scylla_version) >= '2023.1.3':
             dump_cmd = (
-                f"{self.db_node.add_install_prefix('/usr/bin/scylla')} sstable dump-scylla-metadata"
-                f" --scylla-yaml-file {self.db_node.add_install_prefix(SCYLLA_YAML_PATH)}"
+                f"SCYLLA_CONF={Path(self.db_node.add_install_prefix(SCYLLA_YAML_PATH)).parent}"
+                f" {self.db_node.add_install_prefix('/usr/bin/scylla')} sstable dump-scylla-metadata"
                 "  --logger-log-level scylla-sstable=debug"
                 f" --keyspace {self.keyspace} --table {self.table} --sstables"
             )

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -23,6 +23,7 @@ import re
 from functools import wraps, cache
 from typing import List
 import contextlib
+from pathlib import Path
 
 import cassandra
 import tenacity
@@ -806,8 +807,8 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         if should_use_sstabledump:
             dump_cmd = 'sstabledump'
         else:
-            dump_cmd = (f'{first_node.add_install_prefix("/usr/bin/scylla")} sstable dump-data '
-                        f'--scylla-yaml-file {first_node.add_install_prefix(SCYLLA_YAML_PATH)} '
+            dump_cmd = (f'SCYLLA_CONF={Path(first_node.add_install_prefix(SCYLLA_YAML_PATH)).parent} '
+                        f'{first_node.add_install_prefix("/usr/bin/scylla")} sstable dump-data '
                         f'--keyspace {keyspace} '
                         f'--table {table} '
                         '--sstables')


### PR DESCRIPTION
since the scylla sstable code doesn't fallback into any other option but reading schema from sstable of system tables, if --scylla-yaml-file is used.

switching to SCYLLA_CONF env variable should make the tool use other fallback options like reading the assuming the schema from the sstable we want to read.

Ref: scylladb/scylla-enterprise#4660

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/66/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-ubuntu20.04-test/24/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
