### PR TITLE
fix(auth_v2): don't change system_auth

### DIFF
--- a/add_new_dc_test.py
+++ b/add_new_dc_test.py
@@ -21,7 +21,10 @@ class TestAddNewDc(LongevityTest):
 
         self.log.info("Starting add new DC test...")
         assert self.params.get('n_db_nodes').endswith(" 0"), "n_db_nodes must be a list and last dc must equal 0"
-        system_keyspaces = ["system_auth", "system_distributed", "system_traces"]
+        system_keyspaces = ["system_distributed", "system_traces"]
+        # auth-v2 is used when consistent topology is enabled
+        if not self.db_cluster.nodes[0].raft.is_consistent_topology_changes_enabled:
+            system_keyspaces.insert(0, "system_auth")
 
         # reconfigure system keyspaces to use NetworkTopologyStrategy
         status = self.db_cluster.get_nodetool_status()

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4615,7 +4615,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 "add_remove_dc skipped for multi-dc scenario (https://github.com/scylladb/scylla-cluster-tests/issues/5369)")
         InfoEvent(message='Starting New DC Nemesis').publish()
         node = self.cluster.nodes[0]
-        system_keyspaces = ["system_auth", "system_distributed", "system_traces"]
+        system_keyspaces = ["system_distributed", "system_traces"]
+        if not node.raft.is_consistent_topology_changes_enabled:  # auth-v2 is used when consistent topology is enabled
+            system_keyspaces.insert(0, "system_auth")
         self._switch_to_network_replication_strategy(self.cluster.get_test_keyspaces() + system_keyspaces)
         datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())
         self.tester.create_keyspace("keyspace_new_dc", replication_factor={

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1089,6 +1089,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if self.test_config.REUSE_CLUSTER:
             self.log.debug("Skipping change rf of system_auth for reusing cluster")
             return
+        if db_cluster.nodes[0].raft.is_consistent_topology_changes_enabled:
+            self.log.debug("Skipping change rf of system_auth because with consistent topology auth-v2 is enabled")
+            return
         self.set_ks_strategy_to_network_and_rf_according_to_cluster(keyspace="system_auth", db_cluster=db_cluster)
 
     def set_ks_strategy_to_network_and_rf_according_to_cluster(self, keyspace, db_cluster=None, repair_after_alter=True):


### PR DESCRIPTION
If consistent topology is enabled then auth-v2 is enabled, and we don't need to change RF or topology for system_auth keyspace.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
