### PR TITLE
fix(gemini-test-nodes): Increase the number of nodes in the test DB from 3 to 4

### DIFF
--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -1,5 +1,5 @@
 test_duration: 780
-n_db_nodes: 3
+n_db_nodes: 4
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 n_monitor_nodes: 1

--- a/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
@@ -1,5 +1,5 @@
 test_duration: 500
-n_db_nodes: 3
+n_db_nodes: 4
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 n_monitor_nodes: 1

--- a/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
@@ -1,5 +1,5 @@
 test_duration: 500
-n_db_nodes: 3
+n_db_nodes: 4
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 n_monitor_nodes: 1

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -1,5 +1,5 @@
 test_duration: 300
-n_db_nodes: 3
+n_db_nodes: 4
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 n_monitor_nodes: 1

--- a/test-cases/gemini/gemini-8h-large-num-columns.yaml
+++ b/test-cases/gemini/gemini-8h-large-num-columns.yaml
@@ -1,5 +1,5 @@
 test_duration: 500
-n_db_nodes: 3
+n_db_nodes: 4
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 n_monitor_nodes: 1


### PR DESCRIPTION
As observed in a couple of new gemini runs [#6](https://argus.scylladb.com/tests/scylla-cluster-tests/f0c504cb-4bf5-47d4-a6bb-f0a102ec7fe4) [#7](https://argus.scylladb.com/tests/scylla-cluster-tests/26276989-e33c-40f1-9e94-788a4d824344) [#4](https://argus.scylladb.com/tests/scylla-cluster-tests/193e537e-e025-4857-86db-2156cd870fc3) [#2](https://argus.scylladb.com/tests/scylla-cluster-tests/41d1290a-1998-4bf4-9d15-4b21ad98cff9) Gemini's failures are caused by not having enough nodes in the test DB when cluster in run with Tablets, and by that we cannot establish quorum. This PR increases the number of nodes in the test DB to 4 in all relevant cases with nemesis.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
