### PR TITLE
fix(nemesis): get bytes total for correct network device

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -357,6 +357,10 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
     def network_interfaces(self):
         raise NotImplementedError()
 
+    @property
+    def network_configuration(self):
+        raise NotImplementedError()
+
     def init(self) -> None:
         if self.logdir:
             os.makedirs(self.logdir, exist_ok=True)

--- a/sdcm/provision/network_configuration.py
+++ b/sdcm/provision/network_configuration.py
@@ -17,6 +17,8 @@ class NetworkInterface:  # pylint: disable=too-many-instance-attributes
     dns_private_name: str
     dns_public_name: Optional[str]
     device_index: int
+    device_name: Optional[str]
+    mac_address: Optional[str]
 
 
 class ScyllaNetworkConfiguration:
@@ -88,6 +90,15 @@ class ScyllaNetworkConfiguration:
             return self.network_interfaces[0].ipv6_public_addresses[0]
         else:
             return None
+
+    @property
+    def device(self):
+        # Depend on network configuration:
+        # if broadcast_address.device_name if found
+        # else empty string.
+        if address_config := [conf for conf in self.scylla_network_config if conf["address"] == "broadcast_address"]:
+            return "".join([ni.device_name for ni in self.network_interfaces if ni.device_index == address_config[0]['nic']])
+        return ""
 
     def get_ip_by_address_config(self, address_config: dict) -> str:
         if not (interface := [conf for conf in self.network_interfaces if address_config["nic"] == conf.device_index]):

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -458,7 +458,9 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method,too-many-instance-
                                  ipv6_private_address='',
                                  dns_private_name="",
                                  dns_public_name="",
-                                 device_index=0
+                                 device_index=0,
+                                 device_name='',
+                                 mac_address=''
                                  ),
                 NetworkInterface(ipv4_public_address=None,
                                  ipv6_public_addresses=[self._ipv6_ip_address[1]],
@@ -466,7 +468,9 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method,too-many-instance-
                                  ipv6_private_address='',
                                  dns_private_name="",
                                  dns_public_name="",
-                                 device_index=1
+                                 device_index=1,
+                                 device_name='',
+                                 mac_address=''
                                  )
                 ]
 


### PR DESCRIPTION
If test runs with 2 network interfaces configuration, 'disrupt_network_random_interruptions' nemesis fails with error:
```
File '/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py', line 3376, in get_rate_limit_for_network_disruption
return '{}{}'.format(random.randrange(min_limit, max_limit), rate_limit_suffix) ValueError: empty range for randrange() (0, 0, 0)
```

It happened because 'node_network_receive_bytes_total' is reported on device that broadcast_address is configured on it.
Now the device is set hardcoded to 'eth0'.

Failed test: https://argus.scylladb.com/test/b08fa1c7-ae96-4a5b-be2d-98db30813a00/runs?additionalRuns[]=21961db0-285c-4b84-a4da-4d70be149e06

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-50gb-two-interfaces-test](https://argus.scylladb.com/test/b08fa1c7-ae96-4a5b-be2d-98db30813a00/runs?additionalRuns[]=0cc74a59-788d-47a1-a7ba-fb7994ca7af7)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
