### PR TITLE
fix(oel9): use the new ssh key for oel9 artifact test

### DIFF
--- a/configurations/aws/new_ssh_key.yaml
+++ b/configurations/aws/new_ssh_key.yaml
@@ -1,0 +1,1 @@
+user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/jenkins-pipelines/artifacts-oel9.jenkinsfile
+++ b/jenkins-pipelines/artifacts-oel9.jenkinsfile
@@ -4,7 +4,7 @@
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 artifactsPipeline(
-    test_config: 'test-cases/artifacts/oel9.yaml',
+    test_config: '''["test-cases/artifacts/oel9.yaml", "configurations/aws/new_ssh_key.yaml"]''',
     backend: 'aws',
     region: 'eu-west-1',
     provision_type: 'spot_low_price',


### PR DESCRIPTION
`scylla_test_id_ed25519` key is required for accessing the OEL9 instances. This change adds the dedicated configuration with the new key and updates the `artifacts-oel9` job to use the config.

### Testing
- [x] :red_circle: [artifacts-oel9-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/2024.1-artifacts-oel9-test/9/)
The build is failing, which is expected, as branch-2024.1 requires a backport which is in progress in https://github.com/scylladb/scylla-cluster-tests/pull/8815. But the original issue is fixed by this change - as the test now passes the wait_for_ssh step (i.e. the new key enables ssh-ing to the node) and continues to the scylla-manager installation.

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
