### PR TITLE
fix(sct_config): `str_or_list_or_eval` to better return empty values

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -108,7 +108,7 @@ def str_or_list_or_eval(value: Union[str, List[str]]) -> List[str]:
             return ast.literal_eval(value)
         except Exception:  # pylint: disable=broad-except  # noqa: BLE001
             pass
-        return [str(value), ]
+        return [str(value), ] if str(value) else []
 
     if isinstance(value, list):
         ret_values = []


### PR DESCRIPTION
in case we got empty envirment variable for on of the config option using `str_or_list_or_eval`, we end up with `['']` which maps to True (python truthiness)

in turn it did break azure cleanup logic when `SCT_AZURE_REGION_NAME=` was passed empty, and the cleanup didn't found any resources groups to clean.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
