### PR TITLE
improvement(hdr stats): collect throughput and report throughput in Result tab

### DIFF
--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -39,9 +39,11 @@ class LatencyCalculatorMixedResult(GenericResultTable):
             ColumnMetadata(name="P90 read", unit="ms", type=ResultType.FLOAT),
             ColumnMetadata(name="P99 write", unit="ms", type=ResultType.FLOAT),
             ColumnMetadata(name="P99 read", unit="ms", type=ResultType.FLOAT),
+            ColumnMetadata(name="Throughput write", unit="op/s", type=ResultType.INTEGER),
+            ColumnMetadata(name="Throughput read", unit="op/s", type=ResultType.INTEGER),
             ColumnMetadata(name="duration", unit="HH:MM:SS", type=ResultType.DURATION),
             ColumnMetadata(name="Overview", unit="", type=ResultType.TEXT),
-            ColumnMetadata(name="QA dashboard", unit="", type=ResultType.TEXT),
+            ColumnMetadata(name="QA dashboard", unit="", type=ResultType.TEXT)
         ]
 
 
@@ -52,9 +54,10 @@ class LatencyCalculatorWriteResult(GenericResultTable):
         Columns = [
             ColumnMetadata(name="P90 write", unit="ms", type=ResultType.FLOAT),
             ColumnMetadata(name="P99 write", unit="ms", type=ResultType.FLOAT),
+            ColumnMetadata(name="Throughput write", unit="op/s", type=ResultType.INTEGER),
             ColumnMetadata(name="duration", unit="HH:MM:SS", type=ResultType.DURATION),
             ColumnMetadata(name="Overview", unit="", type=ResultType.TEXT),
-            ColumnMetadata(name="QA dashboard", unit="", type=ResultType.TEXT),
+            ColumnMetadata(name="QA dashboard", unit="", type=ResultType.TEXT)
         ]
 
 
@@ -65,9 +68,10 @@ class LatencyCalculatorReadResult(GenericResultTable):
         Columns = [
             ColumnMetadata(name="P90 read", unit="ms", type=ResultType.FLOAT),
             ColumnMetadata(name="P99 read", unit="ms", type=ResultType.FLOAT),
+            ColumnMetadata(name="Throughput read", unit="op/s", type=ResultType.INTEGER),
             ColumnMetadata(name="duration", unit="HH:MM:SS", type=ResultType.DURATION),
             ColumnMetadata(name="Overview", unit="", type=ResultType.TEXT),
-            ColumnMetadata(name="QA dashboard", unit="", type=ResultType.TEXT),
+            ColumnMetadata(name="QA dashboard", unit="", type=ResultType.TEXT)
         ]
 
 
@@ -106,6 +110,13 @@ def send_result_to_argus(argus_client: ArgusClient, workload: str, name: str, de
                                     row=f"Cycle #{cycle}",
                                     value=value,
                                     status=Status.PASS if value < operation_error_thresholds[f"percentile_{percentile}"] else Status.ERROR)
+        if value := summary[operation.upper()].get("throughput", None):
+            # TODO: This column will be validated in the gradual test. `PASS` is temporary status. Should be handled later
+            result_table.add_result(column=f"Throughput {operation.lower()}",
+                                    row=f"Cycle #{cycle}",
+                                    value=value,
+                                    status=Status.UNSET)
+
     result_table.add_result(column="duration", row=f"Cycle #{cycle}",
                             value=result["duration_in_sec"], status=Status.PASS)
     try:

--- a/sdcm/utils/csrangehistogram.py
+++ b/sdcm/utils/csrangehistogram.py
@@ -121,7 +121,8 @@ def _generate_percentile_name(percentile: int):
 
 
 _HistorgramSummary = make_dataclass("HistorgramSummary",
-                                    [(_generate_percentile_name(perc), float) for perc in PERCENTILES],
+                                    [(_generate_percentile_name(perc), float)
+                                     for perc in PERCENTILES] + [("throughput", float)],
                                     bases=(_HistorgramSummaryBase,))
 
 
@@ -366,7 +367,8 @@ class _CSRangeHistogramBuilder:
         if percentiles := histogram.get_percentile_to_value_dict(PERCENTILES):
             for perc, value in percentiles.items():
                 percentiles_data[_generate_percentile_name(perc)] = round(value / 1_000_000, 2)
-
+            percentiles_data["throughput"] = round(histogram.get_total_count(
+            ) / ((histogram.get_end_time_stamp() - histogram.get_start_time_stamp()) / 1000))
             return _HistorgramSummary(
                 start_time=histogram.get_start_time_stamp() or base_start_ts,
                 end_time=histogram.get_end_time_stamp() or base_end_ts,

--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -237,6 +237,10 @@ def latency_calculator_decorator(original_function: Optional[Callable] = None, *
             result["hdr_summary"] = tester.get_cs_range_histogram(stress_operation=workload,
                                                                   start_time=start,
                                                                   end_time=end)
+            hdr_throughput = 0
+            for summary, values in result["hdr_summary"].items():
+                hdr_throughput += values["throughput"]
+            result["cycle_hdr_throughput"] = round(hdr_throughput)
             result["reactor_stalls_stats"] = reactor_stall_stats
 
             if "steady" in func.__name__.lower():


### PR DESCRIPTION
Collect throughput statistics from HDR file and report in Elasticsearch.
Now only latency is reported in the Report tab for performance tests.
This commit add throughput as well

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [-perf-regression-latency-650gb-during-rolling-upgrade](https://argus.scylladb.com/test/8d048290-f7f4-4af5-9e09-882202a35656/runs?additionalRuns[]=c1930454-806a-412c-abb3-7a3f9b9d0e3c)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
