### PR TITLE
fix(integration-tests): update versions used

### DIFF
--- a/unit_tests/test_config_get_version_based_on_conf.py
+++ b/unit_tests/test_config_get_version_based_on_conf.py
@@ -105,21 +105,19 @@ def test_scylla_repo(scylla_version, expected_outcome, distro):
 
 @pytest.mark.parametrize(argnames='scylla_version, expected_outcome',
                          argvalues=[
-                             pytest.param('6.1', ('6.1', False), id='6.1'),
-                             pytest.param('2024.1', ('2024.1', True), id='2024.1'),
+                             pytest.param('6.2', ('6.2', False), id='6.2'),
+                             pytest.param('2024.2', ('2024.2', True), id='2024.2'),
                              pytest.param('master:latest', (None, False), id='master'),
-                             pytest.param('branch-6.0:latest', (None, False), id='branch-6.0'),
+                             pytest.param('branch-6.2:latest', (None, False), id='branch-6.2'),
                              pytest.param('enterprise:latest', (None, True), id='enterprise'),
-                             pytest.param('branch-2023.1:latest', (None, True), id='branch-2023.1'),
                              pytest.param('branch-2024.1:latest', (None, True), id='branch-2024.1'),
+                             pytest.param('branch-2024.2:latest', (None, True), id='branch-2024.2'),
                          ],
                          )
 @pytest.mark.parametrize(argnames='backend',
                          argvalues=('aws', 'gce', 'azure')
                          )
 def test_images(backend, scylla_version, expected_outcome):
-    if backend == "azure" and "2023.1" in scylla_version:
-        pytest.skip("Azure doesn't have 2023.1 images anymore")
     os.environ['SCT_CLUSTER_BACKEND'] = backend
     os.environ['SCT_SCYLLA_VERSION'] = scylla_version
 


### PR DESCRIPTION
some images of older branches aren't available anymore we shouldn't be using that old release in those tests

we should find a better way to stop those test from breaking but for now let just move them to newer versions

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] integration tests 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
