### PR TITLE
fix(manager): update jenkinsfile for Manager Azure tests

### DIFF
--- a/jenkins-pipelines/manager/rhel-manager-backup-azure.jenkinsfile
+++ b/jenkins-pipelines/manager/rhel-manager-backup-azure.jenkinsfile
@@ -9,10 +9,6 @@ managerPipeline(
     azure_region_name: 'eastus',  //TODO: modify to multy region once sct supports more than one region
     test_name: 'mgmt_cli_test.ManagerBackupTests.test_backup_feature',
     test_config: 'test-cases/manager/manager-regression-azure.yaml',
-    scylla_version: '',
-    azure_image_db: '/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/scylla-images/providers/Microsoft.Compute/images/scylla-5.2.1-x86_64-2023-05-09T03-57-04',
-    // scylla 5.2.1
-    // TODO: Advance to the latest enterprise once new builds will be created
 
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',


### PR DESCRIPTION
Changes:
- Removed scylla version hardcode for Azure job. The image defined in azure_image_db contains Scylla 5.2.1 is outdated. Moreover, there are no restrictions with passing scylla_version directly. With this change, the Azure job will be executed with Scylla 2024.2 which is default for Manager jobs (if any specific doesn't redefine it).
- Renamed jenkinsfile to address recent move from Centos-based image for Azure jobs to RHEL-based (https://github.com/scylladb/scylla-cluster-tests/pull/9631).

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Manager Azure [job](https://jenkins.scylladb.com/job/manager-3.4/job/sct-feature-test-backup-azure/5/) - not related to change failure (fix is [here](https://github.com/scylladb/scylla-cluster-tests/pull/9590))

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code