### PR TITLE
fix(nemesis): `disrupt_remove_node_then_add_node` was missing retry=0

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3688,7 +3688,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                           .format(rnd_node.ip_address, host_id))
             with adaptive_timeout(Operations.REMOVE_NODE, rnd_node, timeout=HOUR_IN_SEC * 48):
                 res = rnd_node.run_nodetool("removenode {}".format(
-                    host_id), ignore_status=True, verbose=True, long_running=True)
+                    host_id), ignore_status=True, verbose=True, long_running=True, retry=0)
             if res.failed and re.match(removenode_reject_msg, res.stdout + res.stderr):
                 raise Exception(f"Removenode was rejected {res.stdout}\n{res.stderr}")
 


### PR DESCRIPTION
in ecc2c7e64206a1c4a465873c5c38caa66e2dbde4 `long_running=True` parameter was introduced, but it must come together with `retry=0`, and that was forgotten

Fixes: #9534

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/95/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
