### PR TITLE
fix(RAFT) fix wrong raft.is_enabled usage

### DIFF
--- a/sdcm/utils/health_checker.py
+++ b/sdcm/utils/health_checker.py
@@ -268,25 +268,4 @@ def check_schema_agreement_in_gossip_and_peers(node, retries: int = CHECK_NODE_H
 def check_group0_tokenring_consistency(group0_members: list[dict[str, str]],
                                        tokenring_members: list[dict[str, str]],
                                        current_node) -> HealthEventsGenerator:
-    if not current_node.raft.is_enabled:
-        LOGGER.debug("Raft feature is disabled on node %s (host_id=%s)", current_node.name, current_node.host_id)
-        return
-    LOGGER.debug("Check group0 and token ring consistency on node %s (host_id=%s)...",
-                 current_node.name, current_node.host_id)
-    token_ring_node_ids = [member["host_id"] for member in tokenring_members]
-    for member in group0_members:
-        if member["voter"] and member["host_id"] in token_ring_node_ids:
-            continue
-        error_message = f"Node {current_node.name} has group0 member with host_id {member['host_id']} with " \
-            f"can_vote {member['voter']} and " \
-            f"presents in token ring {member['host_id'] in token_ring_node_ids}. " \
-            f"Inconsistency between group0: {group0_members} " \
-            f"and tokenring: {tokenring_members}"
-        LOGGER.error(error_message)
-        yield ClusterHealthValidatorEvent.Group0TokenRingInconsistency(
-            severity=Severity.ERROR,
-            node=current_node.name,
-            error=error_message,
-        )
-    LOGGER.debug("Group0 and token-ring are consistent on node %s (host_id=%s)...",
-                 current_node.name, current_node.host_id)
+    return current_node.raft.check_group0_tokenring_consistency(group0_members, tokenring_members)

--- a/sdcm/utils/raft/__init__.py
+++ b/sdcm/utils/raft/__init__.py
@@ -8,8 +8,10 @@ from typing import NamedTuple, Mapping, Iterable, Any
 
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.filters import EventsSeverityChangerFilter
+from sdcm.sct_events.health import ClusterHealthValidatorEvent
 from sdcm.sct_events import Severity
 from sdcm.utils.features import is_consistent_topology_changes_feature_enabled, is_consistent_cluster_management_feature_enabled
+from sdcm.utils.health_checker import HealthEventsGenerator
 from sdcm.wait import wait_for
 
 LOGGER = logging.getLogger(__name__)
@@ -80,6 +82,12 @@ class RaftFeatureOperations(ABC):
     @property
     @abstractmethod
     def is_enabled(self) -> bool:
+        """
+                    Please do not use this method in simple statements like:
+                        if not current_node.raft.is_enabled
+                    move logic into separate methods of RaftFeature/NoRaft
+                    classes instead
+                """
         ...
 
     @property
@@ -105,6 +113,11 @@ class RaftFeatureOperations(ABC):
 
     @abstractmethod
     def clean_group0_garbage(self, raise_exception: bool = False) -> None:
+        ...
+
+    def check_group0_tokenring_consistency(
+            self, group0_members: list[dict[str, str]],
+            tokenring_members: list[dict[str, str]]) -> [HealthEventsGenerator | None]:
         ...
 
     def get_message_waiting_timeout(self, message_position: MessagePosition) -> MessageTimeout:
@@ -311,6 +324,29 @@ class RaftFeature(RaftFeatureOperations):
 
         return not diff and not non_voters_ids and len(group0_ids) == len(token_ring_ids) == num_of_nodes
 
+    def check_group0_tokenring_consistency(
+            self, group0_members: list[dict[str, str]],
+            tokenring_members: list[dict[str, str]]) -> HealthEventsGenerator:
+        LOGGER.debug("Check group0 and token ring consistency on node %s (host_id=%s)...",
+                     self._node.name, self._node.host_id)
+        token_ring_node_ids = [member["host_id"] for member in tokenring_members]
+        for member in group0_members:
+            if member["voter"] and member["host_id"] in token_ring_node_ids:
+                continue
+            error_message = f"Node {self._node.name} has group0 member with host_id {member['host_id']} with " \
+                            f"can_vote {member['voter']} and " \
+                            f"presents in token ring {member['host_id'] in token_ring_node_ids}. " \
+                            f"Inconsistency between group0: {group0_members} " \
+                            f"and tokenring: {tokenring_members}"
+            LOGGER.error(error_message)
+            yield ClusterHealthValidatorEvent.Group0TokenRingInconsistency(
+                severity=Severity.ERROR,
+                node=self._node.name,
+                error=error_message,
+            )
+        LOGGER.debug("Group0 and token-ring are consistent on node %s (host_id=%s)...",
+                     self._node.name, self._node.host_id)
+
 
 class NoRaft(RaftFeatureOperations):
     TOPOLOGY_OPERATION_LOG_PATTERNS = {
@@ -362,6 +398,11 @@ class NoRaft(RaftFeatureOperations):
         LOGGER.debug("Number of nodes in sct cluster %s", num_of_nodes)
 
         return len(token_ring_ids) == num_of_nodes
+
+    def check_group0_tokenring_consistency(
+            self, group0_members: list[dict[str, str]],
+            tokenring_members: list[dict[str, str]]) -> None:
+        LOGGER.debug("Raft feature is disabled on node %s (host_id=%s)", self._node.name, self._node.host_id)
 
 
 def get_raft_mode(node) -> RaftFeature | NoRaft:

--- a/sdcm/utils/tablets/common.py
+++ b/sdcm/utils/tablets/common.py
@@ -31,9 +31,6 @@ def wait_for_tablets_balanced(node):
     "currently a small time window after adding nodes and before load balancing starts during which
     topology may appear as quiesced because the state machine goes through an idle state before it enters load balancing state"
     """
-    if not node.raft.is_enabled:
-        LOGGER.info("Raft is disabled, skipping wait for balance")
-        return
     with node.parent_cluster.cql_connection_patient(node=node) as session:
         if not is_tablets_feature_enabled(session):
             LOGGER.info("Tablets are disabled, skipping wait for balance")


### PR DESCRIPTION
the whole idea of putting RAFT into separate module is to remove hundreds of spaghetti lines like:
    if not current_node.raft.is_enabled

and put Raft helper functions under
node.raft.<HELPER> to avoid hundreds of helpers imports

it can be exceptions in case of using raft.is_enabled as part of a complex 'if' when code logic depends not only on the Raft feature

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 5.4.9 (no tablets) https://argus.scylladb.com/tests/scylla-cluster-tests/73916f48-5483-4718-baa0-70388edf66b1

```
< t:2024-10-23 10:26:53,705 f:__init__.py     l:293  c:sdcm.utils.raft      p:DEBUG > Check group0 and token ring consistency on node longevity-10gb-3h-wait-for-db-node-73916f48-1 (host_id=01d35667-0e45-465c-81f1-eaefd772a168)...
```
```
< t:2024-10-23 10:36:55,202 f:common.py       l:36   c:sdcm.utils.tablets.common p:INFO  > Tablets are disabled, skipping wait for balance
```
- [x] master:latest https://argus.scylladb.com/tests/scylla-cluster-tests/8fb46f18-2711-4d92-b5be-c432ddaa30e8
```
< t:2024-10-23 10:49:06,796 f:__init__.py     l:310  c:sdcm.utils.raft      p:DEBUG > Group0 and token-ring are consistent on node longevity-10gb-3h-wait-for-db-node-8fb46f18-1 (host_id=f6b1fdca-29f8-403c-8d0d-f57b6a12432f)...
```
```
< t:2024-10-23 10:57:25,589 f:common.py       l:45   c:sdcm.utils.tablets.common p:INFO  > Tablets are balanced
```


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
