### PR TITLE
fix(loader): update loader images to `scylla-qa-loader-ami-v22-ubuntu22`

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -7,7 +7,7 @@ user_credentials_path: '~/.ssh/scylla_test_id_ed25519'
 instance_type_loader: 'c6i.xlarge'
 instance_type_monitor: 't3.large'
 # manual on creating loader AMI's: see docs/new_loader_ami.md
-ami_id_loader: 'scylla-qa-loader-ami-v21-ubuntu22'  # versions: c-s 2024.2.0-rc0, s-b 0.1.21
+ami_id_loader: 'scylla-qa-loader-ami-v22-ubuntu22'  # versions: c-s 2024.2.0-rc0, s-b 0.1.21
 # manual on updating monitor images see: docs/monitoring-images.md
 ami_id_monitor: 'scylladb-monitor-4-8-0-2024-08-06t03-34-43z'
 

--- a/utils/copy_ami_to_all_regions.sh
+++ b/utils/copy_ami_to_all_regions.sh
@@ -1,10 +1,15 @@
-AMI_ID=ami-0c4e5a2331f97fd0d
-AMI_NAME='scylladb-monitor-4-6-2-2024-02-13t08-06-04z'
-SOURCE_REGION=us-east-1
-TARGET_REGIONS='us-west-2 eu-west-1 eu-west-2 eu-north-1 eu-central-1'
+AMI_ID="ami-0d93dc84c27b5864c"
+AMI_NAME="scylla-qa-loader-ami-v22-ubuntu22"
+SOURCE_REGION="us-east-1"
+TARGET_REGIONS="us-west-2 eu-west-1 eu-west-2 eu-north-1 eu-central-1"
 
-for target_region in $TARGET_REGIONS
-do
-	echo "copy AMI to $target_region"
-	aws ec2 copy-image --region $target_region  --name "$AMI_NAME" --source-region $SOURCE_REGION --source-image-id $AMI_ID
+# Retrieve the tags of the source AMI
+TAGS=$(aws ec2 describe-tags --filters "Name=resource-id,Values=$AMI_ID" --region $SOURCE_REGION --query "Tags[*].{Key:Key,Value:Value}")
+
+for target_region in $TARGET_REGIONS; do
+    echo "Copying AMI to $target_region"
+    NEW_AMI_ID=$(aws ec2 copy-image --region "${target_region}" --name "$AMI_NAME" --source-region $SOURCE_REGION --source-image-id $AMI_ID --query 'ImageId' --output text)
+
+    echo "Applying tags to the new AMI in $target_region"
+    aws ec2 create-tags --resources "${NEW_AMI_ID}" --tags "$TAGS" --region "${target_region}"
 done


### PR DESCRIPTION
seems like the loaders were missing the `PREPARED-LOADER` file, to really stop installing all bunch of unneeded packages, which are already should be in place, and in some cases might lead to errors trying related to identify the correct scylla product

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] aws provision test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
