### PR TITLE
fix(monitor): don't call monitor method when no monitors

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2975,7 +2975,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if self.kafka_cluster:
             with silence(parent=self, name='stopping kafka'):
                 self.kafka_cluster.stop()
-        self.monitors.update_default_time_range(self.start_time, time.time())
+        if self.monitors is not None:
+            self.monitors.update_default_time_range(self.start_time, time.time())
         if self.params.get('collect_logs'):
             self.collect_logs()
         self.clean_resources()


### PR DESCRIPTION
In case `self.monitors` is not defined, sct raises exception upon `update_default_time_range` invocation.

Add protection by checking if `self.monitors` is not `None`.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9023

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
