### PR TITLE
test(elasticity): add mini elasticity test for pre-testing

### DIFF
--- a/configurations/performance/cql-stress-6gb-8-col-i4i-mini-test-throughput.yaml
+++ b/configurations/performance/cql-stress-6gb-8-col-i4i-mini-test-throughput.yaml
@@ -1,0 +1,21 @@
+# mini test based on cql-stress-650gb-8-col-i4i-80-percent-throughput-oss.yaml with reduced data size, throughput and node sizes.
+
+prepare_write_cmd: [ "cql-stress-cassandra-stress write no-warmup cl=ALL n=6500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..6500000",
+]
+
+stress_cmd_w: "cql-stress-cassandra-stress write no-warmup cl=QUORUM duration=2850m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=6000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..6500000,3250000,97500)' "
+stress_cmd_r: "cql-stress-cassandra-stress read no-warmup  cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=5000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..6500000,3250000,97500)' "
+stress_cmd_m: "cql-stress-cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=4000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..6500000,3250000,65000)' "
+use_hdr_cs_histogram: false  # https://github.com/scylladb/cql-stress/issues/95
+use_prepared_loaders: false  # no need for that - using docker anyway
+n_db_nodes: 3
+nemesis_add_node_cnt: 3
+n_loaders: 1
+n_monitor_nodes: 1
+
+instance_type_loader: 'c6i.large'
+instance_type_db: 'i4i.large'
+
+nemesis_class_name: 'GrowShrinkClusterNemesis'
+nemesis_interval: 5
+nemesis_sequence_sleep_between_ops: 5


### PR DESCRIPTION
Sometimes when working on improvement in performance tests it's needed to test it.

Added mini elasticity test configuration to allow such testing and is fast and cheap.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] - tested as part of https://github.com/scylladb/scylla-cluster-tests/pull/8733

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
