### PR TITLE
Revert "test(nemesis): update manager persistent snapshots"

### DIFF
--- a/defaults/manager_persistent_snapshots.yaml
+++ b/defaults/manager_persistent_snapshots.yaml
@@ -6,64 +6,75 @@ aws:
       number_of_rows: 5242880
       expected_timeout: 1800  # 30 minutes
       snapshots:
-        'sm_20240812150136UTC':
-          keyspace_name: "5gb_sizetiered_2024_2_0_rc1"
-          scylla_version: "2024.2.0~rc1"
+        'sm_20230702185929UTC':
+          keyspace_name: "5gb_sizetiered_2022_2"
+          scylla_version: "2022.2.9"
           scylla_product: "enterprise"
-          number_of_nodes: 3
-          # Recording cluster_id which is required for snapshots cleanup from the bucket in the future
-          cluster_id: "36d35f0b-2f9c-4df4-8d24-3a5093cf07d3"
-        'sm_20240812150350UTC':
-          keyspace_name: "5gb_sizetiered_6_0"
-          scylla_version: "6.0.2"
+          number_of_nodes: 5
+        'sm_20230702201949UTC':
+          keyspace_name: "5gb_sizetiered_2022_1"
+          scylla_version: "2022.1.7"
+          scylla_product: "enterprise"
+          number_of_nodes: 5
+        'sm_20230702190638UTC':
+          keyspace_name: "5gb_sizetiered_5_2"
+          scylla_version: "5.2.3"
           scylla_product: "oss"
-          number_of_nodes: 3
-          cluster_id: "9b8c43c0-ebbc-4c59-a23f-dbdbeda9d9e0"
+          number_of_nodes: 5
     10:
       number_of_rows: 10485760
       expected_timeout: 3600  # 60 minutes
       snapshots:
-        'sm_20240812150753UTC':
-          keyspace_name: "10gb_sizetiered_2024_2_0_rc1"
-          scylla_version: "2024.2.0~rc1"
-          scylla_product: "enterprise"
-          number_of_nodes: 3
-          cluster_id: "c1ac4a5f-cb1a-4312-aa00-e9fdddac7afb"
-        'sm_20240812150801UTC':
-          keyspace_name: "10gb_sizetiered_6_0"
-          scylla_version: "6.0.2"
+        'sm_20230223105105UTC':
+          keyspace_name: "10gb_sizetiered"
+          scylla_version: "5.1.6"
           scylla_product: "oss"
           number_of_nodes: 3
-          cluster_id: "947e78ed-e988-41d6-92b5-faaf8ad7bbc0"
+        'sm_20230702173347UTC':
+          keyspace_name: "10gb_sizetiered_2022_2"
+          scylla_version: "2022.2.9"
+          scylla_product: "enterprise"
+          number_of_nodes: 4
+        'sm_20230702173940UTC':
+          keyspace_name: "10gb_sizetiered_2022_1"
+          scylla_version: "2022.1.7"
+          scylla_product: "enterprise"
+          number_of_nodes: 4
+        'sm_20230702173329UTC':
+          keyspace_name: "10gb_sizetiered_5_2"
+          scylla_version: "5.2.3"
+          scylla_product: "oss"
+          number_of_nodes: 4
     100:
       number_of_rows: 104857600
       expected_timeout: 18000  # 300 minutes
       snapshots:
-        'sm_20240812162646UTC':
-          keyspace_name: "100gb_sizetiered_2024_2_0_rc1"
-          scylla_version: "2024.2.0~rc1"
-          scylla_product: "enterprise"
-          number_of_nodes: 3
-          cluster_id: "ebeab8af-cde8-492c-a7ee-d71b88872e4c"
-        'sm_20240812164539UTC':
-          keyspace_name: "100gb_sizetiered_6_0"
-          scylla_version: "6.0.2"
+        'sm_20230223130733UTC':
+          keyspace_name: "100gb_sizetiered"
+          scylla_version: "5.1.6"
           scylla_product: "oss"
           number_of_nodes: 3
-          cluster_id: "931ff656-51c0-432c-9495-9b4850061b65"
+        'sm_20230702235739UTC':
+          keyspace_name: "100gb_sizetiered_2022_2"
+          scylla_version: "2022.2.9"
+          scylla_product: "enterprise"
+          number_of_nodes: 4
+        'sm_20230703000641UTC':
+          keyspace_name: "100gb_sizetiered_2022_1"
+          scylla_version: "2022.1.7"
+          scylla_product: "enterprise"
+          number_of_nodes: 4
+        'sm_20230703000157UTC':
+          keyspace_name: "100gb_sizetiered_5_2"
+          scylla_version: "5.2.3"
+          scylla_product: "oss"
+          number_of_nodes: 4
     2048:
-        number_of_rows: 2147483648
-        expected_timeout: 132000  # 2200 minutes
-        snapshots:
-          'sm_20240904154553UTC':
-            keyspace_name: "2tb_sizetiered_2024_2_0_rc1"
-            scylla_version: "2024.2.0~rc1"
-            scylla_product: "enterprise"
-            number_of_nodes: 3
-            cluster_id: "adb4afb6-27fe-4b26-914e-4f5cc3551955"
-          'sm_20240905214537UTC':
-            keyspace_name: "2tb_sizetiered_6_0"
-            scylla_version: "6.0.2"
-            scylla_product: "oss"
-            number_of_nodes: 3
-            cluster_id: "7fc7ce78-2e7e-4348-a8f7-29ae6494f6c9"
+      number_of_rows: 2147483648
+      expected_timeout: 132000  # 2200 minutes
+      snapshots:
+        'sm_20230226074656UTC':
+          keyspace_name: "2tb_sizetiered"
+          scylla_version: "5.1.6"
+          scylla_product: "oss"
+          number_of_nodes: 3


### PR DESCRIPTION
This reverts commit 64fa8b3970156368af1a614985a2cdfddc4f884b.
It was mistakenly backported initially. Backup snapshots with Scylla 2024.2.0~rc1 can't be restored to node with Scylla 2023.1 - system schema in 2023.1 does not match to schema of 2024.2 and system_schema.scylla_tables does not include committed_by_group0  column.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-10gb-3h-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/longevity-10gb-3h-test/2/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code