### PR TITLE
improvement(latency_calculator): allow use it in longevity tests

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -268,7 +268,7 @@ zero_token_instance_type_db: 'i4i.large'
 use_zero_nodes: false
 
 latte_schema_parameters: {}
-
+workload_name: ''
 latency_decorator_error_thresholds:
   write:
     default:

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1738,6 +1738,10 @@ class SCTConfiguration(dict):
              help="Error thresholds for latency decorator."
                   " Defined by dict: {<write, read, mixed>: {<default|nemesis_name>:{<metric_name>: {<rule>: <value>}}}"),
 
+        dict(name="workload_name", env="SCT_WORKLOAD_NAME", type=str,
+             help="Workload name, can be: write|read|mixed|unset."
+                  "Used for e.g. latency_calculator_decorator (use with 'use_hdr_cs_histogram' set to true)."
+                  "If unset, workload is taken from test name."),
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',

--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -162,6 +162,9 @@ def latency_calculator_decorator(original_function: Optional[Callable] = None, *
     """
     Gets the start time, end time and then calculates the latency based on function 'calculate_latency'.
 
+    For proper usage, it requires workload name (write, read, mixed) to be included in the test name
+    or setting 'workload_name' test parameter. Also requires monitoring set and 'use_hdr_cs_histogram' test parameter to be set to True.
+
     :param func: Remote method to run.
     :return: Wrapped method.
     """
@@ -212,6 +215,8 @@ def latency_calculator_decorator(original_function: Optional[Callable] = None, *
                 workload = 'write'
             elif 'mixed' in test_name:
                 workload = 'mixed'
+            elif tester.params.get('workload_name'):
+                workload = tester.params['workload_name']
             else:
                 return res
 


### PR DESCRIPTION
`latency_calculator_decorator` requires workload to be set. Up to now it was taken from the test name. This change allows to set it by `workload_name` test parameter, so it can be used in all kind of tests.

Added latency verification for all 'individual nemesis' cases (proposal, anyway need to test with something).

closes: https://github.com/scylladb/scylla-cluster-tests/issues/9627

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [argus](https://argus.scylladb.com/tests/scylla-cluster-tests/2280ee26-a67f-473a-b3ad-f636f08d3229)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
