### PR TITLE
fix(gpg): add timeout and debug

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1804,8 +1804,9 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             self.install_package('gnupg2')
             self.remoter.sudo("mkdir -p /etc/apt/keyrings")
             for apt_key in self.parent_cluster.params.get("scylla_apt_keys"):
-                self.remoter.sudo(f"gpg --homedir /tmp --no-default-keyring --keyring /etc/apt/keyrings/scylladb.gpg "
-                                  f"--keyserver hkp://keyserver.ubuntu.com:80 --recv-keys {apt_key}", retry=3)
+                self.remoter.sudo(f"gpg --debug-all --homedir /tmp --no-default-keyring --keyring /etc/apt/keyrings/scylladb.gpg "
+                                  f"--keyserver hkp://keyserver.ubuntu.com:80 --keyserver-options timeout=10 --recv-keys {apt_key}",
+                                  retry=3)
         self.update_repo_cache()
 
     def download_scylla_manager_repo(self, scylla_repo: str) -> None:


### PR DESCRIPTION
We face indefinite freezes upon gpg command.
Added timeout and debug-all flags to enable debugging and potentially fix the issue.

refs: https://github.com/scylladb/scylla-cluster-tests/issues/9017

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - https://jenkins.scylladb.com/job/scylla-staging/job/lukasz/job/rolling-upgrade-debian11-test/3/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
