### PR TITLE
fix(sct lib): raft topology errors during rolling upgrade ignoration …

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -10,7 +10,6 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2020 ScyllaDB
-
 from contextlib import contextmanager, ExitStack, ContextDecorator
 from functools import wraps
 from typing import ContextManager, Callable, Sequence
@@ -96,14 +95,18 @@ def ignore_topology_change_coordinator_errors():
             #   Therefore, it is OK to ignore this particular error until a proper fix is merged.
             stack.enter_context(DbEventsFilter(
                 db_event=DatabaseLogEvent.DATABASE_ERROR,
-                line="raft_topology - topology change coordinator fiber got error exceptions::unavailable_exception"
-                     " (Cannot achieve consistency level for cl ALL.",
+                line=r".*raft_topology - topology change coordinator fiber got error exceptions::unavailable_exception "
+                     r"\(Cannot achieve consistency level for cl ALL\.",
             ))
             stack.enter_context(DbEventsFilter(
                 db_event=DatabaseLogEvent.RUNTIME_ERROR,
-                line="raft_topology - topology change coordinator fiber got error std::runtime_error"
-                     " (raft topology: exec_global_command(barrier) failed with seastar::rpc::closed_error"
-                     " (connection is closed))",
+                line=r".*raft_topology - topology change coordinator fiber got error std::runtime_error"
+                     r" \(raft topology: exec_global_command\(barrier\) failed with seastar::rpc::closed_erro"
+                     r"r \(connection is closed\)\)"
+            ))
+            stack.enter_context(DbEventsFilter(
+                db_event=DatabaseLogEvent.RUNTIME_ERROR,
+                line=r".*raft_topology - drain rpc failed, proceed to fence old writes:.*connection is closed",
             ))
         yield
 

--- a/unit_tests/test_sct_events_filters.py
+++ b/unit_tests/test_sct_events_filters.py
@@ -57,6 +57,29 @@ class TestDbEventsFilter(unittest.TestCase):
         self.assertFalse(db_events_filter.eval_filter(event2))
         self.assertFalse(db_events_filter.eval_filter(event3))
 
+    def test_eval_filter_type_with_regex_line(self):
+        regex = re.compile(r".*raft_topology - drain rpc failed, proceed to fence "
+                           r"old writes:.*connection is closed")
+        db_events_filter = DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR, line=regex)
+        event1 = DatabaseLogEvent.RUNTIME_ERROR().add_info(
+            node="node1",
+            line="raft_topology - drain rpc failed, proceed to fence old writes: connection is closed",
+            line_number=1
+        )
+        event2 = event1.clone().add_info(
+            node="node2",
+            line="unrelated log entry",
+            line_number=1
+        )
+        event3 = DatabaseLogEvent.NO_SPACE_ERROR().add_info(
+            node="node1",
+            line="raft_topology - drain rpc failed, proceed to fence old writes: connection is closed",
+            line_number=1
+        )
+        self.assertTrue(db_events_filter.eval_filter(event1))
+        self.assertFalse(db_events_filter.eval_filter(event2))
+        self.assertFalse(db_events_filter.eval_filter(event3))
+
 
 class TestEventsFilter(unittest.TestCase):
     def test_event_class_and_regex_none(self):


### PR DESCRIPTION
…added

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9511
Such a change is needed to ignore expected raft topology errors that never lead to failure. To reduce argus events at first place

### Testing
Regular expression been tested locally and within this job:
https://jenkins.scylladb.com/job/scylla-staging/job/eugene_test_folder/job/rolling_upgrades_test/14/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
