### PR TITLE
fix(integration-tests): remove tests that search AMI by name

### DIFF
--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -705,44 +705,6 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                              [["config_changes", "topology_changes"], ["topology_changes"], ["disruptive"]],
                              msg=f"Wrong value {conf['nemesis_selector']}")
 
-    @pytest.mark.integration
-    def test_24_convert_ami_multi_region(self):
-        # test converting with all supported regions
-        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'amzn2-ami-hvm-2.0.20221210.1-x86_64-gp2'
-        os.environ['SCT_N_DB_NODES'] = '1 1 1 1 1 1'
-        os.environ['SCT_REGION_NAME'] = 'eu-west-1 eu-west-2 us-west-2 us-east-1 eu-north-1 eu-central-1'
-        conf = sct_config.SCTConfiguration()
-        conf.verify_configuration()
-        conf.verify_configuration_urls_validity()
-        self.assertEqual(len(conf.get('ami_id_db_scylla').split()), 6)
-        self.assertEqual(len(conf.get('ami_id_loader').split()), 6)
-        self.assertEqual(len(conf.get('ami_id_monitor').split()), 6)
-        for ami_id_db_scylla, ami_id_loader, ami_id_monitor in zip(
-                conf.get('ami_id_db_scylla').split(), conf.get('ami_id_loader').split(),
-                conf.get('ami_id_monitor').split()):
-            self.assertTrue(ami_id_db_scylla.startswith("ami-"))
-            self.assertTrue(ami_id_loader.startswith("ami-"))
-            self.assertTrue(ami_id_monitor.startswith("ami-"))
-
-    @pytest.mark.integration
-    def test_25_convert_ami_single_region(self):
-        # test converting with 1 default region
-        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'amzn2-ami-hvm-2.0.20221210.1-x86_64-gp2'
-        conf = sct_config.SCTConfiguration()
-        conf.verify_configuration()
-        conf.verify_configuration_urls_validity()
-        self.assertEqual(len(conf.get('ami_id_db_scylla').split()), 1)
-        self.assertEqual(len(conf.get('ami_id_loader').split()), 1)
-        self.assertEqual(len(conf.get('ami_id_monitor').split()), 1)
-        for ami_id_db_scylla, ami_id_loader, ami_id_monitor in zip(
-                conf.get('ami_id_db_scylla').split(), conf.get('ami_id_loader').split(),
-                conf.get('ami_id_monitor').split()):
-            self.assertTrue(ami_id_db_scylla.startswith("ami-"))
-            self.assertTrue(ami_id_loader.startswith("ami-"))
-            self.assertTrue(ami_id_monitor.startswith("ami-"))
-
     def test_26_run_fullscan_params_validtion_positive(self):
         os.environ['SCT_CONFIG_FILES'] = '''["internal_test_data/minimal_test_case.yaml", \
                                                    "internal_test_data/positive_fullscan_param.yaml"]'''


### PR DESCRIPTION
the image used in those test isn't available anymore, and this feature it now use by default for loader and monitor images.

hence those test are not needed anymore, and would be removed since it gets covered on a daily basis

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] is remove tests, so no testing

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
