### PR TITLE
improvement(loader): set loader version hardcoded

### DIFF
--- a/test-cases/performance/perf-regression-predefined-throughput-steps.yaml
+++ b/test-cases/performance/perf-regression-predefined-throughput-steps.yaml
@@ -58,3 +58,5 @@ append_scylla_yaml:
 
 use_placement_group: true
 use_prepared_loaders: false
+stress_image:
+  cassandra-stress: 'scylladb/cassandra-stress:3.13.0'


### PR DESCRIPTION
Set c-s loader docker version to  'scylladb/cassandra-stress:3.13.0' for perf predefined throughput steps test

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
