### PR TITLE
full_storage_utilization_test: reclaim and scale out tests

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1032,6 +1032,15 @@ Used for scale test: max size of the cluster
 **type:** int_or_space_separated_ints
 
 
+## **cluster_target_instance_type** / SCT_CLUSTER_TARGET_INSTANCE_TYPE
+
+The type of instances added to reach `cluster_target_size`
+
+**default:** N/A
+
+**type:** str (appendable)
+
+
 ## **space_node_threshold** / SCT_SPACE_NODE_THRESHOLD
 
 Space node threshold before starting nemesis (bytes)<br>The default value is 6GB (6x1024^3 bytes)<br>This value is supposed to reproduce<br>https://github.com/scylladb/scylla/issues/1140

--- a/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-double-cluster-smaller-2xl.jenkinsfile
+++ b/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-double-cluster-smaller-2xl.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "aws",
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/features/elasticity/elasticity-90-percent-perf-i4i-8xlarge-grow-fill-i4i-large.yaml',
+)

--- a/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-double-cluster-smaller-8xl.jenkinsfile
+++ b/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-double-cluster-smaller-8xl.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "aws",
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/features/elasticity/elasticity-90-percent-perf-i4i-2xlarge-grow-fill-i4i-large.yaml',
+)

--- a/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-drop.jenkinsfile
+++ b/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-drop.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "aws",
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/features/elasticity/elasticity-90-percent-i4i-2xlarge-drop.yaml',
+)

--- a/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-scale-out-larger.jenkinsfile
+++ b/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-scale-out-larger.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: 'eu-west-1',
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: """["test-cases/features/elasticity/elasticity-90-percent-perf-i4i-large-grow-i4i-4xlarge.yaml", "configurations/disable_kms.yaml"]""",
+    sub_tests: ["test_latency_mixed_with_nemesis"],
+)

--- a/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-scale-out-smaller.jenkinsfile
+++ b/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-scale-out-smaller.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: 'eu-west-1',
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: """["test-cases/features/elasticity/elasticity-90-percent-perf-i4i-4xlarge-grow-i4i-large.yaml", "configurations/disable_kms.yaml"]""",
+    sub_tests: ["test_latency_mixed_with_nemesis"],
+)

--- a/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-truncate.jenkinsfile
+++ b/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-truncate.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "aws",
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/features/elasticity/elasticity-90-percent-i4i-2xlarge-truncate.yaml',
+)

--- a/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-ttl.jenkinsfile
+++ b/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-ttl.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "aws",
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/features/elasticity/elasticity-90-percent-i4i-2xlarge-ttl.yaml',
+)

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -164,6 +164,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
             add_node_cnt = self.params.get('add_node_cnt')
             nodes_by_dcx = group_nodes_by_dc_idx(self.db_cluster.data_nodes)
             current_cluster_size = [len(nodes_by_dcx[dcx]) for dcx in sorted(nodes_by_dcx)]
+            instance_type = self.params.get('cluster_target_instance_type') or self.params.get('instance_type_db')
 
             InfoEvent(
                 message=f"Starting to grow cluster from {self.params.get('n_db_nodes')} to {cluster_target_size}").publish()
@@ -176,7 +177,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
                             target - current_cluster_size[dcx]) >= add_node_cnt else target - current_cluster_size[dcx]
                         InfoEvent(message=f"Adding next number of nodes {add_nodes_num} to dc_idx {dcx}").publish()
                         added_nodes.extend(self.db_cluster.add_nodes(
-                            count=add_nodes_num, enable_auto_bootstrap=True, dc_idx=dcx))
+                            count=add_nodes_num, enable_auto_bootstrap=True, dc_idx=dcx, instance_type=instance_type))
 
                 self.monitors.reconfigure_scylla_monitoring()
                 up_timeout = MAX_TIME_WAIT_FOR_NEW_NODE_UP

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -177,7 +177,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
                             target - current_cluster_size[dcx]) >= add_node_cnt else target - current_cluster_size[dcx]
                         InfoEvent(message=f"Adding next number of nodes {add_nodes_num} to dc_idx {dcx}").publish()
                         added_nodes.extend(self.db_cluster.add_nodes(
-                            count=add_nodes_num, enable_auto_bootstrap=True, dc_idx=dcx, instance_type=instance_type))
+                            count=add_nodes_num, enable_auto_bootstrap=True, dc_idx=dcx, rack=None, instance_type=instance_type))
 
                 self.monitors.reconfigure_scylla_monitoring()
                 up_timeout = MAX_TIME_WAIT_FOR_NEW_NODE_UP

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -683,6 +683,9 @@ class SCTConfiguration(dict):
         dict(name="cluster_target_size", env="SCT_CLUSTER_TARGET_SIZE", type=int_or_space_separated_ints,
              help="""Used for scale test: max size of the cluster"""),
 
+        dict(name="cluster_target_instance_type", env="SCT_CLUSTER_TARGET_INSTANCE_TYPE", type=str,
+             help="""The type of instances added to reach `cluster_target_size`"""),
+
         dict(name="space_node_threshold", env="SCT_SPACE_NODE_THRESHOLD",
              type=int, k8s_multitenancy_supported=True,
              help="""

--- a/test-cases/features/elasticity/elasticity-90-percent-i4i-2xlarge-drop.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-i4i-2xlarge-drop.yaml
@@ -1,0 +1,46 @@
+test_duration: 720
+prepare_write_cmd: [
+  "cassandra-stress write no-warmup cl=QUORUM n=480000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..480000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=480000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=480000001..960000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=480000000 -schema keyspace=ks_90percent_drop 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=960000001..1440000000",
+]
+
+pre_create_keyspace: [
+  "CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};",
+  "CREATE TABLE IF NOT EXISTS keyspace1.standard1 (key blob PRIMARY KEY, \"C0\" blob, \"C1\" blob, \"C2\" blob, \"C3\" blob, \"C4\" blob, \"C5\" blob, \"C6\" blob, \"C7\" blob) WITH tablets = {'min_per_shard_tablet_count': 10};",
+  "CREATE KEYSPACE IF NOT EXISTS ks_90percent_drop WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};",
+  "CREATE TABLE IF NOT EXISTS ks_90percent_drop.standard1 (key blob PRIMARY KEY, \"C0\" blob, \"C1\" blob, \"C2\" blob, \"C3\" blob, \"C4\" blob, \"C5\" blob, \"C6\" blob, \"C7\" blob) WITH tablets = {'min_per_shard_tablet_count': 10};",
+]
+
+post_prepare_cql_cmds: [
+  "DROP TABLE ks_90percent_drop.standard1;"
+]
+
+stress_cmd: [
+  "cassandra-stress mixed no-warmup cl=QUORUM duration=30m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=30000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..720000000,360000000,7200000)'"
+]
+
+n_db_nodes: 3
+availability_zone: 'a'
+simulated_racks: 3
+instance_type_db: 'i4i.2xlarge'
+
+n_loaders: 3
+instance_type_loader: 'c6i.2xlarge'
+
+n_monitor_nodes: 1
+instance_type_monitor: 't3.large'
+
+nemesis_class_name: 'NoOpMonkey'
+nemesis_during_prepare: false
+nemesis_interval: 10
+
+user_prefix: 'elasticity-test'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
+backtrace_decoding: false
+print_kernel_callstack: true
+
+append_scylla_yaml:
+  auto_snapshot: false

--- a/test-cases/features/elasticity/elasticity-90-percent-i4i-2xlarge-truncate.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-i4i-2xlarge-truncate.yaml
@@ -1,0 +1,42 @@
+test_duration: 720
+prepare_write_cmd: [
+  "cassandra-stress write no-warmup cl=QUORUM n=480000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..480000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=480000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=480000001..960000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=480000000 -schema keyspace=ks_90percent_truncate 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=960000001..1440000000",
+]
+
+pre_create_keyspace: [
+  "CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};",
+  "CREATE TABLE IF NOT EXISTS keyspace1.standard1 (key blob PRIMARY KEY, \"C0\" blob, \"C1\" blob, \"C2\" blob, \"C3\" blob, \"C4\" blob, \"C5\" blob, \"C6\" blob, \"C7\" blob) WITH tablets = {'min_per_shard_tablet_count': 10};",
+  "CREATE KEYSPACE IF NOT EXISTS ks_90percent_truncate WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};",
+  "CREATE TABLE IF NOT EXISTS ks_90percent_truncate.standard1 (key blob PRIMARY KEY, \"C0\" blob, \"C1\" blob, \"C2\" blob, \"C3\" blob, \"C4\" blob, \"C5\" blob, \"C6\" blob, \"C7\" blob) WITH tablets = {'min_per_shard_tablet_count': 10};",
+]
+
+stress_cmd: [
+  "cassandra-stress mixed no-warmup cl=QUORUM duration=30m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=30000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..720000000,360000000,7200000)'"
+]
+
+n_db_nodes: 3
+availability_zone: 'a'
+simulated_racks: 3
+instance_type_db: 'i4i.2xlarge'
+
+n_loaders: 3
+instance_type_loader: 'c6i.2xlarge'
+
+n_monitor_nodes: 1
+instance_type_monitor: 't3.large'
+
+nemesis_class_name: 'TruncateMonkey'
+nemesis_during_prepare: false
+nemesis_interval: 10
+
+user_prefix: 'elasticity-test'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
+backtrace_decoding: false
+print_kernel_callstack: true
+
+append_scylla_yaml:
+  auto_snapshot: false

--- a/test-cases/features/elasticity/elasticity-90-percent-i4i-2xlarge-ttl.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-i4i-2xlarge-ttl.yaml
@@ -1,0 +1,39 @@
+test_duration: 1440
+prepare_write_cmd: [
+  "cassandra-stress write no-warmup cl=QUORUM n=480000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..480000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=480000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=480000001..960000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=480000000 -schema keyspace=ks_90percent_ttl 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=960000001..1440000000",
+]
+
+pre_create_keyspace: [
+  "CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};",
+  "CREATE TABLE IF NOT EXISTS keyspace1.standard1 (key blob PRIMARY KEY, \"C0\" blob, \"C1\" blob, \"C2\" blob, \"C3\" blob, \"C4\" blob, \"C5\" blob, \"C6\" blob, \"C7\" blob) WITH tablets = {'min_per_shard_tablet_count': 10};",
+  "CREATE KEYSPACE IF NOT EXISTS ks_90percent_ttl WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};",
+  "CREATE TABLE IF NOT EXISTS ks_90percent_ttl.standard1 (key blob PRIMARY KEY, \"C0\" blob, \"C1\" blob, \"C2\" blob, \"C3\" blob, \"C4\" blob, \"C5\" blob, \"C6\" blob, \"C7\" blob) WITH tablets = {'min_per_shard_tablet_count': 10} AND default_time_to_live = 12000 AND gc_grace_seconds = 12300 AND compaction = { 'class': 'TimeWindowCompactionStrategy', 'compaction_window_size': 1, 'compaction_window_unit': 'HOURS' } AND tombstone_gc = {'mode':'immediate'};",
+]
+
+stress_cmd: [
+  "cassandra-stress mixed no-warmup cl=QUORUM duration=420m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=30000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..720000000,360000000,7200000)'"
+]
+
+n_db_nodes: 3
+availability_zone: 'a'
+simulated_racks: 3
+instance_type_db: 'i4i.2xlarge'
+
+n_loaders: 3
+instance_type_loader: 'c6i.2xlarge'
+
+n_monitor_nodes: 1
+instance_type_monitor: 't3.large'
+
+nemesis_class_name: 'NoOpMonkey'
+nemesis_during_prepare: false
+nemesis_interval: 10
+
+user_prefix: 'elasticity-test'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
+backtrace_decoding: false
+print_kernel_callstack: true

--- a/test-cases/features/elasticity/elasticity-90-percent-perf-i4i-2xlarge-grow-fill-i4i-large.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-perf-i4i-2xlarge-grow-fill-i4i-large.yaml
@@ -1,0 +1,45 @@
+test_duration: 2880
+prepare_write_cmd: [
+  "cassandra-stress write no-warmup cl=QUORUM n=480000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..480000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=480000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=480000001..960000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=480000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=960000001..1440000000",
+]
+
+pre_create_keyspace: [
+  "CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};",
+  "CREATE TABLE IF NOT EXISTS keyspace1.standard1 (key blob PRIMARY KEY, \"C0\" blob, \"C1\" blob, \"C2\" blob, \"C3\" blob, \"C4\" blob, \"C5\" blob, \"C6\" blob, \"C7\" blob) WITH tablets = {'min_per_shard_tablet_count': 10};",
+  "CREATE KEYSPACE IF NOT EXISTS keyspace2 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};",
+  "CREATE TABLE IF NOT EXISTS keyspace2.standard1 (key blob PRIMARY KEY, \"C0\" blob, \"C1\" blob, \"C2\" blob, \"C3\" blob, \"C4\" blob, \"C5\" blob, \"C6\" blob, \"C7\" blob) WITH tablets = {'min_per_shard_tablet_count': 10};",
+]
+
+stress_cmd: [
+  "cassandra-stress write no-warmup cl=QUORUM n=120000000 -schema keyspace=keyspace2 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=20000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..120000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=120000000 -schema keyspace=keyspace2 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=20000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop seq=120000001..240000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=120000000 -schema keyspace=keyspace2 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=20000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop seq=240000001..360000000",
+]
+
+n_db_nodes: 3
+availability_zone: 'a'
+simulated_racks: 3
+instance_type_db: 'i4i.2xlarge'
+
+cluster_target_size: 6
+add_node_cnt: 3
+cluster_target_instance_type: 'i4i.large'
+
+n_loaders: 3
+instance_type_loader: 'c6i.2xlarge'
+
+n_monitor_nodes: 1
+instance_type_monitor: 't3.large'
+
+nemesis_class_name: 'NoOpMonkey'
+
+user_prefix: 'elasticity-test'
+ami_id_db_scylla_desc: 'VERSION_DESC'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
+backtrace_decoding: false
+print_kernel_callstack: true
+parallel_node_operations: true

--- a/test-cases/features/elasticity/elasticity-90-percent-perf-i4i-4xlarge-grow-i4i-large.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-perf-i4i-4xlarge-grow-i4i-large.yaml
@@ -1,0 +1,46 @@
+test_duration: 1800
+prepare_write_cmd: [
+  "cassandra-stress write no-warmup cl=QUORUM n=960000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..960000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=960000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=960000001..1920000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=960000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1920000001..2880000000",
+]
+
+pre_create_keyspace: [
+  "CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};",
+  "CREATE TABLE IF NOT EXISTS keyspace1.standard1 (key blob PRIMARY KEY, \"C0\" blob, \"C1\" blob, \"C2\" blob, \"C3\" blob, \"C4\" blob, \"C5\" blob, \"C6\" blob, \"C7\" blob) WITH tablets = {'min_per_shard_tablet_count': 10};",
+]
+
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=30000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..1440000000,720000000,14400000)'"
+
+
+n_db_nodes: 3
+availability_zone: 'a'
+simulated_racks: 3
+instance_type_db: 'i4i.4xlarge'
+
+nemesis_add_node_cnt: 3
+nemesis_grow_shrink_instance_type: 'i4i.large'
+
+n_loaders: 3
+instance_type_loader: 'c6i.2xlarge'
+
+n_monitor_nodes: 1
+instance_type_monitor: 't3.large'
+
+nemesis_class_name: 'GrowShrinkClusterNemesis'
+nemesis_interval: 30
+nemesis_sequence_sleep_between_ops: 10
+
+user_prefix: 'elasticity-test'
+ami_id_db_scylla_desc: 'VERSION_DESC'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
+backtrace_decoding: false
+print_kernel_callstack: true
+
+store_perf_results: false
+use_hdrhistogram: true
+email_recipients: ["scylla-perf-results@scylladb.com"]
+email_subject_postfix: 'elasticity test'
+parallel_node_operations: true

--- a/test-cases/features/elasticity/elasticity-90-percent-perf-i4i-8xlarge-grow-fill-i4i-large.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-perf-i4i-8xlarge-grow-fill-i4i-large.yaml
@@ -1,0 +1,45 @@
+test_duration: 2880
+prepare_write_cmd: [
+  "cassandra-stress write no-warmup cl=QUORUM n=1920000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..1920000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=1920000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1920000001..3840000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=1920000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=3840000001..5760000000",
+]
+
+pre_create_keyspace: [
+  "CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};",
+  "CREATE TABLE IF NOT EXISTS keyspace1.standard1 (key blob PRIMARY KEY, \"C0\" blob, \"C1\" blob, \"C2\" blob, \"C3\" blob, \"C4\" blob, \"C5\" blob, \"C6\" blob, \"C7\" blob) WITH tablets = {'min_per_shard_tablet_count': 10};",
+  "CREATE KEYSPACE IF NOT EXISTS keyspace2 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};",
+  "CREATE TABLE IF NOT EXISTS keyspace2.standard1 (key blob PRIMARY KEY, \"C0\" blob, \"C1\" blob, \"C2\" blob, \"C3\" blob, \"C4\" blob, \"C5\" blob, \"C6\" blob, \"C7\" blob) WITH tablets = {'min_per_shard_tablet_count': 10};",
+]
+
+stress_cmd: [
+  "cassandra-stress write no-warmup cl=QUORUM n=120000000 -schema keyspace=keyspace2 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=20000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..120000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=120000000 -schema keyspace=keyspace2 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=20000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop seq=120000001..240000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=120000000 -schema keyspace=keyspace2 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=20000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop seq=240000001..360000000",
+]
+
+n_db_nodes: 3
+availability_zone: 'a'
+simulated_racks: 3
+instance_type_db: 'i4i.8xlarge'
+
+cluster_target_size: 6
+add_node_cnt: 3
+cluster_target_instance_type: 'i4i.large'
+
+n_loaders: 3
+instance_type_loader: 'c6i.2xlarge'
+
+n_monitor_nodes: 1
+instance_type_monitor: 't3.large'
+
+nemesis_class_name: 'NoOpMonkey'
+
+user_prefix: 'elasticity-test'
+ami_id_db_scylla_desc: 'VERSION_DESC'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
+backtrace_decoding: false
+print_kernel_callstack: true
+parallel_node_operations: true

--- a/test-cases/features/elasticity/elasticity-90-percent-perf-i4i-large-grow-i4i-4xlarge.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-perf-i4i-large-grow-i4i-4xlarge.yaml
@@ -1,0 +1,46 @@
+test_duration: 1800
+prepare_write_cmd: [
+  "cassandra-stress write no-warmup cl=QUORUM n=120000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..120000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=120000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=120000001..240000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=120000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=240000001..360000000",
+  ]
+
+pre_create_keyspace: [
+  "CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};",
+  "CREATE TABLE IF NOT EXISTS keyspace1.standard1 (key blob PRIMARY KEY, \"C0\" blob, \"C1\" blob, \"C2\" blob, \"C3\" blob, \"C4\" blob, \"C5\" blob, \"C6\" blob, \"C7\" blob) WITH tablets = {'min_per_shard_tablet_count': 10};",
+]
+
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=150 fixed=3300/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..180000000,90000000,1800000)'"
+
+
+n_db_nodes: 3
+availability_zone: 'a'
+simulated_racks: 3
+instance_type_db: 'i4i.large'
+
+nemesis_add_node_cnt: 3
+nemesis_grow_shrink_instance_type: 'i4i.4xlarge'
+
+n_loaders: 3
+instance_type_loader: 'c6i.2xlarge'
+
+n_monitor_nodes: 1
+instance_type_monitor: 't3.large'
+
+nemesis_class_name: 'GrowShrinkClusterNemesis'
+nemesis_interval: 30
+nemesis_sequence_sleep_between_ops: 10
+
+user_prefix: 'elasticity-test'
+ami_id_db_scylla_desc: 'VERSION_DESC'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
+backtrace_decoding: false
+print_kernel_callstack: true
+
+store_perf_results: false
+use_hdrhistogram: true
+email_recipients: ["scylla-perf-results@scylladb.com"]
+email_subject_postfix: 'elasticity test'
+parallel_node_operations: true


### PR DESCRIPTION
Adds test cases and jenkins files for 90% storage utilization tests.
Covers these test cases:

- Space reclaim
- [x] https://github.com/scylladb/scylla-cluster-tests/issues/9169 
- [x] https://github.com/scylladb/scylla-cluster-tests/issues/9166 
- [x] https://github.com/scylladb/scylla-cluster-tests/issues/9167
- Scale out
- [x] https://github.com/scylladb/scylla-cluster-tests/issues/9256
- [x] https://github.com/scylladb/scylla-cluster-tests/issues/9257  
  These test cases are implemented as performance tests, to check that scaling out and scaling in do not cause performance issue at 90% utilization, under a 50% load.
- [x] https://github.com/scylladb/scylla-cluster-tests/issues/9597

The tests are meant to be run manually and checking their monitoring stack is part of their passing condition.

refs: https://github.com/scylladb/scylla-cluster-tests/issues/9129

### [Argus Dashboard of all cases](https://argus.scylladb.com/test_runs?state=WyJkMzE4ZWZjMi05MWIxLTQ5Y2UtOWM0Yi1mNmMwZjBhMzkyMDAiLCJiNDc0NjEzOC02OGI5LTQ0NGQtOGFlNi1jZTA3ZTZkYmMzMGUiLCI4Y2I5NWZkMS01MjdkLTQ5OTMtYjhmOC0wZjYyMTZmOTczZGUiLCIyOWJlYTNkZC0wNDljLTRhNjQtYjM2OC1kYTA2NTk2OGZlYzQiLCI4M2YzYWZmZi0yNTcyLTQ4MjYtYTJiMC0xNWM5ZTE0ZWFjZDgiLCI5MGU1ZDgwYi04Y2NlLTRkOGMtODgxNy1jM2FlYWYyNDE4MTMiXQ)