### PR TITLE
fix(upgrade_test): ignore topology change coordinator errors during upgrades

### DIFF
--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -159,8 +159,11 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
 
     def test_search_cdc_invalid_request(self):
         self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'system_cdc_invalid_request.log')
-        with ignore_upgrade_schema_errors():
-            self._read_and_publish_events()
+        with unittest.mock.patch("sdcm.sct_events.group_common_events.TestConfig"):
+            with unittest.mock.patch("sdcm.sct_events.group_common_events.SkipPerIssues") as skip_per_issues:
+                skip_per_issues.return_value = False
+                with ignore_upgrade_schema_errors():
+                    self._read_and_publish_events()
 
         time.sleep(0.1)
         with self.get_events_logger().events_logs_by_severity[Severity.ERROR].open() as events_file:

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -50,8 +50,13 @@ from sdcm.sct_events.database import (
     DatabaseLogEvent,
 )
 from sdcm.sct_events.filters import EventsSeverityChangerFilter
-from sdcm.sct_events.group_common_events import ignore_upgrade_schema_errors, ignore_ycsb_connection_refused, \
-    ignore_abort_requested_errors, decorate_with_context
+from sdcm.sct_events.group_common_events import (
+    decorate_with_context,
+    ignore_abort_requested_errors,
+    ignore_topology_change_coordinator_errors,
+    ignore_upgrade_schema_errors,
+    ignore_ycsb_connection_refused,
+)
 from sdcm.utils import loader_utils
 from sdcm.utils.features import CONSISTENT_TOPOLOGY_CHANGES_FEATURE
 from sdcm.wait import wait_for
@@ -910,7 +915,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         InfoEvent(
             message=f"Step {step} - Upgrade {node.name} from dc {node.dc_idx}").publish()
         InfoEvent(message='Upgrade Node %s begins' % node.name).publish()
-        with ignore_ycsb_connection_refused():
+        with ignore_ycsb_connection_refused(), ignore_topology_change_coordinator_errors():
             self.upgrade_node(node, upgrade_sstables=self.params.get('upgrade_sstables'))
         InfoEvent(message='Upgrade Node %s ended' % node.name).publish()
         node.check_node_health()


### PR DESCRIPTION
The error messages reported in https://github.com/scylladb/scylladb/issues/20754 and https://github.com/scylladb/scylladb/issues/20950 can be ignored till a proper fix is merged, because it's mostly a bad UX.

Need to be reverted when https://github.com/scylladb/scylladb/issues/20754 and https://github.com/scylladb/scylladb/issues/20950 will be fixed.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/evgeniy/job/rolling-upgrade-ami-test/2/ 6.1 -> master (6.3)
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/evgeniy/job/rolling-upgrade-ubuntu20.04-test/5/ 6.1 -> master (6.3)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)

Fixes https://github.com/scylladb/scylla-cluster-tests/issues/9346
