### PR TITLE
fix(nemesis.py): use system logger to log nemesis start/end on nodes

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3157,8 +3157,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         self.remoter.sudo('systemctl disable firewalld', ignore_status=True)
 
     def log_message(self, message: str, level: str = 'info', verbose: bool = False) -> None:
-        self.remoter.run(
-            f'scylla-api-client system log POST --level {level} --message {shlex.quote(message)}', verbose=verbose)
+        self.remoter.run(f'logger -p {level} -t scylla {shlex.quote(message)}', verbose=verbose)
 
     def query_metadata(self, url: str, headers: dict = None, token_url: str = None, token_header: str = None,
                        token_ttl_header: str = None, token_ttl: int = 21600) -> str:
@@ -5404,6 +5403,10 @@ class BaseLoaderSet():
         for loader in self.nodes:
             LOGGER.debug("Update rack info in Argus for loader '%s'", loader.name)
             loader.update_rack_info_in_argus(loader.datacenter, loader.node_rack)
+
+    def log_message(self, message: str, level: str = 'info', verbose: bool = False) -> None:
+        for node in self.nodes:
+            node.log_message(message, level, verbose)
 
 
 class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instance-attributes

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5472,8 +5472,9 @@ def disrupt_method_wrapper(method, is_exclusive=False):  # pylint: disable=too-m
             start_msg = (f"Started disruption {method_name} ({current_disruption} nemesis) on the target node "
                          f"'{str(args[0].target_node)}'")
             args[0].log.debug("{start_symbol} {msg} {start_symbol}".format(start_symbol='>' * 12, msg=start_msg))
-            args[0].cluster.log_message(
-                "{start_symbol} {msg} {start_symbol}".format(start_symbol='=' * 12, msg=start_msg))
+            for nodes_set in (args[0].cluster, args[0].loaders):
+                nodes_set.log_message(
+                    "{start_symbol} {msg} {start_symbol}".format(start_symbol='=' * 12, msg=start_msg))
 
             class_name = args[0].get_class_name()
             if class_name.find('Chaos') < 0:
@@ -5559,8 +5560,9 @@ def disrupt_method_wrapper(method, is_exclusive=False):  # pylint: disable=too-m
                     end_msg = (f"Finished disruption {method_name} ({current_disruption} nemesis) with status "
                                f"'{get_nemesis_status(nemesis_event)}'")
                     args[0].log.debug("{end_symbol} {msg} {end_symbol}".format(end_symbol='<' * 12, msg=end_msg))
-                    args[0].cluster.log_message(
-                        "{end_symbol} {msg} {end_symbol}".format(end_symbol='=' * 12, msg=end_msg))
+                    for nodes_set in (args[0].cluster, args[0].loaders):
+                        nodes_set.log_message(
+                            "{end_symbol} {msg} {end_symbol}".format(end_symbol='=' * 12, msg=end_msg))
 
             args[0].cluster.check_cluster_health()
             num_data_nodes_after = len(args[0].cluster.data_nodes)

--- a/unit_tests/dummy_remote.py
+++ b/unit_tests/dummy_remote.py
@@ -106,6 +106,9 @@ class LocalLoaderSetDummy(BaseCluster):
     def get_loader(self):
         return self.nodes[0]
 
+    def log_message(self, *args, **kwargs):
+        pass
+
 
 class LocalScyllaClusterDummy(BaseScyllaCluster, BaseCluster):
     # pylint: disable=super-init-not-called

--- a/unit_tests/test_nemesis.py
+++ b/unit_tests/test_nemesis.py
@@ -12,6 +12,7 @@ from sdcm.cluster_k8s.eks import EksScyllaPodCluster
 from sdcm.cluster_gce import ScyllaGCECluster
 from sdcm.cluster_aws import ScyllaAWSCluster
 from sdcm.cluster_docker import ScyllaDockerCluster
+from unit_tests.dummy_remote import LocalLoaderSetDummy
 from unit_tests.test_tester import ClusterTesterForTests
 
 
@@ -56,7 +57,7 @@ class Cluster:
 @dataclass
 class FakeTester:
     params: dict = field(default_factory=lambda: PARAMS)
-    loaders: list = field(default_factory=list)
+    loaders: LocalLoaderSetDummy = field(default_factory=LocalLoaderSetDummy)
     db_cluster: Cluster | BaseScyllaCluster = field(default_factory=lambda: Cluster(nodes=[Node(), Node()]))
     monitors: list = field(default_factory=list)
 


### PR DESCRIPTION
Change logging of nemesis start/end from using `scylla-api-client` to the system logger utility. This makes logging these details more stable, as `scylla-api-client` cannot be used when the scylla-server service is not started on DB nodes.

Additionally, add logging of nemesis start/end on loader nodes. This helps with SCT results investigation activities.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9976

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [PR-provision-test with SisyphusMonkey nemesis class](https://argus.scylladb.com/tests/scylla-cluster-tests/487cac05-ced9-45e2-b8a2-9834ea8cf87f)

loaders nodes log:
```
❯ egrep '(Started|Finished) disruption' -rn loader-set-487cac05/PR-provision-test-fix-db-n-loader-node-487cac05-*/
...
loader-set-487cac05/PR-provision-test-fix-db-n-loader-node-487cac05-1/system.log:10102:Feb 09 18:33:03 PR-provision-test-fix-db-n-loader-node-487cac05-1 scylla[5621]: ============ Started disruption disrupt_hot_reloading_internode_certificate (HotReloadingInternodeCertificate nemesis) on the target node 'Node PR-provision-test-fix-db-n-db-node-487cac05-1 [3.254.143.18 | 10.4.3.165]' ============
loader-set-487cac05/PR-provision-test-fix-db-n-loader-node-487cac05-1/system.log:10103:Feb 09 18:33:05 PR-provision-test-fix-db-n-loader-node-487cac05-1 scylla[5624]: ============ Finished disruption disrupt_hot_reloading_internode_certificate (HotReloadingInternodeCertificate nemesis) with status 'skipped' ============
loader-set-487cac05/PR-provision-test-fix-db-n-loader-node-487cac05-1/system.log:10104:Feb 09 18:33:28 PR-provision-test-fix-db-n-loader-node-487cac05-1 scylla[5636]: ============ Started disruption disrupt_remove_node_then_add_node (RemoveNodeThenAddNode nemesis) on the target node 'Node PR-provision-test-fix-db-n-db-node-487cac05-1 [3.254.143.18 | 10.4.3.165]' ============
loader-set-487cac05/PR-provision-test-fix-db-n-loader-node-487cac05-1/system.log:10203:Feb 09 18:36:01 PR-provision-test-fix-db-n-loader-node-487cac05-1 scylla[7599]: ============ Finished disruption disrupt_remove_node_then_add_node (RemoveNodeThenAddNode nemesis) with status 'skipped' ============
...
```

db nodes log:
```
❯ egrep '(Started|Finished) disruption' -rn db-cluster-487cac05/PR-provision-test-fix-db-n-db-node-487cac05-*/
...
db-cluster-487cac05/PR-provision-test-fix-db-n-db-node-487cac05-1/messages.log:1020:2025-02-09T18:33:03.422+00:00 PR-provision-test-fix-db-n-db-node-487cac05-1     !INFO | scylla[5916]: ============ Started disruption disrupt_hot_reloading_internode_certificate (HotReloadingInternodeCertificate nemesis) on the target node 'Node PR-provision-test-fix-db-n-db-node-487cac05-1 [3.254.143.18 | 10.4.3.165]' ============
db-cluster-487cac05/PR-provision-test-fix-db-n-db-node-487cac05-1/messages.log:1024:2025-02-09T18:33:05.671+00:00 PR-provision-test-fix-db-n-db-node-487cac05-1     !INFO | scylla[5926]: ============ Finished disruption disrupt_hot_reloading_internode_certificate (HotReloadingInternodeCertificate nemesis) with status 'skipped' ============
db-cluster-487cac05/PR-provision-test-fix-db-n-db-node-487cac05-2/messages.log:970:2025-02-09T18:33:03.289+00:00 PR-provision-test-fix-db-n-db-node-487cac05-2     !INFO | scylla[5806]: ============ Started disruption disrupt_hot_reloading_internode_certificate (HotReloadingInternodeCertificate nemesis) on the target node 'Node PR-provision-test-fix-db-n-db-node-487cac05-1 [3.254.143.18 | 10.4.3.165]' ============
db-cluster-487cac05/PR-provision-test-fix-db-n-db-node-487cac05-2/messages.log:971:2025-02-09T18:33:05.789+00:00 PR-provision-test-fix-db-n-db-node-487cac05-2     !INFO | scylla[5809]: ============ Finished disruption disrupt_hot_reloading_internode_certificate (HotReloadingInternodeCertificate nemesis) with status 'skipped' ============
...
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
