### PR TITLE
fix(unit-tests): stop argus heartbeat thread

### DIFF
--- a/unit_tests/test_longevity.py
+++ b/unit_tests/test_longevity.py
@@ -17,6 +17,12 @@ def test_test_user_batch_custom_time(params):
         def _init_params(self):
             self.params = params
 
+        def start_argus_heartbeat_thread(self):
+            # prevent from heartbeat thread to start
+            # because it can be left running after the test
+            # and break other tests
+            return threading.Event()
+
         def _pre_create_templated_user_schema(self, *args, **kwargs):
             pass
 

--- a/unit_tests/test_tester.py
+++ b/unit_tests/test_tester.py
@@ -17,6 +17,7 @@ import logging
 import tempfile
 import time
 import unittest.mock
+import threading
 from time import sleep
 from unittest.mock import MagicMock
 
@@ -96,6 +97,12 @@ class ClusterTesterForTests(ClusterTester):
 
     def argus_collect_manager_version(self):
         pass
+
+    def start_argus_heartbeat_thread(self):
+        # prevent from heartbeat thread to start
+        # because it can be left running after the test
+        # and break other tests
+        return threading.Event()
 
     def tearDown(self):
         self.monitors = MagicMock()

--- a/unit_tests/test_utils_common.py
+++ b/unit_tests/test_utils_common.py
@@ -111,6 +111,9 @@ class DummyDbCluster(BaseCluster, BaseScyllaCluster):  # pylint: disable=abstrac
         self.log = logging.getLogger(__name__)
         self.node_type = "scylla-db"
 
+    def start_nemesis(self):
+        pass
+
 
 class DummyNode(BaseNode):  # pylint: disable=abstract-method
     _system_log = None


### PR DESCRIPTION
new introduced test was leaving the argus heartbeat thread running, casuing `test_sct_events_grafana.py::TestGrafana::test_grafana` to fail catching the POST request from the heartbeat, that it didn't expect.

and failing like the following:
```python
 set_grafana_url("http://localhost", _registry=self.events_processes_registry)
 with unittest.mock.patch("requests.post") as mock:
     for runs in range(1, 4):
         with self.wait_for_n_events(grafana_annotator, count=10, timeout=1):
             for _ in range(10):
                 self.events_main_device.publish_event(
                     ClusterHealthValidatorEvent.NodeStatus(severity=Severity.NORMAL))
         time.sleep(1)
               self.assertEqual(mock.call_count, 0)

AssertionError: 1 != 0
unit_tests/test_sct_events_grafana.py:82: AssertionError
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] unittest would run in CI

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
