### PR TITLE
feature(client-encrypt): enable peer verification for stress commands

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -128,7 +128,8 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
     def run_cassandra_stress(self, args: str):
         stress_cmd = f"{self.node.add_install_prefix(STRESS_CMD)} {args} -node {self.node.ip_address}"
         if self.params.get('client_encrypt'):
-            transport_str = c_s_transport_str(self.params.get('client_encrypt_mtls'))
+            transport_str = c_s_transport_str(
+                self.params.get('peer_verification'), self.params.get('client_encrypt_mtls'))
             stress_cmd += f" -transport '{transport_str}'"
 
         result = self.node.remoter.run(stress_cmd)

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -76,6 +76,7 @@ parallel_node_operations: false  # supported from Scylla 6.0
 
 server_encrypt: false
 client_encrypt: false
+peer_verification: true  # when client encryption is used, peer verification is enabled by default
 client_encrypt_mtls: false
 server_encrypt_mtls: false
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -762,6 +762,15 @@ when enable scylla will use encryption on the client side
 **type:** boolean
 
 
+## **peer_verification** / SCT_PEER_VERIFICATION
+
+enable peer verification for encrypted communication
+
+**default:** True
+
+**type:** boolean
+
+
 ## **client_encrypt_mtls** / SCT_CLIENT_ENCRYPT_MTLS
 
 when enabled scylla will enforce mutual authentication when client-to-node encryption is enabled
@@ -3532,3 +3541,12 @@ Error thresholds for latency decorator. Defined by dict: {<write, read, mixed>: 
 **default:** {'write': {'default': {'P90 write': {'fixed_limit': 5}, 'P99 write': {'fixed_limit': 10}}}, 'read': {'default': {'P90 read': {'fixed_limit': 5}, 'P99 read': {'fixed_limit': 10}}}, 'mixed': {'default': {'P90 write': {'fixed_limit': 5}, 'P90 read': {'fixed_limit': 5}, 'P99 write': {'fixed_limit': 10}, 'P99 read': {'fixed_limit': 10}}}}
 
 **type:** dict_or_str
+
+
+## **workload_name** / SCT_WORKLOAD_NAME
+
+Workload name, can be: write|read|mixed|unset.Used for e.g. latency_calculator_decorator (use with 'use_hdr_cs_histogram' set to true).If unset, workload is taken from test name.
+
+**default:** N/A
+
+**type:** str (appendable)

--- a/sdcm/provision/helpers/certificate.py
+++ b/sdcm/provision/helpers/certificate.py
@@ -327,12 +327,13 @@ def update_certificate(node: BaseNode) -> None:
         crt_file.write(new_cert.public_bytes(serialization.Encoding.PEM))
 
 
-def c_s_transport_str(client_mtls: bool) -> str:
+def c_s_transport_str(peer_verification: bool, client_mtls: bool) -> str:
     """Build transport string for cassandra-stress."""
     transport_str = f'truststore={SCYLLA_SSL_CONF_DIR}/{TLSAssets.JKS_TRUSTSTORE} truststore-password=cassandra'
+    if peer_verification:
+        transport_str += ' hostname-verification=true'
     if client_mtls:
-        transport_str = (
-            f'{transport_str} keystore={SCYLLA_SSL_CONF_DIR}/{TLSAssets.PKCS12_KEYSTORE} keystore-password=cassandra')
+        transport_str += f' keystore={SCYLLA_SSL_CONF_DIR}/{TLSAssets.PKCS12_KEYSTORE} keystore-password=cassandra'
     return transport_str
 
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -571,6 +571,9 @@ class SCTConfiguration(dict):
         dict(name="client_encrypt", env="SCT_CLIENT_ENCRYPT", type=boolean,
              help="when enable scylla will use encryption on the client side"),
 
+        dict(name="peer_verification", env="SCT_PEER_VERIFICATION", type=boolean,
+             help="enable peer verification for encrypted communication"),
+
         dict(name="client_encrypt_mtls", env="SCT_CLIENT_ENCRYPT_MTLS", type=boolean,
              help="when enabled scylla will enforce mutual authentication when client-to-node encryption is enabled"),
 

--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -174,14 +174,12 @@ class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-in
                                               verbose=True)
                 stress_cmd = f'{stress_cmd.strip()} -tls -tls-ca-cert-file {SCYLLA_SSL_CONF_DIR}/{TLSAssets.CA_CERT}'
 
+                if self.params.get("peer_verification"):
+                    stress_cmd = f'{stress_cmd.strip()} -tls-host-verification'
                 if self.params.get("client_encrypt_mtls"):
                     stress_cmd = (
                         f'{stress_cmd.strip()} -tls-client-key-file {SCYLLA_SSL_CONF_DIR}/{TLSAssets.CLIENT_KEY} '
                         f'-tls-client-cert-file {SCYLLA_SSL_CONF_DIR}/{TLSAssets.CLIENT_CERT}')
-
-                    # TBD: update after https://github.com/scylladb/scylla-bench/issues/140 is resolved
-                    # server_names = ' '.join(f'-tls-server-name {ip}' for ip in ips.split(","))
-                    # stress_cmd = f'{stress_cmd.strip()} -tls-host-verification {server_names}'
 
         return stress_cmd
 

--- a/sdcm/stress/latte_thread.py
+++ b/sdcm/stress/latte_thread.py
@@ -122,6 +122,9 @@ class LatteStressThread(DockerBasedStressThread):  # pylint: disable=too-many-in
                            f'--ssl-cert {SCYLLA_SSL_CONF_DIR}/{TLSAssets.CLIENT_CERT} '
                            f'--ssl-key {SCYLLA_SSL_CONF_DIR}/{TLSAssets.CLIENT_KEY}')
 
+            if self.params['peer_verification']:
+                ssl_config += ' --ssl-peer-verification'
+
         auth_config = ''
         if credentials := self.loader_set.get_db_auth():
             auth_config = f' --user {credentials[0]} --password {credentials[1]}'

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -205,7 +205,8 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
             # put the credentials into the right place into -mode section
             stress_cmd = re.sub(r'(-mode.*?)-', r'\1 user={} password={} -'.format(*credentials), stress_cmd)
         if self.client_encrypt and 'transport' not in stress_cmd:
-            transport_str = c_s_transport_str(self.params.get('client_encrypt_mtls'))
+            transport_str = c_s_transport_str(
+                self.params.get('peer_verification'), self.params.get('client_encrypt_mtls'))
             stress_cmd += f" -transport '{transport_str}'"
 
         stress_cmd = self.adjust_cmd_connection_options(stress_cmd, loader, cmd_runner)


### PR DESCRIPTION
Peer verification is now enabled by default for cassandra-stress, scylla-bench, and latte stress tools when client encryption is configured in Scylla. This ensures enhanced security by verifying if peer certificate is signed by the trusted CA and that the hostname/IP of the peer matches SAN specified in the peer's certificate.

Closes: https://github.com/scylladb/qa-tasks/issues/1728

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [PR-provision-test with server+client encryption enabled, covers c-s and s-b stress commands](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/peer-verification-test/3/)
- [x] :green_circle: [artifacts ubuntu test (regression check for non-longevity test, which in the past was affected by changes in certs management logic)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-ubuntu2204-test/3/)
- [x] :green_circle: [manager sanity test (regression check for non-longevity test, which in the past was affected by changes in certs management logic)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/ubuntu22-sanity-test/2/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
