### PR TITLE
fix(sstables_upload): skip large sstables upload

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1280,17 +1280,17 @@ class SSTablesCollector(BaseSCTLogCollector):
             s3_link = upload_remote_files_directly_to_s3(
                 node.ssh_login_info, [snapshot_path], s3_bucket=S3Storage.bucket_name,
                 s3_key=f"{self.test_id}/{self.current_run}/corrupted-sstables-{keyspace}-{table_name}.tar.gz",
-                max_size_gb=400, public_read_acl=True)
+                max_size_gb=20, public_read_acl=True)
             if not s3_link:
                 # upload malformed sstable along with several others and schema file
                 malformed_files = node.remoter.run(
                     f"ls {snapshot_path}/{sstable_name.rsplit('-', 1)[0]}*", ignore_status=True).stdout.split()
-                recent_sstables = node.remoter.run(f"ls -t {snapshot_path}/m?-* | head -n900").stdout.split()
+                recent_sstables = node.remoter.run(f"ls -t {snapshot_path}/m?-* | head -n30").stdout.split()
                 s3_link = upload_remote_files_directly_to_s3(
                     node.ssh_login_info, malformed_files + recent_sstables + [f"{snapshot_path}/schema.cql"],
                     s3_bucket=S3Storage.bucket_name,
                     s3_key=f"{self.test_id}/{self.current_run}/corrupted-sstables-{keyspace}-{table_name}.tar.gz",
-                    max_size_gb=400, public_read_acl=True)
+                    max_size_gb=80, public_read_acl=True)
         except Exception as error:  # pylint: disable=broad-except
             LOGGER.exception("failed collecting malformed sstables:\n%s", error, exc_info=error)
             return []


### PR DESCRIPTION
In case of corrupted sstables we try to upload all the sstables with limit of 400gb (uncompressed). This found out to be unpractical for two reasons: 1. takes too long to upload, 2. it fails due exhaustion of pages (10000 max, basicly around 80GB).

Fix is about sending all sstables only when they are smaller than 20GB in total, otherwise fallback to specific sstables only (one from error event + several latest ones).
Added also more logging messages for better debug experience.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9304

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
