### PR TITLE
fix(force_run_iotune): run `scylla_io_setup` and not directly iotune

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4724,7 +4724,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
         if self.params.get('force_run_iotune'):
             node.remoter.sudo(
-                cmd=f"iotune --evaluation-directory {SCYLLA_DIR} --properties-file /etc/scylla.d/io_properties.yaml", timeout=600)
+                cmd="scylla_io_setup", timeout=600)
 
         if self.params.get('gce_setup_hybrid_raid'):
             gce_n_local_ssd_disk_db = self.params.get('gce_n_local_ssd_disk_db')


### PR DESCRIPTION
the iotune command was generating only `io-properties.yaml` and not the `io.conf` file that should point to it.

so it was working on supported instance types, but was failing to do it's purpose on unsupported instance types.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] proven working on multiple job - https://argus.scylladb.com/tests/scylla-cluster-tests/1c503e7a-87f7-4024-97d0-c7267b6ed154

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
