### PR TITLE
fix(aws-provision): set default for `user_data_format_version=3`

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2474,7 +2474,7 @@ class SCTConfiguration(dict):
                                             ('oracle_user_data_format_version', ami_id_db_oracle)]:
                 if ami_list:
                     user_data_format_versions = set()
-                    self[key_to_update] = '2'
+                    self[key_to_update] = '3'
                     for ami_id, region_name in zip(ami_list, region_names):
                         if not ami_built_by_scylla(ami_id, region_name):
                             continue


### PR DESCRIPTION
the assumption in f2c93cc24982c5d63aab47d951b6bfe9a07cb6c1 was wrong and we can't really boot db node, clean with v2 any more.

changing the default back to using v3

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] 🕥 https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-100gb-4h-fips-test/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
