### PR TITLE
fix(devops-cloud-resources-report): use correct scaling group

### DIFF
--- a/jenkins-pipelines/qa/devops-cloud-resources-report.xml
+++ b/jenkins-pipelines/qa/devops-cloud-resources-report.xml
@@ -19,7 +19,7 @@
     <submoduleCfg class="empty-list"/>
     <extensions/>
   </scm>
-  <assignedNode>aws-sct-builders-eu-west-1-v2-asg || aws-sct-builders-us-east-1-v2-asg</assignedNode>
+  <assignedNode>aws-sct-builders-eu-west-1-v3-asg || aws-sct-builders-us-east-1-v3-asg</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>


### PR DESCRIPTION
this report stopped working at Nov 24, cause it was using the v2 scaling group, that was missing java 21 to work with the new version of Jenkins server.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
