### PR TITLE
fix(oel9-offline-installer): don't install python2

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2027,7 +2027,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         if not nonroot:
             self.install_package(package_name='xfsprogs mdadm')
 
-        if not any((self.distro.is_rocky9, self.distro.is_ubuntu24, self.distro.is_amazon2023, self.distro.is_centos9, self.distro.is_debian12)):
+        if not any((self.distro.is_rocky9, self.distro.is_ubuntu24, self.distro.is_amazon2023, self.distro.is_centos9, self.distro.is_debian12, self.distro.is_oel9)):
             # centos/rocky9/ubuntu24.04/amazon2023/debian12 and above don't have python2 anymore
             self.install_package(package_name='python2')
         # Offline install does't provide openjdk-11, it has to be installed in advance


### PR DESCRIPTION
python2 doesn't exist in oel9, we shouldn't try installing it.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested locally 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
