### PR TITLE
feature(Jenkinsfile): get latest scylla release automaticlly

### DIFF
--- a/vars/getLatestScyllaRelease.groovy
+++ b/vars/getLatestScyllaRelease.groovy
@@ -1,0 +1,13 @@
+#!groovy
+
+import groovy.json.JsonSlurper
+
+String call(String product) {
+    product = product.replaceFirst('^scylla-', '')
+    def url = "https://repositories.scylladb.com/scylla/check_version?system=${product}"
+
+    def response = sh(script: "curl -s ${url}", returnStdout: true).trim()
+
+    def json = new JsonSlurper().parseText(response)
+    return json.version
+}


### PR DESCRIPTION
get this by latest version by using:
`https://repositories.scylladb.com/scylla/check_version`

so we don't need to remember updating it manually once in a while (we didn't update since 5.2)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
