### PR TITLE
fix(SLA): adjust SLA resources verification

### DIFF
--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -334,6 +334,25 @@ class PrometheusDBStats:
                                                     [float(runtime[1]) for runtime in item['values']]})
         return res
 
+    def get_scylla_io_queue_total_operations(self, start_time, end_time, node_ip, irate_sample_sec='30s'):
+        """
+        Get Scylla CPU scheduler runtime from PrometheusDB
+
+        :return: list of tuples (unix time, op/s)
+        """
+        if not self._check_start_end_time(start_time, end_time):
+            return {}
+        # the query is taken from the Grafana Dashborad definition
+        query = f'avg(irate(scylla_io_queue_total_operations{{class=~"sl:.*", instance="{node_ip}"}}  [{irate_sample_sec}] )) by (class, instance)'
+        results = self.query(query=query, start=start_time, end=end_time)
+        # result example:
+        #  {'status': 'success', 'data': {'resultType': 'matrix', 'result': [{'metric': {'class': 'sl:default', 'instance': '10.4.3.205'}, 'values': [[1731495365.897, '1000'], [1731495385.897, '1000'], .....
+        res = defaultdict(dict)
+        for item in results:
+            res[item['metric']['instance']].update({item['metric']['class']:
+                                                    [float(runtime[1]) for runtime in item['values']]})
+        return res
+
     def get_scylla_scheduler_shares_per_sla(self, start_time, end_time, node_ip):  # pylint: disable=invalid-name
         """
         Get scylla_scheduler_shares from PrometheusDB

--- a/sdcm/sla/sla_tests.py
+++ b/sdcm/sla/sla_tests.py
@@ -17,10 +17,10 @@ LOGGER = logging.getLogger(__name__)
 
 class Steps(SlaUtils):
     # pylint: disable=too-many-arguments
-    def run_stress_and_validate_scheduler_runtime_during_load(self, tester, read_cmds, prometheus_stats, read_roles,
-                                                              stress_queue, sleep=600):
+    def run_stress_and_validate_scheduler_io_queue_operations_during_load(self, tester, read_cmds, prometheus_stats, read_roles,
+                                                                          stress_queue, sleep=600):
         # pylint: disable=not-context-manager
-        with TestStepEvent(step="Run stress command and validate scheduler runtime during load") as wp_event:
+        with TestStepEvent(step="Run stress command and validate io_queue_operations during load") as wp_event:
             try:
                 start_time = time.time() + 60
                 # pylint: disable=protected-access
@@ -28,13 +28,13 @@ class Steps(SlaUtils):
                 time.sleep(sleep)
                 end_time = time.time()
 
-                self.validate_scheduler_runtime(start_time=start_time,
-                                                end_time=end_time,
-                                                read_users=read_roles,
-                                                prometheus_stats=prometheus_stats,
-                                                db_cluster=tester.db_cluster,
-                                                possible_issue={'less resources': 'scylla-enterprise#2717'}
-                                                )
+                self.validate_io_queue_operations(start_time=start_time,
+                                                  end_time=end_time,
+                                                  read_users=read_roles,
+                                                  prometheus_stats=prometheus_stats,
+                                                  db_cluster=tester.db_cluster,
+                                                  possible_issue={'less resources': 'scylla-enterprise#2717'}
+                                                  )
                 return None
             except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
                 wp_event.add_error([str(details)])
@@ -43,11 +43,11 @@ class Steps(SlaUtils):
                 return wp_event
 
     # pylint: disable=too-many-arguments
-    def alter_sl_and_validate_scheduler_runtime(self, tester, service_level, new_shares, read_roles, prometheus_stats,
-                                                sleep=600):
+    def alter_sl_and_validate_io_queue_operations(self, tester, service_level, new_shares, read_roles, prometheus_stats,
+                                                  sleep=600):
         # pylint: disable=not-context-manager
         with TestStepEvent(step=f"Alter shares from {service_level.shares} to {new_shares} Service "
-                                f"Level {service_level.name} and validate scheduler runtime "
+                                f"Level {service_level.name} and validate io_queue_operations "
                                 f"during load") as wp_event:
             try:
                 service_level.alter(new_shares=new_shares)
@@ -59,12 +59,12 @@ class Steps(SlaUtils):
                 # Let load to run before validation
                 time.sleep(sleep)
                 end_time = time.time()
-                self.validate_scheduler_runtime(start_time=start_time,
-                                                end_time=end_time,
-                                                read_users=read_roles,
-                                                prometheus_stats=prometheus_stats,
-                                                db_cluster=tester.db_cluster,
-                                                possible_issue={'less resources': "scylla-enterprise#949"})
+                self.validate_io_queue_operations(start_time=start_time,
+                                                  end_time=end_time,
+                                                  read_users=read_roles,
+                                                  prometheus_stats=prometheus_stats,
+                                                  db_cluster=tester.db_cluster,
+                                                  possible_issue={'less resources': "scylla-enterprise#949"})
                 return None
             except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
                 wp_event.add_error([str(details)])
@@ -105,8 +105,8 @@ class Steps(SlaUtils):
                 return wp_event
 
     # pylint: disable=too-many-arguments
-    def attach_sl_and_validate_scheduler_runtime(self, tester, new_service_level, role_for_attach,
-                                                 read_roles, prometheus_stats, sleep=600):
+    def attach_sl_and_validate_io_queue_operations(self, tester, new_service_level, role_for_attach,
+                                                   read_roles, prometheus_stats, sleep=600):
         @retrying(n=15, sleep_time=1, message="Wait for service level has been attached to the role",
                   allowed_exceptions=(Exception, ValueError,))
         def validate_role_service_level_attributes_against_db():
@@ -115,7 +115,7 @@ class Steps(SlaUtils):
         # pylint: disable=not-context-manager
         with TestStepEvent(step=f"Attach service level {new_service_level.name} with "
                                 f"{new_service_level.shares} shares to {role_for_attach.name}. "
-                                f"Validate scheduler runtime during load") as wp_event:
+                                f"Validate io_queue_operations during load") as wp_event:
             try:
                 role_for_attach.attach_service_level(new_service_level)
                 role_for_attach.validate_role_service_level_attributes_against_db()
@@ -149,14 +149,14 @@ class Steps(SlaUtils):
                 start_time = time.time() + 60
                 time.sleep(sleep)
                 end_time = time.time()
-                self.validate_scheduler_runtime(start_time=start_time,
-                                                end_time=end_time,
-                                                read_users=read_roles,
-                                                prometheus_stats=prometheus_stats,
-                                                db_cluster=tester.db_cluster,
-                                                possible_issue={'less resources':
-                                                                'scylla-enterprise#2572 or scylla-enterprise#2717'}
-                                                )
+                self.validate_io_queue_operations(start_time=start_time,
+                                                  end_time=end_time,
+                                                  read_users=read_roles,
+                                                  prometheus_stats=prometheus_stats,
+                                                  db_cluster=tester.db_cluster,
+                                                  possible_issue={'less resources':
+                                                                  'scylla-enterprise#2572 or scylla-enterprise#2717'}
+                                                  )
                 return None
             except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
                 wp_event.add_error([str(details)])
@@ -254,10 +254,10 @@ class SlaTests(Steps):
             new_sl = None
             try:
                 error_events.append(
-                    self.run_stress_and_validate_scheduler_runtime_during_load(tester=tester, read_cmds=read_cmds,
-                                                                               prometheus_stats=prometheus_stats,
-                                                                               read_roles=read_roles,
-                                                                               stress_queue=stress_queue))
+                    self.run_stress_and_validate_scheduler_io_queue_operations_during_load(tester=tester, read_cmds=read_cmds,
+                                                                                           prometheus_stats=prometheus_stats,
+                                                                                           read_roles=read_roles,
+                                                                                           stress_queue=stress_queue))
                 # Create new role and attach it instead of detached
                 new_sl = self._create_new_service_level(session=session,
                                                         auth_entity_name_index=auth_entity_name_index,
@@ -266,12 +266,12 @@ class SlaTests(Steps):
                                                         service_level_for_test_step="NEW_FOR_REPLACE_EXISTING")
 
                 error_events.append(
-                    self.attach_sl_and_validate_scheduler_runtime(tester=tester,
-                                                                  new_service_level=new_sl,
-                                                                  role_for_attach=role_low,
-                                                                  read_roles=read_roles,
-                                                                  prometheus_stats=prometheus_stats,
-                                                                  sleep=600))
+                    self.attach_sl_and_validate_io_queue_operations(tester=tester,
+                                                                    new_service_level=new_sl,
+                                                                    role_for_attach=role_low,
+                                                                    read_roles=read_roles,
+                                                                    prometheus_stats=prometheus_stats,
+                                                                    sleep=600))
 
             finally:
                 self.verify_stress_threads(tester=tester, stress_queue=stress_queue)
@@ -319,15 +319,15 @@ class SlaTests(Steps):
 
             try:
                 error_events.append(
-                    self.run_stress_and_validate_scheduler_runtime_during_load(tester=tester, read_cmds=read_cmds,
-                                                                               prometheus_stats=prometheus_stats,
-                                                                               read_roles=read_roles,
-                                                                               stress_queue=stress_queue))
+                    self.run_stress_and_validate_scheduler_io_queue_operations_during_load(tester=tester, read_cmds=read_cmds,
+                                                                                           prometheus_stats=prometheus_stats,
+                                                                                           read_roles=read_roles,
+                                                                                           stress_queue=stress_queue))
                 error_events.append(
-                    self.alter_sl_and_validate_scheduler_runtime(tester=tester,
-                                                                 service_level=role_low.attached_service_level,
-                                                                 new_shares=900, read_roles=read_roles,
-                                                                 prometheus_stats=prometheus_stats))
+                    self.alter_sl_and_validate_io_queue_operations(tester=tester,
+                                                                   service_level=role_low.attached_service_level,
+                                                                   new_shares=900, read_roles=read_roles,
+                                                                   prometheus_stats=prometheus_stats))
             finally:
                 self.verify_stress_threads(tester=tester, stress_queue=stress_queue)
                 self.clean_auth(entities_list_of_dict=read_roles)
@@ -372,15 +372,15 @@ class SlaTests(Steps):
 
             try:
                 error_events.append(
-                    self.run_stress_and_validate_scheduler_runtime_during_load(tester=tester, read_cmds=read_cmds,
-                                                                               prometheus_stats=prometheus_stats,
-                                                                               read_roles=read_roles,
-                                                                               stress_queue=stress_queue))
+                    self.run_stress_and_validate_scheduler_io_queue_operations_during_load(tester=tester, read_cmds=read_cmds,
+                                                                                           prometheus_stats=prometheus_stats,
+                                                                                           read_roles=read_roles,
+                                                                                           stress_queue=stress_queue))
                 error_events.append(
-                    self.alter_sl_and_validate_scheduler_runtime(tester=tester,
-                                                                 service_level=role_low.attached_service_level,
-                                                                 new_shares=100, read_roles=read_roles,
-                                                                 prometheus_stats=prometheus_stats))
+                    self.alter_sl_and_validate_io_queue_operations(tester=tester,
+                                                                   service_level=role_low.attached_service_level,
+                                                                   new_shares=100, read_roles=read_roles,
+                                                                   prometheus_stats=prometheus_stats))
 
             finally:
                 self.verify_stress_threads(tester=tester, stress_queue=stress_queue)
@@ -429,10 +429,10 @@ class SlaTests(Steps):
 
             try:
                 error_events.append(
-                    self.run_stress_and_validate_scheduler_runtime_during_load(tester=tester, read_cmds=read_cmds,
-                                                                               prometheus_stats=prometheus_stats,
-                                                                               read_roles=read_roles,
-                                                                               stress_queue=stress_queue))
+                    self.run_stress_and_validate_scheduler_io_queue_operations_during_load(tester=tester, read_cmds=read_cmds,
+                                                                                           prometheus_stats=prometheus_stats,
+                                                                                           read_roles=read_roles,
+                                                                                           stress_queue=stress_queue))
 
                 error_events.append(
                     self.detach_service_level_and_run_load(sl_for_detach=role_high.attached_service_level,
@@ -448,12 +448,12 @@ class SlaTests(Steps):
                                                         service_level_for_test_step="NEW_AFTER_DETACH")
 
                 error_events.append(
-                    self.attach_sl_and_validate_scheduler_runtime(tester=tester,
-                                                                  new_service_level=new_sl,
-                                                                  role_for_attach=role_high,
-                                                                  read_roles=read_roles,
-                                                                  prometheus_stats=prometheus_stats,
-                                                                  sleep=600))
+                    self.attach_sl_and_validate_io_queue_operations(tester=tester,
+                                                                    new_service_level=new_sl,
+                                                                    role_for_attach=role_high,
+                                                                    read_roles=read_roles,
+                                                                    prometheus_stats=prometheus_stats,
+                                                                    sleep=600))
 
             finally:
                 self.verify_stress_threads(tester=tester, stress_queue=stress_queue)
@@ -505,10 +505,10 @@ class SlaTests(Steps):
 
             try:
                 error_events.append(
-                    self.run_stress_and_validate_scheduler_runtime_during_load(tester=tester, read_cmds=read_cmds,
-                                                                               prometheus_stats=prometheus_stats,
-                                                                               read_roles=read_roles,
-                                                                               stress_queue=stress_queue))
+                    self.run_stress_and_validate_scheduler_io_queue_operations_during_load(tester=tester, read_cmds=read_cmds,
+                                                                                           prometheus_stats=prometheus_stats,
+                                                                                           read_roles=read_roles,
+                                                                                           stress_queue=stress_queue))
 
                 error_events.append(
                     self.drop_service_level_and_run_load(sl_for_drop=role_low.attached_service_level,
@@ -524,12 +524,12 @@ class SlaTests(Steps):
                                                         service_level_for_test_step="NEW_AFTER_DROP")
 
                 error_events.append(
-                    self.attach_sl_and_validate_scheduler_runtime(tester=tester,
-                                                                  new_service_level=new_sl,
-                                                                  role_for_attach=role_low,
-                                                                  read_roles=read_roles,
-                                                                  prometheus_stats=prometheus_stats,
-                                                                  sleep=600))
+                    self.attach_sl_and_validate_io_queue_operations(tester=tester,
+                                                                    new_service_level=new_sl,
+                                                                    role_for_attach=role_low,
+                                                                    read_roles=read_roles,
+                                                                    prometheus_stats=prometheus_stats,
+                                                                    sleep=600))
 
             finally:
                 self.verify_stress_threads(tester=tester, stress_queue=stress_queue)
@@ -572,11 +572,11 @@ class SlaTests(Steps):
 
             try:
                 error_events.append(
-                    self.run_stress_and_validate_scheduler_runtime_during_load(tester=tester,
-                                                                               read_cmds=read_cmds,
-                                                                               prometheus_stats=prometheus_stats,
-                                                                               read_roles=read_roles,
-                                                                               stress_queue=stress_queue))
+                    self.run_stress_and_validate_scheduler_io_queue_operations_during_load(tester=tester,
+                                                                                           read_cmds=read_cmds,
+                                                                                           prometheus_stats=prometheus_stats,
+                                                                                           read_roles=read_roles,
+                                                                                           stress_queue=stress_queue))
 
             finally:
                 self.verify_stress_threads(tester=tester, stress_queue=stress_queue)

--- a/unit_tests/test_sla_utils.py
+++ b/unit_tests/test_sla_utils.py
@@ -77,7 +77,7 @@ class FakeServiceLevel(ServiceLevel):
 class FakePrometheus:
     @staticmethod
     # pylint: disable=unused-argument
-    def get_scylla_scheduler_runtime_ms(start_time, end_time, node_ip, irate_sample_sec='60s'):
+    def get_scylla_io_queue_total_operations(start_time, end_time, node_ip, irate_sample_sec='60s'):
         return {'127.0.0.1': {'sl:default': [410.5785714285715, 400.36428571428576],
                               'sl:sl200_abc': [177.11428571428573, 182.02857142857144],
                               'sl:sl50_abc': [477.11428571428573, 482.02857142857144]}
@@ -94,7 +94,7 @@ class FakeSession:
 
 
 class TestSlaUtilsTest(unittest.TestCase, SlaUtils):
-    def test_less_runtime_than_expected_error(self):
+    def test_less_operations_than_expected_error(self):
         node = DummyNode(name='test_node',
                          parent_cluster=None,
                          ssh_login_info=dict(key_file='~/.ssh/scylla-test'))
@@ -110,12 +110,12 @@ class TestSlaUtilsTest(unittest.TestCase, SlaUtils):
                       {"role": role_high, 'service_level': role_high.attached_service_level}]
 
         with self.assertRaises(SchedulerRuntimeUnexpectedValue) as error:
-            self.validate_scheduler_runtime(start_time=time.time(),
-                                            end_time=time.time() + 60,
-                                            read_users=read_roles,
-                                            prometheus_stats=prometheus_stats,
-                                            db_cluster=db_cluster,
-                                            publish_wp_error_event=False)
+            self.validate_io_queue_operations(start_time=time.time(),
+                                              end_time=time.time() + 60,
+                                              read_users=read_roles,
+                                              prometheus_stats=prometheus_stats,
+                                              db_cluster=db_cluster,
+                                              publish_wp_error_event=False)
         assert str(error.exception) == str('\n(Node 127.0.0.1) - Service level with higher shares got less resources '
                                            'unexpectedly. CPU%: 100. Runtime per service level group:\n  sl:sl50_abc '
                                            '(shares 50): 479.57\n  sl:sl200_abc (shares 200): 179.57')


### PR DESCRIPTION
change metric that used for SLA resource verification in longevity test cases from scylla_scheduler_runtime_ms to scylla_io_queue_total_operations
because looking into resources/CPU is wrong because 1 operation from low shares user can consume more resources than several operations from height shares user especially when we have a lot of other processes simultaneously(c-s, full_scan, nemesis) and cluster is not loaded to 100%

this PR affects only SLA nemeses. Other tests like  1to5 ratio where we have only 2 C-S loads and high CPU load will continue to work with scylla_scheduler_runtime_ms metric

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/c341fff2-1e4a-44c1-b429-ae42529e3692 - use scylla_scheduler_runtime_ms
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/0a8acd9c-7dfb-4c6b-bc28-2b742b858b17 - use  scylla_io_queue_total_operations. nemeses are pass

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
