### PR TITLE
fix(sct.py): Ignore TEST_ERROR inside finish_argus_test_run

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1783,7 +1783,7 @@ def finish_argus_test_run(jenkins_status):
         test_config.set_test_id_only(params.get('test_id'))
         test_config.init_argus_client(params)
         status = test_config.argus_client().get_status()
-        if status in [TestStatus.PASSED, TestStatus.FAILED]:
+        if status in [TestStatus.PASSED, TestStatus.FAILED, TestStatus.TEST_ERROR]:
             LOGGER.info("Argus TestRun already finished with status %s", status.value)
             return
         new_status = TestStatus.FAILED


### PR DESCRIPTION
This commit corrects an issue where a test that would previously finish
with test error inside sct stage would get overwritten by jenkins
setting status to failed due to pipeline health

Fixes #8614

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
