### PR TITLE
fix(offline-install): return back `tar` pkg installation

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2040,6 +2040,8 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
 
         if not nonroot:
             self.install_package(package_name='xfsprogs mdadm')
+        if self.distro.is_rhel_like:
+            self.install_package(package_name='tar')
 
         package_version_cmds_v2 = dedent("""
             tar -xzO --wildcards -f ./unified_package.tar.gz .relocatable_package_version


### PR DESCRIPTION
One of the recent PRs (https://github.com/scylladb/scylla-cluster-tests/pull/9652) has removed python2 and java installation on the offline installations.
And the problem is that it also removed installation of the `tar` package which is absent by default in some distros like `OEL8`.

So, add back that package installation to make offline installation work again.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
