### PR TITLE
improvement(perf_simple_query): add validation rules for Argus

### DIFF
--- a/microbenchmarking_test.py
+++ b/microbenchmarking_test.py
@@ -30,7 +30,6 @@ class PerfSimpleQueryTest(ClusterTester):
         result = self.db_cluster.nodes[0].remoter.run(
             "scylla perf-simple-query --json-result=perf-simple-query-result.txt --smp 1 -m 1G")
         if result.ok:
-            regression_report = {}
             output = self.db_cluster.nodes[0].remoter.run("cat perf-simple-query-result.txt").stdout
             results = json.loads(output)
             self.create_test_stats(
@@ -38,10 +37,7 @@ class PerfSimpleQueryTest(ClusterTester):
                 doc_id_with_timestamp=True)
             if self.create_stats:
                 is_gce = self.params.get('cluster_backend') == 'gce'
-                regression_report = PerfSimpleQueryAnalyzer(self._test_index, self._es_doc_type).check_regression(
+                PerfSimpleQueryAnalyzer(self._test_index, self._es_doc_type).check_regression(
                     self._test_id, is_gce=is_gce,
                     extra_jobs_to_compare=self.params.get('perf_extra_jobs_to_compare'))
-            send_perf_simple_query_result_to_argus(self.test_config.argus_client(),
-                                                   results,
-                                                   regression_report.get("scylla_date_results_table", [])
-                                                   )
+            send_perf_simple_query_result_to_argus(self.test_config.argus_client(), results)

--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -213,7 +213,7 @@ def send_result_to_argus(argus_client: ArgusClient, workload: str, name: str, de
         submit_results_to_argus(argus_client, result_table)
 
 
-def send_perf_simple_query_result_to_argus(argus_client: ArgusClient, result: dict, previous_results: list = None):
+def send_perf_simple_query_result_to_argus(argus_client: ArgusClient, result: dict):
     stats = result["stats"]
     workload = result["test_properties"]["type"]
     parameters = result["parameters"]
@@ -234,17 +234,15 @@ def send_perf_simple_query_result_to_argus(argus_client: ArgusClient, result: di
                        ColumnMetadata(name="tasks_per_op", unit="", type=ResultType.FLOAT, higher_is_better=False),
                        ]
 
-    def _get_status_based_on_previous_results(metric: str):
-        if previous_results is None:
-            return Status.PASS
-        if all((result.get(f"is_{metric}_within_limits", True) for result in previous_results)):
-            return Status.PASS
-        else:
-            return Status.ERROR
+            ValidationRules = {
+                "allocs_per_op": ValidationRule(best_pct=5),
+                "cpu_cycles_per_op": ValidationRule(best_pct=5),
+                "instructions_per_op": ValidationRule(best_pct=5),
+            }
 
     result_table = PerfSimpleQueryResult()
     for key, value in stats.items():
-        result_table.add_result(column=key, row="#1", value=value, status=_get_status_based_on_previous_results(key))
+        result_table.add_result(column=key, row="#1", value=value, status=Status.UNSET)
     submit_results_to_argus(argus_client, result_table)
 
 


### PR DESCRIPTION
When sending perf_simple_query benchmark results, Argus will validate numbers based on all history (submitted to Argus). Current approach validates only 10 last results.

closes: https://github.com/scylladb/scylla-cluster-tests/issues/9578

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [Argus, see graphs for limits too](https://argus.scylladb.com/tests/scylla-cluster-tests/d4bbaf2b-4e3e-4a53-a378-15d79c5036c2)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
