### PR TITLE
fix(performance): increase latency limits

### DIFF
--- a/configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml
+++ b/configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml
@@ -13,7 +13,7 @@ latency_decorator_error_thresholds:
       P90 read:
         fixed_limit: 1
       P99 read:
-        fixed_limit: 1
+        fixed_limit: 3
     "300000":
       P90 read:
         fixed_limit: 1
@@ -23,7 +23,17 @@ latency_decorator_error_thresholds:
       P90 read:
         fixed_limit: 1
       P99 read:
+        fixed_limit: 5
+    "600000":
+      P90 read:
         fixed_limit: 3
+      P99 read:
+        fixed_limit: 50
+    "700000":
+      P90 read:
+        fixed_limit: 3
+      P99 read:
+        fixed_limit: 60
     unthrottled:
       P90 read:
         fixed_limit: null
@@ -60,6 +70,15 @@ latency_decorator_error_thresholds:
         fixed_limit: 5
       P99 read:
         fixed_limit: 5
+    "450000":
+      P90 write:
+        fixed_limit: 5
+      P90 read:
+        fixed_limit: 5
+      P99 write:
+        fixed_limit: 15
+      P99 read:
+        fixed_limit: 15
     unthrottled:
       P90 write:
         fixed_limit: null

--- a/configurations/performance/latency-decorator-error-thresholds-steps-ent-vnodes.yaml
+++ b/configurations/performance/latency-decorator-error-thresholds-steps-ent-vnodes.yaml
@@ -24,6 +24,16 @@ latency_decorator_error_thresholds:
         fixed_limit: 1
       P99 read:
         fixed_limit: 5
+    "600000":
+      P90 read:
+        fixed_limit: 2
+      P99 read:
+        fixed_limit: 50
+    "700000":
+      P90 read:
+        fixed_limit: 3
+      P99 read:
+        fixed_limit: 50
     unthrottled:
       P90 read:
         fixed_limit: null
@@ -46,7 +56,7 @@ latency_decorator_error_thresholds:
       P90 write:
         fixed_limit: 1
       P90 read:
-        fixed_limit: 2
+        fixed_limit: 1
       P99 write:
         fixed_limit: 3
       P99 read:

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -272,25 +272,25 @@ latency_decorator_error_thresholds:
   write:
     default:
       P90 write:
-        fixed_limit: 5
+        fixed_limit: 7
       P99 write:
         fixed_limit: 10
   read:
     default:
       P90 read:
-        fixed_limit: 5
+        fixed_limit: 7
       P99 read:
         fixed_limit: 10
   mixed:
     default:
       P90 write:
-        fixed_limit: 5
+        fixed_limit: 7
       P90 read:
-          fixed_limit: 5
+        fixed_limit: 7
       P99 write:
-          fixed_limit: 10
+        fixed_limit: 10
       P99 read:
-          fixed_limit: 10
+        fixed_limit: 10
 
 mgmt_snapshots_preparer_params:
   # Such a configuration is used by Manager backup snapshots prepare test


### PR DESCRIPTION
We would not chase issues with slight cross of low latency limits e.g. for p90 or in some low throughput tests. Increased these values to not raise red flag for whole test.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
