### PR TITLE
fix(stress-threads): kill only labeled docker containers on loaders

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5269,9 +5269,12 @@ class BaseLoaderSet():
                                  str(loader), str(ex))
 
     def kill_docker_loaders(self):
+        test_id = self.tags.get('TestId')
         for loader in self.nodes:
             try:
-                loader.remoter.run(cmd='docker ps -a -q | xargs docker rm -f', verbose=True, ignore_status=True)
+                loader.remoter.run(
+                    cmd=f'docker ps -a -q --filter label=TestId={test_id} | xargs docker rm -f',
+                    verbose=True, ignore_status=True)
                 self.log.info("Killed docker loader on node: %s", loader.name)
             except Exception as ex:  # pylint: disable=broad-except  # noqa: BLE001
                 self.log.warning("failed to kill docker stress command on [%s]: [%s]",

--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -22,6 +22,7 @@ class RemoteDocker(BaseNode):
         if docker_network:
             extra_docker_opts += f" --network {docker_network}"
             self.create_network(docker_network)
+        extra_docker_opts += f" --label TestId={node.test_config.test_id()}"
         res = self.node.remoter.run(
             f'{self.sudo_needed} docker run {extra_docker_opts} -d {ports} {image_name} {command_line}',
             verbose=True, retry=3)


### PR DESCRIPTION
There is no any filtering of docker instances, when killing containerized stress threads on loader nodes during teardown of a test. In the case of docker backend this can result in deleting all containers in the system.

The change fixes this by labeling stress thread related docker containers when they are created; and deleting only the labeled containers during the teardown.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9027

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
