### PR TITLE
fix(common): change wait_for_tablets_balanced to represent what it actualy does

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -131,7 +131,7 @@ from sdcm.utils.replication_strategy_utils import temporary_replication_strategy
     NetworkTopologyReplicationStrategy, ReplicationStrategy, SimpleReplicationStrategy
 from sdcm.utils.sstable.load_utils import SstableLoadUtils
 from sdcm.utils.sstable.sstable_utils import SstableUtils
-from sdcm.utils.tablets.common import wait_for_tablets_balanced
+from sdcm.utils.tablets.common import wait_no_tablets_migration_running
 from sdcm.utils.toppartition_util import NewApiTopPartitionCmd, OldApiTopPartitionCmd
 from sdcm.utils.version_utils import (
     MethodVersionNotFound, scylla_versions, ComparableScyllaVersion, get_systemd_version)
@@ -4217,7 +4217,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     @latency_calculator_decorator(legend="Adding new nodes")
     def add_new_nodes(self, count, rack=None, instance_type: str = None) -> list[BaseNode]:
         nodes = self._add_and_init_new_cluster_nodes(count, rack=rack, instance_type=instance_type)
-        wait_for_tablets_balanced(nodes[0])
+        wait_no_tablets_migration_running(nodes[0])
         return nodes
 
     @latency_calculator_decorator(legend="Decommission nodes: remove nodes from cluster")

--- a/sdcm/utils/replication_strategy_utils.py
+++ b/sdcm/utils/replication_strategy_utils.py
@@ -7,7 +7,7 @@ from typing import Callable, Dict, TYPE_CHECKING
 
 from sdcm.utils.cql_utils import cql_quote_if_needed
 from sdcm.utils.database_query_utils import is_system_keyspace, LOGGER
-from sdcm.utils.tablets.common import wait_for_tablets_balanced
+from sdcm.utils.tablets.common import wait_no_tablets_migration_running
 
 if TYPE_CHECKING:
     from sdcm.cluster import BaseNode
@@ -215,7 +215,7 @@ class DataCenterTopologyRfControl:
                     self._alter_keyspace_rf(keyspace=keyspace, replication_factor=self.original_nodes_number,
                                             session=session)
         if node_to_wait_for_balance:
-            wait_for_tablets_balanced(node_to_wait_for_balance)
+            wait_no_tablets_migration_running(node_to_wait_for_balance)
 
     def decrease_keyspaces_rf(self):
         """

--- a/sdcm/utils/tablets/common.py
+++ b/sdcm/utils/tablets/common.py
@@ -23,9 +23,12 @@ class TabletsConfiguration:
         return '{' + ', '.join(items) + '}'
 
 
-def wait_for_tablets_balanced(node):
+def wait_no_tablets_migration_running(node):
     """
-    Waiting for tablets to be balanced using REST API.
+    Waiting for having no ongoing tablets topology operations using REST API.
+    !!! It does not guarantee that tablets are balanced !!!
+    Keep in mind that it is good only to find when ongoing tablets topology operations is done.
+    Very next second another topology operation can be started.
 
     doing it several times as there's a risk of:
     "currently a small time window after adding nodes and before load balancing starts during which
@@ -37,9 +40,9 @@ def wait_for_tablets_balanced(node):
             return
     time.sleep(60)  # one minute gap before checking, just to give some time to the state machine
     client = RemoteCurlClient(host="127.0.0.1:10000", endpoint="", node=node)
-    LOGGER.info("Waiting for tablets to be balanced")
+    LOGGER.info("Waiting for having no ongoing tablets topology operations")
     for _ in range(3):
         client.run_remoter_curl(method="POST", path="storage_service/quiesce_topology",
                                 params={}, timeout=3600, retry=3)
         time.sleep(5)
-    LOGGER.info("Tablets are balanced")
+    LOGGER.info("All ongoing tablets topology operations are done")


### PR DESCRIPTION
This function checks if there are no ongoing tablet topology operations. It does not guarantee that tablets become balanced, this language confuses when you read code and events log.

### Testing
No code changes, testing is not needed.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
