### PR TITLE
fix(mgmt-agent): setup it using the code existing in the branch-2024.2

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4746,15 +4746,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             node.remoter.run(f"mkdir -p {pkg_path}")
             node.remoter.send_files(src=f"{pkg_path}*.rpm", dst=pkg_path)
         node.install_manager_agent(package_path=pkg_path)
-
-        if self.params.get("mgmt_agent_backup_config"):
-            agent_backup_general_config = self.params.get("mgmt_agent_backup_config").dict()
-        else:
-            agent_backup_general_config = None
-        node.update_manager_agent_backup_config(
-            region=next(iter(self.params.region_names), ''),
-            general_config=agent_backup_general_config,
-        )
+        node.update_manager_agent_config(region=next(iter(self.params.region_names), ''))
 
     def _scylla_install(self, node):
         node.update_repo_cache()


### PR DESCRIPTION
Recently was backported the PR (https://github.com/scylladb/scylla-cluster-tests/pull/9683) that started using the code
which is absent in the `branch-2024.2` SCT branch.
It was never backported from the (https://github.com/scylladb/scylla-cluster-tests/pull/7408).

So, fix the problem by using old code which exists in the target branch.

Closes: https://github.com/scylladb/scylla-cluster-tests/issues/9775

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/job/enterprise-2024.2/job/longevity_tablets/job/longevity-gce-custom-d1-worklod1-hybrid-raid-test/6/consoleFull

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
