### PR TITLE
fix(auto_assign): skip `scylladbbot` assignment

### DIFF
--- a/.github/workflows/auto_assign.yaml
+++ b/.github/workflows/auto_assign.yaml
@@ -10,4 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign author to PR/issue
+        if: github.actor != 'scylladbbot'
         uses: technote-space/assign-author@v1


### PR DESCRIPTION
There is no need to assign to backport PRs or `scylladbbot` users, 
let's skip it

