### PR TITLE
[Manager] Adaptation for Multi DC restore

### DIFF
--- a/jenkins-pipelines/manager/ubuntu22-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-sanity.jenkinsfile
@@ -5,9 +5,9 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
     backend: 'aws',
-    region: 'us-east-1',
+    region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.ManagerSanityTests.test_manager_sanity',
-    test_config: 'test-cases/manager/manager-regression-singleDC-set-distro.yaml',
+    test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
 
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -517,6 +517,18 @@ class ManagerTestFunctionsMixIn(
         # FIXME: Make it works with multiple locations or file a bug for scylla-manager.
         return [f"{backend}:{location}" for location in buckets[:1]]
 
+    def get_dc_mapping(self) -> str | None:
+        """Get the datacenter mapping string for the restore task if there are > 1 DCs (multiDC) in the cluster.
+        In case of singleDC, return None.
+
+        Example of return string:
+            eu-west-2scylla_node_west=eu-west-2scylla_node_west,us-eastscylla_node_east=us-eastscylla_node_east
+        """
+        if len(dcs := self.get_all_dcs_names()) > 1:
+            return ",".join([f"{dc}={dc}" for dc in dcs])
+        else:
+            return None
+
     # pylint: disable=too-many-arguments
     def verify_backup_success(self, mgr_cluster, backup_task, ks_names: list = None, tables_names: list = None,
                               truncate=True, restore_data_with_task=False, timeout=None):
@@ -597,9 +609,10 @@ class ManagerTestFunctionsMixIn(
     def restore_backup_with_task(self, mgr_cluster, snapshot_tag, timeout, restore_schema=False, restore_data=False,
                                  location_list=None, extra_params=None):
         location_list = location_list if location_list else self.locations
+        dc_mapping = self.get_dc_mapping()
         restore_task = mgr_cluster.create_restore_task(restore_schema=restore_schema, restore_data=restore_data,
                                                        location_list=location_list, snapshot_tag=snapshot_tag,
-                                                       extra_params=extra_params)
+                                                       dc_mapping=dc_mapping, extra_params=extra_params)
         restore_task.wait_and_get_final_status(step=30, timeout=timeout)
         assert restore_task.status == TaskStatus.DONE, f"Restoration of {snapshot_tag} has failed!"
         InfoEvent(message=f'The restore task has ended successfully. '

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -603,7 +603,7 @@ class ManagerCluster(ScyllaManagerBase):
         self.id = value
 
     def create_restore_task(self, restore_schema=False, restore_data=False, location_list=None, snapshot_tag=None,
-                            extra_params=None):
+                            dc_mapping=None, extra_params=None):
         cmd = f"restore -c {self.id}"
         if restore_schema:
             cmd += " --restore-schema"
@@ -614,6 +614,8 @@ class ManagerCluster(ScyllaManagerBase):
             cmd += " --location {} ".format(locations_names)
         if snapshot_tag:
             cmd += f" --snapshot-tag {snapshot_tag}"
+        if dc_mapping:
+            cmd += f" --dc-mapping {dc_mapping}"
         if extra_params:
             cmd += f" {extra_params}"
 


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-manager/issues/3871

**Changes:**

***Extended sctool restore task with dc-mapping flag***

To run a restore task for multiDC cluster with EaR enabled (otherwise fails https://github.com/scylladb/scylla-manager/issues/3871), the special flag has been introduced in Manager (https://github.com/scylladb/scylla-manager/pull/4213) to map backed up DC with DC to restore into, for example, `sctool restore ... --dc-mapping dc1=dc1,dc2=dc2`.

The change introduces this new flag into `create_restore_task` method and makes sure that if Scylla cluster has more than 1 datacenter - the restore task will be triggered with this flag applied.

***Updated configurations to run ubuntu22 sanity test on multiDC cluster***
- ubuntu22-manager-sanity.jenkinsfile
- manager-regression-multiDC-set-distro.yaml

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [ubuntu22 sanity, multiDC](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-sanity-test/70/)
- [x] [singleDC regression](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master/job/ubuntu22-sanity-test/68/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code