### PR TITLE
fix(BaseNode): fix is_enterprise property for 2025.1

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -123,7 +123,7 @@ from sdcm.utils.version_utils import (
     get_gemini_version,
     get_systemd_version,
     ComparableScyllaVersion,
-    SCYLLA_VERSION_RE,
+    SCYLLA_VERSION_RE, is_enterprise,
 )
 from sdcm.utils.net import get_my_ip
 from sdcm.utils.node import build_node_api_command
@@ -787,7 +787,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         return False
 
     def scylla_pkg(self):
-        return 'scylla-enterprise' if self.is_enterprise else 'scylla'
+        return 'scylla-enterprise' if self.is_product_enterprise else 'scylla'
 
     def file_exists(self, file_path: str) -> Optional[bool]:
         try:
@@ -813,8 +813,12 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             startup_interface_command = "ip link set {} up"
         self.remoter.sudo(startup_interface_command.format(interface_name))
 
+    @property
+    def is_enterprise(self) -> bool:
+        return is_enterprise(self.scylla_version)
+
     @optional_cached_property
-    def is_enterprise(self) -> bool | None:
+    def is_product_enterprise(self) -> bool | None:
         _is_enterprise = None
 
         if self.distro.is_rhel_like:
@@ -2840,17 +2844,10 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
 
     @property
     def is_cqlsh_support_cloud_bundle(self):
-        if bool(self.parent_cluster.connection_bundle_file):
-            if self.is_enterprise:
-                return ComparableScyllaVersion(self.scylla_version) >= "2022.3.0~dev"
-            else:
-                return ComparableScyllaVersion(self.scylla_version) >= "5.2.0~dev"
-        return False
+        return bool(self.parent_cluster.connection_bundle_file)
 
     @property
     def is_replacement_by_host_id_supported(self):
-        if self.is_enterprise:
-            return ComparableScyllaVersion(self.scylla_version) > '2022.3.0~dev'
         return ComparableScyllaVersion(self.scylla_version) > '5.2.0~dev'
 
     def _gen_cqlsh_cmd(self, command, keyspace, timeout, connect_timeout):

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -358,6 +358,7 @@ class TestBaseNodeGetScyllaVersion(unittest.TestCase):
 
     def test_scylla_enterprise_no_scylla_binary(self):
         self.node.is_enterprise = True
+        self.node.is_product_enterprise = True
         self.node.remoter = VersionDummyRemote(self, (
             ("/usr/bin/scylla --version", (127, "", "bash: scylla: command not found\n")),
             ("rpm --query --queryformat '%{VERSION}' scylla-enterprise", (0, "2019.1.4", "")),

--- a/unit_tests/test_utils_common.py
+++ b/unit_tests/test_utils_common.py
@@ -118,6 +118,7 @@ class DummyDbCluster(BaseCluster, BaseScyllaCluster):  # pylint: disable=abstrac
 class DummyNode(BaseNode):  # pylint: disable=abstract-method
     _system_log = None
     is_enterprise = False
+    is_product_enterprise = False
     distro = Distro.CENTOS7
 
     def init(self):


### PR DESCRIPTION
We used to verify installed package if is enterprise to determine product.
With 2025.1 being not enterprise package it no longer works as expected.

Fix by comparing scylla version to 6.3 - all versions above are counted as enterprise: this includes all 202x.x versions.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - tested locally truthiness of comparison
- [x] - provision test 
- [x] - [rocky9 artifact test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/artifacts-rocky9-test/11/) 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
