### PR TITLE
fix(pipeline): fail ci on provision error

### DIFF
--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -289,24 +289,22 @@ def call(Map pipelineParams) {
             }
             stage('Provision Resources') {
                 steps {
-                    catchError(stageResult: 'FAILURE') {
-                        script {
-                            wrap([$class: 'BuildUser']) {
-                                dir('scylla-cluster-tests') {
-                                    timeout(time: 30, unit: 'MINUTES') {
-                                        if (params.backend == 'aws' || params.backend == 'azure') {
-                                            provisionResources(params, builder.region)
-                                        } else if (params.backend.contains('docker')) {
-                                            sh """
-                                                echo 'Tests are to be executed on Docker backend in SCT-Runner. No additional resources to be provisioned.'
-                                            """
-                                        } else {
-                                            sh """
-                                                echo 'Skipping because non-AWS/Azure backends are not supported'
-                                            """
-                                        }
-                                        completed_stages['provision_resources'] = true
+                    script {
+                        wrap([$class: 'BuildUser']) {
+                            dir('scylla-cluster-tests') {
+                                timeout(time: 30, unit: 'MINUTES') {
+                                    if (params.backend == 'aws' || params.backend == 'azure') {
+                                        provisionResources(params, builder.region)
+                                    } else if (params.backend.contains('docker')) {
+                                        sh """
+                                            echo 'Tests are to be executed on Docker backend in SCT-Runner. No additional resources to be provisioned.'
+                                        """
+                                    } else {
+                                        sh """
+                                            echo 'Skipping because non-AWS/Azure backends are not supported'
+                                        """
                                     }
+                                    completed_stages['provision_resources'] = true
                                 }
                             }
                         }
@@ -449,6 +447,17 @@ def call(Map pipelineParams) {
                                         timeout(time: resourceCleanupTimeout, unit: 'MINUTES') {
                                             runCleanupResource(params, builder.region)
                                         }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if (!completed_stages['clean_sct_runner']) {
+                        catchError {
+                            script {
+                                wrap([$class: 'BuildUser']) {
+                                    dir('scylla-cluster-tests') {
+                                      cleanSctRunners(params, currentBuild)
                                     }
                                 }
                             }

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -281,23 +281,21 @@ def call(Map pipelineParams) {
                                         }
 
                                         stage("Provision Resources for ${sub_test}") {
-                                                catchError(stageResult: 'FAILURE') {
-                                                    script {
-                                                        wrap([$class: 'BuildUser']) {
-                                                            dir('scylla-cluster-tests') {
-                                                                timeout(time: 30, unit: 'MINUTES') {
-                                                                    if (params.backend == 'aws' || params.backend == 'azure') {
-                                                                        provisionResources(new_params, builder.region)
-                                                                    } else {
-                                                                        sh """
-                                                                            echo 'Skipping because non-AWS/Azure backends are not supported'
-                                                                        """
-                                                                    }
-                                                                }
+                                            script {
+                                                wrap([$class: 'BuildUser']) {
+                                                    dir('scylla-cluster-tests') {
+                                                        timeout(time: 30, unit: 'MINUTES') {
+                                                            if (params.backend == 'aws' || params.backend == 'azure') {
+                                                                provisionResources(new_params, builder.region)
+                                                            } else {
+                                                                sh """
+                                                                    echo 'Skipping because non-AWS/Azure backends are not supported'
+                                                                """
                                                             }
                                                         }
                                                     }
                                                 }
+                                            }
                                         }
 
                                         stage("Run ${sub_test}"){


### PR DESCRIPTION
When provision step fails there's usually no point in progressing to another step as it probably also fail.

fix by stopping catching errors in provision step.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9083

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - :ok: [longevity failure](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/longevity-5gb-1h-MajorCompactionMonkey-aws-test/16/)
- [x] - :ok: [perf failure](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/mini-elasticity-test/5/)
- [x] - :ok: [longevity pass](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/longevity-5gb-1h-MajorCompactionMonkey-aws-test/17/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
