### PR TITLE
fix(sct_config): define SCT_AWS_ACCOUNT_ID in SCTConfiguration

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -390,3 +390,4 @@
 | **<a href="#user-content-use_zero_nodes" name="use_zero_nodes">use_zero_nodes</a>**  | If True, enable support in sct of zero nodes(configuration, nemesis) | N/A | SCT_USE_ZERO_NODES
 | **<a href="#user-content-n_db_zero_token_nodes" name="n_db_zero_token_nodes">n_db_zero_token_nodes</a>**  | Number of zero token nodes in cluster. Value should be set as "0 1 1"<br>for multidc configuration in same manner as 'n_db_nodes' and should be equal<br>number of regions | N/A | SCT_N_DB_ZERO_TOKEN_NODES
 | **<a href="#user-content-zero_token_instance_type_db" name="zero_token_instance_type_db">zero_token_instance_type_db</a>**  | Instance type for zero token node | i4i.large | SCT_ZERO_TOKEN_INSTANCE_TYPE_DB
+| **<a href="#user-content-sct_aws_account_id" name="sct_aws_account_id">sct_aws_account_id</a>**  | AWS account id on behalf of which the test is run | N/A | SCT_AWS_ACCOUNT_ID

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1681,6 +1681,9 @@ class SCTConfiguration(dict):
         dict(name="zero_token_instance_type_db", env="SCT_ZERO_TOKEN_INSTANCE_TYPE_DB", type=str,
              help="""Instance type for zero token node"""),
 
+        dict(name="sct_aws_account_id", env="SCT_AWS_ACCOUNT_ID", type=str,
+             help="AWS account id on behalf of which the test is run"),
+
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',


### PR DESCRIPTION
Environmental variable SCT_AWS_ACCOUNT_ID is used in aws_okta.py:

`account_id = os.environ.get('SCT_AWS_ACCOUNT_ID', '797456418907')`

The fact it's not defined in sct_config.py fails SCT test execution for non-default AWS account, ID of which is passed as env variable:

`ValueError: Unsupported environment variables were used: -
 SCT_AWS_ACCOUNT_ID=400694452550`

The described above case is relevant for SCT tests with the cluster created in Scylla Cloud.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] None

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code