### PR TITLE
fix(docker-artifacts-test): add missing `,` between params

### DIFF
--- a/jenkins-pipelines/oss/artifacts/artifacts-docker.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-docker.jenkinsfile
@@ -8,7 +8,7 @@ artifactsPipeline(
     backend: 'docker',
 
     timeout: [time: 30, unit: 'MINUTES'],
-    post_behavior_db_nodes: 'destroy'
+    post_behavior_db_nodes: 'destroy',
 
     extra_environment_variables: 'SCT_USE_MGMT=false'
 )


### PR DESCRIPTION
In https://github.com/scylladb/scylla-cluster-tests/pull/9353 a new parameter was added, but a missing `,` is failing the pipeline

fixing it

