### PR TITLE
improvement(cloud_usage_report): add capacity reservations

### DIFF
--- a/sdcm/utils/cloud_monitor/cloud_monitor.py
+++ b/sdcm/utils/cloud_monitor/cloud_monitor.py
@@ -2,6 +2,7 @@ import sys
 from datetime import datetime
 from logging import getLogger
 from sdcm.send_email import Email
+from sdcm.utils.cloud_monitor.resources.capacity_reservations import get_active_capacity_reservations
 from sdcm.utils.cloud_monitor.resources.instances import CloudInstances
 from sdcm.utils.cloud_monitor.report import BaseReport, GeneralReport, DetailedReport, \
     QAonlyInstancesTimeDistributionReport, NonQaInstancesTimeDistributionReport
@@ -27,7 +28,8 @@ def notify_by_email(general_report: BaseReport,
 def cloud_report(mail_to):
     cloud_instances = CloudInstances()
     static_ips = StaticIPs(cloud_instances)
-    notify_by_email(general_report=GeneralReport(cloud_instances=cloud_instances, static_ips=static_ips),
+    crs = get_active_capacity_reservations()
+    notify_by_email(general_report=GeneralReport(cloud_instances=cloud_instances, static_ips=static_ips, crs=crs),
                     detailed_report=DetailedReport(cloud_instances=cloud_instances, static_ips=static_ips),
                     recipients=mail_to)
 

--- a/sdcm/utils/cloud_monitor/report.py
+++ b/sdcm/utils/cloud_monitor/report.py
@@ -24,6 +24,7 @@ import pytz
 
 from sdcm.keystore import KeyStore
 from sdcm.utils.cloud_monitor.resources import CLOUD_PROVIDERS
+from sdcm.utils.cloud_monitor.resources.capacity_reservations import CapacityReservation
 from sdcm.utils.cloud_monitor.resources.instances import CloudInstances
 from sdcm.utils.cloud_monitor.resources.static_ips import StaticIPs
 
@@ -84,9 +85,9 @@ class CloudResourcesReport(BaseReport):
 
 
 class PerUserSummaryReport(BaseReport):
-    def __init__(self, cloud_instances: CloudInstances, static_ips: StaticIPs):
+    def __init__(self, cloud_instances: CloudInstances, static_ips: StaticIPs, crs: list[CapacityReservation]):
         super().__init__(cloud_instances, static_ips, html_template="per_user_summary.html")
-        self.report = {"results": {"qa": {}, "others": {}}, "cloud_providers": CLOUD_PROVIDERS}
+        self.report = {"results": {"qa": {}, "others": {}}, "cloud_providers": CLOUD_PROVIDERS, "crs": crs}
         self.qa_users = KeyStore().get_qa_users()
 
     def user_type(self, user_name: str):
@@ -119,10 +120,10 @@ class PerUserSummaryReport(BaseReport):
 
 
 class GeneralReport(BaseReport):
-    def __init__(self, cloud_instances: CloudInstances, static_ips: StaticIPs):
+    def __init__(self, cloud_instances: CloudInstances, static_ips: StaticIPs, crs: list[CapacityReservation]):
         super().__init__(cloud_instances, static_ips, html_template="base.html")
         self.cloud_resources_report = CloudResourcesReport(cloud_instances=cloud_instances, static_ips=static_ips)
-        self.per_user_report = PerUserSummaryReport(cloud_instances, static_ips)
+        self.per_user_report = PerUserSummaryReport(cloud_instances, static_ips, crs)
 
     def to_html(self):
         cloud_resources_html = self.cloud_resources_report.to_html()

--- a/sdcm/utils/cloud_monitor/resources/capacity_reservations.py
+++ b/sdcm/utils/cloud_monitor/resources/capacity_reservations.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+from datetime import datetime
+from logging import getLogger
+
+import boto3
+
+from sdcm.utils.common import all_aws_regions
+
+LOGGER = getLogger(__name__)
+
+
+@dataclass
+class CapacityReservation:
+    id: str
+    instance_type: str
+    region: str
+    capacity_total: int
+    capacity_available: int
+    start_time: datetime
+    user: str
+    is_unused: bool
+
+
+def get_active_capacity_reservations() -> list[CapacityReservation]:
+    reservations = []
+    LOGGER.info("Getting AWS Capacity Reservations...")
+    try:
+        for region in all_aws_regions():
+            LOGGER.info("Getting AWS Capacity Reservations in %s...", region)
+            client = boto3.client('ec2', region_name=region)
+            response = client.describe_capacity_reservations(
+                Filters=[
+                    {
+                        'Name': 'state',
+                        'Values': ['active']
+                    }]
+            )
+            for cr in response['CapacityReservations']:
+                user = next((tag['Value'] for tag in cr.get('Tags', []) if tag['Key'] == 'RunByUser'), 'N/A')
+                reservations.append(CapacityReservation(
+                    id=cr["CapacityReservationId"],
+                    instance_type=cr["InstanceType"],
+                    region=cr["AvailabilityZone"],
+                    capacity_total=cr["TotalInstanceCount"],
+                    capacity_available=cr["AvailableInstanceCount"],
+                    start_time=cr["StartDate"],
+                    user=user,
+                    is_unused=cr["AvailableInstanceCount"] == cr["TotalInstanceCount"]
+                ))
+        LOGGER.info("Found total %d active capacity reservations", len(reservations))
+    except Exception as e:  # noqa: BLE001
+        LOGGER.error("Failed to get capacity reservations: %s", e)
+    return reservations

--- a/sdcm/utils/cloud_monitor/templates/per_user_summary.html
+++ b/sdcm/utils/cloud_monitor/templates/per_user_summary.html
@@ -37,4 +37,35 @@
         {% endfor %}
     </table>
     {% endfor %}
-    <h2>For detailed report download and open attached html</h2>
+
+{% if report.crs %}
+    <h3>Active Capacity Reservations (AWS)</h3>
+    <table id="results_table">
+        <tr>
+            <th>User</th>
+            <th>Region</th>
+            <th>Instance Type</th>
+            <th>Capacity total</th>
+            <th>Capacity available</th>
+            <th>Start Time</th>
+            <th>id</th>
+        </tr>
+        {% for cr in report.crs %}
+            <tr>
+                <td>{{ cr.user }}</td>
+                <td>{{ cr.region }}</td>
+                <td>{{ cr.instance_type }}</td>
+                <td>{{ cr.capacity_total }}</td>
+                {% if cr.is_unused %}
+                    <td><span class="red fbold">{{ cr.capacity_available }}</span></td>
+                {% else %}
+                    <td>{{ cr.capacity_available }}</td>
+                {% endif %}
+                <td>{{ cr.start_time }}</td>
+                <td>{{ cr.id }}</td>
+            </tr>
+        {% endfor %}
+    </table>
+{% endif %}
+
+<h2>For detailed report download and open attached html</h2>


### PR DESCRIPTION
We want to monitor active AWS capacity reservations. Enhance cloud usage report to list all active capacity reservations and how are used. In case is not used, mark in red given value. CR section will be visible only if there are active CR's and will include:
user, region, instance type, capacity total, capacity available, start time and id.

refs: https://github.com/scylladb/qa-tasks/issues/1846

Report look (below other tables):
![image](https://github.com/user-attachments/assets/9bd9eb81-8e40-4bcc-9bd9-d493ce7025f9)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] -  tested manually

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
