### PR TITLE
test(manager): update version of Manager in upgrade test

### DIFF
--- a/jenkins-pipelines/manager/ubuntu24-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-upgrade.jenkinsfile
@@ -10,7 +10,7 @@ managerPipeline(
     target_manager_version: 'master_latest',
 
     // Upgrade from latest patch release
-    manager_version: '3.3.1',
+    manager_version: '3.4.0',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu24.yaml"]''',


### PR DESCRIPTION
Since we are about to release Manager 3.4.1, updating manager_version to 3.4.0 (the latest patch release) for the upgrade job that verifies upgrades from the latest patch release (ubuntu24-manager-upgrade).

The jobs that check upgrade from minor releases (3.3.*) left unchanged.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Upgrade](https://jenkins.scylladb.com/view/scylla-manager/job/manager-3.4/job/ubuntu24-upgrade-test/2/) from 3.4.0 to the latest Manager from master

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code