### PR TITLE
fix(zeronodes): Job to run cluster with large number of zerotoken nodes

### DIFF
--- a/configurations/zerotoken_nodes/zeronodes_num_4.yaml
+++ b/configurations/zerotoken_nodes/zeronodes_num_4.yaml
@@ -1,0 +1,3 @@
+n_db_zero_token_nodes: 4
+zero_token_instance_type_db: 'i4i.large'
+use_zero_nodes: true

--- a/jenkins-pipelines/oss/longevity/longevity-100gb-4h-with-4-zerotoken-nodes.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-100gb-4h-with-4-zerotoken-nodes.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    availability_zone: 'c',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: """['test-cases/longevity/longevity-100gb-4h.yaml','configurations/zerotoken_nodes/zeronodes_num_4.yaml']""",
+    instance_provision_fallback_on_demand: true
+)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -686,6 +686,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
     @decorate_with_context(ignore_ycsb_connection_refused)
+    @target_all_nodes
     def disrupt_stop_start_scylla_server(self):  # pylint: disable=invalid-name
         self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
         self.target_node.start_scylla_server(verify_up=True, verify_down=False)
@@ -901,6 +902,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     # This nemesis should be run with "private" ip_ssh_connections till the issue #665 is not fixed
 
+    @target_all_nodes
     def disrupt_restart_then_repair_node(self):  # pylint: disable=invalid-name
         with DbEventsFilter(db_event=DatabaseLogEvent.DATABASE_ERROR,
                             line="Can't find a column family with UUID", node=self.target_node), \
@@ -911,6 +913,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.target_node.wait_node_fully_start(timeout=28800)  # 8 hours
         self.repair_nodetool_repair()
 
+    @target_all_nodes
     def disrupt_resetlocalschema(self):  # pylint: disable=invalid-name
         rlocal_schema_res = self.target_node.follow_system_log(patterns=["schema_tables - Schema version changed to"])
         self.target_node.run_nodetool("resetlocalschema")
@@ -927,10 +930,12 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.log.debug("Sleep for 60 sec: the other nodes should pull new version")
         time.sleep(60)
 
+    @target_all_nodes
     def disrupt_hard_reboot_node(self):
         self.reboot_node(target_node=self.target_node, hard=True)
         self.target_node.wait_node_fully_start()
 
+    @target_all_nodes
     def disrupt_multiple_hard_reboot_node(self) -> None:
         cdc_expected_error_patterns = [
             "cdc - Could not update CDC description table with generation",
@@ -976,11 +981,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             raise CdcStreamsWasNotUpdated(
                 f"After '{found_cdc_error[0]}', messages '{' or '.join(cdc_success_msg)}' were not found")
 
+    @target_all_nodes
     def disrupt_soft_reboot_node(self):
         self.reboot_node(target_node=self.target_node, hard=False)
         self.target_node.wait_node_fully_start()
 
     @decorate_with_context(ignore_ycsb_connection_refused)
+    @target_all_nodes
     def disrupt_rolling_restart_cluster(self, random_order=False):
         self.cluster.restart_scylla(random_order=random_order)
 
@@ -1021,6 +1028,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 session.execute('DROP KEYSPACE keyspace_for_authenticator_switch')
 
     @decorate_with_context(ignore_ycsb_connection_refused)
+    @target_all_nodes
     def disrupt_rolling_config_change_internode_compression(self):
         def get_internode_compression_new_value_randomly(current_compression):
             self.log.debug(f"Current compression is {current_compression}")
@@ -1207,6 +1215,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.repair_nodetool_rebuild()
 
     @decorate_with_context(ignore_ycsb_connection_refused)
+    @target_all_nodes
     def disrupt_nodetool_drain(self):
         result = self.target_node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True)
         self.target_node.run_nodetool("status", ignore_status=True, verbose=True,
@@ -1219,6 +1228,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.target_node.stop_scylla_server(verify_up=False, verify_down=True, ignore_status=True)
             self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
+    @target_all_nodes
     def disrupt_ldap_connection_toggle(self):
         if not self.cluster.params.get('use_ldap_authorization'):
             raise UnsupportedNemesis('Cluster is not configured to run with LDAP authorization, hence skipping')
@@ -1235,6 +1245,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         ContainerManager.unpause_container(self.tester.localhost, 'ldap')
         self.log.info('finished with nemesis')
 
+    @target_all_nodes
     def disrupt_disable_enable_ldap_authorization(self):
         if not self.cluster.params.get('use_ldap_authorization'):
             raise UnsupportedNemesis('Cluster is not configured to run with LDAP authorization, hence skipping')
@@ -1376,9 +1387,12 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         dc_topology_rf_change = self.cluster.decommission(self.target_node)
         new_node = None
         if add_node:
+            add_node_kwargs = {"count": 1, "rack": self.target_node.rack}
+            if self.target_node._is_zero_token_node:
+                add_node_kwargs.update({"is_zero_node": True})
             # When adding node after decommission the node is declared as up only after it completed bootstrapping,
             # increasing the timeout for now
-            new_node = self._add_and_init_new_cluster_nodes(count=1, rack=self.target_node.rack)[0]
+            new_node = self._add_and_init_new_cluster_nodes(**add_node_kwargs)[0]
             # after decomission and add_node, the left nodes have data that isn't part of their tokens anymore.
             # In order to eliminate cases that we miss a "data loss" bug because of it, we cleanup this data.
             # This fix important when just user profile is run in the test and "keyspace1" doesn't exist.
@@ -1393,9 +1407,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 self.unset_current_running_nemesis(new_node)
         return new_node
 
+    @target_all_nodes
     def disrupt_nodetool_decommission(self, add_node=True):
         return self._nodetool_decommission(add_node=add_node)
 
+    @target_all_nodes
     def disrupt_nodetool_seed_decommission(self, add_node=True):
         if len(self.cluster.seed_nodes) < 2:
             raise UnsupportedNemesis("To running seed decommission the cluster must contains at least 2 seed nodes")
@@ -1747,7 +1763,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 SstableLoadUtils.run_load_and_stream(load_on_node, **kwargs)
 
     # pylint: disable=too-many-statements
-    @target_data_nodes
+    @target_all_nodes
     def disrupt_nodetool_refresh(self, big_sstable: bool = False):
         # Checking the columns number of keyspace1.standard1
         self.log.debug('Prepare keyspace1.standard1 if it does not exist')
@@ -1817,7 +1833,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             node.restart_scylla_server(verify_up_after=True)
             assert no_space_errors, "There are no 'No space left on device' errors in db log during enospc disruption."
 
-    @target_data_nodes
+    @target_all_nodes
     def disrupt_nodetool_enospc(self, sleep_time=30, all_nodes=False):
 
         if all_nodes:
@@ -1841,7 +1857,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     finally:
                         clean_enospc_on_node(target_node=node, sleep_time=sleep_time)
 
-    @target_data_nodes
+    @target_all_nodes
     def disrupt_end_of_quota_nemesis(self, sleep_time=30):
         """
         Nemesis flow
@@ -2058,6 +2074,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             32, len(self.cluster.nodes)), timeout=HOUR_IN_SEC * 48)
         parallel_objects.run(_nodetool_cleanup)
 
+    @target_all_nodes
     def disrupt_nodetool_cleanup(self):
         self.nodetool_cleanup_on_all_nodes_parallel()
 
@@ -3185,11 +3202,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             mgr_task.stop()
             assert False, f'Backup task {mgr_task.id} timed out - while on status {status}'
 
+    @target_data_nodes
     def disrupt_mgmt_repair_cli(self):
         if not self.cluster.params.get('use_mgmt') and not self.cluster.params.get('use_cloud_manager'):
             raise UnsupportedNemesis('Scylla-manager configuration is not defined!')
         self._mgmt_repair_cli()
 
+    @target_data_nodes
     def disrupt_mgmt_corrupt_then_repair(self):
         if not self.cluster.params.get('use_mgmt') and not self.cluster.params.get('use_cloud_manager'):
             raise UnsupportedNemesis('Scylla-manager configuration is not defined!')
@@ -3366,7 +3385,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                                  f"Expected content: {sorted(keyspace_table)} \n "
                                  f"Actual snapshot content: {sorted(snapshot_content_list)}")
 
-    @target_data_nodes
+    @target_all_nodes
     def disrupt_snapshot_operations(self):  # pylint: disable=too-many-statements
         """
         Extend this nemesis to run 'nodetool snapshot' more options including multiple tables.
@@ -3474,6 +3493,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     # NOTE: '2023.1.rc0' is set in advance, not guaranteed to match when appears
     @scylla_versions(("4.6.rc0", None), ("2023.1.rc0", None))
+    @target_all_nodes
     def disrupt_show_toppartitions(self):
         # NOTE: new API is supported only starting with Scylla 4.6
         #       In Scylla 4.5 it exists but disabled.
@@ -3572,6 +3592,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         experiment.wait_until_finished()
         self.cluster.wait_all_nodes_un()
 
+    @target_all_nodes
     def disrupt_network_random_interruptions(self):  # pylint: disable=invalid-name
         # pylint: disable=too-many-locals
         list_of_timeout_options = [10, 60, 120, 300, 500]
@@ -3632,6 +3653,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         time.sleep(15)
         self.cluster.wait_all_nodes_un()
 
+    @target_all_nodes
     def disrupt_network_block(self):
         list_of_timeout_options = [10, 60, 120, 300, 500]
         if self._is_it_on_kubernetes():
@@ -3665,7 +3687,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 self.target_node.traffic_control(None)
                 self.cluster.wait_all_nodes_un()
 
-    @target_data_nodes
+    @target_all_nodes
     def disrupt_remove_node_then_add_node(self):  # pylint: disable=too-many-branches
         """
         https://docs.scylladb.com/operating-scylla/procedures/cluster-management/remove_node/
@@ -3785,6 +3807,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             finally:
                 self.unset_current_running_nemesis(new_node)
 
+    @target_all_nodes
     def disrupt_network_reject_inter_node_communication(self):
         """
         Generates random firewall rule to drop/reject packets for inter-node communications, port 7000 and 7001
@@ -3822,6 +3845,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 wait_time=wait_time
             )
 
+    @target_all_nodes
     def disrupt_network_reject_node_exporter(self):
         """
         Generates random firewall rule to drop/reject packets for node exporter connections, port 9100
@@ -3847,6 +3871,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             wait_time=wait_time
         )
 
+    @target_all_nodes
     def disrupt_network_reject_thrift(self):
         """
         Generates random firewall rule to drop/reject packets for thrift connections, port 9100
@@ -3976,6 +4001,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if self.tester.params.get('print_kernel_callstack'):
             save_kallsyms_map(node=target_node)
 
+    @target_all_nodes
     def disrupt_network_start_stop_interface(self):  # pylint: disable=invalid-name
         if not self.cluster.extra_network_interface:
             raise UnsupportedNemesis("for this nemesis to work, you need to set `extra_network_interface: True`")
@@ -4203,6 +4229,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.target_node.remoter.run('sudo dd if=/dev/urandom of={} count=1024'.format(sstable_file))
             self.log.debug('File {} was corrupted by dd'.format(sstable_file))
 
+    @target_data_nodes
     def disrupt_corrupt_then_scrub(self):
         """
         Try to rebuild the sstables of all test keyspaces by scrub, the corrupted partitions
@@ -4365,11 +4392,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     # TODO: add support for the 'LocalFileSystemKeyProviderFactory' and 'KmipKeyProviderFactory' key providers
     # TODO: add encryption for a table with large partitions?
 
+    @target_all_nodes
     def disrupt_enable_disable_table_encryption_aws_kms_provider_without_rotation(self):
         self._enable_disable_table_encryption(
             enable_kms_key_rotation=False,
             additional_scylla_encryption_options={'key_provider': 'KmsKeyProviderFactory'})
 
+    @target_all_nodes
     def disrupt_enable_disable_table_encryption_aws_kms_provider_with_rotation(self):
         self._enable_disable_table_encryption(
             enable_kms_key_rotation=True,
@@ -4377,7 +4406,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     @decorate_with_context(ignore_ycsb_connection_refused)
     @scylla_versions(("2023.1.1-dev", None))
-    @target_data_nodes
     def _enable_disable_table_encryption(self, enable_kms_key_rotation, additional_scylla_encryption_options=None):  # noqa: PLR0914
         if self.cluster.params.get("cluster_backend") != "aws":
             raise UnsupportedNemesis("This nemesis is supported only on the AWS cluster backend")
@@ -4518,6 +4546,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             with self.cluster.cql_connection_patient(self.target_node, keyspace=keyspace_name) as session:
                 session.execute(f"DROP TABLE {table_name};")
 
+    @target_all_nodes
     def disrupt_hot_reloading_internode_certificate(self):
         """
         https://github.com/scylladb/scylla/issues/6067
@@ -4619,6 +4648,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         experiment.wait_until_finished()
 
     @decorate_with_context(ignore_reactor_stall_errors)
+    @target_all_nodes
     def disrupt_memory_stress(self):
         """
         Try to run stress-ng to preempt allocated memory of scylla process,
@@ -5064,6 +5094,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                                                   for error in error_events if error)
                                         )
 
+    @target_data_nodes
     def disrupt_create_index(self):
         """
         Create index on a random column (regular or static) of a table with the most number of partitions and wait until it gets build.


### PR DESCRIPTION
Configure to run most of topology, schema, config nemesises to run on any node (data node or zero token node) and created new job with large number of zero toke nodes


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [Test passed](https://jenkins.scylladb.com/view/master/job/scylla-master/job/ClusterCoreQALongevities/job/longevity-100gb-4h-with-4-zerotoken-nodes-test/3)
- [Test passed](https://jenkins.scylladb.com/view/master/job/scylla-master/job/ClusterCoreQALongevities/job/longevity-100gb-4h-with-4-zerotoken-nodes-test/4)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
