### PR TITLE
fix(disrupt_mgmt_restore): adjust getting regions

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3071,7 +3071,12 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             "https://github.com/scylladb/scylla-manager/issues/3829",
             "https://github.com/scylladb/scylla-manager/issues/4049"
         ]
-        is_multi_dc = len(self.cluster.params.get('region_name').split()) > 1
+
+        regions = self.cluster.params.get('region_name')
+        if isinstance(regions, str):
+            regions = regions.split()
+
+        is_multi_dc = len(regions) > 1
         if SkipPerIssues(skip_issues, params=self.tester.params) and is_multi_dc:
             raise UnsupportedNemesis("MultiDC cluster configuration is not supported by this nemesis")
 
@@ -3086,10 +3091,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             cluster_backend = 'aws'
 
         persistent_manager_snapshots_dict = get_persistent_snapshots()
-        region = self.cluster.params.get('region_name').split()[0]
-        target_bucket = persistent_manager_snapshots_dict[cluster_backend]["bucket"].format(region=region)
+        target_bucket = persistent_manager_snapshots_dict[cluster_backend]["bucket"].format(region=regions[0])
         chosen_snapshot_tag, chosen_snapshot_info = (
-            choose_snapshot(snapshots_dict=persistent_manager_snapshots_dict[cluster_backend], region=region)
+            choose_snapshot(snapshots_dict=persistent_manager_snapshots_dict[cluster_backend], region=regions[0])
         )
 
         self.log.info("Restoring the keyspace %s", chosen_snapshot_info["keyspace_name"])


### PR DESCRIPTION
adjust getting region names
due to we have different types of values in 'region_name' for AWS(string) and AZURE(list)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/artsiom_mishuta/job/longevity-1tb-5days-azure-test/2/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
