### PR TITLE
fix(manager): update default Scylla version to 2024.2 for Manager tests

### DIFF
--- a/defaults/manager_versions.yaml
+++ b/defaults/manager_versions.yaml
@@ -20,5 +20,5 @@ scylla_backend_repo_by_version:
     rhel: 'https://downloads.scylladb.com/rpm/centos/scylla-2023.1.repo'
     debian: 'https://downloads.scylladb.com/deb/debian/scylla-2023.1.list'
   "2024":
-    rhel: 'https://downloads.scylladb.com/rpm/centos/scylla-2024.1.repo'
-    debian: 'https://downloads.scylladb.com/deb/debian/scylla-2024.1.list'
+    rhel: 'https://downloads.scylladb.com/rpm/centos/scylla-2024.2.repo'
+    debian: 'https://downloads.scylladb.com/deb/debian/scylla-2024.2.list'

--- a/jenkins-pipelines/manager/debian11-manager-install.jenkinsfile
+++ b/jenkins-pipelines/manager/debian11-manager-install.jenkinsfile
@@ -9,6 +9,8 @@ managerPipeline(
     test_name: 'mgmt_cli_test.ManagerInstallationTests.test_manager_installed_and_functional',
     test_config: '''["test-cases/manager/manager-installation-set-distro.yaml", "configurations/manager/debian11.yaml"]''',
 
+    scylla_version: '2024.1',
+
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/manager/debian11-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian11-manager-sanity.jenkinsfile
@@ -9,6 +9,8 @@ managerPipeline(
     test_name: 'mgmt_cli_test.ManagerSanityTests.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/manager/debian11.yaml"]''',
 
+    scylla_version: '2024.1',
+
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/manager/debian11-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian11-manager-upgrade.jenkinsfile
@@ -7,9 +7,10 @@ managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
 
+    manager_version: '3.3',
     target_manager_version: 'master_latest',
 
-    manager_version: '3.3',
+    scylla_version: '2024.1',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/debian11.yaml"]''',

--- a/jenkins-pipelines/manager/ubuntu22-manager-vnodes-tablets-enterprise.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-vnodes-tablets-enterprise.jenkinsfile
@@ -9,8 +9,6 @@ managerPipeline(
     test_name: 'mgmt_cli_test.ManagerSanityTests.test_manager_sanity_vnodes_tablets_cluster',
     test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/tablets-initial-32.yaml"]''',
 
-    scylla_version: '2024.2',
-
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/unit_tests/test_sdcm_mgmt_common.py
+++ b/unit_tests/test_sdcm_mgmt_common.py
@@ -7,7 +7,7 @@ class TestManagerVersions:
     def test_get_manager_scylla_backend_returns_repo_address(self):  # pylint: disable=no-self-use
         url = get_manager_scylla_backend("2024", Distro.UBUNTU22)
 
-        assert url == 'https://downloads.scylladb.com/deb/debian/scylla-2024.1.list'
+        assert url == 'https://downloads.scylladb.com/deb/debian/scylla-2024.2.list'
 
     def test_get_manager_repo_from_defaults_returns_repo_address(self):  # pylint: disable=no-self-use
         url = get_manager_repo_from_defaults("3.2", Distro.UBUNTU22)

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -76,7 +76,7 @@ def call(Map pipelineParams) {
 
 
             string(defaultValue: '', description: '', name: 'scylla_ami_id')
-            string(defaultValue: "${pipelineParams.get('scylla_version', '2024.1')}", description: '', name: 'scylla_version')
+            string(defaultValue: "${pipelineParams.get('scylla_version', '2024.2')}", description: '', name: 'scylla_version')
             // When branching to manager version branch, set scylla_version to the latest release
             string(defaultValue: '', description: '', name: 'scylla_repo')
             string(defaultValue: "${pipelineParams.get('gce_image_db', '')}",


### PR DESCRIPTION
Default scylla_version is set to 2024.2 instead of 2024.1.

At the same time, to have some coverage for 2024.1 as well, all Debian 11 jobs adjusted to use version 2024.1.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] ubuntu22 sanity [test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-sanity-test/49/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
