### PR TITLE
fix(integration-test): update scylla docker image to lastest master

### DIFF
--- a/data_dir/cassandra-stress-custom.yaml
+++ b/data_dir/cassandra-stress-custom.yaml
@@ -42,8 +42,7 @@ table_definition: |
         uid timeuuid,
         value blob,
         PRIMARY KEY((name,choice), date, address, dbl, lval, ival, uid)
-  ) WITH COMPACT STORAGE
-    AND compaction = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_unit': 'DAYS', 'compaction_window_size': 1}
+  ) WITH compaction = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_unit': 'DAYS', 'compaction_window_size': 1}
     AND comment='A table of many types to test wide rows'
 
 #

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -70,7 +70,8 @@ def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # pylint: di
     entryfile_path = entryfile_path / 'docker' / 'scylla-sct' / ('entry_ssl.sh' if ssl else 'entry.sh')
 
     alternator_flags = f"--alternator-port {ALTERNATOR_PORT} --alternator-write-isolation=always"
-    docker_version = docker_scylla_args.get('image', "scylladb/scylla-nightly:6.1.0-dev-0.20240605.2c3f7c996f98")
+    docker_version = docker_scylla_args.get(
+        'image', "scylladb/scylla-nightly:2025.2.0-dev-0.20250128.4f5550d7f212-x86_64")
     cluster = LocalScyllaClusterDummy(params=params)
 
     ssl_dir = (Path(__file__).parent.parent / 'data_dir' / 'ssl_conf').absolute()

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -761,7 +761,9 @@ def test_get_any_ks_cf_list(docker_scylla, params, events):  # pylint: disable=u
                                 'system.commitlog_cleanups', 'system.discovery', 'system.group0_history',
                                 'system.raft', 'system.raft_snapshot_config', 'system.raft_snapshots', 'system.raft_state',
                                 'system_schema.tables', 'system_schema.columns', 'system.compaction_history',
-                                'system.cdc_local', 'system.versions', 'system_distributed_everywhere.cdc_generation_descriptions_v2',
+                                'system.cdc_local', 'system.versions', 'system.view_build_status_v2',
+                                'system_distributed_everywhere.cdc_generation_descriptions_v2',
+                                'system_replicated_keys.encrypted_keys',
                                 'system.scylla_local', 'system.cluster_status', 'system.protocol_servers',
                                 'system_distributed.cdc_streams_descriptions_v2', 'system_schema.keyspaces',
                                 'system.size_estimates', 'system_schema.scylla_tables',
@@ -782,7 +784,8 @@ def test_get_any_ks_cf_list(docker_scylla, params, events):  # pylint: disable=u
                                 'system.role_attributes', 'system.role_members', 'system.role_permissions',
                                 'system.roles', 'system.service_levels_v2',
                                 'system.topology', 'system.topology_requests',
-                                'system.cdc_generations_v3',
+                                'system.cdc_generations_v3', 'system.tablets', 'system.view_build_status_v2',
+                                'system_replicated_keys.encrypted_keys', 'system.dicts',
                                 '"123_keyspace"."120users"', '"123_keyspace".users'}
 
     table_names = cluster.get_non_system_ks_cf_list(docker_scylla, filter_empty_tables=False, filter_out_mv=True)


### PR DESCRIPTION
we had very old docker image, and for some reason it wasn't booting when configured with SSL, with latest docker image it's working as expeted

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
