### PR TITLE
fix(trigger): set aws_region

### DIFF
--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-master-performance-tablets-trigger.xml
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-master-performance-tablets-trigger.xml
@@ -23,6 +23,7 @@
           <configs>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
               <properties>scylla_version=master:latest
+aws_region=us-east-1
 provision_type=on_demand
 availability_zone=b</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>


### PR DESCRIPTION
aws_region is missed in weekly-master-performance-tablets-trigger.xml. As result the perf-regression-latency-650gb-with-nemesis-tablets test fails to start

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
