### PR TITLE
fix(scylla_yaml): remove duplication of `listen_interface`

### DIFF
--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -32,7 +32,6 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods,too-many-
     broadcast_address: str = None  # ""
     api_port: int = None  # 10000
     api_address: str = None  # ""
-    listen_interface: str = None  # "eth0"
     ssl_storage_port: int = None  # 7001
     background_writer_scheduling_quota: float = None  # 1.0
     auto_adjust_flush_quota: bool = None  # False


### PR DESCRIPTION
by mistake `listen_interface` was duplicated, and ruff PIE check uncovered it.

this change remove the newly introduced definition

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] no need for testing

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
