### PR TITLE
fix(test_workload_types): adjust workload comparison for 2024.2

### DIFF
--- a/sla_per_user_system_test.py
+++ b/sla_per_user_system_test.py
@@ -21,6 +21,7 @@ from sdcm.db_stats import PrometheusDBStats
 from sdcm.es import ES
 from sdcm.sct_events import Severity
 from sdcm.sct_events.workload_prioritisation import WorkloadPrioritisationEvent
+from sdcm.utils.version_utils import ComparableScyllaVersion
 from test_lib.sla import ServiceLevel, Role, User
 
 
@@ -828,8 +829,7 @@ class SlaPerUserTest(LongevityTest):
         comparison_axis = {"latency 95th percentile": 2.0,
                            "latency 99th percentile": 2.0,
                            "op rate": 2.0}
-        release = parse_version(self.db_cluster.nodes[0].scylla_version.replace("~", "-")).release
-        if release[0] > 2024 or (release[0] == 2024 and release[1] >= 3):
+        if ComparableScyllaVersion(self.db_cluster.nodes[0].scylla_version) >= '2024.2.0~rc3':
             # Running the test with 2024.3  - deviation was improved
             comparison_axis = {"latency 95th percentile": 1.0,
                                "latency 99th percentile": 1.0,


### PR DESCRIPTION
adjust change https://github.com/scylladb/scylla-cluster-tests/pull/8922 to work with 2024.2 (https://argus.scylladb.com/tests/scylla-cluster-tests/c4fbed30-dc6d-4eee-b901-d8cb7d3c6519)
and use ComparableScyllaVersion SCT utility as suggested

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/8961

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] https://argus.scylladb.com/tests/scylla-cluster-tests/46c74832-5c39-4ec8-84ab-966d66d3d96f
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
