### PR TITLE
fix(unit-tests): stop triggering health checks in longevity unit test

### DIFF
--- a/unit_tests/test_longevity.py
+++ b/unit_tests/test_longevity.py
@@ -16,6 +16,17 @@ def test_test_user_batch_custom_time(params):
     class DummyLongevityTest(LongevityTest):
         def _init_params(self):
             self.params = params
+            # NOTE: running this test we get a nemesis trigerred,
+            # and if health checks are enabled then the nemesis lock gets held
+            # while it's checks are running. It may run for more than 10 minutes.
+            # Additional problem is that it is not controlled by this test,
+            # thread just runs as a side-car even after finish of this test.
+            # In this case any further unit test which runs a nemesis
+            # will stumble upon a held lock.
+            # One of such tests is following:
+            # - test_nemesis.py::test_list_nemesis_of_added_disrupt_methods
+            # So, disable health checks here.
+            self.params["cluster_health_check"] = False
 
         def start_argus_heartbeat_thread(self):
             # prevent from heartbeat thread to start


### PR DESCRIPTION
The `test_longevity.py::test_test_user_batch_custom_time` unit test uses
the `test-cases/scale/longevity-5000-tables.yaml` config file for running
a short longevity test which triggers a nemesis.

If health checks are enabled then the `nemesis call` runs much longer while health checks
are completed 2 times - before and after the nemesis.
And while it is ongoing the nemesis lock gets held.
And the problem with it is that it runs even after finish of this test.
So, any another unit test which tries to get a nemesis lock will stumble upon a held lock for 10+ minutes.

It started happening after the merge of the PR (https://github.com/scylladb/scylla-cluster-tests/pull/9843) which enabled health checks in the mentioned config file.
The affected test is following:
- `test_nemesis.py::test_list_nemesis_of_added_disrupt_methods`

Alphabetically it runs after the `test_longevity.py::test_test_user_batch_custom_time` one.

So, disable health checks to avoid side-effects and doing redundant stuff which were not planned when the test was written.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
