### PR TITLE
fix(sct_config): remove special characters from `user_perfix`

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1995,6 +1995,10 @@ class SCTConfiguration(dict):
             prefix_max_len -= 3
         self['user_prefix'] = user_prefix[:prefix_max_len]
 
+        # remove any special characters from user_prefix, since later it will be used as a part of the instance names
+        # and some platfrom don't support special characters in the instance names (docker, AWS and such)
+        self['user_prefix'] = re.sub(r"[^a-zA-Z0-9-]", "-", self['user_prefix'])
+
         # 11) validate that supported instance_provision selected
         if self.get('instance_provision') not in ['spot', 'on_demand', 'spot_fleet', 'spot_low_price']:
             raise ValueError(f"Selected instance_provision type '{self.get('instance_provision')}' is not supported!")


### PR DESCRIPTION
remove any special characters from `user_prefix`, since later it will be used as a part of the instance names and some platform don't support special characters in the instance names (docker, AWS and such)

Fixes: #8919

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://argus.scylladb.com/tests/scylla-cluster-tests/3ee7ed29-13b2-4419-9b03-2aa23ab47e89
- [x] 🟢 https://argus.scylladb.com/tests/scylla-cluster-tests/18e9f1ac-5f7c-4f69-930c-ad6ab3feb484
- [x] 🟢 https://argus.scylladb.com/tests/scylla-cluster-tests/5b17b69c-2bfd-4e43-a132-20ca3df09b99

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
