### PR TITLE
fix(sdcm/tester.py): Handle ZonalAllocationFailed in check_error

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -572,6 +572,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         def check_error(event: str):
             errors = [
                 re.compile(r"SpotTerminationEvent", re.IGNORECASE),
+                re.compile(r"ZonalAllocationFailed", re.IGNORECASE),
                 re.compile(r"source=[\w]+.SetUp\(\).+exception=403 FORBIDDEN QUOTA_EXCEEDED",
                            re.IGNORECASE | re.DOTALL),
                 re.compile(r"source=[\w]+.SetUp\(\).+InsufficientInstanceCapacity", re.IGNORECASE | re.DOTALL),


### PR DESCRIPTION
This commit adds a pattern for an Azure allocation event, which is
similar to SpotTerminationEvent, to check_error, which is used to
determine if Argus should set this test's status as TEST_ERROR.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
