### PR TITLE
fix(dependabot): remove quotes from docker configurations

### DIFF
--- a/defaults/docker_images/alternator-dns/values_alternator-dns.yaml
+++ b/defaults/docker_images/alternator-dns/values_alternator-dns.yaml
@@ -1,2 +1,2 @@
 alternator-dns:
-  image: 'scylladb/hydra-loaders:alternator-dns-0.1'
+  image: scylladb/hydra-loaders:alternator-dns-0.1

--- a/defaults/docker_images/cassandra-stress/values_cassandra-stress.yaml
+++ b/defaults/docker_images/cassandra-stress/values_cassandra-stress.yaml
@@ -1,2 +1,2 @@
 cassandra-stress:
-  image: 'scylladb/cassandra-stress:3.17.0'
+  image: scylladb/cassandra-stress:3.17.0

--- a/defaults/docker_images/cdc-stresser/values_cdc-stresser.yaml
+++ b/defaults/docker_images/cdc-stresser/values_cdc-stresser.yaml
@@ -1,2 +1,2 @@
 cdc-stresser:
-  image: 'scylladb/hydra-loaders:cdc-stresser-20210630'
+  image: scylladb/hydra-loaders:cdc-stresser-20210630

--- a/defaults/docker_images/cql-stress-cassandra-stress/values_cql-stress-cassandra-stress.yaml
+++ b/defaults/docker_images/cql-stress-cassandra-stress/values_cql-stress-cassandra-stress.yaml
@@ -1,2 +1,2 @@
 cql-stress-cassandra-stress:
-  image: 'docker.io/scylladb/hydra-loaders:cql-stress-cassandra-stress-20240718'
+  image: docker.io/scylladb/hydra-loaders:cql-stress-cassandra-stress-20240718

--- a/defaults/docker_images/gemini/values_gemini.yaml
+++ b/defaults/docker_images/gemini/values_gemini.yaml
@@ -1,2 +1,2 @@
 gemini:
-  image: 'scylladb/hydra-loaders:gemini-v1.8.6'
+  image: scylladb/hydra-loaders:gemini-v1.8.6

--- a/defaults/docker_images/harry/values_harry.yaml
+++ b/defaults/docker_images/harry/values_harry.yaml
@@ -1,2 +1,2 @@
 harry:
-  image: 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816'
+  image: scylladb/hydra-loaders:cassandra-harry-jdk11-20220816

--- a/defaults/docker_images/kcl/values_kcl.yaml
+++ b/defaults/docker_images/kcl/values_kcl.yaml
@@ -1,2 +1,2 @@
 kcl:
-  image: 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC'
+  image: scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC

--- a/defaults/docker_images/latte/values_latte.yaml
+++ b/defaults/docker_images/latte/values_latte.yaml
@@ -1,2 +1,2 @@
 latte:
-  image: 'scylladb/hydra-loaders:latte-0.28.1-scylladb'
+  image: scylladb/hydra-loaders:latte-0.28.1-scylladb

--- a/defaults/docker_images/ndbench/values_ndbench.yaml
+++ b/defaults/docker_images/ndbench/values_ndbench.yaml
@@ -1,2 +1,2 @@
 ndbench:
-  image: 'scylladb/hydra-loaders:ndbench-jdk8-20210720'
+  image: scylladb/hydra-loaders:ndbench-jdk8-20210720

--- a/defaults/docker_images/nosqlbench/values_nosqlbench.yaml
+++ b/defaults/docker_images/nosqlbench/values_nosqlbench.yaml
@@ -1,2 +1,2 @@
 nosqlbench:
-  image: 'scylladb/hydra-loaders:nosqlbench-5.21.2'
+  image: scylladb/hydra-loaders:nosqlbench-5.21.2

--- a/defaults/docker_images/scylla-bench/values_scylla-bench.yaml
+++ b/defaults/docker_images/scylla-bench/values_scylla-bench.yaml
@@ -1,2 +1,2 @@
 scylla-bench:
-  image: 'scylladb/hydra-loaders:scylla-bench-v0.1.24'
+  image: scylladb/hydra-loaders:scylla-bench-v0.1.24

--- a/defaults/docker_images/ycsb/values_ycsb.yaml
+++ b/defaults/docker_images/ycsb/values_ycsb.yaml
@@ -1,2 +1,2 @@
 ycsb:
-  image: 'scylladb/hydra-loaders:ycsb-jdk8-20220918'
+  image: scylladb/hydra-loaders:ycsb-jdk8-20220918


### PR DESCRIPTION
seem like there's a bug in dependabot-docker, and it can't update the configuration if they are using quotes or double quotes in `image`, like:
```
ycsb:
  image: 'scylladb/hydra-loaders:ycsb-jdk8-20220918'
```

remove them for all docker configuration files for now


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] test locally with dependabot cli

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
