### PR TITLE
fix(aws-provision): have a default for `user_data_format_version`

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2471,6 +2471,7 @@ class SCTConfiguration(dict):
                                             ('oracle_user_data_format_version', ami_id_db_oracle)]:
                 if ami_list:
                     user_data_format_versions = set()
+                    self[key_to_update] = '2'
                     for ami_id, region_name in zip(ami_list, region_names):
                         if not ami_built_by_scylla(ami_id, region_name):
                             continue


### PR DESCRIPTION
since we don't set a default for `user_data_format_version` in case we are using images which are not scylla for the db nodes

we'll be hitting the following error in provision step:

```
pydantic.error_wrappers.ValidationError: 1 validation error for ScyllaUserDataBuilder
user_data_format_version
  none is not an allowed value (type=type_error.none.not_allowed)
```

in all other backend we have default for this value, and in AWS we were missing it, it's only affecting once case we have that is running longevity without scylla images.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x]  🔴 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-fips-test/6/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
