### PR TITLE
fix(Azure): enable WaLinuxAgent

### DIFF
--- a/sdcm/sct_provision/region_definition_builder.py
+++ b/sdcm/sct_provision/region_definition_builder.py
@@ -27,6 +27,7 @@ from sdcm.sct_provision.user_data_objects.apt_daily_triggers import DisableAptTr
 from sdcm.sct_provision.user_data_objects.scylla import ScyllaUserDataObject
 from sdcm.sct_provision.user_data_objects.sshd import SshdUserDataObject
 from sdcm.sct_provision.user_data_objects.syslog_ng import SyslogNgUserDataObject, SyslogNgExporterUserDataObject
+from sdcm.sct_provision.user_data_objects.walinuxagent import EnableWaLinuxAgent
 from sdcm.test_config import TestConfig
 
 
@@ -147,6 +148,7 @@ class DefinitionBuilder(abc.ABC):
             SyslogNgUserDataObject,
             SyslogNgExporterUserDataObject,
             SshdUserDataObject,
+            EnableWaLinuxAgent,
             ScyllaUserDataObject,
         ]
         user_data_objects = [

--- a/sdcm/sct_provision/user_data_objects/walinuxagent.py
+++ b/sdcm/sct_provision/user_data_objects/walinuxagent.py
@@ -1,0 +1,37 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+from dataclasses import dataclass
+from textwrap import dedent
+
+from sdcm.sct_provision.user_data_objects import SctUserDataObject
+
+
+@dataclass
+class EnableWaLinuxAgent(SctUserDataObject):
+    """
+    Scylla machines on Azure have WaLinuxAgent disabled by default. This script enables it.
+    https://github.com/scylladb/scylla-machine-image/pull/627
+    """
+    @property
+    def is_applicable(self) -> bool:
+        return self.node_type == "scylla-db" and self.params.get("cluster_backend") == "azure"
+
+    @property
+    def script_to_run(self) -> str:
+        return dedent("""
+            systemctl daemon-reload
+            systemctl unmask walinuxagent
+            systemctl enable walinuxagent
+            systemctl start walinuxagent
+            systemctl status walinuxagent --no-pager
+        """)


### PR DESCRIPTION
Linux agent on Scylla instances on Azure is disabled by default. https://github.com/scylladb/scylla-machine-image/pull/627

Add cloud init script that enables it back for testing purposes.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [azure artifact test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/artifacts-azure-image-test/24/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
