### PR TITLE
fix(setup): add retrying to download sm repo file

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1804,7 +1804,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             repo_path = '/etc/zypp/repos.d/scylla-manager.repo'
         else:
             repo_path = '/etc/apt/sources.list.d/scylla-manager.list'
-        self.remoter.sudo(f"curl -o {repo_path} -L {scylla_repo}")
+        self.remoter.sudo(f"curl -o {repo_path} -L {scylla_repo} --retry 5 --retry-max-time 300")
 
         # Prevent issue https://github.com/scylladb/scylla/issues/9683
         self.remoter.sudo(f"chmod 644 {repo_path}")


### PR DESCRIPTION
Sometimes SM repo file download fails due various reasons.

Adding retrying as other steps that interact with network.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/8710

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
