### PR TITLE
fix(base_versions): add OSS mapping for 2025.1

### DIFF
--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -134,6 +134,18 @@ class TestBaseVersion(unittest.TestCase):
         version_list = general_test(scylla_repo, linux_distro)
         assert set(version_list) == {'6.0', '2024.1', '2024.2'}
 
+    def test_2025_1_dev(self):
+        scylla_repo = self.url_base + '/master/rpm/centos/2025-01-15T09:25:01Z/scylla.repo'
+        linux_distro = 'centos'
+        version_list = general_test(scylla_repo, linux_distro)
+        assert set(version_list) == {'6.2'}
+
+    def test_2025_1_ubuntu(self):
+        scylla_repo = self.url_base + '-enterprise/enterprise-2025.1/deb/unified/latest/scylladb-2025.1/scylla.list'
+        linux_distro = 'ubuntu-focal'
+        version_list = general_test(scylla_repo, linux_distro)
+        assert {'2024.1', '2024.2'}.issubset(set(version_list))  # TODO: after 2025.1 release, need to add 6.2
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -15,7 +15,7 @@ LOGGER = logging.getLogger(__name__)
 
 # We support to migrate from specific OSS version to enterprise
 supported_src_oss = {'2021.1': '4.3', '2022.1': '5.0',
-                     '2022.2': '5.1', '2023.1': '5.2', '2024.1': '5.4', '2024.2': '6.0'}
+                     '2022.2': '5.1', '2023.1': '5.2', '2024.1': '5.4', '2024.2': '6.0', '2025.1': '6.2'}
 # If new support distro shared repo with others, we need to assign the start support versions. eg: centos8
 start_support_versions = {'centos-8': {'scylla': '4.1', 'enterprise': '2021.1'},
                           'centos-9': {'scylla': '5.4', 'enterprise': '2024.1'}}


### PR DESCRIPTION
* adding 6.2 as a base version for any upgrade into 2025.1
* add unittest to cover the 2025.1 cases

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] unittests
- [x] test it with master (should yield now only 6.2, since it's 6.3.0-dev)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
