### PR TITLE
ci(cql-stress): use newest cql-stress benchmarking tool

### DIFF
--- a/defaults/docker_images/cql-stress-cassandra-stress/values_cql-stress-cassandra-stress.yaml
+++ b/defaults/docker_images/cql-stress-cassandra-stress/values_cql-stress-cassandra-stress.yaml
@@ -1,2 +1,2 @@
 cql-stress-cassandra-stress:
-  image: docker.io/scylladb/hydra-loaders:cql-stress-cassandra-stress-20240718
+  image: docker.io/scylladb/hydra-loaders:cql-stress-cassandra-stress-20250127

--- a/docker/cql-stress-cassandra-stress/Dockerfile
+++ b/docker/cql-stress-cassandra-stress/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.78 AS builder
+FROM rust:1.84-bookworm AS builder
 
 ARG BRANCH
 ARG REPO
@@ -10,7 +10,9 @@ RUN git clone ${REPO} -b ${BRANCH}
 
 RUN cd cql-stress && cargo build --release --bin cql-stress-cassandra-stress
 
-
-FROM rust:1.73-slim AS app
+FROM debian:bookworm-slim
+RUN apt update && apt -y install \
+    openssl \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /cql-stress/target/release/cql-stress-cassandra-stress /usr/local/bin/

--- a/docker/cql-stress-cassandra-stress/image
+++ b/docker/cql-stress-cassandra-stress/image
@@ -1,1 +1,1 @@
-scylladb/hydra-loaders:cql-stress-cassandra-stress-20240718
+scylladb/hydra-loaders:cql-stress-cassandra-stress-20250127


### PR DESCRIPTION
This new version contains following changes compared to the previous one:
- "c-s: Implement insert operation for user profiles" ([PR#93](https://github.com/scylladb/cql-stress/pull/93))
- "cargo: bump rust-driver version to 0.14" ([PR#102](https://github.com/scylladb/cql-stress/pull/102))

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
