### PR TITLE
fix(test_workload_types): adjust workload comparison

### DIFF
--- a/sla_per_user_system_test.py
+++ b/sla_per_user_system_test.py
@@ -828,6 +828,12 @@ class SlaPerUserTest(LongevityTest):
         comparison_axis = {"latency 95th percentile": 2.0,
                            "latency 99th percentile": 2.0,
                            "op rate": 2.0}
+        release = parse_version(self.db_cluster.nodes[0].scylla_version.replace("~", "-")).release
+        if release[0] > 2024 or (release[0] == 2024 and release[1] >= 3):
+            # Running the test with 2024.3  - deviation was improved
+            comparison_axis = {"latency 95th percentile": 1.0,
+                               "latency 99th percentile": 1.0,
+                               "op rate": 1.0}
         workloads_results = {}
         for workload in workloads_queue:
             result = self.get_stress_results(queue=workload, store_results=False)


### PR DESCRIPTION
in last enterprise-master(2024.1.3) deviation of workloads was improved and the test started failing with errors like:
"Actual ratio (0.9841362837441976) is not as expected (2.0)"

I assume it was implemented by design to hit such
improvement and adjust tests accordingly.

value comparison_axis was adjuster for version >=2024.3

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested with disabled_kms ( issue https://github.com/scylladb/scylla-enterprise/issues/4690)   https://jenkins.scylladb.com/job/scylla-staging/job/artsiom_mishuta/job/reanimate_sla/job/features-sla-workload-types-test/3/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
