### PR TITLE
improvement(fill_db_data): Remove 30s sleep of waiting for schema agreement

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -3137,9 +3137,6 @@ class FillDatabaseData(ClusterTester):
                         truncates.append(truncate)
             else:
                 self.all_verification_items[test_num]['skip_condition'] = False
-        # Sleep a while after creating test tables to avoid schema disagreement.
-        # Refs: https://github.com/scylladb/scylla/issues/5235
-        time.sleep(30)
         for truncate in truncates:
             # timeout was enlarged cause of
             # - https://github.com/scylladb/scylladb/issues/22166


### PR DESCRIPTION
Now that all of our recent releases contains raft with consistent scehma management, this sleep isn't needed anymore.

Test: rolling upgrades.

Fixes: #9660

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] https://jenkins.scylladb.com/job/scylla-staging/job/roy/job/rolling-upgrade-ami-test/2/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
