### PR TITLE
improvement(argus): get and report loader's rack name

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -354,7 +354,15 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
                     rack_names = self.parent_cluster.get_rack_names_per_datacenter_and_rack_idx(db_nodes=[self])
                     self._node_rack = list(rack_names.values())[0]
             else:
-                self._node_rack = str(self.rack)
+                if not (rack_names := self.test_config.tester_obj().rack_names_per_datacenter_and_rack_idx_map):
+                    return self._node_rack
+
+                if node_rack := [rack_name for dc_rack_id, rack_name in rack_names.items()
+                                 if dc_rack_id[0] == self.datacenter and dc_rack_id[1] == str(self.rack)]:
+                    self._node_rack = node_rack[0]
+                else:
+                    self._node_rack = str(self.rack)
+            LOGGER.debug("Node rack name: %s", self._node_rack)
         return self._node_rack
 
     @property
@@ -5361,6 +5369,11 @@ class BaseLoaderSet():
             LOGGER.warning('Cannot find summary in c-stress results: %s', lines[-10:])
             return {}
         return results
+
+    def update_rack_info_in_argus(self):
+        for loader in self.nodes:
+            LOGGER.debug("Update rack info in Argus for loader '%s'", loader.name)
+            loader.update_rack_info_in_argus(loader.datacenter, loader.node_rack)
 
 
 class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instance-attributes


### PR DESCRIPTION
Now we do not publish correct rack name for loader instance. 
We save item number of rack in the list of racks that the test runs on. 
The correct rack name may be helpful for rackaware feature testing. 
This commit add change that helps to find the loader's rack name and update the Argus with correct info. Also it will be used in the RackAware feature testing

**Note: not added support for k8s

Task: https://github.com/scylladb/qa-tasks/issues/1819

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [one DC](https://argus.scylladb.com/tests/scylla-cluster-tests/a3a5dcb9-0ac7-4cce-a959-fbbd964677da)
- [x] [multi DC](https://argus.scylladb.com/tests/scylla-cluster-tests/5c348359-ac12-4db1-aee8-b8ba85e32b7b)
- [x]  [GCE](https://argus.scylladb.com/tests/scylla-cluster-tests/97164da6-1323-4492-94f7-5aac098d7c2e)
- [x] [Azure](https://argus.scylladb.com/tests/scylla-cluster-tests/ec5e69c0-e59e-431c-b866-36d85d0d785f)
- [x] [simulated_racks](https://argus.scylladb.com/tests/scylla-cluster-tests/61993061-709a-42a9-bb03-aeea84de6384)
- [x] [artifact docker test - validate that not fail](https://argus.scylladb.com/tests/scylla-cluster-tests/1da12bf0-dd8b-4b4e-ad91-e02f8c3f97e0)

![Screenshot from 2025-01-23 12-52-02](https://github.com/user-attachments/assets/b7d91350-b357-4468-bef7-5bebc48806af)


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
