### PR TITLE
fix(unit-test): unflake cdc cluster test

### DIFF
--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -172,7 +172,7 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
                 with ignore_upgrade_schema_errors():
                     self._read_and_publish_events()
 
-        time.sleep(0.1)
+        time.sleep(0.2)
         with self.get_events_logger().events_logs_by_severity[Severity.ERROR].open() as events_file:
             cdc_err_events = [line for line in events_file if 'cdc - Could not retrieve CDC streams' in line]
             assert cdc_err_events != []


### PR DESCRIPTION
Recently `test_search_cdc_invalid_request` started to be flaky. Increase wait time for event to appear to prevent test from failing randomly.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
