### PR TITLE
feature(sct-runner): version 1.9 with java 21.0.5

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -138,7 +138,7 @@ class SctRunnerInfo:  # pylint: disable=too-many-instance-attributes
 
 class SctRunner(ABC):
     """Provision and configure the SCT runner."""
-    VERSION = "1.8"  # Version of the Image
+    VERSION = "1.9"  # Version of the Image
     NODE_TYPE = "sct-runner"
     RUNNER_NAME = "SCT-Runner"
     LOGIN_USER = "ubuntu"

--- a/sdcm/utils/aws_builder.py
+++ b/sdcm/utils/aws_builder.py
@@ -163,7 +163,7 @@ class AwsBuilder:
                     **launch_template_data
                 )
                 version_number = res.get('LaunchTemplateVersion', {}).get('VersionNumber')
-                self.region.client.modify_launch_template(LaunchTemplateName="aws-sct-builders",
+                self.region.client.modify_launch_template(LaunchTemplateName=self.launch_template_name,
                                                           DefaultVersion=str(version_number))
             except botocore.exceptions.ClientError as error:
                 LOGGER.debug(error.response)


### PR DESCRIPTION
cause of issue caused by mismatch of java version between master and sct builder, we are building a new sct runner image that has up-to-date java version

Ref: scylladb/scylla-cluster-tests#9444

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] provision tests
- [x] testing jenkins builder in eu-central-1: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ami-test/28
- [x] update all ASGs to use sct runner 1.9

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
