### PR TITLE
fix(capacity_reservation): reduce nemesis_add_node_cnt when not needed

### DIFF
--- a/test-cases/performance/perf-regression-latency-1TB.yaml
+++ b/test-cases/performance/perf-regression-latency-1TB.yaml
@@ -32,3 +32,4 @@ use_hdr_cs_histogram: true
 
 use_placement_group: true
 use_capacity_reservation: true
+nemesis_add_node_cnt: 0

--- a/test-cases/performance/perf-regression-latency-650gb-upgrade.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-upgrade.yaml
@@ -9,7 +9,7 @@ stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=800m -schema 
 stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=17500/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,6500000)' "
 
 n_db_nodes: 6
-nemesis_add_node_cnt: 3
+nemesis_add_node_cnt: 0
 n_loaders: 4
 n_monitor_nodes: 1
 
@@ -17,10 +17,6 @@ instance_type_loader: 'c6i.2xlarge'
 instance_type_monitor: 't3.large'
 instance_type_db: 'i3en.2xlarge'
 use_capacity_reservation: true
-
-nemesis_class_name: 'NemesisSequence'
-nemesis_interval: 2
-nemesis_sequence_sleep_between_ops: 10
 
 user_prefix: 'perf-latency-upgrade'
 space_node_threshold: 644245094

--- a/test-cases/performance/perf-regression-predefined-throughput-steps.yaml
+++ b/test-cases/performance/perf-regression-predefined-throughput-steps.yaml
@@ -44,6 +44,7 @@ instance_type_db: 'i4i.4xlarge'
 instance_type_loader: 'c7i.8xlarge'
 instance_type_monitor: 't3.small'
 use_capacity_reservation: true
+nemesis_add_node_cnt: 0
 
 use_preinstalled_scylla: true
 

--- a/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
@@ -50,3 +50,4 @@ append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --
 
 use_placement_group: true
 use_capacity_reservation: true
+nemesis_add_node_cnt: 0


### PR DESCRIPTION
By default `nemesis_add_node_cnt` is set to 1. This number is used to determine required capacity for tests. Some tests don't require it as don't run nemesis.

Reduce `nemesis_add_node_cnt` for these scenarios to 0 to avoid additional unnecessary costs.

refs: https://github.com/scylladb/qa-tasks/issues/1846

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
