### PR TITLE
fix(SLA) fix 1to5 ratio test for 2024.3

### DIFF
--- a/test-cases/features/system-sla-test.yaml
+++ b/test-cases/features/system-sla-test.yaml
@@ -5,7 +5,9 @@ n_loaders: 3
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.2xlarge'
-instance_type_loader: 'c5.2xlarge'
+instance_type_loader: 'c6i.2xlarge'
+
+pre_create_keyspace: "CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1024};"
 
 user_prefix: 'system-sla'
 


### PR DESCRIPTION
fix 1to5 ratio test for 2024.3
where tablets are enabled by default

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/edbfccd0-c328-4dfb-aff2-67d0165573a4 - test failed looks like due to https://github.com/scylladb/scylla-enterprise/issues/3737, but there is no message that cluster is not loaded enought
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
