### PR TITLE
fix(unittest): remove config tests 35 and 36

### DIFF
--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -999,33 +999,6 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 
-    @pytest.mark.integration
-    def test_35_test_required_params_check(self):
-        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['JOB_NAME'] = 'perf-regression-gradual-throughput-grow'
-        os.environ['SCT_CONFIG_FILES'] = '''["test-cases/performance/perf-regression-gradual-throughput-grow-2.3tb.yaml", "configurations/performance/cassandra_stress_gradual_load_steps.yaml"]'''
-
-        conf = sct_config.SCTConfiguration()
-        conf._check_test_required_params()
-        del os.environ['JOB_NAME']
-
-    @pytest.mark.integration
-    def test_36_test_required_params_missed_check(self):
-        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['JOB_NAME'] = 'perf-regression-gradual-throughput-grow'
-        os.environ['SCT_CONFIG_FILES'] = '''["test-cases/performance/perf-regression-gradual-throughput-grow-2.3tb.yaml"]'''
-
-        conf = sct_config.SCTConfiguration()
-
-        with self.assertRaises(AssertionError) as context:
-            conf._check_test_required_params()
-
-        self.assertEqual(
-            "Parameters ['perf_gradual_throttle_steps', 'perf_gradual_threads'] are mandatory parameter "
-            "for the 'perf-regression-gradual-throughput-grow' test", str(context.exception))
-
-        del os.environ['JOB_NAME']
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Desided to remove new gradual performance test required parameters validation (`sct_config._check_test_required_params` function). 2 unit test for this function were not removed.
Remove them now

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
