### PR TITLE
feature(createArgusTestRun.groovy): Add argus link

### DIFF
--- a/vars/createArgusTestRun.groovy
+++ b/vars/createArgusTestRun.groovy
@@ -16,4 +16,17 @@ def call(Map params) {
 
         echo " Argus test run created."
     """
+    if (!currentBuild.description) {
+        currentBuild.description = ''
+    }
+    String runButton = """
+        <div style="margin: 12px 4px;">
+            <a
+                href='https://argus.scylladb.com/tests/scylla-cluster-tests/${SCT_TEST_ID}'
+            >
+                Argus: <span style='font-weight: 500'>${SCT_TEST_ID}</span>
+            </a>
+        </div>
+    """
+    currentBuild.description += "${runButton}"
 }


### PR DESCRIPTION
This commit makes it so that createArgusTestRun stage of the SCT
pipeline now appends a link to the argus page of the run.

Fixes #9634

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Argus](https://argus.scylladb.com/tests/scylla-cluster-tests/da7f287a-7c42-465e-b9bc-21bdf58ae0dd)
- [x] [Jenkins](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/artifacts-ubuntu2204-test/10/)


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
