### PR TITLE
fix(upgrade-tests): enlarge timeout for truncate commands

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -3142,7 +3142,10 @@ class FillDatabaseData(ClusterTester):
         # Refs: https://github.com/scylladb/scylla/issues/5235
         time.sleep(30)
         for truncate in truncates:
-            session.execute(truncate)
+            # timeout was enlarged cause of
+            # - https://github.com/scylladb/scylladb/issues/22166
+            # - https://github.com/scylladb/scylladb/issues/21946
+            session.execute(truncate, timeout=300)
 
     @property
     def parsed_scylla_version(self):


### PR DESCRIPTION
as suggested in scylladb/scylladb#22166, we make the truncate commands timeout longer, to compensate on the fact scylla can't support multiple truncate operation in parallel

Ref: scylladb/scylladb#22166
Ref: scylladb/scylladb#21946

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://argus.scylladb.com/tests/scylla-cluster-tests/eaf8c12a-b155-4f50-9245-b3fe7a39f071

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
