### PR TITLE
test(performance regression): allow pre-creating the test keyspace

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -22,6 +22,7 @@ from enum import Enum
 import yaml
 from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
 
+from sdcm.utils import loader_utils
 from upgrade_test import UpgradeTest
 from sdcm.tester import ClusterTester, teardown_on_exception
 from sdcm.sct_events import Severity
@@ -45,7 +46,7 @@ class PerformanceTestType(Enum):
     LATENCY = "latency"
 
 
-class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-public-methods
+class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):  # pylint: disable=too-many-public-methods
 
     """
     Test Scylla performance regression with cassandra-stress.
@@ -219,6 +220,9 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
 
     @optional_stage('perf_preload_data')
     def preload_data(self, compaction_strategy=None):
+        # Check if the test keyspace should be pre-created
+        if self.params.get('pre_create_keyspace'):
+            self._pre_create_keyspace()
         # if test require a pre-population of data
         prepare_write_cmd = self.params.get('prepare_write_cmd')
         if prepare_write_cmd:


### PR DESCRIPTION
This would allow to set configurations options that cassandara-stress does not support like setting the initial number of tablets.
Similar to what the longevity test does.



### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [X] I added the relevant `backport` labels
- [X] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
