### PR TITLE
feature(argus-results): fail test based on Argus results validation

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -143,3 +143,4 @@ CommitLogCheckErrorEvent: ERROR
 ValidatorEvent: ERROR
 ScrubValidationErrorEvent: ERROR
 PartitionRowsValidationEvent: CRITICAL
+FailedResultEvent: ERROR

--- a/sdcm/sct_events/system.py
+++ b/sdcm/sct_events/system.py
@@ -300,3 +300,13 @@ INSTANCE_STATUS_EVENTS = (
 
 INSTANCE_STATUS_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
     [(re.compile(event.regex, re.IGNORECASE), event) for event in INSTANCE_STATUS_EVENTS]
+
+
+class FailedResultEvent(InformationalEvent):
+    def __init__(self, message: str, severity: Severity = Severity.ERROR):
+        super().__init__(severity)
+        self.message = message
+
+    @property
+    def msgfmt(self) -> str:
+        return super().msgfmt + ": message={0.message}"

--- a/utils/migrate_latency_results_to_argus.py
+++ b/utils/migrate_latency_results_to_argus.py
@@ -2,7 +2,6 @@
 import sys
 import os.path
 import datetime
-import logging
 import logging.config
 from collections import OrderedDict
 
@@ -105,6 +104,9 @@ def migrate(creds, job_name, days=7, index_name="performancestatsv2", dry_run=Tr
                         result=cycle,
                         start_time=start_time
                     )
+                except RuntimeError:
+                    # happens when no EventsDevice is running and trying to raise SCT event
+                    pass
                 except argus.client.base.ArgusClientError:
                     print(
                         f"Failed to send {operation} - {workload} - latencies - cycle {idx} to Argus: {hit['_source']['test_details']['job_url']}")


### PR DESCRIPTION
Argus responds with error if any of the result fails validation (or client sends results with ERROR status). Catch this error and raise error event to make test fail with proper message in that case.

refs: https://github.com/scylladb/qa-tasks/issues/1765

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - tested with migration of latency decorator results script

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
