### PR TITLE
fix(nemesis.py): fix evaluation of stress command result

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2085,8 +2085,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         # To retrieve all results of a thread we need to call the base class method directly
         stress_results = super(stress_thread.__class__, stress_thread).get_results()
         node_errors = {}
-        for node, result, event in stress_results:
-            if event.get('errors'):
+        for node, _, event in stress_results:
+            if event.errors:
                 node_errors.setdefault(node.name, []).extend(event.errors)
 
         if len(node_errors) == len(stress_results):  # stop only if stress command failed on all loaders


### PR DESCRIPTION
Access stress event `errors` attribute directly, no as a dict key, as the stress event object doesn't implement `get` API.

Fixes https://github.com/scylladb/scylla-cluster-tests/issues/9653

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] local test for the change, as it is hard to find a job in CI which would for sure produce error in stress command.
Simple `PR-provision-test` run, with a breakpoint inside `stop_nemesis_on_stress_errors` method to check reading `error.events` attribute value:
- with 'broken' stress command, `error.events` holds the list of errors:
```
> event.errors
Out[1]: ['Stress command completed with bad status 1: ']

...

----- LAST ERROR EVENT -------------------------------------------------------
2025-01-05 17:41:12.182: (DisruptionEvent Severity.ERROR) period_type=end event_id=325cd791-4d07-4e1b-bbba-46102c514801 duration=44s: nemesis_name=Truncate target_node=Node PR-provision-test-dmitriy-db-node-4bfa7bae-3 [34.245.136.52 | 10.4.1.104] errors=Aborting 'TruncateMonkey' nemesis as 'cassandra-stress write blabla n=400000 cl=QUORUM -mode native cql3 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=2)' -log interval=5' stress command failed with the following errors:
on node 'PR-provision-test-dmitriy-loader-node-4bfa7bae-1': ['Stress command completed with bad status 1: ']
Traceback (most recent call last):
File "/home/dmitriy/Work/Scylla/sct_fix_stop_on_stress_error/sdcm/nemesis.py", line 5476, in wrapper
result = method(*args[1:], **kwargs)
File "/home/dmitriy/Work/Scylla/sct_fix_stop_on_stress_error/sdcm/nemesis.py", line 2112, in disrupt_truncate
self._prepare_test_table(ks=keyspace_truncate)
File "/home/dmitriy/Work/Scylla/sct_fix_stop_on_stress_error/sdcm/nemesis.py", line 2080, in _prepare_test_table
self.stop_nemesis_on_stress_errors(cs_thread)
File "/home/dmitriy/Work/Scylla/sct_fix_stop_on_stress_error/sdcm/nemesis.py", line 2094, in stop_nemesis_on_stress_errors
raise NemesisStressFailure(
sdcm.exceptions.NemesisStressFailure: Aborting 'TruncateMonkey' nemesis as 'cassandra-stress write blabla n=400000 cl=QUORUM -mode native cql3 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=2)' -log interval=5' stress command failed with the following errors:
on node 'PR-provision-test-dmitriy-loader-node-4bfa7bae-1': ['Stress command completed with bad status 1: ']
...
```
- stress command is OK,  `error.events` is empty:
```
> event.errors
Out[1]: []

...

----------------------------------------------------------------------
Ran 1 test in 630.830s

OK
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
