### PR TITLE
fix(manager): add --force-conf options to apt cmd for Manager upgrade

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1908,7 +1908,9 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             self.remoter.sudo("zypper update scylla-manager-agent -y")
         else:
             self.remoter.sudo("apt-get update", ignore_status=True)
-            self.remoter.sudo("apt-get install -o DPkg::Lock::Timeout=300 -y scylla-manager-agent")
+            self.remoter.sudo("DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Lock::Timeout=300 "
+                              "-o Dpkg::Options::='--force-confold' -o Dpkg::Options::='--force-confdef' "
+                              "-y scylla-manager-agent")
         self.remoter.sudo("scyllamgr_agent_setup -y")
         if start_agent_after_upgrade:
             if self.is_docker():


### PR DESCRIPTION
Running apt-get install with '--force-confold' and '--force-confdef' options doesn't block the process when the new package version provides a new version of configuration file (old version will be kept).

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-upgrade-test/6/
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu24-upgrade-test/16/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code