### PR TITLE
improvement(syslog-ng): filter audit prints

### DIFF
--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -30,7 +30,13 @@ def configure_syslogng_target_script(hostname: str = "") -> str:
         write_syslog_ng_destination
 
         if ! grep -P "log {{.*destination\\\\(remote_sct\\\\)" /etc/syslog-ng/syslog-ng.conf; then
-            echo "log {{ source($source_name); destination(remote_sct); }};" >> /etc/syslog-ng/syslog-ng.conf
+            echo "
+        filter filter_sct {{
+            # filter audit out
+            not program(\\"^audit\\");
+        }};
+            " >> /etc/syslog-ng/syslog-ng.conf
+            echo "log {{ source($source_name); filter(filter_sct); destination(remote_sct); }};" >> /etc/syslog-ng/syslog-ng.conf
         fi
 
         if [ ! -z "{hostname}" ]; then


### PR DESCRIPTION
since in recent release of scylla audit is enabled by default we are filtering it by default for the time being.

in some nemesis code we are doing lots of separate commands which generate too many audit events, that make our logging system out of sync with the test flow, and generate false positives.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/86/ - [argus](https://argus.scylladb.com/tests/scylla-cluster-tests/4a3083b1-b518-4e45-bd31-e4083f8bba8b)
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/94/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
