### PR TITLE
fix(manager): clean up non-supported SCT_BACKUP_BUCKET_REGION var

### DIFF
--- a/jenkins-pipelines/manager/helpers/prepare-backup-snapshot.jenkinsfile
+++ b/jenkins-pipelines/manager/helpers/prepare-backup-snapshot.jenkinsfile
@@ -13,6 +13,4 @@ managerPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-
-    extra_environment_variables: 'SCT_BACKUP_BUCKET_REGION=us-east-1',
 )


### PR DESCRIPTION
SCT_BACKUP_BUCKET_REGION configuration parameter is not supported by SCT since https://github.com/scylladb/scylla-cluster-tests/pull/9492/commits/2c574e7e7d4b72301aa362946355e7f864f4bd12. 

Therefore, it should be removed from jenkinsfile, otherwise causing SCT to fail (unsupported parameter).

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
Testing is not required.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code