### PR TITLE
Improve Manager restore benchmark Argus charts with new restore metrics

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -1373,6 +1373,11 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
             "repair time": repair_time,
             "total": total_restore_time,
         }
+        download_bw, load_and_stream_bw = task.download_bw, task.load_and_stream_bw
+        if download_bw:
+            results["download bandwidth"] = download_bw
+        if load_and_stream_bw:
+            results["l&s bandwidth"] = load_and_stream_bw
         send_manager_benchmark_results_to_argus(
             argus_client=self.test_config.argus_client(),
             result=results,

--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -103,13 +103,17 @@ class ManagerRestoreBanchmarkResult(GenericResultTable):
         description = "Restore benchmark"
         Columns = [
             ColumnMetadata(name="restore time", unit="s", type=ResultType.DURATION, higher_is_better=False),
+            ColumnMetadata(name="download bandwidth", unit="MiB/s/shard", type=ResultType.FLOAT, higher_is_better=True),
+            ColumnMetadata(name="l&s bandwidth", unit="MiB/s/shard", type=ResultType.FLOAT, higher_is_better=True),
             ColumnMetadata(name="repair time", unit="s", type=ResultType.DURATION, higher_is_better=False),
             ColumnMetadata(name="total", unit="s", type=ResultType.DURATION, higher_is_better=False),
         ]
         ValidationRules = {
             "restore time": ValidationRule(best_pct=10),
+            "download bandwidth": ValidationRule(best_pct=10),
+            "l&s bandwidth": ValidationRule(best_pct=10),
             "repair time": ValidationRule(best_pct=10),
-            "total": ValidationRule(best_pct=10)
+            "total": ValidationRule(best_pct=10),
         }
 
 


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-manager/issues/4108

Changes:
- Two restore metrics were added to be reported to Argus Results - `download` and `l&s` bandwidth.
- The PR also includes a fix for post-restore repair time calculation for Manager >= 3.4 - get duration from task summary rather than sum up across all repaired tables.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
[Argus](https://argus.scylladb.com/workspace?state=WyJkNmY4OTI1Yy0xYTI2LTQzY2YtODY3NS04ZDQ2NjNkMDJlNmMiXQ) - see graphs and Results tab:
- [run #1](https://argus.scylladb.com/tests/scylla-cluster-tests/a3b84057-e98f-4773-9a21-195135283752) - Manager 3.3, no advanced metrics to be reported; workaround approach to calculate repair duration.
- [run #2](https://argus.scylladb.com/tests/scylla-cluster-tests/b4d77fc5-0cd7-4c71-886d-e2c301280270) - Manager 3.4, advanced bandwidth metrics, fixed repair duration.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
