### PR TITLE
fix(trigger): params for upgrade tablet tests

### DIFF
--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-enterprise-performance-tablets-trigger.xml
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-enterprise-performance-tablets-trigger.xml
@@ -29,7 +29,23 @@ provision_type=on_demand</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade-tablets,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-tablets,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-elasticity</projects>
+          <projects>../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-tablets,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-elasticity</projects>
+          <condition>SUCCESS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <triggerFromChildProjects>false</triggerFromChildProjects>
+        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>scylla_version=2024.1
+aws_region=us-east-1
+region=us-east-1
+new_scylla_repo=https://downloads.scylladb.com/unstable/scylla-enterprise/enterprise/deb/unified/latest/scylladb-enterprise/scylla.list
+provision_type=on_demand</properties>
+              <textParamValueOnNewLine>false</textParamValueOnNewLine>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade-tablets</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>

--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-master-performance-tablets-trigger.xml
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-master-performance-tablets-trigger.xml
@@ -29,7 +29,24 @@ availability_zone=b</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>perf-regression/scylla-master-perf-regression-latency-650gb-during-rolling-upgrade-tablets,perf-regression/scylla-master-perf-regression-latency-650gb-with-nemesis-tablets,perf-regression/scylla-master-perf-regression-latency-650gb-elasticity</projects>
+          <projects>perf-regression/scylla-master-perf-regression-latency-650gb-with-nemesis-tablets,perf-regression/scylla-master-perf-regression-latency-650gb-elasticity</projects>
+          <condition>SUCCESS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <triggerFromChildProjects>false</triggerFromChildProjects>
+        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>scylla_version=6.0
+aws_region=us-east-1
+region=us-east-1
+new_scylla_repo=http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list
+provision_type=on_demand
+availability_zone=b</properties>
+              <textParamValueOnNewLine>false</textParamValueOnNewLine>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>perf-regression/scylla-master-perf-regression-latency-650gb-during-rolling-upgrade-tablets</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>


### PR DESCRIPTION
Trigger of upgrade tablet tests are missed 'new_scylla_repo' param. Create its opwn BuildTriggerConfig for tablet upgrade tests and set this parameter and region

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
