### PR TITLE
fix(sct_ssh): fix `UnboundLocalError` in `hydra attach-test-sg`

### DIFF
--- a/sct_ssh.py
+++ b/sct_ssh.py
@@ -319,6 +319,7 @@ def select_instance_group(region: str = None, backends: list | None = None, **ta
     backends = backends or ['aws', 'gce']
     aws_vms = []
     gce_vms = []
+    azure_vms = []
 
     if 'aws' in backends:
         aws_vms = list_instances_aws(tags, running=True, region_name=region)

--- a/unit_tests/test_python_driver.py
+++ b/unit_tests/test_python_driver.py
@@ -44,6 +44,7 @@ def test_01_test_python_driver_serverless_connectivity(params):
             assert len(output) == 1
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize('encrypted', [
     pytest.param(True, marks=pytest.mark.docker_scylla_args(ssl=True), id='encrypted'),
     pytest.param(False, marks=pytest.mark.docker_scylla_args(ssl=False), id='clear')


### PR DESCRIPTION
the new support for Azure we missing some variable definition

and was failing like this:
```
UnboundLocalError: local variable 'azure_vms' referenced before assignment
```

this change is setting this variable upfront with empty list

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
