### PR TITLE
fix(nemesis): replication factor set to 0 before decommission

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4849,8 +4849,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                         "Should have been already switched to NetworkStrategy"
                     strategy.replication_factors_per_dc.update({new_dc_name: 1})  # pylint: disable=protected-access
                     replication_strategy_setter(**{keyspace: strategy})
+
+                for key, preserved_strategy in replication_strategy_setter.preserved.items():
+                    preserved_strategy.replication_factors_per_dc[new_dc_name] = 0
+
                 InfoEvent(message='execute rebuild on new datacenter').publish()
-                with wait_for_log_lines(node=new_node, start_line_patterns=["rebuild.*started with keyspaces=", "Rebuild starts"],
+                with wait_for_log_lines(node=new_node,
+                                        start_line_patterns=["rebuild.*started with keyspaces=", "Rebuild starts"],
                                         end_line_patterns=["rebuild.*finished with keyspaces=", "Rebuild succeeded"],
                                         start_timeout=60, end_timeout=600):
                     new_node.run_nodetool(sub_cmd=f"rebuild -- {datacenters[0]}", long_running=True, retry=0)


### PR DESCRIPTION
this commit changes keyspace replication factor to 0 before removing the DC to avoid scylla failures while decommissioning

refer: 9861

fix: #9861 

### Testing
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/eugene_test_folder/job/add_remove_dc/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
