### PR TITLE
fix(BaseNode): change directory for startup script upload from /tmp to $HOME.

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2911,7 +2911,8 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         return cqlsh_out if not split else list(map(str.strip, cqlsh_out.stdout.splitlines()))
 
     def run_startup_script(self):
-        startup_script_remote_path = '/tmp/sct-startup.sh'
+        remote_home_dir = self.remoter.run("echo $HOME").stdout.strip()
+        startup_script_remote_path = f"{remote_home_dir}/startup_script.sh"
 
         with tempfile.NamedTemporaryFile(mode='w+', delete=False, encoding='utf-8') as tmp_file:
             tmp_file.write(self.test_config.get_startup_script())


### PR DESCRIPTION
Fix changes directory for startup script upload from /tmp to $HOME. 
The change is required for DB nodes deployed in Cloud where /tmp dir is mounted with noexec option what makes script 
execution impossible there.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] siren-sct-integration [test](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/siren-tests/job/siren-sct-integration/123)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code