### PR TITLE
feature(sct_config): appendable configuration values

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1,10 +1,18 @@
 # scylla-cluster-tests configuration options
 
+#### Appending with environment variables or with config files
+* **strings:** can be appended with adding `++` at the beginning of the string:
+`export SCT_APPEND_SCYLLA_ARGS="++ --overprovisioned 1"`
+* **list:** can be appended by adding `++` as the first item of the list
+`export SCT_SCYLLA_D_OVERRIDES_FILES='["++", "extra_file/scylla.d/io.conf"]'`
+
 ## **config_files** / SCT_CONFIG_FILES
 
 a list of config files that would be used
 
 **default:** N/A
+
+**type:** str_or_list_or_eval
 
 
 ## **cluster_backend** / SCT_CLUSTER_BACKEND
@@ -13,12 +21,16 @@ backend that will be used, aws/gce/docker
 
 **default:** N/A
 
+**type:** str
+
 
 ## **test_method** / SCT_TEST_METHOD
 
 class.method used to run the test. Filled automatically with run-test sct command.
 
 **default:** N/A
+
+**type:** str
 
 
 ## **test_duration** / SCT_TEST_DURATION
@@ -27,12 +39,16 @@ Test duration (min). Parameter used to keep instances produced by tests<br>and f
 
 **default:** 60
 
+**type:** int
+
 
 ## **prepare_stress_duration** / SCT_PREPARE_STRESS_DURATION
 
 Time in minutes, which is required to run prepare stress commands<br>defined in prepare_*_cmd for dataset generation, and is used in<br>test duration calculation
 
 **default:** 300
+
+**type:** int
 
 
 ## **stress_duration** / SCT_STRESS_DURATION
@@ -41,12 +57,16 @@ Time in minutes, Time of execution for stress commands from stress_cmd parameter
 
 **default:** N/A
 
+**type:** int
+
 
 ## **n_db_nodes** / SCT_N_DB_NODES
 
 Number list of database data nodes in multiple data centers. To use with<br>multi data centers and zero nodes, dc with zero-nodes only should be set as 0,<br>ex. "3 3 0".
 
 **default:** N/A
+
+**type:** int_or_space_separated_ints
 
 
 ## **n_test_oracle_db_nodes** / SCT_N_TEST_ORACLE_DB_NODES
@@ -55,12 +75,16 @@ Number list of oracle test nodes in multiple data centers.
 
 **default:** 1
 
+**type:** int_or_space_separated_ints
+
 
 ## **n_loaders** / SCT_N_LOADERS
 
 Number list of loader nodes in multiple data centers
 
 **default:** N/A
+
+**type:** int_or_space_separated_ints
 
 
 ## **n_monitor_nodes** / SCT_N_MONITORS_NODES
@@ -69,12 +93,16 @@ Number list of monitor nodes in multiple data centers
 
 **default:** N/A
 
+**type:** int_or_space_separated_ints
+
 
 ## **intra_node_comm_public** / SCT_INTRA_NODE_COMM_PUBLIC
 
 If True, all communication between nodes are via public addresses
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **endpoint_snitch** / SCT_ENDPOINT_SNITCH
@@ -83,12 +111,16 @@ The snitch class scylla would use<br><br>'GossipingPropertyFileSnitch' - default
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **user_credentials_path** / SCT_USER_CREDENTIALS_PATH
 
 Path to your user credentials. qa key are downloaded automatically from S3 bucket
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **cloud_credentials_path** / SCT_CLOUD_CREDENTIALS_PATH
@@ -97,12 +129,16 @@ Path to your user credentials. qa key are downloaded automatically from S3 bucke
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **cloud_cluster_id** / SCT_CLOUD_CLUSTER_ID
 
 scylla cloud cluster id
 
 **default:** N/A
+
+**type:** int
 
 
 ## **cloud_prom_bearer_token** / SCT_CLOUD_PROM_BEARER_TOKEN
@@ -111,12 +147,16 @@ scylla cloud promproxy bearer_token to federate monitoring data into our monitor
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **cloud_prom_path** / SCT_CLOUD_PROM_PATH
 
 scylla cloud promproxy path to federate monitoring data into our monitoring instance
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **cloud_prom_host** / SCT_CLOUD_PROM_HOST
@@ -125,12 +165,16 @@ scylla cloud promproxy hostname to federate monitoring data into our monitoring 
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **ip_ssh_connections** / SCT_IP_SSH_CONNECTIONS
 
 Type of IP used to connect to machine instances.<br>This depends on whether you are running your tests from a machine inside<br>your cloud provider, where it makes sense to use 'private', or outside (use 'public')<br><br>Default: Use public IPs to connect to instances (public)<br>Use private IPs to connect to instances (private)<br>Use IPv6 IPs to connect to instances (ipv6)
 
 **default:** private
+
+**type:** str (appendable)
 
 
 ## **scylla_repo** / SCT_SCYLLA_REPO
@@ -139,12 +183,16 @@ Url to the repo of scylla version to install scylla. Can provide specific versio
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **scylla_apt_keys** / SCT_SCYLLA_APT_KEYS
 
 APT keys for ScyllaDB repos
 
 **default:** ['17723034C56D4B19', '5E08FBD8B5D6EC9C', 'D0A112E067426AB2', '491C93B9DE7496A7', 'A43E06657BAC99E3']
+
+**type:** str_or_list (appendable)
 
 
 ## **unified_package** / SCT_UNIFIED_PACKAGE
@@ -153,12 +201,16 @@ Url to the unified package of scylla version to install scylla
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **nonroot_offline_install** / SCT_NONROOT_OFFLINE_INSTALL
 
 Install Scylla without required root priviledge
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **install_mode** / SCT_INSTALL_MODE
@@ -167,12 +219,16 @@ Scylla install mode, repo/offline/web
 
 **default:** repo
 
+**type:** str
+
 
 ## **scylla_version** / SCT_SCYLLA_VERSION
 
 Version of scylla to install, ex. '2.3.1'<br>Automatically lookup AMIs and repo links for formal versions.<br>WARNING: can't be used together with 'scylla_repo' or 'ami_id_db_scylla'
 
 **default:** N/A
+
+**type:** str
 
 
 ## **user_data_format_version** / SCT_USER_DATA_FORMAT_VERSION
@@ -181,12 +237,16 @@ Format version of the user-data to use for scylla images,<br>default to what tag
 
 **default:** N/A
 
+**type:** str
+
 
 ## **oracle_user_data_format_version** / SCT_ORACLE_USER_DATA_FORMAT_VERSION
 
 Format version of the user-data to use for scylla images,<br>default to what tagged on the image used
 
 **default:** N/A
+
+**type:** str
 
 
 ## **oracle_scylla_version** / SCT_ORACLE_SCYLLA_VERSION
@@ -195,12 +255,16 @@ Version of scylla to use as oracle cluster with gemini tests, ex. '3.0.11'<br>Au
 
 **default:** 2022.1.14
 
+**type:** str
+
 
 ## **scylla_linux_distro** / SCT_SCYLLA_LINUX_DISTRO
 
 The distro name and family name to use. Example: 'ubuntu-jammy' or 'debian-bookworm'.
 
 **default:** ubuntu-focal
+
+**type:** str
 
 
 ## **scylla_linux_distro_loader** / SCT_SCYLLA_LINUX_DISTRO_LOADER
@@ -209,12 +273,16 @@ The distro name and family name to use. Example: 'ubuntu-jammy' or 'debian-bookw
 
 **default:** ubuntu-jammy
 
+**type:** str
+
 
 ## **assert_linux_distro_features** / SCT_ASSERT_LINUX_DISTRO_FEATURES
 
 List of distro features relevant to SCT test. Example: 'fips'.
 
 **default:** N/A
+
+**type:** str_or_list_or_eval (appendable)
 
 
 ## **scylla_repo_m** / SCT_SCYLLA_REPO_M
@@ -223,12 +291,16 @@ Url to the repo of scylla version to install scylla from for managment tests
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **scylla_repo_loader** / SCT_SCYLLA_REPO_LOADER
 
 Url to the repo of scylla version to install c-s for loader
 
 **default:** https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-5.2.list
+
+**type:** str (appendable)
 
 
 ## **scylla_mgmt_address** / SCT_SCYLLA_MGMT_ADDRESS
@@ -237,12 +309,16 @@ Url to the repo of scylla manager version to install for management tests
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **scylla_mgmt_agent_address** / SCT_SCYLLA_MGMT_AGENT_ADDRESS
 
 Url to the repo of scylla manager agent version to install for management tests
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **manager_version** / SCT_MANAGER_VERSION
@@ -251,12 +327,16 @@ Branch of scylla manager server and agent to install. Options in defaults/manage
 
 **default:** 3.4
 
+**type:** str
+
 
 ## **target_manager_version** / SCT_TARGET_MANAGER_VERSION
 
 Branch of scylla manager server and agent to upgrade to. Options in defaults/manager_versions.yaml
 
 **default:** N/A
+
+**type:** str
 
 
 ## **manager_scylla_backend_version** / SCT_MANAGER_SCYLLA_BACKEND_VERSION
@@ -265,12 +345,16 @@ Branch of scylla db enterprise to install. Options in defaults/manager_versions.
 
 **default:** 2024
 
+**type:** str
+
 
 ## **scylla_mgmt_agent_version** / SCT_SCYLLA_MGMT_AGENT_VERSION
 
 
 
 **default:** 3.4.0
+
+**type:** str
 
 
 ## **scylla_mgmt_pkg** / SCT_SCYLLA_MGMT_PKG
@@ -279,12 +363,16 @@ Url to the scylla manager packages to install for management tests
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **stress_cmd_lwt_i** / SCT_STRESS_CMD_LWT_I
 
 Stress command for LWT performance test for INSERT baseline
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **stress_cmd_lwt_d** / SCT_STRESS_CMD_LWT_D
@@ -293,12 +381,16 @@ Stress command for LWT performance test for DELETE baseline
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **stress_cmd_lwt_u** / SCT_STRESS_CMD_LWT_U
 
 Stress command for LWT performance test for UPDATE baseline
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **stress_cmd_lwt_ine** / SCT_STRESS_CMD_LWT_INE
@@ -307,12 +399,16 @@ Stress command for LWT performance test for INSERT with IF NOT EXISTS
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **stress_cmd_lwt_uc** / SCT_STRESS_CMD_LWT_UC
 
 Stress command for LWT performance test for UPDATE with IF <condition>
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **stress_cmd_lwt_ue** / SCT_STRESS_CMD_LWT_UE
@@ -321,12 +417,16 @@ Stress command for LWT performance test for UPDATE with IF EXISTS
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **stress_cmd_lwt_de** / SCT_STRESS_CMD_LWT_DE
 
 Stress command for LWT performance test for DELETE with IF EXISTS
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **stress_cmd_lwt_dc** / SCT_STRESS_CMD_LWT_DC
@@ -335,12 +435,16 @@ Stress command for LWT performance test for DELETE with IF condition>
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **stress_cmd_lwt_mixed** / SCT_STRESS_CMD_LWT_MIXED
 
 Stress command for LWT performance test for mixed lwt load
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **stress_cmd_lwt_mixed_baseline** / SCT_STRESS_CMD_LWT_MIXED_BASELINE
@@ -349,12 +453,16 @@ Stress command for LWT performance test for mixed lwt load baseline
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **use_cloud_manager** / SCT_USE_CLOUD_MANAGER
 
 When define true, will install scylla cloud manager
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **use_ldap** / SCT_USE_LDAP
@@ -363,12 +471,16 @@ When defined true, LDAP is going to be used.
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **use_ldap_authorization** / SCT_USE_LDAP_AUTHORIZATION
 
 When defined true, will create a docker container with LDAP and configure scylla.yaml to use it
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **use_ldap_authentication** / SCT_USE_LDAP_AUTHENTICATION
@@ -377,12 +489,16 @@ When defined true, will create a docker container with LDAP and configure scylla
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **prepare_saslauthd** / SCT_PREPARE_SASLAUTHD
 
 When defined true, will install and start saslauthd service
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **ldap_server_type** / SCT_LDAP_SERVER_TYPE
@@ -391,12 +507,16 @@ This option indicates which server is going to be used for LDAP operations. [ope
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **use_mgmt** / SCT_USE_MGMT
 
 When define true, will install scylla management
 
 **default:** True
+
+**type:** boolean
 
 
 ## **parallel_node_operations** / SCT_PARALLEL_NODE_OPERATIONS
@@ -405,12 +525,16 @@ When defined true, will run node operations in parallel. Supported operations: s
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **manager_prometheus_port** / SCT_MANAGER_PROMETHEUS_PORT
 
 Port to be used by the manager to contact Prometheus
 
 **default:** 5090
+
+**type:** int
 
 
 ## **target_scylla_mgmt_server_address** / SCT_TARGET_SCYLLA_MGMT_SERVER_ADDRESS
@@ -419,12 +543,16 @@ Url to the repo of scylla manager version used to upgrade the manager server
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **target_scylla_mgmt_agent_address** / SCT_TARGET_SCYLLA_MGMT_AGENT_ADDRESS
 
 Url to the repo of scylla manager version used to upgrade the manager agents
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **update_db_packages** / SCT_UPDATE_DB_PACKAGES
@@ -433,12 +561,16 @@ A local directory of rpms to install a custom version on top of<br>the scylla in
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **monitor_branch** / SCT_MONITOR_BRANCH
 
 The port of scylla management
 
 **default:** branch-4.8
+
+**type:** str (appendable)
 
 
 ## **db_type** / SCT_DB_TYPE
@@ -447,12 +579,16 @@ Db type to install into db nodes, scylla/cassandra
 
 **default:** scylla
 
+**type:** str (appendable)
+
 
 ## **user_prefix** / SCT_USER_PREFIX
 
 the prefix of the name of the cloud instances, defaults to username
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **ami_id_db_scylla_desc** / SCT_AMI_ID_DB_SCYLLA_DESC
@@ -461,12 +597,16 @@ version name to report stats to Elasticsearch and tagged on cloud instances
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **sct_public_ip** / SCT_SCT_PUBLIC_IP
 
 Override the default hostname address of the sct test runner,<br>for the monitoring of the Nemesis.<br>can only work out of the box in AWS
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **sct_ngrok_name** / SCT_NGROK_NAME
@@ -475,12 +615,16 @@ Override the default hostname address of the sct test runner,<br>using ngrok ser
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **backtrace_decoding** / SCT_BACKTRACE_DECODING
 
 If True, all backtraces found in db nodes would be decoded automatically
 
 **default:** True
+
+**type:** boolean
 
 
 ## **print_kernel_callstack** / SCT_PRINT_KERNEL_CALLSTACK
@@ -489,12 +633,16 @@ Scylla will print kernel callstack to logs if True, otherwise, it will try and m
 
 **default:** True
 
+**type:** boolean
+
 
 ## **instance_provision** / SCT_INSTANCE_PROVISION
 
 instance_provision: spot|on_demand|spot_fleet
 
 **default:** spot
+
+**type:** str (appendable)
 
 
 ## **instance_provision_fallback_on_demand** / SCT_INSTANCE_PROVISION_FALLBACK_ON_DEMAND
@@ -503,12 +651,16 @@ instance_provision_fallback_on_demand: create instance on_demand provision type 
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **reuse_cluster** / SCT_REUSE_CLUSTER
 
 If reuse_cluster is set it should hold test_id of the cluster that will be reused.<br>`reuse_cluster: 7dc6db84-eb01-4b61-a946-b5c72e0f6d71`
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **test_id** / SCT_TEST_ID
@@ -517,12 +669,16 @@ test id to filter by
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **db_nodes_shards_selection** / SCT_NODES_SHARDS_SELECTION
 
 How to select number of shards of Scylla. Expected values: default/random.<br>Default value: 'default'.<br>In case of random option - Scylla will start with different (random) shards on every node of the cluster
 
 **default:** default
+
+**type:** str (appendable)
 
 
 ## **seeds_selector** / SCT_SEEDS_SELECTOR
@@ -531,12 +687,16 @@ How to select the seeds. Expected values: random/first/all
 
 **default:** all
 
+**type:** str (appendable)
+
 
 ## **seeds_num** / SCT_SEEDS_NUM
 
 Number of seeds to select
 
 **default:** 1
+
+**type:** int
 
 
 ## **email_recipients** / SCT_EMAIL_RECIPIENTS
@@ -545,12 +705,16 @@ list of email of send the performance regression test to
 
 **default:** ['qa@scylladb.com']
 
+**type:** str_or_list (appendable)
+
 
 ## **email_subject_postfix** / SCT_EMAIL_SUBJECT_POSTFIX
 
 Email subject postfix
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **enable_test_profiling** / SCT_ENABLE_TEST_PROFILING
@@ -559,12 +723,16 @@ Turn on sct profiling
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **ssh_transport** / SSH_TRANSPORT
 
 Set type of ssh library to use. Could be 'fabric' (default) or 'libssh2'
 
 **default:** libssh2
+
+**type:** str (appendable)
 
 
 ## **experimental_features** / SCT_EXPERIMENTAL_FEATURES
@@ -573,12 +741,16 @@ unlock specified experimental features
 
 **default:** N/A
 
+**type:** list
+
 
 ## **server_encrypt** / SCT_SERVER_ENCRYPT
 
 when enable scylla will use encryption on the server side
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **client_encrypt** / SCT_CLIENT_ENCRYPT
@@ -587,12 +759,16 @@ when enable scylla will use encryption on the client side
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **client_encrypt_mtls** / SCT_CLIENT_ENCRYPT_MTLS
 
 when enabled scylla will enforce mutual authentication when client-to-node encryption is enabled
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **server_encrypt_mtls** / SCT_SERVER_ENCRYPT_MTLS
@@ -601,12 +777,16 @@ when enabled scylla will enforce mutual authentication when node-to-node encrypt
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **hinted_handoff** / SCT_HINTED_HANDOFF
 
 when enable or disable scylla hinted handoff (enabled/disabled)
 
 **default:** disabled
+
+**type:** str (appendable)
 
 
 ## **authenticator** / SCT_AUTHENTICATOR
@@ -615,12 +795,16 @@ which authenticator scylla will use AllowAllAuthenticator/PasswordAuthenticator
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **authenticator_user** / SCT_AUTHENTICATOR_USER
 
 the username if PasswordAuthenticator is used
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **authenticator_password** / SCT_AUTHENTICATOR_PASSWORD
@@ -629,12 +813,16 @@ the password if PasswordAuthenticator is used
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **authorizer** / SCT_AUTHORIZER
 
 which authorizer scylla will use AllowAllAuthorizer/CassandraAuthorizer
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **sla** / SCT_SLA
@@ -643,12 +831,16 @@ run SLA nemeses if the test is SLA only
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **service_level_shares** / SCT_SERVICE_LEVEL_SHARES
 
 List if service level shares - how many server levels to create and test. Uses in SLA test.list of int, like: [100, 200]
 
 **default:** [1000]
+
+**type:** list
 
 
 ## **alternator_port** / SCT_ALTERNATOR_PORT
@@ -657,12 +849,16 @@ Port to configure for alternator in scylla.yaml
 
 **default:** N/A
 
+**type:** int
+
 
 ## **dynamodb_primarykey_type** / SCT_DYNAMODB_PRIMARYKEY_TYPE
 
 Type of dynamodb table to create with range key or not, can be:<br>HASH,HASH_AND_RANGE
 
 **default:** HASH
+
+**type:** str (appendable)
 
 
 ## **alternator_write_isolation** / SCT_ALTERNATOR_WRITE_ISOLATION
@@ -671,12 +867,16 @@ Set the write isolation for the alternator table, see https://github.com/scyllad
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **alternator_use_dns_routing** / SCT_ALTERNATOR_USE_DNS_ROUTING
 
 If true, spawn a docker with a dns server for the ycsb loader to point to
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **alternator_enforce_authorization** / SCT_ALTERNATOR_ENFORCE_AUTHORIZATION
@@ -685,12 +885,16 @@ If true, enable the authorization check in dynamodb api (alternator)
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **alternator_access_key_id** / SCT_ALTERNATOR_ACCESS_KEY_ID
 
 the aws_access_key_id that would be used for alternator
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **alternator_secret_access_key** / SCT_ALTERNATOR_SECRET_ACCESS_KEY
@@ -699,12 +903,16 @@ the aws_secret_access_key that would be used for alternator
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **region_aware_loader** / SCT_REGION_AWARE_LOADER
 
 When in multi region mode, run stress on loader that is located in the same region as db node
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **append_scylla_args** / SCT_APPEND_SCYLLA_ARGS
@@ -713,12 +921,16 @@ More arguments to append to scylla command line
 
 **default:** --blocked-reactor-notify-ms 25 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1
 
+**type:** str (appendable)
+
 
 ## **append_scylla_args_oracle** / SCT_APPEND_SCYLLA_ARGS_ORACLE
 
 More arguments to append to oracle command line
 
 **default:** --enable-cache false
+
+**type:** str (appendable)
 
 
 ## **append_scylla_yaml** / SCT_APPEND_SCYLLA_YAML
@@ -727,12 +939,16 @@ More configuration to append to /etc/scylla/scylla.yaml
 
 **default:** N/A
 
+**type:** dict_or_str
+
 
 ## **append_scylla_node_exporter_args** / SCT_SCYLLA_NODE_EXPORTER_ARGS
 
 More arguments to append to scylla-node-exporter command line
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **nemesis_class_name** / SCT_NEMESIS_CLASS_NAME
@@ -741,12 +957,16 @@ Nemesis class to use (possible types in sdcm.nemesis).<br>Next syntax supporting
 
 **default:** NoOpMonkey
 
+**type:** _str
+
 
 ## **nemesis_interval** / SCT_NEMESIS_INTERVAL
 
 Nemesis sleep interval to use if None provided specifically in the test
 
 **default:** 5
+
+**type:** int
 
 
 ## **nemesis_sequence_sleep_between_ops** / SCT_NEMESIS_SEQUENCE_SLEEP_BETWEEN_OPS
@@ -755,12 +975,16 @@ Sleep interval between nemesis operations for use in unique_sequence nemesis kin
 
 **default:** N/A
 
+**type:** int
+
 
 ## **nemesis_during_prepare** / SCT_NEMESIS_DURING_PREPARE
 
 Run nemesis during prepare stage of the test
 
 **default:** True
+
+**type:** boolean
 
 
 ## **nemesis_seed** / SCT_NEMESIS_SEED
@@ -769,12 +993,16 @@ A seed number in order to repeat nemesis sequence as part of SisyphusMonkey
 
 **default:** N/A
 
+**type:** int
+
 
 ## **nemesis_add_node_cnt** / SCT_NEMESIS_ADD_NODE_CNT
 
 Add/remove nodes during GrowShrinkCluster nemesis
 
 **default:** 1
+
+**type:** int
 
 
 ## **nemesis_grow_shrink_instance_type** / SCT_NEMESIS_GROW_SHRINK_INSTANCE_TYPE
@@ -783,12 +1011,16 @@ Instance type to use for adding/removing nodes during GrowShrinkCluster nemesis
 
 **default:** N/A
 
+**type:** _str
+
 
 ## **cluster_target_size** / SCT_CLUSTER_TARGET_SIZE
 
 Used for scale test: max size of the cluster
 
 **default:** N/A
+
+**type:** int
 
 
 ## **space_node_threshold** / SCT_SPACE_NODE_THRESHOLD
@@ -797,12 +1029,16 @@ Space node threshold before starting nemesis (bytes)<br>The default value is 6GB
 
 **default:** N/A
 
+**type:** int
+
 
 ## **nemesis_filter_seeds** / SCT_NEMESIS_FILTER_SEEDS
 
 If true runs the nemesis only on non seed nodes
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **stress_cmd** / SCT_STRESS_CMD
@@ -811,12 +1047,16 @@ cassandra-stress commands.<br>You can specify everything but the -node parameter
 
 **default:** N/A
 
+**type:** str_or_list (appendable)
+
 
 ## **gemini_schema_url** / SCT_GEMINI_SCHEMA_URL
 
 Url of the schema/configuration the gemini tool would use
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **gemini_cmd** / SCT_GEMINI_CMD
@@ -825,12 +1065,16 @@ gemini command to run (for now used only in GeminiTest)
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **gemini_seed** / SCT_GEMINI_SEED
 
 Seed number for gemini command
 
 **default:** N/A
+
+**type:** int
 
 
 ## **gemini_table_options** / SCT_GEMINI_TABLE_OPTIONS
@@ -839,12 +1083,16 @@ table options for created table. example:<br>["cdc={'enabled': true}"]<br>["cdc=
 
 **default:** N/A
 
+**type:** list
+
 
 ## **instance_type_loader** / SCT_INSTANCE_TYPE_LOADER
 
 AWS image type of the loader node
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **instance_type_monitor** / SCT_INSTANCE_TYPE_MONITOR
@@ -853,12 +1101,16 @@ AWS image type of the monitor node
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **instance_type_db** / SCT_INSTANCE_TYPE_DB
 
 AWS image type of the db node
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **instance_type_db_oracle** / SCT_INSTANCE_TYPE_DB_ORACLE
@@ -867,12 +1119,16 @@ AWS image type of the oracle node
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **instance_type_runner** / SCT_INSTANCE_TYPE_RUNNER
 
 instance type of the sct-runner node
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **region_name** / SCT_REGION_NAME
@@ -881,12 +1137,16 @@ AWS regions to use
 
 **default:** N/A
 
+**type:** str_or_list_or_eval
+
 
 ## **security_group_ids** / SCT_SECURITY_GROUP_IDS
 
 AWS security groups ids to use
 
 **default:** N/A
+
+**type:** str_or_list (appendable)
 
 
 ## **use_placement_group** / SCT_USE_PLACEMENT_GROUP
@@ -895,12 +1155,16 @@ if true, create 'cluster' placement group for test case for low-latency network 
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **subnet_id** / SCT_SUBNET_ID
 
 AWS subnet ids to use
 
 **default:** N/A
+
+**type:** str_or_list (appendable)
 
 
 ## **ami_id_db_scylla** / SCT_AMI_ID_DB_SCYLLA
@@ -909,12 +1173,16 @@ AMS AMI id to use for scylla db node
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **ami_id_loader** / SCT_AMI_ID_LOADER
 
 AMS AMI id to use for loader node
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **ami_id_monitor** / SCT_AMI_ID_MONITOR
@@ -923,12 +1191,16 @@ AMS AMI id to use for monitor node
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **ami_id_db_cassandra** / SCT_AMI_ID_DB_CASSANDRA
 
 AMS AMI id to use for cassandra node
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **ami_id_db_oracle** / SCT_AMI_ID_DB_ORACLE
@@ -937,12 +1209,16 @@ AMS AMI id to use for oracle node
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **root_disk_size_db** / SCT_ROOT_DISK_SIZE_DB
 
 
 
 **default:** N/A
+
+**type:** int
 
 
 ## **root_disk_size_monitor** / SCT_ROOT_DISK_SIZE_MONITOR
@@ -951,12 +1227,16 @@ AMS AMI id to use for oracle node
 
 **default:** N/A
 
+**type:** int
+
 
 ## **root_disk_size_loader** / SCT_ROOT_DISK_SIZE_LOADER
 
 
 
 **default:** N/A
+
+**type:** int
 
 
 ## **root_disk_size_runner** / SCT_ROOT_DISK_SIZE_RUNNER
@@ -965,12 +1245,16 @@ root disk size in Gb for sct-runner
 
 **default:** N/A
 
+**type:** int
+
 
 ## **ami_db_scylla_user** / SCT_AMI_DB_SCYLLA_USER
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **ami_monitor_user** / SCT_AMI_MONITOR_USER
@@ -979,12 +1263,16 @@ root disk size in Gb for sct-runner
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **ami_loader_user** / SCT_AMI_LOADER_USER
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **ami_db_cassandra_user** / SCT_AMI_DB_CASSANDRA_USER
@@ -993,12 +1281,16 @@ root disk size in Gb for sct-runner
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **spot_max_price** / SCT_SPOT_MAX_PRICE
 
 The max percentage of the on demand price we set for spot/fleet instances
 
 **default:** N/A
+
+**type:** float
 
 
 ## **extra_network_interface** / SCT_EXTRA_NETWORK_INTERFACE
@@ -1007,12 +1299,16 @@ if true, create extra network interface on each node
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **aws_instance_profile_name_db** / SCT_AWS_INSTANCE_PROFILE_NAME_DB
 
 This is the name of the instance profile to set on all db instances
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **aws_instance_profile_name_loader** / SCT_AWS_INSTANCE_PROFILE_NAME_LOADER
@@ -1021,12 +1317,16 @@ This is the name of the instance profile to set on all loader instances
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **backup_bucket_backend** / SCT_BACKUP_BUCKET_BACKEND
 
 the backend to be used for backup (e.g., 's3', 'gcs' or 'azure')
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **backup_bucket_location** / SCT_BACKUP_BUCKET_LOCATION
@@ -1035,12 +1335,16 @@ the bucket name to be used for backup (e.g., 'manager-backup-tests')
 
 **default:** N/A
 
+**type:** str_or_list (appendable)
+
 
 ## **backup_bucket_region** / SCT_BACKUP_BUCKET_REGION
 
 the AWS region of a bucket to be used for backup (e.g., 'eu-west-1')
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **use_prepared_loaders** / SCT_USE_PREPARED_LOADERS
@@ -1049,12 +1353,16 @@ If True, we use prepared VMs for loader (instead of using docker images)
 
 **default:** N/A
 
+**type:** boolean
 
-## **scylla_d_overrides_files** / SCT_scylla_d_overrides_files
+
+## **scylla_d_overrides_files** / SCT_SCYLLA_D_OVERRIDES_FILES
 
 list of files that should upload to /etc/scylla.d/ directory to override scylla config files
 
 **default:** N/A
+
+**type:** str_or_list_or_eval (appendable)
 
 
 ## **gce_project** / SCT_GCE_PROJECT
@@ -1063,12 +1371,16 @@ gcp project name to use
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **gce_datacenter** / SCT_GCE_DATACENTER
 
 Supported: us-east1 - means that the zone will be selected automatically or you can mention the zone explicitly, for example: us-east1-b
 
 **default:** N/A
+
+**type:** str_or_list_or_eval
 
 
 ## **gce_network** / SCT_GCE_NETWORK
@@ -1077,12 +1389,16 @@ Supported: us-east1 - means that the zone will be selected automatically or you 
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **gce_image_db** / SCT_GCE_IMAGE_DB
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **gce_image_monitor** / SCT_GCE_IMAGE_MONITOR
@@ -1091,12 +1407,16 @@ Supported: us-east1 - means that the zone will be selected automatically or you 
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **gce_image_loader** / SCT_GCE_IMAGE_LOADER
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **gce_image_username** / SCT_GCE_IMAGE_USERNAME
@@ -1105,12 +1425,16 @@ Supported: us-east1 - means that the zone will be selected automatically or you 
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **gce_instance_type_loader** / SCT_GCE_INSTANCE_TYPE_LOADER
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **gce_root_disk_type_loader** / SCT_GCE_ROOT_DISK_TYPE_LOADER
@@ -1119,12 +1443,16 @@ Supported: us-east1 - means that the zone will be selected automatically or you 
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **gce_n_local_ssd_disk_loader** / SCT_GCE_N_LOCAL_SSD_DISK_LOADER
 
 
 
 **default:** N/A
+
+**type:** int
 
 
 ## **gce_instance_type_monitor** / SCT_GCE_INSTANCE_TYPE_MONITOR
@@ -1133,12 +1461,16 @@ Supported: us-east1 - means that the zone will be selected automatically or you 
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **gce_root_disk_type_monitor** / SCT_GCE_ROOT_DISK_TYPE_MONITOR
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **gce_n_local_ssd_disk_monitor** / SCT_GCE_N_LOCAL_SSD_DISK_MONITOR
@@ -1147,12 +1479,16 @@ Supported: us-east1 - means that the zone will be selected automatically or you 
 
 **default:** N/A
 
+**type:** int
+
 
 ## **gce_instance_type_db** / SCT_GCE_INSTANCE_TYPE_DB
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **gce_root_disk_type_db** / SCT_GCE_ROOT_DISK_TYPE_DB
@@ -1161,12 +1497,16 @@ Supported: us-east1 - means that the zone will be selected automatically or you 
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **gce_n_local_ssd_disk_db** / SCT_GCE_N_LOCAL_SSD_DISK_DB
 
 
 
 **default:** N/A
+
+**type:** int
 
 
 ## **gce_pd_standard_disk_size_db** / SCT_GCE_PD_STANDARD_DISK_SIZE_DB
@@ -1175,12 +1515,16 @@ Supported: us-east1 - means that the zone will be selected automatically or you 
 
 **default:** N/A
 
+**type:** int
+
 
 ## **gce_pd_ssd_disk_size_db** / SCT_GCE_PD_SSD_DISK_SIZE_DB
 
 
 
 **default:** N/A
+
+**type:** int
 
 
 ## **gce_setup_hybrid_raid** / SCT_GCE_SETUP_HYBRID_RAID
@@ -1189,12 +1533,16 @@ If True, SCT configures a hybrid RAID of NVMEs and an SSD for scylla's data
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **gce_pd_ssd_disk_size_loader** / SCT_GCE_PD_SSD_DISK_SIZE_LOADER
 
 
 
 **default:** N/A
+
+**type:** int
 
 
 ## **gce_pd_ssd_disk_size_monitor** / SCT_GCE_SSD_DISK_SIZE_MONITOR
@@ -1203,12 +1551,16 @@ If True, SCT configures a hybrid RAID of NVMEs and an SSD for scylla's data
 
 **default:** N/A
 
+**type:** int
+
 
 ## **azure_region_name** / SCT_AZURE_REGION_NAME
 
 Supported: eastus
 
 **default:** N/A
+
+**type:** str_or_list_or_eval
 
 
 ## **azure_instance_type_loader** / SCT_AZURE_INSTANCE_TYPE_LOADER
@@ -1217,12 +1569,16 @@ Supported: eastus
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **azure_instance_type_monitor** / SCT_AZURE_INSTANCE_TYPE_MONITOR
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **azure_instance_type_db** / SCT_AZURE_INSTANCE_TYPE_DB
@@ -1231,12 +1587,16 @@ Supported: eastus
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **azure_instance_type_db_oracle** / SCT_AZURE_INSTANCE_TYPE_DB_ORACLE
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **azure_image_db** / SCT_AZURE_IMAGE_DB
@@ -1245,12 +1605,16 @@ Supported: eastus
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **azure_image_monitor** / SCT_AZURE_IMAGE_MONITOR
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **azure_image_loader** / SCT_AZURE_IMAGE_LOADER
@@ -1259,12 +1623,16 @@ Supported: eastus
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **azure_image_username** / SCT_AZURE_IMAGE_USERNAME
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **eks_service_ipv4_cidr** / SCT_EKS_SERVICE_IPV4_CIDR
@@ -1273,12 +1641,16 @@ Supported: eastus
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **eks_vpc_cni_version** / SCT_EKS_VPC_CNI_VERSION
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **eks_role_arn** / SCT_EKS_ROLE_ARN
@@ -1287,12 +1659,16 @@ Supported: eastus
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **eks_cluster_version** / SCT_EKS_CLUSTER_VERSION
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **eks_nodegroup_role_arn** / SCT_EKS_NODEGROUP_ROLE_ARN
@@ -1301,12 +1677,16 @@ Supported: eastus
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **gke_cluster_version** / SCT_GKE_CLUSTER_VERSION
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **gke_k8s_release_channel** / SCT_GKE_K8S_RELEASE_CHANNEL
@@ -1315,12 +1695,16 @@ K8S release channel name to be used. Expected values are: 'rapid', 'regular', 's
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **k8s_scylla_utils_docker_image** / SCT_K8S_SCYLLA_UTILS_DOCKER_IMAGE
 
 Docker image to be used by Scylla operator to tune K8S nodes for performance. Used when k8s_enable_performance_tuning' is defined to 'True'. If not set then the default from operator will be used.
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **k8s_enable_performance_tuning** / SCT_K8S_ENABLE_PERFORMANCE_TUNING
@@ -1329,12 +1713,16 @@ Define whether performance tuning must run or not.
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **k8s_deploy_monitoring** / SCT_K8S_DEPLOY_MONITORING
 
 
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **k8s_local_volume_provisioner_type** / SCT_K8S_LOCAL_VOLUME_PROVISIONER_TYPE
@@ -1343,12 +1731,16 @@ Defines the type of the K8S local volume provisioner to be deployed. It may be e
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **k8s_scylla_operator_docker_image** / SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE
 
 Docker image to be used for installation of scylla operator.
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **k8s_scylla_operator_upgrade_docker_image** / SCT_K8S_SCYLLA_OPERATOR_UPGRADE_DOCKER_IMAGE
@@ -1357,12 +1749,16 @@ Docker image to be used for upgrade of scylla operator.
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **k8s_scylla_operator_helm_repo** / SCT_K8S_SCYLLA_OPERATOR_HELM_REPO
 
 Link to the Helm repository where to get 'scylla-operator' charts from.
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **k8s_scylla_operator_upgrade_helm_repo** / SCT_K8S_SCYLLA_OPERATOR_UPGRADE_HELM_REPO
@@ -1371,12 +1767,16 @@ Link to the Helm repository where to get 'scylla-operator' charts for upgrade.
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **k8s_scylla_operator_chart_version** / SCT_K8S_SCYLLA_OPERATOR_CHART_VERSION
 
 Version of 'scylla-operator' Helm chart to use. If not set then latest one will be used.
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **k8s_scylla_operator_upgrade_chart_version** / SCT_K8S_SCYLLA_OPERATOR_UPGRADE_CHART_VERSION
@@ -1385,12 +1785,16 @@ Version of 'scylla-operator' Helm chart to use for upgrade.
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **k8s_functional_test_dataset** / SCT_K8S_FUNCTIONAL_TEST_DATASET
 
 Defines whether dataset uses for pre-fill cluster in functional test. Defined in sdcm.utils.sstable.load_inventory. Expected values: BIG_SSTABLE_MULTI_COLUMNS_DATA, MULTI_COLUMNS_DATA
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **k8s_scylla_cpu_limit** / SCT_K8S_SCYLLA_CPU_LIMIT
@@ -1399,12 +1803,16 @@ The CPU limit that will be set for each Scylla cluster deployed in K8S. If not s
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **k8s_scylla_memory_limit** / SCT_K8S_SCYLLA_MEMORY_LIMIT
 
 The memory limit that will be set for each Scylla cluster deployed in K8S. If not set, then will be autocalculated. Example: '16384Mi'
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **k8s_scylla_cluster_name** / SCT_K8S_SCYLLA_CLUSTER_NAME
@@ -1413,12 +1821,16 @@ The memory limit that will be set for each Scylla cluster deployed in K8S. If no
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **k8s_n_scylla_pods_per_cluster** / K8S_N_SCYLLA_PODS_PER_CLUSTER
 
 Number of loader pods per loader cluster.
 
 **default:** 3
+
+**type:** int_or_space_separated_ints
 
 
 ## **k8s_scylla_disk_gi** / SCT_K8S_SCYLLA_DISK_GI
@@ -1427,12 +1839,16 @@ Number of loader pods per loader cluster.
 
 **default:** N/A
 
+**type:** int
+
 
 ## **k8s_scylla_disk_class** / SCT_K8S_SCYLLA_DISK_CLASS
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **k8s_loader_cluster_name** / SCT_K8S_LOADER_CLUSTER_NAME
@@ -1441,12 +1857,16 @@ Number of loader pods per loader cluster.
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **k8s_n_loader_pods_per_cluster** / SCT_K8S_N_LOADER_PODS_PER_CLUSTER
 
 Number of loader pods per loader cluster.
 
 **default:** N/A
+
+**type:** int_or_space_separated_ints
 
 
 ## **k8s_loader_run_type** / SCT_K8S_LOADER_RUN_TYPE
@@ -1455,12 +1875,16 @@ Defines how the loader pods must run. It may be either 'static' (default, run st
 
 **default:** dynamic
 
+**type:** str (appendable)
+
 
 ## **k8s_instance_type_auxiliary** / SCT_K8S_INSTANCE_TYPE_AUXILIARY
 
 Instance type for the nodes of the K8S auxiliary/default node pool.
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **k8s_instance_type_monitor** / SCT_K8S_INSTANCE_TYPE_MONITOR
@@ -1469,12 +1893,16 @@ Instance type for the nodes of the K8S monitoring node pool.
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **mini_k8s_version** / SCT_MINI_K8S_VERSION
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **k8s_cert_manager_version** / SCT_K8S_CERT_MANAGER_VERSION
@@ -1483,12 +1911,16 @@ Instance type for the nodes of the K8S monitoring node pool.
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **k8s_minio_storage_size** / SCT_K8S_MINIO_STORAGE_SIZE
 
 
 
 **default:** 10Gi
+
+**type:** str (appendable)
 
 
 ## **k8s_log_api_calls** / SCT_K8S_LOG_API_CALLS
@@ -1497,12 +1929,16 @@ Defines whether the K8S API server logging must be enabled and it's logs gathere
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **k8s_tenants_num** / SCT_TENANTS_NUM
 
 Number of Scylla clusters to create in the K8S cluster.
 
 **default:** 1
+
+**type:** int
 
 
 ## **k8s_enable_tls** / SCT_K8S_ENABLE_TLS
@@ -1511,12 +1947,16 @@ Defines whether we enable the scylla operator TLS feature or not.
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **k8s_enable_sni** / SCT_K8S_ENABLE_SNI
 
 Defines whether we install SNI and use it or not (serverless feature).
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **k8s_enable_alternator** / SCT_K8S_ENABLE_ALTERNATOR
@@ -1525,12 +1965,16 @@ Defines whether we enable the alternator feature using scylla-operator or not.
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **k8s_connection_bundle_file** / SCT_K8S_CONNECTION_BUNDLE_FILE
 
 Serverless configuration bundle file
 
 **default:** N/A
+
+**type:** _file
 
 
 ## **k8s_db_node_service_type** / SCT_K8S_DB_NODE_SERVICE_TYPE
@@ -1539,12 +1983,16 @@ Defines the type of the K8S 'Service' objects type used for ScyllaDB pods. Empty
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **k8s_db_node_to_node_broadcast_ip_type** / SCT_K8S_DB_NODE_TO_NODE_BROADCAST_IP_TYPE
 
 Defines the source of the IP address to be used for the 'broadcast_address' config option in the 'scylla.yaml' files. Empty value means 'do not set and allow scylla-operator to choose'.
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **k8s_db_node_to_client_broadcast_ip_type** / SCT_K8S_DB_NODE_TO_CLIENT_BROADCAST_IP_TYPE
@@ -1553,12 +2001,16 @@ Defines the source of the IP address to be used for the 'broadcast_rpc_address' 
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **k8s_use_chaos_mesh** / SCT_K8S_USE_CHAOS_MESH
 
 enables chaos-mesh for k8s testing
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **k8s_n_auxiliary_nodes** / SCT_K8S_N_AUXILIARY_NODES
@@ -1567,12 +2019,16 @@ Number of nodes in auxiliary pool
 
 **default:** N/A
 
+**type:** int
+
 
 ## **k8s_n_monitor_nodes** / SCT_K8S_N_MONITOR_NODES
 
 Number of nodes in monitoring pool that will be used for scylla-operator's deployed monitoring pods.
 
 **default:** N/A
+
+**type:** int
 
 
 ## **mgmt_docker_image** / SCT_MGMT_DOCKER_IMAGE
@@ -1581,12 +2037,16 @@ Scylla manager docker image, i.e. 'scylladb/scylla-manager:2.2.1'
 
 **default:** scylladb/scylla-manager:3.4.0
 
+**type:** str (appendable)
+
 
 ## **docker_image** / SCT_DOCKER_IMAGE
 
 Scylla docker image repo, i.e. 'scylladb/scylla', if omitted is calculated from scylla_version
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **docker_network** / SCT_DOCKER_NETWORK
@@ -1595,12 +2055,16 @@ local docker network to use, if there's need to have db cluster connect to other
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **s3_baremetal_config** / SCT_S3_BAREMETAL_CONFIG
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **db_nodes_private_ip** / SCT_DB_NODES_PRIVATE_IP
@@ -1609,12 +2073,16 @@ local docker network to use, if there's need to have db cluster connect to other
 
 **default:** N/A
 
+**type:** str_or_list_or_eval (appendable)
+
 
 ## **db_nodes_public_ip** / SCT_DB_NODES_PUBLIC_IP
 
 
 
 **default:** N/A
+
+**type:** str_or_list_or_eval (appendable)
 
 
 ## **loaders_private_ip** / SCT_LOADERS_PRIVATE_IP
@@ -1623,12 +2091,16 @@ local docker network to use, if there's need to have db cluster connect to other
 
 **default:** N/A
 
+**type:** str_or_list_or_eval (appendable)
+
 
 ## **loaders_public_ip** / SCT_LOADERS_PUBLIC_IP
 
 
 
 **default:** N/A
+
+**type:** str_or_list_or_eval (appendable)
 
 
 ## **monitor_nodes_private_ip** / SCT_MONITOR_NODES_PRIVATE_IP
@@ -1637,12 +2109,16 @@ local docker network to use, if there's need to have db cluster connect to other
 
 **default:** N/A
 
+**type:** str_or_list_or_eval (appendable)
+
 
 ## **monitor_nodes_public_ip** / SCT_MONITOR_NODES_PUBLIC_IP
 
 
 
 **default:** N/A
+
+**type:** str_or_list_or_eval (appendable)
 
 
 ## **cassandra_stress_population_size** / SCT_CASSANDRA_STRESS_POPULATION_SIZE
@@ -1651,12 +2127,16 @@ local docker network to use, if there's need to have db cluster connect to other
 
 **default:** 1000000
 
+**type:** int
+
 
 ## **cassandra_stress_threads** / SCT_CASSANDRA_STRESS_THREADS
 
 
 
 **default:** 1000
+
+**type:** int
 
 
 ## **add_node_cnt** / SCT_ADD_NODE_CNT
@@ -1665,12 +2145,16 @@ local docker network to use, if there's need to have db cluster connect to other
 
 **default:** 1
 
+**type:** int
+
 
 ## **stress_multiplier** / SCT_STRESS_MULTIPLIER
 
 Number of cassandra-stress processes
 
 **default:** 1
+
+**type:** int
 
 
 ## **stress_multiplier_w** / SCT_STRESS_MULTIPLIER_W
@@ -1679,12 +2163,16 @@ Number of cassandra-stress processes for write workload
 
 **default:** 1
 
+**type:** int
+
 
 ## **stress_multiplier_r** / SCT_STRESS_MULTIPLIER_R
 
 Number of cassandra-stress processes for read workload
 
 **default:** 1
+
+**type:** int
 
 
 ## **stress_multiplier_m** / SCT_STRESS_MULTIPLIER_M
@@ -1693,12 +2181,16 @@ Number of cassandra-stress processes for mixed workload
 
 **default:** 1
 
+**type:** int
+
 
 ## **run_fullscan** / SCT_RUN_FULLSCAN
 
 
 
 **default:** N/A
+
+**type:** list
 
 
 ## **run_full_partition_scan** / SCT_run_full_partition_scan
@@ -1707,12 +2199,16 @@ Runs a background thread that issues reversed-queries on a table random partitio
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **run_tombstone_gc_verification** / SCT_RUN_TOMBSTONE_GC_VERIFICATION
 
 Runs a background thread that verifies Tombstones GC on a table by an interval
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **keyspace_num** / SCT_KEYSPACE_NUM
@@ -1721,12 +2217,16 @@ Runs a background thread that verifies Tombstones GC on a table by an interval
 
 **default:** 1
 
+**type:** int
+
 
 ## **round_robin** / SCT_ROUND_ROBIN
 
 
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **batch_size** / SCT_BATCH_SIZE
@@ -1735,12 +2235,16 @@ Runs a background thread that verifies Tombstones GC on a table by an interval
 
 **default:** 1
 
+**type:** int
+
 
 ## **pre_create_schema** / SCT_PRE_CREATE_SCHEMA
 
 
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **pre_create_keyspace** / SCT_PRE_CREATE_KEYSPACE
@@ -1749,12 +2253,16 @@ Command to create keysapce to be pre-create before running workload
 
 **default:** N/A
 
+**type:** str_or_list (appendable)
+
 
 ## **post_prepare_cql_cmds** / SCT_POST_PREPARE_CQL_CMDS
 
 CQL Commands to run after prepare stage finished (relevant only to longevity_test.py)
 
 **default:** N/A
+
+**type:** str_or_list (appendable)
 
 
 ## **prepare_wait_no_compactions_timeout** / SCT_PREPARE_WAIT_NO_COMPACTIONS_TIMEOUT
@@ -1763,12 +2271,16 @@ At the end of prepare stage, run major compaction and wait for this time (in min
 
 **default:** N/A
 
+**type:** int
+
 
 ## **compaction_strategy** / SCT_COMPACTION_STRATEGY
 
 Choose a specific compaction strategy to pre-create schema with.
 
 **default:** SizeTieredCompactionStrategy
+
+**type:** str (appendable)
 
 
 ## **sstable_size** / SSTABLE_SIZE
@@ -1777,12 +2289,16 @@ Configure sstable size for the usage of pre-create-schema mode
 
 **default:** N/A
 
+**type:** int
+
 
 ## **cluster_health_check** / SCT_CLUSTER_HEALTH_CHECK
 
 When true, start cluster health checker for all nodes
 
 **default:** True
+
+**type:** boolean
 
 
 ## **data_validation** / SCT_DATA_VALIDATION
@@ -1791,12 +2307,16 @@ A group of sub-parameters: validate_partitions, table_name, primary_key_column,<
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **stress_read_cmd** / SCT_STRESS_READ_CMD
 
 cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list
 
 **default:** N/A
+
+**type:** str_or_list (appendable)
 
 
 ## **prepare_verify_cmd** / SCT_PREPARE_VERIFY_CMD
@@ -1805,12 +2325,16 @@ cassandra-stress commands.<br>You can specify everything but the -node parameter
 
 **default:** N/A
 
+**type:** str_or_list (appendable)
+
 
 ## **user_profile_table_count** / SCT_USER_PROFILE_TABLE_COUNT
 
 number of tables to create for template user c-s
 
 **default:** 1
+
+**type:** int
 
 
 ## **scylla_mgmt_upgrade_to_repo** / SCT_SCYLLA_MGMT_UPGRADE_TO_REPO
@@ -1819,12 +2343,16 @@ Url to the repo of scylla manager version to upgrade to for management tests
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **mgmt_restore_extra_params** / SCT_MGMT_RESTORE_EXTRA_PARAMS
 
 Manager restore operation extra parameters: batch-size, parallel, etc.For example, `--batch-size 2 --parallel 1`. Provided string appends the restore cmd
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **mgmt_agent_backup_config** / SCT_MGMT_AGENT_BACKUP_CONFIG
@@ -1833,12 +2361,16 @@ Manager agent backup general configuration: checkers, transfers, low_level_retri
 
 **default:** N/A
 
+**type:** dict_or_str_or_pydantic
+
 
 ## **mgmt_reuse_backup_snapshot_name** / SCT_MGMT_REUSE_BACKUP_SNAPSHOT_NAME
 
 Name of backup snapshot to use in Manager restore benchmark test, for example, 500gb_2t_ics. The name provides the info about dataset size (500gb), tables number (2) and compaction (ICS)
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **mgmt_skip_post_restore_stress_read** / SCT_MGMT_SKIP_POST_RESTORE_STRESS_READ
@@ -1847,12 +2379,16 @@ Skip post-restore c-s verification read in the Manager restore benchmark tests
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **mgmt_nodetool_refresh_flags** / SCT_MGMT_NODETOOL_REFRESH_FLAGS
 
 Nodetool refresh extra options like --load-and-stream or --primary-replica-only
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **mgmt_prepare_snapshot_size** / SCT_MGMT_PREPARE_SNAPSHOT_SIZE
@@ -1861,12 +2397,16 @@ Size of backup snapshot in Gb to be prepared to be prepared for backup
 
 **default:** N/A
 
+**type:** int
+
 
 ## **stress_cmd_w** / SCT_STRESS_CMD_W
 
 cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list
 
 **default:** N/A
+
+**type:** str_or_list (appendable)
 
 
 ## **stress_cmd_r** / SCT_STRESS_CMD_R
@@ -1875,12 +2415,16 @@ cassandra-stress commands.<br>You can specify everything but the -node parameter
 
 **default:** N/A
 
+**type:** str_or_list (appendable)
+
 
 ## **stress_cmd_m** / SCT_STRESS_CMD_M
 
 cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list
 
 **default:** N/A
+
+**type:** str_or_list (appendable)
 
 
 ## **stress_cmd_cache_warmup** / SCT_STRESS_CMD_CACHE_WARM_UP
@@ -1889,12 +2433,16 @@ cassandra-stress commands for warm-up before read workload.<br>You can specify e
 
 **default:** N/A
 
+**type:** str_or_list (appendable)
+
 
 ## **prepare_write_cmd** / SCT_PREPARE_WRITE_CMD
 
 cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list
 
 **default:** N/A
+
+**type:** str_or_list (appendable)
 
 
 ## **stress_cmd_no_mv** / SCT_STRESS_CMD_NO_MV
@@ -1903,12 +2451,16 @@ cassandra-stress commands.<br>You can specify everything but the -node parameter
 
 **default:** N/A
 
+**type:** str_or_list (appendable)
+
 
 ## **stress_cmd_no_mv_profile** / SCT_STRESS_CMD_NO_MV_PROFILE
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **perf_extra_jobs_to_compare** / SCT_PERF_EXTRA_JOBS_TO_COMPARE
@@ -1917,12 +2469,16 @@ jobs to compare performance results with, for example if running in staging, we 
 
 **default:** N/A
 
+**type:** str_or_list_or_eval (appendable)
+
 
 ## **cs_user_profiles** / SCT_CS_USER_PROFILES
 
 cassandra-stress user-profiles list. Executed in test step
 
 **default:** N/A
+
+**type:** str_or_list (appendable)
 
 
 ## **prepare_cs_user_profiles** / SCT_PREPARE_CS_USER_PROFILES
@@ -1931,12 +2487,16 @@ cassandra-stress user-profiles list. Executed in prepare step
 
 **default:** N/A
 
+**type:** str_or_list (appendable)
+
 
 ## **cs_duration** / SCT_CS_DURATION
 
 
 
 **default:** 50m
+
+**type:** str (appendable)
 
 
 ## **cs_debug** / SCT_CS_DEBUG
@@ -1945,12 +2505,16 @@ enable debug for cassandra-stress
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **stress_cmd_mv** / SCT_STRESS_CMD_MV
 
 cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list
 
 **default:** N/A
+
+**type:** str_or_list (appendable)
 
 
 ## **prepare_stress_cmd** / SCT_PREPARE_STRESS_CMD
@@ -1959,12 +2523,16 @@ cassandra-stress commands.<br>You can specify everything but the -node parameter
 
 **default:** N/A
 
+**type:** str_or_list (appendable)
+
 
 ## **perf_gradual_threads** / SCT_PERF_GRADUAL_THREADS
 
 Threads amount of c-s load for gradual performance test per sub-test. Example: {'read': 100, 'write': 200, 'mixed': 300}
 
 **default:** N/A
+
+**type:** dict
 
 
 ## **perf_gradual_throttle_steps** / SCT_PERF_GRADUAL_THROTTLE_STEPS
@@ -1973,12 +2541,16 @@ Used for gradual performance test. Define throttle for load step in ops. Example
 
 **default:** N/A
 
+**type:** dict
+
 
 ## **skip_download** / SCT_SKIP_DOWNLOAD
 
 
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **sstable_file** / SCT_SSTABLE_FILE
@@ -1987,12 +2559,16 @@ Used for gradual performance test. Define throttle for load step in ops. Example
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **sstable_url** / SCT_SSTABLE_URL
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **sstable_md5** / SCT_SSTABLE_MD5
@@ -2001,12 +2577,16 @@ Used for gradual performance test. Define throttle for load step in ops. Example
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **flush_times** / SCT_FLUSH_TIMES
 
 
 
 **default:** N/A
+
+**type:** int
 
 
 ## **flush_period** / SCT_FLUSH_PERIOD
@@ -2015,12 +2595,16 @@ Used for gradual performance test. Define throttle for load step in ops. Example
 
 **default:** N/A
 
+**type:** int
+
 
 ## **new_scylla_repo** / SCT_NEW_SCYLLA_REPO
 
 
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **new_version** / SCT_NEW_VERSION
@@ -2029,12 +2613,16 @@ Assign new upgrade version, use it to upgrade to specific minor release. eg: 3.0
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **target_upgrade_version** / SCT_TARGET_UPGRADE_VERSION
 
 Assign target upgrade version, use for decide if the truncate entries test should be run. This test should be performed in case the target upgrade version >= 3.1
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **disable_raft** / SCT_DISABLE_RAFT
@@ -2043,12 +2631,16 @@ As for now, raft will be enable by default in all [upgrade] tests, so this flag 
 
 **default:** True
 
+**type:** boolean
+
 
 ## **enable_tablets_on_upgrade** / SCT_ENABLE_TABLETS_ON_UPGRADE
 
 By default, the tablets feature is disabled. With this parameter, created for the upgrade test,the tablets feature will only be enabled after the upgrade
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **upgrade_node_packages** / SCT_UPGRADE_NODE_PACKAGES
@@ -2057,12 +2649,16 @@ By default, the tablets feature is disabled. With this parameter, created for th
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **upgrade_node_system** / SCT_UPGRADE_NODE_SYSTEM
 
 Upgrade system packages on nodes before upgrading Scylla. Enabled by default
 
 **default:** True
+
+**type:** boolean
 
 
 ## **test_sst3** / SCT_TEST_SST3
@@ -2071,12 +2667,16 @@ Upgrade system packages on nodes before upgrading Scylla. Enabled by default
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **test_upgrade_from_installed_3_1_0** / SCT_TEST_UPGRADE_FROM_INSTALLED_3_1_0
 
 Enable an option for installed 3.1.0 for work around a scylla issue if it's true
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **recover_system_tables** / SCT_RECOVER_SYSTEM_TABLES
@@ -2085,12 +2685,16 @@ Enable an option for installed 3.1.0 for work around a scylla issue if it's true
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **stress_cmd_1** / SCT_STRESS_CMD_1
 
 cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list
 
 **default:** N/A
+
+**type:** str_or_list (appendable)
 
 
 ## **stress_cmd_complex_prepare** / SCT_STRESS_CMD_COMPLEX_PREPARE
@@ -2099,12 +2703,16 @@ cassandra-stress commands.<br>You can specify everything but the -node parameter
 
 **default:** N/A
 
+**type:** str_or_list (appendable)
+
 
 ## **prepare_write_stress** / SCT_PREPARE_WRITE_STRESS
 
 cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list
 
 **default:** N/A
+
+**type:** str_or_list (appendable)
 
 
 ## **stress_cmd_read_10m** / SCT_STRESS_CMD_READ_10M
@@ -2113,12 +2721,16 @@ cassandra-stress commands.<br>You can specify everything but the -node parameter
 
 **default:** N/A
 
+**type:** str_or_list (appendable)
+
 
 ## **stress_cmd_read_cl_one** / SCT_STRESS_CMD_READ_CL_ONE
 
 cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.
 
 **default:** N/A
+
+**type:** str_or_list (appendable)
 
 
 ## **stress_cmd_read_60m** / SCT_STRESS_CMD_READ_60M
@@ -2127,12 +2739,16 @@ cassandra-stress commands.<br>You can specify everything but the -node parameter
 
 **default:** N/A
 
+**type:** str_or_list (appendable)
+
 
 ## **stress_cmd_complex_verify_read** / SCT_STRESS_CMD_COMPLEX_VERIFY_READ
 
 cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list
 
 **default:** N/A
+
+**type:** str_or_list (appendable)
 
 
 ## **stress_cmd_complex_verify_more** / SCT_STRESS_CMD_COMPLEX_VERIFY_MORE
@@ -2141,12 +2757,16 @@ cassandra-stress commands.<br>You can specify everything but the -node parameter
 
 **default:** N/A
 
+**type:** str_or_list (appendable)
+
 
 ## **write_stress_during_entire_test** / SCT_WRITE_STRESS_DURING_ENTIRE_TEST
 
 cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list
 
 **default:** N/A
+
+**type:** str_or_list (appendable)
 
 
 ## **verify_data_after_entire_test** / SCT_VERIFY_DATA_AFTER_ENTIRE_TEST
@@ -2155,12 +2775,16 @@ cassandra-stress commands.<br>You can specify everything but the -node parameter
 
 **default:** N/A
 
+**type:** str_or_list (appendable)
+
 
 ## **stress_cmd_read_cl_quorum** / SCT_STRESS_CMD_READ_CL_QUORUM
 
 cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list
 
 **default:** N/A
+
+**type:** str_or_list (appendable)
 
 
 ## **verify_stress_after_cluster_upgrade** / SCT_VERIFY_STRESS_AFTER_CLUSTER_UPGRADE
@@ -2169,12 +2793,16 @@ cassandra-stress commands.<br>You can specify everything but the -node parameter
 
 **default:** N/A
 
+**type:** str_or_list (appendable)
+
 
 ## **stress_cmd_complex_verify_delete** / SCT_STRESS_CMD_COMPLEX_VERIFY_DELETE
 
 cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list
 
 **default:** N/A
+
+**type:** str_or_list (appendable)
 
 
 ## **scylla_encryption_options** / SCT_SCYLLA_ENCRYPTION_OPTIONS
@@ -2183,12 +2811,16 @@ options will be used for enable encryption at-rest for tables
 
 **default:** N/A
 
+**type:** str_or_list (appendable)
+
 
 ## **kms_key_rotation_interval** / SCT_KMS_KEY_ROTATION_INTERVAL
 
 The time interval in minutes which gets waited before the KMS key rotation happens. Applied when the AWS KMS service is configured to be used.
 
 **default:** N/A
+
+**type:** int
 
 
 ## **enterprise_disable_kms** / SCT_ENTERPRISE_DISABLE_KMS
@@ -2197,12 +2829,16 @@ An escape hatch to disable KMS for enterprise run, when needed, we enable kms by
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **logs_transport** / SCT_LOGS_TRANSPORT
 
 How to transport logs: syslog-ng, ssh or docker
 
 **default:** syslog-ng
+
+**type:** str (appendable)
 
 
 ## **collect_logs** / SCT_COLLECT_LOGS
@@ -2211,12 +2847,16 @@ Collect logs from instances and sct runner
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **execute_post_behavior** / SCT_EXECUTE_POST_BEHAVIOR
 
 Run post behavior actions in sct teardown step
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **post_behavior_db_nodes** / SCT_POST_BEHAVIOR_DB_NODES
@@ -2225,12 +2865,16 @@ Failure/post test behavior, i.e. what to do with the db cloud instances at the e
 
 **default:** keep-on-failure
 
+**type:** str (appendable)
+
 
 ## **post_behavior_loader_nodes** / SCT_POST_BEHAVIOR_LOADER_NODES
 
 Failure/post test behavior, i.e. what to do with the loader cloud instances at the end of the test.<br><br>'destroy' - Destroy instances and credentials (default)<br>'keep' - Keep instances running and leave credentials alone<br>'keep-on-failure' - Keep instances if testrun failed
 
 **default:** destroy
+
+**type:** str (appendable)
 
 
 ## **post_behavior_monitor_nodes** / SCT_POST_BEHAVIOR_MONITOR_NODES
@@ -2239,12 +2883,16 @@ Failure/post test behavior, i.e. what to do with the monitor cloud instances at 
 
 **default:** keep-on-failure
 
+**type:** str (appendable)
+
 
 ## **post_behavior_k8s_cluster** / SCT_POST_BEHAVIOR_K8S_CLUSTER
 
 Failure/post test behavior, i.e. what to do with the k8s cluster at the end of the test.<br><br>'destroy' - Destroy k8s cluster and credentials (default)<br>'keep' - Keep k8s cluster running and leave credentials alone<br>'keep-on-failure' - Keep k8s cluster if testrun failed
 
 **default:** keep-on-failure
+
+**type:** str (appendable)
 
 
 ## **internode_compression** / SCT_INTERNODE_COMPRESSION
@@ -2253,12 +2901,16 @@ scylla option: internode_compression
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **internode_encryption** / SCT_INTERNODE_ENCRYPTION
 
 scylla sub option of server_encryption_options: internode_encryption
 
 **default:** all
+
+**type:** str (appendable)
 
 
 ## **jmx_heap_memory** / SCT_JMX_HEAP_MEMORY
@@ -2267,12 +2919,16 @@ The total size of the memory allocated to JMX. Values in MB, so for 1GB enter 10
 
 **default:** N/A
 
+**type:** int
+
 
 ## **store_perf_results** / SCT_STORE_PERF_RESULTS
 
 A flag that indicates whether or not to gather the prometheus stats at the end of the run.<br>Intended to be used in performance testing
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **append_scylla_setup_args** / SCT_APPEND_SCYLLA_SETUP_ARGS
@@ -2281,12 +2937,16 @@ More arguments to append to scylla_setup command line
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **use_preinstalled_scylla** / SCT_USE_PREINSTALLED_SCYLLA
 
 Don't install/update ScyllaDB on DB nodes
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **force_run_iotune** / SCT_FORCE_RUN_IOTUNE
@@ -2295,12 +2955,16 @@ Force running iotune on the DB nodes, regdless if image has predefined values
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **stress_cdclog_reader_cmd** / SCT_STRESS_CDCLOG_READER_CMD
 
 cdc-stressor command to read cdc_log table.<br>You can specify everything but the -node , -keyspace, -table, parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list
 
 **default:** cdc-stressor -stream-query-round-duration 30s
+
+**type:** str (appendable)
 
 
 ## **store_cdclog_reader_stats_in_es** / SCT_STORE_CDCLOG_READER_STATS_IN_ES
@@ -2309,12 +2973,16 @@ Add cdclog reader stats to ES for future performance result calculating
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **stop_test_on_stress_failure** / SCT_STOP_TEST_ON_STRESS_FAILURE
 
 If set to True the test will be stopped immediately when stress command failed.<br>When set to False the test will continue to run even when there are errors in the<br>stress process
 
 **default:** True
+
+**type:** boolean
 
 
 ## **stress_cdc_log_reader_batching_enable** / SCT_STRESS_CDC_LOG_READER_BATCHING_ENABLE
@@ -2323,12 +2991,16 @@ retrieving data from multiple streams in one poll
 
 **default:** True
 
+**type:** boolean
+
 
 ## **use_legacy_cluster_init** / SCT_USE_LEGACY_CLUSTER_INIT
 
 Use legacy cluster initialization with autobootsrap disabled and parallel node setup
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **availability_zone** / SCT_AVAILABILITY_ZONE
@@ -2337,12 +3009,16 @@ Availability zone to use. Specify multiple (comma separated) to deploy resources
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **aws_fallback_to_next_availability_zone** / SCT_AWS_FALLBACK_TO_NEXT_AVAILABILITY_ZONE
 
 Try all availability zones one by one in order to maximize the chances of getting<br>the requested instance capacity.
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **num_nodes_to_rollback** / SCT_NUM_NODES_TO_ROLLBACK
@@ -2351,12 +3027,16 @@ Number of nodes to upgrade and rollback in test_generic_cluster_upgrade
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **upgrade_sstables** / SCT_UPGRADE_SSTABLES
 
 Whether to upgrade sstables as part of upgrade_node or not
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **stress_before_upgrade** / SCT_STRESS_BEFORE_UPGRADE
@@ -2365,12 +3045,16 @@ Stress command to be run before upgrade (preapre stage)
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **stress_during_entire_upgrade** / SCT_STRESS_DURING_ENTIRE_UPGRADE
 
 Stress command to be run during the upgrade - user should take care for suitable duration
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **stress_after_cluster_upgrade** / SCT_STRESS_AFTER_CLUSTER_UPGRADE
@@ -2379,12 +3063,16 @@ Stress command to be run after full upgrade - usually used to read the dataset f
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **jepsen_scylla_repo** / SCT_JEPSEN_SCYLLA_REPO
 
 Link to the git repository with Jepsen Scylla tests
 
 **default:** https://github.com/jepsen-io/scylla.git
+
+**type:** str (appendable)
 
 
 ## **jepsen_test_cmd** / SCT_JEPSEN_TEST_CMD
@@ -2393,12 +3081,16 @@ Jepsen test command (e.g., 'test-all')
 
 **default:** ['test-all -w cas-register --concurrency 10n', 'test-all -w counter --concurrency 10n', 'test-all -w cmap --concurrency 10n', 'test-all -w cset --concurrency 10n', 'test-all -w write-isolation --concurrency 10n', 'test-all -w list-append --concurrency 10n', 'test-all -w wr-register --concurrency 10n']
 
+**type:** str_or_list (appendable)
+
 
 ## **jepsen_test_count** / SCT_JEPSEN_TEST_COUNT
 
 possible number of reruns of single Jepsen test command
 
 **default:** 1
+
+**type:** int
 
 
 ## **jepsen_test_run_policy** / SCT_JEPSEN_TEST_RUN_POLICY
@@ -2407,12 +3099,16 @@ Jepsen test run policy (i.e., what we want to consider as passed for a single te
 
 **default:** all
 
+**type:** str (appendable)
+
 
 ## **max_events_severities** / SCT_MAX_EVENTS_SEVERITIES
 
 Limit severity level for event types
 
 **default:** N/A
+
+**type:** str_or_list (appendable)
 
 
 ## **scylla_rsyslog_setup** / SCT_SCYLLA_RSYSLOG_SETUP
@@ -2421,12 +3117,16 @@ Configure rsyslog on Scylla nodes to send logs to monitoring nodes
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **events_limit_in_email** / SCT_EVENTS_LIMIT_IN_EMAIL
 
 Limit number events in email reports
 
 **default:** 10
+
+**type:** int
 
 
 ## **data_volume_disk_num** / SCT_DATA_VOLUME_DISK_NUM
@@ -2435,12 +3135,16 @@ Number of additional data volumes attached to instances<br>if data_volume_disk_n
 
 **default:** N/A
 
+**type:** int
+
 
 ## **data_volume_disk_type** / SCT_DATA_VOLUME_DISK_TYPE
 
 Type of addtitional volumes: gp2|gp3|io2|io3
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **data_volume_disk_size** / SCT_DATA_VOLUME_DISK_SIZE
@@ -2449,12 +3153,16 @@ Size of additional volume in GB
 
 **default:** N/A
 
+**type:** int
+
 
 ## **data_volume_disk_iops** / SCT_DATA_VOLUME_DISK_IOPS
 
 Number of iops for ebs type io2|io3|gp3
 
 **default:** N/A
+
+**type:** int
 
 
 ## **data_volume_disk_throughput** / SCT_DATA_VOLUME_DISK_THROUGHPUT
@@ -2463,12 +3171,16 @@ Throughput in MiB/sec for ebs type gp3. Min is 125. Max is 1000.
 
 **default:** N/A
 
+**type:** int
+
 
 ## **run_db_node_benchmarks** / SCT_RUN_DB_NODE_BENCHMARKS
 
 Flag for running db node benchmarks before the tests
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **nemesis_selector** / SCT_NEMESIS_SELECTOR
@@ -2477,12 +3189,16 @@ nemesis_selector gets a list of "nemesis properties" and filters IN all the neme
 
 **default:** N/A
 
+**type:** str_or_list (appendable)
+
 
 ## **nemesis_exclude_disabled** / SCT_NEMESIS_EXCLUDE_DISABLED
 
 nemesis_exclude_disabled determines whether 'disabled' nemeses are filtered out from list<br>or are allowed to be used. This allows to easily disable too 'risky' or 'extreme' nemeses by default,<br>for all longevities. For example: it is unwanted to run the ToggleGcModeMonkey in standard longevities<br>that runs a stress with data validation.
 
 **default:** True
+
+**type:** boolean
 
 
 ## **nemesis_multiply_factor** / SCT_NEMESIS_MULTIPLY_FACTOR
@@ -2491,12 +3207,16 @@ Multiply the list of nemesis to execute by the specified factor
 
 **default:** 6
 
+**type:** int
+
 
 ## **nemesis_double_load_during_grow_shrink_duration** / SCT_NEMESIS_DOUBLE_LOAD_DURING_GROW_SHRINK_DURATION
 
 After growing (and before shrink) in GrowShrinkCluster nemesis it will double the load for provided duration.
 
 **default:** N/A
+
+**type:** int
 
 
 ## **raid_level** / SCT_RAID_LEVEL
@@ -2505,12 +3225,16 @@ Number of of raid level: 0 - RAID0, 5 - RAID5
 
 **default:** N/A
 
+**type:** int
+
 
 ## **bare_loaders** / SCT_BARE_LOADERS
 
 Don't install anything but node_exporter to the loaders during cluster setup
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **stress_image** / SCT_STRESS_IMAGE
@@ -2519,12 +3243,16 @@ Dict of the images to use for the stress tools
 
 **default:** N/A
 
+**type:** dict_or_str
+
 
 ## **scylla_network_config** / SCT_SCYLLA_NETWORK_CONFIG
 
 Configure Scylla networking with single or multiple NIC/IP combinations.<br>It must be defined for listen_address and rpc_address. For each address mandatory parameters are:<br>- address: listen_address/rpc_address/broadcast_rpc_address/broadcast_address/test_communication<br>- ip_type: ipv4 or ipv6<br>- public: false or true<br>- nic: number of NIC. 0, 1<br>Supported for AWS only meanwhile
 
 **default:** N/A
+
+**type:** list
 
 
 ## **enable_argus** / SCT_ENABLE_ARGUS
@@ -2533,12 +3261,16 @@ Control reporting to argus
 
 **default:** True
 
+**type:** boolean
+
 
 ## **cs_populating_distribution** / SCT_CS_POPULATING_DISTRIBUTION
 
 set c-s parameter '-pop' with gauss/uniform distribution for<br>performance gradual throughtput grow tests
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **latte_schema_parameters** / SCT_LATTE_SCHEMA_PARAMETERS
@@ -2547,12 +3279,16 @@ Optional. Allows to pass through custom rune script parameters to the 'latte sch
 
 **default:** N/A
 
+**type:** dict
+
 
 ## **num_loaders_step** / SCT_NUM_LOADERS_STEP
 
 Number of loaders which should be added per step
 
 **default:** N/A
+
+**type:** int
 
 
 ## **stress_threads_start_num** / SCT_STRESS_THREADS_START_NUM
@@ -2561,12 +3297,16 @@ Number of threads for c-s command
 
 **default:** N/A
 
+**type:** int
+
 
 ## **num_threads_step** / SCT_NUM_THREADS_STEP
 
 Number of threads which should be added on per step
 
 **default:** N/A
+
+**type:** int
 
 
 ## **stress_step_duration** / SCT_STRESS_STEP_DURATION
@@ -2575,12 +3315,16 @@ Duration of time for stress round
 
 **default:** 15m
 
+**type:** str (appendable)
+
 
 ## **max_deviation** / SCT_MAX_DEVIATION
 
 Max relative difference between best and current throughput,<br>if current throughput larger then best on max_rel_diff, it become new best one
 
 **default:** N/A
+
+**type:** float
 
 
 ## **n_stress_process** / SCT_N_STRESS_PROCESS
@@ -2589,12 +3333,16 @@ Number of stress processes per loader
 
 **default:** N/A
 
+**type:** int
+
 
 ## **stress_process_step** / SCT_STRESS_PROCESS_STEP
 
 add/remove num of process on each round
 
 **default:** N/A
+
+**type:** int
 
 
 ## **use_hdr_cs_histogram** / SCT_USE_HDR_CS_HISTOGRAM
@@ -2603,12 +3351,16 @@ Enable hdr histogram logging for cs
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **stop_on_hw_perf_failure** / SCT_STOP_ON_HW_PERF_FAILURE
 
 Stop sct performance test if hardware performance test failed<br><br>Hardware performance tests runs on each node with sysbench and cassandra-fio tools.<br>Results stored in ES. HW perf tests run during cluster setups and not affect<br>SCT Performance tests. Results calculated as average among all results for certain<br>instance type or among all nodes during single run.<br>if results for a single node is not in margin 0.01 of<br>average result for all nodes, hw test considered as Failed.<br>If stop_on_hw_perf_failure is True, then sct performance test will be terminated<br>after hw perf tests detect node with hw results not in margin with average<br>If stop_on_hw_perf_failure is False, then sct performance test will be run<br>even after hw perf tests detect node with hw results not in margin with average
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **custom_es_index** / SCT_CUSTOM_ES_INDEX
@@ -2617,12 +3369,16 @@ Use custom ES index for storing test results
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **simulated_regions** / SCT_SIMULATED_REGIONS
 
 Defines how many regions must be simulated on the Scylla config side. If set then<br>nodes will be provisioned only using the very first real region defined in the configuration.
 
 **default:** N/A
+
+**type:** int
 
 
 ## **simulated_racks** / SCT_SIMULATED_RACKS
@@ -2631,12 +3387,16 @@ Forces GossipingPropertyFileSnitch (regardless `endpoint_snitch`) to simulate ra
 
 **default:** N/A
 
+**type:** int
+
 
 ## **use_dns_names** / SCT_USE_DNS_NAMES
 
 Use dns names instead of ip addresses for nodes in cluster
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **validate_large_collections** / SCT_VALIDATE_LARGE_COLLECTIONS
@@ -2645,12 +3405,16 @@ Enable validation for large cells in system table and logs
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **run_commit_log_check_thread** / SCT_RUN_COMMIT_LOG_CHECK_THREAD
 
 Run commit log check thread if commitlog_use_hard_size_limit is True
 
 **default:** True
+
+**type:** boolean
 
 
 ## **teardown_validators** / SCT_TEARDOWN_VALIDATORS
@@ -2659,12 +3423,16 @@ Configuration for additional validations executed after the test
 
 **default:** {'scrub': {'enabled': False, 'timeout': 1200, 'keyspace': '', 'table': ''}, 'test_error_events': {'enabled': False, 'failing_events': [{'event_class': 'DatabaseLogEvent', 'event_type': 'RUNTIME_ERROR', 'regex': '.*runtime_error.*'}, {'event_class': 'CoreDumpEvent'}]}}
 
+**type:** dict_or_str
+
 
 ## **use_capacity_reservation** / SCT_USE_CAPACITY_RESERVATION
 
 reserves instances capacity for whole duration of the test run (AWS only).<br>Fallbacks to next availabilit zone if capacity is not available
 
 **default:** N/A
+
+**type:** boolean
 
 
 ## **bisect_start_date** / SCT_BISECT_START_DATE
@@ -2673,12 +3441,16 @@ Scylla build date from which bisecting should start.<br>Setting this date enable
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **bisect_end_date** / SCT_BISECT_END_DATE
 
 Scylla build date until which bisecting should run. Format: YYYY-MM-DD
 
 **default:** N/A
+
+**type:** str (appendable)
 
 
 ## **kafka_backend** / SCT_KAFKA_BACKEND
@@ -2687,12 +3459,16 @@ Enable validation for large cells in system table and logs
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **kafka_connectors** / SCT_KAFKA_CONNECTORS
 
 configuration for setup up kafka connectors
 
 **default:** N/A
+
+**type:** str_or_list_or_eval (appendable)
 
 
 ## **run_scylla_doctor** / SCT_RUN_SCYLLA_DOCTOR
@@ -2701,12 +3477,16 @@ Run scylla-doctor in artifact tests
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **skip_test_stages** / SCT_SKIP_TEST_STAGES
 
 Skip selected stages of a test scenario
 
 **default:** N/A
+
+**type:** dict_or_str
 
 
 ## **use_zero_nodes** / SCT_USE_ZERO_NODES
@@ -2715,12 +3495,16 @@ If True, enable support in sct of zero nodes(configuration, nemesis)
 
 **default:** N/A
 
+**type:** boolean
+
 
 ## **n_db_zero_token_nodes** / SCT_N_DB_ZERO_TOKEN_NODES
 
 Number of zero token nodes in cluster. Value should be set as "0 1 1"<br>for multidc configuration in same manner as 'n_db_nodes' and should be equal<br>number of regions
 
 **default:** N/A
+
+**type:** int_or_space_separated_ints
 
 
 ## **zero_token_instance_type_db** / SCT_ZERO_TOKEN_INSTANCE_TYPE_DB
@@ -2729,6 +3513,8 @@ Instance type for zero token node
 
 **default:** i4i.large
 
+**type:** str (appendable)
+
 
 ## **sct_aws_account_id** / SCT_AWS_ACCOUNT_ID
 
@@ -2736,9 +3522,13 @@ AWS account id on behalf of which the test is run
 
 **default:** N/A
 
+**type:** str (appendable)
+
 
 ## **latency_decorator_error_thresholds** / SCT_LATENCY_DECORATOR_ERROR_THRESHOLDS
 
 Error thresholds for latency decorator. Defined by dict: {<write, read, mixed>: {<default|nemesis_name>:{<metric_name>: {<rule>: <value>}}}
 
 **default:** {'write': {'default': {'P90 write': {'fixed_limit': 5}, 'P99 write': {'fixed_limit': 10}}}, 'read': {'default': {'P90 read': {'fixed_limit': 5}, 'P99 read': {'fixed_limit': 10}}}, 'mixed': {'default': {'P90 write': {'fixed_limit': 5}, 'P90 read': {'fixed_limit': 5}, 'P99 write': {'fixed_limit': 10}, 'P99 read': {'fixed_limit': 10}}}}
+
+**type:** dict_or_str

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -24,6 +24,7 @@ import getpass
 import pathlib
 import tempfile
 import yaml
+import copy
 from copy import deepcopy
 from typing import List, Union, Set
 
@@ -182,6 +183,40 @@ def boolean(value):
         raise ValueError("{} isn't a boolean".format(type(value)))
 
 
+def is_config_option_appendable(option_name: str) -> bool:
+    for option in SCTConfiguration.config_options:
+        if option['name'] == option_name:
+            break
+    else:
+        raise ValueError(f"Option {option_name} not found in SCTConfiguration.config_options")
+
+    return option.get('appendable', option.get('type') in (str, str_or_list_or_eval, str_or_list))
+
+
+def merge_dicts_append_strings(d1, d2):
+    """
+    merge two dictionaries, while having option
+    to append string if the value starts with '++'
+    and append list if first item is '++'
+    """
+
+    for key, value in copy.deepcopy(d2).items():
+        if isinstance(value, str) and value.startswith('++'):
+            assert is_config_option_appendable(key), f"Option {key} is not appendable"
+            if key not in d1:
+                d1[key] = ''
+            d1[key] += value[2:]
+            del d2[key]
+        if isinstance(value, list) and value and isinstance(value[0], str) and value[0].startswith('++'):
+            assert is_config_option_appendable(key), f"Option {key} is not appendable"
+            if key not in d1:
+                d1[key] = []
+            d1[key].extend(value[1:])
+            del d2[key]
+
+    anyconfig.merge(d1, d2, ac_merge=anyconfig.MS_DICTS)
+
+
 class SCTConfiguration(dict):
     """
     Class the hold the SCT configuration
@@ -200,13 +235,14 @@ class SCTConfiguration(dict):
 
     config_options = [
         dict(name="config_files", env="SCT_CONFIG_FILES", type=str_or_list_or_eval,
-             help="a list of config files that would be used"),
+             help="a list of config files that would be used", appendable=False),
 
         dict(name="cluster_backend", env="SCT_CLUSTER_BACKEND", type=str,
-             help="backend that will be used, aws/gce/docker"),
+             help="backend that will be used, aws/gce/docker", appendable=False),
 
         dict(name="test_method", env="SCT_TEST_METHOD", type=str,
-             help="class.method used to run the test. Filled automatically with run-test sct command."),
+             help="class.method used to run the test. Filled automatically with run-test sct command.",
+             appendable=False),
 
         dict(name="test_duration", env="SCT_TEST_DURATION", type=int,
              help="""
@@ -295,38 +331,46 @@ class SCTConfiguration(dict):
              help="Install Scylla without required root priviledge"),
 
         dict(name="install_mode", env="SCT_INSTALL_MODE", type=str,
-             help="Scylla install mode, repo/offline/web"),
+             help="Scylla install mode, repo/offline/web",
+             appendable=False),
 
         dict(name="scylla_version", env="SCT_SCYLLA_VERSION",
              type=str,
              help="""Version of scylla to install, ex. '2.3.1'
                      Automatically lookup AMIs and repo links for formal versions.
-                     WARNING: can't be used together with 'scylla_repo' or 'ami_id_db_scylla'"""),
+                     WARNING: can't be used together with 'scylla_repo' or 'ami_id_db_scylla'""",
+             appendable=False),
 
         dict(name="user_data_format_version", env="SCT_USER_DATA_FORMAT_VERSION",
              type=str,
              help="""Format version of the user-data to use for scylla images,
-                     default to what tagged on the image used"""),
+                     default to what tagged on the image used""",
+             appendable=False),
 
         dict(name="oracle_user_data_format_version", env="SCT_ORACLE_USER_DATA_FORMAT_VERSION",
              type=str,
              help="""Format version of the user-data to use for scylla images,
-                 default to what tagged on the image used"""),
+                 default to what tagged on the image used""",
+             appendable=False),
 
         dict(name="oracle_scylla_version", env="SCT_ORACLE_SCYLLA_VERSION",
              type=str,
              help="""Version of scylla to use as oracle cluster with gemini tests, ex. '3.0.11'
                      Automatically lookup AMIs for formal versions.
-                     WARNING: can't be used together with 'ami_id_db_oracle'"""),
+                     WARNING: can't be used together with 'ami_id_db_oracle'""",
+             appendable=False),
 
         dict(name="scylla_linux_distro", env="SCT_SCYLLA_LINUX_DISTRO", type=str,
-             help="""The distro name and family name to use. Example: 'ubuntu-jammy' or 'debian-bookworm'."""),
+             help="""The distro name and family name to use. Example: 'ubuntu-jammy' or 'debian-bookworm'.""",
+             appendable=False),
 
         dict(name="scylla_linux_distro_loader", env="SCT_SCYLLA_LINUX_DISTRO_LOADER", type=str,
-             help="""The distro name and family name to use. Example: 'ubuntu-jammy' or 'debian-bookworm'."""),
+             help="""The distro name and family name to use. Example: 'ubuntu-jammy' or 'debian-bookworm'.""",
+             appendable=False),
 
         dict(name="assert_linux_distro_features", env="SCT_ASSERT_LINUX_DISTRO_FEATURES", type=str_or_list_or_eval,
-             help="""List of distro features relevant to SCT test. Example: 'fips'."""),
+             help="""List of distro features relevant to SCT test. Example: 'fips'.""",
+             appendable=True),
 
         dict(name="scylla_repo_m", env="SCT_SCYLLA_REPO_M", type=str,
              help="Url to the repo of scylla version to install scylla from for managment tests"),
@@ -344,18 +388,22 @@ class SCTConfiguration(dict):
 
         dict(name="manager_version", env="SCT_MANAGER_VERSION",
              type=str,
-             help="Branch of scylla manager server and agent to install. Options in defaults/manager_versions.yaml"),
+             help="Branch of scylla manager server and agent to install. Options in defaults/manager_versions.yaml",
+             appendable=False),
 
         dict(name="target_manager_version", env="SCT_TARGET_MANAGER_VERSION",
              type=str,
-             help="Branch of scylla manager server and agent to upgrade to. Options in defaults/manager_versions.yaml"),
+             help="Branch of scylla manager server and agent to upgrade to. Options in defaults/manager_versions.yaml",
+             appendable=False),
 
         dict(name="manager_scylla_backend_version", env="SCT_MANAGER_SCYLLA_BACKEND_VERSION",
              type=str,
-             help="Branch of scylla db enterprise to install. Options in defaults/manager_versions.yaml"),
+             help="Branch of scylla db enterprise to install. Options in defaults/manager_versions.yaml",
+             appendable=False),
 
         dict(name="scylla_mgmt_agent_version", env="SCT_SCYLLA_MGMT_AGENT_VERSION", type=str,
-             help=""),
+             help="",
+             appendable=False),
 
         dict(name="scylla_mgmt_pkg", env="SCT_SCYLLA_MGMT_PKG",
              type=str,
@@ -508,7 +556,7 @@ class SCTConfiguration(dict):
         dict(name="email_subject_postfix", env="SCT_EMAIL_SUBJECT_POSTFIX", type=str,
              help="""Email subject postfix"""),
 
-        dict(name="enable_test_profiling", env="SCT_ENABLE_TEST_PROFILING", type=bool,
+        dict(name="enable_test_profiling", env="SCT_ENABLE_TEST_PROFILING", type=boolean,
              help="""Turn on sct profiling"""),
         dict(name="ssh_transport", env="SSH_TRANSPORT", type=str,
              help="""Set type of ssh library to use. Could be 'fabric' (default) or 'libssh2'"""),
@@ -572,7 +620,7 @@ class SCTConfiguration(dict):
         dict(name="alternator_secret_access_key", env="SCT_ALTERNATOR_SECRET_ACCESS_KEY", type=str,
              help="the aws_secret_access_key that would be used for alternator"),
 
-        dict(name="region_aware_loader", env="SCT_REGION_AWARE_LOADER", type=bool,
+        dict(name="region_aware_loader", env="SCT_REGION_AWARE_LOADER", type=boolean,
              help="When in multi region mode, run stress on loader that is located in the same region as db node"),
 
         dict(name="append_scylla_args", env="SCT_APPEND_SCYLLA_ARGS", type=str,
@@ -682,7 +730,7 @@ class SCTConfiguration(dict):
              help="instance type of the sct-runner node"),
 
         dict(name="region_name", env="SCT_REGION_NAME", type=str_or_list_or_eval,
-             help="AWS regions to use"),
+             help="AWS regions to use", appendable=False),
 
         dict(name="security_group_ids", env="SCT_SECURITY_GROUP_IDS", type=str_or_list,
              help="AWS security groups ids to use"),
@@ -758,7 +806,7 @@ class SCTConfiguration(dict):
         dict(name="use_prepared_loaders", env="SCT_USE_PREPARED_LOADERS", type=boolean,
              help="If True, we use prepared VMs for loader (instead of using docker images)"),
 
-        dict(name="scylla_d_overrides_files", env="SCT_scylla_d_overrides_files", type=str_or_list_or_eval,
+        dict(name="scylla_d_overrides_files", env="SCT_SCYLLA_D_OVERRIDES_FILES", type=str_or_list_or_eval,
              help="list of files that should upload to /etc/scylla.d/ directory to override scylla config files"),
 
         # GCE config options
@@ -767,7 +815,8 @@ class SCTConfiguration(dict):
 
         dict(name="gce_datacenter", env="SCT_GCE_DATACENTER", type=str_or_list_or_eval,
              help="Supported: us-east1 - means that the zone will be selected automatically or "
-                  "you can mention the zone explicitly, for example: us-east1-b"),
+                  "you can mention the zone explicitly, for example: us-east1-b",
+             appendable=False),
 
         dict(name="gce_network", env="SCT_GCE_NETWORK", type=str,
              help=""),
@@ -828,7 +877,8 @@ class SCTConfiguration(dict):
 
         # azure options
         dict(name="azure_region_name", env="SCT_AZURE_REGION_NAME", type=str_or_list_or_eval,
-             help="Supported: eastus "),
+             help="Supported: eastus ",
+             appendable=False),
 
         dict(name="azure_instance_type_loader", env="SCT_AZURE_INSTANCE_TYPE_LOADER", type=str,
              help=""),
@@ -1466,7 +1516,7 @@ class SCTConfiguration(dict):
              type=boolean,
              help="""retrieving data from multiple streams in one poll"""),
 
-        dict(name="use_legacy_cluster_init", env="SCT_USE_LEGACY_CLUSTER_INIT", type=bool,
+        dict(name="use_legacy_cluster_init", env="SCT_USE_LEGACY_CLUSTER_INIT", type=boolean,
              help="""Use legacy cluster initialization with autobootsrap disabled and parallel node setup"""),
         dict(name="availability_zone", env="SCT_AVAILABILITY_ZONE",
              type=str,
@@ -1670,7 +1720,7 @@ class SCTConfiguration(dict):
         dict(name="skip_test_stages", env="SCT_SKIP_TEST_STAGES", type=dict_or_str,
              help="""Skip selected stages of a test scenario"""),
 
-        dict(name="use_zero_nodes", env="SCT_USE_ZERO_NODES", type=bool,
+        dict(name="use_zero_nodes", env="SCT_USE_ZERO_NODES", type=boolean,
              help="If True, enable support in sct of zero nodes(configuration, nemesis)"),
 
         dict(name="n_db_zero_token_nodes", env="SCT_N_DB_ZERO_TOKEN_NODES", type=int_or_space_separated_ints,
@@ -1821,7 +1871,7 @@ class SCTConfiguration(dict):
 
         # 1) load the default backend config files
         files = anyconfig.load(list(backend_config_files))
-        anyconfig.merge(self, files)
+        merge_dicts_append_strings(self, files)
 
         # 2) load the config files
         try:
@@ -1829,7 +1879,7 @@ class SCTConfiguration(dict):
                 if not os.path.exists(conf_file):
                     raise FileNotFoundError(f"Couldn't find config file: {conf_file}")
             files = anyconfig.load(list(config_files))
-            anyconfig.merge(self, files)
+            merge_dicts_append_strings(self, files)
         except ValueError:
             self.log.warning("Failed to load configuration files: %s", config_files)
 
@@ -1861,7 +1911,7 @@ class SCTConfiguration(dict):
                         raise ValueError(f"{region} isn't supported, use: {self.aws_supported_regions}")
 
         # 3) overwrite with environment variables
-        anyconfig.merge(self, env)
+        merge_dicts_append_strings(self, env)
 
         # 4) update events max severities
         add_severity_limit_rules(self.get("max_events_severities"))
@@ -2745,6 +2795,12 @@ class SCTConfiguration(dict):
         header = """
             # scylla-cluster-tests configuration options
 
+            #### Appending with environment variables or with config files
+            * **strings:** can be appended with adding `++` at the beginning of the string:
+                   `export SCT_APPEND_SCYLLA_ARGS="++ --overprovisioned 1"`
+            * **list:** can be appended by adding `++` as the first item of the list
+                   `export SCT_SCYLLA_D_OVERRIDES_FILES='["++", "extra_file/scylla.d/io.conf"]'`
+
         """
 
         def strip_help_text(text):
@@ -2761,11 +2817,10 @@ class SCTConfiguration(dict):
                 help_text = '<br>'.join(strip_help_text(opt['help']).splitlines())
             else:
                 help_text = ''
-
+            appendable = ' (appendable)' if is_config_option_appendable(opt.get('name')) else ''
             default = self.get_default_value(opt['name'])
             default_text = default if default else 'N/A'
-            ret += """## **{name}** / {env}\n\n{help_text}\n\n**default:** {default_text}\n\n\n""".format(
-                help_text=help_text, default_text=default_text, **opt)
+            ret += f"""## **{opt['name']}** / {opt['env']}\n\n{help_text}\n\n**default:** {default_text}\n\n**type:** {opt.get('type').__name__}{appendable}\n\n\n"""
 
         return ret
 

--- a/unit_tests/test_teardown_validator.py
+++ b/unit_tests/test_teardown_validator.py
@@ -57,7 +57,7 @@ class TestErrorEventsValidator(unittest.TestCase):
 
     @patch('sdcm.teardown_validators.events.get_events_main_device')
     def test_validate_no_failing_events_no_critical_events(self, get_events_main_device_mock):
-        self.setup_validator(FAILING_EVENTS.values())
+        self.setup_validator(list(FAILING_EVENTS.values()))
         event_data = (
             '{"severity": "WARNING", "base": "Event1", "type": "Type1", "line": "failing event line"}\n'
             '{"severity": "ERROR", "base": "Event4", "type": "Type1", "line": "failing event line"}\n')


### PR DESCRIPTION
introduce new option for appending to string or list configuration values

1) strings: can be appended with adding `++` at the begining of the string:
   `export SCT_APPEND_SCYLLA_ARGS="++ --overprovisioned 1"`

2) list: can be appended by adding `++` as the first item of the list
   `export SCT_SCYLLA_D_OVERRIDES_FILES='["++", "extra_file/scylla.d/io.conf"]'`

Note list would work on every config defiend with `str_or_list_or_eval` with the expection of `config_files`, `region_name`, `gce_datacenter` and `gce_datacenter` which can't be appended, and would need to be overriden completly

Ref: https://github.com/scylladb/scylla-cluster-tests/issues/7653

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
