### PR TITLE
improvement(nemesis): allow specify different seeds for parallel nemesis

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4548,7 +4548,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         for nem in nemesis:
             nemesis_obj = nem['nemesis'](tester_obj=tester_obj,
                                          termination_event=self.nemesis_termination_event,
-                                         nemesis_selector=nem['nemesis_selector'])
+                                         nemesis_selector=nem['nemesis_selector'],
+                                         nemesis_seed=nem['nemesis_seed'])
             if hdr_tags:
                 nemesis_obj.hdr_tags = hdr_tags
             self.nemesis.append(nemesis_obj)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -666,8 +666,9 @@ class SCTConfiguration(dict):
              help="""Run nemesis during prepare stage of the test"""),
 
         dict(name="nemesis_seed", env="SCT_NEMESIS_SEED",
-             type=int, k8s_multitenancy_supported=True,
-             help="""A seed number in order to repeat nemesis sequence as part of SisyphusMonkey"""),
+             type=int_or_space_separated_ints, k8s_multitenancy_supported=True,
+             help="""A seed number in order to repeat nemesis sequence as part of SisyphusMonkey.
+             Can provide a list of seeds for multiple nemesis"""),
 
         dict(name="nemesis_add_node_cnt",
              env="SCT_NEMESIS_ADD_NODE_CNT",

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1188,11 +1188,16 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         nemesis_threads = []
         list_class_name = self.params.get('nemesis_class_name')
         nemesis_selectors = self.params.get("nemesis_selector")
+        nemesis_seeds = self.params.get("nemesis_seed")
 
         if nemesis_selectors and isinstance(nemesis_selectors, str):
             nemesis_selectors = [nemesis_selectors]
         if nemesis_selectors and isinstance(nemesis_selectors[0], str):
             nemesis_selectors = [nemesis_selectors[:]]
+        if nemesis_seeds and isinstance(nemesis_seeds, int):
+            nemesis_seeds = [nemesis_seeds]
+        if nemesis_seeds and isinstance(nemesis_seeds, str):
+            nemesis_seeds = [int(seed) for seed in nemesis_seeds.split()]
 
         nemesis_class_names = []
         for i, klass in enumerate(list_class_name.split(' ')):
@@ -1216,7 +1221,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                     self.log.warning("Missing nemesis selector. use default. %s", details)
 
             nemesis_threads.append({'nemesis': getattr(nemesis, nemesis_name),
-                                    'nemesis_selector': nemesis_selector})
+                                    'nemesis_selector': nemesis_selector,
+                                    'nemesis_seed': int(nemesis_seeds[i % len(nemesis_seeds)]) if nemesis_seeds else None})
 
         self.log.debug("Nemesis threads %s", nemesis_threads)
         return nemesis_threads

--- a/sdcm/utils/operations_thread.py
+++ b/sdcm/utils/operations_thread.py
@@ -118,6 +118,10 @@ class OperationThread:
         self.log = logging.getLogger(self.__class__.__name__)
         self.log.debug("Thread params: %s", thread_params)
         nemesis_seed = self.thread_params.db_cluster.params.get("nemesis_seed")
+        if isinstance(nemesis_seed, list):
+            nemesis_seed = nemesis_seed[0]
+        if isinstance(nemesis_seed, str):
+            nemesis_seed = int(nemesis_seed.split()[0])
         self.generator = random.Random(int(nemesis_seed)) if nemesis_seed else random.Random()
         self._thread = threading.Thread(daemon=True, name=f"{self.__class__.__name__}_{thread_name}", target=self.run)
         self.termination_event = thread_params.termination_event

--- a/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
@@ -19,6 +19,7 @@ instance_type_db: 'i3en.2xlarge'
 
 nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
 nemesis_selector: [["topology_changes"],["!disruptive","schema_changes"]]
+nemesis_seed: '253 328'
 nemesis_interval: 10
 nemesis_filter_seeds: false
 nemesis_during_prepare: false


### PR DESCRIPTION
When running parallel nemesis all take the same seed. Sometimes one might specify different ones for each.

This commit allows to specify seeds as a list (or space separated ints) so each nemesis will get own seed.
It works by cycling through nemesis_seed list when defining nemesis arguments.

closes: https://github.com/scylladb/scylla-cluster-tests/issues/9333

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [multiple nemesis test](https://argus.scylladb.com/tests/scylla-cluster-tests/1bd8d781-6fdf-45d1-b0f5-61d276b4eda6) aborted, but in logs seeds are used properly
- [x] - [single seed](https://argus.scylladb.com/tests/scylla-cluster-tests/d73428a8-e717-4ef2-b110-9fef66f3422d)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
