### PR TITLE
fix(advanced-rpc-compression): set up internode_compression_enable_advanced

### DIFF
--- a/configurations/advanced-rpc-compression.yaml
+++ b/configurations/advanced-rpc-compression.yaml
@@ -4,5 +4,6 @@ append_scylla_yaml:
   rpc_dict_training_min_bytes: 100000000
   internode_compression_zstd_max_cpu_fraction: 0.05
   rpc_dict_training_when: 'when_leader'
+  internode_compression_enable_advanced: true
 
 internode_compression: 'all'

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -148,6 +148,7 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods,too-many-
     internode_send_buff_size_in_bytes: int = None  # 0
     internode_recv_buff_size_in_bytes: int = None  # 0
     internode_compression: Literal['none', 'all', 'dc'] = None  # "none"
+    internode_compression_enable_advanced: bool = None
     rpc_dict_training_when: Literal['always', 'never', 'when_leader'] = None
     rpc_dict_training_min_time_seconds: int = None
     rpc_dict_update_period_seconds: int = None

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -268,6 +268,7 @@ class ScyllaYamlTest(unittest.TestCase):
                 'inter_dc_tcp_nodelay': None,
                 'internode_authenticator': None,
                 'internode_compression': None,
+                'internode_compression_enable_advanced': None,
                 'rpc_dict_training_when': None,
                 'rpc_dict_training_min_time_seconds': None,
                 'rpc_dict_update_period_seconds': None,


### PR DESCRIPTION
Since scylladb/scylla-enterprise@e951f5d3a7fd69e53fb4c51859ee96cbd5a56ebc, new RPC compression implementation is hidden behind an additional config entry: internode_compression_enable_advanced.

Tests which want to enable new RPC compression should set it to `true`.

I did not test this PR in any way, and I don't know how it could/should be tested.