### PR TITLE
fix(cleanup): fix capacity reservation in clean resources

### DIFF
--- a/sdcm/provision/aws/capacity_reservation.py
+++ b/sdcm/provision/aws/capacity_reservation.py
@@ -56,9 +56,9 @@ class SCTCapacityReservation:
         return instance_counts, duration
 
     @classmethod
-    def get_cr_from_aws(cls, params) -> None:
+    def get_cr_from_aws(cls, params, force_fetch=False) -> None:
         """Retrieves capacity reservations for given test_id from AWS."""
-        if not cls.is_capacity_reservation_enabled(params):
+        if not cls.is_capacity_reservation_enabled(params) and not force_fetch:
             LOGGER.info("Capacity reservation is not enabled. Skipping reservation.")
             return
         test_id = params.get("reuse_cluster") or params.get("test_id")

--- a/sdcm/utils/resources_cleanup.py
+++ b/sdcm/utils/resources_cleanup.py
@@ -88,6 +88,7 @@ def clean_cloud_resources(tags_dict, config=None, dry_run=False):
 
     if cluster_backend in ('aws', 'k8s-eks', ''):
         clean_instances_aws(tags_dict, regions=aws_regions, dry_run=dry_run)
+        SCTCapacityReservation.get_cr_from_aws(config, force_fetch=True)
         SCTCapacityReservation.cancel(config)
         clean_elastic_ips_aws(tags_dict, regions=aws_regions, dry_run=dry_run)
         clean_test_security_groups(tags_dict, regions=aws_regions, dry_run=dry_run)


### PR DESCRIPTION
When cleaning resources with `clean_cloud_resources` capacity
reservations are not cleaned because not all params are passed
to the command. This causes leakage when test is aborted.

Fix by force fetch CR's from AWS before cancelling.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] - https://jenkins.scylladb.com/job/scylla-staging/job/lukasz/job/scylla-enterprise-perf-regression-scylla-predefined-steps-tablets/3/ - test with abort

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
