### PR TITLE
fix(sct_config): change type of perf_gradual_ params

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1283,10 +1283,10 @@ class SCTConfiguration(dict):
             be provided by the test suite infrastructure.
             multiple commands can passed as a list"""),
 
-        dict(name="perf_gradual_threads", env="SCT_PERF_GRADUAL_THREADS", type=dict,
+        dict(name="perf_gradual_threads", env="SCT_PERF_GRADUAL_THREADS", type=dict_or_str,
              help="Threads amount of c-s load for gradual performance test per sub-test. "
                   "Example: {'read': 100, 'write': 200, 'mixed': 300}"),
-        dict(name="perf_gradual_throttle_steps", env="SCT_PERF_GRADUAL_THROTTLE_STEPS", type=dict,
+        dict(name="perf_gradual_throttle_steps", env="SCT_PERF_GRADUAL_THROTTLE_STEPS", type=dict_or_str,
              help="Used for gradual performance test. Define throttle for load step in ops. Example: {'read': ['100000', '150000'], 'mixed': ['300']}"),
 
         # RefreshTest


### PR DESCRIPTION
The parameters 'perf_gradual_threads' and 'perf_gradual_throttle_steps' are defined with type 'dict'. It prevents dynamicaly changing them in the 'extra_environment_variables' parameter in Jenkins job (if we want to change them while running job, without push commit).
Changing the type to 'dict_or_str' allow us to change those params dynamically

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [use extra_environment_variables](https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/performance/job/scylla-enterprise-perf-regression-scylla-predefined-steps-vnodes/19/console)

The 'perf_gradual_threads' and 'perf_gradual_throttle_steps' values are according to `extra_environment_variables` and config validation step did not fail

![Screenshot from 2025-01-28 11-19-45](https://github.com/user-attachments/assets/d31b2230-e8f7-4ddf-98b8-7ca5ec54b62c)


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
