### PR TITLE
fix(logcollector): silent errors from saving of schema details

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2958,6 +2958,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         self.destroy_credentials()
 
+    @silence(name='Save node schema')
     def save_nodes_schema(self):
         if self.db_cluster is None:
             self.log.info("No nodes found in the Scylla cluster")


### PR DESCRIPTION
Silent collection schema details failure.
Now it fails in the K8S test. Need be fixed later

Collection schema is presented by https://github.com/scylladb/scylla-cluster-tests/pull/9329

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
