### PR TITLE
fix(ToggleAuditNemesisSyslog): Remove enterprise-only restriction for audit feature

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5166,8 +5166,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             reduce categories by excluding DML and QUERY,
             verify DDL are logged in audit log correctly. Leaves audit log enabled this way.
         """
-        if not self.target_node.is_enterprise:
-            raise UnsupportedNemesis("Auditing feature is only supported by Scylla Enterprise")
+        if not self.target_node.is_enterprise and ComparableScyllaVersion(self.target_node.scylla_version) < "2025.1.0~dev":
+            raise UnsupportedNemesis(
+                "Auditing feature is only supported by Scylla Enterprise or non-enterprise versions greater than 6")
 
         if store == "syslog" and self._is_it_on_kubernetes():
             # generally syslog is not supported on K8S because of different log line format


### PR DESCRIPTION
This patch allows audit feature tested across all Scylla versions.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] https://argus.scylladb.com/tests/scylla-cluster-tests/c6bdd560-030a-4438-9c0e-9514db09a2be

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
