### PR TITLE
fix(trigger): set 'region' in perf master triggers

### DIFF
--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-enterprise-performance-trigger.xml
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-enterprise-performance-trigger.xml
@@ -54,6 +54,8 @@ provision_type=on_demand</properties>
           <configs>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
               <properties>scylla_version=2024.1
+aws_region=us-east-1
+region=us-east-1
 new_scylla_repo=https://downloads.scylladb.com/unstable/scylla-enterprise/enterprise/deb/unified/latest/scylladb-enterprise/scylla.list
 provision_type=on_demand</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>

--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-master-performance-tablets-trigger.xml
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-master-performance-tablets-trigger.xml
@@ -24,6 +24,7 @@
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
               <properties>scylla_version=master:latest
 aws_region=us-east-1
+region=us-east-1
 provision_type=on_demand
 availability_zone=b</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>

--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-master-performance-trigger.xml
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-master-performance-trigger.xml
@@ -39,6 +39,7 @@ availability_zone=b</properties>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
               <properties>scylla_version=master:latest
 aws_region=us-east-1
+region=us-east-1
 provision_type=on_demand
 availability_zone=b</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
@@ -54,6 +55,7 @@ availability_zone=b</properties>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
               <properties>scylla_version=master:latest
 aws_region=us-east-1
+region=us-east-1
 provision_type=on_demand
 availability_zone=b</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>


### PR DESCRIPTION
Master performance tests are triggered in eu-west-1 instead of us-east-1 due to 'region' parameter is missed in the trigger files. Fix it

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
