### PR TITLE
fix(performance): add sleep after warm-up

### DIFF
--- a/performance_regression_gradual_grow_throughput.py
+++ b/performance_regression_gradual_grow_throughput.py
@@ -196,6 +196,8 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
     def run_gradual_increase_load(self, workload: Workload, stress_num, num_loaders, test_name):  # noqa: PLR0914
         if workload.cs_cmd_warm_up is not None:
             self.warmup_cache(workload.cs_cmd_warm_up, workload.num_threads)
+            # Wait for 4 minutes after warmup to let for all background processes to finish
+            time.sleep(240)
 
         if not self.exists():
             self.log.debug("Create test statistics in ES")


### PR DESCRIPTION
Add 2 minutes sleep after warm-up and before step start in predefined steps performnace test. This is for let to all background processes to finish. It may have the impact especially in tablet test - to complete tablets rebuild

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9852

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
