### PR TITLE
improvement(artifacts): switch to syslog-ng logs transport

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -611,6 +611,10 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         return self.parent_cluster.params.get("unified_package") \
             and self.parent_cluster.params.get("nonroot_offline_install")
 
+    @cached_property
+    def is_scylla_logging_to_journal(self):
+        return self.remoter.run('sudo test -e /var/log/journal', ignore_status=True).exit_status == 0
+
     @property
     def is_client_encrypt(self):
         result = self.remoter.run(
@@ -2929,10 +2933,14 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
     def configure_remote_logging(self):
         if self.parent_cluster.params.get('logs_transport') not in ['syslog-ng',]:
             return
+        log_file = ""
+        if 'db-node' in self.name and self.is_nonroot_install and not self.is_scylla_logging_to_journal:
+            log_file = str(self.offline_install_dir / "scylla-server.log")
         script = ConfigurationScriptBuilder(
             syslog_host_port=self.test_config.get_logging_service_host_port(),
             logs_transport=self.parent_cluster.params.get('logs_transport'),
             hostname=self.name,
+            log_file=log_file,
         ).to_string()
         self.remoter.sudo(shell_script_cmd(script, quote="'"))
 
@@ -4704,7 +4712,20 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             save_kallsyms_map(node=node)
         if node.is_nonroot_install:
             self.scylla_configure_non_root_installation(node=node, devname=nic_devname)
+            if node.distro.is_rhel_like and not node.is_scylla_logging_to_journal:
+                # In case of nonroot installation on CentOS/Rocky, scylla-server log is redirected to a
+                # log file (as described in the https://github.com/scylladb/scylladb/issues/7131).
+                # To allow syslog-ng to read logs from the file and send them to test runner, we need to:
+                # - change SELinux context of the scylla installation directory
+                # - allow syslog-ng to use the port of the remote log destination
+                node.remoter.sudo(f"chcon -R -t var_log_t {node.offline_install_dir}")
+                self._allow_syslog_port_in_selinux(node)
+                node.remoter.sudo("systemctl restart syslog-ng")
             return
+        if 'no-selinux-setup' in (self.params.get('append_scylla_setup_args') or ''):
+            # If Scylla doesn't configure SELinux policies, allow syslog-ng to use the remote log destination port
+            self._allow_syslog_port_in_selinux(node)
+            node.remoter.sudo("systemctl restart syslog-ng")
 
         if self.test_config.BACKTRACE_DECODING:
             node.install_scylla_debuginfo()
@@ -4866,6 +4887,12 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         # remove dependency when using scylla ami but installing from repo
         node.remoter.sudo("sudo rm /etc/systemd/system/scylla-server.service.requires/scylla-image-*",
                           ignore_status=True)
+
+    def _allow_syslog_port_in_selinux(self, node: BaseNode) -> None:
+        """Allow syslog-ng to use the remote log destination port under the syslogd_port_t SELinux context."""
+        node.install_package("policycoreutils-python-utils")
+        _, syslogng_port = self.test_config.get_logging_service_host_port()
+        node.remoter.sudo(f"semanage port -a -t syslogd_port_t -p tcp {syslogng_port}")
 
     @staticmethod
     def _wait_for_preinstalled_scylla(node):

--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -207,3 +207,16 @@ def configure_syslogng_destination_conf(host: str, port: int, throttle_per_secon
         EOF
         }}
         """).format(host=host, port=port, throttle_per_second=throttle_per_second)
+
+
+def configure_syslogng_file_source(log_file: str) -> str:
+    """Configures an additional syslog-ng source for ScyllaDB logs from a file."""
+    return dedent(f"""
+        cat <<EOF >/etc/syslog-ng/conf.d/scylla_file_source.conf
+        source s_scylla_file {{
+            file("{log_file}" follow-freq(1) flags(no-parse));
+        }};
+        EOF
+
+        echo "log {{ source(s_scylla_file); filter(filter_sct); destination(remote_sct); rewrite(r_host); }};" >> /etc/syslog-ng/syslog-ng.conf
+    """)

--- a/sdcm/utils/aws_builder.py
+++ b/sdcm/utils/aws_builder.py
@@ -139,7 +139,7 @@ class AwsBuilder:
                 ],
                 'ImageId': runner.image.id,
                 'KeyName': self.region.SCT_KEY_PAIR_NAME,
-                'SecurityGroupIds': [self.region.sct_ssh_security_group.id],
+                'SecurityGroupIds': [self.region.sct_ssh_security_group.id, self.region.sct_security_group.id],
             }
         )
 

--- a/sdcm/utils/remote_logger.py
+++ b/sdcm/utils/remote_logger.py
@@ -582,8 +582,7 @@ def get_system_logging_thread(logs_transport, node, target_log_file):  # pylint:
         return K8sClientLogger(node, target_log_file)
     if logs_transport == 'ssh':
         if node.distro.uses_systemd:
-            if 'db-node' in node.name and node.is_nonroot_install and node.remoter.run(
-                    'sudo test -e /var/log/journal', ignore_status=True).exit_status != 0:
+            if 'db-node' in node.name and node.is_nonroot_install and not node.is_scylla_logging_to_journal:
                 return SSHNonRootScyllaSystemdLogger(node, target_log_file)
             if 'db-node' in node.name:
                 return SSHScyllaSystemdLogger(node, target_log_file)

--- a/test-cases/artifacts/ami.yaml
+++ b/test-cases/artifacts/ami.yaml
@@ -4,7 +4,6 @@ cluster_backend: 'aws'
 instance_type_db: 'i4i.large'
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/azure-image.yaml
+++ b/test-cases/artifacts/azure-image.yaml
@@ -8,7 +8,6 @@ azure_instance_type_db: 'Standard_L8s_v3'
 #azure_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: false  # todo lukasz: add support for fallback on demand for azure
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/centos7.yaml
+++ b/test-cases/artifacts/centos7.yaml
@@ -7,7 +7,6 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/centos9-selinux.yaml
+++ b/test-cases/artifacts/centos9-selinux.yaml
@@ -7,7 +7,6 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/centos9.yaml
+++ b/test-cases/artifacts/centos9.yaml
@@ -7,7 +7,6 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/debian11.yaml
+++ b/test-cases/artifacts/debian11.yaml
@@ -7,7 +7,6 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/debian12.yaml
+++ b/test-cases/artifacts/debian12.yaml
@@ -7,7 +7,6 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/gce-image-persistent-disk.yaml
+++ b/test-cases/artifacts/gce-image-persistent-disk.yaml
@@ -7,7 +7,6 @@ gce_n_local_ssd_disk_db: 0
 gce_pd_standard_disk_size_db: 50
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/gce-image.yaml
+++ b/test-cases/artifacts/gce-image.yaml
@@ -6,7 +6,6 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 16
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/oel76.yaml
+++ b/test-cases/artifacts/oel76.yaml
@@ -6,7 +6,6 @@ cluster_backend: 'aws'
 instance_type_db: 'i4i.large'
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/oel8.yaml
+++ b/test-cases/artifacts/oel8.yaml
@@ -6,7 +6,6 @@ cluster_backend: 'aws'
 instance_type_db: 'i4i.large'
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/oel9.yaml
+++ b/test-cases/artifacts/oel9.yaml
@@ -6,7 +6,6 @@ cluster_backend: 'aws'
 instance_type_db: 'i4i.large'
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/rhel7.yaml
+++ b/test-cases/artifacts/rhel7.yaml
@@ -7,7 +7,6 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/rhel8.yaml
+++ b/test-cases/artifacts/rhel8.yaml
@@ -7,7 +7,6 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/rocky8.yaml
+++ b/test-cases/artifacts/rocky8.yaml
@@ -7,7 +7,6 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/rocky9-selinux.yaml
+++ b/test-cases/artifacts/rocky9-selinux.yaml
@@ -7,7 +7,6 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/rocky9.yaml
+++ b/test-cases/artifacts/rocky9.yaml
@@ -7,7 +7,6 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/ubuntu2004-fips.yaml
+++ b/test-cases/artifacts/ubuntu2004-fips.yaml
@@ -6,7 +6,6 @@ cluster_backend: 'aws'
 instance_type_db: 'i4i.large'
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/ubuntu2004.yaml
+++ b/test-cases/artifacts/ubuntu2004.yaml
@@ -7,7 +7,6 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/ubuntu2204.yaml
+++ b/test-cases/artifacts/ubuntu2204.yaml
@@ -7,7 +7,6 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/ubuntu2404.yaml
+++ b/test-cases/artifacts/ubuntu2404.yaml
@@ -7,7 +7,6 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
-logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0


### PR DESCRIPTION
Switch artifacts tests from ssh to syslog-ng logs transport.

For most of the artifacts test cases simply changing logs transport from `ssh` to `syslog-ng` is enough.
But there are also few scenarios where additional adjustments were needed:
- AWS backend: the `SCT-sg-2` security group is added to the `aws-sct-builders` launch templates. This change allows syslog-ng communication to pass firewall and send logs
from DB nodes to builder instances.
- nonroot installation of scylla on CentOS/Rocky: syslog-ng configuration is adjusted to read scylla-server logs from file. Also SELinux policies are adjusted to allow
nonroot syslog-ng process to send logs to remote log destination.
- scylla installation with `no-selinux-setup` option: SELinux policy is added to allow syslog-ng to use the port of the remote log destination.

For `artifacts-amazon2023-*` configurations the `ssh` logs transport is still to be used due to https://github.com/amazonlinux/amazon-linux-2023/issues/639.

Closes: https://github.com/scylladb/qa-tasks/issues/1848
Closes: https://github.com/scylladb/scylla-cluster-tests/issues/8532
Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9925

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
AWS jenkins builders were updated after this change in sdcm/utils/aws_builder.py (i.e. additional SG is used in launch template):
```
❯ ./sct.py configure-jenkins-builders -c aws -r us-east-1
logged in as arn:aws:sts::797456418907:assumed-role/DeveloperAccessRole/dmytro.kruglov@scylladb.com
New directory created: /home/dmitriy/sct-results/20250127-223926-992009-configure-jenkins-builders
eu-west-1: create_launch_template
eu-west-1: checking if template needs update
eu-west-1: updating template
eu-west-1: create_auto_scaling_group
eu-west-1: add_scaling_group_to_jenkins
us-east-1: create_launch_template
us-east-1: checking if template needs update
us-east-1: updating template
us-east-1: create_auto_scaling_group
us-east-1: add_scaling_group_to_jenkins
```
Some artifacts tests on AWS backend:
- [x] :green_circle: [artifacts-ami-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-ami-test/11/)
- [x] :green_circle: [artifacts-ubuntu2404-arm-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-ami-test/12/)
- [x] :green_circle: [artifacts-ubuntu2004-fips](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-ami-test/13/)
- [x] :green_circle: [artifacts-oel9-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-ami-test/14/)

Some artifacts tests on GCE backend:
- [x] :green_circle: [artifacts-gce-image-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-gce-image-test/4/)
- [x] :green_circle: [artifacts-debian12-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-gce-image-test/5/)

Azure backend artifacts test:
- [x] :green_circle: [artifacts-azure-image-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-azure-image-test/4/)

Nonroot/selinux installation tests:
- [x] :green_circle: [artifacts-offline-install centos9 nonroot](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-centos9-nonroot-test/13/)
- [x] :green_circle: [artifacts-offline-install rocky9 nonroot](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-centos9-nonroot-test/14/)
- [x] :green_circle: [artifacts-offline-install centos9 selinux](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-centos9-nonroot-test/12/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
