### PR TITLE
fix(setup): remove `--retry-all-errors` from manager repo file download

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1815,7 +1815,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         else:
             repo_path = '/etc/apt/sources.list.d/scylla-manager.list'
         self.remoter.sudo(f"curl -o {repo_path} -L {scylla_repo} "
-                          f"--connect-timeout 10 --retry 5 --retry-all-errors --retry-max-time 100", retry=3)
+                          f"--connect-timeout 10 --retry 5 --retry-max-time 100", retry=3)
 
         # Prevent issue https://github.com/scylladb/scylla/issues/9683
         self.remoter.sudo(f"chmod 644 {repo_path}")


### PR DESCRIPTION
since this flag is only supported from curl 7.71.0 and up, we should yet be using it.

The warnings on this flag kind of make it a bit less helpful in our case, cause it can end up with multiple data in the output, and break our the repo definition.

Ref: https://curl.se/docs/manpage.html#--retry-all-errors

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] artifact test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
