### PR TITLE
fix(upgrade-test): fix is_enterprise on rollback to oss

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -800,7 +800,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             raise ValueError(f"Unsupported OS [{self.distro}]")
 
         oss_installed = self.remoter.sudo(oss_command, ignore_status=True).ok
-        enterprise_installed = self.remoter.sudo(enterprise_command, ignore_status=True).ok
+        enterprise_installed = "scylla-enterprise" in self.remoter.sudo(enterprise_command, ignore_status=True).stdout
         if oss_installed or enterprise_installed:
             _is_enterprise = enterprise_installed
         else:


### PR DESCRIPTION
When rolling back from Scylla enterprise to oss, `is_enterprise` verification verifies only rc, which is 0 in that scenario.

There were recent change around this logic, where `scylla-enterprise` was asserted to be in the stdout of `apt-cache show scylla-enterprise` command - which this commit brings back.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/8841

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - [testing as part of other work where it breaks](https://argus.scylladb.com/test/8fd69d22-74ff-4ec6-b745-41521080c83d/runs?additionalRuns[]=c8705573-0c10-4530-99e4-519602dad2d4)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
