### PR TITLE
improvement(capacity_reservations): add RunByUser and JenkinsJobTag tags

### DIFF
--- a/sdcm/provision/aws/capacity_reservation.py
+++ b/sdcm/provision/aws/capacity_reservation.py
@@ -11,6 +11,7 @@
 #
 # Copyright (c) 2024 ScyllaDB
 import logging
+import os
 import time
 from datetime import datetime, timedelta
 from typing import List, Dict, Tuple
@@ -20,6 +21,7 @@ from botocore.exceptions import ClientError
 import boto3
 
 from sdcm.exceptions import CapacityReservationError
+from sdcm.utils.get_username import get_username
 
 LOGGER = logging.getLogger(__name__)
 
@@ -51,7 +53,7 @@ class SCTCapacityReservation:
         instance_counts[params.get("instance_type_db")] += cluster_max_size
         instance_counts[params.get("instance_type_loader")] += params.get("n_loaders")
         # don't reserve capacity for monitor - as usually it's not a problem to spin it
-        duration = params.get("test_duration") + 60  # 60 to have margin for test setup
+        duration = params.get("test_duration")
         instance_counts = {k: v for k, v in instance_counts.items() if v > 0}  # remove 0 values
         return instance_counts, duration
 
@@ -218,6 +220,15 @@ class SCTCapacityReservation:
                                 'Key': 'test_id',
                                 'Value': test_id
                             },
+                            {
+                                'Key': 'RunByUser',
+                                'Value': get_username()
+                            },
+                            {
+                                'Key': 'JenkinsJobTag',
+                                'Value': os.environ.get('BUILD_TAG')
+                            }
+
                         ]
                     },
                 ],


### PR DESCRIPTION
For better traceability we want to tag capacity reservations with user and job that run it. 
Reduced duration as provision part is quick. 

refs: https://github.com/scylladb/qa-tasks/issues/1846

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] - [verified tags manually after run by jenkins](https://argus.scylladb.com/tests/scylla-cluster-tests/a70b0a8f-ecdd-4a3c-b420-cc7eba50ea20)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
