### PR TITLE
fix(tests): fix integration tests

### DIFF
--- a/sdcm/stress/latte_thread.py
+++ b/sdcm/stress/latte_thread.py
@@ -166,7 +166,8 @@ class LatteStressThread(DockerBasedStressThread):  # pylint: disable=too-many-in
         """
         ops_regex = re.compile(r'\s*Throughput(.*?)\[op\/s\]\s*(?P<op_rate>\d*)\s')
         latency_99_regex = re.compile(r'\s* 99 \s*(?P<latency_99th_percentile>\d*\.\d*)\s')
-        latency_mean_regex = re.compile(r'\s*Mean resp. time\s*(?:\[(ms|s)\])?\s*(?P<latency_mean>\d+\.\d+)')
+        latency_mean_regex = re.compile(
+            r'\s*(?:Mean resp\. time|Request latency)\s*(?:\[(ms|s)\])?\s*(?P<latency_mean>\d+\.\d+)')
 
         output = {'latency 99th percentile': 0,
                   'latency mean': 0,

--- a/unit_tests/test_config_get_version_based_on_conf.py
+++ b/unit_tests/test_config_get_version_based_on_conf.py
@@ -117,6 +117,8 @@ def test_scylla_repo(scylla_version, expected_outcome, distro):
                          argvalues=('aws', 'gce', 'azure')
                          )
 def test_images(backend, scylla_version, expected_outcome):
+    if backend == "azure" and "2023.1" in scylla_version:
+        pytest.skip("Azure doesn't have 2023.1 images anymore")
     os.environ['SCT_CLUSTER_BACKEND'] = backend
     os.environ['SCT_SCYLLA_VERSION'] = scylla_version
 


### PR DESCRIPTION
Two latte tests started failing after we switched to the latest latte version
where output got changed a bit and one of regexes stopped matching.
So, fix this part by supporting both outputs - old and new one.

Also, fix test with check for images presence in Azure backend.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
