### PR TITLE
fix(stress_threads): clearing `stress_multiplier` option, and `stress_num` arguments

### DIFF
--- a/configurations/operator/perf-serverless-thrpt-1vcpu.yaml
+++ b/configurations/operator/perf-serverless-thrpt-1vcpu.yaml
@@ -5,7 +5,6 @@ k8s_scylla_cluster_name: "sct-perf-thrpt-1vcpu"
 user_prefix: "perf-thrpt-1vcpu"
 
 n_loaders: 1
-stress_multiplier: 1
 instance_type_loader: 'c6i.2xlarge'
 round_robin: true
 # https://github.com/scylladb/scylla-cluster-tests/issues/5883

--- a/configurations/operator/perf-serverless-thrpt-2vcpu.yaml
+++ b/configurations/operator/perf-serverless-thrpt-2vcpu.yaml
@@ -5,7 +5,6 @@ k8s_scylla_cluster_name: "sct-perf-thrpt-2vcpus"
 user_prefix: "perf-thrpt-2vcpus"
 
 n_loaders: 1
-stress_multiplier: 1
 instance_type_loader: 'c6i.2xlarge'
 round_robin: true
 # https://github.com/scylladb/scylla-cluster-tests/issues/5883

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -115,10 +115,6 @@ oracle_scylla_version: '2022.1.14'
 append_scylla_args_oracle: '--enable-cache false'
 
 # cassandra-stress defaults
-stress_multiplier: 1
-stress_multiplier_w: 1
-stress_multiplier_r: 1
-stress_multiplier_m: 1
 keyspace_num: 1
 cs_user_profiles: []
 prepare_cs_user_profiles: []

--- a/docs/bisecting-with-sct.md
+++ b/docs/bisecting-with-sct.md
@@ -28,15 +28,12 @@ from sdcm.utils.bisect_test import bisect_test
 @bisect_test
 def test_write(self):
     base_cmd_w = self.params.get('stress_cmd_w')
-    stress_multiplier = self.params.get('stress_multiplier')
-    if stress_multiplier_w := self.params.get("stress_multiplier_w"):
-        stress_multiplier = stress_multiplier_w
 
     self.create_test_stats(doc_id_with_timestamp=True)
     self.run_fstrim_on_all_db_nodes()
 
     stress_queue = self.run_stress_thread(
-        stress_cmd=base_cmd_w, stress_num=stress_multiplier, stats_aggregate_cmds=False)
+        stress_cmd=base_cmd_w, stats_aggregate_cmds=False)
     results = self.get_stress_results(queue=stress_queue)
 
     # set bisect_ref_value only for the first test run

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -234,10 +234,6 @@
 | **<a href="#user-content-cassandra_stress_population_size" name="cassandra_stress_population_size">cassandra_stress_population_size</a>**  |  | 1000000 | SCT_CASSANDRA_STRESS_POPULATION_SIZE
 | **<a href="#user-content-cassandra_stress_threads" name="cassandra_stress_threads">cassandra_stress_threads</a>**  |  | 1000 | SCT_CASSANDRA_STRESS_THREADS
 | **<a href="#user-content-add_node_cnt" name="add_node_cnt">add_node_cnt</a>**  |  | 1 | SCT_ADD_NODE_CNT
-| **<a href="#user-content-stress_multiplier" name="stress_multiplier">stress_multiplier</a>**  | Number of cassandra-stress processes | 1 | SCT_STRESS_MULTIPLIER
-| **<a href="#user-content-stress_multiplier_w" name="stress_multiplier_w">stress_multiplier_w</a>**  | Number of cassandra-stress processes for write workload | 1 | SCT_STRESS_MULTIPLIER_W
-| **<a href="#user-content-stress_multiplier_r" name="stress_multiplier_r">stress_multiplier_r</a>**  | Number of cassandra-stress processes for read workload | 1 | SCT_STRESS_MULTIPLIER_R
-| **<a href="#user-content-stress_multiplier_m" name="stress_multiplier_m">stress_multiplier_m</a>**  | Number of cassandra-stress processes for mixed workload | 1 | SCT_STRESS_MULTIPLIER_M
 | **<a href="#user-content-run_fullscan" name="run_fullscan">run_fullscan</a>**  |  | N/A | SCT_RUN_FULLSCAN
 | **<a href="#user-content-run_full_partition_scan" name="run_full_partition_scan">run_full_partition_scan</a>**  | Runs a background thread that issues reversed-queries on a table random partition by an interval | N/A | SCT_run_full_partition_scan
 | **<a href="#user-content-run_tombstone_gc_verification" name="run_tombstone_gc_verification">run_tombstone_gc_verification</a>**  | Runs a background thread that verifies Tombstones GC on a table by an interval | N/A | SCT_RUN_TOMBSTONE_GC_VERIFICATION

--- a/performance_regression_alternator_test.py
+++ b/performance_regression_alternator_test.py
@@ -28,7 +28,7 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
         self.stack.enter_context(ignore_alternator_client_errors())
         self.stack.enter_context(ignore_operation_errors())
 
-    def _workload(self, stress_cmd, stress_num, test_name=None, sub_type=None, keyspace_num=1, prefix='', debug_message='',  # pylint: disable=too-many-arguments,arguments-differ
+    def _workload(self, stress_cmd, test_name=None, sub_type=None, keyspace_num=1, prefix='', debug_message='',  # pylint: disable=too-many-arguments,arguments-differ
                   save_stats=True, is_alternator=True):
         if not is_alternator:
             stress_cmd = stress_cmd.replace('dynamodb', 'cassandra-cql')
@@ -39,7 +39,7 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
         if save_stats:
             self.create_test_stats(test_name=test_name, sub_type=sub_type,
                                    doc_id_with_timestamp=True, append_sub_test_to_name=False)
-        stress_queue = self.run_stress_thread(stress_cmd=stress_cmd, stress_num=stress_num, keyspace_num=keyspace_num,
+        stress_queue = self.run_stress_thread(stress_cmd=stress_cmd, keyspace_num=keyspace_num,
                                               prefix=prefix, stats_aggregate_cmds=False)
         self.get_stress_results(queue=stress_queue, store_results=True)
         if save_stats:
@@ -85,7 +85,7 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
                     # Check if it should be round_robin across loaders
                     if self.params.get('round_robin'):
                         self.log.debug('Populating data using round_robin')
-                        params.update({'stress_num': 1, 'round_robin': True})
+                        params.update({'round_robin': True})
 
                     for stress_cmd in prepare_write_cmd:
                         params.update({'stress_cmd': stress_cmd.replace('dynamodb', stress_type)})
@@ -97,7 +97,7 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
 
                 # One stress cmd command
                 else:
-                    stress_queue.append(self.run_stress_thread(stress_cmd=prepare_write_cmd.replace('dynamodb', stress_type), stress_num=1,
+                    stress_queue.append(self.run_stress_thread(stress_cmd=prepare_write_cmd.replace('dynamodb', stress_type),
                                                                prefix='preload-', stats_aggregate_cmds=False))
 
             for stress in stress_queue:
@@ -117,24 +117,22 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
         """
         # run a write workload
         base_cmd_w = self.params.get('stress_cmd_w')
-        stress_multiplier = self.params.get('stress_multiplier')
 
         self.create_cql_ks_and_table(field_number=10)
 
-        self._workload(sub_type='cql', stress_cmd=base_cmd_w,
-                       stress_num=stress_multiplier, keyspace_num=1, is_alternator=False)
+        self._workload(sub_type='cql', stress_cmd=base_cmd_w, keyspace_num=1, is_alternator=False)
 
         schema = self.params.get("dynamodb_primarykey_type")
         # run a workload without lwt as baseline
         self.create_alternator_table(
             schema=schema, alternator_write_isolation=alternator.enums.WriteIsolation.FORBID_RMW)
 
-        self._workload(sub_type='without-lwt', stress_cmd=base_cmd_w, stress_num=stress_multiplier, keyspace_num=1)
+        self._workload(sub_type='without-lwt', stress_cmd=base_cmd_w, keyspace_num=1)
 
         # run a workload with lwt
         self.create_alternator_table(
             schema=schema, alternator_write_isolation=alternator.enums.WriteIsolation.ALWAYS_USE_LWT)
-        self._workload(sub_type='with-lwt', stress_cmd=base_cmd_w, stress_num=stress_multiplier, keyspace_num=1)
+        self._workload(sub_type='with-lwt', stress_cmd=base_cmd_w, keyspace_num=1)
 
         self.check_regression_with_baseline('cql')
 
@@ -150,7 +148,6 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
         node = self.db_cluster.nodes[0]
 
         base_cmd_r = self.params.get('stress_cmd_r')
-        stress_multiplier = self.params.get('stress_multiplier')
         self.run_fstrim_on_all_db_nodes()
         # run a prepare write workload
         self.create_cql_ks_and_table(field_number=10)
@@ -160,16 +157,15 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
 
         self.preload_data()
 
-        self._workload(sub_type='cql', stress_cmd=base_cmd_r,
-                       stress_num=stress_multiplier, keyspace_num=1, is_alternator=False)
+        self._workload(sub_type='cql', stress_cmd=base_cmd_r, keyspace_num=1, is_alternator=False)
 
         # run a workload without lwt as baseline
         self.alternator.set_write_isolation(node=node, isolation=alternator.enums.WriteIsolation.FORBID_RMW)
-        self._workload(sub_type='without-lwt', stress_cmd=base_cmd_r, stress_num=stress_multiplier, keyspace_num=1)
+        self._workload(sub_type='without-lwt', stress_cmd=base_cmd_r, keyspace_num=1)
 
         # run a workload with lwt
         self.alternator.set_write_isolation(node=node, isolation=alternator.enums.WriteIsolation.ALWAYS_USE_LWT)
-        self._workload(sub_type='with-lwt', stress_cmd=base_cmd_r, stress_num=stress_multiplier, keyspace_num=1)
+        self._workload(sub_type='with-lwt', stress_cmd=base_cmd_r, keyspace_num=1)
 
         self.check_regression_with_baseline('cql')
 
@@ -185,7 +181,6 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
         node = self.db_cluster.nodes[0]
 
         base_cmd_m = self.params.get('stress_cmd_m')
-        stress_multiplier = self.params.get('stress_multiplier')
         self.run_fstrim_on_all_db_nodes()
 
         self.create_cql_ks_and_table(field_number=10)
@@ -195,17 +190,16 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
         # run a write workload as a preparation
         self.preload_data()
 
-        self._workload(sub_type='cql', stress_cmd=base_cmd_m,
-                       stress_num=stress_multiplier, keyspace_num=1, is_alternator=False)
+        self._workload(sub_type='cql', stress_cmd=base_cmd_m, keyspace_num=1, is_alternator=False)
 
         # run a mixed workload
         # run a workload without lwt as baseline
         self.alternator.set_write_isolation(node=node, isolation=alternator.enums.WriteIsolation.FORBID_RMW)
-        self._workload(sub_type='without-lwt', stress_cmd=base_cmd_m, stress_num=stress_multiplier, keyspace_num=1)
+        self._workload(sub_type='without-lwt', stress_cmd=base_cmd_m, keyspace_num=1)
 
         # run a workload with lwt
         self.alternator.set_write_isolation(node=node, isolation=alternator.enums.WriteIsolation.ALWAYS_USE_LWT)
-        self._workload(sub_type='with-lwt', stress_cmd=base_cmd_m, stress_num=stress_multiplier, keyspace_num=1)
+        self._workload(sub_type='with-lwt', stress_cmd=base_cmd_m, keyspace_num=1)
 
         self.check_regression_with_baseline('cql')
 
@@ -239,69 +233,66 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
         base_cmd_r = self.params.get('stress_cmd_r')
         base_cmd_m = self.params.get('stress_cmd_m')
 
-        stress_multiplier = 2
         self.wait_no_compactions_running(n=120)
 
         self.run_fstrim_on_all_db_nodes()
         self._workload(
-            test_name=self.id() + '_read', sub_type='cql', stress_cmd=base_cmd_r, stress_num=stress_multiplier,
+            test_name=self.id() + '_read', sub_type='cql', stress_cmd=base_cmd_r,
             keyspace_num=1, is_alternator=False)
 
         # run a workload without lwt as baseline
         self.alternator.set_write_isolation(node=node, isolation=alternator.enums.WriteIsolation.FORBID_RMW)
         self._workload(
-            test_name=self.id() + '_read', sub_type='without-lwt', stress_cmd=base_cmd_r, stress_num=stress_multiplier,
+            test_name=self.id() + '_read', sub_type='without-lwt', stress_cmd=base_cmd_r,
             keyspace_num=1)
 
         self.wait_no_compactions_running()
         # run a workload with lwt
         self.alternator.set_write_isolation(node=node, isolation=alternator.enums.WriteIsolation.ALWAYS_USE_LWT)
         self._workload(
-            test_name=self.id() + '_read', sub_type='with-lwt', stress_cmd=base_cmd_r, stress_num=stress_multiplier,
+            test_name=self.id() + '_read', sub_type='with-lwt', stress_cmd=base_cmd_r,
             keyspace_num=1)
         self.check_regression_with_baseline('cql')
 
-        stress_multiplier = 1
         self.run_fstrim_on_all_db_nodes()
 
         self.wait_no_compactions_running()
         self._workload(
             test_name=self.id() + '_write', sub_type='cql', stress_cmd=base_cmd_w + " -target 10000",
-            stress_num=stress_multiplier, keyspace_num=1, is_alternator=False)
+            keyspace_num=1, is_alternator=False)
 
         self.wait_no_compactions_running()
         # run a workload without lwt as baseline
         self.alternator.set_write_isolation(node=node, isolation=alternator.enums.WriteIsolation.FORBID_RMW)
         self._workload(
             test_name=self.id() + '_write', sub_type='without-lwt', stress_cmd=base_cmd_w + " -target 10000",
-            stress_num=stress_multiplier, keyspace_num=1)
+            keyspace_num=1)
 
         self.wait_no_compactions_running(n=120)
         # run a workload with lwt
         self.alternator.set_write_isolation(node=node, isolation=alternator.enums.WriteIsolation.ALWAYS_USE_LWT)
         self._workload(
             test_name=self.id() + '_write', sub_type='with-lwt', stress_cmd=base_cmd_w + " -target 3000",
-            stress_num=stress_multiplier, keyspace_num=1)
+            keyspace_num=1)
         self.check_regression_with_baseline('cql')
 
-        stress_multiplier = 1
         self.wait_no_compactions_running(n=120)
         self.run_fstrim_on_all_db_nodes()
 
         self._workload(
             test_name=self.id() + '_mixed', sub_type='cql', stress_cmd=base_cmd_m + " -target 10000",
-            stress_num=stress_multiplier, keyspace_num=1, is_alternator=False)
+            keyspace_num=1, is_alternator=False)
 
         self.wait_no_compactions_running()
         # run a workload without lwt as baseline
         self.alternator.set_write_isolation(node=node, isolation=alternator.enums.WriteIsolation.FORBID_RMW)
         self._workload(test_name=self.id() + '_mixed', sub_type='without-lwt',
-                       stress_cmd=base_cmd_m + " -target 10000", stress_num=stress_multiplier, keyspace_num=1)
+                       stress_cmd=base_cmd_m + " -target 10000", keyspace_num=1)
 
         self.wait_no_compactions_running()
         # run a workload with lwt
         self.alternator.set_write_isolation(node=node, isolation=alternator.enums.WriteIsolation.ALWAYS_USE_LWT)
         self._workload(test_name=self.id() + '_mixed', sub_type='with-lwt',
-                       stress_cmd=base_cmd_m + " -target 5000", stress_num=stress_multiplier, keyspace_num=1)
+                       stress_cmd=base_cmd_m + " -target 5000", keyspace_num=1)
 
         self.check_regression_with_baseline('cql')

--- a/performance_regression_gradual_grow_throughput.py
+++ b/performance_regression_gradual_grow_throughput.py
@@ -139,7 +139,7 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
         stress_queue = []
         if self.params.get('round_robin'):
             self.log.debug('Populating data using round_robin')
-            params.update({'stress_num': 1, 'round_robin': True})
+            params.update({'round_robin': True})
         if compaction_strategy:
             self.log.debug('Next compaction strategy will be used %s', compaction_strategy)
             params['compaction_strategy'] = compaction_strategy

--- a/performance_regression_operator_multi_tenant_test.py
+++ b/performance_regression_operator_multi_tenant_test.py
@@ -60,7 +60,7 @@ class PerformanceRegressionOperatorMultiTenantTest(MultiTenantTestMixin, Perform
             if self.params.get('round_robin'):
                 self.log.debug(
                     "'%s' DB cluster: Populating data using round_robin", db_cluster_name)
-                params.update({'stress_num': 1, 'round_robin': True})
+                params.update({'round_robin': True})
             for stress_cmd in prepare_write_cmd:
                 params.update({'stress_cmd': stress_cmd})
                 # Run all stress commands

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -509,9 +509,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         """
         # run a write workload
         base_cmd_w = self.params.get('stress_cmd_w')
-        stress_multiplier = self.params.get('stress_multiplier')
-        if stress_multiplier_w := self.params.get("stress_multiplier_w"):
-            stress_multiplier = stress_multiplier_w
+
         # create new document in ES with doc_id = test_id + timestamp
         # allow to correctly save results for future compare
         self.create_test_stats(doc_id_with_timestamp=True)
@@ -519,7 +517,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
 
         # run a workload
         stress_queue = self.run_stress_thread(
-            stress_cmd=base_cmd_w, stress_num=stress_multiplier, stats_aggregate_cmds=False)
+            stress_cmd=base_cmd_w, stats_aggregate_cmds=False)
         results = self.get_stress_results(queue=stress_queue)
 
         self.build_histogram(PerformanceTestWorkload.WRITE, PerformanceTestType.THROUGHPUT)
@@ -536,9 +534,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         """
 
         base_cmd_r = self.params.get('stress_cmd_r')
-        stress_multiplier = self.params.get('stress_multiplier')
-        if stress_multiplier_r := self.params.get("stress_multiplier_r"):
-            stress_multiplier = stress_multiplier_r
+
         self.run_fstrim_on_all_db_nodes()
         # run a write workload
         self.preload_data()
@@ -551,7 +547,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         self.run_fstrim_on_all_db_nodes()
         # run a read workload
         stress_queue = self.run_stress_thread(
-            stress_cmd=base_cmd_r, stress_num=stress_multiplier, stats_aggregate_cmds=False)
+            stress_cmd=base_cmd_r, stats_aggregate_cmds=False)
         results = self.get_stress_results(queue=stress_queue)
 
         self.build_histogram(PerformanceTestWorkload.READ, PerformanceTestType.THROUGHPUT)
@@ -568,9 +564,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         """
 
         base_cmd_m = self.params.get('stress_cmd_m')
-        stress_multiplier = self.params.get('stress_multiplier')
-        if stress_multiplier_m := self.params.get("stress_multiplier_m"):
-            stress_multiplier = stress_multiplier_m
+
         self.run_fstrim_on_all_db_nodes()
         # run a write workload as a preparation
         self.preload_data()
@@ -582,7 +576,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         self.wait_no_compactions_running(n=240, sleep_time=180)
         self.run_fstrim_on_all_db_nodes()
         stress_queue = self.run_stress_thread(
-            stress_cmd=base_cmd_m, stress_num=stress_multiplier, stats_aggregate_cmds=False)
+            stress_cmd=base_cmd_m, stats_aggregate_cmds=False)
         results = self.get_stress_results(queue=stress_queue)
 
         self.build_histogram(PerformanceTestWorkload.MIXED, PerformanceTestType.THROUGHPUT)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1060,14 +1060,6 @@ class SCTConfiguration(dict):
              help=""),
 
         # LongevityTest
-        dict(name="stress_multiplier", env="SCT_STRESS_MULTIPLIER", type=int,
-             help="Number of cassandra-stress processes"),
-        dict(name="stress_multiplier_w", env="SCT_STRESS_MULTIPLIER_W", type=int,
-             help="Number of cassandra-stress processes for write workload"),
-        dict(name="stress_multiplier_r", env="SCT_STRESS_MULTIPLIER_R", type=int,
-             help="Number of cassandra-stress processes for read workload"),
-        dict(name="stress_multiplier_m", env="SCT_STRESS_MULTIPLIER_M", type=int,
-             help="Number of cassandra-stress processes for mixed workload"),
         dict(name="run_fullscan", env="SCT_RUN_FULLSCAN", type=list,
              help=""),
         dict(name="run_full_partition_scan", env="SCT_run_full_partition_scan", type=str,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1975,12 +1975,12 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.verify_stress_thread(cs_thread_pool=cs_thread_pool)
 
     # pylint: disable=too-many-arguments,too-many-return-statements
-    def run_stress_thread(self, stress_cmd, duration=None, stress_num=1, keyspace_num=1, profile=None, prefix='',  # pylint: disable=too-many-arguments  # noqa: PLR0911, PLR0913
+    def run_stress_thread(self, stress_cmd, duration=None, keyspace_num=1, profile=None, prefix='',  # pylint: disable=too-many-arguments  # noqa: PLR0911, PLR0913
                           round_robin=False, stats_aggregate_cmds=True, keyspace_name=None, compaction_strategy='',
                           use_single_loader=False,
                           stop_test_on_failure=True):
 
-        params = dict(stress_cmd=stress_cmd, duration=duration, stress_num=stress_num, keyspace_num=keyspace_num,
+        params = dict(stress_cmd=stress_cmd, duration=duration, keyspace_num=keyspace_num,
                       keyspace_name=keyspace_name, profile=profile, prefix=prefix, round_robin=round_robin,
                       stats_aggregate_cmds=stats_aggregate_cmds, use_single_loader=use_single_loader)
 
@@ -2019,7 +2019,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     # pylint: disable=too-many-arguments
     def run_stress_cassandra_thread(  # noqa: PLR0913
-            self, stress_cmd, duration=None, stress_num=1, keyspace_num=1, profile=None, prefix='', round_robin=False,
+            self, stress_cmd, duration=None, keyspace_num=1, profile=None, prefix='', round_robin=False,
             stats_aggregate_cmds=True, keyspace_name=None, compaction_strategy='', stop_test_on_failure=True, params=None, **_):
         # pylint: disable=too-many-locals
         # stress_cmd = self._cs_add_node_flag(stress_cmd)
@@ -2040,7 +2040,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         cs_thread = CassandraStressThread(loader_set=self.loaders,
                                           stress_cmd=stress_cmd,
                                           timeout=timeout,
-                                          stress_num=stress_num,
                                           keyspace_num=keyspace_num,
                                           compaction_strategy=compaction_strategy,
                                           profile=profile,
@@ -2055,7 +2054,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     # pylint: disable=too-many-arguments
     def run_cql_stress_cassandra_thread(  # noqa: PLR0913
-            self, stress_cmd, duration=None, stress_num=1, keyspace_num=1, profile=None, prefix='', round_robin=False,
+            self, stress_cmd, duration=None, keyspace_num=1, profile=None, prefix='', round_robin=False,
             stats_aggregate_cmds=True, keyspace_name=None, compaction_strategy='', stop_test_on_failure=True, params=None, **_):
         # pylint: disable=too-many-locals
         if duration:
@@ -2075,7 +2074,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         cs_thread = CqlStressCassandraStressThread(loader_set=self.loaders,
                                                    stress_cmd=stress_cmd,
                                                    timeout=timeout,
-                                                   stress_num=stress_num,
                                                    keyspace_num=keyspace_num,
                                                    compaction_strategy=compaction_strategy,
                                                    profile=profile,
@@ -2141,7 +2139,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         return harry_thread
 
     # pylint: disable=too-many-arguments
-    def run_ycsb_thread(self, stress_cmd, duration=None, stress_num=1, prefix='',
+    def run_ycsb_thread(self, stress_cmd, duration=None, prefix='',
                         round_robin=False, stats_aggregate_cmds=True, **_):
 
         timeout = self.get_duration(duration)
@@ -2152,11 +2150,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         return YcsbStressThread(loader_set=self.loaders,
                                 stress_cmd=stress_cmd,
                                 timeout=timeout,
-                                stress_num=stress_num,
                                 node_list=self.db_cluster.nodes,
                                 round_robin=round_robin, params=self.params).run()
 
-    def run_latte_thread(self, stress_cmd, duration=None, stress_num=1, prefix='',
+    def run_latte_thread(self, stress_cmd, duration=None, prefix='',
                          round_robin=False, stats_aggregate_cmds=True, stop_test_on_failure=True, **_):
         if duration:
             timeout = self.get_duration(duration)
@@ -2173,14 +2170,13 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         return LatteStressThread(loader_set=self.loaders,
                                  stress_cmd=stress_cmd,
                                  timeout=timeout,
-                                 stress_num=stress_num,
                                  node_list=self.db_cluster.nodes,
                                  round_robin=round_robin,
                                  stop_test_on_failure=stop_test_on_failure,
                                  params=self.params).run()
 
     # pylint: disable=too-many-arguments
-    def run_hydra_kcl_thread(self, stress_cmd, duration=None, stress_num=1, prefix='',
+    def run_hydra_kcl_thread(self, stress_cmd, duration=None, prefix='',
                              round_robin=False, stats_aggregate_cmds=True, **_):
 
         timeout = self.get_duration(duration)
@@ -2191,12 +2187,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         return KclStressThread(loader_set=self.loaders,
                                stress_cmd=stress_cmd,
                                timeout=timeout,
-                               stress_num=stress_num,
                                node_list=self.db_cluster.nodes,
                                round_robin=round_robin, params=self.params).run()
 
     # pylint: disable=too-many-arguments
-    def run_nosqlbench_thread(self, stress_cmd, duration=None, stress_num=1, prefix='', round_robin=False,
+    def run_nosqlbench_thread(self, stress_cmd, duration=None, prefix='', round_robin=False,
                               stats_aggregate_cmds=True, stop_test_on_failure=True, **_):
 
         timeout = self.get_duration(duration)
@@ -2209,26 +2204,24 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             loader_set=self.loaders,
             stress_cmd=stress_cmd,
             timeout=timeout,
-            stress_num=stress_num,
             node_list=self.db_cluster.nodes,
             round_robin=round_robin,
             stop_test_on_failure=stop_test_on_failure,
             params=self.params).run()
 
     # pylint: disable=too-many-arguments
-    def run_table_compare_thread(self, stress_cmd, duration=None, stress_num=1, round_robin=False, **_):
+    def run_table_compare_thread(self, stress_cmd, duration=None, round_robin=False, **_):
 
         timeout = self.get_duration(duration)
 
         return CompareTablesSizesThread(loader_set=self.loaders,
                                         stress_cmd=stress_cmd,
                                         timeout=timeout,
-                                        stress_num=stress_num,
                                         node_list=self.db_cluster.nodes,
                                         round_robin=round_robin, params=self.params).run()
 
     # pylint: disable=too-many-arguments
-    def run_ndbench_thread(self, stress_cmd, duration=None, stress_num=1, prefix='',
+    def run_ndbench_thread(self, stress_cmd, duration=None, prefix='',
                            round_robin=False, stats_aggregate_cmds=True, **_):
 
         timeout = self.get_duration(duration)
@@ -2239,12 +2232,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         return NdBenchStressThread(loader_set=self.loaders,
                                    stress_cmd=stress_cmd,
                                    timeout=timeout,
-                                   stress_num=stress_num,
                                    node_list=self.db_cluster.nodes,
                                    round_robin=round_robin, params=self.params).run()
 
     # pylint: disable=too-many-arguments
-    def run_cdclog_reader_thread(self, stress_cmd, duration=None, stress_num=1, prefix='',
+    def run_cdclog_reader_thread(self, stress_cmd, duration=None, prefix='',
                                  round_robin=False, stats_aggregate_cmds=True, enable_batching=True,
                                  keyspace_name=None, base_table_name=None):
         timeout = self.get_duration(duration)
@@ -2254,7 +2246,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         return CDCLogReaderThread(loader_set=self.loaders,
                                   stress_cmd=stress_cmd,
                                   timeout=timeout,
-                                  stress_num=stress_num,
                                   node_list=self.db_cluster.nodes,
                                   keyspace_name=keyspace_name,
                                   base_table_name=base_table_name,

--- a/sdcm/utils/loader_utils.py
+++ b/sdcm/utils/loader_utils.py
@@ -96,10 +96,6 @@ class LoaderUtilsMixin:
         stress_cmds = params['stress_cmd']
         if not isinstance(stress_cmds, list):
             stress_cmds = [stress_cmds]
-        # In some cases we want the same stress_cmd to run several times (can be used with round_robin or not).
-        stress_multiplier = self.params.get('stress_multiplier')
-        if stress_multiplier > 1:
-            stress_cmds *= stress_multiplier
 
         for stress_cmd in stress_cmds:
             stress_params = dict(params)

--- a/test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml
@@ -38,7 +38,6 @@ instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.small'
 instance_type_db: 'i3.4xlarge'
 
-stress_multiplier: 1
 alternator_write_isolation: 'forbid'
 alternator_port: 8080
 dynamodb_primarykey_type: HASH_AND_RANGE

--- a/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
@@ -35,7 +35,8 @@ stress_cmd_m: >-2
   -p readproportion=0.5 -p updateproportion=0 -p scanproportion=0 -p insertproportion=0.5
   -p maxexecutiontime=1200 -p operationcount=60000000
 
-stress_multiplier: 6
+# this option was removed
+# stress_multiplier: 6
 alternator_write_isolation: 'forbid'
 
 n_db_nodes: 3

--- a/test-cases/performance/perf-regression-throughput-125gb.yaml
+++ b/test-cases/performance/perf-regression-throughput-125gb.yaml
@@ -9,7 +9,8 @@ prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=31250000 -schema 
 stress_cmd_w: "cassandra-stress write no-warmup cl=ALL n=125000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..125000000"
 stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..125000000,62500000,125000000)' "
 stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..125000000,62500000,125000000)' "
-stress_multiplier: 2
+# this option was removed
+# stress_multiplier: 2
 
 n_db_nodes: 3
 n_loaders: 4

--- a/test-cases/performance/perf-regression-throughput-baremetal-5gb.yaml
+++ b/test-cases/performance/perf-regression-throughput-baremetal-5gb.yaml
@@ -9,7 +9,7 @@ prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=312500 -schema 'r
 stress_cmd_w: "cassandra-stress write no-warmup cl=ALL n=1250000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=4 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..1250000"
 stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=30m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=4 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..1250000,625001,1250000)' "
 stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=30m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=4 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..1250000,625001,1250000)' "
-stress_multiplier: 1
+
 instance_type_db: 'i3.2xlarge'
 
 cluster_backend: baremetal

--- a/test-cases/performance/perf-regression.100threads.100M-keys-z3-enterprise.yaml
+++ b/test-cases/performance/perf-regression.100threads.100M-keys-z3-enterprise.yaml
@@ -20,9 +20,11 @@ n_monitor_nodes: 1
 # Loaders
 gce_instance_type_loader: 'c2-standard-30'
 n_loaders: 5
-stress_multiplier_r: 1
-stress_multiplier_w: 1
-stress_multiplier_m: 1
+
+# this option was removed
+# stress_multiplier_r: 1
+# stress_multiplier_w: 1
+# stress_multiplier_m: 1
 
 
 # AWS

--- a/test-cases/performance/perf-regression.100threads.30M-keys-i4i-enterprise.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys-i4i-enterprise.yaml
@@ -4,9 +4,6 @@ stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema '
 prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM n=30000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=100 -pop seq=1..30000000"
 stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=460 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
 stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=150 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
-stress_multiplier_w: 4
-stress_multiplier_r: 1
-stress_multiplier_m: 2
 
 # NOTE: following is needed for the K8S case
 k8s_loader_run_type: 'static'

--- a/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
@@ -4,9 +4,11 @@ stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema '
 prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM n=30000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=100 -pop seq=1..30000000"
 stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
 stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
-stress_multiplier_w: 6
-stress_multiplier_r: 1
-stress_multiplier_m: 1
+
+# this option was removed
+# stress_multiplier_w: 6
+# stress_multiplier_r: 1
+# stress_multiplier_m: 1
 
 # NOTE: following is needed for the K8S case
 k8s_loader_run_type: 'static'

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -4,9 +4,11 @@ stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema '
 prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM n=30000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=100 -pop seq=1..30000000"
 stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=50m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=100 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
 stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=50m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=100 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
-stress_multiplier_w: 2
-stress_multiplier_r: 2
-stress_multiplier_m: 2
+
+# this option was removed
+# stress_multiplier_w: 2
+# stress_multiplier_r: 2
+# stress_multiplier_m: 2
 
 # NOTE: following is needed for the K8S case
 k8s_loader_run_type: 'static'


### PR DESCRIPTION
those option are not really optimal was to double load, since they are doing the same exact commands, we stopped using them in performance tests and we should stop using it across the board, hence it is removed.

Fixes: #8370

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
