### PR TITLE
improvement(upgrade-test): upgrade node system early in the test

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -140,6 +140,7 @@ test_upgrade_from_installed_3_1_0: false
 target_upgrade_version: ''
 disable_raft: true
 enable_tablets_on_upgrade: false
+upgrade_node_system: true
 
 stress_cdclog_reader_cmd: "cdc-stressor -stream-query-round-duration 30s"
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -293,6 +293,7 @@
 | **<a href="#user-content-disable_raft" name="disable_raft">disable_raft</a>**  | As for now, raft will be enable by default in all [upgrade] tests, so this flag will allow usto still run [upgrade] test without raft enabled (or disabling raft), so we will have bettercoverage | True | SCT_DISABLE_RAFT
 | **<a href="#user-content-enable_tablets_on_upgrade" name="enable_tablets_on_upgrade">enable_tablets_on_upgrade</a>**  | By default, the tablets feature is disabled. With this parameter, created for the upgrade test,the tablets feature will only be enabled after the upgrade | N/A | SCT_ENABLE_TABLETS_ON_UPGRADE
 | **<a href="#user-content-upgrade_node_packages" name="upgrade_node_packages">upgrade_node_packages</a>**  |  | N/A | SCT_UPGRADE_NODE_PACKAGES
+| **<a href="#user-content-upgrade_node_system" name="upgrade_node_system">upgrade_node_system</a>**  | Upgrade system packages on nodes before upgrading Scylla. Enabled by default | N/A | SCT_UPGRADE_NODE_SYSTEM
 | **<a href="#user-content-test_sst3" name="test_sst3">test_sst3</a>**  |  | N/A | SCT_TEST_SST3
 | **<a href="#user-content-test_upgrade_from_installed_3_1_0" name="test_upgrade_from_installed_3_1_0">test_upgrade_from_installed_3_1_0</a>**  | Enable an option for installed 3.1.0 for work around a scylla issue if it's true | N/A | SCT_TEST_UPGRADE_FROM_INSTALLED_3_1_0
 | **<a href="#user-content-recover_system_tables" name="recover_system_tables">recover_system_tables</a>**  |  | N/A | SCT_RECOVER_SYSTEM_TABLES

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1270,6 +1270,9 @@ class SCTConfiguration(dict):
         dict(name="upgrade_node_packages", env="SCT_UPGRADE_NODE_PACKAGES", type=str,
              help=""),
 
+        dict(name="upgrade_node_system", env="SCT_UPGRADE_NODE_SYSTEM", type=boolean,
+             help="Upgrade system packages on nodes before upgrading Scylla. Enabled by default"),
+
         dict(name="test_sst3", env="SCT_TEST_SST3", type=boolean,
              help=""),
 


### PR DESCRIPTION
During rolling upgrade scenarios the Scylla upgrade cycle starts with the system packages upgrade. The upgrade cycle has to be performed sequentially, a node at a time, but this is not a strict requirement for the step of upgrading system.

The change moves the step of upgrading system packages to the start of the test and parallelizes it across the nodes. This would save up to 65% of time needed for upgrading system on all nodes.
Additionally, a flag is added to the SCT config to indicate whether system upgrade is to be perfomed during rolling upgrade scenarios (enabled by default).

Closes: https://github.com/scylladb/qa-tasks/issues/1773

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [rolling-upgrade-ubuntu22-test with enabled system upgrades on nodes](https://argus.scylladb.com/tests/scylla-cluster-tests/c35b0b8c-2aea-488b-b24d-fac136072b73)
- [x] :green_circle: [rolling-upgrade-ubuntu22-test with disabled system upgrades on nodes](https://argus.scylladb.com/tests/scylla-cluster-tests/c655d3ba-3a89-4c0a-a255-e6f3aaee73a2)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code