### PR TITLE
fix(nemesis): move selection out of pool into `_get_target_nodes`

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1184,6 +1184,8 @@ def get_scylla_gce_images_versions(project: str = SCYLLA_GCE_IMAGES_PROJECT, ver
 
 ScyllaProduct = Literal['scylla', 'scylla-enterprise']
 
+SctDbNodesTypes = Literal['all_nodes', 'data_nodes', 'zero_nodes']
+
 
 def get_latest_scylla_ami_release(region: str = 'eu-west-1',
                                   product: ScyllaProduct = 'scylla') -> str:


### PR DESCRIPTION
since decorators can happen multiple times, and much before a nemesis might select a target node, we don't want to hold the any stale information about the db nodes, for example when multiple nemesis are called inside other nemesis.
(in NemesisSequence it can lead to selection of already remove node)

so in the commit we are change to hold just the type of the pool we expect to use, and picking from that pool only on target selection

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
