### PR TITLE
fix(performance): not trigger old tests

### DIFF
--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-enterprise-performance-trigger.xml
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-enterprise-performance-trigger.xml
@@ -30,7 +30,7 @@ provision_type=on_demand</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-tablets,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-vnodes,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-tablets,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-shard-aware-1TB,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-throughput-shard-aware-i4i</projects>
+          <projects>../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-tablets,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-vnodes,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-tablets,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>

--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-master-performance-trigger.xml
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-master-performance-trigger.xml
@@ -45,22 +45,6 @@ availability_zone=b</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>perf-regression/scylla-master-perf-regression-latency-shard-aware-1TB,perf-regression/scylla-master-perf-regression-throughput-shard-aware-i4i</projects>
-          <condition>SUCCESS</condition>
-          <triggerWithNoParameters>false</triggerWithNoParameters>
-          <triggerFromChildProjects>false</triggerFromChildProjects>
-        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-          <configs>
-            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-              <properties>scylla_version=master:latest
-aws_region=us-east-1
-region=us-east-1
-provision_type=on_demand
-availability_zone=b</properties>
-              <textParamValueOnNewLine>false</textParamValueOnNewLine>
-            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-          </configs>
           <projects>perf-regression/scylla-master-perf-simple-query-weekly-microbenchmark_arm64,perf-regression/scylla-master-perf-simple-query-weekly-microbenchmark_x86_64</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>


### PR DESCRIPTION
Old tests perf-regression-latency-shard-aware-1TB and perf-regression-throughput-shard-aware-i4i should not be triggered

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
