### PR TITLE
fix(kubernetis): get device name for k8s node

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3585,7 +3585,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if not self.target_node.install_traffic_control():
             raise UnsupportedNemesis("Traffic control package not installed on system")
 
-        if not self.target_node.scylla_network_configuration.device:
+        if (not self.target_node.scylla_network_configuration or
+                (self.target_node.scylla_network_configuration and not self.target_node.scylla_network_configuration.device)):
             raise ValueError("The network device name is not recognized")
 
         rate_limit: Optional[str] = self.get_rate_limit_for_network_disruption()

--- a/sdcm/provision/network_configuration.py
+++ b/sdcm/provision/network_configuration.py
@@ -98,7 +98,8 @@ class ScyllaNetworkConfiguration:
         # else empty string.
         if address_config := [conf for conf in self.scylla_network_config if conf["address"] == "broadcast_address"]:
             return "".join([ni.device_name for ni in self.network_interfaces if ni.device_index == address_config[0]['nic']])
-        return ""
+        # Workaround for k8s, while it does not support `scylla_network_config`
+        return self.network_interfaces[0].device_name if self.network_interfaces and self.network_interfaces[0].device_name else ""
 
     def get_ip_by_address_config(self, address_config: dict) -> str:
         if not (interface := [conf for conf in self.network_interfaces if address_config["nic"] == conf.device_index]):


### PR DESCRIPTION
After merging of https://github.com/scylladb/scylla-cluster-tests/pull/8925 Scylla Operator EKS longevity tests started to fail with error: AttributeError: 'NoneType' object has no attribute 'device'. K8s tests do not support 'node.scylla_network_configuration', it is supported by AWS only. Define 'scylla_network_configuration' for k8s and return hardcoded 'eth0' device name.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/10009

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] [longevity with disrupt_network_random_interruptions nemesis](https://argus.scylladb.com/tests/scylla-cluster-tests/2cdd0a38-76d0-4dfa-ac00-46a315772d83)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
