### PR TITLE
fix(rolling-upgrades): remove procedure for downgrade cqlsh

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -416,15 +416,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         elif self.upgrade_rollback_mode == 'minor_release':
             node.remoter.run(r'sudo yum downgrade scylla\*%s-\* -y' % self.orig_ver.split('-')[0])
         else:
-            # first check if scylla-cqlsh had version to downgrade to
-            # and if not, we need to remove it before downgrade whole of scylla
-            result = node.remoter.sudo(r"yum downgrade scylla-\*cqlsh -y", ignore_status=True)
-            new_introduced_pkgs = r"scylla-\*cqlsh" if ("Nothing to do" in result.stdout or result.failed) else ""
-            if new_introduced_pkgs:
-                node.remoter.run('sudo yum remove %s -y' % new_introduced_pkgs)
             node.remoter.run(r'sudo yum downgrade scylla\* -y')
-            if new_introduced_pkgs:
-                node.remoter.run('sudo yum install %s -y' % node.scylla_pkg())
             recover_conf(node)
             node.remoter.run('sudo systemctl daemon-reload')
 


### PR DESCRIPTION
RPM base installation had specific procedure to handle rolling back into version that didn't had scylla-cqlsh,

now for rollback to a version that does have scylla-cqlsh, it was actually downgrading scylla twice, cause of the two downgrade commands.

we are removing this code, since current release doesn't need it anymore.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
