### PR TITLE
fix(nemesis): fix typo in the `mgmt_restore` nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3069,7 +3069,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             "https://github.com/scylladb/scylla-manager/issues/3829",
             "https://github.com/scylladb/scylla-manager/issues/4049"
         ]
-        is_multi_dc = (len(self.cluster.params.region_names) > 1) or ((self.params.get("simulated_regions") or 0) > 1)
+        is_multi_dc = len(self.cluster.params.region_names) > 1 or (
+            self.cluster.params.get("simulated_regions") or 0) > 1
         if SkipPerIssues(skip_issues, params=self.tester.params) and is_multi_dc:
             raise UnsupportedNemesis("MultiDC cluster configuration is not supported by this nemesis")
 


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9853

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
