### PR TITLE
improvement(argus): disable argus for local runs

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -96,7 +96,6 @@ from sdcm.sct_events.loaders import CassandraStressLogEvent, ScyllaBenchEvent
 from sdcm.sct_events.nemesis import DisruptionEvent
 from sdcm.sct_events.system import InfoEvent
 from sdcm.sla.sla_tests import SlaTests
-from sdcm.utils.argus import get_argus_client
 from sdcm.utils.aws_kms import AwsKms
 from sdcm.utils import cdc
 from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations
@@ -5156,7 +5155,7 @@ def disrupt_method_wrapper(method, is_exclusive=False):  # pylint: disable=too-m
         if not isinstance(start_time, int):
             start_time = int(start_time)
         try:
-            argus_client = get_argus_client(run_id=nemesis.cluster.test_config.test_id())
+            argus_client = nemesis.cluster.test_config.argus_client()
             if nemesis_event.severity == Severity.ERROR:
                 argus_client.finalize_nemesis(name=method_name, start_time=start_time,
                                               status=NemesisStatus.FAILED, message=nemesis_event.full_traceback)

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -14,6 +14,7 @@ from sdcm.provision.common.configuration_script import ConfigurationScriptBuilde
 from sdcm.sct_events import Severity
 from sdcm.sct_events.system import TestFrameworkEvent
 from sdcm.utils.argus import ArgusError, get_argus_client
+from sdcm.utils.ci_tools import get_job_name
 from sdcm.utils.net import get_my_ip
 from sdcm.utils.decorators import retrying
 from sdcm.utils.docker_utils import ContainerManager
@@ -258,7 +259,7 @@ class TestConfig(metaclass=Singleton):  # pylint: disable=too-many-public-method
 
     @classmethod
     def init_argus_client(cls, params: dict, test_id: str | None = None):
-        if params.get("enable_argus"):
+        if params.get("enable_argus") and get_job_name() != 'local_run':
             LOGGER.info("Initializing Argus connection...")
             try:
                 cls._argus_client = get_argus_client(run_id=cls.test_id() if not test_id else test_id)


### PR DESCRIPTION
When running locally, all results are still sent to argus to 'local_run' test. We don't see it, we don't use it. It just create more data.

This commit skips creating argus client in case job name is 'local_run' (which maps to argus `test`).

closes: https://github.com/scylladb/scylla-cluster-tests/issues/7361

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [short test in CI](https://argus.scylladb.com/test/20c7e63e-f5ba-4ca2-946a-efec89b57949/runs?additionalRuns[]=fc369d66-bc28-4f57-a47e-8654a554a286)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
