### PR TITLE
fix(createindex): Disable nemesis to run in parallel nemesis jobs

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5068,6 +5068,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         Create index on a random column (regular or static) of a table with the most number of partitions and wait until it gets build.
         Then verify it can be used in a query. Finally, drop the index.
         """
+        if self.cluster.nemesis_count > 1 and SkipPerIssues(issues="https://github.com/scylladb/scylladb/issues/21695", params=self.tester.params):
+            raise UnsupportedNemesis("Skip create index nemesis with parallel nemesis run")
+
         with self.cluster.cql_connection_patient(self.target_node, connect_timeout=300) as session:
 
             ks_cf_list = self.cluster.get_non_system_ks_cf_list(self.target_node, filter_out_mv=True)


### PR DESCRIPTION
Disable nemesis CreateIndex from runs with parallel nemesis to stabilze jobs:
 - longevity-schema-topology-changes-12h-test
 - longevity-multi-dc-rack-aware-zero-token-dc-test
 - longevity-multidc-schema-topology-changes-12h-test

After issue scylladb/scylladb#21695 will be fixed, nemesis could be again enabled in parallel running

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [Passed job](https://argus.scylladb.com/tests/scylla-cluster-tests/dc9079ff-d838-4ec5-b3da-6ac49972a905)
- [Passed job](https://argus.scylladb.com/tests/scylla-cluster-tests/3771cd6e-c0a1-42bc-b3a1-f46e93336545)
- [Passed job](https://argus.scylladb.com/tests/scylla-cluster-tests/d9524334-6096-40d6-b303-5660fe81fe14)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
