### PR TITLE
improvement(azure): add instance state debug log after provision

### DIFF
--- a/unit_tests/provisioner/fake_azure_service.py
+++ b/unit_tests/provisioner/fake_azure_service.py
@@ -570,7 +570,7 @@ class FakeVirtualMachines:
             resource_group_name, nic.ip_configurations[0].public_ip_address.name)
         return WaitableObject()
 
-    def get(self, resource_group_name: str, vm_name: str) -> VirtualMachine:
+    def get(self, resource_group_name: str, vm_name: str, expand: str = "") -> VirtualMachine:
         try:
             with open(self.path / resource_group_name / f"vm-{vm_name}.json", "r", encoding="utf-8") as file:
                 return VirtualMachine.deserialize(json.load(file))


### PR DESCRIPTION
Sometimes we cannot connect to Azure instance after provisioning and we don't know why.

Added debug log after provisioning instance with states info.

closes: https://github.com/scylladb/scylla-cluster-tests/issues/9201

example log line:
```
< t:2024-11-15 11:30:46,488 f:virtual_machine_provider.py l:119  c:sdcm.provision.azure.virtual_machine_provider p:DEBUG > Provisioned VM artifacts-azure-image-jenkins-db-node-3e60f00a-eastus-1 instance state: ProvisioningState/succeeded: Provisioning succeeded, PowerState/running: VM running
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [azure artifact test](https://argus.scylladb.com/tests/scylla-cluster-tests/3e60f00a-c341-44a2-a35f-47143e56b328)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
