### PR TITLE
refactor(hdrh): support HDR histograms for multiple benchmarking tools

### DIFF
--- a/performance_regression_gradual_grow_throughput.py
+++ b/performance_regression_gradual_grow_throughput.py
@@ -185,7 +185,8 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
         for stress in stress_queue:
             results.extend(self.get_stress_results(queue=stress, store_results=False))
             self.log.debug("One c-s command results: %s", results[-1])
-        return results
+        # NOTE: 'stress_queue' will be used by the 'latency_calculator_decorator' decorator
+        return results, stress_queue
 
     def drop_keyspace(self):
         self.log.debug(f'Drop keyspace {"keyspace1"}')
@@ -209,8 +210,8 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
             current_throttle = f"fixed={int(int(throttle_step) // (num_loaders * stress_num))}/s" if throttle_step != "unthrottled" else ""
             run_step = ((latency_calculator_decorator(legend=f"Gradual test step {throttle_step} op/s",
                                                       cycle_name=throttle_step))(self.run_step))
-            results = run_step(stress_cmds=workload.cs_cmd_tmpl, current_throttle=current_throttle,
-                               num_threads=workload.num_threads)
+            results, _ = run_step(
+                stress_cmds=workload.cs_cmd_tmpl, current_throttle=current_throttle, num_threads=workload.num_threads)
 
             calculate_result = self._calculate_average_max_latency(results)
             self.update_test_details(scylla_conf=True)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4534,11 +4534,13 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                           key=key, threshold=size, keyspaces=keyspace, throw_exc=False)
 
     @optional_stage('nemesis')
-    def add_nemesis(self, nemesis, tester_obj):
+    def add_nemesis(self, nemesis, tester_obj, hdr_tags: list[str] = None):
         for nem in nemesis:
             nemesis_obj = nem['nemesis'](tester_obj=tester_obj,
                                          termination_event=self.nemesis_termination_event,
                                          nemesis_selector=nem['nemesis_selector'])
+            if hdr_tags:
+                nemesis_obj.hdr_tags = hdr_tags
             self.nemesis.append(nemesis_obj)
         self.nemesis_count = len(nemesis)
 

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -897,7 +897,7 @@ class LoaderLogCollector(LogCollector):
                 search_locally=True),
         FileLog(name='*cassandra-harry*.log',
                 search_locally=True),
-        FileLog(name="*cs-hdr-*.hdr",
+        FileLog(name="hdrh-*.hdr",
                 search_locally=True),
         FileLog(name='*latte*',
                 search_locally=True),

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -280,6 +280,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.es_publisher = NemesisElasticSearchPublisher(self.tester)
         self._init_num_deletions_factor()
         self._target_node_pool_type = NEMESIS_TARGET_POOLS.data_nodes
+        self.hdr_tags = []
 
     def _init_num_deletions_factor(self):
         # num_deletions_factor is a numeric divisor. It's a factor by which the available-partitions-for-deletion
@@ -4280,6 +4281,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         results = self.tester.get_stress_results(queue=stress_queue, store_results=False)
         self.stop_nemesis_on_stress_errors(stress_queue)
         self.log.info(f"Double load results: {results}")
+        return stress_queue
 
     @target_data_nodes
     def disrupt_grow_shrink_cluster(self):

--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -137,6 +137,10 @@ class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-in
         self.sb_mode: ScyllaBenchModes = ScyllaBenchModes(re.search(r"-mode=(.+?) ", stress_cmd).group(1))
         self.sb_workload: ScyllaBenchWorkloads = ScyllaBenchWorkloads(
             re.search(r"-workload=(.+?) ", stress_cmd).group(1))
+        # NOTE: scylla-bench doesn't have 'mixed' workload. Its hdr tag names are the same in all cases.
+        #       Another "raw" tag/metric is ignored because it is coordinated omission affected
+        #       and not really needed having 'coordinated omission fixed' latency one.
+        self.hdr_tags = ["co-fixed"]
 
     def verify_results(self):
         sb_summary = []

--- a/sdcm/stress/base.py
+++ b/sdcm/stress/base.py
@@ -16,6 +16,7 @@ import random
 import concurrent.futures
 from pathlib import Path
 from functools import cached_property
+import uuid
 
 from sdcm.cluster import BaseLoaderSet
 from sdcm.utils.common import generate_random_string
@@ -51,6 +52,7 @@ class DockerBasedStressThread:  # pylint: disable=too-many-instance-attributes
         self.shell_marker = generate_random_string(20)
         self.shutdown_timeout = 180  # extra 3 minutes
         self.stop_test_on_failure = stop_test_on_failure
+        self.hdr_tags = []
 
         if "k8s" not in self.params.get("cluster_backend") and self.docker_image_name:
             for loader in self.loader_set.nodes:
@@ -145,6 +147,11 @@ class DockerBasedStressThread:  # pylint: disable=too-many-instance-attributes
         else:
             stress_event.severity = Severity.ERROR
         stress_event.add_error(errors=[error_msg])
+
+    @staticmethod
+    def _build_log_file_id(loader_idx, cpu_idx, keyspace_idx):
+        keyspace_suffix = f"-k{keyspace_idx}" if keyspace_idx else ""
+        return f"l{loader_idx}-c{cpu_idx}{keyspace_suffix}-{uuid.uuid4()}"
 
 
 def format_stress_cmd_error(exc: Exception) -> str:

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -14,13 +14,13 @@
 import os
 import re
 import time
-import uuid
 import logging
 import contextlib
 from typing import Any
 from itertools import chain
 from pathlib import Path
 
+from sdcm.db_stats import get_stress_cmd_params
 from sdcm.loader import CassandraStressExporter, CassandraStressHDRExporter
 from sdcm.cluster import BaseLoaderSet
 from sdcm.prometheus import nemesis_metrics_obj
@@ -85,6 +85,24 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
         self.client_encrypt = client_encrypt
         self.stop_test_on_failure = stop_test_on_failure
         self.compaction_strategy = compaction_strategy
+        self.set_hdr_tags(stress_cmd)
+
+    def set_hdr_tags(self, stress_cmd):
+        # TODO: add support for the "counter_write" and "user" modes?
+        params = get_stress_cmd_params(stress_cmd)
+        if "fixed threads" in params:
+            if " mixed " in stress_cmd:
+                self.hdr_tags = ["WRITE-rt", "READ-rt"]
+            elif " read " in stress_cmd:
+                self.hdr_tags = ["READ-rt"]
+            else:
+                self.hdr_tags = ["WRITE-rt"]
+        elif " mixed " in stress_cmd:
+            self.hdr_tags = ["WRITE-st", "READ-st"]
+        elif " read " in stress_cmd:
+            self.hdr_tags = ["READ-st"]
+        else:
+            self.hdr_tags = ["WRITE-st"]
 
     @staticmethod
     def append_no_warmup_to_cmd(stress_cmd):
@@ -223,10 +241,6 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
 
         return stress_cmd
 
-    @staticmethod
-    def _build_log_file_id(loader_idx, cpu_idx, keyspace_idx):
-        return f"l{loader_idx}-c{cpu_idx}-k{keyspace_idx}-{uuid.uuid4()}"
-
     def _run_stress(self, loader, loader_idx, cpu_idx):
         pass
 
@@ -242,8 +256,8 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
         log_file_name = \
             os.path.join(loader.logdir, f'cassandra-stress-{stress_cmd_opt}-{log_id}.log')
         LOGGER.debug('cassandra-stress local log: %s', log_file_name)
-        remote_hdr_file_name = f"cs-hdr-{stress_cmd_opt}-{log_id}.hdr"
-        LOGGER.debug("cassandra-stress remote HDR log file: %s", remote_hdr_file_name)
+        remote_hdr_file_name = f"hdrh-cs-{stress_cmd_opt}-{log_id}.hdr"
+        LOGGER.debug("cassandra-stress remote HDR histogram log file: %s", remote_hdr_file_name)
         local_hdr_file_name = os.path.join(loader.logdir, remote_hdr_file_name)
         LOGGER.debug("cassandra-stress HDR local file %s", local_hdr_file_name)
 
@@ -298,13 +312,13 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
 
         if self.params.get("use_hdrhistogram"):
             stress_cmd = self._add_hdr_log_option(stress_cmd, remote_hdr_file_name)
-            hdr_logger_context = HDRHistogramFileLogger(
+            hdrh_logger_context = HDRHistogramFileLogger(
                 node=loader,
                 remote_log_file=remote_hdr_file_name_full_path,
                 target_log_file=os.path.join(loader.logdir, remote_hdr_file_name),
             )
         else:
-            hdr_logger_context = contextlib.nullcontext()
+            hdrh_logger_context = contextlib.nullcontext()
 
         LOGGER.info('Stress command:\n%s', stress_cmd)
 
@@ -336,11 +350,12 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
                 CassandraStressEvent(node=loader, stress_cmd=self.stress_cmd,
                                      log_file_name=log_file_name) as cs_stress_event, \
                 CassandraStressHDRExporter(instance_name=cmd_runner_name,
+                                           hdr_tags=self.hdr_tags,
                                            metrics=nemesis_metrics_obj(),
                                            stress_operation=stress_cmd_opt,
                                            stress_log_filename=local_hdr_file_name,
                                            loader_idx=loader_idx, cpu_idx=cpu_idx), \
-                hdr_logger_context:
+                hdrh_logger_context:
             publisher.event_id = cs_stress_event.event_id
             try:
                 with SoftTimeoutContext(timeout=self.soft_timeout, operation="cassandra-stress"):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -144,10 +144,8 @@ from sdcm.utils.auth_context import temp_authenticator
 from sdcm.keystore import KeyStore
 from sdcm.utils.latency import calculate_latency, analyze_hdr_percentiles
 from sdcm.utils.hdrhistogram import (
-    CSHistogramTagTypes,
-    CSWorkloadTypes,
-    make_cs_range_histogram_summary,
-    make_cs_range_histogram_summary_by_interval,
+    make_hdrhistogram_summary,
+    make_hdrhistogram_summary_by_interval,
 )
 from sdcm.utils.raft.common import validate_raft_on_nodes
 from sdcm.commit_log_check_thread import CommitLogCheckThread
@@ -2008,7 +2006,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         params = dict(stress_cmd=stress_cmd, duration=duration, stress_num=stress_num, keyspace_num=keyspace_num,
                       keyspace_name=keyspace_name, profile=profile, prefix=prefix, round_robin=round_robin,
                       stats_aggregate_cmds=stats_aggregate_cmds, use_single_loader=use_single_loader)
-
         if 'cql-stress-cassandra-stress' in stress_cmd:
             params['stop_test_on_failure'] = stop_test_on_failure
             params['compaction_strategy'] = compaction_strategy
@@ -2185,9 +2182,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                          round_robin=False, stats_aggregate_cmds=True, stop_test_on_failure=True, **_):
         if duration:
             timeout = self.get_duration(duration)
-        elif self._stress_duration and ' --duration' in stress_cmd:
+        elif self._stress_duration and (' --duration' in stress_cmd or ' -d' in stress_cmd):
             timeout = self.get_duration(self._stress_duration)
-            stress_cmd = re.sub(r'\s--duration\s+\d+[mhd]\s', f' --duration {self._stress_duration}m ', stress_cmd)
+            stress_cmd = re.sub(
+                r'\s(?:--duration|-d)[ =]\d+[mhd]?\s',
+                f' --duration {self._stress_duration}m ', stress_cmd)
         else:
             timeout = get_timeout_from_stress_cmd(stress_cmd) or self.get_duration(duration)
 
@@ -3303,7 +3302,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         assert used >= size, f"Waiting for Scylla data dir to reach '{size}', " \
                              f"current size is: '{used}'"
 
-    def check_latency_during_ops(self):
+    def check_latency_during_ops(self, hdr_tags: list[str]):
         start_time = self.start_time if not self.create_stats else self._stats["test_details"]["start_time"]
         end_time = time.time()
         analyzer = LatencyDuringOperationsPerformanceAnalyzer
@@ -3320,12 +3319,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         benchmarks_results = self.db_cluster.get_node_benchmarks_results() if self.db_cluster else {}
         if latency_results and self.create_stats:
             workload = self._test_index.split("-")[-1]
-            histogram_total_data = self.get_cs_range_histogram(stress_operation=workload,
-                                                               start_time=start_time,
-                                                               end_time=end_time)
-            histogram_data_by_interval = self.get_cs_range_histogram_by_interval(stress_operation=workload,
-                                                                                 start_time=start_time,
-                                                                                 end_time=end_time)
+            histogram_total_data = self.get_hdrhistogram(
+                hdr_tags=hdr_tags, stress_operation=workload, start_time=start_time, end_time=end_time)
+            histogram_data_by_interval = self.get_hdrhistogram_by_interval(
+                hdr_tags=hdr_tags, stress_operation=workload, start_time=start_time, end_time=end_time)
             latency_results["summary"] = {"hdr_summary": histogram_total_data,
                                           "hdr": histogram_data_by_interval}
             latency_results = calculate_latency(latency_results)
@@ -3873,29 +3870,26 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 return True
         return False
 
-    def get_cs_range_histogram(self, stress_operation: str,
-                               start_time: float, end_time: float,
-                               tag_type: CSHistogramTagTypes = CSHistogramTagTypes.LATENCY) -> dict[str, Any]:
+    def get_hdrhistogram(self, hdr_tags: list[str], stress_operation: str,
+                         start_time: float, end_time: float) -> dict[str, Any]:
         if not self.params["use_hdrhistogram"]:
             return {}
-        self.log.info("Build HDR histogram with start time: %s, end time: %s; for operation: %s",
-                      start_time, end_time, stress_operation)
-        histogram_data = make_cs_range_histogram_summary(
-            workload=CSWorkloadTypes(stress_operation),
-            base_path=self.loaders.logdir, start_time=start_time, end_time=end_time,
-            tag_type=tag_type)
+        self.log.info("Build HDR histogram (tags: %s) with start time: %s, end time: %s; for operation: %s",
+                      hdr_tags, start_time, end_time, stress_operation)
+        histogram_data = make_hdrhistogram_summary(
+            hdr_tags=hdr_tags, stress_operation=stress_operation,
+            start_time=start_time, end_time=end_time, base_path=self.loaders.logdir)
         self.log.info("HDR histogram summary result: %s", histogram_data)
         return histogram_data[0] if histogram_data else {}
 
-    def get_cs_range_histogram_by_interval(
-            self, stress_operation: str,
-            start_time: float, end_time: float, time_interval: int = 600,
-            tag_type: CSHistogramTagTypes = CSHistogramTagTypes.LATENCY) -> list[dict[str, Any]]:
+    def get_hdrhistogram_by_interval(self, hdr_tags: list[str], stress_operation: str,
+                                     start_time: float, end_time: float,
+                                     time_interval: int = 600) -> list[dict[str, Any]]:
         if not self.params["use_hdrhistogram"]:
             return []
-        self.log.info("Build HDR histogram with start time: %s, end time: %s, time interval: %s for operation: %s",
-                      start_time, end_time, time_interval, stress_operation)
-        return make_cs_range_histogram_summary_by_interval(
-            workload=CSWorkloadTypes(stress_operation),
-            path=self.loaders.logdir, start_time=start_time, end_time=end_time,
-            interval=time_interval, tag_type=tag_type)
+        self.log.info(
+            "Build HDR histogram (tags: %s) with start time: %s, end time: %s, time interval: %s for operation: %s",
+            hdr_tags, start_time, end_time, time_interval, stress_operation)
+        return make_hdrhistogram_summary_by_interval(
+            hdr_tags=hdr_tags, stress_operation=stress_operation,
+            path=self.loaders.logdir, start_time=start_time, end_time=end_time, interval=time_interval)

--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -157,6 +157,22 @@ def measure_time(func):
     return wrapped
 
 
+def _find_hdr_tags(*args):
+    for input_arg in args:
+        if isinstance(input_arg, dict) and "hdr_tags" in input_arg:
+            # NOTE: case when some method has 'hdr_tags' kwarg
+            return input_arg["hdr_tags"]
+        elif hasattr(input_arg, "hdr_tags"):
+            # NOTE: case of 'stress_queue.hdr_tags' and 'nemesis.hdr_tags'
+            return input_arg.hdr_tags
+        elif isinstance(input_arg, tuple):
+            # NOTE: case when 'stress_queue' is part of a returned tuple
+            for input_subarg in input_arg:
+                if hasattr(input_subarg, "hdr_tags"):
+                    return input_subarg.hdr_tags
+    raise ValueError("Failed to find 'hdr_tags'")
+
+
 def latency_calculator_decorator(original_function: Optional[Callable] = None, *, legend: Optional[str] = None,
                                  cycle_name: Optional[str] = None):
     """
@@ -239,21 +255,27 @@ def latency_calculator_decorator(original_function: Optional[Callable] = None, *
             result["screenshots"] = screenshots
             result["duration"] = f"{datetime.timedelta(seconds=int(end - start))}"
             result["duration_in_sec"] = int(end - start)
+
             try:
-                result["hdr"] = tester.get_cs_range_histogram_by_interval(stress_operation=workload,
-                                                                          start_time=start,
-                                                                          end_time=end)
+                hdr_tags = _find_hdr_tags(kwargs, res, _self)
+            except Exception as err:  # noqa: BLE001
+                LOGGER.error("Failed to find 'hdr_tags': %s", err)
+                hdr_tags = []
+            try:
+                result["hdr"] = tester.get_hdrhistogram_by_interval(
+                    hdr_tags=hdr_tags, stress_operation=workload,
+                    start_time=start, end_time=end)
                 LOGGER.debug("hdr: %s", result["hdr"])
             except Exception as err:  # noqa: BLE001
-                LOGGER.error("Failed to get cs_range_histogram_by_interval error: %s", err)
+                LOGGER.error("Failed to get hdrhistogram_by_interval error: %s", err)
                 result["hdr"] = {}
 
             try:
-                result["hdr_summary"] = tester.get_cs_range_histogram(stress_operation=workload,
-                                                                      start_time=start,
-                                                                      end_time=end)
+                result["hdr_summary"] = tester.get_hdrhistogram(
+                    hdr_tags=hdr_tags, stress_operation=workload,
+                    start_time=start, end_time=end)
             except Exception as err:  # noqa: BLE001
-                LOGGER.error("Failed to get cs_range_histogram error: %s", err)
+                LOGGER.error("Failed to get hdrhistogram error: %s", err)
                 result["hdr_summary"] = {}
             hdr_throughput = 0
             for summary, values in result["hdr_summary"].items():

--- a/sdcm/utils/hdrhistogram.py
+++ b/sdcm/utils/hdrhistogram.py
@@ -1,11 +1,9 @@
-import copy
 import glob
 import os.path
-import sys
+import time
 import logging
 import multiprocessing
 from typing import Any
-from enum import Enum
 from dataclasses import asdict, dataclass, make_dataclass
 from concurrent.futures.process import ProcessPoolExecutor
 
@@ -19,94 +17,68 @@ TIME_INTERVAL = 600
 PERCENTILES = [50, 90, 95, 99, 99.9, 99.99, 99.999]
 
 
-class CSHistogramTags(Enum):
-    WRITE = "WRITE-rt"
-    READ = "READ-rt"
-
-
-class CSHistogramTagTypes(Enum):
-    LATENCY = 0
-    THROUGHPUT = 1
-
-
-class CSWorkloadTypes(Enum):
-    WRITE = "write"
-    READ = "read"
-    MIXED = "mixed"
-
-
-def make_cs_range_histogram_summary(  # pylint: disable=too-many-arguments,unused-argument
-        workload: CSWorkloadTypes, pattern: str = "", base_path="", start_time: int | float = 0, end_time: int | float = sys.maxsize,
-        absolute_time: bool = True, tag_type: CSHistogramTagTypes = CSHistogramTagTypes.LATENCY) -> list[dict[str, dict[str, int]]]:
+def make_hdrhistogram_summary(
+        hdr_tags: list[str], stress_operation: str,
+        start_time: int | float, end_time: int | float,
+        pattern: str = "", base_path="", absolute_time: bool = True) -> list[dict[str, dict[str, int]]]:
     """
-    Build Range Histogram Summary with time interval (start_time, end_time)
+    Build time range HDR Histogram summary with time interval (start_time, end_time)
     from provided hdr log file.
     For timestamps is used absolute time in ms since epoch start
     """
-    builder = _CSRangeHistogramBuilder(workload, tag_type, start_time, end_time)
+    builder = _HdrRangeHistogramBuilder(
+        hdr_tags=hdr_tags,
+        stress_operation=stress_operation,
+        start_time=start_time,
+        end_time=end_time,
+    )
     if pattern:
-        builder.cs_files_pattern = pattern
+        builder.hdrh_files_pattern = pattern
     builder.absolute_time = absolute_time
     return builder.build_histogram_summary(base_path)
 
 
-def make_cs_range_histogram_summary_by_interval(  # pylint: disable=too-many-arguments,unused-argument
-        workload: CSWorkloadTypes, path: str, start_time: int | float, end_time: int | float, interval=TIME_INTERVAL,
-        absolute_time=True, tag_type: CSHistogramTagTypes = CSHistogramTagTypes.LATENCY) -> list[dict[str, dict[str, int]]]:
+def make_hdrhistogram_summary_by_interval(
+        hdr_tags: list[str], stress_operation: str,
+        path: str,
+        start_time: int | float, end_time: int | float,
+        interval: int | float = TIME_INTERVAL, absolute_time: bool = True) -> list[dict[str, dict[str, int]]]:
     """
-    Build set of time range histograms (as list) from
+    Build set of time range HDR histograms (as list) from
     single file or files search by pattern in provided
     dir path for time range (start_time, end_time) with
     interval 'interval'. each Time range histogram will
     have results with time duration 'interval'.
     """
-    builder = _CSRangeHistogramBuilder(workload, tag_type, start_time, end_time)
+    builder = _HdrRangeHistogramBuilder(
+        hdr_tags=hdr_tags,
+        stress_operation=stress_operation,
+        start_time=start_time,
+        end_time=end_time,
+    )
     builder.absolute_time = absolute_time
     return builder.build_histograms_summary_with_interval(path, interval)
 
 
-def make_cs_range_histogram_summary_from_log_line(
-        workload: CSWorkloadTypes, log_line: str, hst_log_start_time: float,
-        tag_type: CSHistogramTagTypes = CSHistogramTagTypes.LATENCY) -> dict[str, dict[str, int]]:
+def make_hdrhistogram_summary_from_log_line(
+        hdr_tags: list[str], stress_operation: str,
+        log_line: str, hst_log_start_time: float) -> dict[str, dict[str, int]]:
     """
-    Build time range histogram Summary from singe hdr log file line
-    log line example:
+    Build time range HDR histogram summary from a single hdr log file line. Example:
+
     #[BaseTime: 1665956621.000 (seconds since epoch)]
     #[StartTime: 1665956621.000 (seconds since epoch), Sun Oct 16 21:43:41 UTC 2022]
     "StartTimestamp","Interval_Length","Interval_Max","Interval_Compressed_Histogram"
     Tag=READ-st,0.000,4.999,20.726,HISTFAAAA9d42jVUMY/kN...
     """
-    builder = _CSRangeHistogramBuilder(workload, tag_type)
+    now, time_deviation = time.time(), 60 * 60 * 24
+    builder = _HdrRangeHistogramBuilder(
+        hdr_tags=hdr_tags,
+        stress_operation=stress_operation,
+        start_time=now - time_deviation,
+        end_time=now + time_deviation,
+    )
     return builder.build_from_log_line(log_line, hst_log_start_time)
-
-
-class _CSHistogramThroughputTags(Enum):
-    WRITE = "WRITE-st"
-    READ = "READ-st"
-
-
-TAG_PAIRS = {"WRITE": [_CSHistogramThroughputTags.WRITE.value, CSHistogramTags.WRITE.value],
-             "READ": [_CSHistogramThroughputTags.READ.value, CSHistogramTags.READ.value]}
-
-
-_CSHISTOGRAM_TAGS_MAPPING = {
-    CSHistogramTagTypes.LATENCY: {
-        CSWorkloadTypes.WRITE: [CSHistogramTags.WRITE],
-        CSWorkloadTypes.READ: [CSHistogramTags.READ],
-        CSWorkloadTypes.MIXED: [
-            CSHistogramTags.WRITE,
-            CSHistogramTags.READ
-        ]
-    },
-    CSHistogramTagTypes.THROUGHPUT: {
-        CSWorkloadTypes.WRITE: [_CSHistogramThroughputTags.WRITE],
-        CSWorkloadTypes.READ: [_CSHistogramThroughputTags.READ],
-        CSWorkloadTypes.MIXED: [
-            _CSHistogramThroughputTags.WRITE,
-            _CSHistogramThroughputTags.READ
-        ]
-    }
-}
 
 
 @dataclass
@@ -126,38 +98,34 @@ _HistorgramSummary = make_dataclass("HistorgramSummary",
                                     bases=(_HistorgramSummaryBase,))
 
 
-class _CSHistogram(HdrHistogram):
+class _HdrHistogram(HdrHistogram):
     LOWEST = 1
     HIGHEST = 24 * 3600_000_000_000
     SIGNIFICANT = 3
 
     def __init__(self, *args, **kwargs):
-        super().__init__(lowest_trackable_value=_CSHistogram.LOWEST,
-                         highest_trackable_value=_CSHistogram.HIGHEST,
-                         significant_figures=_CSHistogram.SIGNIFICANT, *args, **kwargs)
+        super().__init__(lowest_trackable_value=_HdrHistogram.LOWEST,
+                         highest_trackable_value=_HdrHistogram.HIGHEST,
+                         significant_figures=_HdrHistogram.SIGNIFICANT, *args, **kwargs)
 
 
 @dataclass
-class _CSRangeHistogram:
+class _HdrRangeHistogram:
     start_time: float
     end_time: float
     hdr_tag: str | None
-    histogram: _CSHistogram | None
+    histogram: _HdrHistogram | None
 
 
-class _CSRangeHistogramBuilder:
-    def __init__(self, workload: CSWorkloadTypes, tag_type: CSHistogramTagTypes,
-                 start_time: int = 0,
-                 end_time: int = sys.maxsize):
-        self.workload = workload
-        self.tag_type = tag_type
-        if self.workload and self.tag_type:
-            self.hdr_tags = [w.value for w in _CSHISTOGRAM_TAGS_MAPPING[tag_type][workload]]
+class _HdrRangeHistogramBuilder:
+    def __init__(self, hdr_tags: list[str], stress_operation: str,
+                 start_time: int | float, end_time: int | float,
+                 hdr_file_pattern: str = "*/hdrh-*.hdr"):
+        self.hdr_tags = hdr_tags
+        self.stress_operation = stress_operation.upper().strip()
         self.start_time = start_time
         self.end_time = end_time
-
-# defaults
-        self.cs_files_pattern = "*/cs-hdr-*.hdr"
+        self.hdrh_files_pattern = hdr_file_pattern
         self.absolute_time = True
 
     def build_histogram_summary(self, path: str) -> list[dict[str, dict[str, int]]]:
@@ -173,7 +141,8 @@ class _CSRangeHistogramBuilder:
                 scan_results.update(result)
         return [scan_results]
 
-    def build_histograms_summary_with_interval(self, path: str, interval=TIME_INTERVAL) -> list[dict[str, dict[str, int]]]:  # pylint: disable=too-many-locals
+    def build_histograms_summary_with_interval(self, path: str,
+                                               interval=TIME_INTERVAL) -> list[dict[str, dict[str, int]]]:
         """
         Build Several Range Histogram Summaries from provided hdr logs files path splitted by interval
         """
@@ -222,35 +191,25 @@ class _CSRangeHistogramBuilder:
             raise TypeError(f"build_from_log_line: log_line has tag {tag} but expected one of {self.hdr_tags}")
         hst_start_ts = hst_log_start_time + float(start)
         hst_end_ts = hst_start_ts + float(interval_len)
-        histogram = _CSHistogram()
+        histogram = _HdrHistogram()
         histogram.set_tag(tag)
         histogram.set_start_time_stamp(hst_start_ts)
         histogram.set_end_time_stamp(hst_end_ts)
         histogram.decode_and_add(encoded_hist)
 
-        histogram = _CSRangeHistogram(start_time=hst_start_ts,
-                                      end_time=hst_end_ts,
-                                      histogram=histogram,
-                                      hdr_tag=tag)
+        histogram = _HdrRangeHistogram(
+            start_time=hst_start_ts, end_time=hst_end_ts, histogram=histogram, hdr_tag=tag)
 
-        return _CSRangeHistogramBuilder._get_summary_for_operation_by_hdr_tag(histogram)
+        return self._get_summary_for_operation_by_hdr_tag(histogram)
 
-    @staticmethod
-    def switch_tags(hdr_tag: str):
-        tag_pairs = copy.deepcopy(TAG_PAIRS)
-        # hdr_tag value like: WRITE-st
-        tags = tag_pairs[hdr_tag.split("-")[0]]
-        tags.remove(hdr_tag)
-        return tags
-
-    def _build_histogram_from_file(self, hdr_file: str, hdr_tag: str) -> _CSRangeHistogram | None:
+    def _build_histogram_from_file(self, hdr_file: str, hdr_tag: str) -> _HdrRangeHistogram | None:
         def analyze_hdr_file():
             """
             :return: tuple(tag_not_found, file_with_correct_time_interval)
             tag_not_found: bool - row with HDR tag (like "WRITE-st") is not found in the file
             file_with_correct_time_interval: bool - HDR file keep the data for different time interval
             """
-            hdr_reader = HistogramLogReader(hdr_file, _CSHistogram())
+            hdr_reader = HistogramLogReader(hdr_file, _HdrHistogram())
             if not (next_hist := hdr_reader.get_next_interval_histogram(range_start_time_sec=self.start_time,
                                                                         range_end_time_sec=self.end_time,
                                                                         absolute=self.absolute_time)):
@@ -273,11 +232,11 @@ class _CSRangeHistogramBuilder:
 
         if not os.path.exists(hdr_file):
             LOGGER.error("File doesn't exists: %s", hdr_file)
-            return _CSRangeHistogram(start_time=0, end_time=0, histogram=None, hdr_tag=None)
+            return _HdrRangeHistogram(start_time=0, end_time=0, histogram=None, hdr_tag=None)
 
-        histogram = _CSHistogram()
+        histogram = _HdrHistogram()
         histogram.set_tag(hdr_tag)
-        tag_not_found, file_with_correct_time_interval = analyze_hdr_file()
+        _, file_with_correct_time_interval = analyze_hdr_file()
 
         if not file_with_correct_time_interval:
             # Keep this message for future debug
@@ -288,24 +247,11 @@ class _CSRangeHistogramBuilder:
         # Keep this message for future debug
         LOGGER.debug("Collect data from the file '%s' (time interval from `%s` to `%s`)",
                      hdr_file, self.start_time, self.end_time)
-        # When c-s load runs without fixed/throttle, the histogram data with WRITE-rt/READ-rt (latency) tags is not created in the HDR file.
-        # In this case all statistics will be reported with WRITE-st/READ-st (throughput) tags.
-        # It is according to the cassandra-stress code.
-        # So if rows with the hdr_tag is not found - try to find data with another tag
-        # For more explanation see https://github.com/scylladb/qa-tasks/issues/1675#issuecomment-2331257420
-        if tag_not_found:
-            tags = self.switch_tags(hdr_tag)
-            while tags:
-                hdr_tag = tags[0]
-                analyze_hdr_file()
-                tags.remove(hdr_tag)
-
         if histogram.get_start_time_stamp() == 0:
             return None
 
-        return _CSRangeHistogram(start_time=self.start_time,
-                                 end_time=self.end_time,
-                                 histogram=histogram, hdr_tag=histogram.get_tag())
+        return _HdrRangeHistogram(
+            start_time=self.start_time, end_time=self.end_time, histogram=histogram, hdr_tag=histogram.get_tag())
 
     def _get_list_of_hdr_files(self, base_path: str) -> list[str]:
         """
@@ -315,17 +261,17 @@ class _CSRangeHistogramBuilder:
         if not base_path:
             base_path = os.path.abspath(os.path.curdir)
         hdr_files = []
-        for hdr_file in glob.glob(self.cs_files_pattern, root_dir=base_path, recursive=True):
+        for hdr_file in glob.glob(self.hdrh_files_pattern, root_dir=base_path, recursive=True):
             hdr_files.append(os.path.join(base_path, hdr_file))
         return hdr_files
 
     @staticmethod
-    def _merge_range_histograms(range_histograms: list[_CSRangeHistogram]) -> _CSRangeHistogram:
+    def _merge_range_histograms(range_histograms: list[_HdrRangeHistogram]) -> _HdrRangeHistogram:
         """
             Merge several time range histogram to one containg summary result.
         """
         if not range_histograms:
-            return _CSRangeHistogram(start_time=0, end_time=0, histogram=None, hdr_tag=None)
+            return _HdrRangeHistogram(start_time=0, end_time=0, histogram=None, hdr_tag=None)
 
         final_hst = range_histograms.pop(0)
         for hst in range_histograms:
@@ -336,14 +282,14 @@ class _CSRangeHistogramBuilder:
             final_hst.end_time = max(final_hst.end_time, hst.end_time)
         return final_hst
 
-    def _build_histogram_from_dir(self, base_path: str, hdr_tag: str, ) -> _CSRangeHistogram:
+    def _build_histogram_from_dir(self, base_path: str, hdr_tag: str, ) -> _HdrRangeHistogram:
         """
             search in dir from 'base_path' with provided pattern or
             default global pattern 'CS_HDR_FILE_WC' hdr log files
             and build Range Histogram with time interval (start_time, end_time)
             For timestamps is used absolute time in ms since epoch start
         """
-        collected_histograms: list[_CSRangeHistogram] = []
+        collected_histograms: list[_HdrRangeHistogram] = []
         hdr_files = self._get_list_of_hdr_files(base_path)
         for hdr_file in hdr_files:
             if os.stat(hdr_file).st_size == 0:
@@ -355,16 +301,38 @@ class _CSRangeHistogramBuilder:
                 collected_histograms.append(file_range_histogram)
         return self._merge_range_histograms(collected_histograms)
 
-    @staticmethod
-    def _get_summary_for_operation_by_hdr_tag(histogram: _CSRangeHistogram) -> dict[str, dict[str, int]] | None:
-        if histogram.histogram and (parsed_summary := _CSRangeHistogramBuilder._convert_raw_histogram(histogram.histogram,
-                                                                                                      histogram.start_time,
-                                                                                                      histogram.end_time)):
-            return {histogram.hdr_tag[:-3]: asdict(parsed_summary)}
+    def _get_workload_type_by_hdr_tag(self, hdr_tag):
+        # NOTE: different benchmarking tools have completly different approaches for HDR tag usages.
+        #
+        # 1) 'cassandra-stress' uses "WRITE-rt" and "READ-rt" tags for coordinated omission fixed latencies.
+        #    It is when "-rate 'fixed=100/s'" is specified.
+        #    In all other cases it's tags are coordinated omission affected latencies with
+        #    the 'WRITE-st' and 'READ-st' tags.
+        # 2) 'latte' may have arbitrary tag names, they are based on the user-defined rune function names.
+        #    Examples: 'fn--write', 'fn--write-batch', 'fn--get', 'fn--get-many', 'fn--read'.
+        # 3) 'scylla-bench' has identical tag names for reads and writes - 'co-fixed' and 'raw'.
+        #    It doesn't have 'mixed' workload type, so it's mode should be used for detecting the tag data type.
+        # 4) NOT_SUPPORTED: 'ycsb', it supports HDR histograms, but doesn't use tags in it.
+        #    So, the 'ycsb' case should be handled separately.
+        hdr_tag = hdr_tag.lower().strip()
+        if any(w_word in hdr_tag for w_word in ("write", "insert", "update")):
+            return "WRITE"
+        elif any(r_word in hdr_tag for r_word in ("read", "select", "get")):
+            return "READ"
+        elif self.stress_operation in ("WRITE", "READ"):
+            # branch for the scylla-bench case with its 'co-fixed' and 'raw' tags
+            return self.stress_operation
+        # NOTE: following exception raising is not expected in the properly configured test scenarios
+        raise ValueError(f"Failed to detect the workload type for the following hdr_tag: {hdr_tag}")
+
+    def _get_summary_for_operation_by_hdr_tag(self, histogram: _HdrRangeHistogram) -> dict[str, dict[str, int]] | None:
+        if histogram.histogram and (parsed_summary := self._convert_raw_histogram(
+                histogram.histogram, histogram.start_time, histogram.end_time)):
+            return {self._get_workload_type_by_hdr_tag(histogram.hdr_tag): asdict(parsed_summary)}
         return None
 
     @staticmethod
-    def _convert_raw_histogram(histogram: _CSHistogram,
+    def _convert_raw_histogram(histogram: _HdrHistogram,
                                base_start_ts: float = 0.0,
                                base_end_ts: float = 0.0) -> "_HistorgramSummary":
         percentiles_data = {}
@@ -382,24 +350,26 @@ class _CSRangeHistogramBuilder:
 
     def build_histogram_summary_by_tag(self, path: str, hdr_tag: str) -> dict[str, dict[str, int]] | None:
         if os.path.exists(path) and os.path.isfile(path):
-            histogram = self._build_histogram_from_file(
-                hdr_file=path, hdr_tag=hdr_tag)
+            histogram = self._build_histogram_from_file(hdr_file=path, hdr_tag=hdr_tag)
             if not histogram:
                 return None
         elif os.path.exists(path) and os.path.isdir(path):
-            histogram = self._build_histogram_from_dir(
-                base_path=path, hdr_tag=hdr_tag)
+            histogram = self._build_histogram_from_dir(base_path=path, hdr_tag=hdr_tag)
         else:
             return None
 
-        return _CSRangeHistogramBuilder._get_summary_for_operation_by_hdr_tag(histogram)
+        return self._get_summary_for_operation_by_hdr_tag(histogram)
 
-    @staticmethod
-    def _build_histograms_summary_with_interval_by_tag(path: str, hdr_tag: str, start_interval: int,
-                                                       end_interval: int, interval_num: int) -> dict[str, Any] | None:
-
-        result = _CSRangeHistogramBuilder(None, None, start_interval,
-                                          end_interval).build_histogram_summary_by_tag(path, hdr_tag)
+    def _build_histograms_summary_with_interval_by_tag(
+            self, path: str, hdr_tag: str,
+            start_interval: int, end_interval: int,
+            interval_num: int) -> dict[str, Any] | None:
+        result = _HdrRangeHistogramBuilder(
+            hdr_tags=[hdr_tag],
+            stress_operation=self.stress_operation,
+            start_time=start_interval,
+            end_time=end_interval,
+        ).build_histogram_summary_by_tag(path, hdr_tag)
         if result:
             return {"interval_num": interval_num, "result": result}
         return None

--- a/ycsb_performance_regression_test.py
+++ b/ycsb_performance_regression_test.py
@@ -88,7 +88,7 @@ class BaseYCSBPerformanceRegressionTest(PerformanceRegressionTest):
         if not nemesis:
             self.check_regression()
         else:
-            self.check_latency_during_ops()
+            self.check_latency_during_ops(hdr_tags=stress_queue.hdr_tags)
 
     def test_latency(self):
         """


### PR DESCRIPTION
Current solution for HDR histograms assumes we use only `cassandra-stress`.
We are going to start using one more benchmarking tool that supports HDR histograms - `latte`.
So, refactor it's logic making the hdr tags be provided by the stress thread code which can detect it automatically.

With this refactor, we will be able to add HDR histograms support in SCT not only for `latte`,
but also for other benchmarking tools such as `scylla-bench` or `cql-stress-cassandra-stress`.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- cassandra-stress, regression test: [scylla-staging/valerii/vp-perf-regression-latency-650gb-during-rolling-upgrade#22](https://argus.scylladb.com/tests/scylla-cluster-tests/f3841cb3-dd97-4d0d-b8b4-0cd65dd74a15)
- cassandra-stress, regression test: [scylla-staging/valerii/vp-scylla-master-perf-regression-latency-650gb-with-nemesis#3](https://argus.scylladb.com/tests/scylla-cluster-tests/26d8078d-592f-4802-b93b-464af87b6f8f)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
