### PR TITLE
fix(performance): split base versions for rolling upgrade test

### DIFF
--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -177,7 +177,7 @@ def call(Map pipelineParams) {
                                         checkout scm
                                         dockerLogin(params)
                                         (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout) = getJobTimeouts(params, builder.region)
-                                        base_versions_list = params.base_versions.contains('.') ? params.base_versions.split('\\,') : []
+                                        ArrayList base_versions_list = params.base_versions.contains('.') ? params.base_versions.split('\\,') : []
                                         def new_repo = params.new_scylla_repo
                                         supportedVersions = ''
                                         new_params = params.collectEntries { param -> [param.key, param.value] }


### PR DESCRIPTION
When base version was added by release trigger, the performance rolling upgrade test started to fail with error:
```
No signature of method: supportedUpgradeFromVersions.call()
```

The problem is **'ArrayList'** missed and **'base_versions_list'** parameted was created as string and not as list, as supportedUpgradeFromVersions.call() function expects.

Fixes: https://github.com/scylladb/qa-tasks/issues/1851

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [rolling upgrade test with base_versions applied](https://argus.scylladb.com/tests/scylla-cluster-tests/c198f587-b675-4f75-a909-da666a2e3e59)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
