### PR TITLE
fix(sstbale dump): select the suitable sstable-dump command everywhere it is used

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -23,7 +23,6 @@ import re
 from functools import wraps, cache
 from typing import List
 import contextlib
-from pathlib import Path
 
 import cassandra
 import tenacity
@@ -38,10 +37,10 @@ from sdcm.sct_events import Severity
 from sdcm.stress_thread import CassandraStressThread
 from sdcm.utils.common import ParallelObject
 from sdcm.utils.decorators import retrying
+from sdcm.utils.sstable.sstable_utils import get_sstable_data_dump_command
 from sdcm.utils.user_profile import get_profile_content
 from sdcm.utils.version_utils import (
     get_node_supported_sstable_versions,
-    ComparableScyllaVersion,
     is_enterprise,
     get_node_enabled_sstable_version
 )
@@ -61,7 +60,6 @@ from sdcm.sct_events.group_common_events import (
 from sdcm.utils import loader_utils
 from sdcm.utils.features import CONSISTENT_TOPOLOGY_CHANGES_FEATURE
 from sdcm.wait import wait_for
-from sdcm.paths import SCYLLA_YAML_PATH
 from sdcm.rest.raft_upgrade_procedure import RaftUpgradeProcedure
 from test_lib.sla import create_sla_auth
 
@@ -806,18 +804,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         first_node = self.db_cluster.nodes[0]
         keyspace = "keyspace_complex"
         table = "user_with_ck"
-        if first_node.is_enterprise:
-            should_use_sstabledump = ComparableScyllaVersion(first_node.scylla_version) < "2023.1.3"
-        else:
-            should_use_sstabledump = ComparableScyllaVersion(first_node.scylla_version) < "5.4.0~rc0"
-        if should_use_sstabledump:
-            dump_cmd = 'sstabledump'
-        else:
-            dump_cmd = (f'SCYLLA_CONF={Path(first_node.add_install_prefix(SCYLLA_YAML_PATH)).parent} '
-                        f'{first_node.add_install_prefix("/usr/bin/scylla")} sstable dump-data '
-                        f'--keyspace {keyspace} '
-                        f'--table {table} '
-                        '--sstables')
+        dump_cmd = get_sstable_data_dump_command(first_node, keyspace, table)
         first_node.remoter.run(
             f'for i in `sudo find /var/lib/scylla/data/{keyspace}/ -type f |grep -v manifest.json |'
             'grep -v snapshots |head -n 1`; do echo $i; '


### PR DESCRIPTION
rewrite a new util function of get_sstable_dump_command() to be used across sct tests.
refs: https://github.com/scylladb/scylla-cluster-tests/pull/6828

refs: https://github.com/scylladb/scylla-cluster-tests/pull/5737#issuecomment-2520369854

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- tombstone gc thread [test](https://argus.scylladb.com/tests/scylla-cluster-tests/1f4ff9fa-bb84-4a99-8a46-ac3db4f6807e)
- [upgrade test](https://argus.scylladb.com/tests/scylla-cluster-tests/23fdaa41-2bbe-4ef2-ae02-cf1ae9ebe698)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
