### PR TITLE
fix(config): Raise proper error for missing config file

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1766,6 +1766,9 @@ class SCTConfiguration(dict):
 
         # 2) load the config files
         try:
+            for conf_file in list(config_files):
+                if not os.path.exists(conf_file):
+                    raise FileNotFoundError(f"Couldn't find config file: {conf_file}")
             files = anyconfig.load(list(config_files))
             anyconfig.merge(self, files)
         except ValueError:


### PR DESCRIPTION
When user supplies invalid config files setting it causes `anyconfig` to raise problem with parsing `yaml` file - which is misleading.

Fix by verification of existence of config files before proceeding to anyconfig.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/8844

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [typo in config files](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/simple_query_weekly_microbenchmark/15/)
- [x] - [valid run](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/simple_query_weekly_microbenchmark/16/) 
- [x] - [missing config file](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/simple_query_weekly_microbenchmark/17/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
