### PR TITLE
fix(manager): fix awscli installation on Ubuntu24 nodes

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -113,9 +113,9 @@ class BackupFunctionsMixIn(LoaderUtilsMixin):
     def install_awscli_dependencies(self, node):
         if node.distro.is_ubuntu or node.distro.is_debian:
             cmd = dedent("""
-            apt update
-            apt install -y python3-pip
-            pip install awscli==1.18.140
+                apt update
+                apt install -y python3-pip
+                PIP_BREAK_SYSTEM_PACKAGES=1 pip install awscli
             """)
         elif node.distro.is_rhel_like:
             cmd = dedent("""


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-manager/issues/4105

Changes:
- break-system-packages allows pip to modify an externally-manager Python installation while installing package on Ubuntu24.
- removed version specifying for the package since of compatibility issues with system-wide installation.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] ScyllaDB [6.2](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-sanity-test/34/)
- [x] ScyllaDB [2024.2](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-sanity-test/35/)
- [x] Scylla [2024.1](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-sanity-test/37/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code