### PR TITLE
fix(gce-backend): replace GCP instance types n1 with n2

### DIFF
--- a/configurations/nemesis/longevity-5gb-1h-nemesis.yaml
+++ b/configurations/nemesis/longevity-5gb-1h-nemesis.yaml
@@ -16,7 +16,7 @@ n_monitor_nodes: 1
 seeds_num: 3
 
 instance_type_db: 'i4i.large'
-gce_instance_type_db: 'n1-highmem-2'
+gce_instance_type_db: 'n2-highmem-2'
 gce_instance_type_loader: 'e2-standard-2'
 azure_instance_type_db: 'Standard_L8s_v3'
 instance_type_loader: 'c5.large'

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -18,7 +18,7 @@ gce_root_disk_type_monitor: 'pd-standard'
 root_disk_size_monitor: 50
 gce_n_local_ssd_disk_monitor: 0
 
-gce_instance_type_db: 'n1-highmem-8'
+gce_instance_type_db: 'n2-highmem-8'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 3

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -6,7 +6,7 @@ gce_network: 'qa-vpc'
 gke_cluster_version: '1.27'
 gke_k8s_release_channel: ''
 
-gce_instance_type_db: 'n1-standard-8'
+gce_instance_type_db: 'n2-standard-8'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 3
@@ -16,7 +16,7 @@ k8s_n_scylla_pods_per_cluster: 3
 k8s_n_monitor_nodes: 0
 k8s_n_auxiliary_nodes: 2
 
-k8s_instance_type_auxiliary: 'n1-standard-2'
+k8s_instance_type_auxiliary: 'n2-standard-2'
 
 scylla_version: '5.2.11'
 

--- a/internal_test_data/complex_test_case_with_version.yaml
+++ b/internal_test_data/complex_test_case_with_version.yaml
@@ -27,14 +27,14 @@ gce_network: 'qa-vpc'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
 gce_datacenter: 'us-east1-b'
 gce_image_username: 'scylla-test'
-gce_instance_type_db: 'n1-highmem-16'
+gce_instance_type_db: 'n2-highmem-16'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 2
-gce_instance_type_loader: 'n1-standard-4'
+gce_instance_type_loader: 'n2-standard-4'
 gce_root_disk_type_loader: 'pd-standard'
 gce_n_local_ssd_disk_loader: 0
-gce_instance_type_monitor: 'n1-standard-2'
+gce_instance_type_monitor: 'n2-standard-2'
 gce_root_disk_type_monitor: 'pd-standard'
 root_disk_size_monitor: 50
 gce_n_local_ssd_disk_monitor: 0

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -249,7 +249,7 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
     _gce_service: compute_v1.InstancesClient
 
     def __init__(self, gce_image, gce_image_type, gce_image_size, gce_network, gce_service, credentials,  # pylint: disable=too-many-arguments  # noqa: PLR0913
-                 cluster_uuid=None, gce_instance_type='n1-standard-1', gce_region_names=None,
+                 cluster_uuid=None, gce_instance_type='n2-standard-1', gce_region_names=None,
                  gce_n_local_ssd=1, gce_image_username='root', cluster_prefix='cluster',
                  node_prefix='node', n_nodes=3, add_disks=None, params=None, node_type=None,
                  service_accounts=None, add_nodes=True):
@@ -538,7 +538,7 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
 class ScyllaGCECluster(cluster.BaseScyllaCluster, GCECluster):
 
     def __init__(self, gce_image, gce_image_type, gce_image_size, gce_network, gce_service, credentials,  # pylint: disable=too-many-arguments  # noqa: PLR0913
-                 gce_instance_type='n1-standard-1', gce_n_local_ssd=1,
+                 gce_instance_type='n2-standard-1', gce_n_local_ssd=1,
                  gce_image_username='centos',
                  user_prefix=None, n_nodes=3, add_disks=None, params=None, gce_datacenter=None, service_accounts=None):
         # pylint: disable=too-many-locals
@@ -577,7 +577,7 @@ class ScyllaGCECluster(cluster.BaseScyllaCluster, GCECluster):
 class LoaderSetGCE(cluster.BaseLoaderSet, GCECluster):
 
     def __init__(self, gce_image, gce_image_type, gce_image_size, gce_network, gce_service, credentials,  # pylint: disable=too-many-arguments  # noqa: PLR0913
-                 gce_instance_type='n1-standard-1', gce_n_local_ssd=1,
+                 gce_instance_type='n2-standard-1', gce_n_local_ssd=1,
                  gce_image_username='centos',
                  user_prefix=None, n_nodes=10, add_disks=None, params=None, gce_datacenter=None):
         # pylint: disable=too-many-locals
@@ -608,7 +608,7 @@ class LoaderSetGCE(cluster.BaseLoaderSet, GCECluster):
 class MonitorSetGCE(cluster.BaseMonitorSet, GCECluster):
 
     def __init__(self, gce_image, gce_image_type, gce_image_size, gce_network, gce_service, credentials,  # pylint: disable=too-many-arguments  # noqa: PLR0913
-                 gce_instance_type='n1-standard-1', gce_n_local_ssd=1,
+                 gce_instance_type='n2-standard-1', gce_n_local_ssd=1,
                  gce_image_username='centos', user_prefix=None, n_nodes=1,
                  targets=None, add_disks=None, params=None, gce_datacenter=None,
                  add_nodes=True, monitor_id=None):

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -274,7 +274,7 @@ class GkeCluster(KubernetesCluster):
                  gce_disk_type,
                  gce_network,
                  gce_service: tuple[compute_v1.InstancesClient, dict],
-                 gce_instance_type='n1-standard-2',
+                 gce_instance_type='n2-standard-2',
                  user_prefix=None,
                  params=None,
                  gce_datacenter=None,

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -448,7 +448,7 @@ def create_instance(  # pylint: disable=too-many-arguments,too-many-locals,too-m
     zone: str,
     instance_name: str,
     disks: List[compute_v1.AttachedDisk],
-    machine_type: str = "n1-standard-1",
+    machine_type: str = "n2-standard-1",
     network_name: str = None,
     subnetwork_link: str = None,
     internal_ip: str = None,

--- a/templates/test_config/template-longevity-5gb-1h-base.yaml.j2
+++ b/templates/test_config/template-longevity-5gb-1h-base.yaml.j2
@@ -16,7 +16,7 @@ n_monitor_nodes: 1
 seeds_num: 3
 
 instance_type_db: 'i4i.large'
-gce_instance_type_db: 'n1-highmem-2'
+gce_instance_type_db: 'n2-highmem-2'
 gce_instance_type_loader: 'e2-standard-2'
 azure_instance_type_db: 'Standard_L8s_v3'
 instance_type_loader: 'c6i.large'

--- a/test-cases/artifacts/centos7.yaml
+++ b/test-cases/artifacts/centos7.yaml
@@ -1,7 +1,7 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
-gce_instance_type_db: 'n1-standard-2'
+gce_instance_type_db: 'n2-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1

--- a/test-cases/artifacts/centos9-selinux.yaml
+++ b/test-cases/artifacts/centos9-selinux.yaml
@@ -1,7 +1,7 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-9'
-gce_instance_type_db: 'n1-standard-2'
+gce_instance_type_db: 'n2-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1

--- a/test-cases/artifacts/centos9.yaml
+++ b/test-cases/artifacts/centos9.yaml
@@ -1,7 +1,7 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-9'
-gce_instance_type_db: 'n1-standard-2'
+gce_instance_type_db: 'n2-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1

--- a/test-cases/artifacts/debian11.yaml
+++ b/test-cases/artifacts/debian11.yaml
@@ -1,7 +1,7 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-11'
-gce_instance_type_db: 'n1-standard-2'
+gce_instance_type_db: 'n2-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1

--- a/test-cases/artifacts/debian12.yaml
+++ b/test-cases/artifacts/debian12.yaml
@@ -1,7 +1,7 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-12'
-gce_instance_type_db: 'n1-standard-2'
+gce_instance_type_db: 'n2-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1

--- a/test-cases/artifacts/gce-image-persistent-disk.yaml
+++ b/test-cases/artifacts/gce-image-persistent-disk.yaml
@@ -1,6 +1,6 @@
 cluster_backend: 'gce'
 backtrace_decoding: false
-gce_instance_type_db: 'n1-standard-2'
+gce_instance_type_db: 'n2-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 0

--- a/test-cases/artifacts/gce-image.yaml
+++ b/test-cases/artifacts/gce-image.yaml
@@ -1,6 +1,6 @@
 cluster_backend: 'gce'
 backtrace_decoding: false
-gce_instance_type_db: 'n1-standard-2'
+gce_instance_type_db: 'n2-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 16

--- a/test-cases/artifacts/rhel7.yaml
+++ b/test-cases/artifacts/rhel7.yaml
@@ -1,7 +1,7 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/family/rhel-7'
-gce_instance_type_db: 'n1-standard-2'
+gce_instance_type_db: 'n2-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1

--- a/test-cases/artifacts/rhel8.yaml
+++ b/test-cases/artifacts/rhel8.yaml
@@ -1,7 +1,7 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/family/rhel-8'
-gce_instance_type_db: 'n1-standard-2'
+gce_instance_type_db: 'n2-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1

--- a/test-cases/artifacts/rocky8.yaml
+++ b/test-cases/artifacts/rocky8.yaml
@@ -1,7 +1,7 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/rocky-linux-cloud/global/images/family/rocky-linux-8'
-gce_instance_type_db: 'n1-standard-2'
+gce_instance_type_db: 'n2-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1

--- a/test-cases/artifacts/rocky9-selinux.yaml
+++ b/test-cases/artifacts/rocky9-selinux.yaml
@@ -1,7 +1,7 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/rocky-linux-cloud/global/images/family/rocky-linux-9'
-gce_instance_type_db: 'n1-standard-2'
+gce_instance_type_db: 'n2-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1

--- a/test-cases/artifacts/rocky9.yaml
+++ b/test-cases/artifacts/rocky9.yaml
@@ -1,7 +1,7 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/rocky-linux-cloud/global/images/family/rocky-linux-9'
-gce_instance_type_db: 'n1-standard-2'
+gce_instance_type_db: 'n2-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1

--- a/test-cases/artifacts/ubuntu2004.yaml
+++ b/test-cases/artifacts/ubuntu2004.yaml
@@ -1,7 +1,7 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2004-lts'
-gce_instance_type_db: 'n1-standard-2'
+gce_instance_type_db: 'n2-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1

--- a/test-cases/artifacts/ubuntu2204.yaml
+++ b/test-cases/artifacts/ubuntu2204.yaml
@@ -1,7 +1,7 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts'
-gce_instance_type_db: 'n1-standard-2'
+gce_instance_type_db: 'n2-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1

--- a/test-cases/artifacts/ubuntu2404.yaml
+++ b/test-cases/artifacts/ubuntu2404.yaml
@@ -1,7 +1,7 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64'
-gce_instance_type_db: 'n1-standard-2'
+gce_instance_type_db: 'n2-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1

--- a/test-cases/jepsen/jepsen.yaml
+++ b/test-cases/jepsen/jepsen.yaml
@@ -3,8 +3,8 @@ cluster_backend: 'gce'
 gce_image_username: 'sct'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-11'
 gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-11'
-gce_instance_type_db: 'n1-standard-4'
-gce_instance_type_loader: 'n1-highmem-8'
+gce_instance_type_db: 'n2-standard-4'
+gce_instance_type_loader: 'n2-highmem-8'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1

--- a/test-cases/jepsen/jepsen_with_raft.yaml
+++ b/test-cases/jepsen/jepsen_with_raft.yaml
@@ -3,8 +3,8 @@ cluster_backend: 'gce'
 gce_image_username: 'sct'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-11'
 gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-11'
-gce_instance_type_db: 'n1-standard-4'
-gce_instance_type_loader: 'n1-highmem-8'
+gce_instance_type_db: 'n2-standard-4'
+gce_instance_type_loader: 'n2-highmem-8'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1

--- a/test-cases/longevity/longevity-nosqlbench-3h.yaml
+++ b/test-cases/longevity/longevity-nosqlbench-3h.yaml
@@ -9,7 +9,7 @@ n_loaders: 1
 n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
-gce_instance_type_db: 'n1-highmem-16'
+gce_instance_type_db: 'n2-highmem-16'
 gce_instance_type_loader: 'e2-standard-4'
 
 ssh_transport: 'libssh2'

--- a/test-cases/manager/manager-backup-1TB-gce.yaml
+++ b/test-cases/manager/manager-backup-1TB-gce.yaml
@@ -19,7 +19,7 @@ n_db_nodes: 4
 n_loaders: 2
 n_monitor_nodes: 1
 
-gce_instance_type_db: 'n1-highmem-16'
+gce_instance_type_db: 'n2-highmem-16'
 gce_n_local_ssd_disk_db: 8
 gce_instance_type_loader: 'e2-standard-16'
 

--- a/test-cases/nemesis/longevity-5gb-1h-EndOfQuotaNemesis.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-EndOfQuotaNemesis.yaml
@@ -12,7 +12,7 @@ n_monitor_nodes: 1
 seeds_num: 3
 
 instance_type_db: 'i4i.large'
-gce_instance_type_db: 'n1-highmem-2'
+gce_instance_type_db: 'n2-highmem-2'
 gce_instance_type_loader: 'e2-standard-2'
 azure_instance_type_db: 'Standard_L8s_v3'
 instance_type_loader: 'c6i.large'

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-nodetool-flush-and-reshard.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-nodetool-flush-and-reshard.yaml
@@ -16,7 +16,7 @@ n_loaders: 2
 n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
-gce_instance_type_db: 'n1-highmem-16'
+gce_instance_type_db: 'n2-highmem-16'
 
 nemesis_class_name: 'OperatorNodetoolFlushAndReshard'
 nemesis_interval: 5

--- a/test-cases/scylla-operator/longevity-scylla-operator-basic-12h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-basic-12h.yaml
@@ -17,7 +17,7 @@ n_loaders: 2
 n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
-gce_instance_type_db: 'n1-highmem-16'
+gce_instance_type_db: 'n2-highmem-16'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_selector: ['kubernetes']

--- a/test-cases/scylla-operator/longevity-scylla-operator-multidc-12h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-multidc-12h.yaml
@@ -38,7 +38,7 @@ k8s_scylla_disk_gi: 3490
 
 # GKE
 gce_datacenter: 'us-east1 us-west1'
-gce_instance_type_db: 'n1-standard-16'
+gce_instance_type_db: 'n2-standard-16'
 gce_root_disk_type_db: 'pd-ssd'
 gce_n_local_ssd_disk_db: 3
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-multidc-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-multidc-3h.yaml
@@ -38,7 +38,7 @@ k8s_scylla_disk_gi: 1500
 
 # GKE
 gce_datacenter: 'us-east1 us-west1'
-gce_instance_type_db: 'n1-standard-8'
+gce_instance_type_db: 'n2-standard-8'
 gce_root_disk_type_db: 'pd-ssd'
 gce_n_local_ssd_disk_db: 3
 

--- a/test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml
+++ b/test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml
@@ -14,7 +14,7 @@ n_loaders: 2
 n_monitor_nodes: 1
 
 gce_instance_type_db: 'n2-highmem-8'
-gce_instance_type_loader: 'n1-highmem-8'
+gce_instance_type_loader: 'n2-highmem-8'
 gce_n_local_ssd_disk_db: 2
 gce_pd_ssd_disk_size_db: 750
 gce_setup_hybrid_raid: true

--- a/unit_tests/test_data/test_scylla_yaml_builders/jepsen.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/jepsen.yaml
@@ -3,8 +3,8 @@ cluster_backend: 'gce'
 gce_image_username: 'sct'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-10'
 gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-10'
-gce_instance_type_db: 'n1-standard-4'
-gce_instance_type_loader: 'n1-highmem-8'
+gce_instance_type_db: 'n2-standard-4'
+gce_instance_type_loader: 'n2-highmem-8'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1

--- a/unit_tests/test_data/test_scylla_yaml_builders/longevity-10gb-3h.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/longevity-10gb-3h.yaml
@@ -7,7 +7,7 @@ n_loaders: 2
 n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
-gce_instance_type_db: 'n1-highmem-16'
+gce_instance_type_db: 'n2-highmem-16'
 gce_instance_type_loader: 'e2-standard-4'
 
 nemesis_class_name: 'SisyphusMonkey'

--- a/unit_tests/test_data/test_scylla_yaml_builders/manager-backup-1TB-gce.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/manager-backup-1TB-gce.yaml
@@ -19,7 +19,7 @@ n_db_nodes: 4
 n_loaders: 2
 n_monitor_nodes: 1
 
-gce_instance_type_db: 'n1-highmem-16'
+gce_instance_type_db: 'n2-highmem-16'
 gce_n_local_ssd_disk_db: 8
 gce_instance_type_loader: 'e2-standard-16'
 

--- a/unit_tests/test_data/test_scylla_yaml_builders/multi_network_interfaces/longevity-10gb-3h.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/multi_network_interfaces/longevity-10gb-3h.yaml
@@ -7,7 +7,7 @@ n_loaders: 2
 n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
-gce_instance_type_db: 'n1-highmem-16'
+gce_instance_type_db: 'n2-highmem-16'
 gce_instance_type_loader: 'e2-standard-4'
 
 nemesis_class_name: 'SisyphusMonkey'


### PR DESCRIPTION
Closes: https://github.com/scylladb/scylla-cluster-tests/issues/8971

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
couple of tests where n2 instances are used:
- [x] :green_circle: [artifacts-centos9-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-centos9-test/)
- [x] :green_circle: [longevity-5gb-1h-EndOfQuotaNemesis.yaml](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/sct-pr-provision-test/130/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
