### PR TITLE
fix(disrupt_snapshot_operations): filter out virtual tables as needed

### DIFF
--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -13,6 +13,7 @@
 
 # pylint: disable=too-few-public-methods
 
+import re
 import json
 import time
 import shutil
@@ -36,8 +37,13 @@ from sdcm.sct_events.database import SYSTEM_ERROR_EVENTS_PATTERNS
 from sdcm.sct_events.group_common_events import ignore_upgrade_schema_errors
 from sdcm.sct_events.filters import DbEventsFilter
 from sdcm.sct_events.system import InstanceStatusEvent
-from sdcm.utils.common import get_keyspace_partition_ranges, keyspace_min_max_tokens
+from sdcm.utils.common import (
+    get_keyspace_partition_ranges,
+    keyspace_min_max_tokens,
+    parse_nodetool_listsnapshots,
+)
 from sdcm.utils.distro import Distro
+from sdcm.utils.version_utils import ComparableScyllaVersion
 
 from unit_tests.dummy_remote import DummyRemote
 from unit_tests.lib.events_utils import EventsUtilsMixin
@@ -798,6 +804,63 @@ def test_filter_out_ks_with_rf_one(docker_scylla, params, events):  # pylint: di
 
         table_names = cluster.get_non_system_ks_cf_list(docker_scylla, filter_func=cluster.is_ks_rf_one)
         assert table_names == []
+
+
+@pytest.mark.integration
+def test_is_table_has_no_sstables(docker_scylla, params, events):  # pylint: disable=unused-argument
+    """
+    test is_table_has_no_sstables filter function, as it would be used in `disrupt_snapshot_operations` nemesis
+    """
+    cluster = DummyScyllaCluster([docker_scylla])
+    cluster.params = params
+
+    with cluster.cql_connection_patient(docker_scylla) as session:
+        session.execute(
+            "CREATE KEYSPACE mview WITH replication = {'class': 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1'} "
+            "AND durable_writes = true AND tablets = {'enabled': false}")
+        session.execute(
+            "CREATE TABLE mview.users (username text, first_name text, last_name text, password text, email text, "
+            "last_access timeuuid, PRIMARY KEY(username))")
+        session.execute(
+            "INSERT INTO mview.users (username, first_name, last_name, password) VALUES "
+            "('fruch', 'Israel', 'Fruchter', '1111')")
+        docker_scylla.run_nodetool('flush')
+
+        def is_virtual_tables_get_snapshot():
+            """
+            scylla commit https://github.com/scylladb/scylladb/commit/24589cf00cf8f1fae0b19a2ac1bd7b637061301a
+            has stopped creating snapshots for virtual tables.
+            hence we need to filter them out when compare tables to snapshot content.
+            """
+            if docker_scylla.is_enterprise:
+                return ComparableScyllaVersion(docker_scylla.scylla_version) >= "2024.3.0-dev"
+            else:
+                return ComparableScyllaVersion(docker_scylla.scylla_version) >= "6.3.0-dev"
+
+        if is_virtual_tables_get_snapshot():
+            ks_cf = cluster.get_any_ks_cf_list(
+                docker_scylla, filter_func=cluster.is_table_has_no_sstables, filter_empty_tables=False)
+        else:
+            ks_cf = cluster.get_any_ks_cf_list(docker_scylla, filter_empty_tables=False)
+
+        keyspace_table = []
+        ks_cf = [k_c.replace('"', '') for k_c in ks_cf]
+        keyspace_table.extend([k_c.split('.') for k_c in ks_cf])
+
+        result = docker_scylla.run_nodetool('snapshot')
+        snapshot_name = re.findall(r'(\d+)', result.stdout.split("snapshot name")[1])[0]
+
+        result = docker_scylla.run_nodetool('listsnapshots')
+        logging.debug(result)
+        snapshots_content = parse_nodetool_listsnapshots(listsnapshots_output=result.stdout)
+        snapshot_content = snapshots_content[snapshot_name]
+        logging.debug(snapshot_content)
+
+        snapshot_content_list = [[elem.keyspace_name, elem.table_name] for elem in snapshot_content]
+        if sorted(keyspace_table) != sorted(snapshot_content_list):
+            raise AssertionError(f"Snapshot content not as expected. \n"
+                                 f"Expected content: {sorted(keyspace_table)} \n "
+                                 f"Actual snapshot content: {sorted(snapshot_content_list)}")
 
 
 class TestNodetool(unittest.TestCase):


### PR DESCRIPTION
scylla commit https://github.com/scylladb/scylladb/commit/24589cf00cf8f1fae0b19a2ac1bd7b637061301a has stopped creating snapshots for virtual tables. 
hence we need to filter them out when compare tables to snapshot content.

without this change we'll be getting a mismatch between the expect list of tables to the actual tables that got snapshot

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] integration tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
