### PR TITLE
fix(tearown): fix set grafana time range when no monitors

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5894,6 +5894,8 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
         This method will find all JSON files in the `grafana/build/<subdir>` directories and replace
         the "from" and "to" time range values with the provided start and end timestamps.
         """
+        if not self.nodes:
+            return  # no monitor nodes
         start_iso = datetime.fromtimestamp(start_timestamp, tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
         end_iso = datetime.fromtimestamp(end_timestamp, tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
         cmd = (f"find {os.path.join(self.monitor_install_path, 'grafana/build/')} -name '*.json' -exec "


### PR DESCRIPTION
On docker backend, getting monitor install path requires monitor nodes - which fail in tests without monitor.

Fix by returning early from the `update_default_time_range` method when no monitor nodes are present.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
