### PR TITLE
fix(get_version_based_on_conf): master is now "enterprise"

### DIFF
--- a/unit_tests/test_config_get_version_based_on_conf.py
+++ b/unit_tests/test_config_get_version_based_on_conf.py
@@ -79,7 +79,7 @@ def test_docker(scylla_version, expected_docker_image, expected_outcome):
                          argvalues=[
                              pytest.param('6.1', ('6.1', False), id='6.1'),
                              pytest.param('2024.1', ('2024.1', True), id='2024.1'),
-                             pytest.param('master:latest', (None, False), id='master'),
+                             pytest.param('master:latest', (None, True), id='master'),
                              pytest.param('branch-6.0:latest', (None, False), id='branch-6.0'),
                              pytest.param('enterprise:latest', (None, True), id='enterprise'),
                              pytest.param('enterprise-2023.1:latest', (None, True), id='enterprise-2023.1'),
@@ -107,7 +107,7 @@ def test_scylla_repo(scylla_version, expected_outcome, distro):
                          argvalues=[
                              pytest.param('6.2', ('6.2', False), id='6.2'),
                              pytest.param('2024.2', ('2024.2', True), id='2024.2'),
-                             pytest.param('master:latest', (None, False), id='master'),
+                             pytest.param('master:latest', (None, True), id='master'),
                              pytest.param('branch-6.2:latest', (None, False), id='branch-6.2'),
                              pytest.param('enterprise:latest', (None, True), id='enterprise'),
                              pytest.param('branch-2024.1:latest', (None, True), id='branch-2024.1'),


### PR DESCRIPTION
test was assuming any version from master wouldn't be with enterprise version scheme, that has change and now master is with 2025.1 and that's expected, the logic of the test has change to expect enterprise like version

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] unittests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
