### PR TITLE
improvement(reporting): Add argus links to email template and elastic

### DIFF
--- a/sdcm/report_templates/results_base.html
+++ b/sdcm/report_templates/results_base.html
@@ -176,6 +176,7 @@
             {% endif %}
             {% if test_id %}
             <li>Test-id: {{ test_id }}</li>
+            <li><a href="https://argus.scylladb.com/tests/scylla-cluster-tests/{{ test_id }}">Link to argus</a></li>
             {% endif %}
             {% if start_time %}
             <li>Start time: {{ start_time }}</li>

--- a/sdcm/reporting/elastic_reporter.py
+++ b/sdcm/reporting/elastic_reporter.py
@@ -45,6 +45,7 @@ class ElasticRunReporter:
             "status": status,
             "build_id": job_name,
             "build_url": build_url,
+            "argus_url": f"https://argus.scylladb.com/tests/scylla-cluster-tests/{run_id}",
             "build_number": build_number,
         }
 


### PR DESCRIPTION
This commit adds links to argus to the elastic search index and email
templates, allowing users to find argus runs quickly from those places.

Fixes scylladb/qa-tasks#1490

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] [Jenkins](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/alexey/job/alexey-argus-testing/100/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
