### PR TITLE
fix(ami-t3_micro): remove extra disk

### DIFF
--- a/configurations/t3_micro.yaml
+++ b/configurations/t3_micro.yaml
@@ -1,0 +1,2 @@
+instance_type_db: 't3.micro'
+

--- a/configurations/t3_micro_data_volumes.yaml
+++ b/configurations/t3_micro_data_volumes.yaml
@@ -1,3 +1,0 @@
-instance_type_db: 't3.micro'
-data_volume_disk_num: 1  # t3.micro doesn't include any local volumes (outside of root), so an additional disk is required for scylla
-data_volume_disk_size: 50

--- a/jenkins-pipelines/oss/artifacts/artifacts-ami-t3_micro.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-ami-t3_micro.jenkinsfile
@@ -4,7 +4,7 @@
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 artifactsPipeline(
-    test_config: '''["test-cases/artifacts/ami.yaml", "configurations/t3_micro_data_volumes.yaml"]''',
+    test_config: '''["test-cases/artifacts/ami.yaml", "configurations/t3_micro.yaml"]''',
     backend: 'aws',
     provision_type: 'spot_low_price',
 


### PR DESCRIPTION
Following https://github.com/scylladb/siren/issues/12513#issuecomment-2531280261, removing the extra disk that we are attaching to this artifact

