### PR TITLE
Report Manager restore results to Argus

### DIFF
--- a/jenkins-pipelines/manager/ubuntu22-manager-restore-benchmark.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-restore-benchmark.jenkinsfile
@@ -1,0 +1,17 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    region: 'us-east-1',
+    provision_type: 'on_demand',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_restore_benchmark',
+    test_config: '''["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/manager/1TB_dataset.yaml"]''',
+    mgmt_reuse_backup_snapshot_name: '1tb_1t_ics',
+
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy'
+)

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -30,8 +30,9 @@ import yaml
 from invoke import exceptions
 
 from sdcm import mgmt
+from sdcm.argus_results import send_manager_benchmark_results_to_argus
 from sdcm.mgmt import ScyllaManagerError, TaskStatus, HostStatus, HostSsl, HostRestStatus
-from sdcm.mgmt.cli import ScyllaManagerTool
+from sdcm.mgmt.cli import ScyllaManagerTool, RestoreTask
 from sdcm.mgmt.common import reconfigure_scylla_manager, get_persistent_snapshots
 from sdcm.provision.helpers.certificate import TLSAssets
 from sdcm.remote import shell_script_cmd
@@ -1359,6 +1360,22 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         extra_params = self.params.get('mgmt_restore_extra_params')
         return extra_params if extra_params else None
 
+    def _send_restore_results_to_argus(self, task: RestoreTask, manager_version_timestamp: int,
+                                       dataset_label: str = None):
+        total_restore_time = int(task.duration.total_seconds())
+        repair_time = int(task.post_restore_repair_duration.total_seconds())
+        results = {
+            "restore time": (total_restore_time - repair_time),
+            "repair time": repair_time,
+            "total": total_restore_time,
+        }
+        send_manager_benchmark_results_to_argus(
+            argus_client=self.test_config.argus_client(),
+            result=results,
+            sut_timestamp=manager_version_timestamp,
+            row_name=dataset_label,
+        )
+
     def test_backup_and_restore_only_data(self):
         """The test is extensively used for restore benchmarking purposes and consists of the following steps:
         1. Populate the cluster with data (currently operates with datasets of 500GB, 1TB, 2TB, 5TB);
@@ -1388,6 +1405,9 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         task = self.restore_backup_with_task(mgr_cluster=mgr_cluster, snapshot_tag=backup_task.get_snapshot_tag(),
                                              timeout=110000, restore_data=True, extra_params=extra_params)
         self.manager_test_metrics.restore_time = task.duration
+
+        manager_version_timestamp = manager_tool.sctool.client_version_timestamp
+        self._send_restore_results_to_argus(task, manager_version_timestamp)
 
         self.run_verification_read_stress()
 
@@ -1433,6 +1453,9 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
                                                  timeout=snapshot_data.exp_timeout, restore_data=True,
                                                  location_list=location, extra_params=extra_params)
             restore_time = task.duration
+            manager_version_timestamp = manager_tool.sctool.client_version_timestamp
+            self._send_restore_results_to_argus(task, manager_version_timestamp, dataset_label=snapshot_name)
+
         self.manager_test_metrics.restore_time = restore_time
 
         if not (self.params.get('mgmt_skip_post_restore_stress_read') or snapshot_data.prohibit_verification_read):

--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -88,6 +88,17 @@ class ReactorStallStatsResult(GenericResultTable):
         ]
 
 
+class ManagerRestoreBanchmarkResult(GenericResultTable):
+    class Meta:
+        name = "Restore benchmark"
+        description = "Restore benchmark"
+        Columns = [
+            ColumnMetadata(name="restore time", unit="s", type=ResultType.DURATION),
+            ColumnMetadata(name="repair time", unit="s", type=ResultType.DURATION),
+            ColumnMetadata(name="total", unit="s", type=ResultType.DURATION),
+        ]
+
+
 workload_to_table = {
     "mixed": LatencyCalculatorMixedResult,
     "write": LatencyCalculatorWriteResult,
@@ -169,4 +180,15 @@ def send_perf_simple_query_result_to_argus(argus_client: ArgusClient, result: di
     result_table = PerfSimpleQueryResult()
     for key, value in stats.items():
         result_table.add_result(column=key, row="#1", value=value, status=_get_status_based_on_previous_results(key))
+    argus_client.submit_results(result_table)
+
+
+def send_manager_benchmark_results_to_argus(argus_client: ArgusClient, result: dict, sut_timestamp: int,
+                                            row_name: str = None) -> None:
+    if not row_name:
+        row_name = "#1"
+
+    result_table = ManagerRestoreBanchmarkResult(sut_timestamp=sut_timestamp)
+    for key, value in result.items():
+        result_table.add_result(column=key, row=row_name, value=value, status=Status.PASS)
     argus_client.submit_results(result_table)

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -506,6 +506,27 @@ class RestoreTask(ManagerTask):
     def __init__(self, task_id, cluster_id, manager_node):
         ManagerTask.__init__(self, task_id=task_id, cluster_id=cluster_id, manager_node=manager_node)
 
+    @property
+    def post_restore_repair_duration(self) -> datetime.timedelta:
+        """Restore task consists of two parts and includes two duration marks:
+        - overall restore duration
+        - post restore repair duration
+
+        If we are interested in the post restore repair duration, we need to extract the post-restore repair progress
+        table and sum all per table durations (last column).
+        """
+        res = self.progress_string()
+
+        if ['Post-restore repair progress'] not in res:
+            return duration_to_timedelta(duration_string="0")
+
+        # Extract the post-restore repair progress table
+        res = res[res.index(['Keyspace', 'Table', 'Progress', 'Duration']) + 1:]
+        # Overall repair duration is the sum of all the durations (last column) in the table
+        per_table_duration_timedelta = [duration_to_timedelta(table[-1]) for table in res]
+        duration_timedelta = sum(per_table_duration_timedelta, datetime.timedelta(0))
+        return duration_timedelta
+
 
 class ManagerCluster(ScyllaManagerBase):
 
@@ -1301,6 +1322,17 @@ class SCTool:
     @property
     def parsed_client_version(self):
         return LooseVersion(self.client_version)
+
+    @property
+    def client_version_timestamp(self) -> int:
+        """Gets the timestamp of the client version
+
+        Example, for client version `3.3.3-0.20240912.924034e0d` the timestamp is `1726099200` (2024-09-12 00:00:00)
+        """
+        date_str = self.client_version.split('.')[-2]
+        date_obj = datetime.datetime.strptime(date_str, "%Y%m%d")
+        timestamp = int(date_obj.timestamp())
+        return timestamp
 
     @property
     def is_v3_cli(self):


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-manager/issues/4027
Closes https://github.com/scylladb/scylla-manager/issues/4016

The goal is to keep and visualize Manager restore benchmark results in Argus.

Changes:
- Implemented the separate function to send Manager restore benchmark results to Argus. Resulting table consist of three fields: overall restore, download and load&stream and post-restore repair durations;
- Such Argus handler is added into restore benchmark tests;
- New properties were added into Manager cli to return info about version timestamp and post restore repair duration.
- Added jenkinsfile for manager restore benchmark test which will be included into release pipelines. Thus, we will
have the history of restore speed improvements or degradation release after release.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/scylla-manager/job/manager-master/job/restore-benchmark-test-test/3/
- [x] https://jenkins.scylladb.com/view/scylla-manager/job/manager-master/job/restore-benchmark-test-test/4/

Example of graphs in [Argus](https://argus.scylladb.com/workspace?state=WyJlYjkzYjA2MS1mNjZiLTQ5NDQtYWIxMi0wZjhjMjI2NmYzODgiXQ) (the dataset is very small (1Gb) exclusively for testing purposes):
![image](https://github.com/user-attachments/assets/baf41ae1-bbc4-42dc-8076-18bb9732bc01)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
