### PR TITLE
improvement(node_exporter): upgrade to v1.8.2, remove unneeded collectors

### DIFF
--- a/sdcm/node_exporter_setup.py
+++ b/sdcm/node_exporter_setup.py
@@ -1,7 +1,7 @@
 from sdcm.remote import shell_script_cmd
 
 
-NODE_EXPORTER_VERSION = '1.7.0'
+NODE_EXPORTER_VERSION = '1.8.2'
 
 
 class NodeExporterSetup:  # pylint: disable=too-few-public-methods
@@ -31,7 +31,7 @@ class NodeExporterSetup:  # pylint: disable=too-few-public-methods
             User=node_exporter
             Group=node_exporter
             Type=simple
-            ExecStart=/usr/local/bin/node_exporter
+            ExecStart=/usr/local/bin/node_exporter --no-collector.interrupts --no-collector.hwmon --no-collector.bcache --no-collector.btrfs --no-collector.fibrechannel --no-collector.infiniband --no-collector.ipvs --no-collector.nfs --no-collector.nfsd --no-collector.powersupplyclass --no-collector.rapl --no-collector.tapestats --no-collector.thermal_zone --no-collector.udp_queues --no-collector.zfs
 
             [Install]
             WantedBy=multi-user.target


### PR DESCRIPTION
This PR update node_exporter to v1.8.2 (just like Scylla) and removes the unneeded collectors that are enabled by default (just like Scylla). The only exception is interrupts - which are still enabled by default by Scylla and are not needed here.

### Testing
- NOT tested.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
