### PR TITLE
fix(artifacts-docker-fips-pipeline): do not install manager by default

### DIFF
--- a/jenkins-pipelines/enterprise/artifacts/artifacts-docker-fips.jenkinsfile
+++ b/jenkins-pipelines/enterprise/artifacts/artifacts-docker-fips.jenkinsfile
@@ -9,5 +9,7 @@ artifactsPipeline(
     region: 'fips',
 
     timeout: [time: 30, unit: 'MINUTES'],
-    post_behavior_db_nodes: 'destroy'
+    post_behavior_db_nodes: 'destroy',
+
+    extra_environment_variables: 'SCT_USE_MGMT=false'
 )


### PR DESCRIPTION
After https://github.com/scylladb/scylla-cluster-tests/pull/9331 change was introduced the artifacts-docker-fips test should have SCT_USE_MGMT=false set in the pipeline, for SCT to pass config validation.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
