### PR TITLE
fix(manager): up manager default version to the latest released 3.4

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -8,7 +8,7 @@ ip_ssh_connections: 'private'
 
 scylla_repo: ''
 
-manager_version: '3.3'
+manager_version: '3.4'
 manager_scylla_backend_version: '2024'
 # Notice: that centos (default monitor), ubuntu 22, ubuntu 20 and debian 11 monitors use 2024, while debian 10 ubuntu 18 use 2023, since we support both
 
@@ -157,8 +157,8 @@ jepsen_test_count: 1
 jepsen_test_run_policy: all
 
 max_events_severities: ""
-scylla_mgmt_agent_version: '3.3.0'
-mgmt_docker_image: 'scylladb/scylla-manager:3.3.0'
+scylla_mgmt_agent_version: '3.4.0'
+mgmt_docker_image: 'scylladb/scylla-manager:3.4.0'
 k8s_log_api_calls: false
 k8s_deploy_monitoring: false
 k8s_minio_storage_size: '10Gi'


### PR DESCRIPTION
Set default Manager version to 3.4.

The version was released on 05 Nov 2024 and passed through the standard flow of Manager release testing - [Argus release](https://argus.scylladb.com/dashboard/manager-3.4).

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] None

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code