### PR TITLE
fix(distro): add back ubuntu 24.04 support

### DIFF
--- a/sdcm/utils/distro.py
+++ b/sdcm/utils/distro.py
@@ -38,7 +38,7 @@ KNOWN_OS = (
     ("AMAZON", "amzn", ["2"], DistroBase.RHEL),
     ("ROCKY", "rocky", ["8", "9"], DistroBase.RHEL),
     ("DEBIAN", "debian", ["10", "11"], DistroBase.DEBIAN),
-    ("UBUNTU", "ubuntu", ["20.04", "21.04", "21.10", "22.04"], DistroBase.DEBIAN),
+    ("UBUNTU", "ubuntu", ["20.04", "21.04", "21.10", "22.04", "24.04"], DistroBase.DEBIAN),
     ("SLES", "sles", ["15"], DistroBase.UNKNOWN),
     ("FEDORA", "fedora", ["34", "35", "36"], DistroBase.RHEL),
     ("MINT", "linuxmint", ["20", "21"], DistroBase.DEBIAN),


### PR DESCRIPTION
for some reason during backporting of old PRs
this was removed, and causing issues for some code that is depened on it

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
