### PR TITLE
fix(manager): upload new backup snapshot for nemesis

### DIFF
--- a/defaults/manager_persistent_snapshots.yaml
+++ b/defaults/manager_persistent_snapshots.yaml
@@ -23,12 +23,12 @@ aws:
       number_of_rows: 10485760
       expected_timeout: 3600  # 60 minutes
       snapshots:
-        'sm_20240812150753UTC':
-          keyspace_name: "10gb_sizetiered_2024_2_0_rc1"
-          scylla_version: "2024.2.0~rc1"
+        'sm_20241010102035UTC':
+          keyspace_name: "10gb_sizetiered_2024_2_0_rc3"
+          scylla_version: "2024.2.0~rc3"
           scylla_product: "enterprise"
           number_of_nodes: 3
-          cluster_id: "c1ac4a5f-cb1a-4312-aa00-e9fdddac7afb"
+          cluster_id: "c5ae2ea7-72f3-4350-85d4-7956c1837b8a"
         'sm_20240812150801UTC':
           keyspace_name: "10gb_sizetiered_6_0"
           scylla_version: "6.0.2"


### PR DESCRIPTION
10Gb snapshot made on Scylla 2024.2.0-rc1 is replaced by the image from fresher Enterprise version 2024.2.0-rc3.

It fixes the issue with restore of snapshot from rc1 to the latest versions, see for details:
https://github.com/scylladb/scylla-enterprise/issues/4737.

The change fixes frequent nemesis failures related to mgr restore.

Considering this solution as temporary and replacing only one snapshot (10GB) which is in wide use in nemesis. The rest of the snapshots will be replaced when the official 2024.2.0 version is released.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Enterprise 2024.1 [test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/longevity-10gb-3h-test/2/)
- [x] Enterprise 2024.2 [test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/longevity-twcs-3h-test/8/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
