### PR TITLE
fix(hydra): enable python faulthandler by default

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -283,6 +283,7 @@ function run_in_docker () {
         ${AWS_OPTIONS} \
         --env GIT_BRANCH \
         --env CHANGE_TARGET \
+        --env PYTHONFAULTHANDLER=yes \
         --env TERM \
         --net=host \
         --name="${SCT_TEST_ID}_$(date +%s)" \


### PR DESCRIPTION
we are running into case SCT is core dumping during shutdown of the tests we don't have enough information to understand what's going on

hopefully this can add some information that can help us figure it out

Ref: https://docs.python.org/3/library/faulthandler.html

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] provision tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
