### PR TITLE
improvement(logcollector): collect schema info

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -309,6 +309,12 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         self._node_rack = None
         self._is_zero_token_node = False
 
+    def save_cqlsh_output_in_file(self, cmd: str, log_file: str):
+        self.log.info("Save command '%s' output in the file. Node %s", cmd, self.name)
+        result_tables = self.run_cqlsh(cmd, split=True)
+        for line in result_tables:
+            self.remoter.run(f"echo '{line}' >> {log_file}")
+
     def _is_node_ready_run_scylla_commands(self) -> bool:
         """
         When node is just created and started to configure, during first node initializing, it is impossible to connect to the node yet and

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -749,6 +749,10 @@ class ScyllaLogCollector(LogCollector):
                                command='cat /var/log/cloud-init-output.log'),
                     CommandLog(name='cloud-init.log',
                                command='cat /var/log/cloud-init.log'),
+                    CommandLog(name='schema.log',
+                               command='cat schema.log'),
+                    CommandLog(name='system_schema_tables.log',
+                               command='cat system_schema_tables.log'),
                     ]
     cluster_log_type = "db-cluster"
     cluster_dir_prefix = "db-cluster"

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2953,10 +2953,21 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         self.destroy_credentials()
 
+    def save_nodes_schema(self):
+        if self.db_cluster is None:
+            self.log.info("No nodes found in the Scylla cluster")
+
+        self.log.info("Save nodes user schema in the files")
+        for node in self.db_cluster.nodes:
+            node.save_cqlsh_output_in_file(cmd="desc schema", log_file="schema.log")
+            node.save_cqlsh_output_in_file(cmd="select JSON * from system_schema.tables",
+                                           log_file="system_schema_tables.log")
+
     def tearDown(self):
         self.teardown_started = True
         with silence(parent=self, name='Sending test end event'):
             InfoEvent(message="TEST_END").publish()
+        self.save_nodes_schema()
         self.log.info("Post test validators are starting...")
         for validator_class in teardown_validators_list:
             validator_class(self.params, self).validate()

--- a/unit_tests/test_tester.py
+++ b/unit_tests/test_tester.py
@@ -178,6 +178,9 @@ class ClusterTesterForTests(ClusterTester):
         time.sleep(0.5)
         super().stop_event_device()
 
+    def save_nodes_schema(self):
+        pass
+
 
 class SubtestAndTeardownFailsTest(ClusterTesterForTests):
     def test(self):


### PR DESCRIPTION
Collect `schema` and `system_schema.tables` info and save it on the runner. Add the new logs to the node logs archive.

Task: https://github.com/scylladb/qa-tasks/issues/1813

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [one network interface, 2 user keyspaces](https://argus.scylladb.com/tests/scylla-cluster-tests/ca364d5a-8eb5-4b51-a17a-4d49672a000a)
- [x] [two network interfaces](https://argus.scylladb.com/tests/scylla-cluster-tests/ea63a965-db70-4687-9264-711439bd2a37)
- [x] [gce](https://argus.scylladb.com/tests/scylla-cluster-tests/9ace342a-50af-48c2-8987-17e8a7fda145)
- [x] [artifacts-azure-image-test](https://argus.scylladb.com/tests/scylla-cluster-tests/0672b5aa-cbd9-45c8-a81e-b5160cb4a8df)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
