### PR TITLE
Revert "improvement(artifacts): switch to syslog-ng logs transport"

### DIFF
--- a/test-cases/artifacts/azure-image.yaml
+++ b/test-cases/artifacts/azure-image.yaml
@@ -8,6 +8,7 @@ azure_instance_type_db: 'Standard_L8s_v3'
 #azure_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: false  # todo lukasz: add support for fallback on demand for azure
+logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/centos7.yaml
+++ b/test-cases/artifacts/centos7.yaml
@@ -7,6 +7,7 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/centos9-selinux.yaml
+++ b/test-cases/artifacts/centos9-selinux.yaml
@@ -7,6 +7,7 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/centos9.yaml
+++ b/test-cases/artifacts/centos9.yaml
@@ -7,6 +7,7 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/debian11.yaml
+++ b/test-cases/artifacts/debian11.yaml
@@ -7,6 +7,7 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/debian12.yaml
+++ b/test-cases/artifacts/debian12.yaml
@@ -7,6 +7,7 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/gce-image-persistent-disk.yaml
+++ b/test-cases/artifacts/gce-image-persistent-disk.yaml
@@ -7,6 +7,7 @@ gce_n_local_ssd_disk_db: 0
 gce_pd_standard_disk_size_db: 50
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/gce-image.yaml
+++ b/test-cases/artifacts/gce-image.yaml
@@ -6,6 +6,7 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 16
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/rhel7.yaml
+++ b/test-cases/artifacts/rhel7.yaml
@@ -7,6 +7,7 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/rhel8.yaml
+++ b/test-cases/artifacts/rhel8.yaml
@@ -7,6 +7,7 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/rocky8.yaml
+++ b/test-cases/artifacts/rocky8.yaml
@@ -7,6 +7,7 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/rocky9-selinux.yaml
+++ b/test-cases/artifacts/rocky9-selinux.yaml
@@ -7,6 +7,7 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/rocky9.yaml
+++ b/test-cases/artifacts/rocky9.yaml
@@ -7,6 +7,7 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/ubuntu2004.yaml
+++ b/test-cases/artifacts/ubuntu2004.yaml
@@ -7,6 +7,7 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/ubuntu2204.yaml
+++ b/test-cases/artifacts/ubuntu2204.yaml
@@ -7,6 +7,7 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0

--- a/test-cases/artifacts/ubuntu2404.yaml
+++ b/test-cases/artifacts/ubuntu2404.yaml
@@ -7,6 +7,7 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
 instance_provision_fallback_on_demand: true
+logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 0


### PR DESCRIPTION
Seems like we didn't fully tested this on on the jobs not based scylla images

Revering for now

Reverts scylladb/scylla-cluster-tests#9917