### PR TITLE
fix(integration-test): fix test_03_cassandra_stress_client_encrypt test

### DIFF
--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -1,5 +1,6 @@
 import logging
 import shlex
+import socket
 from functools import cached_property, cache
 from pathlib import Path
 
@@ -8,6 +9,7 @@ from invoke.exceptions import UnexpectedExit
 from sdcm.cluster import BaseNode
 from sdcm.remote.libssh2_client import UnexpectedExit as Libssh2_UnexpectedExit
 from sdcm.utils.common import get_data_dir_path
+from sdcm.utils.net import resolve_ip_to_dns
 
 LOGGER = logging.getLogger(__name__)
 
@@ -66,7 +68,10 @@ class RemoteDocker(BaseNode):
 
     @property
     def public_dns_name(self) -> str:
-        raise NotImplementedError()
+        try:
+            return resolve_ip_to_dns(self.external_address)
+        except (ValueError, socket.herror):
+            return self.external_address
 
     @cached_property
     def running_in_docker(self):

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -92,7 +92,8 @@ def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # pylint: di
         try:
             os.chdir(Path(__file__).parent.parent)
             create_certificate(CLIENT_FACING_CERTFILE, CLIENT_FACING_KEYFILE, cname="scylladb",
-                               ca_cert_file=CA_CERT_FILE, ca_key_file=CA_KEY_FILE, ip_addresses=[scylla.ip_address])
+                               ca_cert_file=CA_CERT_FILE, ca_key_file=CA_KEY_FILE,
+                               ip_addresses=[scylla.ip_address], dns_names=[scylla.public_dns_name])
             create_certificate(CLIENT_CERT_FILE, CLIENT_KEY_FILE, cname="scylladb",
                                ca_cert_file=CA_CERT_FILE, ca_key_file=CA_KEY_FILE)
         finally:

--- a/unit_tests/test_cassandra_stress_thread.py
+++ b/unit_tests/test_cassandra_stress_thread.py
@@ -79,7 +79,6 @@ def test_02_cassandra_stress_user_profile(request, docker_scylla, params):
     assert float(output[0]["latency 99th percentile"]) > 0
 
 
-@pytest.mark.skip("Disabled due to the https://github.com/scylladb/scylla-cluster-tests/issues/9988")
 @pytest.mark.docker_scylla_args(ssl=True)
 def test_03_cassandra_stress_client_encrypt(request, docker_scylla, params):
 


### PR DESCRIPTION
When peer verification is enabled for encrypted communication, the cassandra-stress command checks DNS names in SAN extension of server certificates.

This change fixes integration tests for cassandra-stress thread, by including DNS name of a dummy server node in its certificate.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9988

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle:  executing the test_03_cassandra_stress_client_encrypt locally:
```
❯ python -m pytest -v -p no:warnings -m integration unit_tests/test_cassandra_stress_thread.py::test_03_cassandra_stress_client_encrypt
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.10.0, pytest-7.2.0, pluggy-1.5.0 -- /home/dmitriy/.pyenv/versions/sct310/bin/python
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /home/dmitriy/Work/Scylla/sct_fix_cs_client_encryption_unit_test/unit_tests, configfile: pytest.ini
plugins: random-order-1.0.4
collected 1 item                                                                                                                                                                                                    

unit_tests/test_cassandra_stress_thread.py::test_03_cassandra_stress_client_encrypt PASSED                                                                                                                    [100%]

=============================================================================================== slowest 20 durations ================================================================================================
71.14s call     test_cassandra_stress_thread.py::test_03_cassandra_stress_client_encrypt
7.22s setup    test_cassandra_stress_thread.py::test_03_cassandra_stress_client_encrypt
5.92s teardown test_cassandra_stress_thread.py::test_03_cassandra_stress_client_encrypt
=========================================================================================== 1 passed in 84.30s (0:01:24) ============================================================================================
```
- [x] :green_circle: [PR CI with integration tests](https://jenkins.scylladb.com/job/sct-github-PRs-scan/job/scylla-cluster-tests/job/PR-10011/1/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
