### PR TITLE
improvement(test-stages): add skip test stages option for perf tests

### DIFF
--- a/configurations/skip_test_stages.yaml
+++ b/configurations/skip_test_stages.yaml
@@ -5,3 +5,5 @@ skip_test_stages:
   post_test_load: false
   nemesis: false
   data_validation: false
+  perf_preload_data: false
+  perf_steady_state_calc: false

--- a/docs/skip-test-stages.md
+++ b/docs/skip-test-stages.md
@@ -16,6 +16,8 @@ For the moment, the following test stages can be skipped:
 - post_test_load
 - nemesis
 - data_validation
+- perf_preload_data: false
+- perf_steady_state_calc: false
 
 ### Configuration
 

--- a/performance_regression_alternator_test.py
+++ b/performance_regression_alternator_test.py
@@ -16,6 +16,7 @@ import contextlib
 from performance_regression_test import PerformanceRegressionTest
 from sdcm.sct_events.group_common_events import ignore_operation_errors, ignore_alternator_client_errors
 from sdcm.utils import alternator
+from sdcm.utils.decorators import optional_stage
 
 
 class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
@@ -68,6 +69,7 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
                                 y_id varchar primary key,
                                 {fields});""")
 
+    @optional_stage('perf_preload_data')
     def preload_data(self, compaction_strategy=None):
         # if test require a pre-population of data
         prepare_write_cmd = self.params.get('prepare_write_cmd')

--- a/performance_regression_gradual_grow_throughput.py
+++ b/performance_regression_gradual_grow_throughput.py
@@ -7,6 +7,7 @@ import json
 from typing import NamedTuple
 
 from performance_regression_test import PerformanceRegressionTest
+from sdcm.utils.common import skip_optional_stage
 from sdcm.sct_events import Severity
 from sdcm.sct_events.system import TestFrameworkEvent
 from sdcm.results_analyze import PredefinedStepsTestPerformanceAnalyzer
@@ -115,7 +116,7 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
         num_loaders = len(self.loaders.nodes)
         self.run_fstrim_on_all_db_nodes()
         # run a write workload as a preparation
-        if workload.preload_data:
+        if workload.preload_data and not skip_optional_stage('perf_preload_data'):
             self.preload_data()
             self.wait_no_compactions_running(n=400, sleep_time=120)
             self.run_fstrim_on_all_db_nodes()

--- a/performance_regression_row_level_repair_test.py
+++ b/performance_regression_row_level_repair_test.py
@@ -19,7 +19,7 @@ from textwrap import dedent
 import six
 
 from sdcm.tester import ClusterTester
-from sdcm.utils.decorators import measure_time, retrying
+from sdcm.utils.decorators import measure_time, retrying, optional_stage
 from test_lib.scylla_bench_tools import create_scylla_bench_table_query
 
 THOUSAND = 1000
@@ -63,6 +63,7 @@ class PerformanceRegressionRowLevelRepairTest(ClusterTester):
         self.log.debug("Could not find a 'cl' parameter in stress command: {}".format(str_stress_cmd))
         return str_stress_cmd
 
+    @optional_stage('perf_preload_data')
     def preload_data(self, consistency_level=None):
         # if test require a pre-population of data
 

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -28,7 +28,7 @@ from sdcm.sct_events import Severity
 from sdcm.sct_events.filters import EventsSeverityChangerFilter
 from sdcm.sct_events.loaders import CassandraStressEvent
 from sdcm.sct_events.system import HWPerforanceEvent, InfoEvent
-from sdcm.utils.decorators import log_run_info, latency_calculator_decorator
+from sdcm.utils.decorators import log_run_info, latency_calculator_decorator, optional_stage
 from sdcm.utils.csrangehistogram import CSHistogramTagTypes
 from sdcm.utils.nemesis_utils.indexes import wait_for_view_to_be_built
 
@@ -218,6 +218,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
                                          extra_time_to_expiration=60):
             self.loaders.kill_stress_thread()
 
+    @optional_stage('perf_preload_data')
     def preload_data(self, compaction_strategy=None):
         # if test require a pre-population of data
         prepare_write_cmd = self.params.get('prepare_write_cmd')
@@ -818,6 +819,7 @@ class PerformanceRegressionUpgradeTest(PerformanceRegressionTest, UpgradeTest): 
                                          extra_time_to_expiration=60):
             self.loaders.kill_stress_thread()
 
+    @optional_stage('perf_steady_state_calc')
     @latency_calculator_decorator
     def steady_state_latency(self):  # pylint: disable=no-self-use
         sleep_time = self.db_cluster.params.get('nemesis_interval') * 60


### PR DESCRIPTION
Add possibility to skip selected stages of performances.

Closes: https://github.com/scylladb/qa-tasks/issues/1761

### Testing
- [x] [perf-regression-throughput-shard-aware-i4i](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/perf-regression-throughput-shard-aware-i4i/4/) build re-uses [previously provisioned cluster](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/perf-regression-throughput-shard-aware-i4i/2/) skipping preload_data step

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
