### PR TITLE
Improve Manager snapshot preparer helper

### DIFF
--- a/defaults/manager_restore_benchmark_snapshots.yaml
+++ b/defaults/manager_restore_benchmark_snapshots.yaml
@@ -1,110 +1,164 @@
 bucket: "manager-backup-tests-permanent-snapshots-us-east-1"
-cs_read_cmd_template: "cassandra-stress read cl=ONE n={num_of_rows} -schema 'keyspace={keyspace_name} replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq={sequence_start}..{sequence_end}"
+cs_read_cmd_template: "cassandra-stress read cl={cl} n={num_of_rows} -schema 'keyspace={keyspace_name} replication(strategy={replication},replication_factor={rf}) compaction(strategy={compaction})' -mode cql3 native -rate threads=500 -col 'size=FIXED({col_size}) n=FIXED({col_n})' -pop seq={sequence_start}..{sequence_end}"
 sizes:  # size of backed up dataset in GB
   1gb_1t_ics:
     tag: "sm_20240812100424UTC"
-    schema:
-      keyspace1:
-        - standard1: 1
-    number_of_rows: 1073760
     exp_timeout: 1200  # 20 minutes (timeout for restore data operation)
     scylla_version: "2024.2.0-rc1"
     number_of_nodes: 3
-    compaction_strategy: "IncrementalCompactionStrategy"
     prohibit_verification_read: false
+    dataset:
+      schema:
+        keyspace1:
+          - standard1: 1
+      num_of_rows: 1073760
+      compaction: "IncrementalCompactionStrategy"
+      cl: "ONE"
+      col_size: 1024
+      col_n: 1
+      replication: "NetworkTopologyStrategy"
+      rf: 3
   500gb_1t_ics:
     tag: "sm_20240813112034UTC"
-    schema:
-      keyspace1:
-        - standard1: 500
-    number_of_rows: 524288000
     exp_timeout: 14400  # 4 hours
     scylla_version: "2024.2.0-rc1"
     number_of_nodes: 3
-    compaction_strategy: "IncrementalCompactionStrategy"
     prohibit_verification_read: false
+    dataset:
+      schema:
+        keyspace1:
+          - standard1: 500
+      num_of_rows: 524288000
+      compaction: "IncrementalCompactionStrategy"
+      cl: "ONE"
+      col_size: 1024
+      col_n: 1
+      replication: "NetworkTopologyStrategy"
+      rf: 3
   500gb_1t_ics_tablets:
     tag: "sm_20240813114617UTC"
-    schema:
-      keyspace1:
-        - standard1: 500
-    number_of_rows: 524288000
     exp_timeout: 14400  # 4 hours
     scylla_version: "2024.2.0-rc1"
     number_of_nodes: 3
-    compaction_strategy: "IncrementalCompactionStrategy"
     prohibit_verification_read: false
+    dataset:
+      schema:
+        keyspace1:
+          - standard1: 500
+      num_of_rows: 524288000
+      compaction: "IncrementalCompactionStrategy"
+      cl: "ONE"
+      col_size: 1024
+      col_n: 1
+      replication: "NetworkTopologyStrategy"
+      rf: 3
   500gb_2t_ics:
     tag: "sm_20240819203428UTC"
-    schema:
-      keyspace1:
-        - standard1: 250
-      keyspace2:
-        - standard1: 250
-    number_of_rows: 524288000
     exp_timeout: 14400  # 4 hours
     scylla_version: "2024.2.0-rc1"
     number_of_nodes: 3
-    compaction_strategy: "IncrementalCompactionStrategy"
     prohibit_verification_read: true
+    dataset:
+      schema:
+        keyspace1:
+          - standard1: 250
+        keyspace2:
+          - standard1: 250
+      num_of_rows: 524288000
+      compaction: "IncrementalCompactionStrategy"
+      cl: "ONE"
+      col_size: 1024
+      col_n: 1
+      replication: "NetworkTopologyStrategy"
+      rf: 3
   1tb_1t_ics:
     tag: "sm_20240814180009UTC"
-    schema:
-      keyspace1:
-        - standard1: 1024
-    number_of_rows: 1073741824
     exp_timeout: 28800  # 8 hours
     scylla_version: "2024.2.0-rc1"
     number_of_nodes: 3
-    compaction_strategy: "IncrementalCompactionStrategy"
     prohibit_verification_read: false
+    dataset:
+      schema:
+        keyspace1:
+          - standard1: 1024
+      num_of_rows: 1073741824
+      compaction: "IncrementalCompactionStrategy"
+      cl: "ONE"
+      col_size: 1024
+      col_n: 1
+      replication: "NetworkTopologyStrategy"
+      rf: 3
   1tb_4t_twcs:
     tag: "sm_20240821145503UTC"
-    schema:
-      keyspace1:
-        - t_10gb: 10
-        - t_90gb: 90
-        - t_300gb: 300
-        - t_600gb: 600
-    number_of_rows: 428571429
     exp_timeout: 28800  # 8 hours
     scylla_version: "2024.2.0-rc1"
     number_of_nodes: 3
-    compaction_strategy: "TimeWindowCompactionStrategy"
     prohibit_verification_read: true
+    dataset:
+      schema:
+        keyspace1:
+          - t_10gb: 10
+          - t_90gb: 90
+          - t_300gb: 300
+          - t_600gb: 600
+      num_of_rows: 428571429
+      compaction: "TimeWindowCompactionStrategy"
+      cl:
+      col_size:
+      col_n:
+      replication: "NetworkTopologyStrategy"
+      rf: 3
   1tb_2t_twcs:
     tag: "sm_20240827191125UTC"
-    schema:
-      keyspace1:
-        - t_300gb: 300
-        - t_700gb: 700
-    number_of_rows: 428571429
     exp_timeout: 28800  # 8 hours
     scylla_version: "2024.2.0-rc1"
     number_of_nodes: 9
-    compaction_strategy: "TimeWindowCompactionStrategy"
     prohibit_verification_read: true
+    dataset:
+      schema:
+        keyspace1:
+          - t_300gb: 300
+          - t_700gb: 700
+      num_of_rows: 428571429
+      compaction: "TimeWindowCompactionStrategy"
+      cl:
+      col_size:
+      col_n:
+      replication: "NetworkTopologyStrategy"
+      rf: 3
   1.5tb_2t_ics:
     tag: "sm_20240820180152UTC"
-    schema:
-      keyspace1:
-        - standard1: 500
-      keyspace2:
-        - standard1: 1024
-    number_of_rows: 1598029824
     exp_timeout: 43200  # 12 hours
     scylla_version: "2024.2.0-rc1"
     number_of_nodes: 3
-    compaction_strategy: "IncrementalCompactionStrategy"
     prohibit_verification_read: true
+    dataset:
+      schema:
+        keyspace1:
+          - standard1: 500
+        keyspace2:
+          - standard1: 1024
+      num_of_rows: 1598029824
+      compaction: "IncrementalCompactionStrategy"
+      cl: "ONE"
+      col_size: 1024
+      col_n: 1
+      replication: "NetworkTopologyStrategy"
+      rf: 3
   2tb_1t_ics:
     tag: "sm_20240816185129UTC"
-    schema:
-      keyspace1:
-        - standard1: 2048
-    number_of_rows: 2147483648
     exp_timeout: 57600  # 16 hours
     scylla_version: "2024.2.0-rc1"
     number_of_nodes: 3
-    compaction_strategy: "IncrementalCompactionStrategy"
     prohibit_verification_read: false
+    dataset:
+      schema:
+        keyspace1:
+          - standard1: 2048
+      num_of_rows: 2147483648
+      compaction: "IncrementalCompactionStrategy"
+      cl: "ONE"
+      col_size: 1024
+      col_n: 1
+      replication: "NetworkTopologyStrategy"
+      rf: 3

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -290,3 +290,20 @@ latency_decorator_error_thresholds:
           fixed_limit: 10
       P99 read:
           fixed_limit: 10
+
+mgmt_snapshots_preparer_params:
+  # Such a configuration is used by Manager backup snapshots prepare test
+  cs_cmd_template: "cassandra-stress {operation} cl={cl} n={num_of_rows} -schema 'keyspace={ks_name} replication(strategy={replication},replication_factor={rf}) compaction(strategy={compaction})' -mode cql3 native -rate threads={threads_num} -col 'size=FIXED({col_size}) n=FIXED({col_n})' -pop seq={sequence_start}..{sequence_end}"
+  operation: "write"
+  cl: "QUORUM"
+  replication: "NetworkTopologyStrategy"
+  rf: 3
+  compaction: "IncrementalCompactionStrategy"
+  threads_num: 500
+  col_size: 1024
+  col_n: 1
+  # Defined in a runtime based on backup size, number of loaders, scylla version, etc
+  ks_name: ''
+  num_of_rows: ''
+  sequence_start: ''
+  sequence_end: ''

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -40,7 +40,7 @@ from sdcm.mgmt import ScyllaManagerError, TaskStatus, HostStatus, HostSsl, HostR
 from sdcm.mgmt.cli import ScyllaManagerTool, RestoreTask
 from sdcm.mgmt.common import reconfigure_scylla_manager, get_persistent_snapshots
 from sdcm.provision.helpers.certificate import TLSAssets
-from sdcm.remote import shell_script_cmd
+from sdcm.remote import shell_script_cmd, LOCALRUNNER
 from sdcm.tester import ClusterTester
 from sdcm.cluster import TestConfig
 from sdcm.nemesis import MgmtRepair
@@ -363,6 +363,43 @@ class BucketOperations(ClusterTester):
         # azure://<bucket>/<path> -> https://<account>.blob.core.windows.net/<bucket>/<path>?SAS
         source = f"{source.replace('azure://', self.backup_azure_blob_service)}{self.backup_azure_blob_sas}"
         node.remoter.sudo(f"azcopy copy '{source}' '{destination}'")
+
+    @staticmethod
+    def create_s3_bucket(name: str, region: str) -> None:
+        LOCALRUNNER.run(f"aws s3 mb s3://{name} --region {region}")
+
+    @staticmethod
+    def create_gs_bucket(name: str, region: str) -> None:
+        LOCALRUNNER.run(f"gsutil mb -l {region} gs://{name}")
+
+    @staticmethod
+    def sync_s3_buckets(source: str, destination: str, acl: str = 'bucket-owner-full-control') -> None:
+        LOCALRUNNER.run(f"aws s3 sync s3://{source} s3://{destination} --acl {acl}")
+
+    @staticmethod
+    def sync_gs_buckets(source: str, destination: str) -> None:
+        LOCALRUNNER.run(f"gsutil -m rsync -r gs://{source} gs://{destination}")
+
+    def copy_backup_snapshot_bucket(self, source: str, destination: str) -> None:
+        """Copy bucket with Manager backup snapshots.
+        The process consists of two stages - new bucket creation and data sync (original bucket -> newly created).
+        The main use case is to make a copy of a bucket created in a test with Cloud (siren) cluster since siren
+        deletes the bucket together with cluster. Thus, if there is a goal to reuse backup snapshot of such cluster
+        afterward, it should be copied to a new bucket.
+
+        Only AWS and GCE backends are supported.
+        """
+        cluster_backend = self.params.get("cluster_backend")
+        region = next(iter(self.params.region_names), '')
+
+        if cluster_backend == "aws":
+            self.create_s3_bucket(name=destination, region=region)
+            self.sync_s3_buckets(source=source, destination=destination)
+        elif cluster_backend == "gce":
+            self.create_gs_bucket(name=destination, region=region)
+            self.sync_gs_buckets(source=source, destination=destination)
+        else:
+            raise ValueError(f"Unsupported cluster backend - {cluster_backend}, should be either aws or gce")
 
 
 class SnapshotOperations(ClusterTester):
@@ -1361,6 +1398,8 @@ class ManagerHelperTests(ManagerTestFunctionsMixIn):
         2. Run backup and wait for it to finish.
         3. Log snapshot details into console.
         """
+        is_cloud_manager = self.params.get("use_cloud_manager")
+
         self.log.info("Populate the cluster with data")
         backup_size = self.params.get("mgmt_prepare_snapshot_size")  # in Gb
         assert backup_size and backup_size >= 1, "Backup size must be at least 1Gb"
@@ -1369,20 +1408,35 @@ class ManagerHelperTests(ManagerTestFunctionsMixIn):
         self.run_and_verify_stress_in_threads(cs_cmds=cs_write_cmds, stop_on_failure=True)
 
         self.log.info("Initialize Scylla Manager")
-        manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
-        mgr_cluster = self.ensure_and_get_cluster(manager_tool)
+        mgr_cluster = self.db_cluster.get_cluster_manager()
+
+        self.log.info("Define backup location")
+        if is_cloud_manager:
+            # Extract location from automatically scheduled backup task
+            auto_backup_task = mgr_cluster.backup_task_list[0]
+            location_list = [auto_backup_task.get_task_info_dict()["location"]]
+        else:
+            location_list = self.locations
 
         self.log.info("Run backup and wait for it to finish")
-        backup_task = mgr_cluster.create_backup_task(location_list=self.locations, rate_limit_list=["0"])
+        backup_task = mgr_cluster.create_backup_task(location_list=location_list, rate_limit_list=["0"])
         backup_task_status = backup_task.wait_and_get_final_status(timeout=200000)
         assert backup_task_status == TaskStatus.DONE, \
             f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"
+
+        if is_cloud_manager:
+            self.log.info("Copy bucket with snapshot since the original bucket is deleted together with cluster")
+            # from ["'AWS_US_EAST_1:s3:scylla-cloud-backup-8072-7216-v5dn53'"] to scylla-cloud-backup-8072-7216-v5dn53
+            original_bucket_name = location_list[0].split(":")[-1].rstrip("'")
+            bucket_name = original_bucket_name + "-manager-tests"
+
+            self.copy_backup_snapshot_bucket(source=original_bucket_name, destination=bucket_name)
 
         self.log.info("Log snapshot details")
         self.log.info(
             f"Snapshot tag: {backup_task.get_snapshot_tag()}\n"
             f"Keyspace name: {ks_name}\n"
-            f"Bucket: {self.locations}\n"
+            f"Bucket: {location_list}\n"
             f"Cluster id: {mgr_cluster.id}\n"
         )
 

--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -135,6 +135,20 @@ class ManagerBackupReadResult(GenericResultTable):
         ]
 
 
+class ManagerSnapshotDetails(GenericResultTable):
+    class Meta:
+        name = "Snapshot details"
+        description = "Manager snapshots (pre-created for next utilization in restore tests) details"
+        Columns = [
+            ColumnMetadata(name="tag", unit="", type=ResultType.TEXT),
+            ColumnMetadata(name="size", unit="GB", type=ResultType.INTEGER),
+            ColumnMetadata(name="bucket", unit="", type=ResultType.TEXT),
+            ColumnMetadata(name="ks_name", unit="", type=ResultType.TEXT),
+            ColumnMetadata(name="cluster_id", unit="", type=ResultType.TEXT),
+            ColumnMetadata(name="scylla_version", unit="", type=ResultType.TEXT),
+        ]
+
+
 workload_to_table = {
     "mixed": LatencyCalculatorMixedResult,
     "write": LatencyCalculatorWriteResult,
@@ -256,4 +270,11 @@ def send_manager_benchmark_results_to_argus(argus_client: ArgusClient, result: d
     result_table = ManagerRestoreBanchmarkResult(sut_timestamp=sut_timestamp)
     for key, value in result.items():
         result_table.add_result(column=key, row=row_name, value=value, status=Status.UNSET)
+    submit_results_to_argus(argus_client, result_table)
+
+
+def send_manager_snapshot_details_to_argus(argus_client: ArgusClient, snapshot_details: dict) -> None:
+    result_table = ManagerSnapshotDetails()
+    for key, value in snapshot_details.items():
+        result_table.add_result(column=key, row="#1", value=value, status=Status.UNSET)
     submit_results_to_argus(argus_client, result_table)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1202,7 +1202,11 @@ class SCTConfiguration(dict):
 
         dict(name="mgmt_prepare_snapshot_size",
              env="SCT_MGMT_PREPARE_SNAPSHOT_SIZE", type=int,
-             help="Size of backup snapshot in Gb to be prepared to be prepared for backup"),
+             help="Size of backup snapshot in Gb to be prepared for backup"),
+
+        dict(name="mgmt_snapshots_preparer_params",
+             env="SCT_MGMT_SNAPSHOTS_PREPARER_PARAMS", type=dict_or_str,
+             help="Custom parameters of c-s write operation used in snapshots preparer"),
 
         # PerformanceRegressionTest
 

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -170,11 +170,12 @@ def call(Map pipelineParams) {
                    name: 'requested_by_user')
             text(defaultValue: "${pipelineParams.get('extra_environment_variables', '')}",
                  description: (
-                     'Extra environment variables to be set in the test environment, uses the java Properties File Format.\n' +
-                     'Example:\n' +
-                     '\tSCT_MGMT_RESTORE_EXTRA_PARAMS=--batch-size 50 --parallel 0\n' +
-                     '\tSCT_N_DB_NODES=6' +
-                     '\tSCT_MGMT_SKIP_POST_RESTORE_STRESS_READ=true\n'
+                     """Extra environment variables to be set in the test environment, uses the java Properties File Format.
+                        Example:
+                        SCT_MGMT_RESTORE_EXTRA_PARAMS=--batch-size 50 --parallel 0
+                        SCT_N_DB_NODES=6
+                        SCT_MGMT_SKIP_POST_RESTORE_STRESS_READ=true
+                        SCT_MGMT_SNAPSHOTS_PREPARER_PARAMS={'compaction': 'SizeTieredCompactionStrategy', 'rf': 3}"""
                      ),
                  name: 'extra_environment_variables')
         }


### PR DESCRIPTION
refs: 
https://github.com/scylladb/scylla-manager/issues/4190
https://github.com/scylladb/scylla-manager/issues/4208

The PR addresses two main topics:

1. Manager snapshot preparer helper extension
- Dataset parameters (which defined in c-s cmd) aren't hardcoded anymore what gives an opportunity to widely vary its properties (replication, compaction, cl, rf, etc). 
manager_restore_benchmark_snapshots.yaml file with snapshots config for current benchmark tests is extended to include such a parameters. These params are later used on C-S read command generation stage. 
Thus, snapshot preparation test becomes widely customizable with more flexibility to adjust dataset.
- Generated backup snapshot details are sent to Argus Results instead of logging what improves usability.

2. Cloud clusters support
- Extension for test_prepare_backup_snapshot that allows to run the test either for standard cluster created via SCT or for clusters created in via siren-tests (Cloud cluster).

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Cloud cluster snapshot](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/siren-tests/job/siren-sct-integration/160/), [Argus](https://argus.scylladb.com/tests/scylla-cluster-tests/f162625b-815f-4644-be20-6fab77496ce8) (see Results tab)
- [x] [Regular SCT cluster snapshot creation](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master/job/helper-prepare-backup-snapshot/13/), [Argus](https://argus.scylladb.com/tests/scylla-cluster-tests/52b0856f-4f06-426a-99bb-f5a2bb89a498) (see Results tab)
- [x] [Restore from snapshot generated with a new approach](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master/job/restore-benchmark/18/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code