### PR TITLE
fix(nemesis.py): ignore networkd coredump in RandomInterruptionNetwork

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1745,9 +1745,8 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             # we don't have systemd working inside docker
             return
 
-        systemd_version = get_systemd_version(self.remoter.run("systemctl --version", ignore_status=True).stdout)
-        if systemd_version >= 240:
-            self.log.debug("systemd version %d >= 240: we can change FinalKillSignal", systemd_version)
+        if self.systemd_version >= 240:
+            self.log.debug("systemd version %d >= 240: we can change FinalKillSignal", self.systemd_version)
             self.remoter.sudo(shell_script_cmd("""\
                 mkdir -p /etc/systemd/system/scylla-server.service.d
                 cat <<EOF > /etc/systemd/system/scylla-server.service.d/override.conf
@@ -3171,6 +3170,10 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             curl_headers += f' -H "{token_header}: {self._metadata_token["token"]}"'
 
         return self.remoter.run(f'curl -s {curl_headers} "{url}"').stdout.strip()
+
+    @cached_property
+    def systemd_version(self) -> int:
+        return get_systemd_version(self.remoter.run("systemctl --version", ignore_status=True).stdout)
 
 
 class FlakyRetryPolicy(RetryPolicy):


### PR DESCRIPTION
Reduce coredump event severity during disrupt_network_random_interruptions disruption, if coredump was triggered by an error in networkd service of version 255 or lower (the root cause is https://github.com/systemd/systemd/issues/32247).

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/10053

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-5gb-1h-aws-test with networking nemeses selector](https://argus.scylladb.com/tests/scylla-cluster-tests/250c016d-243a-4a9d-9f6d-e9c4c955da1c) (the build failed on teardown validator execution, but the test itself is OK, all nemeses were successful)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
