### PR TITLE
fix(nemesis.py): log nemesis start/end on db nodes logs

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -32,6 +32,7 @@ import traceback
 import itertools
 import json
 import ipaddress
+import shlex
 from importlib import import_module
 from typing import List, Optional, Dict, Union, Set, Iterable, ContextManager, Any, IO, AnyStr, Callable
 from datetime import datetime, timezone
@@ -3138,6 +3139,10 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         self.remoter.sudo('systemctl stop firewalld', ignore_status=True)
         self.remoter.sudo('systemctl disable firewalld', ignore_status=True)
 
+    def log_message(self, message: str, level: str = 'info', verbose: bool = False) -> None:
+        self.remoter.run(
+            f'scylla-api-client system log POST --level {level} --message {shlex.quote(message)}', verbose=verbose)
+
 
 class FlakyRetryPolicy(RetryPolicy):
 
@@ -5115,6 +5120,10 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             for feature in feature_list:
                 enabled_features_state.append(feature in enabled_features)
         return all(enabled_features_state)
+
+    def log_message(self, message: str, level: str = 'info', verbose: bool = False) -> None:
+        for node in self.nodes:
+            node.log_message(message, level, verbose)
 
 
 class BaseLoaderSet():

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1960,11 +1960,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def execute_disrupt_method(self, disrupt_method):
         disrupt_method_name = disrupt_method.__name__.replace('disrupt_', '')
-        self.log.info(">>>>>>>>>>>>>Started random_disrupt_method %s" % disrupt_method_name)
         self.metrics_srv.event_start(disrupt_method_name)
         try:
             disrupt_method()
-            self.log.info("<<<<<<<<<<<<<Finished random_disrupt_method %s" % disrupt_method_name)
         finally:
             self.metrics_srv.event_stop(disrupt_method_name)
 
@@ -5418,6 +5416,13 @@ def disrupt_method_wrapper(method, is_exclusive=False):  # pylint: disable=too-m
         except Exception:  # pylint: disable=broad-except
             nemesis.log.error("Error finalizing nemesis information in Argus", exc_info=True)
 
+    def get_nemesis_status(nemesis_event: DisruptionEvent) -> str:
+        if nemesis_event.severity == Severity.ERROR:
+            return NemesisStatus.FAILED
+        if nemesis_event.is_skipped:
+            return NemesisStatus.SKIPPED
+        return NemesisStatus.SUCCEEDED
+
     def data_validation_prints(args):
         try:
             if hasattr(args[0].tester, 'data_validator') and args[0].tester.data_validator:
@@ -5435,7 +5440,7 @@ def disrupt_method_wrapper(method, is_exclusive=False):  # pylint: disable=too-m
             args[0].log.debug(f'Data validator error: {err}')
 
     @wraps(method)
-    def wrapper(*args, **kwargs):  # pylint: disable=too-many-statements  # noqa: PLR0914
+    def wrapper(*args, **kwargs):  # pylint: disable=too-many-statements  # noqa: PLR0914, PLR0915
         # pylint: disable=too-many-locals
         # pylint: disable=too-many-branches
         method_name = method.__name__
@@ -5451,15 +5456,20 @@ def disrupt_method_wrapper(method, is_exclusive=False):  # pylint: disable=too-m
                     # NOTE: exclusive nemesis will wait before the end of all other ones
                     time.sleep(10)
 
-            current_disruption = "".join(p.capitalize() for p in method_name.replace("disrupt_", "").split("_"))
-            args[0].set_target_node_pool_type(target_pool_type)
-            args[0].set_target_node(current_disruption=current_disruption)
-
             args[0].cluster.check_cluster_health()
             num_data_nodes_before = len(args[0].cluster.data_nodes)
             num_zero_nodes_before = len(args[0].cluster.zero_nodes)
             start_time = time.time()
-            args[0].log.debug('Start disruption at `%s`', datetime.datetime.fromtimestamp(start_time))
+
+            current_disruption = "".join(p.capitalize() for p in method_name.replace("disrupt_", "").split("_"))
+            args[0].set_target_node_pool_type(target_pool_type)
+            args[0].set_target_node(current_disruption=current_disruption)
+            start_msg = (f"Started disruption {method_name} ({current_disruption} nemesis) on the target node "
+                         f"'{str(args[0].target_node)}'")
+            args[0].log.debug("{start_symbol} {msg} {start_symbol}".format(start_symbol='>' * 12, msg=start_msg))
+            args[0].cluster.log_message(
+                "{start_symbol} {msg} {start_symbol}".format(start_symbol='=' * 12, msg=start_msg))
+
             class_name = args[0].get_class_name()
             if class_name.find('Chaos') < 0:
                 args[0].metrics_srv.event_start(class_name)
@@ -5540,6 +5550,12 @@ def disrupt_method_wrapper(method, is_exclusive=False):  # pylint: disable=too-m
                     if nemesis_info:
                         argus_finalize_nemesis_info(nemesis=args[0], method_name=method_name, start_time=int(
                             start_time), nemesis_event=nemesis_event)
+
+                    end_msg = (f"Finished disruption {method_name} ({current_disruption} nemesis) with status "
+                               f"'{get_nemesis_status(nemesis_event)}'")
+                    args[0].log.debug("{end_symbol} {msg} {end_symbol}".format(end_symbol='<' * 12, msg=end_msg))
+                    args[0].cluster.log_message(
+                        "{end_symbol} {msg} {end_symbol}".format(end_symbol='=' * 12, msg=end_msg))
 
             args[0].cluster.check_cluster_health()
             num_data_nodes_after = len(args[0].cluster.data_nodes)

--- a/unit_tests/test_nemesis.py
+++ b/unit_tests/test_nemesis.py
@@ -29,6 +29,9 @@ class Node:
     def scylla_shards(self):
         return 8
 
+    def log_message(self, *args, **kwargs):
+        pass
+
 
 @dataclass
 class Cluster:
@@ -45,6 +48,9 @@ class Cluster:
     @property
     def zero_nodes(self):
         return self.nodes
+
+    def log_message(self, *args, **kwargs):
+        pass
 
 
 @dataclass


### PR DESCRIPTION
Add logging of the following nemesis details in logs of each db node of a cluster under test:
- nemesis start with disruption/nemesis name
- target node for the nemesis
- nemesis end with status

Closes: https://github.com/scylladb/scylla-cluster-tests/issues/6088 

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [PR-provision-test test config with SisyphusMonkey class](https://argus.scylladb.com/tests/scylla-cluster-tests/6288cf64-4539-4de4-899c-e1168029a277)

Example of how the start/end is logged in:
- sct.log
```
❯ egrep '>>>>|<<<<.*disruption' -irn sct-6288cf64.log
21138:< t:2025-01-13 16:05:06,583 f:nemesis.py      l:5469 c:sdcm.nemesis         p:DEBUG > sdcm.nemesis.SisyphusMonkey: >>>>>>>>>>>> Started disruption disrupt_kill_scylla (KillScylla nemesis) on the target node 'Node PR-provision-test-log-neme-db-node-6288cf64-2 [3.253.12.15 | 10.4.3.181]' >>>>>>>>>>>>
22492:< t:2025-01-13 16:05:30,440 f:nemesis.py      l:5556 c:sdcm.nemesis         p:DEBUG > sdcm.nemesis.SisyphusMonkey: <<<<<<<<<<<< Finished disruption disrupt_kill_scylla (KillScylla nemesis) with status 'succeeded' <<<<<<<<<<<<
```
- db node log
```
❯ egrep '======.*disruption' -irn db-cluster-6288cf64/PR-provision-test-log-neme-db-node-6288cf64-*/system.log
db-cluster-6288cf64/PR-provision-test-log-neme-db-node-6288cf64-1/system.log:1145:Jan 13 16:05:07.963018 PR-provision-test-log-neme-db-node-6288cf64-1 scylla[5435]:  [shard 0:strm] api - /system/log: ============ Started disruption disrupt_kill_scylla (KillScylla nemesis) on the target node 'Node PR-provision-test-log-neme-db-node-6288cf64-2 [3.253.12.15 | 10.4.3.181]' ============
db-cluster-6288cf64/PR-provision-test-log-neme-db-node-6288cf64-1/system.log:1174:Jan 13 16:05:31.041321 PR-provision-test-log-neme-db-node-6288cf64-1 scylla[5435]:  [shard 0:strm] api - /system/log: ============ Finished disruption disrupt_kill_scylla (KillScylla nemesis) with status 'succeeded' ============
db-cluster-6288cf64/PR-provision-test-log-neme-db-node-6288cf64-2/system.log:1077:Jan 13 16:05:08.605344 PR-provision-test-log-neme-db-node-6288cf64-2 scylla[5447]:  [shard 0:strm] api - /system/log: ============ Started disruption disrupt_kill_scylla (KillScylla nemesis) on the target node 'Node PR-provision-test-log-neme-db-node-6288cf64-2 [3.253.12.15 | 10.4.3.181]' ============
db-cluster-6288cf64/PR-provision-test-log-neme-db-node-6288cf64-2/system.log:1626:Jan 13 16:05:31.620427 PR-provision-test-log-neme-db-node-6288cf64-2 scylla[5910]:  [shard 1:strm] api - /system/log: ============ Finished disruption disrupt_kill_scylla (KillScylla nemesis) with status 'succeeded' ============
db-cluster-6288cf64/PR-provision-test-log-neme-db-node-6288cf64-3/system.log:1058:Jan 13 16:05:09.198262 PR-provision-test-log-neme-db-node-6288cf64-3 scylla[5456]:  [shard 0:strm] api - /system/log: ============ Started disruption disrupt_kill_scylla (KillScylla nemesis) on the target node 'Node PR-provision-test-log-neme-db-node-6288cf64-2 [3.253.12.15 | 10.4.3.181]' ============
db-cluster-6288cf64/PR-provision-test-log-neme-db-node-6288cf64-3/system.log:1065:Jan 13 16:05:32.099599 PR-provision-test-log-neme-db-node-6288cf64-3 scylla[5456]:  [shard 0:strm] api - /system/log: ============ Finished disruption disrupt_kill_scylla (KillScylla nemesis) with status 'succeeded' ============
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
