### PR TITLE
fix(add_remove_dc): Lock new added node for other nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4784,8 +4784,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                         self.cluster.decommission(new_node)
             context_manager.push(finalizer)
 
-            with temporary_replication_strategy_setter(node) as replication_strategy_setter:
+            with self.run_nemesis(node_list=self.cluster.data_nodes, nemesis_label=self.current_disruption) as node, \
+                    temporary_replication_strategy_setter(node) as replication_strategy_setter:
                 new_node = self._add_new_node_in_new_dc()
+                self.set_current_disruption(new_node)
                 node_added = True
                 status = self.tester.db_cluster.get_nodetool_status()
                 new_dc_list = [dc for dc in list(status.keys()) if dc.endswith("_nemesis_dc")]


### PR DESCRIPTION
New added node in new dc don't locked by disrupt method and could be used by another nemesis. The new added node is destroyed at the end of nemesis add_remove_dc and could cause failing another nemesis if it runs on that node

Fixes: #8929

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
