### PR TITLE
fix(wait_for_log_lines): fix saturating cpu when waiting for log lines

### DIFF
--- a/sdcm/wait.py
+++ b/sdcm/wait.py
@@ -156,12 +156,14 @@ def wait_for_log_lines(node, start_line_patterns, end_line_patterns, start_timeo
         started = any(start_follower)
         while not started and (time.time() - start_time < start_timeout):
             started = any(start_follower)
+            time.sleep(0.1)
         if not started:
             raise TimeoutError(start_ctx)
         LOGGER.debug("Start line patterns %s were found.%s", start_line_patterns, error_msg_ctx)
         ended = any(end_follower)
         while not ended and (time.time() - start_time < end_timeout):
             ended = any(end_follower)
+            time.sleep(0.1)
         if not ended:
             raise TimeoutError(end_ctx)
         LOGGER.debug("End line patterns %s were found.%s", end_line_patterns, error_msg_ctx)

--- a/unit_tests/test_wait.py
+++ b/unit_tests/test_wait.py
@@ -223,7 +223,7 @@ class TestWaitForLogLines:
         t.daemon = True
         file_path.touch()
         with pytest.raises(TimeoutError, match="Timeout occurred while waiting for start log line"), \
-                wait_for_log_lines(node=node, start_line_patterns=["start"], end_line_patterns=["end"], start_timeout=0.3, end_timeout=1):
+                wait_for_log_lines(node=node, start_line_patterns=["start"], end_line_patterns=["end"], start_timeout=0.4, end_timeout=1.2):
             t.start()
 
     def test_wait_for_log_timeout_when_no_end_line(self, tmp_path):
@@ -234,7 +234,7 @@ class TestWaitForLogLines:
         t.daemon = True
         file_path.touch()
         with pytest.raises(TimeoutError, match="Timeout occurred while waiting for end log line"), \
-                wait_for_log_lines(node=node, start_line_patterns=["start"], end_line_patterns=["end"], start_timeout=0.1, end_timeout=0.3):
+                wait_for_log_lines(node=node, start_line_patterns=["start"], end_line_patterns=["end"], start_timeout=0.5, end_timeout=0.7):
             t.start()
 
     def test_wait_for_log_reraises_exception(self, tmp_path):
@@ -245,7 +245,7 @@ class TestWaitForLogLines:
         t.daemon = True
         file_path.touch()
         with pytest.raises(ValueError, match="dummy error"), \
-                wait_for_log_lines(node=node, start_line_patterns=["start"], end_line_patterns=["end"], start_timeout=0.1, end_timeout=0.3):
+                wait_for_log_lines(node=node, start_line_patterns=["start"], end_line_patterns=["end"], start_timeout=0.5, end_timeout=0.7):
             t.start()
             raise ValueError('dummy error')
 
@@ -254,7 +254,7 @@ class TestWaitForLogLines:
         node = DummyNode(log_path=file_path)
         file_path.touch()
         with pytest.raises(TimeoutError, match="Timeout occurred while waiting for start log line") as exc_info, \
-                wait_for_log_lines(node=node, start_line_patterns=["start"], end_line_patterns=["end"], start_timeout=0.1, end_timeout=0.3):
+                wait_for_log_lines(node=node, start_line_patterns=["start"], end_line_patterns=["end"], start_timeout=0.4, end_timeout=0.7):
             raise ValueError('dummy error')
         assert "ValueError" in str(exc_info.getrepr())
 
@@ -267,5 +267,5 @@ class TestWaitForLogLines:
         file_path.touch()
         expected_match = "Timeout occurred while waiting for end log line \['end'\] on node: node_1. Context: Wait end line"
         with pytest.raises(TimeoutError, match=expected_match), \
-                wait_for_log_lines(node=node, start_line_patterns=["start"], end_line_patterns=["end"], start_timeout=0.1, end_timeout=0.3, error_msg_ctx="Wait end line"):
+                wait_for_log_lines(node=node, start_line_patterns=["start"], end_line_patterns=["end"], start_timeout=0.4, end_timeout=0.7, error_msg_ctx="Wait end line"):
             t.start()


### PR DESCRIPTION
We missed waiting time before recreating iterator. This causes unnecessary high cpu utilization.

refs: https://github.com/scylladb/scylla-cluster-tests/issues/8720

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
