### PR TITLE
feature(ruff): scan for mutable-argument-default (B006)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ lint.select = [
     "YTT",
     "F541",
     "PIE",
+    "B006",
 ]
 
 lint.ignore = ["E501", "PLR2004"]

--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -586,7 +586,7 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):  # pylint: disable=
         cmd = "get node --no-headers -o custom-columns=:.spec.providerID"
         return [name.split("/")[-1] for name in self.kubectl(cmd).stdout.split()]
 
-    def set_tags(self, instance_ids, memo={}):  # pylint: disable=dangerous-default-value
+    def set_tags(self, instance_ids, memo={}):  # pylint: disable=dangerous-default-value  # noqa: B006
         if not instance_ids:
             return
         if isinstance(instance_ids, str):
@@ -609,7 +609,7 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):  # pylint: disable=
         # So, we add it for each node explicitly.
         self.set_tags(self._get_all_instance_ids())
 
-    def set_security_groups(self, instance_id, memo={}):  # pylint: disable=dangerous-default-value
+    def set_security_groups(self, instance_id, memo={}):  # pylint: disable=dangerous-default-value  # noqa: B006
         if not instance_id or instance_id in memo:
             return
         with EC2_INSTANCE_UPDATE_LOCK:

--- a/sdcm/remote/kubernetes_cmd_runner.py
+++ b/sdcm/remote/kubernetes_cmd_runner.py
@@ -440,7 +440,7 @@ class KubernetesPodWatcher(KubernetesRunner):
             pod_name, result)
         return result
 
-    def _is_pod_failed_or_completed(self, _cache={}) -> bool:  # pylint: disable=dangerous-default-value
+    def _is_pod_failed_or_completed(self, _cache={}) -> bool:  # pylint: disable=dangerous-default-value  # noqa: B006
         last_call_at = _cache.get('last_call_at')
         if last_call_at and time.time() - last_call_at < 3:
             time.sleep(3)

--- a/sdcm/remote/libssh2_client/session.py
+++ b/sdcm/remote/libssh2_client/session.py
@@ -53,7 +53,7 @@ class Session(LibSSH2Session):  # pylint: disable=too-few-public-methods
         except (ValueError, SocketRecvError):  # under high load it can throw these errors, on next try it will be ok
             pass
 
-    def eagain(self, func, args=(), kwargs={},  # pylint: disable=dangerous-default-value
+    def eagain(self, func, args=(), kwargs={},  # pylint: disable=dangerous-default-value  # noqa: B006
                timeout: NullableTiming = None) -> int:
         """Running function followed by simple_select up until it return anything but `LIBSSH2_ERROR_EAGAIN`"""
         with self.lock:

--- a/sdcm/sct_events/events_analyzer.py
+++ b/sdcm/sct_events/events_analyzer.py
@@ -51,7 +51,7 @@ class EventsAnalyzer(BaseEventsProcess[Tuple[str, Any], None], threading.Thread)
                 except TestFailure:
                     self.kill_test(sys.exc_info())
 
-    def kill_test(self, backtrace_with_reason, memo={}) -> None:  # pylint: disable=dangerous-default-value
+    def kill_test(self, backtrace_with_reason, memo={}) -> None:  # pylint: disable=dangerous-default-value  # noqa: B006
         self.terminate()
         if tester := TestConfig().tester_obj():
             if memo:

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -230,7 +230,7 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
             return stress_cmd
         return stress_cmd.replace(current_error_option, 'errors ' + ' '.join(new_error_suboptions))
 
-    def _get_available_suboptions(self, loader, option, _cache={}):  # pylint: disable=dangerous-default-value
+    def _get_available_suboptions(self, loader, option, _cache={}):  # pylint: disable=dangerous-default-value  # noqa: B006
         if cached_value := _cache.get(option):
             return cached_value
         try:
@@ -245,7 +245,7 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
         return findings
 
     @staticmethod
-    def _disable_logging_for_cs(node, cmd_runner, _cache={}):  # pylint: disable=dangerous-default-value
+    def _disable_logging_for_cs(node, cmd_runner, _cache={}):  # pylint: disable=dangerous-default-value  # noqa: B006
         if not (node.is_kubernetes() or node.name in _cache):
             cmd_runner.run("cp /etc/scylla/cassandra/logback-tools.xml .", ignore_status=True)
             _cache[node.name] = 'done'

--- a/sdcm/utils/k8s/__init__.py
+++ b/sdcm/utils/k8s/__init__.py
@@ -870,7 +870,7 @@ class ScyllaPodsIPChangeTrackerThread(threading.Thread):
         self.log = SDCMAdapter(LOGGER, extra={'prefix': k8s_kluster.region_name})
 
     @retrying(n=3600, sleep_time=1, allowed_exceptions=(ConnectionError, ))
-    def _open_stream(self, cache={}) -> None:  # pylint: disable=dangerous-default-value
+    def _open_stream(self, cache={}) -> None:  # pylint: disable=dangerous-default-value  # noqa: B006
         try:
             now = time.time()
             if cache.get("last_call_at", 0) + 5 > now:

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -116,7 +116,7 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
 
     DOCKER_IMAGE_PARAM_NAME = "stress_image.ycsb"
 
-    def copy_template(self, cmd_runner, loader_name, memo={}):  # pylint: disable=dangerous-default-value,too-many-branches
+    def copy_template(self, cmd_runner, loader_name, memo={}):  # pylint: disable=dangerous-default-value,too-many-branches  # noqa: B006
         if loader_name in memo:
             return None
         web_protocol = "http"


### PR DESCRIPTION
we shouldn't let those get into the the code without a very good reason (like memoize/cache)

Ref: https://docs.astral.sh/ruff/rules/mutable-argument-default/

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] no testing needed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
