### PR TITLE
ci(custom-d1-w1): use more DB nodes

### DIFF
--- a/test-cases/longevity/longevity-gce-custom-d1-workload1-hybrid-raid.yaml
+++ b/test-cases/longevity/longevity-gce-custom-d1-workload1-hybrid-raid.yaml
@@ -1,5 +1,5 @@
 test_duration: 900
-n_db_nodes: 6
+n_db_nodes: 8
 n_loaders: 2
 n_monitor_nodes: 1
 


### PR DESCRIPTION
The `custom-d1/w1` workflow gets easily overloaded by disruptions to one from existing 6 nodes.

So, add 2 more DB nodes making the cluster be 8 nodes in total.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
