### PR TITLE
test(java driver): performance test

### DIFF
--- a/configurations/performance/cassandra_stress_gradual_load_reduced_steps_number.yaml
+++ b/configurations/performance/cassandra_stress_gradual_load_reduced_steps_number.yaml
@@ -1,0 +1,4 @@
+# Define load ops for steps
+perf_gradual_threads: {"read": 620, "write": 400, "mixed": 1900}
+perf_gradual_throttle_steps: {"read": ['450000', '700000', 'unthrottled'], "mixed": ['300000', '450000', 'unthrottled'], "write": ['200000', 'unthrottled']}  # where every value is in ops
+perf_gradual_step_duration: {"read": '20m', "write": None, "mixed": '20m'}

--- a/configurations/performance/cassandra_stress_gradual_load_steps.yaml
+++ b/configurations/performance/cassandra_stress_gradual_load_steps.yaml
@@ -1,3 +1,4 @@
 # Define load ops for steps
 perf_gradual_threads: {"read": 620, "write": 400, "mixed": 1900}
 perf_gradual_throttle_steps: {"read": ['150000', '300000', '450000', '600000', '700000', 'unthrottled'], "mixed": ['50000', '150000', '300000', '450000', 'unthrottled'], "write": ['200000', '300000', 'unthrottled']}  # where every value is in ops
+perf_gradual_step_duration: {"read": '30m', "write": None, "mixed": '30m'}

--- a/configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml
+++ b/configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml
@@ -1,3 +1,4 @@
 # Define load ops for steps
 perf_gradual_threads: {"read": 620, "write": 400, "mixed": 1900}
 perf_gradual_throttle_steps: {"read": ['150000', '300000', '450000', '600000', '700000', 'unthrottled'], "mixed": ['50000', '150000', '300000', '450000', 'unthrottled'], "write": ['200000', '300000', 'unthrottled']}  # where every value is in ops
+perf_gradual_step_duration: {"read": '30m', "write": None, "mixed": '30m'}

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -2532,7 +2532,7 @@ Threads amount of c-s load for gradual performance test per sub-test. Example: {
 
 **default:** N/A
 
-**type:** dict
+**type:** dict_or_str
 
 
 ## **perf_gradual_throttle_steps** / SCT_PERF_GRADUAL_THROTTLE_STEPS
@@ -2541,7 +2541,16 @@ Used for gradual performance test. Define throttle for load step in ops. Example
 
 **default:** N/A
 
-**type:** dict
+**type:** dict_or_str
+
+
+## **perf_gradual_step_duration** / SCT_PERF_GRADUAL_STEP_DURATION
+
+Step duration of c-s load for gradual performance test per sub-test. Example: {'read': '30m, 'write': None, 'mixed': '30m'}
+
+**default:** N/A
+
+**type:** dict_or_str
 
 
 ## **skip_download** / SCT_SKIP_DOWNLOAD

--- a/jenkins-pipelines/drivers/java-driver/perf-regression-predefined-throughput-steps-vnodes.jenkinsfile
+++ b/jenkins-pipelines/drivers/java-driver/perf-regression-predefined-throughput-steps-vnodes.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    aws_region: "us-east-1",
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_reduced_steps_number.yaml", "configurations/disable_kms.yaml", "configurations/tablets_disabled.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-vnodes.yaml"]''',
+    sub_tests: ["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_write_gradual_increase_load"],
+)

--- a/performance_regression_gradual_grow_throughput.py
+++ b/performance_regression_gradual_grow_throughput.py
@@ -29,6 +29,7 @@ class Workload(NamedTuple):
     preload_data: bool
     drop_keyspace: bool
     wait_no_compactions: bool
+    step_duration: str
 
 
 class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # pylint: disable=too-many-instance-attributes
@@ -54,6 +55,15 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
                                severity=Severity.CRITICAL).publish()
         return throttle_steps[workload_type]
 
+    def step_duration(self, workload_type):
+        step_duration = self.params["perf_gradual_step_duration"]
+        if workload_type not in step_duration:
+            TestFrameworkEvent(source=self.__class__.__name__,
+                               message=f"Step duration for '{workload_type}' test is not defined in "
+                                       f"'perf_gradual_step_duration' parameter",
+                               severity=Severity.CRITICAL).publish()
+        return step_duration[workload_type]
+
     def test_mixed_gradual_increase_load(self):  # pylint: disable=too-many-locals
         """
         Test steps:
@@ -69,7 +79,8 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
                             throttle_steps=self.throttle_steps(workload_type),
                             preload_data=True,
                             drop_keyspace=False,
-                            wait_no_compactions=True)
+                            wait_no_compactions=True,
+                            step_duration=self.step_duration(workload_type))
         self._base_test_workflow(workload=workload,
                                  test_name="test_mixed_gradual_increase_load (read:50%,write:50%)")
 
@@ -88,7 +99,8 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
                             throttle_steps=self.throttle_steps(workload_type),
                             preload_data=False,
                             drop_keyspace=True,
-                            wait_no_compactions=False)
+                            wait_no_compactions=False,
+                            step_duration=self.step_duration(workload_type))
         self._base_test_workflow(workload=workload,
                                  test_name="test_write_gradual_increase_load (100% writes)")
 
@@ -107,7 +119,8 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
                             throttle_steps=self.throttle_steps(workload_type),
                             preload_data=True,
                             drop_keyspace=False,
-                            wait_no_compactions=True)
+                            wait_no_compactions=True,
+                            step_duration=self.step_duration(workload_type))
         self._base_test_workflow(workload=workload,
                                  test_name="test_read_gradual_increase_load (100% reads)")
 
@@ -170,13 +183,15 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
             self.update({"latency_during_ops": latency_results})
             return latency_results
 
-    def run_step(self, stress_cmds, current_throttle, num_threads):
+    def run_step(self, stress_cmds, current_throttle, num_threads, step_duration):
         results = []
         stress_queue = []
         for stress_cmd in stress_cmds:
             params = {"round_robin": True, "stats_aggregate_cmds": False}
             stress_cmd_to_run = stress_cmd.replace(
                 "$threads", f"{num_threads}").replace("$throttle", f"{current_throttle}")
+            if step_duration is not None:
+                stress_cmd_to_run = stress_cmd_to_run.replace("$duration", step_duration)
             params.update({'stress_cmd': stress_cmd_to_run})
             # Run all stress commands
             self.log.debug('RUNNING stress cmd: %s', stress_cmd_to_run)
@@ -210,8 +225,8 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
             current_throttle = f"fixed={int(int(throttle_step) // (num_loaders * stress_num))}/s" if throttle_step != "unthrottled" else ""
             run_step = ((latency_calculator_decorator(legend=f"Gradual test step {throttle_step} op/s",
                                                       cycle_name=throttle_step))(self.run_step))
-            results, _ = run_step(
-                stress_cmds=workload.cs_cmd_tmpl, current_throttle=current_throttle, num_threads=workload.num_threads)
+            results, _ = run_step(stress_cmds=workload.cs_cmd_tmpl, current_throttle=current_throttle,
+                                  num_threads=workload.num_threads, step_duration=workload.step_duration)
 
             calculate_result = self._calculate_average_max_latency(results)
             self.update_test_details(scylla_conf=True)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1297,6 +1297,10 @@ class SCTConfiguration(dict):
         dict(name="perf_gradual_throttle_steps", env="SCT_PERF_GRADUAL_THROTTLE_STEPS", type=dict_or_str,
              help="Used for gradual performance test. Define throttle for load step in ops. Example: {'read': ['100000', '150000'], 'mixed': ['300']}"),
 
+        dict(name="perf_gradual_step_duration", env="SCT_PERF_GRADUAL_STEP_DURATION", type=dict_or_str,
+             help="Step duration of c-s load for gradual performance test per sub-test. "
+                  "Example: {'read': '30m', 'write': None, 'mixed': '30m'}"),
+
         # RefreshTest
         dict(name="skip_download", env="SCT_SKIP_DOWNLOAD", type=boolean,
              help=""),

--- a/test-cases/performance/perf-regression-predefined-throughput-steps.yaml
+++ b/test-cases/performance/perf-regression-predefined-throughput-steps.yaml
@@ -14,10 +14,10 @@ stress_cmd_w:  [
 ]
 
 stress_cmd_r: [
-  "cassandra-stress read  cl=QUORUM duration=30m -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..5000000",
-  "cassandra-stress read  cl=QUORUM duration=30m -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=5000001..10000000",
-  "cassandra-stress read  cl=QUORUM duration=30m -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=10000001..15000000",
-  "cassandra-stress read  cl=QUORUM duration=30m -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=15000001..20000000"
+  "cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..5000000",
+  "cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=5000001..10000000",
+  "cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=10000001..15000000",
+  "cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=15000001..20000000"
 ]
 
 stress_cmd_cache_warmup: [
@@ -28,10 +28,10 @@ stress_cmd_cache_warmup: [
 ]
 
 stress_cmd_m: [
-  "cassandra-stress mixed  cl=QUORUM duration=30m -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..5000000",
-  "cassandra-stress mixed  cl=QUORUM duration=30m -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=5000001..10000000",
-  "cassandra-stress mixed  cl=QUORUM duration=30m -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=10000001..15000000",
-  "cassandra-stress mixed  cl=QUORUM duration=30m -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=15000001..20000000"
+  "cassandra-stress mixed  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..5000000",
+  "cassandra-stress mixed  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=5000001..10000000",
+  "cassandra-stress mixed  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=10000001..15000000",
+  "cassandra-stress mixed  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=15000001..20000000"
 ]
 
 round_robin: true


### PR DESCRIPTION
New predefined steps performance test for java driver.

For performance driver tests we need to run shorter tests. To be able to change
step duration dynamicaly, add 'perf_gradual_step_duration' parameter per load type

Task: https://github.com/scylladb/qa-tasks/issues/1825

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [read](https://argus.scylladb.com/tests/scylla-cluster-tests/75a9bbe3-669c-4841-8e13-9fa35a825c39)
- [x] [write](https://argus.scylladb.com/tests/scylla-cluster-tests/64ca9a81-d208-479e-9489-9a4279861c11)
- [x] [mixed](https://argus.scylladb.com/tests/scylla-cluster-tests/7da12f06-0398-436d-a021-0b8c43c5a01a)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
