### PR TITLE
fix(logcollection): save schema info output

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -309,12 +309,6 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         self._node_rack = None
         self._is_zero_token_node = False
 
-    def save_cqlsh_output_in_file(self, cmd: str, log_file: str):
-        self.log.info("Save command '%s' output in the file. Node %s", cmd, self.name)
-        result_tables = self.run_cqlsh(cmd, split=True)
-        for line in result_tables:
-            self.remoter.run(f"echo '{line}' >> {log_file}")
-
     def _is_node_ready_run_scylla_commands(self) -> bool:
         """
         When node is just created and started to configure, during first node initializing, it is impossible to connect to the node yet and

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2961,22 +2961,43 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         self.destroy_credentials()
 
-    @silence(name='Save node schema')
-    def save_nodes_schema(self):
+    @silence(name=f"Save node schema", raise_error_event=False)
+    def save_cqlsh_output_in_file(self, node, cmd: str, log_file: str):
+        self.log.info("Save command '%s' output in the file. Node %s", cmd, node.name)
+
+        log_file_path = Path(self.logdir) / self.db_cluster.logdir / log_file
+        self.log.debug("Schema file path: %s", log_file_path)
+        if not (result := node.run_cqlsh(cmd).stdout):
+            return
+
+        with open(log_file_path, "w", encoding="utf-8") as res_file:
+            res_file.write(result.strip())
+
+    def save_schema(self):
         if self.db_cluster is None:
-            self.log.info("No nodes found in the Scylla cluster")
+            self.log.error("Didn't find the nodes in the cluster for saving the schema.")
+            return
 
         self.log.info("Save nodes user schema in the files")
+        # Collect schema info from one node only. Not need to collect from every node
+        found_live_node = False
         for node in self.db_cluster.nodes:
-            node.save_cqlsh_output_in_file(cmd="desc schema", log_file="schema.log")
-            node.save_cqlsh_output_in_file(cmd="select JSON * from system_schema.tables",
+            if not node._is_node_ready_run_scylla_commands():
+                continue
+            found_live_node = True
+            self.save_cqlsh_output_in_file(node=node, cmd="desc schema", log_file="schema.log")
+            self.save_cqlsh_output_in_file(node=node, cmd="select JSON * from system_schema.tables",
                                            log_file="system_schema_tables.log")
+            break
+
+        if not found_live_node:
+            self.log.error("Didn't find any live node for saving the schema.")
 
     def tearDown(self):
         self.teardown_started = True
         with silence(parent=self, name='Sending test end event'):
             InfoEvent(message="TEST_END").publish()
-        self.save_nodes_schema()
+        self.save_schema()
         self.log.info("Post test validators are starting...")
         for validator_class in teardown_validators_list:
             validator_class(self.params, self).validate()

--- a/unit_tests/test_tester.py
+++ b/unit_tests/test_tester.py
@@ -185,7 +185,7 @@ class ClusterTesterForTests(ClusterTester):
         time.sleep(0.5)
         super().stop_event_device()
 
-    def save_nodes_schema(self):
+    def save_schema(self):
         pass
 
 


### PR DESCRIPTION
This commit brings the few fixes:
1. save schema info on the runner locally and collect it in SCT folder
2. use silence decorator for every run of schema info command. It's to prevent stop info collection on failure
3. collect schema info from one live node

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [1 network interface](https://argus.scylladb.com/tests/scylla-cluster-tests/cd8bf28a-f284-4961-ac08-89f2635460a4)
- [x] [2 network interfaces](https://argus.scylladb.com/tests/scylla-cluster-tests/8612f141-949a-4b61-8da9-8c2ca956e300)
- [x] [gce](https://argus.scylladb.com/tests/scylla-cluster-tests/8b471661-13b7-4616-9944-e92992be1d7e)
- [x] [upgrade-scylla-k8s-gke-test](https://argus.scylladb.com/tests/scylla-cluster-tests/f647ad37-995d-4c47-941b-7236e8701e11)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
