### PR TITLE
Pipeline configuration changes for Manager release 3.4

### DIFF
--- a/jenkins-pipelines/manager/debian11-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian11-manager-upgrade.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.2',
+    manager_version: '3.3',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/debian11.yaml"]''',

--- a/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
@@ -10,7 +10,7 @@ managerPipeline(
     target_manager_version: 'master_latest',
 
     // Upgrade from previous minor release (the first one)
-    manager_version: '3.2.0',
+    manager_version: '3.3.0',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu20.yaml"]''',

--- a/jenkins-pipelines/manager/ubuntu22-manager-older-enterprise-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-older-enterprise-sanity.jenkinsfile
@@ -7,7 +7,7 @@ managerPipeline(
     backend: 'aws',
     region: '''["us-east-1", "us-west-2"]''',
 
-    scylla_version: '2022.1',
+    scylla_version: '2022.2',
 
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',

--- a/jenkins-pipelines/manager/ubuntu22-manager-older-enterprise-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-older-enterprise-upgrade.jenkinsfile
@@ -7,7 +7,7 @@ managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
 
-    scylla_version: '2022.1',
+    scylla_version: '2022.2',
 
     target_manager_version: 'master_latest',
 

--- a/jenkins-pipelines/manager/ubuntu22-manager-older-enterprise-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-older-enterprise-upgrade.jenkinsfile
@@ -11,7 +11,7 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    manager_version: '3.2',
+    manager_version: '3.3',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: 'test-cases/upgrades/manager-upgrade.yaml',

--- a/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
@@ -9,8 +9,8 @@ managerPipeline(
 
     target_manager_version: 'master_latest',
 
-    // Upgrade from previous minor release (the last one), for this specific case it'd be 3.2.8
-    manager_version: '3.2',
+    // Upgrade from previous minor release (the last one), for this specific case it'd be 3.3.3
+    manager_version: '3.3',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: 'test-cases/upgrades/manager-upgrade.yaml',


### PR DESCRIPTION
Some pipelines configuration changes related to Manager 3.4 coming release:
- upgrade pipelines adjusted to run upgrade from version 3.3.* instead of 3.2.*;
- older enterprise test is switched to use the oldest version mentioned (2022.2) in official documentation.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code