### PR TITLE
feature(sdcm) wait less for schema agreement

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2781,7 +2781,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
                 cql_results)
         return peers_details
 
-    @retrying(n=5, sleep_time=10, raise_on_exceeded=False)
+    @retrying(n=10, sleep_time=5, raise_on_exceeded=False)
     def get_gossip_info(self) -> dict[BaseNode, dict]:
         gossip_info = self.run_nodetool('gossipinfo', verbose=False, warning_event_on_exception=(Exception,),
                                         publish_event=False)
@@ -4394,7 +4394,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             message=f"There are more then expected nodes running nemesis: {message}",
         ).publish()
 
-    @retrying(n=6, sleep_time=10, allowed_exceptions=(AssertionError,))
+    @retrying(n=10, sleep_time=5, allowed_exceptions=(AssertionError,))
     def wait_for_schema_agreement(self):
 
         for node in self.nodes:

--- a/sdcm/utils/health_checker.py
+++ b/sdcm/utils/health_checker.py
@@ -19,8 +19,8 @@ from sdcm.sct_events import Severity
 from sdcm.sct_events.health import ClusterHealthValidatorEvent
 
 
-CHECK_NODE_HEALTH_RETRIES = 3
-CHECK_NODE_HEALTH_RETRY_DELAY = 45
+CHECK_NODE_HEALTH_RETRIES = 10
+CHECK_NODE_HEALTH_RETRY_DELAY = 15
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
I hope by now it's stable and we can wait less (but retry more to compensate) on the 2 functions that are related to schema agrement. Cut the wait time from 10s to 5s and increased the retry count to 10.

Probably need a similar change in dtest.
BTW, the Python driver sleeps for 0.2s before retrying.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/101/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
