### PR TITLE
fix(eks.py): use correct signature for method

### DIFF
--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -847,9 +847,9 @@ class MonitorSetEKS(MonitorSetAWS):
         instances = sorted(instances, key=sort_by_index)
         return [ec2.get_instance(instance['InstanceId']) for instance in instances]
 
-    def _create_instances(self, count, ec2_user_data='', dc_idx=0, az_idx=0, instance_type=None):  # pylint: disable=too-many-arguments
+    def _create_instances(self, count, ec2_user_data='', dc_idx=0, az_idx=0, instance_type=None, is_zero_node=False):  # pylint: disable=too-many-arguments
         instances = super()._create_instances(count=count, ec2_user_data=ec2_user_data, dc_idx=dc_idx,
-                                              az_idx=az_idx, instance_type=instance_type)
+                                              az_idx=az_idx, instance_type=instance_type, is_zero_node=is_zero_node)
         for instance in instances:
             self._ec2_services[dc_idx].create_tags(
                 Resources=[instance.id],


### PR DESCRIPTION
MonitorSetEKS inherits  AWSCluster. It overrides the _create_instance method. The signature has been updated to include the previously missing argument, is_zero_node.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [Job with fix](https://jenkins.scylladb.com/job/scylla-staging/job/abykov/job/upgrade-scylla-k8s-eks-test/3/execution/node/127/log/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
