### PR TITLE
fix(_get_keyspaces_to_decrease_rf): Address a case where no keyspace RF value of DC

### DIFF
--- a/sdcm/utils/replication_strategy_utils.py
+++ b/sdcm/utils/replication_strategy_utils.py
@@ -180,8 +180,12 @@ class DataCenterTopologyRfControl:
                 continue  # Skip keyspace using SimpleStrategy
 
             if 'NetworkTopologyStrategy' in replication['class']:
-                rf = int(replication.get(self.datacenter))
-                if rf == self.original_nodes_number:
+                rf = replication.get(self.datacenter)
+                if rf is None:
+                    LOGGER.warning(
+                        f"Datacenter {self.datacenter} not found in replication strategy for keyspace {keyspace_name}.")
+                    continue
+                if int(rf) == self.original_nodes_number:
                     matching_keyspaces.append(keyspace_name)
             else:
                 LOGGER.warning("Unexpected replication strategy found: %s", replication['class'])


### PR DESCRIPTION
In case no keyspace replication-factor value is retrieved in a DC,
A warning is logged and the keyspace is ignored (skipped).

Fixes: #8694

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
