### PR TITLE
fix(tester): missed Path import

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -24,6 +24,7 @@ import time
 import traceback
 import unittest
 import unittest.mock
+from pathlib import Path
 from typing import NamedTuple, Optional, Union, List, Dict, Any
 from uuid import uuid4
 from functools import wraps, cache


### PR DESCRIPTION
Due to not backported commit, import Path does not exist in the branch-perf-v15. As result schema info collection failed with 'NameError'

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9818

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
