### PR TITLE
fix(sct_events): ignore 'aborting on shard' events on rpc errors

### DIFF
--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -144,5 +144,12 @@ def enable_default_filters(sct_config: SCTConfiguration):  # pylint: disable=unu
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: suppressed').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.WARNING, line='abort_requested_exception').publish()
 
+    # As per discussion in https://github.com/scylladb/scylla-enterprise/issues/4691#issuecomment-2348867638 and
+    # https://github.com/scylladb/scylla-cluster-tests/issues/8693#issuecomment-2358147285
+    # the 'aborting on shard' error is acceptable when RPC connections are dropped
+    EventsSeverityChangerFilter(new_severity=Severity.WARNING,
+                                event_class=DatabaseLogEvent.ABORTING_ON_SHARD,
+                                regex=r'.*Parent connection [\d]+ is aborting on shard').publish()
+
 
 __all__ = ("start_events_device", "stop_events_device", "enable_default_filters")


### PR DESCRIPTION
Closes: https://github.com/scylladb/scylla-cluster-tests/issues/8693

### Testing
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
