### PR TITLE
fix(pipeline): missed comma

### DIFF
--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/perf-regression/scylla-master-perf-regression-latency-650gb-with-nemesis-tablets.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/perf-regression/scylla-master-perf-regression-latency-650gb-with-nemesis-tablets.jenkinsfile
@@ -8,6 +8,6 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: """["test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml"]""",
     sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
-    test_email_title: "latency during operations / tablets"
+    test_email_title: "latency during operations / tablets",
     perf_extra_jobs_to_compare: "scylla-master/perf-regression/scylla-master-perf-regression-latency-650gb-with-nemesis-tablets",
 )


### PR DESCRIPTION
The comma is missed after test_email_title It caused to failure: WorkflowScript: 12: expecting ')', found 'perf_extra_jobs_to_compare' @ line 12, column 5. perf_extra_jobs_to_compare: scylla-master/perf-regression/scylla-master-perf-regression-

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
