### PR TITLE
test(hdr logs): use thread instead process

### DIFF
--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -17,6 +17,8 @@ import time
 import uuid
 import logging
 import contextlib
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 from typing import Any
 from itertools import chain
 from pathlib import Path
@@ -76,7 +78,26 @@ class CSHDRFileLogger(SSHLoggerBase):
 
     def __init__(self, node: BaseNode, remote_log_file: str, target_log_file: str):
         super().__init__(node=node, target_log_file=target_log_file)
+        self._child_process = None
         self._remote_log_file = remote_log_file
+        self.target_log_file = target_log_file
+        self._child_thread = ThreadPoolExecutor(max_workers=1)
+        self._thread = None
+
+    def start(self) -> None:
+        LOGGER.debug("Start to read target_log_file: %s", self.target_log_file)
+        self._termination_event.clear()
+        self._thread = self._child_thread.submit(self._journal_thread)
+        LOGGER.debug("Journal thread started for target_log_file: %s", self.target_log_file)
+
+    def stop(self, timeout: float | None = None) -> None:
+        self._termination_event.set()
+        thread_cancelled = self._thread.cancel()
+        LOGGER.debug("Is thread cancelled?: %s, target_log_file: %s", thread_cancelled, self.target_log_file)
+        self._child_thread.shutdown(wait=False, cancel_futures=True)
+        LOGGER.debug("Is thread shutdown?: %s, target_log_file: %s", self._thread.running(), self.target_log_file)
+        if self._thread.running():
+            self._thread.cancel()  # pylint: disable=no-member
 
     @cached_property
     def _logger_cmd_template(self) -> str:
@@ -94,6 +115,8 @@ class CSHDRFileLogger(SSHLoggerBase):
 
         LOGGER.debug("'%s' file is not found on the runner. Try to find it on the loader %s",
                      self._target_log_file, self._node.name)
+        HDRFileMissed(message=f"'{self._remote_log_file}' HDR file was not copied to the runner from loader",
+                      severity=Severity.WARNING).publish()
         result = self._node.remoter.run(f"test -f {self._remote_log_file}", ignore_status=True)
         if not result.ok:
             HDRFileMissed(message=f"'{self._remote_log_file}' HDR file was not created on the loader {self._node.name}",
@@ -104,6 +127,30 @@ class CSHDRFileLogger(SSHLoggerBase):
         except Exception:  # noqa: BLE001
             HDRFileMissed(message=f"'{self._remote_log_file}' HDR file couldn't copied from loader {self._node.name}",
                           severity=Severity.ERROR).publish()
+
+    # @raise_event_on_failure
+    def _journal_thread(self) -> None:
+        LOGGER.debug("Start journal thread. %s", self._remote_log_file)
+        read_from_timestamp = None
+        te_is_set = self._termination_event.is_set()
+        while not te_is_set:
+            LOGGER.debug("Start check if remoter ready. %s", self._remote_log_file)
+            if self._is_ready_to_retrieve():
+                LOGGER.debug("Remoter ready. %s", self._remote_log_file)
+                self._retrieve(since=read_from_timestamp)
+                LOGGER.debug("Retrieve finished. %s", self._remote_log_file)
+                read_from_timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+            else:
+                LOGGER.debug("Remoter is not ready. %s", self._remote_log_file)
+                time.sleep(self.READINESS_CHECK_DELAY)
+            te_is_set = self._termination_event.is_set()
+            LOGGER.debug("_termination_event is set?: %s. %s", te_is_set, self._remote_log_file)
+
+    def _is_ready_to_retrieve(self) -> bool:
+        LOGGER.debug("Before remoter is_up. %s", self._remote_log_file)
+        is_up = self._remoter.is_up()
+        LOGGER.debug("After remoter is_up. Result: %s. %s", is_up, self._remote_log_file)
+        return is_up
 
     def __enter__(self):
         self.start()


### PR DESCRIPTION
Use ThreadPoolExecutor instead of Process in CSHDRFileLogger class.
This change is added due to issue that c-s hdr file is not always
copied from loader to runner. As the root of the problem was not found,
it was decided to use thread.

Add HDRFileMissed warning event when found not copied HDR file.

The issue with not-copied HDR file was not reproduced while testing this commit, but I still keep a few debug log messages for a future.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [mixed test](https://argus.scylladb.com/tests/scylla-cluster-tests/0db3cac1-4f95-455a-8a2a-c05f45898d43)
- [ ] [read test](https://argus.scylladb.com/tests/scylla-cluster-tests/1a7e60a7-fcaa-4490-b2d4-d05ae36adec0)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
