### PR TITLE
fix(docker-backend): do not start scylla-manager installation

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2349,6 +2349,8 @@ class SCTConfiguration(dict):
         if backend in ('aws', 'gce') and db_type != 'cloud_scylla' and (
                 self.get('simulated_regions') or 0) < 2:
             self._check_multi_region_params(backend)
+        if backend == 'docker':
+            self._validate_docker_backend_parameters()
 
         self._verify_data_volume_configuration(backend)
 
@@ -2795,6 +2797,10 @@ class SCTConfiguration(dict):
                         raise ValueError(f"Scylla-bench command {cmd} doesn't have parameter -mode")
                     if "-workload=" not in cmd:
                         raise ValueError(f"Scylla-bench command {cmd} doesn't have parameter -workload")
+
+    def _validate_docker_backend_parameters(self):
+        if self.get("use_mgmt"):
+            raise ValueError(f"Scylla Manager is not supported for docker backend")
 
 
 def init_and_verify_sct_config() -> SCTConfiguration:

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -95,6 +95,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
     def test_05_docker(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'docker'
+        os.environ['SCT_USE_MGMT'] = 'false'
         os.environ['SCT_SCYLLA_VERSION'] = '3.0.3'
 
         conf = sct_config.SCTConfiguration()
@@ -104,6 +105,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
     def test_06a_docker_latest_no_loader(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'docker'
+        os.environ['SCT_USE_MGMT'] = 'false'
         os.environ['SCT_SCYLLA_VERSION'] = 'latest'
         os.environ['SCT_N_LOADERS'] = "0"
         docker_tag_after_processing = "fake_specific_docker_tag"
@@ -118,6 +120,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
     def test_06b_docker_development(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'docker'
+        os.environ['SCT_USE_MGMT'] = 'false'
         os.environ['SCT_SCYLLA_VERSION'] = '666.development-blah'
         os.environ['SCT_SCYLLA_REPO_LOADER'] = RPM_URL
 
@@ -884,6 +887,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
     @pytest.mark.integration
     def test_31_check_network_config_docker(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'docker'
+        os.environ['SCT_USE_MGMT'] = 'false'
         os.environ['SCT_SCYLLA_VERSION'] = get_latest_scylla_release(product='scylla')
 
         conf = sct_config.SCTConfiguration()

--- a/unit_tests/test_config_get_version_based_on_conf.py
+++ b/unit_tests/test_config_get_version_based_on_conf.py
@@ -58,6 +58,7 @@ def function_setup():
                          )
 def test_docker(scylla_version, expected_docker_image, expected_outcome):
     os.environ['SCT_CLUSTER_BACKEND'] = 'docker'
+    os.environ['SCT_USE_MGMT'] = 'false'
     os.environ['SCT_SCYLLA_VERSION'] = scylla_version
 
     conf = sct_config.SCTConfiguration()


### PR DESCRIPTION
If scylla-manager is not disabled in a test config when running a test on docker backend, the test will try to install the manager and eventually fail (this is due to the fact that SCT installs scylla-manager server on monitor node and docker backend doesn't support dedicated monitoring node docker instance).

The change adds a check for this situation, to be able to fail fast and do not continue with manager installation on docker backend.

Closes: https://github.com/scylladb/scylla-cluster-tests/issues/9028

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [pr-provision-test-docker with enabled use_mgmt setting (fails during sct_config preparation, as expected)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/sct-pr-provision-test/133/)
- [x] :green_circle: [pr-provision-test-docker with disabled use_mgmt setting](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/sct-pr-provision-test/134/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
