### PR TITLE
test_default.yaml: Add missing default latte parameter

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -265,3 +265,5 @@ skip_test_stages: {}
 n_db_zero_token_nodes: 0
 zero_token_instance_type_db: 'i4i.large'
 use_zero_nodes: false
+
+latte_schema_parameters: {}


### PR DESCRIPTION
Recent latte feature implementation missed adding a default parameter, namely:
    latte_schema_parameters: {}

causing SCT tests fail with the following error message:
    File "/home/ubuntu/scylla-cluster-tests/sdcm/stress/latte_thread.py", line 142, in build_stress_cmd
    if latte_schema_parameters := self.params['latte_schema_parameters']:
    KeyError: 'latte_schema_parameters'

The patch adds the missing parameter to defaults/test_default.yaml

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
