### PR TITLE
fix(oel9): stop/disable iptables and firewalld

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4607,7 +4607,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
     def node_setup(self, node: BaseNode, verbose: bool = False, timeout: int = 3600):  # pylint: disable=too-many-branches,too-many-statements,too-many-locals
         node.wait_ssh_up(verbose=verbose, timeout=timeout)
-        if node.distro.is_centos9 or node.distro.is_rhel8 or node.distro.is_oel8 or node.distro.is_rocky8 or node.distro.is_rocky9:
+        if node.distro.is_rhel_like:
             node.remoter.sudo('systemctl stop iptables', ignore_status=True)
             node.remoter.sudo('systemctl disable iptables', ignore_status=True)
             node.remoter.sudo('systemctl stop firewalld', ignore_status=True)


### PR DESCRIPTION
the logic was missed when enabling oel9, and it made the jenkins job to get stuck on trying to connect to the CQL port

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
