### PR TITLE
fix(manager): update expected error message for enospc restore test

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -46,7 +46,6 @@ from sdcm.cluster import TestConfig
 from sdcm.nemesis import MgmtRepair
 from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations
 from sdcm.utils.common import reach_enospc_on_node, clean_enospc_on_node
-from sdcm.utils.issues import SkipPerIssues
 from sdcm.utils.loader_utils import LoaderUtilsMixin
 from sdcm.utils.time_utils import ExecutionTimer
 from sdcm.sct_events.system import InfoEvent
@@ -830,13 +829,6 @@ class ManagerBackupTests(ManagerRestoreTests):
                 assert final_status == TaskStatus.ERROR, \
                     f"The restore task is supposed to fail, since node {target_node} lacks the disk space to download" \
                     f"the snapshot files"
-
-                if not SkipPerIssues("scylladb/scylla-manager#4087", self.params):
-                    full_progress_string = restore_task.progress_string(parse_table_res=False,
-                                                                        is_verify_errorless_result=True).stdout
-                    assert "not enough disk space" in full_progress_string.lower(), \
-                        f"The restore failed as expected when one of the nodes was out of disk space, " \
-                        f"but with an ill fitting error message: {full_progress_string}"
             finally:
                 clean_enospc_on_node(target_node=target_node, sleep_time=30)
         self.log.info('finishing test_enospc_before_restore')


### PR DESCRIPTION
Error message that Manager returns for enospc scenario has been changed to more generic one. So, this change updates expected error message and removes skip per issue since it was closed without resolution.

refs:
https://github.com/scylladb/scylla-manager/issues/4087

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/scylla-manager/job/manager-3.4/job/sct-feature-test-backup/6/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
