### PR TITLE
fix(raft): retry search topology coordinator

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5311,7 +5311,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.use_nemesis_seed()
         num_of_restarts = random.randint(1, len(self.cluster.nodes))
         self.log.debug("Number of serial restart of topology coordinator: %s", num_of_restarts)
-        election_wait_timeout = random.choice([1, 5, 10, 15])
+        election_wait_timeout = random.choice([5, 10, 15])
         self.log.debug("Wait new topology coordinator election timeout: %s", election_wait_timeout)
         for num_of_restart in range(num_of_restarts):
             with self.run_nemesis(node_list=self.cluster.nodes, nemesis_label="search coordinator") as verification_node:

--- a/sdcm/utils/raft/common.py
+++ b/sdcm/utils/raft/common.py
@@ -19,6 +19,7 @@ from sdcm.utils.raft import get_node_status_from_system_by
 from sdcm.cluster import BaseMonitorSet, NodeSetupFailed, BaseScyllaCluster, BaseNode
 from sdcm.exceptions import RaftTopologyCoordinatorNotFound
 from sdcm.rest.storage_service_client import StorageServiceClient
+from sdcm.utils.decorators import retrying
 
 LOGGER = logging.getLogger(__name__)
 UUID_REGEX = re.compile(r"([0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12})")
@@ -50,6 +51,7 @@ def validate_raft_on_nodes(nodes: list[BaseNode]) -> None:
     LOGGER.debug("Raft is ready!")
 
 
+@retrying(n=3, allowed_exceptions=(RaftTopologyCoordinatorNotFound, ), message="Waiting topology coordinator election ...")
 def get_topology_coordinator_node(node: BaseNode) -> BaseNode:
     active_nodes: list[BaseNode] = node.parent_cluster.get_nodes_up_and_normal(node)
     stm = "select description from system.group0_history where key = 'history' and \


### PR DESCRIPTION
Raft coordinator could be elected later than
1 second as it happened:
https://argus.scylladb.com/tests/scylla-cluster-tests/174c3e71-e15a-454a-a473-9452c86519ab

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [Passsed job](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/longevity-100gb-4h/131)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
