### PR TITLE
refactor(upgrade_test): Support only smooth upgrades for 2025.1 and above

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -400,7 +400,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             else:
                 node.remoter.sudo(r'apt-get remove scylla\* -y')
                 node.remoter.sudo(
-                    rf'DEBIAN_FRONTEND=noninteractive apt-get install {node.scylla_pkg()}\* -y'
+                    rf'DEBIAN_FRONTEND=noninteractive apt-get install {node.scylla_pkg()} -y'
                     rf' -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"'
                 )
             recover_conf(node)


### PR DESCRIPTION
Starting 2025.1 the upgrades from previous enterprise releases will behave like upgrade from OSS and won't require reinstall but just 'update'. However, a rollback during upgrade to 2025.1 will require reinstall. rollback from 2025.1 to OSS won't require reinstall.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
