### PR TITLE
fix(web_install): always use scylla as product

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2123,10 +2123,9 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
 
         https://github.com/scylladb/scylla-web-install
         """
-        is_enterprise, version = assume_version(self.parent_cluster.params, scylla_version)
-        product_type = '--scylla-product scylla-enterprise' if is_enterprise else ''
+        version = assume_version(self.parent_cluster.params, scylla_version)
         self.remoter.run(
-            f"curl -sSf get.scylladb.com/server | sudo bash -s -- --scylla-version {version} {product_type}")
+            f"curl -sSf get.scylladb.com/server | sudo bash -s -- --scylla-version {version}")
 
     def install_scylla_debuginfo(self) -> None:
         if self.distro.is_rhel_like or self.distro.is_sles:

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -437,9 +437,9 @@ def is_enterprise(scylla_version):
     return bool(re.search(r"^20[0-9]{2}.*", scylla_version))
 
 
-def assume_version(params: dict[str], scylla_version: Optional[str] = None) -> tuple[bool, str]:
+def assume_version(params: dict[str], scylla_version: Optional[str] = None) -> str:
     # Try to get the major version from the branch name, it will only be used when scylla_version isn't assigned.
-    # It can be switched to RELEASE_BRANCH from upstream job
+    # It can be switched to RELEASE_BRANCH from an upstream job
     git_branch = os.environ.get('GIT_BRANCH')  # origin/branch-4.5
     scylla_repo = params.get('scylla_repo')
 
@@ -448,16 +448,11 @@ def assume_version(params: dict[str], scylla_version: Optional[str] = None) -> t
     if match := re.match(r'[\D\d]*-(\d+\.\d+)', scylla_version_source) or \
             re.match(r'\D*(\d+\.\d+)', scylla_version_source):
         version_type = f"nightly-{match.group(1)}"
-        is_enterprise_version = is_enterprise(match.group(1))
-    elif scylla_version_source and 'enterprise' in scylla_version_source:
-        version_type = "nightly-enterprise"
-        is_enterprise_version = True
     elif scylla_version_source and 'master' in scylla_version_source:
         version_type = "nightly-master"
-        is_enterprise_version = False
     else:
         raise Exception("Scylla version for web install isn't identified")
-    return is_enterprise_version, version_type
+    return version_type
 
 
 def get_gemini_version(output: str):

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -141,42 +141,20 @@ class TestVersionUtils(unittest.TestCase):
         self.assertIn('4.5.3', get_all_versions(
             'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.5.repo'))
 
-    def test_08_assume_versions_oss(self):
-        with unittest.mock.patch.object(os.environ, 'get', return_value='branch-5.0', clear=True):
-            params = {}
-            is_version_enterprise, version = assume_version(params)
-            self.assertTrue(not is_version_enterprise, 'This should be OSS')
-            self.assertEqual(version, 'nightly-5.0', 'Version should be 5.0')
-
-            scylla_version = '5.0'
-            is_version_enterprise, version = assume_version(params, scylla_version)
-            self.assertTrue(not is_version_enterprise, 'This should be OSS')
-            self.assertEqual(version, 'nightly-5.0', 'Version should be 5.0')
-
-            repo_url = 'https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla/branch-5.0/rpm/centos/' \
-                       '2022-05-10T07:40:41Z/scylla.repo'
-            params.update({'scylla_repo': repo_url})
-            is_version_enterprise, version = assume_version(params)
-            self.assertTrue(not is_version_enterprise, 'This should be OSS')
-            self.assertEqual(version, 'nightly-5.0', 'Version should be 5.0')
-
-    def test_09_assume_versions_enterprise(self):
+    def test_09_assume_versions(self):
         with unittest.mock.patch.object(os.environ, 'get', return_value='branch-2022.1', clear=True):
             params = {}
-            is_version_enterprise, version = assume_version(params)
-            self.assertTrue(is_version_enterprise, 'This should be enterprise')
+            version = assume_version(params)
             self.assertEqual(version, 'nightly-2022.1', 'Version should be 2022.1')
 
             scylla_version = '2022.1'
-            is_version_enterprise, version = assume_version(params, scylla_version)
-            self.assertTrue(is_version_enterprise, 'This should be enterprise')
+            version = assume_version(params, scylla_version)
             self.assertEqual(version, 'nightly-2022.1', 'Version should be 2022.1')
 
             repo_url = 'http://downloads.scylladb.com/unstable/scylla-enterprise/enterprise-2022.1/deb/unified/' \
                        '2022-05-10T22:12:50Z/scylladb-2022.1/scylla.list'
             params.update({'scylla_repo': repo_url})
-            is_version_enterprise, version = assume_version(params)
-            self.assertTrue(is_version_enterprise, 'This should be enterprise')
+            version = assume_version(params)
             self.assertEqual(version, 'nightly-2022.1', 'Version should be 2022.1')
 
 


### PR DESCRIPTION
artifacts-centos9-web-test failed with the following error:

```
'curl -sSf get.scylladb.com/server | sudo bash -s -- --scylla-version nightly-2025.1 --scylla-product scylla-enterprise'
Exit code: 1
Stdout:
Installing Scylla version nightly-2025.1 for CentOS ...
The specified scylla-version 'nightly-2025.1' has reached End of Life (EOL) or not available.
• For OSS supported ScyllaDB versions please refer to https://docs.scylladb.com/stable/getting-started/os-support
• For Enterprise supported ScyllaDB versions please refer to \
https://enterprise.docs.scylladb.com/stable/getting-started/os-support
```
modifying web_install to always use `scylla` as the  product

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/releng-testing/job/artifacts/job/artifacts-centos9-web-test/8/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
