### PR TITLE
[Manager] Force non ssl session port utilization for Nemesis tests

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -611,6 +611,14 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         return 'true' in result.stdout.lower()
 
     @property
+    def is_native_transport_port_ssl(self):
+        result = self.remoter.run(
+            cmd=f"grep '^native_transport_port_ssl:' {self.add_install_prefix(SCYLLA_YAML_PATH)}",
+            ignore_status=True,
+        )
+        return 'native_transport_port_ssl' in result.stdout
+
+    @property
     def cpu_cores(self) -> Optional[int]:
         try:
             result = self.remoter.run("nproc", ignore_status=True)
@@ -5095,8 +5103,13 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         if host_ip is None:
             host_ip = self.nodes[0].scylla_listen_address
         credentials = self.get_db_auth()  # pylint: disable=no-member
-        return manager_tool.add_cluster(name=cluster_name, host=host_ip, auth_token=self.scylla_manager_auth_token,
-                                        credentials=credentials)
+        return manager_tool.add_cluster(
+            name=cluster_name,
+            host=host_ip,
+            auth_token=self.scylla_manager_auth_token,
+            credentials=credentials,
+            force_non_ssl_session_port=manager_tool.is_force_non_ssl_session_port(db_cluster=self),
+        )
 
     def is_additional_data_volume_used(self) -> bool:
         """return true if additional data volume is configured

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -1037,7 +1037,7 @@ class ScyllaManagerTool(ScyllaManagerBase):
         return [[n, n.ip_address] for n in db_cluster.nodes]
 
     def add_cluster(self, name, host=None, db_cluster=None, client_encrypt=None, disable_automatic_repair=True,  # pylint: disable=too-many-arguments
-                    auth_token=None, credentials=None):
+                    auth_token=None, credentials=None, force_non_ssl_session_port=False):
         """
         :param name: cluster name
         :param host: cluster node IP
@@ -1047,6 +1047,7 @@ class ScyllaManagerTool(ScyllaManagerBase):
          This param removes that task.
         :param auth_token: a token used to authenticate requests to the Agent
         :param credentials: a tuple of the username and password that are used to access the cluster.
+        :param force_non_ssl_session_port: force SM to always use the non-SSL port for TLS-enabled cluster CQL sessions.
         :return: ManagerCluster
 
         Add a cluster to manager
@@ -1079,6 +1080,10 @@ class ScyllaManagerTool(ScyllaManagerBase):
         # FIXME: if cluster already added, print a warning, but not fail
         cmd = 'cluster add --host={}  --name={} --auth-token {}'.format(
             host, name, auth_token)
+
+        if force_non_ssl_session_port:
+            cmd += " --force-non-ssl-session-port"
+
         # Adding client-encryption parameters if required
         if client_encrypt:
             if not db_cluster:
@@ -1115,6 +1120,11 @@ class ScyllaManagerTool(ScyllaManagerBase):
 
     def rollback_upgrade(self, scylla_mgmt_address):
         raise NotImplementedError
+
+    @staticmethod
+    def is_force_non_ssl_session_port(db_cluster) -> bool:
+        _node = db_cluster.nodes[0]
+        return _node.is_client_encrypt and not _node.is_native_transport_port_ssl
 
 
 class ScyllaManagerToolRedhatLike(ScyllaManagerTool):

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -1053,33 +1053,19 @@ class ScyllaManagerTool(ScyllaManagerBase):
         Add a cluster to manager
 
         Usage:
-          sctool cluster add [flags]
-
-        Flags:
-          -h, --help                      help for add
-              --host string               hostname or IP of one of the cluster nodes
-          -n, --name alias                alias you can give to your cluster
-              --ssl-user-cert-file path   path to client certificate when using client/server encryption with require_client_auth enabled
-              --ssl-user-key-file path    path to key associated with ssl-user-cert-file
-
-        Global Flags:
-              --api-url URL    URL of Scylla Manager server (default "https://127.0.0.1:5443/api/v1")
-          -c, --cluster name   target cluster name or ID
+          sctool cluster add --host <IP> [--name <alias>] [--auth-token <token>] [flags]
 
         Scylla Docs:
-          https://docs.scylladb.com/operating-scylla/manager/1.4/add-a-cluster/
-          https://docs.scylladb.com/operating-scylla/manager/1.4/sctool/#cluster-add
-
-
+          https://manager.docs.scylladb.com/stable/add-a-cluster.html
+          https://manager.docs.scylladb.com/stable/sctool#cluster-add
         """
         # pylint: disable=too-many-locals
-
         if not any([host, db_cluster]):
             raise ScyllaManagerError("Neither host or db_cluster parameter were given to Manager add_cluster")
+
         host = host or self.get_cluster_hosts_ip(db_cluster=db_cluster)[0]
-        # FIXME: if cluster already added, print a warning, but not fail
-        cmd = 'cluster add --host={}  --name={} --auth-token {}'.format(
-            host, name, auth_token)
+
+        cmd = 'cluster add --host {} --name {} --auth-token {}'.format(host, name, auth_token)
 
         if force_non_ssl_session_port:
             cmd += " --force-non-ssl-session-port"
@@ -1091,17 +1077,20 @@ class ScyllaManagerTool(ScyllaManagerBase):
                                "fail since not using client-encryption parameters.")
             else:  # check if scylla-node has client-encrypt
                 db_node, _ip = self.get_cluster_hosts_with_ips(db_cluster=db_cluster)[0]
-                if client_encrypt or db_node.is_client_encrypt:
+                if db_node.is_client_encrypt:
                     cmd += " --ssl-user-cert-file {} --ssl-user-key-file {}".format(SSL_USER_CERT_FILE,
                                                                                     SSL_USER_KEY_FILE)
+
         if credentials:
             username, password = credentials
             cmd += f" --username {username} --password {password}"
+
         res_cluster_add = self.sctool.run(cmd, parse_table_res=False)
         if not res_cluster_add or 'Cluster added' not in res_cluster_add.stderr:
             raise ScyllaManagerError("Encountered an error on 'sctool cluster add' command response: {}".format(
                 res_cluster_add))
         cluster_id = res_cluster_add.stdout.split('\n')[0]
+
         # return ManagerCluster instance with the manager's new cluster-id
         manager_cluster = self.clusterClass(manager_node=self.manager_node, cluster_id=cluster_id,
                                             client_encrypt=client_encrypt)

--- a/sdcm/mgmt/operator.py
+++ b/sdcm/mgmt/operator.py
@@ -421,7 +421,7 @@ class ScyllaManagerToolOperator(ScyllaManagerTool):
         raise NotImplementedError()
 
     def add_cluster(self, name, host=None, db_cluster=None, client_encrypt=None, disable_automatic_repair=True,
-                    auth_token=None, credentials=None):
+                    auth_token=None, credentials=None, force_non_ssl_session_port=False):
         raise NotImplementedError()
 
     def upgrade(self, scylla_mgmt_upgrade_to_repo):


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-manager/issues/4206

This PR enhances the ScyllaManagerTool.add_cluster method by introducing the force_non_ssl_session_port parameter, ensuring that the --force-non-ssl-session-port flag is used appropriately in sctool cluster add operations.

This flag will be applied in `sctool cluster add` operation in Nemesis tests if:
- Scylla client encryption is enabled;
- Scylla doesn't utilize native_transport_port_ssl (9142).

Also, PR includes a tiny refactoring for ScyllaManagerTool.add_cluster method:
- Updated docstrings with relevant information;
- Removed unnecessary empty lines and duplicate conditions.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [disrupt_mgr_backup](https://argus.scylladb.com/tests/scylla-cluster-tests/08737630-011e-460b-a116-4866ab45cebe)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code