### PR TITLE
fix(nemesis): new node in add remove dc

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4790,6 +4790,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 status = self.tester.db_cluster.get_nodetool_status()
                 new_dc_list = [dc for dc in list(status.keys()) if dc.endswith("_nemesis_dc")]
                 assert new_dc_list, "new datacenter was not registered"
+                # Mark a new node as "running nemesis" to prevent it be marked as "target node" by parallel nemesis.
+                # This new node should not be unset as running nemesis because the node will be terminated in the end of nemesis
+                # and removed from the list of nodes
+                self.set_current_running_nemesis(new_node)
                 new_dc_name = new_dc_list[0]
                 for keyspace in system_keyspaces + ["keyspace_new_dc"]:
                     strategy = ReplicationStrategy.get(node, keyspace)


### PR DESCRIPTION
The issue is relevant for parallel nemesis tests.
The node that is created by AddRemoveDc nemesis, may be set as target node by another nemesis. But this node is terminated in the end of nemesis. In this case the second (running in parallel) nemesis fails.

Use 'set_current_running_nemesis' on the new node in AddRemoveDC.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/8401

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-100gb-4h](https://argus.scylladb.com/tests/scylla-cluster-tests/4457917a-976a-4e78-834e-cda07f33e699)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
