### PR TITLE
fix(LoaderUtilsMixin): table_enabled was allways True as this feature is allways enabled

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5070,10 +5070,9 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
     def decommission(self, node: BaseNode, timeout: int | float = None) -> DataCenterTopologyRfControl | None:
         if not node._is_zero_token_node:
-            with node.parent_cluster.cql_connection_patient(node) as session:
-                if tablets_enabled := is_tablets_feature_enabled(session):
-                    dc_topology_rf_change = DataCenterTopologyRfControl(target_node=node)
-                    dc_topology_rf_change.decrease_keyspaces_rf()
+            if tablets_enabled := is_tablets_feature_enabled(node):
+                dc_topology_rf_change = DataCenterTopologyRfControl(target_node=node)
+                dc_topology_rf_change.decrease_keyspaces_rf()
         with adaptive_timeout(operation=Operations.DECOMMISSION, node=node):
             node.run_nodetool("decommission", timeout=timeout, long_running=True, retry=0)
         self.verify_decommission(node)

--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -3195,8 +3195,7 @@ class FillDatabaseData(ClusterTester):
     @property
     def tablets_enabled(self) -> bool:
         """Check is tablets enabled on cluster"""
-        with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
-            return is_tablets_feature_enabled(session)
+        return is_tablets_feature_enabled(self.db_cluster.nodes[0])
 
     @retrying(n=3, sleep_time=20, allowed_exceptions=ProtocolException)
     def truncate_table(self, session, truncate):  # pylint: disable=no-self-use

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1051,10 +1051,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 "Run 'disrupt_nodetool_flush_and_reshard_on_kubernetes' instead")
 
         # If tablets in use, skipping resharding since it is not supported.
-        with self.cluster.cql_connection_patient(self.target_node) as session:
-            if is_tablets_feature_enabled(session=session):
-                if SkipPerIssues('https://github.com/scylladb/scylladb/issues/16739', params=self.tester.params):
-                    raise UnsupportedNemesis('https://github.com/scylladb/scylladb/issues/16739')
+        if is_tablets_feature_enabled(self.target_node):
+            if SkipPerIssues('https://github.com/scylladb/scylladb/issues/16739', params=self.tester.params):
+                raise UnsupportedNemesis('https://github.com/scylladb/scylladb/issues/16739')
 
         murmur3_partitioner_ignore_msb_bits = 15  # pylint: disable=invalid-name
         self.log.info(f'Restart node with resharding. New murmur3_partitioner_ignore_msb_bits value: '

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -802,11 +802,12 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         """
         n_db_nodes = str(self.params.get('n_db_nodes'))
         min_nodes_dc = min([int(nodes_num) for nodes_num in n_db_nodes.split() if int(nodes_num) > 0])
-        with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
-            # In case tablets are enabled, it's better to set RF smaller than dc-nodes-number, so decommission is allowed.
-            rf_candidate = max([min_nodes_dc - 1, 1]) if is_tablets_feature_enabled(session) else min_nodes_dc
-            # NOTE: use RF=3 at max to avoid problems on big setups
-            return min(rf_candidate, 3)
+
+        # In case tablets are enabled, it's better to set RF smaller than dc-nodes-number, so decommission is allowed.
+        rf_candidate = max([min_nodes_dc - 1, 1]
+                           ) if is_tablets_feature_enabled(self.db_cluster.nodes[0]) else min_nodes_dc
+        # NOTE: use RF=3 at max to avoid problems on big setups
+        return min(rf_candidate, 3)
 
     @property
     def test_id(self):

--- a/sdcm/utils/loader_utils.py
+++ b/sdcm/utils/loader_utils.py
@@ -98,8 +98,7 @@ class LoaderUtilsMixin:
     @cached_property
     def tablets_enabled(self):
         # is tablets feature enabled in Scylla configuration.
-        with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
-            return is_tablets_feature_enabled(session)
+        return is_tablets_feature_enabled(self.db_cluster.nodes[0])
 
     def _run_all_stress_cmds(self, stress_queue, params):
         stress_cmds = params['stress_cmd']

--- a/sdcm/utils/tablets/common.py
+++ b/sdcm/utils/tablets/common.py
@@ -34,10 +34,9 @@ def wait_no_tablets_migration_running(node):
     "currently a small time window after adding nodes and before load balancing starts during which
     topology may appear as quiesced because the state machine goes through an idle state before it enters load balancing state"
     """
-    with node.parent_cluster.cql_connection_patient(node=node) as session:
-        if not is_tablets_feature_enabled(session):
-            LOGGER.info("Tablets are disabled, skipping wait for balance")
-            return
+    if not is_tablets_feature_enabled(node):
+        LOGGER.info("Tablets are disabled, skipping wait for balance")
+        return
     time.sleep(60)  # one minute gap before checking, just to give some time to the state machine
     client = RemoteCurlClient(host="127.0.0.1:10000", endpoint="", node=node)
     LOGGER.info("Waiting for having no ongoing tablets topology operations")

--- a/sla_per_user_system_test.py
+++ b/sla_per_user_system_test.py
@@ -374,7 +374,7 @@ class SlaPerUserTest(LongevityTest):
     def _two_users_load_througput_workload(self, shares, load, expected_shares_ratio=None):
         session = self.prepare_schema()
 
-        if is_tablets_feature_enabled(session=session):
+        if is_tablets_feature_enabled(self.db_cluster.nodes[0]):
             self.run_pre_create_keyspace()
             # after several test runs with Tablets decided to decrease by half of the percent(usually tests show about 96.8 - 97.5)
             # due to unbalanced shards utilization with tablets(particular tablet belong to particular shard)


### PR DESCRIPTION
Enabling/disabling tablets was changed. Now we have to check scylla yaml or keystore schema.
For more info see
- https://github.com/scylladb/scylladb/pull/21451
- https://github.com/scylladb/scylladb/pull/21614

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/jsmolar/job/longevity-counters-3h-test/9/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
