### PR TITLE
fix(artifact-centos9-arm): change fixed AMI to resolve by owner

### DIFF
--- a/configurations/arm/centos9.yaml
+++ b/configurations/arm/centos9.yaml
@@ -1,6 +1,5 @@
 ami_db_scylla_user: 'ec2-user'
-ami_id_db_scylla: 'ami-0e35cc6c9c975d78f' # CentOS Stream 9 aarch64
-region_name: 'eu-west-1'
+ami_id_db_scylla: 'resolve:owner:125523088429/arm64/CentOS*Stream*9*aarch64*' # CentOS Stream 9 aarch64
 instance_type_db: 'im4gn.xlarge'
 use_preinstalled_scylla: false
 # enhanced network isn't supported


### PR DESCRIPTION
the image we were using is now deleted from AWS, so we are switching to use `resolve:owner` option, so we can get the update centos9 image every time, without changing the hard coded AMIs every time.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :clock1: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-centos9-arm-test/12/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
