### PR TITLE
fix(cdc_reader): overwrite "run" method in cdc_reader_thread

### DIFF
--- a/sdcm/cdclog_reader_thread.py
+++ b/sdcm/cdclog_reader_thread.py
@@ -33,6 +33,7 @@ class CDCLogReaderThread(DockerBasedStressThread):
 
     def __init__(self, *args, **kwargs):
 
+        self.termination_event = kwargs.pop("termination_event")
         self.keyspace = kwargs.pop("keyspace_name")
         self.cdc_log_table = kwargs.pop("base_table_name") + CDC_LOGTABLE_SUFFIX
         self.batching = kwargs.pop("enable_batching")
@@ -44,6 +45,24 @@ class CDCLogReaderThread(DockerBasedStressThread):
         self.stress_cmd = f"{self.stress_cmd} -keyspace {self.keyspace} -table {self.cdc_log_table} \
                             -nodes {node_ips} -group-size {shards_per_node} \
                             -worker-id {worker_id} -worker-count {worker_count}"
+
+    def run(self):
+        """
+        Overrides the base class's `run` method to customize how stress threads are spawned.
+        In the original `DockerBasedStressThread.run()`, each stress thread is submitted
+        by iterating directly over the loader objects  and then by indexing CPU cores or stress workers.
+        Here it specifically iterates over the loader indices
+        ensuring worker_id is in the valid range [0..worker_count - 1].
+        Previously, because loader indexing began at 1, the tool would fail with “worker id must be
+        from range [0..N-1].”
+        ref: https://github.com/scylladb/scylla-cluster-tests/issues/9819
+        """
+        self.configure_executer()
+        for loader_idx in range(len(self.loaders)):
+            for cpu_idx in range(self.stress_num):
+                self.results_futures += [self.executor.submit(self._run_stress,
+                                                              *(self.loaders[loader_idx], loader_idx, cpu_idx))]
+        return self
 
     def _run_stress(self, loader, loader_idx, cpu_idx):  # pylint: disable=unused-argument
         loader_node_logdir = Path(loader.logdir)
@@ -74,7 +93,7 @@ class CDCLogReaderThread(DockerBasedStressThread):
                                     verbose=True,
                                     retry=0
                                     )
-                if not result.ok:
+                if not result.ok and not self.termination_event.is_set():
                     CDCReaderStressEvent.error(node=loader,
                                                stress_cmd=self.stress_cmd,
                                                errors=result.stderr.split("\n")).publish()

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2262,6 +2262,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if self.create_stats:
             self.update_stress_cmd_details(stress_cmd, prefix, stresser="cdcreader", aggregate=stats_aggregate_cmds)
         return CDCLogReaderThread(loader_set=self.loaders,
+                                  termination_event=self.db_cluster.nemesis_termination_event,
                                   stress_cmd=stress_cmd,
                                   timeout=timeout,
                                   stress_num=stress_num,


### PR DESCRIPTION
overwrite run method to avoid wrong loaders calculation 
termination event handling added to avoid uncritical errors during test termination
fixes:9819

fixes: #9819
### Testing
https://jenkins.scylladb.com/job/scylla-staging/job/eugene_test_folder/job/cdc_stressor_4h/12/
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/eugene_test_folder/job/cdc_stressor_4h/15/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ x] I added the relevant `backport` labels
- [x ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
