### PR TITLE
fix(ipv6-reboot): ignore Prometheus failures in node init

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -91,6 +91,7 @@ from sdcm.sct_events.group_common_events import (
     ignore_raft_transport_failing,
     decorate_with_context_if_issues_open,
     ignore_take_snapshot_failing,
+    ignore_ipv6_failure_to_assign,
 )
 from sdcm.sct_events.health import DataValidatorEvent
 from sdcm.sct_events.loaders import CassandraStressLogEvent, ScyllaBenchEvent
@@ -3937,6 +3938,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     @decorate_with_context([
         ignore_ycsb_connection_refused,
     ])
+    @decorate_with_context_if_issues_open(
+        ignore_ipv6_failure_to_assign,
+        issue_refs=['https://github.com/scylladb/scylladb/issues/20387'])
     def reboot_node(self, target_node, hard=True, verify_ssh=True):
         target_node.reboot(hard=hard, verify_ssh=verify_ssh)
         if self.tester.params.get('print_kernel_callstack'):

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -474,6 +474,22 @@ def ignore_take_snapshot_failing():
         yield
 
 
+@contextmanager
+def ignore_ipv6_failure_to_assign():
+    with ExitStack() as stack:
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*init - Startup failed:.*Cannot assign requested address",
+            extra_time_to_expiration=60))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*init - Could not start Prometheus API server.*Cannot assign requested address",
+            extra_time_to_expiration=60))
+        yield
+
+
 def decorate_with_context(context_list: list[Callable | ContextManager] | Callable | ContextManager):
     """
     helper to decorate a function to run with a list of callables that return context managers


### PR DESCRIPTION
since this issue was declared P4, we'll gonna ignore it for now, since after one or two retries the node does spin up

Ref: scylladb/scylladb#20387

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢  test with the ipv6 case - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-10gb-3h-ipv6-test/23 - [argus](https://argus.scylladb.com/tests/scylla-cluster-tests/58f62ece-8e5a-4be9-a0f7-59478a0d01c7)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
