### PR TITLE
Add backup benchmarking under read stress

### DIFF
--- a/configurations/manager/100GB_dataset.yaml
+++ b/configurations/manager/100GB_dataset.yaml
@@ -1,0 +1,14 @@
+test_duration: 120
+
+prepare_write_cmd: [ "cassandra-stress write cl=ALL n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..26214400",
+                     "cassandra-stress write cl=ALL n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=26214401..52428800",
+                     "cassandra-stress write cl=ALL n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=52428801..78643200",
+                     "cassandra-stress write cl=ALL n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=78643201..104857600" ]
+
+stress_read_cmd: [ "cassandra-stress read cl=ALL n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..26214400",
+                   "cassandra-stress read cl=ALL n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=26214401..52428800",
+                   "cassandra-stress read cl=ALL n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=52428801..78643200",
+                   "cassandra-stress read cl=ALL n=26214400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native  -rate threads=50 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=78643201..104857600" ]
+
+instance_type_db: 'i3en.3xlarge'
+instance_type_loader: 'c6i.xlarge'

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -16,6 +16,8 @@
 
 # pylint: disable=too-many-lines
 import random
+import threading
+from enum import Enum
 from pathlib import Path
 from functools import cached_property
 import re
@@ -26,11 +28,14 @@ from dataclasses import dataclass
 
 import boto3
 import yaml
+from docker.errors import InvalidArgument
 
 from invoke import exceptions
 
+from argus.client.generic_result import Status
 from sdcm import mgmt
-from sdcm.argus_results import send_manager_benchmark_results_to_argus
+from sdcm.argus_results import send_manager_benchmark_results_to_argus, submit_results_to_argus, \
+    ManagerBackupReadResult, ManagerBackupBenchmarkResult
 from sdcm.mgmt import ScyllaManagerError, TaskStatus, HostStatus, HostSsl, HostRestStatus
 from sdcm.mgmt.cli import ScyllaManagerTool, RestoreTask
 from sdcm.mgmt.common import reconfigure_scylla_manager, get_persistent_snapshots
@@ -572,7 +577,7 @@ class ManagerTestFunctionsMixIn(
         restore_task.wait_and_get_final_status(step=30, timeout=timeout)
         assert restore_task.status == TaskStatus.DONE, f"Restoration of {snapshot_tag} has failed!"
         InfoEvent(message=f'The restore task has ended successfully. '
-                          f'Restore run time: {restore_task.duration}.').publish()
+                  f'Restore run time: {restore_task.duration}.').publish()
         if restore_schema:
             self.db_cluster.restart_scylla()  # After schema restoration, you should restart the nodes
         return restore_task
@@ -1550,3 +1555,93 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
                                "Please provide the 'mgmt_reuse_backup_snapshot_name' parameter.")
 
         self.test_restore_from_precreated_backup(snapshot_name, restore_outside_manager=True)
+
+
+class ManagerReportType(Enum):
+    READ = 1
+    BACKUP = 2
+
+
+class ManagerBackupRestoreConcurrentTests(ManagerTestFunctionsMixIn):
+    def report_to_argus(self, report_type: ManagerReportType, data: dict, label: str):
+        if report_type == ManagerReportType.READ:
+            table = ManagerBackupReadResult(sut_timestamp=mgmt.get_scylla_manager_tool(
+                manager_node=self.monitors.nodes[0]).sctool.client_version_timestamp)
+        elif report_type == ManagerReportType.BACKUP:
+            table = ManagerBackupBenchmarkResult(sut_timestamp=mgmt.get_scylla_manager_tool(
+                manager_node=self.monitors.nodes[0]).sctool.client_version_timestamp)
+        else:
+            raise InvalidArgument("Unknown report type")
+
+        for key, value in data.items():
+            table.add_result(column=key, value=value, row=label, status=Status.UNSET)
+        submit_results_to_argus(self.test_config.argus_client(), table)
+
+    def create_backup_and_report(self, mgr_cluster, label: str):
+        # After the issue https://github.com/scylladb/scylla-manager/issues/4125 is resolved try to rerun it with
+        # different `transfers` settings to apply more IO pressure on the scylla cluster
+        task = mgr_cluster.create_backup_task(location_list=self.locations, rate_limit_list=["0"])
+
+        backup_status = task.wait_and_get_final_status(timeout=7200)
+        assert backup_status == TaskStatus.DONE, "Backup upload has failed!"
+
+        InfoEvent(
+            message=f'Backup total time is: {task.duration}.').publish()
+        backup_report = {
+            "backup time": int(task.duration.total_seconds()),
+        }
+        self.report_to_argus(ManagerReportType.BACKUP, backup_report, label)
+        return task
+
+    def run_read_stress_and_report(self, label):
+        stress_queue = []
+
+        for command in self.params.get('stress_read_cmd'):
+            stress_queue.append(self.run_stress_thread(command, round_robin=True, stop_test_on_failure=False))
+
+        with ExecutionTimer() as stress_timer:
+            for stress in stress_queue:
+                assert self.verify_stress_thread(cs_thread_pool=stress), "Read stress command"
+        InfoEvent(message=f'Read stress duration: {stress_timer.duration}s.').publish()
+
+        read_stress_report = {
+            "read time": int(stress_timer.duration.total_seconds()),
+        }
+        self.report_to_argus(ManagerReportType.READ, read_stress_report, label)
+
+    def test_backup_benchmark(self):
+        self.log.info("Executing test_backup_restore_benchmark...")
+
+        self.log.info("Write data to table")
+        self.run_prepare_write_cmd()
+
+        self.log.info("Disable clusterwide compaction")
+        compaction_ops = CompactionOps(cluster=self.db_cluster)
+        #  Disable keyspace autocompaction cluster-wide since we dont want it to interfere with our restore timing
+        for node in self.db_cluster.nodes:
+            compaction_ops.disable_autocompaction_on_ks_cf(node=node)
+
+        manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
+        mgr_cluster = self.ensure_and_get_cluster(manager_tool)
+
+        self.log.info("Create and report backup time")
+        backup_task = self.create_backup_and_report(mgr_cluster, "Backup")
+
+        self.log.info("Remove backup")
+        backup_task.delete_backup_snapshot()
+
+        self.log.info("Run read test")
+        self.run_read_stress_and_report("Read stress")
+
+        self.log.info("Create and report backup time during read stress")
+
+        backup_thread = threading.Thread(target=self.create_backup_and_report,
+                                         kwargs={"mgr_cluster": mgr_cluster, "label": "Backup during read stress"})
+
+        read_stress_thread = threading.Thread(target=self.run_read_stress_and_report,
+                                              kwargs={"label": "Read stress during backup"})
+        backup_thread.start()
+        read_stress_thread.start()
+
+        backup_thread.join()
+        read_stress_thread.join()

--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -117,6 +117,24 @@ class ManagerRestoreBanchmarkResult(GenericResultTable):
         }
 
 
+class ManagerBackupBenchmarkResult(GenericResultTable):
+    class Meta:
+        name = "Backup benchmark"
+        description = "Backup benchmark"
+        Columns = [
+            ColumnMetadata(name="backup time", unit="s", type=ResultType.DURATION, higher_is_better=False),
+        ]
+
+
+class ManagerBackupReadResult(GenericResultTable):
+    class Meta:
+        name = "Read timing"
+        description = "Read timing"
+        Columns = [
+            ColumnMetadata(name="read time", unit="s", type=ResultType.DURATION, higher_is_better=False),
+        ]
+
+
 workload_to_table = {
     "mixed": LatencyCalculatorMixedResult,
     "write": LatencyCalculatorWriteResult,

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -625,7 +625,8 @@ class ManagerCluster(ScyllaManagerBase):
     def create_backup_task(self, dc_list=None,  # pylint: disable=too-many-arguments,too-many-locals,too-many-branches  # noqa: PLR0913
                            dry_run=None, interval=None, keyspace_list=None, cron=None,
                            location_list=None, num_retries=None, rate_limit_list=None, retention=None, show_tables=None,
-                           snapshot_parallel_list=None, start_date=None, upload_parallel_list=None, legacy_args=None):
+                           snapshot_parallel_list=None, start_date=None, upload_parallel_list=None, transfers=None,
+                           legacy_args=None):
         cmd = "backup -c {}".format(self.id)
 
         if dc_list is not None:
@@ -653,6 +654,8 @@ class ManagerCluster(ScyllaManagerBase):
         if snapshot_parallel_list is not None:
             snapshot_parallel_string = ','.join(snapshot_parallel_list)
             cmd += " --snapshot-parallel {} ".format(snapshot_parallel_string)
+        if transfers is not None:
+            cmd += " --transfers {} ".format(transfers)
         if start_date is not None:
             cmd += " --start-date {} ".format(start_date)
         # Since currently we support both manager 2.6 and 3.0, I left the start-date parameter in,


### PR DESCRIPTION
Introduce the `test_backup_benchmark` test, which measures backup time under read stress conditions. This test performs multiple actions to consolidate all necessary data into a single table. Initially, it runs and measures the backup process, followed by the read stress test. Finally, it executes both processes asynchronously to observe how the performance of reading and backing up degrades.

More metrics could be added after https://github.com/scylladb/scylla-manager/issues/4123 is completed
Test should be re-ran after https://github.com/scylladb/scylla-manager/issues/4125 is completed

Argus results:
For [100GB run](https://argus.scylladb.com/tests/scylla-cluster-tests/83b4a96b-28bb-4501-8116-01f909250c03)
|  | backup time [s] |
| --- | --- |
| Backup during read stress | 00:18:48 |
| Backup | 00:10:18 |

|  | read time [s] |
| --- | --- |
| Read stress | 00:11:29 |
| Read stress during backup | 00:11:31 |

fixes: #8752 