### PR TITLE
fix(client_encrypt): make it work when server encryption is disabled

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4692,7 +4692,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 datacenters = self.datacenter  # pylint: disable=no-member
             SnitchConfig(node=node, datacenters=datacenters).apply()
 
-        if self.params.get('server_encrypt'):
+        if any([self.params.get('server_encrypt'), self.params.get('client_encrypt')]):
             # Create node certificate for internode communication
             node.create_node_certificate(cert_file=node.ssl_conf_dir / TLSAssets.DB_CERT,
                                          cert_key=node.ssl_conf_dir / TLSAssets.DB_KEY,


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/8846

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-longevity-aws-custom-d2-workload1-multidc#14](https://argus.scylladb.com/test/2c0a3aad-2dc8-4718-923e-af6271930f70/runs?additionalRuns[]=19520099-2f6f-41eb-999e-ebf170baa282)
- :green_circle: [pr-provision-test with client encrypt](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/sct-pr-provision-test/79/)
- :green_circle: [pr-provision-test with server encrypt](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/sct-pr-provision-test/80/)
- :green_circle: [pr-provision-test with server+client encrypt](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/sct-pr-provision-test/82/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
