### PR TITLE
fix(nemesis): skip truncate large partition nemesis with zero node

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2109,6 +2109,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         it's used to cover one improvement of compaction.
         The increase frequency of checking abortion is very useful for truncate.
         """
+        if (SkipPerIssues(issues="https://github.com/scylladb/scylladb/issues/20356",
+                          params=self.tester.params)
+                and self.tester.params.get("use_zero_nodes")):
+            raise UnsupportedNemesis("Unsupported nemesis due to scylladb/scylladb#20356")
         ks_name = 'ks_truncate_large_partition'
         table = 'test_table'
         stress_cmd = "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10 " + \

--- a/test-cases/longevity/longevity-multi-dc-rack-aware-with-znode-in-diff_dc.yaml
+++ b/test-cases/longevity/longevity-multi-dc-rack-aware-with-znode-in-diff_dc.yaml
@@ -7,7 +7,7 @@ stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'repl
              "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3,eu-northscylla_node_north=0) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5 -errors retries=50",
              ]
 
-n_db_nodes: '3 3 0'
+n_db_nodes: '4 4 0'
 n_loaders: '1 1'
 n_monitor_nodes: 1
 n_db_zero_token_nodes: '0 1 1'


### PR DESCRIPTION
due to scylladb/scylladb#20356, need to skip nemesis disuprt_truncate_large_partition nemesis, because it use hardcoded scylla-bench command with autoresize rf

Number of nodes in DC increased, this allow to safely
decommission node with tablets feature enabled


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [Job with skipped truncate large partition nemesis](https://argus.scylladb.com/test/bbd702fb-2f87-4b0b-a068-c2c83d74cb77/runs?additionalRuns[]=bee77312-2370-4ea9-9ad7-7733096daa64)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
