### PR TITLE
fix(c-s): working directory for docker running c-s

### DIFF
--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -280,11 +280,12 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
             cmd_runner = cleanup_context = RemoteDocker(loader, self.docker_image_name,
                                                         command_line="-c 'tail -f /dev/null'",
                                                         extra_docker_opts=f'{cpu_options} '
-                                                                          '--network=host '
-                                                                          '--security-opt seccomp=unconfined '
-                                                                          f'--label shell_marker={self.shell_marker}'
-                                                                          f' --entrypoint /bin/bash'
-                                                                          f' -v $HOME/{remote_hdr_file_name}:/{remote_hdr_file_name}')
+                                                        '--network=host '
+                                                        '--security-opt seccomp=unconfined '
+                                                        f'--label shell_marker={self.shell_marker}'
+                                                        f' --entrypoint /bin/bash'
+                                                        f' -w /'
+                                                        f' -v $HOME/{remote_hdr_file_name}:/{remote_hdr_file_name}')
 
         stress_cmd = self.create_stress_cmd(cmd_runner, keyspace_idx, loader)
         if self.params.get('cs_debug'):


### PR DESCRIPTION
When HDR is enabled and expected, output inside the docker container is WORKDIR for c-s (currently /scylla-tools-java), but SCT is expecting it to be in root (/), the quickest way to tackle this issue is to make a working directory of the running docker container /.

This quick-fix is to make sure our mappings are ok and HDR output file is not empty as reported in https://github.com/scylladb/cassandra-stress/issues/23

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
