### PR TITLE
fix(full scan thread): Added missing fetch-next-page to fetch_result_pages

### DIFF
--- a/sdcm/scan_operation_thread.py
+++ b/sdcm/scan_operation_thread.py
@@ -188,6 +188,7 @@ class FullscanOperationBase:
         self.log.debug('Will fetch up to %s result pages..', read_pages)
         pages = 0
         while result.has_more_pages and pages <= read_pages:
+            result.fetch_next_page()
             if read_pages > 0:
                 pages += 1
 


### PR DESCRIPTION

fetch_result_pages had a "while" loop where a call to result.fetch_next_page() is missing. Adding it back.
Fixes: #8287

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
