### PR TITLE
Replace out-of-support CentOS distro with RHEL9 for Manager tests on Azure

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5591,6 +5591,15 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
                     dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
                     dnf install -y docker-ce docker-ce-cli containerd.io
                 """)
+            elif node.distro.is_rhel9:
+                # TODO: Temporary workaround for RHEL9 installation issue https://github.com/moby/moby/issues/49169
+                # Install packages manually hardcoding the OS version ($releasever) in /etc/yum.repos.d/docker-ce.repo
+                # After issue resolution, we can return the previous approach with installation script
+                install_docker_cmd = dedent("""
+                    dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
+                    sed -i \"s/\\$releasever/9/g\" /etc/yum.repos.d/docker-ce.repo
+                    dnf install -y docker-ce docker-ce-cli containerd.io
+                """)
             else:
                 install_docker_cmd = dedent("""
                     curl -fsSL get.docker.com --retry 5 --retry-max-time 300 -o get-docker.sh

--- a/sdcm/provision/user_data.py
+++ b/sdcm/provision/user_data.py
@@ -66,12 +66,12 @@ class UserDataBuilder:
             "yum_repos":
                 {
                     "epel-release": {
-                        "baseurl": "http://download.fedoraproject.org/pub/epel/7/$basearch",
+                        "baseurl": "https://dl.fedoraproject.org/pub/epel/9/Everything/$basearch",
                         "enabled": True,
                         "failovermethod": "priority",
                         "gpgcheck": True,
-                        "gpgkey": "http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7",
-                        "name": "Extra Packages for Enterprise Linux 7 - Release"
+                        "gpgkey": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9",
+                        "name": "Extra Packages for Enterprise Linux 9 - Everything"
                     }
                 }
         }

--- a/test-cases/manager/manager-regression-azure.yaml
+++ b/test-cases/manager/manager-regression-azure.yaml
@@ -7,7 +7,9 @@ n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
 
-azure_image_monitor: 'OpenLogic:CentOS:7_9:latest'
+azure_image_monitor: 'RedHat:RHEL:9_5:latest'
+# Default 50 GB value is changed here as the size of the corresponding disk in the VM image: 64 GB
+root_disk_size_monitor: 64
 
 post_behavior_db_nodes: "destroy"
 post_behavior_loader_nodes: "destroy"


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-cluster-tests/issues/9630 https://github.com/scylladb/scylla-cluster-tests/issues/8226

The PR switches Manager tests on Azure from using centos-based to rhel-based.

Together with that, it implements a couple of different fixes to make such node setup possible (see list of commits for details).

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Azure backup [test](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master/job/sct-feature-test-backup-azure/42/) - not related to PR failure, should be fixed [here](https://github.com/scylladb/scylla-cluster-tests/pull/9590)
- [x] Artifacts CentOS9 [test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/artifacts-centos9-test/2)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code