### PR TITLE
 Add backup benchmarking under read stress

### DIFF
--- a/configurations/manager/100GB_dataset.yaml
+++ b/configurations/manager/100GB_dataset.yaml
@@ -1,0 +1,15 @@
+test_duration: 72000
+
+prepare_write_cmd: [ "cassandra-stress write cl=ALL n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..26214400",
+                     "cassandra-stress write cl=ALL n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=26214401..52428800",
+                     "cassandra-stress write cl=ALL n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=52428801..78643200",
+                     "cassandra-stress write cl=ALL n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=78643201..104857600" ]
+
+stress_read_cmd: [ "cassandra-stress read cl=ALL n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..26214400",
+                   "cassandra-stress read cl=ALL n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=26214401..52428800",
+                   "cassandra-stress read cl=ALL n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=52428801..78643200",
+                   "cassandra-stress read cl=ALL n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=78643201..104857600" ]
+
+instance_type_db: 'i4i.4xlarge'
+instance_type_loader: 'c6i.xlarge'
+store_perf_results: true

--- a/configurations/manager/1TB_dataset.yaml
+++ b/configurations/manager/1TB_dataset.yaml
@@ -1,14 +1,14 @@
-test_duration: 2880
+test_duration: 72000
 
-prepare_write_cmd: ["cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..268435456",
-                    "cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=268435457..536870912",
-                    "cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..805306368",
-                    "cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1073741824"]
+prepare_write_cmd: [ "cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..268435456",
+                     "cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=268435457..536870912",
+                     "cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..805306368",
+                     "cassandra-stress write cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1073741824" ]
 
-stress_read_cmd: ["cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..268435456",
-                  "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=268435457..536870912",
-                  "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..805306368",
-                  "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1073741824"]
+stress_read_cmd: [ "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..268435456",
+                   "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=268435457..536870912",
+                   "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..805306368",
+                   "cassandra-stress read cl=ONE n=268435456 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1073741824" ]
 
-instance_type_db: 'i3en.2xlarge'
+instance_type_db: 'i4i.4xlarge'
 instance_type_loader: 'c6i.2xlarge'

--- a/configurations/manager/2TB_dataset.yaml
+++ b/configurations/manager/2TB_dataset.yaml
@@ -1,14 +1,14 @@
-test_duration: 4320
+test_duration: 72000
 
-prepare_write_cmd: ["cassandra-stress write cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..536870912",
-                    "cassandra-stress write cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..1073741824",
-                    "cassandra-stress write cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1073741825..1610612736",
-                    "cassandra-stress write cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1610612737..2147483648"]
+prepare_write_cmd: [ "cassandra-stress write cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..536870912",
+                     "cassandra-stress write cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..1073741824",
+                     "cassandra-stress write cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1073741825..1610612736",
+                     "cassandra-stress write cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1610612737..2147483648" ]
 
-stress_read_cmd: ["cassandra-stress read cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..536870912",
-                  "cassandra-stress read cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..1073741824",
-                  "cassandra-stress read cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1073741825..1610612736",
-                  "cassandra-stress read cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1610612737..2147483648"]
+stress_read_cmd: [ "cassandra-stress read cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..536870912",
+                   "cassandra-stress read cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=536870913..1073741824",
+                   "cassandra-stress read cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1073741825..1610612736",
+                   "cassandra-stress read cl=ONE n=536870912 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1610612737..2147483648" ]
 
-instance_type_db: 'i3en.3xlarge'
+instance_type_db: 'i4i.4xlarge'
 instance_type_loader: 'c6i.2xlarge'

--- a/configurations/manager/3TB_dataset.yaml
+++ b/configurations/manager/3TB_dataset.yaml
@@ -1,0 +1,14 @@
+test_duration: 72000
+
+prepare_write_cmd: [ "cassandra-stress write cl=ONE n=805306368 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..805306368",
+                     "cassandra-stress write cl=ONE n=805306368 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1610612736",
+                     "cassandra-stress write cl=ONE n=805306368 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1610612737..2415919104",
+                     "cassandra-stress write cl=ONE n=805306368 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=2415919105..3221225472" ]
+
+stress_read_cmd: [ "cassandra-stress read cl=ONE n=805306368 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..805306368",
+                   "cassandra-stress read cl=ONE n=805306368 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=805306369..1610612736",
+                   "cassandra-stress read cl=ONE n=805306368 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1610612737..2415919104",
+                   "cassandra-stress read cl=ONE n=805306368 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=2415919105..3221225472" ]
+
+instance_type_db: 'i4i.4xlarge'
+instance_type_loader: 'c6i.2xlarge'

--- a/configurations/manager/500GB_dataset.yaml
+++ b/configurations/manager/500GB_dataset.yaml
@@ -1,14 +1,14 @@
-test_duration: 1440
+test_duration: 72000
 
-prepare_write_cmd: ["cassandra-stress write cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..131072000",
-                    "cassandra-stress write cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=131072001..262144000",
-                    "cassandra-stress write cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=262144001..393216000",
-                    "cassandra-stress write cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=393216001..524288000"]
+prepare_write_cmd: [ "cassandra-stress write cl=ALL n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..131072000",
+                     "cassandra-stress write cl=ALL n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=131072001..262144000",
+                     "cassandra-stress write cl=ALL n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=262144001..393216000",
+                     "cassandra-stress write cl=ALL n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=393216001..524288000" ]
 
-stress_read_cmd: ["cassandra-stress read cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..131072000",
-                  "cassandra-stress read cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=131072001..262144000",
-                  "cassandra-stress read cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=262144001..393216000",
-                  "cassandra-stress read cl=ONE n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=393216001..524288000"]
+stress_read_cmd: [ "cassandra-stress read cl=ALL n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..131072000",
+                   "cassandra-stress read cl=ALL n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=131072001..262144000",
+                   "cassandra-stress read cl=ALL n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=262144001..393216000",
+                   "cassandra-stress read cl=ALL n=131072000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=393216001..524288000" ]
 
-instance_type_db: 'i4i.2xlarge'
+instance_type_db: 'i4i.4xlarge'
 instance_type_loader: 'c6i.xlarge'

--- a/configurations/manager/5TB_dataset.yaml
+++ b/configurations/manager/5TB_dataset.yaml
@@ -1,14 +1,14 @@
-test_duration: 7200
+test_duration: 72000
 
-prepare_write_cmd: ["cassandra-stress write cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1342177280",
-                    "cassandra-stress write cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1342177281..2684354560",
-                    "cassandra-stress write cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=2684354561..4026531840",
-                    "cassandra-stress write cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=4026531841..5368709120"]
+prepare_write_cmd: [ "cassandra-stress write cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1342177280",
+                     "cassandra-stress write cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1342177281..2684354560",
+                     "cassandra-stress write cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=2684354561..4026531840",
+                     "cassandra-stress write cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=4026531841..5368709120" ]
 
-stress_read_cmd: ["cassandra-stress read cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1342177280",
-                  "cassandra-stress read cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1342177281..2684354560",
-                  "cassandra-stress read cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=2684354561..4026531840",
-                  "cassandra-stress read cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=4026531841..5368709120"]
+stress_read_cmd: [ "cassandra-stress read cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1342177280",
+                   "cassandra-stress read cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1342177281..2684354560",
+                   "cassandra-stress read cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=2684354561..4026531840",
+                   "cassandra-stress read cl=ONE n=1342177280 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=4026531841..5368709120" ]
 
 instance_type_db: 'i4i.4xlarge'
 instance_type_loader: 'c6i.2xlarge'

--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -104,6 +104,9 @@ class ManagerRestoreBanchmarkResult(GenericResultTable):
         Columns = [
             ColumnMetadata(name="restore time", unit="s", type=ResultType.DURATION, higher_is_better=False),
             ColumnMetadata(name="repair time", unit="s", type=ResultType.DURATION, higher_is_better=False),
+            ColumnMetadata(name="backup time", unit="s", type=ResultType.DURATION, higher_is_better=False),
+            ColumnMetadata(name="upload time", unit="s", type=ResultType.DURATION, higher_is_better=False),
+            ColumnMetadata(name="read stress time", unit="s", type=ResultType.DURATION, higher_is_better=False),
             ColumnMetadata(name="total", unit="s", type=ResultType.DURATION, higher_is_better=False),
         ]
         ValidationRules = {

--- a/test-cases/manager/manager-backup-restore-set-dataset.yaml
+++ b/test-cases/manager/manager-backup-restore-set-dataset.yaml
@@ -6,7 +6,7 @@ round_robin: true
 prepare_write_cmd: ["cassandra-stress write cl=ONE n=1048576 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=50 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1048576"]
 stress_read_cmd: ["cassandra-stress read cl=ONE n=1048576 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=50 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1048576"]
 
-instance_type_db: 'i4i.xlarge'
+instance_type_db: 'i4i.4xlarge'
 instance_type_loader: 'c6i.xlarge'
 
 region_name: us-east-1


### PR DESCRIPTION
Introduce the `test_backup_benchmark` test, which measures backup time under read stress conditions. This test performs multiple actions to consolidate all necessary data into a single table. Initially, it runs and measures the backup process, followed by the read stress test. Finally, it executes both processes asynchronously to observe how the performance of reading and backing up degrades.

Argus results:
For 100GB run
|  | backup time [s] | upload time [s] | read stress time [s] | total [s] |
| --- | --- | --- | --- | --- |
| Backup times | $${\color{green}00:00:13}$$ | $${\color{green}00:14:02}$$ | $${\color{gray}N/A}$$ | $${\color{red}00:14:16}$$ |
| Read stress | $${\color{gray}N/A}$$ | $${\color{gray}N/A}$$ | $${\color{green}00:13:43}$$ | $${\color{gray}N/A}$$ |
| Read stress during backup | $${\color{gray}N/A}$$ | $${\color{gray}N/A}$$ | $${\color{green}00:13:43}$$ | $${\color{gray}N/A}$$ |
| Backup during read stress | $${\color{green}00:00:13}$$ | $${\color{green}00:19:24}$$ | $${\color{gray}N/A}$$ | $${\color{red}00:19:38}$$ |

