### PR TITLE
test(trigger): gradual enterprise test

### DIFF
--- a/configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml
+++ b/configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml
@@ -1,0 +1,3 @@
+# Define load ops for steps
+perf_gradual_threads: {"read": 620, "write": 400, "mixed": 1900}
+perf_gradual_throttle_steps: {"read": ['150000', '300000', '450000', '600000', '700000', 'unthrottled'], "mixed": ['50000', '150000', '300000', '450000', 'unthrottled'], "write": ['200000', '300000', '400000', 'unthrottled']}  # where every value is in ops

--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-scylla-gradual-throughput-grow-2.3gb.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-scylla-gradual-throughput-grow-2.3gb.jenkinsfile
@@ -1,0 +1,14 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    aws_region: "us-east-1",
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionGradualGrowThroughputTest",
+    test_config: '''["test-cases/performance/perf-regression-gradual-throughput-grow-2.3tb.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml", "configurations/disable_kms.yaml", "configurations/tablets_disabled.yaml", "configurations/disable_speculative_retry.yaml"]''',
+    sub_tests: ["test_write_gradual_increase_load", "test_read_gradual_increase_load", "test_mixed_gradual_increase_load"],
+
+    timeout: [time: 1600, unit: "MINUTES"]
+)

--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-scylla-gradual-throughput-grow-2.3gb.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-scylla-gradual-throughput-grow-2.3gb.jenkinsfile
@@ -9,6 +9,4 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionGradualGrowThroughputTest",
     test_config: '''["test-cases/performance/perf-regression-gradual-throughput-grow-2.3tb.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml", "configurations/disable_kms.yaml", "configurations/tablets_disabled.yaml", "configurations/disable_speculative_retry.yaml"]''',
     sub_tests: ["test_write_gradual_increase_load", "test_read_gradual_increase_load", "test_mixed_gradual_increase_load"],
-
-    timeout: [time: 1600, unit: "MINUTES"]
 )

--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/perf-regression/scylla-master-perf-regression-scylla-gradual-throughput-grow-2.3gb.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/perf-regression/scylla-master-perf-regression-scylla-gradual-throughput-grow-2.3gb.jenkinsfile
@@ -9,6 +9,4 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionGradualGrowThroughputTest",
     test_config: '''["test-cases/performance/perf-regression-gradual-throughput-grow-2.3tb.yaml", "configurations/performance/cassandra_stress_gradual_load_steps.yaml", "configurations/disable_kms.yaml", "configurations/tablets_disabled.yaml", "configurations/disable_speculative_retry.yaml"]''',
     sub_tests: ["test_write_gradual_increase_load", "test_read_gradual_increase_load", "test_mixed_gradual_increase_load"],
-
-    timeout: [time: 1600, unit: "MINUTES"]
 )

--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/perf-regression/scylla-master-perf-regression-scylla-gradual-throughput-grow-2.3gb.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/perf-regression/scylla-master-perf-regression-scylla-gradual-throughput-grow-2.3gb.jenkinsfile
@@ -1,0 +1,14 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    aws_region: "us-east-1",
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionGradualGrowThroughputTest",
+    test_config: '''["test-cases/performance/perf-regression-gradual-throughput-grow-2.3tb.yaml", "configurations/performance/cassandra_stress_gradual_load_steps.yaml", "configurations/disable_kms.yaml", "configurations/tablets_disabled.yaml", "configurations/disable_speculative_retry.yaml"]''',
+    sub_tests: ["test_write_gradual_increase_load", "test_read_gradual_increase_load", "test_mixed_gradual_increase_load"],
+
+    timeout: [time: 1600, unit: "MINUTES"]
+)

--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-enterprise-performance-trigger.xml
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-enterprise-performance-trigger.xml
@@ -30,7 +30,7 @@ provision_type=on_demand</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-shard-aware-1TB,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-throughput-shard-aware-i4i</projects>
+          <projects>../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-scylla-gradual-throughput-grow-2.3gb.jenkinsfile,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-shard-aware-1TB,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-throughput-shard-aware-i4i</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>


### PR DESCRIPTION
Put gradual performance test pipeline to official master and enterprise folders. 
Separate configuration load_steps yaml for enterprise version.
Trigger new gradual enterprise test weekly instead latency and throughput tests


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
