### PR TITLE
fix(tester): fix `reliable_replication_factor` method by setting proper RF

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -804,7 +804,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         min_nodes_dc = min([int(nodes_num) for nodes_num in n_db_nodes.split() if int(nodes_num) > 0])
         with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
             # In case tablets are enabled, it's better to set RF smaller than dc-nodes-number, so decommission is allowed.
-            return max([min_nodes_dc - 1, 1]) if is_tablets_feature_enabled(session) else min_nodes_dc
+            rf_candidate = max([min_nodes_dc - 1, 1]) if is_tablets_feature_enabled(session) else min_nodes_dc
+            # NOTE: use RF=3 at max to avoid problems on big setups
+            return min(rf_candidate, 3)
 
     @property
     def test_id(self):


### PR DESCRIPTION
Various nemesis use `_prepare_test_table` method for creation of
keyspaces and tables if it is absent.
This method uses `reliable_replication_factor` property from the tester module.
    
The problem with it is the improper replication factor calculation.
It takes maximum nodes amount in a region, reduces by 1, and then uses it as RF.
In test setups which don't have those keyspaces
and have many nodes per each region,
the resulted keyspaces get replicated to much more nodes then it is needed.
    
Example: `5dcs` with `12` DB nodes each will have `RF=11`.
In summary, it will be `55` DB nodes out of `60`.
    
So, fix it by using python `min` function which will choose
either "3" or smaller value if DB nodes count requires it.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
