### PR TITLE
[Manager] Run Manager tests with enabled client encryption

### DIFF
--- a/configurations/disable_client_encrypt.yaml
+++ b/configurations/disable_client_encrypt.yaml
@@ -1,0 +1,1 @@
+client_encrypt: false

--- a/jenkins-pipelines/manager/ubuntu24-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-sanity.jenkinsfile
@@ -7,7 +7,7 @@ managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
     test_name: 'mgmt_cli_test.ManagerSanityTests.test_manager_sanity',
-    test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/manager/ubuntu24.yaml"]''',
+    test_config: '''["test-cases/manager/manager-regression-singleDC-set-distro.yaml", "configurations/manager/ubuntu24.yaml", "configurations/disable_client_encrypt.yaml"]''',
 
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/jenkins-pipelines/manager/ubuntu24-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-upgrade.jenkinsfile
@@ -13,7 +13,7 @@ managerPipeline(
     manager_version: '3.4.0',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
-    test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu24.yaml"]''',
+    test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu24.yaml", "configurations/disable_client_encrypt.yaml"]''',
 
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -1147,18 +1147,21 @@ class ManagerHealthCheckTests(ManagerTestFunctionsMixIn):
 
 class ManagerEncryptionTests(ManagerTestFunctionsMixIn):
 
+    def _disable_client_encryption(self) -> None:
+        for node in self.db_cluster.nodes:
+            with node.remote_scylla_yaml() as scylla_yml:
+                scylla_yml.client_encryption_options.enabled = False
+            node.restart_scylla()
+
     def test_client_encryption(self):
         self.log.info('starting test_client_encryption')
+
+        self.log.info('ENABLED client encryption checks')
+        if not self.db_cluster.nodes[0].is_client_encrypt:
+            self.db_cluster.enable_client_encrypt()
+
         manager_node = self.monitors.nodes[0]
         manager_tool = mgmt.get_scylla_manager_tool(manager_node=manager_node)
-        mgr_cluster = self.ensure_and_get_cluster(manager_tool)
-        dict_host_health = mgr_cluster.get_hosts_health()
-        for host_health in dict_host_health.values():
-            assert host_health.ssl == HostSsl.OFF, "Not all hosts ssl is 'OFF'"
-
-        healthcheck_task = mgr_cluster.get_healthcheck_task()
-
-        self.db_cluster.enable_client_encrypt()
 
         self.log.info("Create and send client TLS certificate/key to the manager node")
         manager_node.create_node_certificate(cert_file=manager_node.ssl_conf_dir / TLSAssets.CLIENT_CERT,
@@ -1166,24 +1169,29 @@ class ManagerEncryptionTests(ManagerTestFunctionsMixIn):
         manager_node.remoter.run(f'mkdir -p {mgmt.cli.SSL_CONF_DIR}')
         manager_node.remoter.send_files(src=str(manager_node.ssl_conf_dir) + '/', dst=str(mgmt.cli.SSL_CONF_DIR))
 
-        # SM caches scylla nodes configuration and the healthcheck svc is independent from the cache updates.
-        # Cache is being updated periodically, every 1 minute following the manager config for SCT.
-        # We need to wait until SM is aware about the configuration change.
-        mgr_cluster.update(
-            client_encrypt=True,
-            force_non_ssl_session_port=mgr_cluster.sctool.is_minimum_3_2_6_or_snapshot
-        )
-        time.sleep(90)
+        mgr_cluster = self.ensure_and_get_cluster(manager_tool, force_add=True, client_encrypt=True)
 
+        healthcheck_task = mgr_cluster.get_healthcheck_task()
         healthcheck_task.wait_for_status(list_status=[TaskStatus.DONE], step=5, timeout=240)
-        sleep = 40
-        self.log.debug('Sleep {} seconds, waiting for health-check task to run by schedule on first time'.format(sleep))
-        time.sleep(sleep)
         self.log.debug("Health-check task history is: {}".format(healthcheck_task.history))
+
         dict_host_health = mgr_cluster.get_hosts_health()
         for host_health in dict_host_health.values():
             assert host_health.ssl == HostSsl.ON, "Not all hosts ssl is 'ON'"
             assert host_health.status == HostStatus.UP, "Not all hosts status is 'UP'"
+
+        self.log.info('DISABLED client encryption checks')
+        self._disable_client_encryption()
+        # SM caches scylla nodes configuration and the healthcheck svc is independent on the cache updates.
+        # Cache is being updated periodically, every 1 minute following the manager config for SCT.
+        # We need to wait until SM is aware about the configuration change.
+        sleep_time = 90
+        self.log.debug('Sleep %s seconds, waiting for SM is aware about the configuration change', sleep_time)
+        time.sleep(sleep_time)
+
+        dict_host_health = mgr_cluster.get_hosts_health()
+        for host_health in dict_host_health.values():
+            assert host_health.ssl == HostSsl.OFF, "Not all hosts ssl is 'OFF'"
 
         mgr_cluster.delete()  # remove cluster at the end of the test
         self.log.info('finishing test_client_encryption')

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -73,8 +73,13 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
             LOGGER.info("The new Scylla Manager is:\n{}".format(scylla_manager_yaml))
         manager_node.restart_manager_server(port=new_manager_http_port)
         manager_tool = get_scylla_manager_tool(manager_node=manager_node)
-        manager_tool.add_cluster(name="cluster_under_test", db_cluster=self.db_cluster,
-                                 auth_token=self.monitors.mgmt_auth_token)
+        is_force_non_ssl_session_port = manager_tool.is_force_non_ssl_session_port(db_cluster=self.db_cluster)
+        manager_tool.add_cluster(
+            name="cluster_under_test",
+            db_cluster=self.db_cluster,
+            auth_token=self.monitors.mgmt_auth_token,
+            force_non_ssl_session_port=is_force_non_ssl_session_port,
+        )
         current_manager_version = manager_tool.sctool.version
 
         LOGGER.debug("Generating load")

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -1388,10 +1388,6 @@ class SCTool:
     def is_v3_cli(self):
         return self.parsed_client_version >= new_command_structure_minimum_version
 
-    @property
-    def is_minimum_3_2_6_or_snapshot(self):
-        return self.parsed_client_version >= forcing_tls_minimum_version or self.client_version == "Snapshot"
-
 
 class ScyllaMgmt:
     """

--- a/test-cases/manager/manager-backup-restore-set-dataset.yaml
+++ b/test-cases/manager/manager-backup-restore-set-dataset.yaml
@@ -14,6 +14,8 @@ n_db_nodes: 3
 n_loaders: 4
 n_monitor_nodes: 1
 
+client_encrypt: true
+
 post_behavior_db_nodes: "destroy"
 post_behavior_loader_nodes: "destroy"
 post_behavior_monitor_nodes: "destroy"

--- a/test-cases/manager/manager-installation-set-distro.yaml
+++ b/test-cases/manager/manager-installation-set-distro.yaml
@@ -6,4 +6,6 @@ n_db_nodes: 1
 n_loaders: 0
 n_monitor_nodes: 1
 
+client_encrypt: true
+
 user_prefix: manager-installation

--- a/test-cases/manager/manager-no-delta-backup-set-dataset.yaml
+++ b/test-cases/manager/manager-no-delta-backup-set-dataset.yaml
@@ -11,4 +11,6 @@ n_db_nodes: 3
 n_monitor_nodes: 1
 n_loaders: 1
 
+client_encrypt: true
+
 user_prefix: manager-backup

--- a/test-cases/manager/manager-regression-azure.yaml
+++ b/test-cases/manager/manager-regression-azure.yaml
@@ -11,6 +11,8 @@ azure_image_monitor: 'RedHat:RHEL:9_5:latest'
 # Default 50 GB value is changed here as the size of the corresponding disk in the VM image: 64 GB
 root_disk_size_monitor: 64
 
+client_encrypt: true
+
 post_behavior_db_nodes: "destroy"
 post_behavior_loader_nodes: "destroy"
 post_behavior_monitor_nodes: "destroy"

--- a/test-cases/manager/manager-regression-ipv6.yaml
+++ b/test-cases/manager/manager-regression-ipv6.yaml
@@ -11,6 +11,8 @@ n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
 
+client_encrypt: true
+
 post_behavior_db_nodes: "destroy"
 post_behavior_loader_nodes: "destroy"
 post_behavior_monitor_nodes: "keep-on-failure"

--- a/test-cases/manager/manager-regression-multiDC-gce.yaml
+++ b/test-cases/manager/manager-regression-multiDC-gce.yaml
@@ -7,6 +7,8 @@ n_db_nodes: "2 1"
 n_loaders: 1
 n_monitor_nodes: 1
 
+client_encrypt: true
+
 post_behavior_db_nodes: "destroy"
 post_behavior_loader_nodes: "destroy"
 post_behavior_monitor_nodes: "destroy"

--- a/test-cases/manager/manager-regression-multiDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-multiDC-set-distro.yaml
@@ -11,6 +11,8 @@ n_db_nodes: '2 1'
 n_loaders: 1
 n_monitor_nodes: 1
 
+client_encrypt: true
+
 post_behavior_db_nodes: "destroy"
 post_behavior_loader_nodes: "destroy"
 post_behavior_monitor_nodes: "destroy"

--- a/test-cases/manager/manager-regression-singleDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-singleDC-set-distro.yaml
@@ -11,6 +11,8 @@ n_db_nodes: '3'
 n_loaders: 1
 n_monitor_nodes: 1
 
+client_encrypt: true
+
 post_behavior_db_nodes: "destroy"
 post_behavior_loader_nodes: "destroy"
 post_behavior_monitor_nodes: "destroy"

--- a/test-cases/manager/manager-restore-outside.yaml
+++ b/test-cases/manager/manager-restore-outside.yaml
@@ -7,6 +7,8 @@ n_db_nodes: 3
 n_monitor_nodes: 1
 n_loaders: 0
 
+client_encrypt: true
+
 mgmt_reuse_backup_snapshot_name: '500gb_1t_ics'
 mgmt_skip_post_restore_stress_read: true
 

--- a/test-cases/upgrades/manager-upgrade.yaml
+++ b/test-cases/upgrades/manager-upgrade.yaml
@@ -11,6 +11,8 @@ n_db_nodes: '3'
 n_loaders: 1
 n_monitor_nodes: 1
 
+client_encrypt: true
+
 post_behavior_db_nodes: "destroy"
 post_behavior_loader_nodes: "destroy"
 post_behavior_monitor_nodes: "destroy"


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-manager/issues/4164

**Changes:**
- Updated `ensure_and_get_cluster` method to apply `--force_non_ssl_session_port` flag in add cluster command if client encryption is enabled. Together with that, updated `add_cluster` method in upgrade and installation tests as well.
- Updated `test_client_encryption` to make it independent of initial cluster state.
- Enabled client encryption for most Manager tests, except of one sanity (ubuntu24-manager-sanity) and one upgrade test (ubuntu24-manager-upgrade).

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [ubuntu22-upgrade-test](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master-clone/job/ubuntu22-upgrade-test/1/), enabled encryption
- [x] [ubuntu24-upgrade-test](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master-clone/job/ubuntu24-upgrade-test/2/), disabled encryption
- [x] [sct-manager-backup-test](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master-clone/job/sct-feature-test-backup/1/), enabled encryption
- [x] [rocky9-installation-test](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master-clone/job/rocky9-installation-test/2), enabled encryption
- [x] [ubuntu22-sanity-test](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master-clone/job/ubuntu22-sanity-test/3/), enabled encryption

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code