### PR TITLE
fix(util): fix skip_optional_stage logic

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2670,5 +2670,5 @@ def skip_optional_stage(stage_names: str | list[str]) -> bool:
     if skipped_stages:
         skipped_stages_str = ', '.join(skipped_stages)
         LOGGER.warning("'%s' test stage(s) is disabled.", skipped_stages_str)
-        return False
-    return True
+        return True
+    return False


### PR DESCRIPTION
if stage skipped in test we expect that skip_optional_stage func returns true, but in fact returned false. This pr fix this issue

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- Issue was reproduced https://argus.scylladb.com/tests/scylla-cluster-tests/3cee27f8-d6ff-4270-a4bf-d63f31948b5e
- Currently the test running on the same job with the same params (https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/eugene_test_folder/job/longevity-1tb-5days-azure-test/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
