### PR TITLE
fix(region_name): handle case of `region_name` doesn't exist

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -460,7 +460,7 @@ class SnapshotOperations(ClusterTester):
     def get_all_snapshot_files(self, cluster_id):
         bucket_name = self.params.get('backup_bucket_location').split()[0]
         if self.params.get('backup_bucket_backend') == 's3':
-            region_name = self.params.get("region_name").split()[0]
+            region_name = next(iter(self.params.region_names), '')
             return self._get_all_snapshot_files_s3(cluster_id=cluster_id, bucket_name=bucket_name,
                                                    region_name=region_name)
         elif self.params.get('backup_bucket_backend') == 'gcs':

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -178,7 +178,7 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
                     "The missing table is still in s3, even though it should have been purged"
 
     def update_all_agent_config_files(self):
-        region_name = self.params.get("region_name").split()[0]
+        region_name = next(iter(self.params.region_names), '')
         for node in self.db_cluster.nodes:
             node.update_manager_agent_backup_config(region=region_name)
         sleep(60)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4799,7 +4799,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         else:
             agent_backup_general_config = None
         node.update_manager_agent_backup_config(
-            region=self.params.get("region_name").split()[0],
+            region=next(iter(self.params.region_names), ''),
             general_config=agent_backup_general_config,
         )
 

--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -575,7 +575,7 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):  # pylint: disable=
         if self.params.get("use_mgmt"):
             data["s3"] = {
                 "provider": "AWS",
-                "region": self.params.get("region_name").split()[0],
+                "region": next(iter(self.params.region_names), ''),
             }
         # Create kubernetes secret that holds scylla manager agent configuration
         self.update_secret_from_data(SCYLLA_AGENT_CONFIG_NAME, namespace, {


### PR DESCRIPTION
in #9492 some code changed to assume `region_name` always exists and when not using AWS, it doesn't exist (or it's empty)

switch to retrieving it in a safer way

Ref: #9492

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] provision test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
