### PR TITLE
fix(nemesis): skip `disrupt_no_corrupt_repair` if needed

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1628,6 +1628,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._kill_scylla_daemon()
 
     def disrupt_no_corrupt_repair(self):
+
+        if SkipPerIssues("https://github.com/scylladb/scylladb/issues/18059", self.tester.params):
+            raise UnsupportedNemesis('Disabled due to https://github.com/scylladb/scylladb/issues/18059 not fixed yet')
+
         # prepare test tables and fill test data
         for i in range(10):
             self.log.debug('Prepare test tables if they do not exist')


### PR DESCRIPTION
since there currently no for fix for scylladb/scylladb#18059 we'll be skipping this nemesis until a fix for that issue would be available

Ref: scylladb/scylladb#18059

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
