### PR TITLE
feature(ruff): start lint `flake8-pie` (PIE)

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -361,7 +361,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
                                     scylla_encryption_options=self.params.get('scylla_encryption_options'))
 
         num_of_batches = int(total_stress / batch_size)
-        for batch in range(0, num_of_batches):
+        for batch in range(num_of_batches):
             for i in range(1 + batch * batch_size, (batch + 1) * batch_size + 1):
                 keyspace_name = self._get_keyspace_name(i)
                 if not isinstance(stress_cmd, list):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ lint.select = [
     "PL", "PLR0913","PLR0914", "PLR0916",
     "YTT",
     "F541",
+    "PIE",
 ]
 
 lint.ignore = ["E501", "PLR2004"]

--- a/sct_ssh.py
+++ b/sct_ssh.py
@@ -508,7 +508,7 @@ def update_scylla_packages(test_id: str, backend: str, region: str, packages_loc
     if not (packages_location := packages_location or os.getenv('SCT_UPDATE_DB_PACKAGES')):
         LOGGER.error("No location is provided where new packages are placed")
         sys.exit(1)
-    if packages_location.startswith('s3') or packages_location.startswith('gs'):
+    if packages_location.startswith(('s3', 'gs')):
         packages_location = download_dir_from_cloud(packages_location)
     if not packages_location.endswith('/'):
         packages_location += '/'

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -814,7 +814,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
                         f"--version {new_chart_version} --destination {tmpdir}")
                     crd_basedir = os.path.join(tmpdir, 'scylla-operator/crds')
                     for current_file in os.listdir(crd_basedir):
-                        if not (current_file.endswith(".yaml") or current_file.endswith(".yml")):
+                        if not current_file.endswith((".yaml", ".yml")):
                             continue
                         self.apply_file(
                             os.path.join(crd_basedir, current_file), modifiers=[], envsubst=False)

--- a/sdcm/coredump.py
+++ b/sdcm/coredump.py
@@ -470,7 +470,7 @@ class CoredumpExportSystemdThread(CoredumpThreadBase):
                 executable = line[12:].strip()
             elif line.startswith('Command Line:'):
                 command_line = line[14:].strip()
-            elif line.startswith('Coredump:') or line.startswith('Storage:'):
+            elif line.startswith(('Coredump:', 'Storage:')):
                 # Ignore inaccessible cores
                 # Storage: /var/lib/systemd/coredump/core.vi.1000.6c4de4c206a0476e88444e5ebaaac482.18554.1578994298000000.lz4 (inaccessible)
                 if "inaccessible" in line:

--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -324,7 +324,7 @@ class FillDatabaseData(ClusterTester):
             'truncates': ['TRUNCATE limit_ranges_test'],
             'inserts': [
                 "INSERT INTO limit_ranges_test (userid, url, time) VALUES ({}, 'http://foo.{}', 42)".format(_id, tld)
-                for _id in range(0, 4) for tld in ['com', 'org', 'net']],
+                for _id in range(4) for tld in ['com', 'org', 'net']],
             'queries': [
                 "SELECT * FROM limit_ranges_test WHERE token(userid) >= token(2) LIMIT 1",
                 "SELECT * FROM limit_ranges_test WHERE token(userid) > token(2) LIMIT 1"],  # issue ##2574
@@ -346,7 +346,7 @@ class FillDatabaseData(ClusterTester):
             'inserts': [
                 "INSERT INTO limit_multiget_test (userid, url, time) VALUES ({}, 'http://foo.{}', 42)".format(_id,
                                                                                                               tld)
-                for _id in range(0, 100) for tld in ['com', 'org', 'net']],
+                for _id in range(100) for tld in ['com', 'org', 'net']],
             'queries': [
                 "SELECT * FROM limit_multiget_test WHERE userid IN (48, 2) LIMIT 1"],
             'results': [
@@ -392,7 +392,7 @@ class FillDatabaseData(ClusterTester):
             'truncates': ['TRUNCATE limit_sparse_test'],
             'inserts': [
                 "INSERT INTO limit_sparse_test (userid, url, day, month, year) VALUES ({}, 'http://foo.{}', 1, 'jan', 2012)".format(
-                    _id, tld) for _id in range(0, 100) for tld in ['com', 'org', 'net']],
+                    _id, tld) for _id in range(100) for tld in ['com', 'org', 'net']],
             'queries': [
                 "SELECT * FROM limit_sparse_test LIMIT 4"],
             'results': [
@@ -760,9 +760,9 @@ class FillDatabaseData(ClusterTester):
             ) WITH CLUSTERING ORDER BY (c1 ASC, c2 DESC)"""],
             'truncates': ['TRUNCATE reversed_comparator_test1', 'TRUNCATE reversed_comparator_test2'],
             'inserts': [f"INSERT INTO reversed_comparator_test1 (k, c, v) VALUES (0, {x}, {x})" for x in
-                        range(0, 10)] + [
+                        range(10)] + [
                 f"INSERT INTO reversed_comparator_test2 (k, c1, c2, v) VALUES (0, {x}, {y}, '{x}{y}')"
-                for x in range(0, 10) for y in range(0, 10)],
+                for x in range(10) for y in range(10)],
             'queries': [
                 "SELECT c, v FROM reversed_comparator_test1 WHERE k = 0 ORDER BY c ASC",
                 "SELECT c, v FROM reversed_comparator_test1 WHERE k = 0 ORDER BY c DESC",
@@ -771,11 +771,11 @@ class FillDatabaseData(ClusterTester):
                 "SELECT c1, c2, v FROM reversed_comparator_test2 WHERE k = 0 ORDER BY c1 DESC, c2 ASC"
             ],
             'results': [
-                [[x, x] for x in range(0, 10)],
+                [[x, x] for x in range(10)],
                 [[x, x] for x in range(9, -1, -1)],
-                [[x, y, '{}{}'.format(x, y)] for x in range(0, 10) for y in range(9, -1, -1)],
-                [[x, y, '{}{}'.format(x, y)] for x in range(0, 10) for y in range(9, -1, -1)],
-                [[x, y, '{}{}'.format(x, y)] for x in range(9, -1, -1) for y in range(0, 10)]],
+                [[x, y, '{}{}'.format(x, y)] for x in range(10) for y in range(9, -1, -1)],
+                [[x, y, '{}{}'.format(x, y)] for x in range(10) for y in range(9, -1, -1)],
+                [[x, y, '{}{}'.format(x, y)] for x in range(9, -1, -1) for y in range(10)]],
             'invalid_queries': [
                 "SELECT c1, c2, v FROM reversed_comparator_test2 WHERE k = 0 ORDER BY c1 ASC, c2 ASC",
                 "SELECT c1, c2, v FROM reversed_comparator_test2 WHERE k = 0 ORDER BY c1 DESC, c2 DESC",
@@ -1043,7 +1043,7 @@ class FillDatabaseData(ClusterTester):
                                                                               birth_year bigint)"""
                               ],
             'truncates': ['TRUNCATE no_range_ghost_test', 'TRUNCATE ks_no_range_ghost_test.users'],
-            'inserts': ["INSERT INTO no_range_ghost_test (k, v) VALUES (%d, 0)" % k for k in range(0, 5)],
+            'inserts': ["INSERT INTO no_range_ghost_test (k, v) VALUES (%d, 0)" % k for k in range(5)],
             'queries': ["#SORTED SELECT k FROM no_range_ghost_test",
                         "DELETE FROM no_range_ghost_test WHERE k = 2",
                         "#SORTED SELECT k FROM no_range_ghost_test",
@@ -1054,9 +1054,9 @@ class FillDatabaseData(ClusterTester):
                         "SELECT * FROM ks_no_range_ghost_test.users",
                         "SELECT * FROM ks_no_range_ghost_test.users WHERE KEY='user1'"
                         ],
-            'results': [[[k] for k in range(0, 5)],
+            'results': [[[k] for k in range(5)],
                         [],
-                        [[k] for k in range(0, 5) if not k == 2],
+                        [[k] for k in range(5) if not k == 2],
                         [],
                         [],
                         [],
@@ -1097,9 +1097,9 @@ class FillDatabaseData(ClusterTester):
                         )"""],
             'truncates': [],
             'inserts': ["INSERT INTO range_tombstones_test (k, c1, c2, v1, v2) VALUES (%d, %d, %d, %d, %d)" % (
-                i, j, k, (i * 4) + (j * 2) + k, (i * 4) + (j * 2) + k) for i in range(0, 5) for j in range(0, 2)
+                i, j, k, (i * 4) + (j * 2) + k, (i * 4) + (j * 2) + k) for i in range(5) for j in range(2)
                 for k
-                in range(0, 2)],
+                in range(2)],
             'queries': ["SELECT v1, v2 FROM range_tombstones_test where k = %d" % 0,
                         "SELECT v1, v2 FROM range_tombstones_test where k = %d" % 1,
                         "SELECT v1, v2 FROM range_tombstones_test where k = %d" % 2,
@@ -1157,7 +1157,7 @@ class FillDatabaseData(ClusterTester):
                         )"""],
             'truncates': [],
             'inserts': ["INSERT INTO range_tombstones_compaction_test (k, c1, c2, v1) VALUES (0, %d, %d, '%s')" % (
-                c1, c2, '%i%i' % (c1, c2)) for c1 in range(0, 4) for c2 in range(0, 2)],
+                c1, c2, '%i%i' % (c1, c2)) for c1 in range(4) for c2 in range(2)],
             'queries': ["#REMOTER_RUN nodetool flush",
                         "DELETE FROM range_tombstones_compaction_test WHERE k = 0 AND c1 = 1",
                         "#REMOTER_RUN nodetool flush",
@@ -1167,7 +1167,7 @@ class FillDatabaseData(ClusterTester):
                         [],
                         None,
                         None,
-                        [['%i%i' % (c1, c2)] for c1 in range(0, 4) for c2 in range(0, 2) if c1 != 1]],
+                        [['%i%i' % (c1, c2)] for c1 in range(4) for c2 in range(2) if c1 != 1]],
             'min_version': '',
             'max_version': '',
             'skip': ''},
@@ -1376,7 +1376,7 @@ class FillDatabaseData(ClusterTester):
             'truncates': ["TRUNCATE composite_row_key_test"],
             'inserts': [
                 f"INSERT INTO composite_row_key_test (k1, k2, c, v) VALUES (0, {i}, {i}, {i})" for i
-                in range(0, 4)
+                in range(4)
             ],
             'queries': [
                 "SELECT * FROM composite_row_key_test",
@@ -1444,8 +1444,8 @@ class FillDatabaseData(ClusterTester):
                         )
                     """],
             'truncates': ["TRUNCATE only_pk_test1", "TRUNCATE only_pk_test2"],
-            'inserts': ["INSERT INTO only_pk_test1 (k, c) VALUES (%s, %s)" % (k, c) for k in range(0, 2) for c in
-                        range(0, 2)],
+            'inserts': ["INSERT INTO only_pk_test1 (k, c) VALUES (%s, %s)" % (k, c) for k in range(2) for c in
+                        range(2)],
             'queries': ["#SORTED SELECT * FROM only_pk_test1",
                         "INSERT INTO only_pk_test2(k, c) VALUES(0, 0)",
                         "INSERT INTO only_pk_test2(k, c) VALUES(0, 1)",
@@ -1453,12 +1453,12 @@ class FillDatabaseData(ClusterTester):
                         "INSERT INTO only_pk_test2(k, c) VALUES(1, 1)",
                         "#SORTED SELECT * FROM only_pk_test2"
                         ],
-            'results': [[[x, y] for x in range(0, 2) for y in range(0, 2)],
+            'results': [[[x, y] for x in range(2) for y in range(2)],
                         [],
                         [],
                         [],
                         [],
-                        [[x, y] for x in range(0, 2) for y in range(0, 2)]],
+                        [[x, y] for x in range(2) for y in range(2)]],
             'min_version': '',
             'max_version': '',
             'skip': '',
@@ -1658,7 +1658,7 @@ class FillDatabaseData(ClusterTester):
                     )"""],
             'truncates': ["TRUNCATE remove_range_slice_test"],
             'inserts': [f"INSERT INTO remove_range_slice_test (k, v) VALUES ({i}, {i})" for i in
-                        range(0, 3)] + [
+                        range(3)] + [
                 "DELETE FROM remove_range_slice_test WHERE k = 1"],
             'queries': ["SELECT * FROM remove_range_slice_test"],
             'results': [[[0, 0], [2, 2]]],
@@ -1748,7 +1748,7 @@ class FillDatabaseData(ClusterTester):
                 """],
             'truncates': ["TRUNCATE reversed_compact_test1", "TRUNCATE reversed_compact_test2"],
             'inserts': [
-                "INSERT INTO %s(k, c, v) VALUES ('foo', %s, %s)" % (k, i, i) for i in range(0, 10) for k in
+                "INSERT INTO %s(k, c, v) VALUES ('foo', %s, %s)" % (k, i, i) for i in range(10) for k in
                 ['reversed_compact_test1', 'reversed_compact_test2']
             ],
             'queries': ["SELECT c FROM reversed_compact_test1 WHERE c > 2 AND c < 6 AND k = 'foo'",
@@ -1793,8 +1793,8 @@ class FillDatabaseData(ClusterTester):
             'truncates': ["TRUNCATE reversed_compact_multikey_test"],
             'inserts': [
                 "INSERT INTO reversed_compact_multikey_test(key, c1, c2, value) VALUES ('foo', %i, %i, 'bar');" % (
-                    i, j) for i in range(0, 3)
-                for j in range(0, 3)
+                    i, j) for i in range(3)
+                for j in range(3)
             ],
             'queries': ["SELECT c1, c2 FROM reversed_compact_multikey_test WHERE key='foo' AND c1 = 1",
                         "SELECT c1, c2 FROM reversed_compact_multikey_test WHERE key='foo' AND c1 = 1 ORDER BY c1 ASC, c2 ASC",
@@ -1909,8 +1909,8 @@ class FillDatabaseData(ClusterTester):
             ) WITH CLUSTERING ORDER BY (c1 ASC, c2 DESC)"""],
             'truncates': ["TRUNCATE multiordering_test"],
             'inserts': ["INSERT INTO multiordering_test(k, c1, c2) VALUES ('foo', %i, %i)" % (i, j) for i in
-                        range(0, 2) for j in
-                        range(0, 2)],
+                        range(2) for j in
+                        range(2)],
             'queries': ["SELECT c1, c2 FROM multiordering_test WHERE k = 'foo'",
                         "SELECT c1, c2 FROM multiordering_test WHERE k = 'foo' ORDER BY c1 ASC, c2 DESC",
                         "SELECT c1, c2 FROM multiordering_test WHERE k = 'foo' ORDER BY c1 DESC, c2 ASC"
@@ -2004,7 +2004,7 @@ class FillDatabaseData(ClusterTester):
             """],
             'truncates': ["TRUNCATE truncate_clean_cache_test"],
             'inserts': ["INSERT INTO truncate_clean_cache_test(k, v1, v2) VALUES (%d, %d, %d)" % (i, i, i * 2) for i
-                        in range(0, 3)
+                        in range(3)
                         ],
             'queries': ["SELECT v1, v2 FROM truncate_clean_cache_test WHERE k IN (0, 1, 2)",
                         "TRUNCATE truncate_clean_cache_test",
@@ -2025,7 +2025,7 @@ class FillDatabaseData(ClusterTester):
             """],
             'truncates': ["TRUNCATE range_with_deletes_test"],
             'inserts': [f"INSERT INTO range_with_deletes_test(k, v) VALUES ({i}, {i})" for i in
-                        range(0, 30)] + [
+                        range(30)] + [
                 f"DELETE FROM range_with_deletes_test WHERE k = {i}" for i in
                 random.sample(range(30), 5)],
             'queries': ["#LENGTH SELECT * FROM range_with_deletes_test LIMIT {}".format(15)],
@@ -2323,7 +2323,7 @@ class FillDatabaseData(ClusterTester):
                 ) WITH CLUSTERING ORDER BY (t DESC)"""],
             'truncates': ["TRUNCATE clustering_order_and_functions_test"],
             'inserts': ["INSERT INTO clustering_order_and_functions_test (k, t) VALUES (%d, now())" % i for i in
-                        range(0, 5)] + ["SELECT dateOf(t) FROM clustering_order_and_functions_test"],
+                        range(5)] + ["SELECT dateOf(t) FROM clustering_order_and_functions_test"],
             'queries': [],
             'results': [],
             'min_version': '',
@@ -2520,9 +2520,9 @@ class FillDatabaseData(ClusterTester):
                 "CREATE TABLE empty_in_test2 (k1 int, k2 int, v int, PRIMARY KEY (k1, k2)) "],
             'truncates': ["TRUNCATE empty_in_test1", "TRUNCATE empty_in_test2"],
             'inserts': ["INSERT INTO empty_in_test1 (k1, k2, v) VALUES (%d, %d, %d)" % (i, j, i + j) for i in
-                        range(0, 2) for j in range(0, 2)] +
+                        range(2) for j in range(2)] +
                        ["INSERT INTO empty_in_test2 (k1, k2, v) VALUES (%d, %d, %d)" % (i, j, i + j) for i in
-                        range(0, 2) for j in range(0, 2)],
+                        range(2) for j in range(2)],
             'queries': ["SELECT v FROM empty_in_test1 WHERE k1 IN ()",
                         "SELECT v FROM empty_in_test1 WHERE k1 = 0 AND k2 IN ()",
                         "DELETE FROM empty_in_test1 WHERE k1 IN ()",
@@ -2575,15 +2575,15 @@ class FillDatabaseData(ClusterTester):
             'truncates': ["TRUNCATE select_distinct_test1", "TRUNCATE select_distinct_test2",
                           "TRUNCATE select_distinct_test3"],
             'inserts': ['INSERT INTO select_distinct_test1 (pk0, pk1, ck0, val) VALUES (%d, %d, 0, 0)' % (i, i) for
-                        i in range(0, 3)] +
+                        i in range(3)] +
                        ['INSERT INTO select_distinct_test1 (pk0, pk1, ck0, val) VALUES (%d, %d, 1, 1)' % (i, i) for
-                        i in range(0, 3)] +
+                        i in range(3)] +
                        ['INSERT INTO select_distinct_test2 (pk0, pk1, val) VALUES (%d, %d, %d)' % (i, i, i) for i in
-                        range(0, 3)] +
+                        range(3)] +
                        ["INSERT INTO select_distinct_test3 (pk, name, val) VALUES (%d, 'name0', 0)" % i for i in
-                        range(0, 3)] +
+                        range(3)] +
                        ["INSERT INTO select_distinct_test3 (pk, name, val) VALUES (%d, 'name1', 1)" % i for i in
-                        range(0, 3)],
+                        range(3)],
             'queries': ['SELECT DISTINCT pk0, pk1 FROM select_distinct_test1 LIMIT 1',
                         '#SORTED SELECT DISTINCT pk0, pk1 FROM select_distinct_test1 LIMIT 3',
                         'SELECT DISTINCT pk0, pk1 FROM select_distinct_test2 LIMIT 1',
@@ -2622,8 +2622,8 @@ class FillDatabaseData(ClusterTester):
                           "UPDATE cas_simple_test SET consumed = TRUE WHERE tkn = {} IF consumed = FALSE;".format(
                               k),
                           "UPDATE cas_simple_test SET consumed = TRUE WHERE tkn = {} IF consumed = FALSE;".format(
-                              k).format(i)] for k in range(1, 10)][j][i] for j in range(0, 9) for i in
-                        range(0, 3)],
+                              k).format(i)] for k in range(1, 10)][j][i] for j in range(9) for i in
+                        range(3)],
             'results': [[], [[True]], [[False, True]]] * 3,
             'min_version': '',
             'max_version': '',
@@ -2943,8 +2943,8 @@ class FillDatabaseData(ClusterTester):
                 "CREATE TABLE tuple_notation_test (k int, v1 int, v2 int, v3 int, PRIMARY KEY (k, v1, v2, v3))"],
             'truncates': ["TRUNCATE tuple_notation_test"],
             'inserts': ["INSERT INTO tuple_notation_test(k, v1, v2, v3) VALUES (0, %d, %d, %d)" % (i, j, k) for i in
-                        range(0, 2)
-                        for j in range(0, 2) for k in range(0, 2)],
+                        range(2)
+                        for j in range(2) for k in range(2)],
             'queries': ["SELECT v1, v2, v3 FROM tuple_notation_test WHERE k = 0",
                         "SELECT v1, v2, v3 FROM tuple_notation_test WHERE k = 0 AND (v1, v2, v3) >= (1, 0, 1)",
                         "SELECT v1, v2, v3 FROM tuple_notation_test WHERE k = 0 AND (v1, v2) >= (1, 1)",

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -1245,8 +1245,7 @@ class SCTool:
         if filtered_lines:
             if '╭' in res.stdout:
                 filtered_lines = [line.replace('│', "|") for line in filtered_lines if
-                                  not (line.startswith('╭') or line.startswith('├') or line.startswith(
-                                      '╰'))]  # filter out the dashes lines
+                                  not line.startswith(('╭', '├', '╰'))]  # filter out the dashes lines
             else:
                 filtered_lines = [line for line in filtered_lines if
                                   not line.startswith('+')]  # filter out the dashes lines

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -187,7 +187,6 @@ class DefaultValue:  # pylint: disable=too-few-public-methods
     """
     This is class is intended to be used as default value for the cases when None is not applicable
     """
-    ...
 
 
 def target_data_nodes(func: Callable) -> Callable:

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -215,7 +215,7 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods,too-many-
     def set_authenticator(cls, authenticator: str):
         if authenticator is None:
             return authenticator
-        if authenticator.startswith('org.apache.cassandra.auth.') or authenticator.startswith('com.scylladb.auth.'):
+        if authenticator.startswith(('org.apache.cassandra.auth.', 'com.scylladb.auth.')):
             return authenticator
         if authenticator in ['PasswordAuthenticator', 'AllowAllAuthenticator']:
             return 'org.apache.cassandra.auth.' + authenticator
@@ -236,7 +236,7 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods,too-many-
     def set_authorizer(cls, authorizer: str):
         if authorizer is None:
             return authorizer
-        if authorizer.startswith('org.apache.cassandra.auth.') or authorizer.startswith('com.scylladb.auth.'):
+        if authorizer.startswith(('org.apache.cassandra.auth.', 'com.scylladb.auth.')):
             return authorizer
         if authorizer in ['AllowAllAuthorizer', 'CassandraAuthorizer']:
             return 'org.apache.cassandra.auth.' + authorizer

--- a/sdcm/scan_operation_thread.py
+++ b/sdcm/scan_operation_thread.py
@@ -47,7 +47,6 @@ class FullScanAggregateCommands(NamedTuple):
 
 class FullscanException(Exception):
     """ Exception during running a fullscan"""
-    ...
 
 
 # pylint: disable=too-many-instance-attributes

--- a/unit_tests/provisioner/fake_azure_service.py
+++ b/unit_tests/provisioner/fake_azure_service.py
@@ -50,10 +50,8 @@ class ResultableObject:  # pylint: disable=too-few-public-methods
         self.stderr = stderr
 
     def result(self,):
-        value = InstanceViewStatus(**{'additional_properties': {}, 'code': 'ProvisioningState/succeeded',
-                                      'level': 'Info', 'display_status': 'Provisioning succeeded',
-                                      'message': f'Enable succeeded: \n[stdout]\n{self.stdout}\n[stderr]\n{self.stderr}',
-                                      'time': None})
+        value = InstanceViewStatus(additional_properties={}, code='ProvisioningState/succeeded', level='Info',
+                                   display_status='Provisioning succeeded', message=f'Enable succeeded: \n[stdout]\n{self.stdout}\n[stderr]\n{self.stderr}', time=None)
         return RunCommandResult(value=[value])
 
 

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -543,48 +543,40 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method,too-many-instance-
 
 
 class IntegrationTests(unittest.TestCase):
-    get_scylla_ami_version_output = ObjectDict(**{
-        'Architecture': 'x86_64', 'CreationDate': '2022-10-13T13:17:17.000Z',
-        'ImageId': 'ami-0dfb316a2cc0ab399', 'ImageLocation': '797456418907/ScyllaDB Enterprise 2021.1.15',
-        'ImageType': 'machine', 'Public': True, 'OwnerId': '797456418907',
-        'PlatformDetails': 'Linux/UNIX', 'UsageOperation': 'RunInstances',
-        'State': 'available', 'BlockDeviceMappings': [
-            {'DeviceName': '/dev/sda1',
-             'Ebs': {'DeleteOnTermination': True,
-                     'SnapshotId': 'snap-0717a2bee0a38bc84',
-                     'VolumeSize': 30,
-                     'VolumeType': 'gp3',
-                     'Encrypted': False}},
-            {'DeviceName': '/dev/sdb',
-             'VirtualName': 'ephemeral0'},
-            {'DeviceName': '/dev/sdc',
-             'VirtualName': 'ephemeral1'},
-            {'DeviceName': '/dev/sdd',
-             'VirtualName': 'ephemeral2'},
-            {'DeviceName': '/dev/sde',
-             'VirtualName': 'ephemeral3'},
-            {'DeviceName': '/dev/sdf',
-             'VirtualName': 'ephemeral4'},
-            {'DeviceName': '/dev/sdg',
-             'VirtualName': 'ephemeral5'},
-            {'DeviceName': '/dev/sdh',
-             'VirtualName': 'ephemeral6'},
-            {'DeviceName': '/dev/sdi',
-             'VirtualName': 'ephemeral7'}],
-        'Description': 'ScyllaDB Enterprise 2021.1.15', 'EnaSupport': True, 'Hypervisor': 'xen',
-        'Name': 'ScyllaDB Enterprise 2021.1.15', 'RootDeviceName': '/dev/sda1', 'RootDeviceType': 'ebs',
-        'Tags': [
-            {'Key': 'ScyllaMachineImageVersion', 'Value': '2021.1.15-20221011.82741b636ba-1'},
-            {'Key': 'ScyllaPython3Version', 'Value': '2021.1.15-20221011.82741b636ba-1'},
-            {'Key': 'user_data_format_version', 'Value': '2'},
-            {'Key': 'ScyllaToolsVersion', 'Value': '2021.1.15-20221011.82741b636ba-1'},
-            {'Key': 'ScyllaJMXVersion', 'Value': '2021.1.15-20221011.82741b636ba-1'},
-            {'Key': 'branch', 'Value': 'branch-2021.1'},
-            {'Key': 'scylla-git-commit', 'Value': '3d8c23d0b20af12302608c6286ace0c3dc070828'},
-            {'Key': 'build-tag', 'Value': 'jenkins-enterprise-2021.1-promote-release-213'},
-            {'Key': 'ScyllaVersion', 'Value': '2021.1.15-20221011.82741b636ba-1'},
-            {'Key': 'build-id', 'Value': '213'}
-        ], 'VirtualizationType': 'hvm'})
+    get_scylla_ami_version_output = ObjectDict(Architecture='x86_64', CreationDate='2022-10-13T13:17:17.000Z', ImageId='ami-0dfb316a2cc0ab399', ImageLocation='797456418907/ScyllaDB Enterprise 2021.1.15', ImageType='machine', Public=True, OwnerId='797456418907', PlatformDetails='Linux/UNIX', UsageOperation='RunInstances', State='available', BlockDeviceMappings=[
+        {'DeviceName': '/dev/sda1',
+         'Ebs': {'DeleteOnTermination': True,
+                 'SnapshotId': 'snap-0717a2bee0a38bc84',
+                 'VolumeSize': 30,
+                 'VolumeType': 'gp3',
+                 'Encrypted': False}},
+        {'DeviceName': '/dev/sdb',
+         'VirtualName': 'ephemeral0'},
+        {'DeviceName': '/dev/sdc',
+         'VirtualName': 'ephemeral1'},
+        {'DeviceName': '/dev/sdd',
+         'VirtualName': 'ephemeral2'},
+        {'DeviceName': '/dev/sde',
+         'VirtualName': 'ephemeral3'},
+        {'DeviceName': '/dev/sdf',
+         'VirtualName': 'ephemeral4'},
+        {'DeviceName': '/dev/sdg',
+         'VirtualName': 'ephemeral5'},
+        {'DeviceName': '/dev/sdh',
+         'VirtualName': 'ephemeral6'},
+        {'DeviceName': '/dev/sdi',
+         'VirtualName': 'ephemeral7'}], Description='ScyllaDB Enterprise 2021.1.15', EnaSupport=True, Hypervisor='xen', Name='ScyllaDB Enterprise 2021.1.15', RootDeviceName='/dev/sda1', RootDeviceType='ebs', Tags=[
+        {'Key': 'ScyllaMachineImageVersion', 'Value': '2021.1.15-20221011.82741b636ba-1'},
+        {'Key': 'ScyllaPython3Version', 'Value': '2021.1.15-20221011.82741b636ba-1'},
+        {'Key': 'user_data_format_version', 'Value': '2'},
+        {'Key': 'ScyllaToolsVersion', 'Value': '2021.1.15-20221011.82741b636ba-1'},
+        {'Key': 'ScyllaJMXVersion', 'Value': '2021.1.15-20221011.82741b636ba-1'},
+        {'Key': 'branch', 'Value': 'branch-2021.1'},
+        {'Key': 'scylla-git-commit', 'Value': '3d8c23d0b20af12302608c6286ace0c3dc070828'},
+        {'Key': 'build-tag', 'Value': 'jenkins-enterprise-2021.1-promote-release-213'},
+        {'Key': 'ScyllaVersion', 'Value': '2021.1.15-20221011.82741b636ba-1'},
+        {'Key': 'build-id', 'Value': '213'}
+    ], VirtualizationType='hvm')
 
     @property
     def temp_dir(self):


### PR DESCRIPTION
those lint rule helps removing unneeded code parts

Ref: https://docs.astral.sh/ruff/rules/#flake8-pie-pie

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
