### PR TITLE
fix(logcollector): fix remote collect cmd to support non-bash shells

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -597,7 +597,7 @@ class LogCollector:
     def collect_log_remotely(node, cmd: str, log_filename: str) -> Optional[str]:
         if not node.remoter:
             return None
-        collect_log_command = f"{cmd} >& '{log_filename}'"
+        collect_log_command = f"{cmd} > '{log_filename}' 2>&1"
         node.remoter.run(collect_log_command, ignore_status=True, verbose=True)
         result = node.remoter.run(f"test -f '{log_filename}'", ignore_status=True)
         return log_filename if result.ok else None


### PR DESCRIPTION
`>&` redirecting syntax has been replaced by `> file 2>&1` to support shells like sh. 
Such a shell is a default on Manager node deployed in Cloud. That makes impossible logs collection there.

In terms of compatibility, `> file 2>&1` should behave consistently across different systems and shells.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [SCT test](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/siren-tests/job/siren-sct-integration/115/) for siren-created cluster.
Has logs for siren-manager.
- [x] Manager [SCT sanity test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-sanity-test/48/)
Checked that all log files were collected, no regression.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code