### PR TITLE
fix(DecommissionStreamingErr): new log lines added

### DIFF
--- a/sdcm/utils/raft/__init__.py
+++ b/sdcm/utils/raft/__init__.py
@@ -51,14 +51,14 @@ BACKEND_TIMEOUTS: dict[str, Mapping[LogPosition, int]] = {
 
 ABORT_DECOMMISSION_LOG_PATTERNS: Iterable[MessagePosition] = [
     MessagePosition("api - decommission", LogPosition.BEGIN),
-    MessagePosition("DECOMMISSIONING: unbootstrap starts", LogPosition.BEGIN),
-    MessagePosition("DECOMMISSIONING: unbootstrap done", LogPosition.END),
-    MessagePosition("becoming a group 0 non-voter", LogPosition.END),
-    MessagePosition("became a group 0 non-voter", LogPosition.END),
-    MessagePosition("leaving token ring", LogPosition.END),
-    MessagePosition("left token ring", LogPosition.END),
     MessagePosition("raft_topology - decommission: waiting for completion", LogPosition.BEGIN),
-    MessagePosition("repair - decommission_with_repair", LogPosition.END)
+    MessagePosition("repair - decommission_with_repair", LogPosition.END),
+    MessagePosition("raft_topology - request decommission for", LogPosition.BEGIN),
+    MessagePosition("storage_service - Started batchlog replay for decommission", LogPosition.END),
+    MessagePosition("raft_topology - start streaming", LogPosition.BEGIN),
+    MessagePosition("raft_topology - streaming completed", LogPosition.END),
+    MessagePosition("raft_topology - decommission: successfully removed from topology", LogPosition.END),
+    MessagePosition("raft_topology - Decommission succeeded", LogPosition.END),
 ]
 
 ABORT_BOOTSTRAP_LOG_PATTERNS: Iterable[MessagePosition] = [


### PR DESCRIPTION
new log lines added for aborting the decommission process

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9501

### Testing
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/eugene_test_folder/job/decommission_logs_testing/
https://argus.scylladb.com/tests/scylla-cluster-tests/d4151c1d-bce7-4689-91f4-67269dc2ef44

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
