### PR TITLE
Manager installation test for Rocky9 distribution

### DIFF
--- a/configurations/manager/rocky9.yaml
+++ b/configurations/manager/rocky9.yaml
@@ -1,3 +1,3 @@
-ami_id_monitor: 'ami-011ef2017d41cb239'  # Rocky Linux 8 (Official) image, region - us-east-1
+ami_id_monitor: 'ami-09fb459fad4613d55'  # Rocky Linux 9 (Official) image, region - us-east-1
 ami_monitor_user: 'rocky'
 monitor_branch: 'branch-4.7'  # Pass it as rocky image is not the formal monitor image

--- a/jenkins-pipelines/manager/rocky9-manager-install.jenkinsfile
+++ b/jenkins-pipelines/manager/rocky9-manager-install.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    region: 'us-east-1',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_installed_and_functional',
+    test_config: '''["test-cases/manager/manager-installation-set-distro.yaml", "configurations/manager/rocky9.yaml"]''',
+
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+)


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-manager/issues/3854
Closes https://github.com/scylladb/scylla-cluster-tests/issues/7678

The PR introduces Manager installation test for Rocky9 distribution since we were missing due to https://github.com/scylladb/scylla-cluster-tests/issues/7678.

PR to scylla-pkg to adjust corresponding test triggers:
https://github.com/scylladb/scylla-pkg/pull/4573

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/rocky9-installation-test/3/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code