### PR TITLE
fix(setup): stabilise manager repo file download

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1814,7 +1814,8 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             repo_path = '/etc/zypp/repos.d/scylla-manager.repo'
         else:
             repo_path = '/etc/apt/sources.list.d/scylla-manager.list'
-        self.remoter.sudo(f"curl -o {repo_path} -L {scylla_repo} --retry 5 --retry-max-time 300")
+        self.remoter.sudo(f"curl -o {repo_path} -L {scylla_repo} "
+                          f"--connect-timeout 10 --retry 5 --retry-all-errors --retry-max-time 100", retry=3)
 
         # Prevent issue https://github.com/scylladb/scylla/issues/9683
         self.remoter.sudo(f"chmod 644 {repo_path}")


### PR DESCRIPTION
Even with curl retry mechanism we still get issues with connection reset by peer, failing quickly and breaking test.

Improve retry mechanism by adding `--retry-all-errors` and decreased connection timeout to 10 seconds. Additionally use remoter retry mechanism.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9314

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - provision aws

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
