### PR TITLE
fix(gce): change default number of disks to 4

### DIFF
--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -21,7 +21,7 @@ gce_n_local_ssd_disk_monitor: 0
 gce_instance_type_db: 'n2-highmem-8'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
-gce_n_local_ssd_disk_db: 3
+gce_n_local_ssd_disk_db: 4
 
 gce_pd_standard_disk_size_db: 0
 gce_pd_ssd_disk_size_db: 0

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -9,7 +9,7 @@ gke_k8s_release_channel: ''
 gce_instance_type_db: 'n2-standard-8'
 gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
-gce_n_local_ssd_disk_db: 3
+gce_n_local_ssd_disk_db: 4
 
 n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3

--- a/test-cases/scylla-operator/longevity-scylla-operator-multidc-12h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-multidc-12h.yaml
@@ -40,6 +40,6 @@ k8s_scylla_disk_gi: 3490
 gce_datacenter: 'us-east1 us-west1'
 gce_instance_type_db: 'n2-standard-16'
 gce_root_disk_type_db: 'pd-ssd'
-gce_n_local_ssd_disk_db: 3
+gce_n_local_ssd_disk_db: 4
 
 # NOTE: for GKE job the 'k8s_scylla_disk_gi' and 'user_prefix' options must be redefined

--- a/test-cases/scylla-operator/longevity-scylla-operator-multidc-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-multidc-3h.yaml
@@ -40,6 +40,6 @@ k8s_scylla_disk_gi: 1500
 gce_datacenter: 'us-east1 us-west1'
 gce_instance_type_db: 'n2-standard-8'
 gce_root_disk_type_db: 'pd-ssd'
-gce_n_local_ssd_disk_db: 3
+gce_n_local_ssd_disk_db: 4
 
 # NOTE: for GKE job the 'k8s_scylla_disk_gi' and 'user_prefix' options must be redefined


### PR DESCRIPTION
since 831116f450065f2d6b8f9d695cd4feadd6821348 changes the default instance type for gce, we need to chaneg the default disk number so we won't run into following error:

```
Number of local SSDs for an instance of type n2-highmem-8 should be one of
[0, 1, 2, 4, 8, 16, 24], while [3] is requested.
```

Ref: https://github.com/scylladb/scylla-cluster-tests/pull/9332

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://argus.scylladb.com/tests/scylla-cluster-tests/a17e5ddf-c3c2-4f89-96e0-9acaf5b3e5d8

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
