### PR TITLE
fix(nemesis.py): abort nemesis on stress command failure

### DIFF
--- a/sdcm/cassandra_harry_thread.py
+++ b/sdcm/cassandra_harry_thread.py
@@ -87,6 +87,8 @@ class CassandraHarryThread(DockerBasedStressThread):
 
         CassandraHarryEvent.start(node=loader, stress_cmd=self.stress_cmd).publish()
 
+        result = {}
+        harry_failure_event = harry_finish_event = None
         with CassandraHarryStressExporter(instance_name=loader.ip_address,
                                           metrics=nemesis_metrics_obj(),
                                           stress_operation='write',
@@ -106,22 +108,23 @@ class CassandraHarryThread(DockerBasedStressThread):
             except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
                 errors_str = format_stress_cmd_error(exc)
                 if "timeout" in errors_str:
-                    event_type = CassandraHarryEvent.timeout
+                    harry_failure_event = CassandraHarryEvent.timeout
                 elif self.stop_test_on_failure:
-                    event_type = CassandraHarryEvent.failure
+                    harry_failure_event = CassandraHarryEvent.failure
                 else:
-                    event_type = CassandraHarryEvent.error
-                event_type(
+                    harry_failure_event = CassandraHarryEvent.error
+                harry_failure_event(
                     node=loader,
                     stress_cmd=self.stress_cmd,
                     log_file_name=log_file_name,
                     errors=[errors_str, ],
                 ).publish()
             else:
-                CassandraHarryEvent.finish(node=loader, stress_cmd=self.stress_cmd,
-                                           log_file_name=log_file_name).publish()
+                harry_finish_event = CassandraHarryEvent.finish(node=loader, stress_cmd=self.stress_cmd,
+                                                                log_file_name=log_file_name)
+                harry_finish_event.publish()
 
-        return result
+        return loader, result, harry_failure_event or harry_finish_event
 
     @staticmethod
     def _parse_harry_summary(lines):  # pylint: disable=too-many-branches
@@ -137,3 +140,6 @@ class CassandraHarryThread(DockerBasedStressThread):
         else:
             results['status'] = 'failed'
         return results
+
+    def get_results(self) -> list:
+        return [result for _, result, _ in super().get_results()]

--- a/sdcm/exceptions.py
+++ b/sdcm/exceptions.py
@@ -87,3 +87,7 @@ class CapacityReservationError(Exception):
 
 class RaftTopologyCoordinatorNotFound(Exception):
     """Raise exception if no host id for raft topology was not found in group0 history"""
+
+
+class NemesisStressFailure(Exception):
+    """Exception to be raised to stop Nemesis flow, if stress command failed"""

--- a/sdcm/ndbench_thread.py
+++ b/sdcm/ndbench_thread.py
@@ -148,25 +148,33 @@ class NdBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-many-
 
         NdBenchStressEvent.start(node=loader, stress_cmd=self.stress_cmd).publish()
 
+        result = {}
+        ndbench_failure_event = ndbench_finish_event = None
         with NdBenchStatsPublisher(loader, loader_idx, ndbench_log_filename=log_file_name), \
                 NdBenchStressEventsPublisher(node=loader, ndbench_log_filename=log_file_name), \
                 cleanup_context:
             try:
-                docker_run_result = docker.run(cmd=node_cmd,
-                                               timeout=self.timeout + self.shutdown_timeout,
-                                               ignore_status=True,
-                                               log_file=log_file_name,
-                                               verbose=True,
-                                               retry=0,
-                                               )
-                return docker_run_result
+                result = docker.run(cmd=node_cmd,
+                                    timeout=self.timeout + self.shutdown_timeout,
+                                    ignore_status=True,
+                                    log_file=log_file_name,
+                                    verbose=True,
+                                    retry=0)
             except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
-                NdBenchStressEvent.failure(node=str(loader),
-                                           stress_cmd=self.stress_cmd,
-                                           log_file_name=log_file_name,
-                                           errors=[format_stress_cmd_error(exc), ]).publish()
+                ndbench_failure_event = NdBenchStressEvent.failure(
+                    node=str(loader),
+                    stress_cmd=self.stress_cmd,
+                    log_file_name=log_file_name,
+                    errors=[format_stress_cmd_error(exc), ])
+                ndbench_failure_event.publish()
             finally:
-                NdBenchStressEvent.finish(node=loader,
-                                          stress_cmd=self.stress_cmd,
-                                          log_file_name=log_file_name).publish()
-        return None
+                ndbench_finish_event = NdBenchStressEvent.finish(
+                    node=loader,
+                    stress_cmd=self.stress_cmd,
+                    log_file_name=log_file_name)
+                ndbench_finish_event.publish()
+
+        return loader, result, ndbench_failure_event or ndbench_finish_event
+
+    def get_results(self) -> list:
+        return [result for _, result, _ in super().get_results()]

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -98,6 +98,7 @@ from sdcm.sct_events.loaders import CassandraStressLogEvent, ScyllaBenchEvent
 from sdcm.sct_events.nemesis import DisruptionEvent
 from sdcm.sct_events.system import InfoEvent, CoreDumpEvent
 from sdcm.sla.sla_tests import SlaTests
+from sdcm.stress_thread import DockerBasedStressThread
 from sdcm.utils.aws_kms import AwsKms
 from sdcm.utils import cdc
 from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations
@@ -155,6 +156,7 @@ from sdcm.exceptions import (
     AuditLogTestFailure,
     BootstrapStreamErrorFailure,
     QuotaConfigurationFailure,
+    NemesisStressFailure,
 )
 from test_lib.compaction import CompactionStrategy, get_compaction_strategy, get_compaction_random_additional_params, \
     get_gc_mode, GcMode, calculate_allowed_twcs_ttl_borders, get_table_compaction_info
@@ -2075,6 +2077,23 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             cs_thread = self.tester.run_stress_thread(
                 stress_cmd=stress_cmd, keyspace_name=ks, stop_test_on_failure=False, round_robin=True)
             cs_thread.verify_results()
+            self.stop_nemesis_on_stress_errors(cs_thread)
+
+    def stop_nemesis_on_stress_errors(self, stress_thread: DockerBasedStressThread) -> None:
+        # Some implementations of stress threads override logic of the base class method
+        # DockerBasedStressThread.get_results() and filter out 'events' portion of a result (e.g. c-s stress thread).
+        # To retrieve all results of a thread we need to call the base class method directly
+        stress_results = super(stress_thread.__class__, stress_thread).get_results()
+        node_errors = {}
+        for node, result, event in stress_results:
+            if event.get('errors'):
+                node_errors.setdefault(node.name, []).extend(event.errors)
+
+        if len(node_errors) == len(stress_results):  # stop only if stress command failed on all loaders
+            errors_str = ''.join(f"  on node '{node_name}': {errors}\n" for node_name, errors in node_errors.items())
+            raise NemesisStressFailure(
+                f"Aborting '{self.__class__.__name__}' nemesis as '{stress_thread.stress_cmd}' stress command failed "
+                f"with the following errors:\n{errors_str}")
 
     @scylla_versions(("5.2.rc0", None), ("2023.1.rc0", None))
     def _truncate_cmd_timeout_suffix(self, truncate_timeout):  # pylint: disable=no-self-use
@@ -2121,6 +2140,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         bench_thread = self.tester.run_stress_thread(
             stress_cmd=stress_cmd, stop_test_on_failure=False)
         self.tester.verify_stress_thread(bench_thread)
+        self.stop_nemesis_on_stress_errors(bench_thread)
 
         # In order to workaround issue #4924 when truncate timeouts, we try to flush before truncate.
         with adaptive_timeout(Operations.FLUSH, self.target_node, timeout=HOUR_IN_SEC * 2):
@@ -4248,6 +4268,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         stress_queue = self.tester.run_stress_thread(
             stress_cmd=self.tester.stress_cmd, stress_num=1, stats_aggregate_cmds=False, duration=duration)
         results = self.tester.get_stress_results(queue=stress_queue, store_results=False)
+        self.stop_nemesis_on_stress_errors(stress_queue)
         self.log.info(f"Double load results: {results}")
 
     @target_data_nodes
@@ -4422,6 +4443,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     regex=".*sstable - Error while linking SSTable.*filesystem error: stat failed: No such file or directory.*"):
                 write_thread = self.tester.run_stress_thread(stress_cmd=write_cmd, stop_test_on_failure=False)
                 self.tester.verify_stress_thread(write_thread)
+                self.stop_nemesis_on_stress_errors(write_thread)
 
         try:
             for i in range(2 if (aws_kms and kms_key_alias_name and enable_kms_key_rotation) else 1):
@@ -4441,6 +4463,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     " -iterations=1 -concurrency=10 -connection-count=10 -rows-per-request=10")
                 read_thread = self.tester.run_stress_thread(stress_cmd=read_cmd, stop_test_on_failure=False)
                 self.tester.verify_stress_thread(read_thread)
+                self.stop_nemesis_on_stress_errors(read_thread)
 
                 # Rotate KMS key
                 if enable_kms_key_rotation and aws_kms and kms_key_alias_name and i == 0:
@@ -4466,6 +4489,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 # ReRead data
                 read_thread2 = self.tester.run_stress_thread(stress_cmd=read_cmd, stop_test_on_failure=False)
                 self.tester.verify_stress_thread(read_thread2)
+                self.stop_nemesis_on_stress_errors(read_thread2)
 
                 # ReWrite data making the sstables be rewritten
                 run_write_scylla_bench_load(write_cmd)
@@ -4474,6 +4498,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 # ReRead data
                 read_thread3 = self.tester.run_stress_thread(stress_cmd=read_cmd, stop_test_on_failure=False)
                 self.tester.verify_stress_thread(read_thread3)
+                self.stop_nemesis_on_stress_errors(read_thread3)
 
                 # Check that sstables of that table are not encrypted anymore
                 check_encryption_fact(sstable_util, False)
@@ -4740,6 +4765,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     f"-mode cql3 native compression=lz4 -rate threads=5 -pop seq=1..10000 -log interval=5"
         write_thread = self.tester.run_stress_thread(stress_cmd=write_cmd, round_robin=True, stop_test_on_failure=False)
         self.tester.verify_stress_thread(cs_thread_pool=write_thread)
+        self.stop_nemesis_on_stress_errors(write_thread)
         self._verify_multi_dc_keyspace_data(consistency_level="ALL")
 
     def _verify_multi_dc_keyspace_data(self, consistency_level: str = "ALL"):
@@ -4748,6 +4774,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                    f"-pop seq=1..10000 -log interval=5"
         read_thread = self.tester.run_stress_thread(stress_cmd=read_cmd, round_robin=True, stop_test_on_failure=False)
         self.tester.verify_stress_thread(cs_thread_pool=read_thread)
+        self.stop_nemesis_on_stress_errors(read_thread)
 
     def _switch_to_network_replication_strategy(self, keyspaces: List[str]) -> None:
         """Switches replication strategy to NetworkTopology for given keyspaces.
@@ -5161,6 +5188,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             write_thread = self.tester.run_stress_thread(
                 stress_cmd=write_cmd, round_robin=True, stop_test_on_failure=False)
             self.tester.verify_stress_thread(cs_thread_pool=write_thread)
+            self.stop_nemesis_on_stress_errors(write_thread)
             read_cmd = f"cassandra-stress read no-warmup cl=ONE n=1000 " \
                        f" -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)" \
                        f" keyspace={audit_keyspace}' -mode cql3 native -rate 'threads=1 throttle=1000/s'" \
@@ -5168,6 +5196,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             read_thread = self.tester.run_stress_thread(
                 stress_cmd=read_cmd, round_robin=True, stop_test_on_failure=False)
             self.tester.verify_stress_thread(cs_thread_pool=read_thread)
+            self.stop_nemesis_on_stress_errors(read_thread)
             InfoEvent(message='Verifying Audit table contents').publish()
             rows = audit.get_audit_log(from_datetime=audit_start, category="DML", limit_rows=1500)
             # filter out USE keyspace rows due to https://github.com/scylladb/scylla-enterprise/issues/3169

--- a/sdcm/nosql_thread.py
+++ b/sdcm/nosql_thread.py
@@ -86,6 +86,7 @@ class NoSQLBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-ma
                                      (loader_idx, cpu_idx, uuid.uuid4()))
         LOGGER.debug('nosql-bench-stress local log: %s', log_file_name)
         LOGGER.debug("'running: %s", stress_cmd)
+        result = {}
         with NoSQLBenchStressEvent(node=loader, stress_cmd=stress_cmd, log_file_name=log_file_name) as stress_event, \
                 NoSQLBenchEventsPublisher(node=loader, log_filename=log_file_name):
             try:
@@ -107,12 +108,16 @@ class NoSQLBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-ma
                                    log_file=log_file_name,
                                    ignore_status=True)
 
-                return loader.remoter.run(cmd=f'docker run '
-                                          '--name=nb '
-                                          '--network=nosql '
-                                          f'{self.docker_image_name} '
-                                          f'{stress_cmd} --report-graphite-to graphite-exporter:9109',
-                                          timeout=self.timeout + self.shutdown_timeout, log_file=log_file_name)
+                result = loader.remoter.run(cmd=f'docker run '
+                                            '--name=nb '
+                                            '--network=nosql '
+                                            f'{self.docker_image_name} '
+                                            f'{stress_cmd} --report-graphite-to graphite-exporter:9109',
+                                            timeout=self.timeout + self.shutdown_timeout, log_file=log_file_name)
             except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
                 self.configure_event_on_failure(stress_event=stress_event, exc=exc)
-            return None
+
+            return loader, result, stress_event
+
+    def get_results(self) -> list:
+        return [result for _, result, _ in super().get_results()]

--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -144,7 +144,7 @@ class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-in
 
         results = self.get_results()
 
-        for _, result in results:
+        for _, result, _ in results:
             if not result:
                 # Silently skip if stress command threw an error, since it was already reported in _run_stress
                 continue
@@ -251,7 +251,7 @@ class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-in
             except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
                 self.configure_event_on_failure(stress_event=scylla_bench_event, exc=exc)
 
-        return loader, result
+        return loader, result, scylla_bench_event
 
     @classmethod
     def _parse_bench_summary(cls, lines):

--- a/sdcm/stress/latte_thread.py
+++ b/sdcm/stress/latte_thread.py
@@ -219,6 +219,7 @@ class LatteStressThread(DockerBasedStressThread):  # pylint: disable=too-many-in
 
         operation = self.function_name(stress_cmd)
 
+        result = {}
         with cleanup_context, \
                 LatteStatsPublisher(loader, loader_idx, latte_log_filename=log_file_name,
                                     operation=operation), \
@@ -233,12 +234,11 @@ class LatteStressThread(DockerBasedStressThread):  # pylint: disable=too-many-in
                     log_file=log_file_name,
                     retry=0,
                 )
-                return self.parse_final_output(result)
-
+                result = self.parse_final_output(result)
             except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
                 self.configure_event_on_failure(stress_event=latte_stress_event, exc=exc)
 
-        return {}
+        return loader, result, latte_stress_event
         # TODOs:
         # 1) take back the report workload..3.0.8.p128.t1.c1.20231025.220812.json
 
@@ -252,6 +252,9 @@ class LatteStressThread(DockerBasedStressThread):  # pylint: disable=too-many-in
         else:
             stress_event.severity = Severity.ERROR
         stress_event.add_error(errors=[error_msg])
+
+    def get_results(self) -> list:
+        return [result for _, result, _ in super().get_results()]
 
 
 def format_stress_cmd_error(exc: Exception) -> str:

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -289,6 +289,8 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
 
         YcsbStressEvent.start(node=cmd_runner_name, stress_cmd=stress_cmd).publish()
 
+        result = {}
+        ycsb_failure_event = ycsb_finish_event = None
         with YcsbStatsPublisher(loader, loader_idx, ycsb_log_filename=log_file_name):
             try:
                 result = cmd_runner.run(
@@ -304,17 +306,23 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
                     ],
                     retry=0,
                 )
-                return self.parse_final_output(result)
-
+                result = self.parse_final_output(result)
             except Exception as exc:
                 errors_str = format_stress_cmd_error(exc)
-                YcsbStressEvent.failure(
+                ycsb_failure_event = YcsbStressEvent.failure(
                     node=cmd_runner_name,
                     stress_cmd=self.stress_cmd,
                     log_file_name=log_file_name,
                     errors=[errors_str, ],
-                ).publish()
+                )
+                ycsb_failure_event.publish()
                 raise
             finally:
-                YcsbStressEvent.finish(
-                    node=cmd_runner_name, stress_cmd=stress_cmd, log_file_name=log_file_name).publish()
+                ycsb_finish_event = YcsbStressEvent.finish(
+                    node=cmd_runner_name, stress_cmd=stress_cmd, log_file_name=log_file_name)
+                ycsb_finish_event.publish()
+
+        return loader, result, ycsb_failure_event or ycsb_finish_event
+
+    def get_results(self) -> list:
+        return [result for _, result, _ in super().get_results()]


### PR DESCRIPTION
Abort the nemesis flow early when a stress command fails, as continuing it is often invalid due to the cluster being in an unexpected state.
For example, if the _prepare_test_table routine fails, subsequent steps that depend on the test table (or attempt disruptions on top of it) will also fail.

This change adds a check for results of stress command triggered within the nemesis code, ensuring the nemesis halts early if the stress command is unsuccessful.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/8722

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [GrowShrinkClusterNemesis, both c-s and s-b loads are executed during the nemesis](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-5gb-1h-aws-test/31/)
- [x] [TruncateMonkey, both c-s and s-b loads are executed during the nemesis](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-5gb-1h-aws-test/33/)
- [x] Tested locally to ensure/simulate a failed stress command - added an invalid parameter to cassandra-stress command in Nemesis._prepare_test_table (here https://github.com/scylladb/scylla-cluster-tests/blob/532ed3f5708429402eb83d10096b348cdd211442/sdcm/nemesis.py#L2072), which makes the stress command fail.
Executed PR-provision-test configuration for TruncateMonkey nemesis class. As a result the disrupt_truncate disruption was started few times, but interrupted early as the stress command in  _prepare_test_table
was failing:
```
< t:2024-12-20 22:04:24,417 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:INFO  > sdcm.exceptions.NemesisStressFailure: Aborting 'TruncateMonkey' nemesis as 'cassandra-stress write whoa n=400000 cl=QUORUM -mode native cql3 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -log interval=5' stress command failed with the following errors:
< t:2024-12-20 22:04:24,417 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:INFO  >   on node 'PR-provision-test-dmitriy-loader-node-a2eaf144-2': ['Stress command completed with bad status 1: ']
< t:2024-12-20 22:04:24,417 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:INFO  >   on node 'PR-provision-test-dmitriy-loader-node-a2eaf144-1': ['Stress command completed with bad status 1: ']
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
