### PR TITLE
fix(test_parallelobject): replace `self.assertAlmostEqual` with  `pytest.approx`

### DIFF
--- a/unit_tests/test_parallelobject.py
+++ b/unit_tests/test_parallelobject.py
@@ -4,6 +4,7 @@ import logging
 import random
 import concurrent.futures
 
+import pytest
 
 from sdcm.utils.common import ParallelObject, ParallelObjectException
 
@@ -79,11 +80,12 @@ class ParallelObjectTester(unittest.TestCase):
         test_timeout = min(self.rand_timeouts)
         start_time = time.time()
         with self.assertRaises(ParallelObjectException) as exp:
-            parallel_object = ParallelObject(self.rand_timeouts, timeout=test_timeout)
+            parallel_object = ParallelObject(self.rand_timeouts, timeout=test_timeout,
+                                             num_workers=len(self.rand_timeouts))
             parallel_object.run(dummy_func_return_tuple)
         assert any(isinstance(e.exc, concurrent.futures.TimeoutError) for e in exp.exception.results)
-        run_time = int(time.time() - start_time)
-        self.assertAlmostEqual(first=test_timeout, second=run_time, delta=1)
+        run_time = time.time() - start_time
+        assert float(test_timeout) == pytest.approx(run_time, rel=1.0e+02)
 
     def test_parallel_object_exception_raised(self):
         with self.assertRaises(ParallelObjectException):


### PR DESCRIPTION
test was casting time into int, and then diffing with expected timeout that was causing cases it might fail, if test was slowed down even by a little bit.

also defined the num_workers, so it won't be automatically set by number of CPU the test machine has, and won't be more deterministic

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
