### PR TITLE
feature(ruff): add `f-string-missing-placeholders (F541)` to linter

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -1611,7 +1611,7 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
                                                           keyspace_name=snapshot_data.keyspaces[0],
                                                           num_of_rows=snapshot_data.number_of_rows)
         else:
-            self.log.info(f"Skipping verification read stress because of the test or snapshot configuration")
+            self.log.info("Skipping verification read stress because of the test or snapshot configuration")
 
     def test_restore_benchmark(self):
         """Benchmark restore operation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ lint.select = [
     "F401", "F821", "F823", "F841",
     "PL", "PLR0913","PLR0914", "PLR0916",
     "YTT",
+    "F541",
 ]
 
 lint.ignore = ["E501", "PLR2004"]

--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -204,7 +204,7 @@ def send_result_to_argus(argus_client: ArgusClient, workload: str, name: str, de
         result_table = ReactorStallStatsResult()
         result_table.name = f"{workload} - {name} - stalls - {event_name}"
         result_table.description = f"{event_name} event counts"
-        result_table.add_result(column=f"total", row=f"Cycle #{cycle}",
+        result_table.add_result(column="total", row=f"Cycle #{cycle}",
                                 value=stall_stats["counter"], status=Status.PASS)
         for interval, value in stall_stats["ms"].items():
             result_table.add_result(column=f"{interval}ms", row=f"Cycle #{cycle}",

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2823,7 +2823,7 @@ class SCTConfiguration(dict):
 
     def _validate_docker_backend_parameters(self):
         if self.get("use_mgmt"):
-            raise ValueError(f"Scylla Manager is not supported for docker backend")
+            raise ValueError("Scylla Manager is not supported for docker backend")
 
 
 def init_and_verify_sct_config() -> SCTConfiguration:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2961,7 +2961,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         self.destroy_credentials()
 
-    @silence(name=f"Save node schema", raise_error_event=False)
+    @silence(name="Save node schema", raise_error_event=False)
     def save_cqlsh_output_in_file(self, node, cmd: str, log_file: str):
         self.log.info("Save command '%s' output in the file. Node %s", cmd, node.name)
 

--- a/unit_tests/rest/test_compaction_manager_client.py
+++ b/unit_tests/rest/test_compaction_manager_client.py
@@ -39,4 +39,4 @@ def test_compaction_manager_stop_compaction():
     client = CompactionManagerClient(FakeNode())
     result = partial(client.stop_compaction, compaction_type="reshape")()
 
-    assert result.stdout == f'curl -v -X POST "http://localhost:10000/compaction_manager/stop_compaction?type=RESHAPE"'
+    assert result.stdout == 'curl -v -X POST "http://localhost:10000/compaction_manager/stop_compaction?type=RESHAPE"'


### PR DESCRIPTION
since we have this check on older branches using pylint and it's easily fixable checked, we are introducing this one to minimize issues with backporting

Ref: https://docs.astral.sh/ruff/rules/f-string-missing-placeholders/#f-string-missing-placeholders-f541

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
