### PR TITLE
improvement(events): add rack aware policy event

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -86,6 +86,7 @@ CassandraStressLogEvent.OperationOnKey: CRITICAL
 # TODO: mechanism.
 CassandraStressLogEvent.TooManyHintsInFlight: ERROR
 CassandraStressLogEvent.ShardAwareDriver: NORMAL
+CassandraStressLogEvent.RackAwarePolicy: NORMAL
 CassandraStressLogEvent.SchemaDisagreement: WARNING
 CqlStressCassandraStressLogEvent.ReadValidationError: CRITICAL
 SchemaDisagreementErrorEvent: ERROR

--- a/sdcm/report_templates/results_base.html
+++ b/sdcm/report_templates/results_base.html
@@ -209,6 +209,9 @@
             {% if shard_awareness_driver %}
                 <li> Cassandra-stress uses shared-aware driver</li>
             {% endif %}
+            {% if rack_aware_policy %}
+                <li> Cassandra-stress uses RackAwareRoundRobinPolicy with provided rack name</li>
+            {% endif %}
         </ul>
     </div>
 

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -180,6 +180,7 @@ class CassandraStressLogEvent(LogEvent, abstract=True):
     OperationOnKey: Type[LogEventProtocol]
     TooManyHintsInFlight: Type[LogEventProtocol]
     ShardAwareDriver: Type[LogEventProtocol]
+    RackAwarePolicy: Type[LogEventProtocol]
     SchemaDisagreement: Type[LogEventProtocol]
 
 
@@ -230,6 +231,8 @@ CassandraStressLogEvent.add_subevent_type("ShardAwareDriver", severity=Severity.
                                           regex="Using optimized driver")
 CassandraStressLogEvent.add_subevent_type("SchemaDisagreement", severity=Severity.WARNING,
                                           regex="No schema agreement")
+CassandraStressLogEvent.add_subevent_type("RackAwarePolicy", severity=Severity.NORMAL,
+                                          regex=r"Using provided rack name '.+' for RackAwareRoundRobinPolicy")
 
 
 CS_ERROR_EVENTS = (
@@ -239,7 +242,7 @@ CS_ERROR_EVENTS = (
     CassandraStressLogEvent.ConsistencyError(),
     CassandraStressLogEvent.SchemaDisagreement(),
 )
-CS_NORMAL_EVENTS = (CassandraStressLogEvent.ShardAwareDriver(), )
+CS_NORMAL_EVENTS = (CassandraStressLogEvent.ShardAwareDriver(), CassandraStressLogEvent.RackAwarePolicy(), )
 
 CS_ERROR_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
     [(re.compile(event.regex), event) for event in CS_ERROR_EVENTS]

--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -152,6 +152,7 @@ class BaseEmailReporter:
         "test_status",
         "username",
         "shard_awareness_driver",
+        "rack_aware_policy",
         "restore_monitor_job_base_link",
     )
     _fields = ()

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3808,6 +3808,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 "test_status": test_status,
                 "username": get_username(),
                 "shard_awareness_driver": self.is_shard_awareness_driver,
+                "rack_aware_policy": self.is_rack_aware_policy,
                 "restore_monitor_job_base_link": restore_monitor_job_base_link,
                 "relocatable_pkg": get_relocatable_pkg_url(scylla_version)}
 
@@ -3845,6 +3846,14 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         all_events = get_events_grouped_by_category()
         for event_str in all_events["NORMAL"]:
             if "type=ShardAwareDriver" in event_str:
+                return True
+        return False
+
+    @property
+    def is_rack_aware_policy(self) -> bool:
+        all_events = get_events_grouped_by_category()
+        for event_str in all_events["NORMAL"]:
+            if "type=RackAwarePolicy" in event_str:
                 return True
         return False
 

--- a/unit_tests/test_sct_events_loaders.py
+++ b/unit_tests/test_sct_events_loaders.py
@@ -402,6 +402,7 @@ class TestCassandraStressLogEvent(unittest.TestCase):
 
     def test_known_cs_normal(self):
         self.assertTrue(issubclass(CassandraStressLogEvent.ShardAwareDriver, CassandraStressLogEvent))
+        self.assertTrue(issubclass(CassandraStressLogEvent.RackAwarePolicy, CassandraStressLogEvent))
 
     def test_cs_all_events_list(self):
         self.assertSetEqual(set(dir(CassandraStressLogEvent)) - set(dir(LogEvent)),
@@ -440,6 +441,12 @@ class TestCassandraStressLogEvent(unittest.TestCase):
     def test_cs_normal_shared_awarnes_event(self):
         self.get_event(line='com.datastax.driver.core.Cluster - ===== Using optimized driver!!! =====',
                        expected_type='ShardAwareDriver',
+                       expected_severity=Severity.NORMAL)
+
+    def test_cs_normal_rack_awarnes_event(self):
+        self.get_event(line="Using provided rack name '1a' for RackAwareRoundRobinPolicy (if this is incorrect, please provide the correct "
+                            "rack name with RackAwareRoundRobinPolicy constructor",
+                       expected_type='RackAwarePolicy',
                        expected_severity=Severity.NORMAL)
 
 


### PR DESCRIPTION
Add RackAwarePolicy cassandra-stress log event when a test runs with multiple availability zone.

```
2025-01-01 09:53:27.896: (CassandraStressLogEvent Severity.NORMAL) period_type=one-time event_id=db556fb0-db45-42a1-8068-7abd224b3997: type=RackAwarePolicy regex=Using provided rack name '.+' for RackAwareRoundRobinPolicy line_number=143 node=Node longevity-cdc-100gb-4h-rack-awa-loader-node-82ae1911-1 [34.245.189.8 | 10.4.7.144] (rack: 0)
INFO  [main] 2025-01-01 09:53:27,319 RackAwareRoundRobinPolicy.java:114 - Using provided rack name '1b' for RackAwareRoundRobinPolicy
```

Task: https://github.com/scylladb/qa-tasks/issues/1819

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [multi AZ longevity](https://argus.scylladb.com/tests/scylla-cluster-tests/ee42c9a3-fe4a-4f96-bfe8-b30e8fc1cc72)

Printed in an email:
```
Test details
Test: longevity_test.LongevityTest.test_custom_time
Build number: 6
Backend: aws: ['eu-west-1']
Kernel version: 5.15.0-1073-aws
Test-id: ee42c9a3-fe4a-4f96-bfe8-b30e8fc1cc72
[Link to argus](https://argus.scylladb.com/tests/scylla-cluster-tests/ee42c9a3-fe4a-4f96-bfe8-b30e8fc1cc72)
Start time: 2025-01-02 11:21:43
End time: 2025-01-02 11:38:23
Started by user: julia.yakovlev
Cassandra-stress uses shared-aware driver
Cassandra-stress uses RackAwareRoundRobinPolicy with provided rack name
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
