### PR TITLE
fix(perf trigger): change Scylla version from enterprise to master

### DIFF
--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-enterprise-performance-tablets-trigger.xml
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-enterprise-performance-tablets-trigger.xml
@@ -22,7 +22,7 @@
         <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
           <configs>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-              <properties>scylla_version=enterprise:latest
+              <properties>scylla_version=master:latest
 aws_region=us-east-1
 region=us-east-1
 provision_type=on_demand</properties>

--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-enterprise-performance-trigger.xml
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-enterprise-performance-trigger.xml
@@ -23,14 +23,14 @@ Performance master tests (latency &amp; throughput) - currently don't pass scyll
         <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
           <configs>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-              <properties>scylla_version=enterprise:latest
+              <properties>scylla_version=master:latest
 aws_region=us-east-1
 region=us-east-1
 provision_type=on_demand</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-tablets,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-vnodes,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-vnodes,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-tablets,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-tablets,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-rbno-disabled</projects>
+          <projects>../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-vnodes,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-vnodes,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-tablets,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-tablets,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis,../scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-rbno-disabled</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>
@@ -38,7 +38,7 @@ provision_type=on_demand</properties>
         <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
           <configs>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-              <properties>scylla_version=enterprise:latest
+              <properties>scylla_version=master:latest
 aws_region=us-east-1
 region=us-east-1
 provision_type=on_demand</properties>
@@ -56,7 +56,7 @@ provision_type=on_demand</properties>
               <properties>scylla_version=2024.1
 aws_region=us-east-1
 region=us-east-1
-new_scylla_repo=https://downloads.scylladb.com/unstable/scylla-enterprise/enterprise/deb/unified/latest/scylladb-enterprise/scylla.list
+new_scylla_repo=https://downloads.scylladb.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list
 provision_type=on_demand</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>

--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-master-performance-tablets-trigger.xml
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-master-performance-tablets-trigger.xml
@@ -6,7 +6,7 @@
   <keepDependencies>false</keepDependencies>
   <scm class="hudson.scm.NullSCM"/>
   <canRoam>true</canRoam>
-  <disabled>false</disabled>
+  <disabled>true</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <triggers>

--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-master-performance-trigger.xml
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-master/weekly-master-performance-trigger.xml
@@ -7,7 +7,7 @@ Performance master tests (latency &amp; throughput) - currently don't pass scyll
   <keepDependencies>false</keepDependencies>
   <scm class="hudson.scm.NullSCM"/>
   <canRoam>true</canRoam>
-  <disabled>false</disabled>
+  <disabled>true</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <triggers>


### PR DESCRIPTION
As the enterprise version does not exist anymore and master now is 2025.x, we need to run all performance tests with 'master:latest' instead of 'enterprise:latest' and disable master trigger

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
