### PR TITLE
fix(perf test): remove 100K step in write test

### DIFF
--- a/configurations/performance/cassandra_stress_gradual_load_steps.yaml
+++ b/configurations/performance/cassandra_stress_gradual_load_steps.yaml
@@ -1,3 +1,3 @@
 # Define load ops for steps
 perf_gradual_threads: {"read": 620, "write": 400, "mixed": 1900}
-perf_gradual_throttle_steps: {"read": ['150000', '300000', '450000', '600000', '700000', 'unthrottled'], "mixed": ['50000', '150000', '300000', '450000', 'unthrottled'], "write": ['100000', '200000', '300000', 'unthrottled']}  # where every value is in ops
+perf_gradual_throttle_steps: {"read": ['150000', '300000', '450000', '600000', '700000', 'unthrottled'], "mixed": ['50000', '150000', '300000', '450000', 'unthrottled'], "write": ['200000', '300000', 'unthrottled']}  # where every value is in ops

--- a/configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml
+++ b/configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml
@@ -1,3 +1,3 @@
 # Define load ops for steps
 perf_gradual_threads: {"read": 620, "write": 400, "mixed": 1900}
-perf_gradual_throttle_steps: {"read": ['150000', '300000', '450000', '600000', '700000', 'unthrottled'], "mixed": ['50000', '150000', '300000', '450000', 'unthrottled'], "write": ['100000', '200000', '300000', 'unthrottled']}  # where every value is in ops
+perf_gradual_throttle_steps: {"read": ['150000', '300000', '450000', '600000', '700000', 'unthrottled'], "mixed": ['50000', '150000', '300000', '450000', 'unthrottled'], "write": ['200000', '300000', 'unthrottled']}  # where every value is in ops


### PR DESCRIPTION
The first run of write predefined steps test with changed steps presented by https://github.com/scylladb/scylla-cluster-tests/pull/9820, demonstrated that 100K step duration is 04:29:02. It caused to test time out. Decided to remove 100K step ate all
(https://argus.scylladb.com/tests/scylla-cluster-tests/86a3a793-d226-4925-acc7-cc1366513f41)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
