### PR TITLE
refactor(instance_provision_fallback): Change default to true in AWS

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -1,6 +1,6 @@
 instance_provision: 'spot'
 spot_max_price: 0.80
-instance_provision_fallback_on_demand: false
+instance_provision_fallback_on_demand: true
 region_name:
   - eu-west-1
 user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -63,7 +63,7 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('provision_type', 'spot')}",
                    description: 'spot|on_demand|spot_fleet',
                    name: 'provision_type')
-            string(defaultValue: "${pipelineParams.get('instance_provision_fallback_on_demand', 'false')}",
+            string(defaultValue: "${pipelineParams.get('instance_provision_fallback_on_demand', '')}",
                    description: 'true|false',
                    name: 'instance_provision_fallback_on_demand')
 


### PR DESCRIPTION
Recently we're facing too many provision failures of spot instances, hence we would like to change the default in AWS of instance_provision_fallback_on_demand from false to true which should retry the proviosn with on_demand.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
