### PR TITLE
improvement(stress_thread): HDR file collection

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -145,3 +145,4 @@ ValidatorEvent: ERROR
 ScrubValidationErrorEvent: ERROR
 PartitionRowsValidationEvent: CRITICAL
 FailedResultEvent: ERROR
+HDRFileMissed: ERROR

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -66,6 +66,13 @@ class GeminiStressEvent(BaseStressEvent):
         return fmt
 
 
+class HDRFileMissed(SctEvent):
+    def __init__(self, message: str, severity=Severity.NORMAL):
+        super().__init__(severity=severity)
+
+        self.message = message
+
+
 class CassandraStressEvent(StressEvent):
     ...
 

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -30,7 +30,7 @@ from sdcm.reporting.tooling_reporter import CassandraStressVersionReporter
 from sdcm.sct_events import Severity
 from sdcm.utils.common import FileFollowerThread, get_data_dir_path, time_period_str_to_seconds, SoftTimeoutContext
 from sdcm.utils.user_profile import get_profile_content, replace_scylla_qa_internal_path
-from sdcm.sct_events.loaders import CassandraStressEvent, CS_ERROR_EVENTS_PATTERNS, CS_NORMAL_EVENTS_PATTERNS
+from sdcm.sct_events.loaders import CassandraStressEvent, CS_ERROR_EVENTS_PATTERNS, CS_NORMAL_EVENTS_PATTERNS, HDRFileMissed
 from sdcm.stress.base import DockerBasedStressThread
 from sdcm.utils.docker_remote import RemoteDocker
 from sdcm.utils.remote_logger import SSHLoggerBase
@@ -82,11 +82,32 @@ class CSHDRFileLogger(SSHLoggerBase):
     def _logger_cmd_template(self) -> str:
         return f"tail -f {self._remote_log_file}"
 
+    def validate_and_collect_hdr_file(self):
+        """
+        Validate that HDR file exists on the SCT runner.
+        If it does not exist check if the file was created on the loader.
+        If the HDR file found on the loader, try to copy to the runner.
+        If the file is missed even on the loader - print error event.
+        """
+        if os.path.exists(self._target_log_file):
+            return
+
+        LOGGER.debug("'%s' file is not found on the runner. Try to find it on the loader %s",
+                     self._target_log_file, self._node.name)
+        result = self._node.remoter.run(f"test -f {self._remote_log_file}", ignore_status=True)
+        if not result.ok:
+            HDRFileMissed(message=f"'{self._remote_log_file}' HDR file was not created on the loader {self._node.name}",
+                          severity=Severity.ERROR).publish()
+
+        LOGGER.debug("The '%s' file found on the loader %s", self._remote_log_file, self._node.name)
+        self._node.remoter.receive_files(src=self._remote_log_file, dst=self._target_log_file)
+
     def __enter__(self):
         self.start()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        self.validate_and_collect_hdr_file()
         self.stop()
 
 


### PR DESCRIPTION
From time to time we faced out with the problem that HDR file was not collected. But it is not clear if the file was not created or collected. This commit check if the file was not collected and try to collect it. If the file does not exist on the loader - throw error

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/8949

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [read load](https://argus.scylladb.com/tests/scylla-cluster-tests/1763b2b4-4dec-4952-8351-52f16c10e933)
Two HDR files were not copied to runner. The problem was recognised, the files were found on the loaders and copied to runner:

```
< t:2024-11-14 12:26:12,418 f:performance_regression_gradual_grow_throughput.py l:227  c:PerformanceRegressionPredefinedStepsTest p:INFO  > Run cs command with rate: 450000 Kops
< t:2024-11-14 12:56:26,262 f:stress_thread.py l:95   c:sdcm.stress_thread   p:DEBUG > '/home/ubuntu/sct-results/20241114-101651-000443/perf-regression-predefined-steps-ub-loader-set-1763b2b4/perf-regression-predefined-steps-ub-loader-node-1763b2b4-3/cs-hdr-read-l3-c0-k1-6e9f0b16-6f9d-43d9-a4bf-8108c7c7a173.hdr' file is not found on the runner. Try to find it from loader
< t:2024-11-14 12:56:26,765 f:stress_thread.py l:101  c:sdcm.stress_thread   p:DEBUG > The 'cs-hdr-read-l3-c0-k1-6e9f0b16-6f9d-43d9-a4bf-8108c7c7a173.hdr' file found on the loader perf-regression-predefined-steps-ub-loader-node-1763b2b4-3
< t:2024-11-14 12:56:26,765 f:remote_base.py  l:215  c:RemoteLibSSH2CmdRunner p:DEBUG > <10.12.3.196>: Receive files (src) cs-hdr-read-l3-c0-k1-6e9f0b16-6f9d-43d9-a4bf-8108c7c7a173.hdr -> (dst) /home/ubuntu/sct-results/20241114-101651-000443/perf-regression-predefined-steps-ub-loader-set-1763b2b4/perf-regression-predefined-steps-ub-loader-node-1763b2b4-3/cs-hdr-read-l3-c0-k1-6e9f0b16-6f9d-43d9-a4bf-8108c7c7a173.hdr
< t:2024-11-14 12:56:26,849 f:stress_thread.py l:95   c:sdcm.stress_thread   p:DEBUG > '/home/ubuntu/sct-results/20241114-101651-000443/perf-regression-predefined-steps-ub-loader-set-1763b2b4/perf-regression-predefined-steps-ub-loader-node-1763b2b4-4/cs-hdr-read-l4-c0-k1-761af81b-c265-4103-bea7-d28a3d4e30de.hdr' file is not found on the runner. Try to find it from loader
< t:2024-11-14 12:56:27,351 f:stress_thread.py l:101  c:sdcm.stress_thread   p:DEBUG > The 'cs-hdr-read-l4-c0-k1-761af81b-c265-4103-bea7-d28a3d4e30de.hdr' file found on the loader perf-regression-predefined-steps-ub-loader-node-1763b2b4-4
< t:2024-11-14 12:56:27,351 f:remote_base.py  l:215  c:RemoteLibSSH2CmdRunner p:DEBUG > <10.12.1.24>: Receive files (src) cs-hdr-read-l4-c0-k1-761af81b-c265-4103-bea7-d28a3d4e30de.hdr -> (dst) /home/ubuntu/sct-results/20241114-101651-000443/perf-regression-predefined-steps-ub-loader-set-1763b2b4/perf-regression-predefined-steps-ub-loader-node-1763b2b4-4/cs-hdr-read-l4-c0-k1-761af81b-c265-4103-bea7-d28a3d4e30de.hdr
< t:2024-11-14 12:58:06,390 f:remote_base.py  l:215  c:RemoteLibSSH2CmdRunner p:DEBUG > <10.12.2.156>: Receive files (src) /home/ubuntu/scylla-monitoring-data/snapshots/prometheus_snapshot_20241114_125802.tar.gz -> (dst) /home/ubuntu/sct-results/20241114-101651-000443/perf-regression-predefined-steps-ub-monitor-set-1763b2b4
```

Throughput is correct now

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
