### PR TITLE
fix(nemesis): decorator for ignoring mutation errors added

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3702,7 +3702,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         assert removed_node_status is not None, "failed to get host_id using nodetool status"
         host_id = removed_node_status["host_id"]
 
-        with ignore_ycsb_connection_refused():
+        if SkipPerIssues('https://github.com/scylladb/scylladb/issues/21815', params=self.tester.params):
+            # TBD: To be removed after https://github.com/scylladb/scylladb/issues/21815 is resolved
+            ignore_stream_mutation_errors_due_to_issue = ignore_stream_mutation_fragments_errors
+        else:
+            ignore_stream_mutation_errors_due_to_issue = contextlib.nullcontext
+
+        with ignore_ycsb_connection_refused(), ignore_stream_mutation_errors_due_to_issue():
             # node stop and make sure its "DN"
             node_to_remove.stop_scylla_server(verify_up=True, verify_down=True)
 


### PR DESCRIPTION
this commit adds decorator for ignoring mutation writes during remove_node_then_add_node nemesis

Ref: https://github.com/scylladb/scylladb/issues/21815


### Testing
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/eugene_test_folder/job/ignore_mutations/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
