### PR TITLE
fix(sct_config): use the 'get' correctly when reading experimental features

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2781,8 +2781,9 @@ class SCTConfiguration(dict):
 
     def update_config_based_on_version(self):
         if self.is_enterprise and ComparableScyllaVersion(self.scylla_version) >= "2025.1.0~dev":
-            if 'views-with-tablets' not in self.get('experimental_features', []):
-                self['experimental_features'].append('views-with-tablets')
+            if experimental_features := self.get('experimental_features'):
+                if 'views-with-tablets' not in experimental_features:
+                    self['experimental_features'].append('views-with-tablets')
 
     def dict(self):
         out = deepcopy(self)


### PR DESCRIPTION
Because the SCTConfiguration is also a dict, in https://github.com/scylladb/scylla-cluster-tests/pull/9615 we used the dict's `get` method with a default value to check the contents of the list of experimental features (there may be none). However, SCTConfiguration overrides this `get` method without allowing any defaults. As a result, we called it with too many parameters.
We work around this in this patch by using an extra if.
