### PR TITLE
improvement(results): store cycle's 'start time'

### DIFF
--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -11,6 +11,8 @@
 #
 # Copyright (c) 2024 ScyllaDB
 import json
+import time
+from datetime import timezone, datetime
 
 from argus.client import ArgusClient
 from argus.client.generic_result import GenericResultTable, ColumnMetadata, ResultType, Status, ValidationRule
@@ -41,8 +43,10 @@ class LatencyCalculatorMixedResult(GenericResultTable):
             ColumnMetadata(name="Throughput write", unit="op/s", type=ResultType.INTEGER, higher_is_better=True),
             ColumnMetadata(name="Throughput read", unit="op/s", type=ResultType.INTEGER, higher_is_better=True),
             ColumnMetadata(name="duration", unit="HH:MM:SS", type=ResultType.DURATION, higher_is_better=False),
+            # help jump into proper place in logs/monitoring
+            ColumnMetadata(name="start time", unit="", type=ResultType.TEXT),
             ColumnMetadata(name="Overview", unit="", type=ResultType.TEXT),
-            ColumnMetadata(name="QA dashboard", unit="", type=ResultType.TEXT)
+            ColumnMetadata(name="QA dashboard", unit="", type=ResultType.TEXT),
         ]
 
 
@@ -55,8 +59,10 @@ class LatencyCalculatorWriteResult(GenericResultTable):
             ColumnMetadata(name="P99 write", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="Throughput write", unit="op/s", type=ResultType.INTEGER, higher_is_better=True),
             ColumnMetadata(name="duration", unit="HH:MM:SS", type=ResultType.DURATION, higher_is_better=False),
+            # help jump into proper place in logs/monitoring
+            ColumnMetadata(name="start time", unit="", type=ResultType.TEXT),
             ColumnMetadata(name="Overview", unit="", type=ResultType.TEXT),
-            ColumnMetadata(name="QA dashboard", unit="", type=ResultType.TEXT)
+            ColumnMetadata(name="QA dashboard", unit="", type=ResultType.TEXT),
         ]
 
 
@@ -69,8 +75,10 @@ class LatencyCalculatorReadResult(GenericResultTable):
             ColumnMetadata(name="P99 read", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="Throughput read", unit="op/s", type=ResultType.INTEGER, higher_is_better=True),
             ColumnMetadata(name="duration", unit="HH:MM:SS", type=ResultType.DURATION, higher_is_better=False),
+            # help jump into proper place in logs/monitoring
+            ColumnMetadata(name="start time", unit="", type=ResultType.TEXT),
             ColumnMetadata(name="Overview", unit="", type=ResultType.TEXT),
-            ColumnMetadata(name="QA dashboard", unit="", type=ResultType.TEXT)
+            ColumnMetadata(name="QA dashboard", unit="", type=ResultType.TEXT),
         ]
 
 
@@ -110,11 +118,16 @@ workload_to_table = {
 }
 
 
-def send_result_to_argus(argus_client: ArgusClient, workload: str, name: str, description: str, cycle: int, result: dict):
+def send_result_to_argus(argus_client: ArgusClient, workload: str, name: str, description: str, cycle: int, result: dict,
+                         start_time: float = 0):
     result_table = workload_to_table[workload]()
     result_table.name = f"{workload} - {name} - latencies"
     result_table.description = f"{workload} workload - {description}"
     operation_error_thresholds = LATENCY_ERROR_THRESHOLDS.get(name, LATENCY_ERROR_THRESHOLDS["default"])
+    try:
+        start_time = datetime.fromtimestamp(start_time or time.time(), tz=timezone.utc).strftime('%H:%M:%S')
+    except ValueError:
+        start_time = "N/A"
     for operation in ["write", "read"]:
         summary = result["hdr_summary"]
         if operation.upper() not in summary:
@@ -147,6 +160,8 @@ def send_result_to_argus(argus_client: ArgusClient, workload: str, name: str, de
                                 value=qa_screenshot, status=Status.UNSET)
     except IndexError:
         pass
+    result_table.add_result(column="start time", row=f"Cycle #{cycle}",
+                            value=start_time, status=Status.UNSET)
     argus_client.submit_results(result_table)
     for event in result["reactor_stalls_stats"]:  # each stall event has own table
         event_name = event.split(".")[-1]

--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -264,7 +264,8 @@ def latency_calculator_decorator(original_function: Optional[Callable] = None, *
                         name="Steady State",
                         description="Latencies without any operation running",
                         cycle=0,
-                        result=result
+                        result=result,
+                        start_time=start,
                     )
             else:
                 latency_results[func_name]['cycles'].append(result)
@@ -274,7 +275,8 @@ def latency_calculator_decorator(original_function: Optional[Callable] = None, *
                     name=f"{func_name}",
                     description=legend or "",
                     cycle=len(latency_results[func_name]['cycles']),
-                    result=result
+                    result=result,
+                    start_time=start,
                 )
 
             with open(latency_results_file_path, 'w', encoding="utf-8") as file:

--- a/unit_tests/test_argus_results.py
+++ b/unit_tests/test_argus_results.py
@@ -30,7 +30,8 @@ def test_send_latency_decorator_result_to_argus():
         name="test",
         description="test",
         cycle=1,
-        result=result
+        result=result,
+        start_time=1721564063.4528425
     )
     expected_calls = [
         call(LatencyCalculatorMixedResult(
@@ -50,7 +51,8 @@ def test_send_latency_decorator_result_to_argus():
                      value='https://cloudius-jenkins-test.s3.amazonaws.com/a9b9a308-6ff8-4cc8-b33d-c439f75c9949/20240721_125838/'
                            'grafana-screenshot-scylla-master-perf-regression-latency-650gb-grow-shrink-scylla-per-server-metrics-nemesis'
                            '-20240721_125845-perf-latency-grow-shrink-ubuntu-monitor-node-a9b9a308-1.png',
-                     status=Status.UNSET)
+                     status=Status.UNSET),
+                Cell(column='start time', row='Cycle #1', value='12:14:23', status=Status.UNSET)
             ]
         )),
         call(ReactorStallStatsResult(


### PR DESCRIPTION
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [example result](https://argus.scylladb.com/test/47ee4c1d-bff9-42fc-8911-29bc79f2ef40/runs?additionalRuns[]=9684194c-1815-4dd9-a717-f82300d001cc) - see final solution moved 'start time' column before screenshot links.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
