### PR TITLE
fix(sct_config): `param.get()` doesn't accept default argument

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -19,6 +19,7 @@ round_robin: false
 append_scylla_args: '--blocked-reactor-notify-ms 25 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'
 append_scylla_setup_args: ''
 append_scylla_node_exporter_args: ''
+experimental_features: []
 
 db_nodes_shards_selection: 'default'
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2781,7 +2781,7 @@ class SCTConfiguration(dict):
 
     def update_config_based_on_version(self):
         if self.is_enterprise and ComparableScyllaVersion(self.scylla_version) >= "2025.1.0~dev":
-            if 'views-with-tablets' not in self.get('experimental_features', []):
+            if 'views-with-tablets' not in self.get('experimental_features'):
                 self['experimental_features'].append('views-with-tablets')
 
     def dict(self):

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -1007,6 +1007,14 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
         assert 'Option manager_version is not appendable' == str(context.value)
 
+    @staticmethod
+    def test_36_update_config_based_on_version():
+        conf = sct_config.SCTConfiguration()
+        conf.verify_configuration()
+        conf.scylla_version = "2025.1.0~dev"
+        conf.is_enterprise = True
+        conf.update_config_based_on_version()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
the newly introduced `update_config_based_on_version()` had faulty code that assumed there a default vaule argument
default should be configured in `test_default.yaml`

a new unit test introduce to cover this part of the sct_config.py

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
