### PR TITLE
fix(gradual): run post_prepare_cql_cmds after prepare

### DIFF
--- a/performance_regression_gradual_grow_throughput.py
+++ b/performance_regression_gradual_grow_throughput.py
@@ -121,9 +121,9 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
             self.wait_no_compactions_running(n=400, sleep_time=120)
             self.run_fstrim_on_all_db_nodes()
 
-        if post_prepare_cql_cmds := self.params.get('post_prepare_cql_cmds'):
-            self.log.debug("Execute post prepare queries: %s", post_prepare_cql_cmds)
-            self._run_cql_commands(post_prepare_cql_cmds)
+            if post_prepare_cql_cmds := self.params.get('post_prepare_cql_cmds'):
+                self.log.debug("Execute post prepare queries: %s", post_prepare_cql_cmds)
+                self._run_cql_commands(post_prepare_cql_cmds)
 
         self.run_gradual_increase_load(workload=workload,
                                        stress_num=stress_num,


### PR DESCRIPTION
Prepare does not run during write load. So 'keyspace1' keyspace does not exist. It caused to failure of speculative_retry disable script. 
Error: `keyspace keyspace1 does not exist`
Start post_prepare_cql_cmds after prepare load only

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
