### PR TITLE
fix(capacity-reservation): disable for multi-dc

### DIFF
--- a/sdcm/provision/aws/capacity_reservation.py
+++ b/sdcm/provision/aws/capacity_reservation.py
@@ -118,10 +118,12 @@ class SCTCapacityReservation:
     @staticmethod
     def is_capacity_reservation_enabled(params: dict) -> bool:
         """Returns True if capacity reservation is enabled."""
+        is_single_dc = str(params.get("n_db_nodes")).isdigit() or params.get('simulated_regions') > 0
         return (params.get("cluster_backend") == "aws"
                 and (params.get("test_id") or params.get("reuse_cluster"))
                 and params.get('use_capacity_reservation') is True
-                and params.get('instance_provision') == 'on_demand')
+                and params.get('instance_provision') == 'on_demand'
+                and is_single_dc)
 
     @classmethod
     def reserve(cls, params) -> None:


### PR DESCRIPTION
multi-dc scenarios are not supported in capacity reservations. Disable it when multi-dc is used to not raise errors.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9274

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
