### PR TITLE
fix(update-db-packages): stop only updated nodes

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4246,26 +4246,10 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
         start_time = time.time()
 
-        if len(node_list) == 1:
-            # Stop only new nodes
-            self.run_func_parallel(func=stop_scylla, node_list=node_list)  # pylint: disable=no-member
-            # Then, update packages only on requested node
-            self.run_func_parallel(func=update_scylla_packages, node_list=node_list)  # pylint: disable=no-member
-            if start_service:
-                # Start new nodes
-                self.run_func_parallel(func=start_scylla, node_list=node_list)  # pylint: disable=no-member
-        else:
-            # First, stop *all* non seed nodes
-            self.run_func_parallel(func=stop_scylla, node_list=self.non_seed_nodes)  # pylint: disable=no-member
-            # First, stop *all* seed nodes
-            self.run_func_parallel(func=stop_scylla, node_list=self.seed_nodes)  # pylint: disable=no-member
-            # Then, update packages only on requested nodes
-            self.run_func_parallel(func=update_scylla_packages, node_list=node_list)  # pylint: disable=no-member
-            if start_service:
-                # Start all seed nodes
-                self.run_func_parallel(func=start_scylla, node_list=self.seed_nodes)  # pylint: disable=no-member
-                # Start all non seed nodes
-                self.run_func_parallel(func=start_scylla, node_list=self.non_seed_nodes)  # pylint: disable=no-member
+        self.run_func_parallel(func=stop_scylla, node_list=node_list)  # pylint: disable=no-member
+        self.run_func_parallel(func=update_scylla_packages, node_list=node_list)  # pylint: disable=no-member
+        if start_service:
+            self.run_func_parallel(func=start_scylla, node_list=node_list)  # pylint: disable=no-member
 
         time_elapsed = time.time() - start_time
         self.log.info('Update DB packages duration -> %s s', int(time_elapsed))


### PR DESCRIPTION
When updating multiple nodes db packages, SCT stops all the nodes. This is wrong and causes tests to fail when providing `update_db_packages` param.

Fix by removing broken logic and dropping code for nodes stop ordering.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/8551

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
