### PR TITLE
mergify: add support for branch-6.2

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,44 +6,6 @@ pull_request_rules:
     actions:
       edit:
          draft: true
-  - name: Automate backport pull request 5.2
-    conditions:
-      - base=master # Ensure this rule only applies to PRs merged into the master branch
-      - label=backport/5.2 # The PR must have this label to trigger the backport
-    actions:
-      backport:
-        title: "[Backport 5.2] {{ title }}"
-        body: |
-          {{ body }}
-
-          {% for c in commits %}
-          (cherry picked from commit {{ c.sha }} )
-          {% endfor %}
-
-          Parent PR: #{{number}}
-        branches:
-          - branch-5.2
-        assignees:
-          - "{{ author }}"
-  - name: Automate backport pull request 5.4
-    conditions:
-      - base=master # Ensure this rule only applies to PRs merged into the master branch
-      - label=backport/5.4 # The PR must have this label to trigger the backport
-    actions:
-      backport:
-        title: "[Backport 5.4] {{ title }}"
-        body: |
-          {{ body }}
-
-          {% for c in commits %}
-          (cherry picked from commit {{ c.sha }})
-          {% endfor %}
-
-          Parent PR: #{{number}}
-        branches:
-          - branch-5.4
-        assignees:
-          - "{{ author }}"
   - name: Automate backport pull request 6.0
     conditions:
       - base=master # Ensure this rule only applies to PRs merged into the master branch
@@ -80,6 +42,25 @@ pull_request_rules:
           Parent PR: #{{number}}
         branches:
           - branch-6.1
+        assignees:
+          - "{{ author }}"
+  - name: Automate backport pull request 6.2
+    conditions:
+      - base=master # Ensure this rule only applies to PRs merged into the master branch
+      - label=backport/6.2 # The PR must have this label to trigger the backport
+    actions:
+      backport:
+        title: "[Backport 6.2] {{ title }}"
+        body: |
+          {{ body }}
+
+          {% for c in commits %}
+          (cherry picked from commit {{ c.sha }})
+          {% endfor %}
+
+          Parent PR: #{{number}}
+        branches:
+          - branch-6.2
         assignees:
           - "{{ author }}"
   - name: Automate backport pull request 2023.1


### PR DESCRIPTION
branch-6.2 is already available, adding support for it in mergify to allow backport to this new branch
in addition, since branches 5.2 and 5.4 already EOL - removing it


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

