### PR TITLE
fix(rolling-upgrade): remove branch filter

### DIFF
--- a/vars/supportedUpgradeFromVersions.groovy
+++ b/vars/supportedUpgradeFromVersions.groovy
@@ -14,21 +14,6 @@ def call(List base_versions_list, String linux_distro, String new_scylla_repo, S
         println("Did not find a valid base versions string!")
             throw new Exception("Didn't get valid base versions automatically!")
         }
-
     }
-    if (new_scylla_repo.contains('enterprise')) {
-        return base_versions_list
-    } else {
-        return base_versions_list.findAll{ ! is_enterprise_version(it) }
-    }
-}
-
-def is_enterprise_version(String version) {
-    def first_version = 0
-    try {
-        first_version = version.tokenize('.')[0] as Integer
-    } catch (java.lang.NumberFormatException ex) {
-        println "WARN: non formal/versioned branch '$version', assuming opensource version"
-    }
-    return first_version > 2000
+    return base_versions_list
 }


### PR DESCRIPTION
this filter was assuming enterprise repo url, would have `enterprise` in them, that is not completly correct, the offical releases urls don't have `enterprise` in them.

regardless the code nowdays return the exact list of version needed for upgrade, and there no need for this filtering. (that was introduce in 2019, by fruch)

(cherry picked from commit 2f99132e8fd69ee289327c219c1f9e6fdf6372de)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
