### PR TITLE
fix(pipelines): call docker login on all pipelines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,6 +92,7 @@ pipeline {
             }
             steps {
                 script {
+                    dockerLogin(params)
                     try {
                         sh './docker/env/hydra.sh pre-commit'
                         // also check the commit-messge for the rules we want
@@ -172,6 +173,8 @@ pipeline {
                             dir('scylla-cluster-tests') {
                                 checkout scm
 
+                                dockerLogin(params)
+
                                 wrap([$class: 'BuildUser']) {
                                     echo "calling createSctRunner"
                                     timeout(time: 5, unit: 'MINUTES') {
@@ -225,6 +228,7 @@ pipeline {
                                         dir(working_dir) {
                                             checkout scm
                                         }
+                                        dockerLogin(params)
                                         if (sct_runner_backends.contains(backend)){
                                             try {
                                                 wrap([$class: 'BuildUser']) {

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -136,6 +136,7 @@ def call(Map pipelineParams) {
                                                     checkout scm
                                                 }
                                             }
+                                            dockerLogin(params)
                                         }
                                         stage('Create Argus Test Run') {
                                             catchError(stageResult: 'FAILURE') {

--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -134,6 +134,7 @@ def call() {
 
                       checkoutQaInternal(params)
                   }
+                  dockerLogin(params)
                }
             }
             stage('Create SCT Runner') {

--- a/vars/dockerLogin.groovy
+++ b/vars/dockerLogin.groovy
@@ -1,0 +1,10 @@
+#!groovy
+
+def call(Map params = [:]) {
+    withCredentials([
+			string(credentialsId: 'docker-hub-jenkins-user', variable: 'DOCKER_USERNAME'),
+			string(credentialsId: 'docker-hub-api-key', variable: 'DOCKER_PASSWORD')
+		]) {
+	        sh 'docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD'
+    }
+}

--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -114,6 +114,7 @@ def call(Map pipelineParams) {
                             checkoutQaInternal(params)
                         }
                     }
+                    dockerLogin(params)
                 }
             }
             stage('Create Argus Test Run') {

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -215,6 +215,7 @@ def call(Map pipelineParams) {
                             checkoutQaInternal(params)
                         }
                     }
+                    dockerLogin(params)
                 }
             }
             stage('Create Argus Test Run') {

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -197,6 +197,7 @@ def call(Map pipelineParams) {
                         checkout scm
                         checkoutQaInternal(params)
                     }
+                    dockerLogin(params)
                }
             }
             stage('Create Argus Test Run') {

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -175,6 +175,7 @@ def call(Map pipelineParams) {
                                     loadEnvFromString(params.extra_environment_variables)
                                     dir('scylla-cluster-tests') {
                                         checkout scm
+                                        dockerLogin(params)
                                         (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout) = getJobTimeouts(params, builder.region)
                                         base_versions_list = params.base_versions.contains('.') ? params.base_versions.split('\\,') : []
                                         def new_repo = params.new_scylla_repo
@@ -265,6 +266,7 @@ def call(Map pipelineParams) {
                                                             dir('scylla-cluster-tests') {
                                                                 checkout scm
                                                             }
+                                                        dockerLogin(params)
                                                         }
                                                     }
                                                 }

--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -154,6 +154,7 @@ def call(Map pipelineParams) {
                                 wrap([$class: 'BuildUser']) {
                                     dir('scylla-cluster-tests') {
                                         checkout scm
+                                        dockerLogin(params)
                                         (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout) = getJobTimeouts(params, builder.region)
                                     }
                                 }

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -119,6 +119,7 @@ def call(Map pipelineParams) {
                                 wrap([$class: 'BuildUser']) {
                                     dir('scylla-cluster-tests') {
                                         checkout scm
+                                        dockerLogin(params)
                                         (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout) = getJobTimeouts(params, builder.region)
                                     }
                                 }

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -131,6 +131,7 @@ def call(Map pipelineParams) {
                                     dir('scylla-cluster-tests') {
                                         checkout scm
                                         checkoutQaInternal(params)
+                                        dockerLogin(params)
 
                                         ArrayList base_versions_list = params.base_versions.contains('.') ? params.base_versions.split('\\,') : []
                                         supportedVersions = supportedUpgradeFromVersions(
@@ -207,6 +208,7 @@ def call(Map pipelineParams) {
                                                                 checkoutQaInternal(params)
                                                             }
                                                         }
+                                                        dockerLogin(params)
                                                     }
                                                 }
                                             }


### PR DESCRIPTION
we introduce this call on top of the call we having in SCT code so we won't hit the limit while pulling hydra images themselves

Fixes: scylladb/scylla-pkg#4634

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 provision tests
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/88/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ami-test/25/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-amazon2023-test/16/
- [x] 🟢 : https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-ubuntu20.04-test/26/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
