### PR TITLE
fix(keystore): add a lock on boto3 client creation

### DIFF
--- a/test_sync.py
+++ b/test_sync.py
@@ -1,0 +1,25 @@
+import socket
+from pathlib import Path
+
+import pytest
+
+from sdcm.keystore import KeyStore
+
+
+@pytest.mark.integration
+def test_multiple_sync_on_lots_of_files():
+    """
+    this start multiple client of boto3 in multiple thread,
+    opening boto3 session isn't thread safe, so this test is to make sure our lock is working
+    """
+    def is_using_aws_mock():
+        try:
+            socket.gethostbyname("aws-mock.itself")
+            return True
+        except socket.gaierror:
+            return False
+
+    if not is_using_aws_mock():
+        key_store = KeyStore()
+        key_store.sync(keys=['scylla-qa-ec2', 'scylla-test', 'scylla_test_id_ed25519'] * 20,
+                       local_path=Path('~/.ssh/').expanduser(), permissions=0o0600)


### PR DESCRIPTION
since the `KeyStore.sync()` call is start multiple threads that each start it's own boto3 client, we are running into cases we fail like:
```
self = <botocore.session.ComponentLocator object at 0x719afedcfb20>
name = 'credential_provider'
    def get_component(self, name):
        if name in self._deferred:
            factory = self._deferred[name]
            self._components[name] = factory()
>           del self._deferred[name]
E           KeyError: 'credential_provider'
```

so we are putting a lock ontop of client creation, to make sure we don't thread unsafe code of boto3 session creation in parallel

Fix: scylladb/scylla-cluster-tests#9024

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
