### PR TITLE
fix(bucket-locations): add templating to `backup_bucket_location`

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -26,7 +26,7 @@ ami_id_db_oracle: ''
 use_preinstalled_scylla: true
 
 backup_bucket_backend: 's3'
-backup_bucket_location: 'manager-backup-tests-us-east-1'
+backup_bucket_location: 'manager-backup-tests-{region}'
 
 data_volume_disk_num: 0
 data_volume_disk_type: 'gp2'

--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -432,7 +432,8 @@ def test_mgmt_backup(db_cluster, manager_version):
 
     # Run manager backup operation
     mgr_cluster = db_cluster.get_cluster_manager()
-    backup_bucket_location = db_cluster.params.get('backup_bucket_location')
+    region = next(iter(db_cluster.params.region_names), '')
+    backup_bucket_location = db_cluster.params.get('backup_bucket_location').format(region=region)
     bucket_name = f"s3:{backup_bucket_location.split()[0]}"
     mgr_task = mgr_cluster.create_backup_task(location_list=[bucket_name, ])
     assert mgr_task, "Failed to create backup task"

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -458,9 +458,9 @@ class SnapshotOperations(ClusterTester):
         return file_set
 
     def get_all_snapshot_files(self, cluster_id):
-        bucket_name = self.params.get('backup_bucket_location').split()[0]
+        region_name = next(iter(self.params.region_names), '')
+        bucket_name = self.params.get('backup_bucket_location').split()[0].format(region=region_name)
         if self.params.get('backup_bucket_backend') == 's3':
-            region_name = next(iter(self.params.region_names), '')
             return self._get_all_snapshot_files_s3(cluster_id=cluster_id, bucket_name=bucket_name,
                                                    region_name=region_name)
         elif self.params.get('backup_bucket_backend') == 'gcs':
@@ -509,7 +509,8 @@ class ManagerTestFunctionsMixIn(
     def locations(self) -> list[str]:
         backend = self.params.get("backup_bucket_backend")
 
-        buckets = self.params.get("backup_bucket_location")
+        region = next(iter(self.params.region_names), '')
+        buckets = self.params.get("backup_bucket_location").format(region=region)
         if not isinstance(buckets, list):
             buckets = buckets.split()
 
@@ -646,7 +647,8 @@ class ManagerRestoreTests(ManagerTestFunctionsMixIn):
             self.log.error("Test supports only AWS ATM")
             return
         persistent_manager_snapshots_dict = get_persistent_snapshots()
-        target_bucket = persistent_manager_snapshots_dict[cluster_backend]["bucket"]
+        region = next(iter(self.params.region_names), '')
+        target_bucket = persistent_manager_snapshots_dict[cluster_backend]["bucket"].format(region=region)
         backup_bucket_backend = self.params.get("backup_bucket_backend")
         location_list = [f"{backup_bucket_backend}:{target_bucket}"]
         confirmation_stress_template = persistent_manager_snapshots_dict[cluster_backend]["confirmation_stress_template"]

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3165,7 +3165,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 raise UnsupportedNemesis('backup bucket location configuration is not defined!')
 
             backup_bucket_backend = self.cluster.params.get("backup_bucket_backend")
-            backup_bucket_location = self.cluster.params.get("backup_bucket_location")
+            region = next(iter(self.cluster.params.region_names), '')
+            backup_bucket_location = self.cluster.params.get("backup_bucket_location").format(region=region)
             location = f"{backup_bucket_backend}:{backup_bucket_location.split()[0]}"
         self._delete_existing_backups(mgr_cluster)
         if backup_specific_tables:


### PR DESCRIPTION
since now we are doing backup/restore in the test region and `backup_bucket_region` was remove.

the code for this configuration need to be templated as it was done for restore nemesis

otherwise we fail like the following:
```
23:22:43  Command: 'sudo sctool backup -c a05d9ea2-312c-4c8d-99b0-9f9b57e8cbde
          --keyspace scylla_bench,keyspace1  --location s3:manager-backup-tests-us-east-1 '
23:22:43  Exit code: 1
23:22:43  Stdout:
23:22:43  Stderr:
23:22:43  Error: create backup target: location is not accessible
23:22:43  10.4.2.70: agent [HTTP 400] operation put: s3 upload: 301 Moved Permanently:
          The bucket you are attempting to access must be addressed using the specified endpoint.
          Please send all future requests to this endpoint. (code:PermanentRedirect) - make sure the location
          is correct and credentials are set, to debug SSH to 10.4.2.70 and run
          "scylla-manager-agent check-location -L s3:manager-backup-tests-us-east-1 --debug"
23:22:43  Trace ID: DXvyKGPjQMKUCkJpyxlKCQ (grep in scylla-manager logs)
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] :clock1: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/97/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
