### PR TITLE
fix(manager): fix upgrade flow to use apt install instead dist-upgrade

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2286,11 +2286,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             self.remoter.sudo("zypper update scylla-manager-server scylla-manager-client -y")
         else:
             self.remoter.sudo("apt-get update", ignore_status=True)
-            # Upgrade should update packages of:
-            # 1) scylla-manager
-            # 2) scylla-manager-client
-            # 3) scylla-manager-server
-            self.remoter.sudo('DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade '
+            self.remoter.sudo('DEBIAN_FRONTEND=noninteractive apt-get install '
                               '-o Dpkg::Options::="--force-confold" '
                               '-o Dpkg::Options::="--force-confdef" '
                               'scylla-manager-server scylla-manager-client -y ')


### PR DESCRIPTION
Closes: 
https://github.com/scylladb/scylla-manager/issues/4112

According to [documentation](https://manager.docs.scylladb.com/stable/upgrade/index.html#upgrade-the-scylladb-manager-server-and-client), manager packages should be upgraded via running `sudo apt-get install scylla-manager-server scylla-manager-client -y`. 

`dist-upgrade` is used in current implementation. It may lead to some unexpected issues related to non-manager related packages upgrade. One of such issues is described in [ticket](https://github.com/scylladb/scylla-manager/issues/4112) where docker was upgraded as part of dist-upgrade. It led to stopping of all running containers (all monitoring stack).

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-upgrade-test/7/) with Scylla 2024.1 (regression)
- [x] [test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-upgrade-test/8/) with Scylla 2024.2 (which was affected by monitor containers unavailability.)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code