### PR TITLE
fix(nemesis): filter raft-topology errors when starting/stopping nodes

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -673,6 +673,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.target_node.wait_jmx_up()
         self.cluster.wait_for_schema_agreement()
 
+    @decorate_with_context(ignore_raft_topology_cmd_failing)
     @target_all_nodes
     def disrupt_stop_wait_start_scylla_server(self, sleep_time=300):  # pylint: disable=invalid-name
         self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
@@ -1141,7 +1142,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         return sstables
 
-    @decorate_with_context(ignore_ycsb_connection_refused)
+    @decorate_with_context([ignore_ycsb_connection_refused, ignore_raft_topology_cmd_failing])
     def _destroy_data_and_restart_scylla(self, keyspaces_for_destroy: list = None, sstables_to_destroy_perc: int = 50):  # pylint: disable=too-many-statements
         tables = self.cluster.get_non_system_ks_cf_list(db_node=self.target_node, filter_empty_tables=False,
                                                         filter_by_keyspace=keyspaces_for_destroy)
@@ -1361,7 +1362,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         InfoEvent(message="FinishEvent - New Nodes are up and normal").publish()
         return new_nodes
 
-    @decorate_with_context(ignore_ycsb_connection_refused)
+    @decorate_with_context([ignore_ycsb_connection_refused, ignore_raft_topology_cmd_failing])
     def _terminate_cluster_node(self, node):
         self.cluster.terminate_node(node)
         self.monitoring_set.reconfigure_scylla_monitoring()
@@ -1684,7 +1685,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 new_node.set_seed_flag(True)
                 self.cluster.update_seed_provider()
 
-    @decorate_with_context(ignore_ycsb_connection_refused)
+    @decorate_with_context([ignore_ycsb_connection_refused, ignore_raft_topology_cmd_failing])
     @target_all_nodes
     def disrupt_kill_scylla(self):
         self._kill_scylla_daemon()


### PR DESCRIPTION
raft is generating the following errors:
raft_topology - topology change coordinator fiber got error std::runtime_error
when one of the nodes is stopped, it was decided we can safely ignore those errors

fixes: #9031

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
