### PR TITLE
fix(sla): explicit ServisLevel creation

### DIFF
--- a/test_lib/sla.py
+++ b/test_lib/sla.py
@@ -83,8 +83,13 @@ class ServiceLevel:
     @classmethod
     def from_row(cls, session, row):
         row_dict = row._asdict()
-        row_dict["name"] = row_dict.pop("service_level")
-        return ServiceLevel(session=session, **row_dict)
+        LOGGER.debug("SERVICE_LEVEL row: %s", row_dict)
+        return ServiceLevel(
+            session=session,
+            name=row_dict["service_level"],
+            shares=row_dict["shares"],
+            timeout=row_dict["timeout"],
+            workload_type=row_dict["workload_type"])
 
     @property
     def scheduler_group_name(self) -> str:
@@ -180,10 +185,7 @@ class ServiceLevel:
         if len(res) == 0:
             return None
 
-        result_dict = res[0]._asdict()
-        result_dict["name"] = result_dict.pop("service_level")
-
-        return ServiceLevel(session=self.session, **result_dict)
+        return ServiceLevel.from_row(self.session, res[0])
 
     def list_all_service_levels(self) -> list[ServiceLevel]:
         query = 'LIST ALL SERVICE_LEVELS'
@@ -193,9 +195,7 @@ class ServiceLevel:
         output = []
 
         for res in res_list:
-            result_dict = res._asdict()
-            result_dict["name"] = result_dict.pop("service_level")
-            output.append(ServiceLevel(session=self.session, **result_dict))
+            output.append(ServiceLevel.from_row(self.session, res))
         return output
 
 # pylint: disable=too-many-arguments, too-many-instance-attributes, unused-argument


### PR DESCRIPTION
due to implicit servis level creation
by put **cql_result into ```__init__```,
in 2024.3 we start got python exception:
```
"ServiceLevel.__init__() got an unexpected keyword argument"
```
This PR fixes this issue by putting arguments into ```__init__``` explicitly and added additional log message before ```__init__```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested inhttps://argus.scylladb.com/test/18f3a99f-66ae-4d3a-a528-81a683fc52fa/runs?additionalRuns[]=b5b12efa-5ba9-43b7-af2a-0bbb9264245e,  python error has gone and I  hit issue https://github.com/scylladb/scylla-enterprise/issues/4801

```
< t:2024-10-08 11:51:57,846 f:sla.py          l:86   c:test_lib.sla         p:DEBUG > SERVICE_LEVEL row: {'service_level': 'sl200_0', 'timeout': None, 'workload_type': None, 'shares': 200, 'percentage_of_all_service_level_shares': '12.50%'}
< t:2024-10-08 11:51:57,847 f:sla.py          l:86   c:test_lib.sla         p:DEBUG > SERVICE_LEVEL row: {'service_level': 'sl600_0', 'timeout': None, 'workload_type': None, 'shares': 600, 'percentage_of_all_service_level_shares': '37.50%'}
< t:2024-10-08 11:51:57,847 f:sla.py          l:86   c:test_lib.sla         p:DEBUG > SERVICE_LEVEL row: {'service_level': 'sl800_1', 'timeout': None, 'workload_type': None, 'shares': 800, 'percentage_of_all_service_level_shares': '50.00%'}
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
