### PR TITLE
ci(latte): bump latte version to `0.28.1-scylladb`

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -216,7 +216,7 @@ stress_image:
   cdc-stresser: 'scylladb/hydra-loaders:cdc-stresser-20210630'
   kcl: 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC'
   harry: 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816'
-  latte: 'scylladb/hydra-loaders:latte-0.28.0-scylladb'
+  latte: 'scylladb/hydra-loaders:latte-0.28.1-scylladb'
   cql-stress-cassandra-stress: 'docker.io/scylladb/hydra-loaders:cql-stress-cassandra-stress-20240718'
 
 service_level_shares: [1000]

--- a/docker/latte/README.md
+++ b/docker/latte/README.md
@@ -1,6 +1,6 @@
 ```
 # See latte version at the 'Cargo.toml' file in the 'latte' repo
-export LATTE_VERSION=0.28.0-scylladb
+export LATTE_VERSION=0.28.1-scylladb
 export LATTE_DOCKER_IMAGE=scylladb/hydra-loaders:latte-${LATTE_VERSION}
 docker build . -t ${LATTE_DOCKER_IMAGE}
 docker push ${LATTE_DOCKER_IMAGE}


### PR DESCRIPTION
It is needed to be able to use `batch` queries we plan to use for `custom-d1` cases.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
