### PR TITLE
fix(offline-artifact-tests): use the correct nodetool script

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2426,7 +2426,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             SCYLLA_PROPERTIES_PATH: self.offline_install_dir / SCYLLA_PROPERTIES_PATH[1:],
             '/etc/scylla.d/io.conf': self.offline_install_dir / 'etc/scylla.d/io.conf',
             '/usr/bin/scylla': self.offline_install_dir / 'bin/scylla',
-            '/usr/bin/nodetool': self.offline_install_dir / 'share/cassandra/bin/nodetool',
+            '/usr/bin/nodetool': self.offline_install_dir / 'bin/nodetool',
             '/usr/bin/cqlsh': self.offline_install_dir / 'share/cassandra/bin/cqlsh',
             '/usr/bin/cassandra-stress': self.offline_install_dir / 'share/cassandra/bin/cassandra-stress',
             '/opt/scylladb/scripts/perftune.py': self.offline_install_dir / 'scripts/perftune.py',


### PR DESCRIPTION
so far the code was using the `/share/cassandra/bin/nodetool` that is the old java based nodetool that depends on JMX

and now it would use the script from `/bin/nodetool` that should default to using `scylla nodetool` command

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟡 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-rocky8-test/16/
- [x] 🔴  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-rocky9-test/46/
- [x] 🔴  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-debian11-test/7/
- [x] 🟡 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-amazon2023-test/13/
- [x] 🟡 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-amazon2023-arm-test/8/
- [x] 🔴 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2004-arm-test/18/
- [x] 🔴  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2004-test/29/
- [x] 🔴 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2404-test/16/
- [x] 🔴 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2404-arm-test/9/


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
