### PR TITLE
fix(sstables_validator): fix upload sstables

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1325,7 +1325,7 @@ class SSTablesCollector(BaseSCTLogCollector):
             with open(raw_events_file_path, "r", encoding="utf-8") as events_file:
                 for raw_line in events_file.readlines():
                     event = json.loads(raw_line)
-                    if event.get("type") == "CORRUPTED_SSTABLE":
+                    if event.get("type") == "CORRUPTED_SSTABLE" and event.get("severity") == "CRITICAL":
                         try:
                             sstable_dir, keyspace, table_name, sstable_name = self.get_sstable_details(
                                 event.get("line"))

--- a/sdcm/teardown_validators/sstables.py
+++ b/sdcm/teardown_validators/sstables.py
@@ -1,10 +1,13 @@
 import logging
+import re
 from functools import partial
 
 from sdcm import wait
 from sdcm.cluster import BaseNode
 from sdcm.exceptions import WaitForTimeoutError
 from sdcm.sct_events import Severity
+from sdcm.sct_events.database import DatabaseLogEvent
+from sdcm.sct_events.filters import EventsSeverityChangerFilter
 from sdcm.sct_events.teardown_validators import ValidatorEvent, ScrubValidationErrorEvent
 from sdcm.teardown_validators.base import TeardownValidator
 from sdcm.utils.common import S3Storage, ParallelObject
@@ -17,20 +20,21 @@ class SstablesValidator(TeardownValidator):  # pylint: disable=too-few-public-me
     validator_name = 'scrub'
 
     @staticmethod
-    def _upload_corrupted_files(node: BaseNode, quarantine_log_lines):
-        # get quarantine dir from lines:
+    def _upload_corrupted_files(node: BaseNode, invalid_sstables_lines):
+        # get corrupted sstables from lines:
         # INFO  2024-04-02 12:40:24,787 [shard 0:stre] sstable - Moving sstable /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/me-3gey_0z3c_2h5vl2ogebmg26ku9t-big-Data.db to "/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/quarantine"  # pylint: disable=line-too-long
-        # print(log_lines)
-        quarantine_dirs = {line.split(' to "')[1][:-2]
-                           for line in quarantine_log_lines
-                           if 'sstable - Moving sstable' in line and 'quarantine' in line}
-        if not quarantine_dirs:
-            LOGGER.error('No quarantine directories found in db logs on node: %s', node.name)
-            return "<No quarantine directories found>"
+        # scylla[5976]:  [shard 6:strm] compaction - Finished scrubbing in validate mode /var/lib/scylla/data/keyspace1/standard1-01b9f260d55311ef8caf5992914eabbe/me-3gn1_0bxv_16fs02rr7ufpbjejzy-big-Data.db - sstable is invalid"  # pylint: disable=line-too-long
+        corrupted_sstables = []
+        sstable_path_regexp = re.compile(r'[./\w\-]+(\.db|quarantine)')
+        for line in invalid_sstables_lines:
+            if matches := sstable_path_regexp.finditer(line):
+                corrupted_sstables.append(list(matches)[-1].group(0))
+        # remove duplicates from corrupted_sstables
+        corrupted_sstables = list(set(corrupted_sstables))
         s3_link = upload_remote_files_directly_to_s3(
-            node.ssh_login_info, list(quarantine_dirs), s3_bucket=S3Storage.bucket_name,
+            node.ssh_login_info, list(corrupted_sstables), s3_bucket=S3Storage.bucket_name,
             s3_key=f"{node.parent_cluster.uuid}/{node.name}-corrupted-sstables.tar.gz",
-            max_size_gb=100, public_read_acl=True)
+            max_size_gb=30, public_read_acl=True)
         return s3_link
 
     def _run_nodetool_scrub(self, node: BaseNode, keyspace: str, table: str, timeout=1200):
@@ -56,10 +60,11 @@ class SstablesValidator(TeardownValidator):  # pylint: disable=too-few-public-me
             ValidatorEvent(
                 message=f'No scrubbing validation message found in db logs on node: {node.name}', severity=Severity.ERROR).publish()
             return
-        invalid_sstables = [line for line in scrub_finish_lines if 'sstable is invalid' in line]
-        if invalid_sstables:
-            LOGGER.error("Invalid sstables found: %s.", invalid_sstables)
-            s3_link = self._upload_corrupted_files(node, list(quarantine_lines))
+        invalid_sstables_lines = [line for line in scrub_finish_lines if 'sstable is invalid' in line]
+        if invalid_sstables_lines:
+            invalid_sstables_lines += list(quarantine_lines)
+            LOGGER.error("Invalid sstables found: %s.", invalid_sstables_lines)
+            s3_link = self._upload_corrupted_files(node, list(invalid_sstables_lines))
             ScrubValidationErrorEvent(node.name, s3_link).publish()
 
     def validate(self):
@@ -72,7 +77,10 @@ class SstablesValidator(TeardownValidator):  # pylint: disable=too-few-public-me
             try:
                 LOGGER.info("Running nodetool scrub on all nodes in validation mode")
                 parallel_obj = ParallelObject(objects=cluster.nodes, timeout=timeout)
-                parallel_obj.run(run_scrub, ignore_exceptions=False, unpack_objects=True)
+                with EventsSeverityChangerFilter(new_severity=Severity.ERROR,  # killing stress creates Critical error
+                                                 event_class=DatabaseLogEvent.CORRUPTED_SSTABLE,
+                                                 extra_time_to_expiration=60):
+                    parallel_obj.run(run_scrub, ignore_exceptions=False, unpack_objects=True)
                 LOGGER.info("Nodetool scrub validation finished")
             except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
                 LOGGER.error("Error during nodetool scrub validation: %s", exc)

--- a/sdcm/utils/sstable/sstable_utils.py
+++ b/sdcm/utils/sstable/sstable_utils.py
@@ -216,6 +216,17 @@ class SstableUtils:
         full_deletion_date_datetime = datetime.datetime.strptime(full_deletion_date, '%Y-%m-%d %H:%M:%S')
         return full_deletion_date_datetime
 
+    def corrupt_sstables(self, sstables_to_corrupt_count: int = 1):
+        """
+        Corrupts sstables by replace it's content with random data.
+        """
+        sstables = self.get_sstables()
+        if len(sstables) < sstables_to_corrupt_count:
+            sstables_to_corrupt_count = len(sstables)
+
+        for sstable in sstables[:sstables_to_corrupt_count]:
+            self.db_node.remoter.sudo(f"dd if=/dev/urandom of={sstable} bs=1M count=1", verbose=True)
+
 
 def is_new_sstable_dump_supported(node) -> bool:
     """


### PR DESCRIPTION
Error message changed for scrub validation and upload sstables in validator stopped working. Still event handler catched that and uploaded
- but actually should not when scrub validator sends them.

Fix by adjusting to error line (should be more elastic) and adjusted event handler to not send corrupted sstables in context of sstables validator.

Added sstable util to corrupt sstable (just for testing this and possibly may be used in other contexts).

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9854

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [argus](https://argus.scylladb.com/tests/scylla-cluster-tests/da1fc225-f1b7-4271-b2fd-e444ee81c0c2)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
