### PR TITLE
fix(raft): drop stale log pattern as trigger for interrupting decommission

### DIFF
--- a/sdcm/utils/raft/__init__.py
+++ b/sdcm/utils/raft/__init__.py
@@ -56,7 +56,6 @@ ABORT_DECOMMISSION_LOG_PATTERNS: Iterable[MessagePosition] = [
     MessagePosition("became a group 0 non-voter", LogPosition.END),
     MessagePosition("leaving token ring", LogPosition.END),
     MessagePosition("left token ring", LogPosition.END),
-    MessagePosition("Finished token ring movement", LogPosition.END),
     MessagePosition("raft_topology - decommission: waiting for completion", LogPosition.BEGIN),
     MessagePosition("repair - decommission_with_repair", LogPosition.END)
 ]


### PR DESCRIPTION
Since https://github.com/scylladb/scylladb/commit/36520250623a, scylla does not log "Finished token ring movement". Watching the log for this message would inevitably time out, consequently. Remove this log pattern.

Fixes #9281

The backporting question looks pretty bleak on this one:
- https://github.com/scylladb/scylladb/commit/36520250623a is part of `scylla-5.3.0-rc0` and `scylla-5.4.0` (in other words, even 5.4 *no longer logs* `Finished token ring movement`).
- the log pattern matching this message was first introduced in SCT commit 879fc686c55a, moved around in 607b8ba00a80, duplicated in 9a62d61e0af8, and de-duplicated in 2aa7dc9c5d38. The first of these, commit 879fc686c55a, is part of all the following branches:
  - branch-2023.1
  - branch-2023.1-future
  - branch-2024.1
  - branch-2024.2
  - branch-5.3
  - branch-5.4
  - branch-6.0
  - branch-6.1
  - branch-6.2
  - branch-perf-v15
  - branch-perf-v16

This means that the patch should be backported *minimally* to branch-5.3 through branch-6.2 (because I *presume* those target identically-versioned, released scylla binaries, and those binaries no longer emit the message).

I don't know how the *other* SCT branch names (i.e., those that include a year number, or the word "perf") relate to scylla binary 5.3. Thus, those branches may or may not be backporting targets.