### PR TITLE
fix(get-images): retrun exact versions as needed

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1134,7 +1134,11 @@ def get_scylla_ami_versions(region_name: str, arch: AwsArchType = 'x86_64', vers
     name_filter = "ScyllaDB *"
 
     if version and version != "all":
-        name_filter = f"ScyllaDB *{version.replace('enterprise-', 'Enterprise ')}*"
+        name_filter = f"ScyllaDB *{version.replace('enterprise-', 'Enterprise ')}"
+
+        if len(version.split('.')) < 3:
+            # if version is not exact version, we need to add the wildcard to the end, to catch all minor versions
+            name_filter = f"{name_filter}*"
 
     ec2_resource: EC2ServiceResource = boto3.resource('ec2', region_name=region_name)
     images = []
@@ -1165,7 +1169,7 @@ def get_scylla_gce_images_versions(project: str = SCYLLA_GCE_IMAGES_PROJECT, ver
 
     if version and version != "all":
         filters += f"(name eq 'scylla(db)?(-enterprise)?-{version.replace('.', '-')}"
-        if 'rc' not in version:
+        if 'rc' not in version and len(version.split('.')) < 3:
             filters += "(-\\d)?(\\d)?(\\d)?(-rc)?(\\d)?(\\d)?')"
         else:
             filters += "')"


### PR DESCRIPTION
when we ask for exact version so far, we might get newer version that contains the version asked

for example asking for `2024.1.1`, we would get both `2024.1.1` and `2024.1.10` sorted in a way that newer is first, and that what would be used.

this change is limiting the filters in both AWS and GCE, if exact version was asked

(similar as it's now on Azure backend)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
