### PR TITLE
fix(azure): fix log collector

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1512,7 +1512,7 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
             instances = sum([provisioner.list_instances() for provisioner in provisioners], [])
             collecting_nodes = [CollectingNode(name=instance.name,
                                                ssh_login_info={
-                                                   "hostname": instance.public_ip_address,
+                                                   "hostname": instance.public_ip_address or instance.private_ip_address,
                                                    "user": instance.user_name,
                                                    "key_file": f"~/.ssh/{instance.ssh_key_name}"},
                                                instance=instance,


### PR DESCRIPTION
After switching Azure to use only private IP's we stopped collecting logs properly after the test in 'collect logs' jenkins stage. This is due using public ip for this.

Fix is about to use private ip if public is not available.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9178

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - https://jenkins.scylladb.com/job/scylla-staging/job/lukasz/job/longevity-10gb-3h-azure-test/2/ - retesting issue https://github.com/scylladb/scylla-cluster-tests/issues/9174

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
