### PR TITLE
fix(nemesis): ignore networkd coredumps during BlockNetwork nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -94,7 +94,7 @@ from sdcm.sct_events.group_common_events import (
 from sdcm.sct_events.health import DataValidatorEvent
 from sdcm.sct_events.loaders import CassandraStressLogEvent, ScyllaBenchEvent
 from sdcm.sct_events.nemesis import DisruptionEvent
-from sdcm.sct_events.system import InfoEvent
+from sdcm.sct_events.system import InfoEvent, CoreDumpEvent
 from sdcm.sla.sla_tests import SlaTests
 from sdcm.utils.aws_kms import AwsKms
 from sdcm.utils import cdc
@@ -131,7 +131,8 @@ from sdcm.utils.sstable.load_utils import SstableLoadUtils
 from sdcm.utils.sstable.sstable_utils import SstableUtils
 from sdcm.utils.tablets.common import wait_for_tablets_balanced
 from sdcm.utils.toppartition_util import NewApiTopPartitionCmd, OldApiTopPartitionCmd
-from sdcm.utils.version_utils import MethodVersionNotFound, scylla_versions, ComparableScyllaVersion
+from sdcm.utils.version_utils import (
+    MethodVersionNotFound, scylla_versions, ComparableScyllaVersion, get_systemd_version)
 from sdcm.utils.raft import Group0MembersNotConsistentWithTokenRingMembersException, TopologyOperations
 from sdcm.utils.raft.common import NodeBootstrapAbortManager, get_topology_coordinator_node
 from sdcm.utils.issues import SkipPerIssues
@@ -3624,16 +3625,26 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if not self.target_node.install_traffic_control():
             raise UnsupportedNemesis("Traffic control package not installed on system")
 
+        systemd_version = get_systemd_version(
+            self.target_node.remoter.run("systemctl --version", ignore_status=True).stdout)
+        if systemd_version < 256:
+            context_manager = EventsSeverityChangerFilter(
+                new_severity=Severity.WARNING, event_class=CoreDumpEvent, regex=r".*executable=.*networkd.*",
+                extra_time_to_expiration=60)
+        else:
+            context_manager = contextlib.nullcontext()
+
         selected_option = "--loss 100%"
         wait_time = random.choice(list_of_timeout_options)
         self.log.debug("BlockNetwork: [%s] for %dsec", selected_option, wait_time)
-        self.target_node.traffic_control(None)
-        try:
-            self.target_node.traffic_control(selected_option)
-            time.sleep(wait_time)
-        finally:
+        with context_manager:
             self.target_node.traffic_control(None)
-            self.cluster.wait_all_nodes_un()
+            try:
+                self.target_node.traffic_control(selected_option)
+                time.sleep(wait_time)
+            finally:
+                self.target_node.traffic_control(None)
+                self.cluster.wait_all_nodes_un()
 
     @target_data_nodes
     def disrupt_remove_node_then_add_node(self):  # pylint: disable=too-many-branches

--- a/sdcm/sct_events/system.py
+++ b/sdcm/sct_events/system.py
@@ -221,7 +221,9 @@ class CoreDumpEvent(InformationalEvent):
                  corefile_url: str,
                  backtrace: str,
                  download_instructions: str,
-                 source_timestamp: Optional[float] = None):
+                 source_timestamp: Optional[float] = None,
+                 executable: Optional[str] = None,
+                 executable_version: Optional[str] = None):
 
         super().__init__(severity=Severity.ERROR)
 
@@ -229,6 +231,8 @@ class CoreDumpEvent(InformationalEvent):
         self.corefile_url = corefile_url
         self.backtrace = backtrace
         self.download_instructions = download_instructions
+        self.executable = executable
+        self.executable_version = executable_version
         if source_timestamp is not None:
             self.source_timestamp = source_timestamp
 
@@ -245,6 +249,11 @@ class CoreDumpEvent(InformationalEvent):
             fmt += "Info about modules can be found in SCT logs by search for 'Coredump Modules info'\n"
         if self.download_instructions:
             fmt += "download_instructions:\n{0.download_instructions}\n"
+        if self.executable:
+            fmt += "executable={0.executable}"
+            if self.executable_version:
+                fmt += " executable_version={0.executable_version}"
+            fmt += "\n"
 
         return fmt
 

--- a/unit_tests/test_data/test_coredump/filebased/fail_upload_test_remoter.json
+++ b/unit_tests/test_data/test_coredump/filebased/fail_upload_test_remoter.json
@@ -234,5 +234,59 @@
       "exited": 0,
       "exit_status": 0
     }
+  ],
+  "sudo coredumpctl list 5711 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661621,\"pid\":609,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/bin/scylla\",\"size\":776650}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "sudo coredumpctl list 41537 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661631,\"pid\":709,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/bin/bsh\",\"size\":776660}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "sudo dpkg -S /usr/bin/scylla" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "scylla-server: /usr/bin/scylla\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "sudo dpkg -S /usr/bin/bsh" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "bash: /usr/bin/bsh\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "dpkg-query --showformat='${Version}' --show scylla-server" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "6.3.0~dev-0.20241208.f744007e1365-1\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "dpkg-query --showformat='${Version}' --show bash" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "5.2.21-2ubuntu4\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
   ]
 }

--- a/unit_tests/test_data/test_coredump/filebased/fail_upload_test_results.json
+++ b/unit_tests/test_data/test_coredump/filebased/fail_upload_test_results.json
@@ -9,7 +9,8 @@
       "download_instructions": "failed to upload core",
       "download_url": "",
       "command_line": "/usr/bin/scylla --log-to-syslog 0 --log-to-stdout 1 --default-log-level info --",
-      "executable": ""
+      "executable": "/usr/bin/scylla",
+      "executable_version": "6.3.0"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -20,7 +21,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/ac7d8023a369-41537-0-0-11-1600150672.core/ac7d8023a369-41537-0-0-11-1600150672.core.gz .\ngunzip ac7d8023a369-41537-0-0-11-1600150672.core.gz",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/ac7d8023a369-41537-0-0-11-1600150672.core/ac7d8023a369-41537-0-0-11-1600150672.core.gz",
       "command_line": "/bin/bash /scylla-housekeeping-service.sh",
-      "executable": ""
+      "executable": "/usr/bin/bsh",
+      "executable_version": "5.2.21"
     }
   ],
   "in_progress": [],
@@ -34,7 +36,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/ac7d8023a369-41537-0-0-11-1600150672.core/ac7d8023a369-41537-0-0-11-1600150672.core.gz .\ngunzip ac7d8023a369-41537-0-0-11-1600150672.core.gz",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/ac7d8023a369-41537-0-0-11-1600150672.core/ac7d8023a369-41537-0-0-11-1600150672.core.gz",
       "command_line": "/bin/bash /scylla-housekeeping-service.sh",
-      "executable": ""
+      "executable": "/usr/bin/bsh",
+      "executable_version": "5.2.21"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -45,7 +48,8 @@
       "download_instructions": "failed to upload core",
       "download_url": "",
       "command_line": "/usr/bin/scylla --log-to-syslog 0 --log-to-stdout 1 --default-log-level info --",
-      "executable": ""
+      "executable": "/usr/bin/scylla",
+      "executable_version": "6.3.0"
     }
   ],
   "uploaded": [
@@ -58,7 +62,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/ac7d8023a369-41537-0-0-11-1600150672.core/ac7d8023a369-41537-0-0-11-1600150672.core.gz .\ngunzip ac7d8023a369-41537-0-0-11-1600150672.core.gz",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/ac7d8023a369-41537-0-0-11-1600150672.core/ac7d8023a369-41537-0-0-11-1600150672.core.gz",
       "command_line": "/bin/bash /scylla-housekeeping-service.sh",
-      "executable": ""
+      "executable": "/usr/bin/bsh",
+      "executable_version": "5.2.21"
     }
   ]
 }

--- a/unit_tests/test_data/test_coredump/filebased/success_test_remoter.json
+++ b/unit_tests/test_data/test_coredump/filebased/success_test_remoter.json
@@ -241,5 +241,59 @@
       "exited": 0,
       "exit_status": 0
     }
+  ],
+  "sudo coredumpctl list 5711 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661621,\"pid\":609,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/bin/scylla\",\"size\":776650}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "sudo coredumpctl list 41537 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661631,\"pid\":709,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/bin/bsh\",\"size\":776660}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "sudo dpkg -S /usr/bin/scylla" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "scylla-server: /usr/bin/scylla\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "sudo dpkg -S /usr/bin/bsh" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "bash: /usr/bin/bsh\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "dpkg-query --showformat='${Version}' --show scylla-server" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "6.3.0~dev-0.20241208.f744007e1365-1\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "dpkg-query --showformat='${Version}' --show bash" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "5.2.21-2ubuntu4\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
   ]
 }

--- a/unit_tests/test_data/test_coredump/filebased/success_test_results.json
+++ b/unit_tests/test_data/test_coredump/filebased/success_test_results.json
@@ -9,7 +9,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/45d8a24d50d3-5711-0-0-6-1600105104.core/45d8a24d50d3-5711-0-0-6-1600105104.core.gz .\ngunzip 45d8a24d50d3-5711-0-0-6-1600105104.core.gz",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/45d8a24d50d3-5711-0-0-6-1600105104.core/45d8a24d50d3-5711-0-0-6-1600105104.core.gz",
       "command_line": "/usr/bin/scylla --log-to-syslog 0 --log-to-stdout 1 --default-log-level info --",
-      "executable": ""
+      "executable": "/usr/bin/scylla",
+      "executable_version": "6.3.0"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -20,7 +21,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/ac7d8023a369-41537-0-0-11-1600150672.core/ac7d8023a369-41537-0-0-11-1600150672.core.gz .\ngunzip ac7d8023a369-41537-0-0-11-1600150672.core.gz",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/ac7d8023a369-41537-0-0-11-1600150672.core/ac7d8023a369-41537-0-0-11-1600150672.core.gz",
       "command_line": "/bin/bash /scylla-housekeeping-service.sh",
-      "executable": ""
+      "executable": "/usr/bin/bsh",
+      "executable_version": "5.2.21"
     }
   ],
   "in_progress": [],
@@ -34,7 +36,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/ac7d8023a369-41537-0-0-11-1600150672.core/ac7d8023a369-41537-0-0-11-1600150672.core.gz .\ngunzip ac7d8023a369-41537-0-0-11-1600150672.core.gz",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/ac7d8023a369-41537-0-0-11-1600150672.core/ac7d8023a369-41537-0-0-11-1600150672.core.gz",
       "command_line": "/bin/bash /scylla-housekeeping-service.sh",
-      "executable": ""
+      "executable": "/usr/bin/bsh",
+      "executable_version": "5.2.21"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -45,7 +48,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/45d8a24d50d3-5711-0-0-6-1600105104.core/45d8a24d50d3-5711-0-0-6-1600105104.core.gz .\ngunzip 45d8a24d50d3-5711-0-0-6-1600105104.core.gz",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/45d8a24d50d3-5711-0-0-6-1600105104.core/45d8a24d50d3-5711-0-0-6-1600105104.core.gz",
       "command_line": "/usr/bin/scylla --log-to-syslog 0 --log-to-stdout 1 --default-log-level info --",
-      "executable": ""
+      "executable": "/usr/bin/scylla",
+      "executable_version": "6.3.0"
     }
   ],
   "uploaded": [
@@ -58,7 +62,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/ac7d8023a369-41537-0-0-11-1600150672.core/ac7d8023a369-41537-0-0-11-1600150672.core.gz .\ngunzip ac7d8023a369-41537-0-0-11-1600150672.core.gz",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/ac7d8023a369-41537-0-0-11-1600150672.core/ac7d8023a369-41537-0-0-11-1600150672.core.gz",
       "command_line": "/bin/bash /scylla-housekeeping-service.sh",
-      "executable": ""
+      "executable": "/usr/bin/bsh",
+      "executable_version": "5.2.21"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -69,7 +74,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/45d8a24d50d3-5711-0-0-6-1600105104.core/45d8a24d50d3-5711-0-0-6-1600105104.core.gz .\ngunzip 45d8a24d50d3-5711-0-0-6-1600105104.core.gz",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/45d8a24d50d3-5711-0-0-6-1600105104.core/45d8a24d50d3-5711-0-0-6-1600105104.core.gz",
       "command_line": "/usr/bin/scylla --log-to-syslog 0 --log-to-stdout 1 --default-log-level info --",
-      "executable": ""
+      "executable": "/usr/bin/scylla",
+      "executable_version": "6.3.0"
     }
   ]
 }

--- a/unit_tests/test_data/test_coredump/systemd/exceptions_limit_not_reached_test_remoter.json
+++ b/unit_tests/test_data/test_coredump/systemd/exceptions_limit_not_reached_test_remoter.json
@@ -139,5 +139,68 @@
       "exited": 0,
       "exit_status": 0
     }
+  ],
+  "sudo coredumpctl list 24393 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661621,\"pid\":609,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/bin/python3.8\",\"size\":776650}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "sudo coredumpctl list 160718 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661621,\"pid\":609,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/bin/python3.8\",\"size\":776650}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "sudo coredumpctl list 307283 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661631,\"pid\":609,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/sbin/sshd\",\"size\":776650}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "rpm -qf /usr/bin/python3.8" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "python38\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "rpm -qf /usr/sbin/sshd" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "openssh-server\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "rpm -q --queryformat '%{VERSION}' openssh-server" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "8.0\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "rpm -q --queryformat '%{VERSION}' python38" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "3.8\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
   ]
 }

--- a/unit_tests/test_data/test_coredump/systemd/exceptions_limit_not_reached_test_results.json
+++ b/unit_tests/test_data/test_coredump/systemd/exceptions_limit_not_reached_test_results.json
@@ -9,7 +9,8 @@
       "download_instructions": "",
       "download_url": "",
       "command_line": "python -m unittest tests.test_multithreading",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -20,7 +21,8 @@
       "download_instructions": "",
       "download_url": "",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -31,7 +33,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000./core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000.lz4 .\nunlz4 core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000./core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000.lz4",
       "command_line": "sshd: dkropachev [net]",
-      "executable": "/usr/sbin/sshd"
+      "executable": "/usr/sbin/sshd",
+      "executable_version": "8.0"
     }
   ],
   "in_progress": [],
@@ -45,7 +48,8 @@
       "download_instructions": "",
       "download_url": "",
       "command_line": "python -m unittest tests.test_multithreading",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -56,7 +60,8 @@
       "download_instructions": "",
       "download_url": "",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -67,7 +72,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000./core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000.lz4 .\nunlz4 core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000./core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000.lz4",
       "command_line": "sshd: dkropachev [net]",
-      "executable": "/usr/sbin/sshd"
+      "executable": "/usr/sbin/sshd",
+      "executable_version": "8.0"
     }
   ],
   "uploaded": [
@@ -80,7 +86,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000./core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000.lz4 .\nunlz4 core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000./core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000.lz4",
       "command_line": "sshd: dkropachev [net]",
-      "executable": "/usr/sbin/sshd"
+      "executable": "/usr/sbin/sshd",
+      "executable_version": "8.0"
     }
   ],
   "exception": null

--- a/unit_tests/test_data/test_coredump/systemd/fail_upload_test_remoter.json
+++ b/unit_tests/test_data/test_coredump/systemd/fail_upload_test_remoter.json
@@ -178,5 +178,86 @@
       "exited": 0,
       "exit_status": 0
     }
+  ],
+  "sudo coredumpctl list 24393 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661621,\"pid\":609,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/bin/python3.8\",\"size\":776650}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "sudo coredumpctl list 160718 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661621,\"pid\":609,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/bin/python3.8\",\"size\":776650}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "sudo coredumpctl list 307283 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661631,\"pid\":609,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/sbin/sshd\",\"size\":776650}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "sudo coredumpctl list 1245911 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661631,\"pid\":609,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/bin/python3.8\",\"size\":776650}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "sudo coredumpctl list 1404017 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661631,\"pid\":609,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/bin/python3.8\",\"size\":776650}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "rpm -qf /usr/bin/python3.8" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "python38\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+    "rpm -qf /usr/sbin/sshd" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "openssh-server\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "rpm -q --queryformat '%{VERSION}' openssh-server" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "8.0\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "rpm -q --queryformat '%{VERSION}' python38" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "3.8\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
   ]
 }

--- a/unit_tests/test_data/test_coredump/systemd/fail_upload_test_results.json
+++ b/unit_tests/test_data/test_coredump/systemd/fail_upload_test_results.json
@@ -9,7 +9,8 @@
       "download_instructions": "",
       "download_url": "",
       "command_line": "python -m unittest tests.test_multithreading",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -20,7 +21,8 @@
       "download_instructions": "",
       "download_url": "",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -31,7 +33,8 @@
       "download_instructions": "failed to upload core",
       "download_url": "",
       "command_line": "sshd: dkropachev [net]",
-      "executable": "/usr/sbin/sshd"
+      "executable": "/usr/sbin/sshd",
+      "executable_version": "8.0"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -42,7 +45,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000.lz4 .\nunlz4 core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000.lz4",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -53,7 +57,8 @@
       "download_instructions": "failed to upload core",
       "download_url": "",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     }
   ],
   "in_progress": [],
@@ -67,7 +72,8 @@
       "download_instructions": "",
       "download_url": "",
       "command_line": "python -m unittest tests.test_multithreading",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -78,7 +84,8 @@
       "download_instructions": "",
       "download_url": "",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -89,7 +96,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000.lz4 .\nunlz4 core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000.lz4",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -100,7 +108,8 @@
       "download_instructions": "failed to upload core",
       "download_url": "",
       "command_line": "sshd: dkropachev [net]",
-      "executable": "/usr/sbin/sshd"
+      "executable": "/usr/sbin/sshd",
+      "executable_version": "8.0"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -111,7 +120,8 @@
       "download_instructions": "failed to upload core",
       "download_url": "",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     }
   ],
   "uploaded": [
@@ -124,7 +134,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000.lz4 .\nunlz4 core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000.lz4",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     }
   ],
   "exception": null

--- a/unit_tests/test_data/test_coredump/systemd/success_test_remoter.json
+++ b/unit_tests/test_data/test_coredump/systemd/success_test_remoter.json
@@ -214,5 +214,95 @@
       "exited": 0,
       "exit_status": 0
     }
+  ],
+  "sudo coredumpctl list 24393 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661621,\"pid\":609,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/bin/python3.8\",\"size\":776650}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "sudo coredumpctl list 160718 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661621,\"pid\":609,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/bin/python3.8\",\"size\":776650}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "sudo coredumpctl list 307283 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661631,\"pid\":609,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/sbin/sshd\",\"size\":776650}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "sudo coredumpctl list 1245911 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661631,\"pid\":609,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/bin/python3.8\",\"size\":776650}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "sudo coredumpctl list 1404017 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661631,\"pid\":609,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/bin/python3.8\",\"size\":776650}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "sudo coredumpctl list 1404018 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661631,\"pid\":609,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/bin/python3.8\",\"size\":776650}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "rpm -qf /usr/bin/python3.8" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "python38\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+    "rpm -qf /usr/sbin/sshd" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "openssh-server\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "rpm -q --queryformat '%{VERSION}' openssh-server" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "8.0\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "rpm -q --queryformat '%{VERSION}' python38" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "3.8\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
   ]
 }

--- a/unit_tests/test_data/test_coredump/systemd/success_test_results.json
+++ b/unit_tests/test_data/test_coredump/systemd/success_test_results.json
@@ -9,7 +9,8 @@
       "download_instructions": "",
       "download_url": "",
       "command_line": "python -m unittest tests.test_multithreading",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -20,7 +21,8 @@
       "download_instructions": "",
       "download_url": "",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -31,7 +33,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000./core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000.lz4 .\nunlz4 core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000./core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000.lz4",
       "command_line": "sshd: dkropachev [net]",
-      "executable": "/usr/sbin/sshd"
+      "executable": "/usr/sbin/sshd",
+      "executable_version": "8.0"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -42,7 +45,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000.lz4 .\nunlz4 core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000.lz4",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -53,7 +57,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000.lz4 .\nunlz4 core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000.lz4",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -64,7 +69,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000.lz4 .\nunlz4 core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000.lz4",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     }
   ],
   "in_progress": [],
@@ -78,7 +84,8 @@
       "download_instructions": "",
       "download_url": "",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -89,7 +96,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000.lz4 .\nunlz4 core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000.lz4",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -100,7 +108,8 @@
       "download_instructions": "",
       "download_url": "",
       "command_line": "python -m unittest tests.test_multithreading",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -111,7 +120,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000./core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000.lz4 .\nunlz4 core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000./core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000.lz4",
       "command_line": "sshd: dkropachev [net]",
-      "executable": "/usr/sbin/sshd"
+      "executable": "/usr/sbin/sshd",
+      "executable_version": "8.0"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -122,7 +132,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000.lz4 .\nunlz4 core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000.lz4",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -133,7 +144,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000.lz4 .\nunlz4 core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000.lz4",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     }
   ],
   "uploaded": [
@@ -146,7 +158,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000.lz4 .\nunlz4 core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1245911.1598259111000000000000.lz4",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -157,7 +170,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000./core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000.lz4 .\nunlz4 core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000./core.sshd.1000.3ee441d8238246e79d2c30f6619ceeac.307283.1598239861000000000000.lz4",
       "command_line": "sshd: dkropachev [net]",
-      "executable": "/usr/sbin/sshd"
+      "executable": "/usr/sbin/sshd",
+      "executable_version": "8.0"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -168,7 +182,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000.lz4 .\nunlz4 core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000.lz4",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -179,7 +194,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000.lz4 .\nunlz4 core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000./core.python.1000.3ee441d8238246e79d2c30f6619ceeac.1404017.1598260030000000000000.lz4",
       "command_line": "/usr/src/scylladb/scylla-cluster-tests/venv/bin/python /snap/pycharm-professional/211/plugins/python/helpers/pycharm/_jb_unittest_runner.py --path /usr/src/scylladb/scylla-cluster-tests/dkropachev/unit_tests/test_remoter.py",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     }
   ],
   "exception": null

--- a/unit_tests/test_data/test_coredump/systemd/success_test_systemd_248_remoter.json
+++ b/unit_tests/test_data/test_coredump/systemd/success_test_systemd_248_remoter.json
@@ -149,5 +149,59 @@
       "exited": 0,
       "exit_status": 0
     }
+  ],
+  "sudo coredumpctl list 24393 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661621,\"pid\":609,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/usr/bin/python3.8\",\"size\":776650}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "sudo coredumpctl list 5348 -q --json=short" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "[{\"time\":1733783727661631,\"pid\":609,\"uid\":998,\"gid\":998,\"sig\":11,\"corefile\":\"present\",\"exe\":\"/opt/scylladb/libexec/scylla\",\"size\":776650}]\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "rpm -qf /usr/bin/python3.8" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "python38\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "rpm -qf /opt/scylladb/libexec/scylla" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "scylla-server\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "rpm -q --queryformat '%{VERSION}' scylla-server" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "6.3.0\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
+  ],
+  "rpm -q --queryformat '%{VERSION}' python38" : [
+    {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "3.8\n",
+      "stderr": "",
+      "exited": 0,
+      "exit_status": 0
+    }
   ]
 }

--- a/unit_tests/test_data/test_coredump/systemd/success_test_systemd_248_results.json
+++ b/unit_tests/test_data/test_coredump/systemd/success_test_systemd_248_results.json
@@ -9,7 +9,8 @@
       "download_instructions": "",
       "download_url": "",
       "command_line": "python -m unittest tests.test_multithreading",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -20,7 +21,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.scylla.112.ff0f302ef93d4366812e6c5bcca67a90.5348.1669637980000000./core.scylla.112.ff0f302ef93d4366812e6c5bcca67a90.5348.1669637980000000.lz4 .\nunlz4 core.scylla.112.ff0f302ef93d4366812e6c5bcca67a90.5348.1669637980000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.scylla.112.ff0f302ef93d4366812e6c5bcca67a90.5348.1669637980000000./core.scylla.112.ff0f302ef93d4366812e6c5bcca67a90.5348.1669637980000000.lz4",
       "command_line": "/usr/bin/scylla --blocked-reactor-notify-ms 25 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1 --smp 5 --log-to-syslog 1 --log-to-stdout 0 --default-log-level info --network-stack posix --io-properties-file=/etc/scylla.d/io_properties.yaml --cpuset 1-7 --lock-memory=1",
-      "executable": "/opt/scylladb/libexec/scylla"
+      "executable": "/opt/scylladb/libexec/scylla",
+      "executable_version": "6.3.0"
     }
   ],
   "in_progress": [],
@@ -34,7 +36,8 @@
       "download_instructions": "",
       "download_url": "",
       "command_line": "python -m unittest tests.test_multithreading",
-      "executable": "/usr/bin/python3.8"
+      "executable": "/usr/bin/python3.8",
+      "executable_version": "3.8"
     },
     {
       "__instance__": "sdcm.coredump.CoreDumpInfo",
@@ -45,7 +48,8 @@
       "download_instructions": "gsutil cp gs://upload.scylladb.com/core.scylla.112.ff0f302ef93d4366812e6c5bcca67a90.5348.1669637980000000./core.scylla.112.ff0f302ef93d4366812e6c5bcca67a90.5348.1669637980000000.lz4 .\nunlz4 core.scylla.112.ff0f302ef93d4366812e6c5bcca67a90.5348.1669637980000000.lz4",
       "download_url": "https://storage.cloud.google.com/upload.scylladb.com/core.scylla.112.ff0f302ef93d4366812e6c5bcca67a90.5348.1669637980000000./core.scylla.112.ff0f302ef93d4366812e6c5bcca67a90.5348.1669637980000000.lz4",
       "command_line": "/usr/bin/scylla --blocked-reactor-notify-ms 25 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1 --smp 5 --log-to-syslog 1 --log-to-stdout 0 --default-log-level info --network-stack posix --io-properties-file=/etc/scylla.d/io_properties.yaml --cpuset 1-7 --lock-memory=1",
-      "executable": "/opt/scylladb/libexec/scylla"
+      "executable": "/opt/scylladb/libexec/scylla",
+      "executable_version": "6.3.0"
     }
   ],
   "exception": null


### PR DESCRIPTION
The change adds reducing of coredump event severity during disrupt_network_block disruption, if coredump was triggered by an error in networkd service of
version 255 or lower (the root cause is decribed in https://github.com/scylladb/scylla-cluster-tests/issues/9135).

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9135

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [longevity-5gb-1h-nemesis.yaml + BlockNetworkMonkey configs](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-5gb-1h-aws-test/15/)
The CoreDumpEvent events severity is reduced during the test:
```
❯ grep 'CoreDumpEvent Severity' -rn -A1 sct-runner-events-8e69a961
sct-runner-events-8e69a961/events.log:728:2024-12-10 09:10:06.374: (CoreDumpEvent Severity.WARNING) period_type=one-time event_id=a53eda06-9288-4679-ba76-61781b5cd728 during_nemesis=NetworkBlock node=Node longevity-5gb-1h-BlockNetworkMonkey-db-node-8e69a961-1 [63.33.152.9 | 10.4.20.40]
sct-runner-events-8e69a961/events.log-729-executable=/usr/lib/systemd/systemd-networkd executable_version=255.4
--
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
