### PR TITLE
fix(sct_config): don't fail on empty instance type

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1964,7 +1964,7 @@ class SCTConfiguration(dict):
             if not self.get('ami_id_db_oracle') and self.get('cluster_backend') == 'aws':
                 ami_list = []
                 for region in region_names:
-                    aws_arch = get_arch_from_instance_type(self.get('instance_type_db'), region_name=region)
+                    aws_arch = get_arch_from_instance_type(self.get('instance_type_db_oracle'), region_name=region)
                     try:
                         if ':' in oracle_scylla_version:
                             ami = get_branched_ami(

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -441,13 +441,15 @@ def ec2_ami_get_root_device_name(image_id, region_name):
 
 @functools.cache
 def get_arch_from_instance_type(instance_type: str, region_name: str) -> AwsArchType:
-    client: EC2Client = boto3.client('ec2', region_name=region_name)
-    instance_type_info = client.describe_instance_types(InstanceTypes=[instance_type])
     arch = 'x86_64'
-    try:
-        arch = instance_type_info['InstanceTypes'][0].get('ProcessorInfo', {}).get('SupportedArchitectures')[0]
-    except (IndexError, KeyError):
-        pass
+    if instance_type:
+        client: EC2Client = boto3.client('ec2', region_name=region_name)
+        instance_type_info = client.describe_instance_types(InstanceTypes=[instance_type])
+
+        try:
+            arch = instance_type_info['InstanceTypes'][0].get('ProcessorInfo', {}).get('SupportedArchitectures')[0]
+        except (IndexError, KeyError):
+            pass
     return arch
 
 


### PR DESCRIPTION
fix the code not to do API calls to ec2 when instance type isn't defines, and fallback to assume x86 image is requested.

it was failing during cleanup command where we might not have a full configuration available, but we should still carry on and execute the cleanup (we don't really need instance types for cleanups)

Fixes: #8352

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested it locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
