### PR TITLE
fix(_rotate_kms_key): remove SkipPerIssues since the ticket is resolved

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4586,9 +4586,6 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                     AwsKmsEvent(
                         message=f"Failed to rotate AWS KMS key for the '{kms_key_alias_name}' alias",
                         traceback=traceback.format_exc()).publish()
-                if SkipPerIssues("https://github.com/scylladb/scylla-enterprise/issues/3896", self.params):
-                    self.log.warning("KMS encryption check is skipped due to the 'scylla-enterprise/issues/3896'")
-                    continue
                 try:
                     nemesis_class = self.nemesis[0] if self.nemesis else getattr(
                         import_module('sdcm.nemesis'), "Nemesis")


### PR DESCRIPTION
As per discussion in https://github.com/scylladb/scylla-cluster-tests/issues/9134, this clause can be removed as the ticket is resolved and doesn't have sct skip label (what could have made it being skipped). At the same, it led to unexpected failures when self.params appeared to be dict type instance instead of SCTConfiguration as expected.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/older-enterprise-ami-sanity-test/5/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
