### PR TITLE
fix(kms): set proper node regions in multi-dc setups

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import contextlib
+import copy
 import queue
 import logging
 import os
@@ -509,7 +510,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             scylla_yml.replace_address_first_boot = self.replacement_node_ip
         if self.replacement_host_id:
             scylla_yml.replace_node_first_boot = self.replacement_host_id
-        if append_scylla_yaml := self.parent_cluster.params.get('append_scylla_yaml') or {}:
+        if append_scylla_yaml := copy.deepcopy(self.parent_cluster.params.get('append_scylla_yaml')) or {}:
             if any(key in append_scylla_yaml for key in (
                     "system_key_directory", "system_info_encryption", "kmip_hosts")):
                 install_encryption_at_rest_files(self.remoter)


### PR DESCRIPTION
The AWS-KMS code in DB node python class uses shared dictionary
from the DB cluster class for updating the KMS endpoint region.

It was not a problem when DB nodes setup was serial.
In this case shared object was changed by each node but had proper value in needed time frame.

After implementation of the parallel DB nodes setup (https://github.com/scylladb/scylla-cluster-tests/pull/7383) 
we started getting problems that only one state of that shared object was being applied for all nodes.

In single-dc setups everything was correct just because there was no diff among DB node's region names.
But in multi-dc setups values from DB nodes started being applied to each other.

So, fix it by just deep-copying that shared dictionary to avoid updates of a shared object.

Closes: https://github.com/scylladb/scylla-cluster-tests/issues/9025

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://argus.scylladb.com/tests/scylla-cluster-tests/42b2d981-559b-4b64-b931-289e9f4ab928

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
