### PR TITLE
fix(add_remove_dc): Use correct method to get cluster status

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4744,7 +4744,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             with temporary_replication_strategy_setter(node) as replication_strategy_setter:
                 new_node = self._add_new_node_in_new_dc()
                 node_added = True
-                status = self.tester.db_cluster.get_node()
+                status = self.tester.db_cluster.get_nodetool_status()
                 new_dc_list = [dc for dc in list(status.keys()) if dc.endswith("_nemesis_dc")]
                 assert new_dc_list, "new datacenter was not registered"
                 new_dc_name = new_dc_list[0]


### PR DESCRIPTION
Use correct method to get cluster nodes status in disrupt_add_remove_dc method

Fixes: #9204

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [Individual Nemesis](https://argus.scylladb.com/tests/scylla-cluster-tests/d1e41d11-83c9-4020-8fd8-775158cb7438) - Nemsis passed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
