### PR TITLE
improvement(decorator): not raise error event by silence decorator

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -224,10 +224,11 @@ class silence:  # pylint: disable=invalid-name
     test = None
     name: str = None
 
-    def __init__(self, parent=None, name: str = None, verbose: bool = False):
+    def __init__(self, parent=None, name: str = None, verbose: bool = False, raise_error_event=True):
         self.parent = parent
         self.name = name
         self.verbose = verbose
+        self.raise_error_event = raise_error_event
         self.log = logging.getLogger(self.__class__.__name__)
 
     def __enter__(self):
@@ -259,8 +260,10 @@ class silence:  # pylint: disable=invalid-name
             self._store_test_result(self.parent, exc_val, exc_tb, self.name)
         return True
 
-    @staticmethod
-    def _store_test_result(parent, exc_val, exc_tb, name):
+    def _store_test_result(self, parent, exc_val, exc_tb, name):
+        if not self.raise_error_event:
+            return
+
         TestFrameworkEvent(
             source=parent.__class__.__name__,
             source_method=name,


### PR DESCRIPTION
There are cases when it is not needed to send error event from silence decorator. It just needs to silence the failure and keed its info in the log

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
