### PR TITLE
improvement(logs): collect db logs upon VM termination

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -58,6 +58,7 @@ from cassandra.policies import RetryPolicy
 from cassandra.policies import WhiteListRoundRobinPolicy, HostFilterPolicy, RoundRobinPolicy
 from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
 from argus.backend.util.enums import ResourceState
+from argus.client.sct.types import LogLink
 from sdcm.node_exporter_setup import NodeExporterSetup
 from sdcm.db_log_reader import DbLogReader
 from sdcm.mgmt import AnyManagerCluster, ScyllaManagerError
@@ -136,7 +137,7 @@ from sdcm.sct_events.filters import EventsSeverityChangerFilter
 from sdcm.utils.auto_ssh import AutoSshContainerMixin
 from sdcm.monitorstack.ui import AlternatorDashboard
 from sdcm.logcollector import GrafanaScreenShot, PrometheusSnapshots, upload_archive_to_s3, \
-    save_kallsyms_map, collect_diagnostic_data
+    save_kallsyms_map, collect_diagnostic_data, ScyllaLogCollector
 from sdcm.utils.ldap import LDAP_SSH_TUNNEL_LOCAL_PORT, LDAP_BASE_OBJECT, LDAP_PASSWORD, LDAP_USERS, \
     LDAP_PORT, DEFAULT_PWD_SUFFIX
 from sdcm.utils.remote_logger import get_system_logging_thread
@@ -3460,6 +3461,15 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
             ))
         if node in self.nodes:
             self.nodes.remove(node)
+        try:
+            ScyllaLogCollector.cluster_log_type = node.name
+            log_links = ScyllaLogCollector([node],
+                                           test_id=self.test_config.test_id(),
+                                           storage_dir=os.path.join(self.logdir, "collected_logs"),
+                                           params=self.params).collect_logs()
+            self.test_config.argus_client().submit_sct_logs([LogLink(log_name=node.name, log_link=log_links[0])])
+        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            self.log.error("Failed to collect logs for node %s: %s", node.name, exc)
         node.destroy()
 
     def get_db_auth(self):


### PR DESCRIPTION
We need `system.log` to be collected for decommissioned/removed nodes for bugs investigation - this log contain proper timestamps. Also other collected usually files might be useful.

Collect logs like we collect them after tests for terminated VM's.

fixes: #6688

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/longevity-5gb-1h-GrowShrinkClusterNemesis-aws-test/24/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
