### PR TITLE
fix(test_user_batch_custom_time): handle stress command correctly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,6 +109,8 @@ pipeline {
             steps {
                 script {
                     try {
+                        checkoutQaInternal(params)
+
                         sh './docker/env/hydra.sh unit-tests'
                         pullRequestSetResult('success', 'jenkins/unittests', 'All unit tests are passed')
                     } catch(Exception ex) {

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -19,11 +19,13 @@ import string
 import tempfile
 import itertools
 import contextlib
+from typing import List, Dict
 
 import yaml
 from cassandra import AlreadyExists, InvalidRequest
 from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
 
+from sdcm import sct_abs_path
 from sdcm.sct_events.group_common_events import \
     ignore_large_collection_warning, \
     ignore_max_memory_for_unlimited_query_soft_limit
@@ -119,7 +121,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
         if not res:
             InfoEvent("Did not find expected log message warning: {}".format(msg), severity=Severity.ERROR)
 
-    def test_custom_time(self):
+    def test_custom_time(self):  # noqa: PLR0914
         """
         Run cassandra-stress with params defined in data_dir/scylla.yaml
         """
@@ -181,6 +183,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
         if customer_profiles:
             cs_duration = self.params.get('cs_duration')
             for cs_profile in customer_profiles:
+                cs_profile = sct_abs_path(cs_profile)  # noqa: PLW2901
                 assert os.path.exists(cs_profile), 'File not found: {}'.format(cs_profile)
                 self.log.debug('Run stress test with user profile {}, duration {}'.format(cs_profile, cs_duration))
                 profile_dst = os.path.join('/tmp', os.path.basename(cs_profile))
@@ -296,6 +299,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
             duration = int(cs_duration.translate(str.maketrans('', '', string.ascii_letters)))
 
             for cs_profile in customer_profiles:
+                cs_profile = sct_abs_path(cs_profile)  # noqa: PLW2901
                 assert os.path.exists(cs_profile), 'File not found: {}'.format(cs_profile)
                 self.log.debug('Run stress test with user profile {}, duration {}'.format(cs_profile, cs_duration))
 
@@ -332,12 +336,13 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
             # add few stress threads with tables that weren't pre-created
             customer_profiles = self.params.get('cs_user_profiles')
             for cs_profile in customer_profiles:
+                cs_profile = sct_abs_path(cs_profile)  # noqa: PLW2901
                 # for now we'll leave to just one fresh table, to kick schema update
                 num_of_newly_created_tables = 1
                 self._pre_create_templated_user_schema(batch_start=extra_tables_idx,
                                                        batch_end=extra_tables_idx+num_of_newly_created_tables)
                 for i in range(num_of_newly_created_tables):
-                    batch.append(self.create_templated_user_stress_params(extra_tables_idx + i, cs_profile=cs_profile))
+                    batch += self.create_templated_user_stress_params(extra_tables_idx + i, cs_profile=cs_profile)  # noqa: PLW2901
 
             nodes_ips = self.all_node_ips_for_stress_command
             for params in batch:
@@ -426,7 +431,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
         cs_user_profiles = self.params.get('cs_user_profiles')
         # read user-profile
         for profile_file in cs_user_profiles:
-            with open(profile_file, encoding="utf-8") as fobj:
+            with open(sct_abs_path(profile_file), encoding="utf-8") as fobj:
                 profile_yaml = yaml.safe_load(fobj)
             keyspace_definition = profile_yaml['keyspace_definition']
             keyspace_name = profile_yaml['keyspace']
@@ -487,7 +492,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
         })
         return email_data
 
-    def create_templated_user_stress_params(self, idx, cs_profile):  # pylint: disable=invalid-name
+    def create_templated_user_stress_params(self, idx, cs_profile) -> List[Dict]:  # pylint: disable=invalid-name
         # pylint: disable=too-many-locals
         params_list = []
         cs_duration = self.params.get('cs_duration')
@@ -508,7 +513,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
             # example:
             # cassandra-stress user profile={} cl=QUORUM 'ops(insert=1)' duration={} -rate threads=100 -pop 'dist=gauss(0..1M)'
             for cmd in [line.lstrip('#').strip() for line in cont if line.find('cassandra-stress') > 0]:
-                stress_cmd = (cmd.format(profile_dst, cs_duration))
+                stress_cmd = cmd.format(profile_dst, cs_duration)
                 params = {'stress_cmd': stress_cmd, 'profile': profile_dst}
                 self.log.debug('Stress cmd: {}'.format(stress_cmd))
                 params_list.append(params)

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -61,6 +61,13 @@ class DummyDbCluster(BaseCluster, BaseScyllaCluster):  # pylint: disable=abstrac
         self.log = logging.getLogger(__name__)
         self.node_type = "scylla-db"
 
+    def add_nodes(self, count, ec2_user_data='', dc_idx=0, rack=0, enable_auto_bootstrap=False, instance_type=None):
+        for _ in range(count):
+            self.nodes += [self.nodes[-1]]
+
+    def wait_for_init(*_, node_list=None, verbose=False, timeout=None, **__):
+        pass
+
 
 class DummyDbLogReader(DbLogReader):
     def get_scylla_debuginfo_file(self):

--- a/unit_tests/test_longevity.py
+++ b/unit_tests/test_longevity.py
@@ -1,0 +1,39 @@
+from longevity_test import LongevityTest
+from unit_tests.test_utils_common import DummyDbCluster, DummyNode
+from unit_tests.test_cluster import DummyDbCluster
+
+import pytest
+import threading
+from unittest.mock import MagicMock
+
+
+LongevityTest = pytest.mark.skip(reason="we don't need to run those tests")(LongevityTest)
+
+
+@pytest.mark.sct_config(files='test-cases/scale/longevity-5000-tables.yaml')
+def test_test_user_batch_custom_time(params):
+
+    class DummyLongevityTest(LongevityTest):
+        def _init_params(self):
+            self.params = params
+
+        def _pre_create_templated_user_schema(self, *args, **kwargs):
+            pass
+
+        def _run_all_stress_cmds(self, stress_queue, params):
+            for _ in range(len(params['stress_cmd'])):
+                m = MagicMock()
+                m.verify_results.return_value = ('', [])
+                stress_queue.append(m)
+
+    test = DummyLongevityTest()
+    node = DummyNode(name='test_node',
+                     parent_cluster=None,
+                     ssh_login_info=dict(key_file='~/.ssh/scylla-test'))
+    node.parent_cluster = DummyDbCluster([node], params=params)
+    node.parent_cluster.nemesis_termination_event = threading.Event()
+    node.parent_cluster.nemesis = []
+    node.parent_cluster.nemesis_threads = []
+    test.db_cluster = node.parent_cluster
+    test.monitors = MagicMock()
+    test.test_user_batch_custom_time()

--- a/unit_tests/test_utils_common.py
+++ b/unit_tests/test_utils_common.py
@@ -128,6 +128,10 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method
     def _get_public_ip_address(self) -> str:
         return '127.0.0.1'
 
+    @property
+    def cql_address(self):
+        return '127.0.0.1'
+
     def start_task_threads(self) -> None:
         # disable all background threads
         pass


### PR DESCRIPTION
seems like we were running into situations we try to add all nodes ips into stress commands, and it's the test code
```
File ".../longevity_test.py", line 300, in test_user_batch_custom_time
self._run_user_stress_in_batches(batch_size=batch_size,
File ".../longevity_test.py", line 336, in _run_user_stress_in_batches
batch_params['stress_cmd'] += [params['stress_cmd'] + nodes_ips]
TypeError: list indices must be integers or slices, not str
```

in this change remove a parentheses that was causing function to return tuple and not string as expected

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://argus.scylladb.com/tests/scylla-cluster-tests/8d280858-295a-482a-970e-e62bfcfed597

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
