### PR TITLE
feature(pipelines): collect builders logs

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -329,7 +329,7 @@ def list_logs_by_test_id(test_id):
     log_types = ['db-cluster', 'monitor-set', 'loader-set', 'event', 'sct', 'jepsen-data', 'siren-manager-set',
                  'prometheus', 'grafana', 'kubernetes', 'job', 'monitoring_data_stack', 'output', 'error',
                  'summary', 'warning', 'critical', 'normal', 'debug', 'left_processes', 'email_data', 'corrupted-sstables',
-                 'sstables']
+                 'sstables', 'builder']
 
     results = []
 

--- a/vars/collectBuilderLogs.groovy
+++ b/vars/collectBuilderLogs.groovy
@@ -1,0 +1,14 @@
+#!groovy
+
+def call(){
+    sh """#!/bin/bash
+
+	set -xe
+
+	SHORT_SCT_TEST_ID=\$(echo \$SCT_TEST_ID | cut -c1-8)
+    sudo journalctl --no-tail --no-pager -o short-precise > builder-\$SHORT_SCT_TEST_ID.log
+    tar -zcvf builder-\$SHORT_SCT_TEST_ID.log.tar.gz builder-\$SHORT_SCT_TEST_ID.log
+
+    ./docker/env/hydra.sh upload --test-id \$SCT_TEST_ID builder-\$SHORT_SCT_TEST_ID.log.tar.gz
+    """
+}

--- a/vars/runCollectLogs.groovy
+++ b/vars/runCollectLogs.groovy
@@ -34,4 +34,6 @@ def call(Map params, String region){
     fi
     echo "end collect logs"
     """
+
+    collectBuilderLogs()
 }


### PR DESCRIPTION
we have multiple issue related to builder, and we don't have any logs from their end saved

this commit add code that collect the journalctl logs from builder and upload it to s3 and Argus.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] provision test
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2404-test/30/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/96/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
