### PR TITLE
fix(latte): run latte docker container setting entrypoint explicitly

### DIFF
--- a/sdcm/stress/latte_thread.py
+++ b/sdcm/stress/latte_thread.py
@@ -208,8 +208,10 @@ class LatteStressThread(DockerBasedStressThread):  # pylint: disable=too-many-in
         if self.stress_num > 1:
             cpu_options = f'--cpuset-cpus="{cpu_idx}"'
 
-        cmd_runner = cleanup_context = RemoteDocker(loader, self.docker_image_name,
-                                                    extra_docker_opts=f'{cpu_options} --label shell_marker={self.shell_marker}')
+        cmd_runner = cleanup_context = RemoteDocker(
+            loader, self.docker_image_name,
+            command_line="-c 'tail -f /dev/null'",
+            extra_docker_opts=f'--entrypoint /bin/bash {cpu_options} --label shell_marker={self.shell_marker}')
         stress_cmd = self.build_stress_cmd(cmd_runner, loader)
 
         if not os.path.exists(loader.logdir):


### PR DESCRIPTION
Recently we switched to the new latte docker image (https://github.com/scylladb/scylla-cluster-tests/pull/10015).
It is built from another Dockerfile which is stored in the latte repo.
And this new image has the latte binary as an entrypoint. Before it was bash.

So, set entrypoint and parameters for it explicitly in the latte code
to make latte container start and run for whole test as it is expected and was before.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
