### PR TITLE
refactor(SCHEMA_FAILURE): Change default severity of SCHEMA_FAILURE

### DIFF
--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -115,8 +115,9 @@ DatabaseLogEvent.add_subevent_type("COMPACTION_STOPPED", severity=Severity.NORMA
                                    regex="compaction_stopped_exception")
 DatabaseLogEvent.add_subevent_type("BAD_ALLOC", severity=Severity.ERROR,
                                    regex="std::bad_alloc")
+# Due to scylla issue https://github.com/scylladb/scylladb/issues/19093, we need to suppress the below error
 DatabaseLogEvent.add_subevent_type("SCHEMA_FAILURE", severity=Severity.ERROR,
-                                   regex="Failed to load schema version")
+                                   regex=r'(.*ERROR|!ERR).*Failed to load schema version')
 DatabaseLogEvent.add_subevent_type("RUNTIME_ERROR", severity=Severity.ERROR,
                                    regex="std::runtime_error")
 # remove below workaround after dropping support for Scylla 2023.1 and 5.2 (see scylladb/scylla#13538)

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -117,7 +117,7 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
 
     def test_search_system_log(self):
         critical_errors = list(self.node.follow_system_log(start_from_beginning=True))
-        self.assertEqual(34, len(critical_errors))
+        self.assertEqual(33, len(critical_errors))
 
     def test_search_system_log_specific_log(self):
         errors = list(self.node.follow_system_log(

--- a/unit_tests/test_data/system.log
+++ b/unit_tests/test_data/system.log
@@ -479,7 +479,7 @@
 [10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 0] gossip - InetAddress 10.0.222.111 is now UP, status = NORMAL
 [10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 0] migration_manager - Requesting schema pull from 10.0.222.111:0
 [10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 0] Failed to load schema version
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 0] Failed to load schema version
+[10.0.73.70] [stdout] Apr 02 11:24:39 ERROR   | scylla[124]:  [shard 0] Failed to load schema version
 [10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 0] migration_manager - Pulling schema from 10.0.222.111:0
 [10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 0] migration_manager - Requesting schema pull from 10.0.222.111:0
 [10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 0] migration_manager - Pulling schema from 10.0.222.111:0


### PR DESCRIPTION
SCT detects the regex "Failed to load schema version" and creates an ERROR event out of it even if the message in scylla is with INFO severity. this behviour raises issues like
"https://github.com/scylladb/scylladb/issues/19093" which gets P3 priority but continue failing SCT tests over and over. Hence, this commit suggests to reduce this message severity.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
