### PR TITLE
fix(get_supported_scylla_base_version): skip upgrade from 6.0 to 2024.2

### DIFF
--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -126,13 +126,13 @@ class TestBaseVersion(unittest.TestCase):
         scylla_repo = self.url_base + '-enterprise/enterprise-2024.2/rpm/centos/latest/scylla.repo'
         linux_distro = 'centos-9'
         version_list = general_test(scylla_repo, linux_distro)
-        assert set(version_list) == {'2024.1', '2024.2', '6.0'}
+        assert set(version_list) == {'2024.1', '2024.2'}
 
     def test_2024_2_ubuntu(self):
         scylla_repo = self.url_base + '-enterprise/enterprise-2024.2/deb/unified/latest/scylladb-2024.2/scylla.list'
         linux_distro = 'ubuntu-focal'
         version_list = general_test(scylla_repo, linux_distro)
-        assert set(version_list) == {'6.0', '2024.1', '2024.2'}
+        assert set(version_list) == {'2024.1', '2024.2'}
 
 
 if __name__ == "__main__":

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -4,6 +4,9 @@ import sys
 import re
 import os
 
+from aenum import NamedTuple
+
+from sdcm.utils.issues import SkipPerIssues
 from sdcm.utils.version_utils import is_enterprise, get_all_versions
 from sdcm.utils.version_utils import ComparableScyllaVersion, get_s3_scylla_repos_mapping
 
@@ -99,7 +102,10 @@ class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
             if version in supported_versions:
                 # The dest version is a released enterprise version
                 idx = ent_release_list.index(version)
-                oss_base_version.append(supported_src_oss.get(version))
+
+                params = NamedTuple("params", ["scylla_version"])  # at this point there is no test object
+                if not (version == '2024.2' and SkipPerIssues("https://github.com/scylladb/scylla-enterprise/issues/4740", params=params(scylla_version=version))):
+                    oss_base_version.append(supported_src_oss.get(version))
                 ent_base_version.append(version)
                 if idx != 0:
                     lts_version = re.compile(r'\d{4}\.1')  # lts = long term support


### PR DESCRIPTION
Skip this upgrade combination due to a repair during rollback  bug

refs: scylladb/scylla-enterprise#4740

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/15cdc0a9-022c-4537-8dcd-3edb207c3d0a

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
