### PR TITLE
improvement(monitoring): restore monitor with test time range

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2972,6 +2972,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if self.kafka_cluster:
             with silence(parent=self, name='stopping kafka'):
                 self.kafka_cluster.stop()
+        self.monitors.update_default_time_range(self.start_time, time.time())
         if self.params.get('collect_logs'):
             self.collect_logs()
         self.clean_resources()
@@ -2982,8 +2983,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.argus_collect_gemini_results()
         self.destroy_localhost()
         self.stop_event_device()
-        if self.params.get('collect_logs'):
-            self.collect_sct_logs()
         with silence(parent=self, name='Cleaning up SSL config directory'):
             cleanup_ssl_config()
 

--- a/unit_tests/test_tester.py
+++ b/unit_tests/test_tester.py
@@ -18,6 +18,7 @@ import tempfile
 import time
 import unittest.mock
 from time import sleep
+from unittest.mock import MagicMock
 
 from sdcm.sct_events import Severity
 from sdcm.sct_events.health import ClusterHealthValidatorEvent
@@ -97,6 +98,7 @@ class ClusterTesterForTests(ClusterTester):
         pass
 
     def tearDown(self):
+        self.monitors = MagicMock()
         super().tearDown()
         self._validate_results()
         self.events_processes_registry_patcher.stop()
@@ -273,6 +275,7 @@ class SetupFailsTest(ClusterTesterForTests):
         pass
 
     def tearDown(self):
+        self.monitors = MagicMock()
         ClusterTester.tearDown(self)
 
     def _validate_results(self):


### PR DESCRIPTION
Restoring monitor data with `hydra investigate show-monitor` sets default time range to recent 30m. This is unconvinient as requires to find test related time range manually.

This change hardcodes time range in dashboard defaults to range of test duration.

closes: https://github.com/scylladb/scylla-cluster-tests/issues/5045
closes: https://github.com/scylladb/argus/issues/454

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - provision test - try restoring `hydra investigate show-monitor 81aa1353-e2c5-4ac3-b864-ca4b0f81dede`

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
