### PR TITLE
Fix cloud snapshot preparer

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -624,11 +624,14 @@ class ManagerTestFunctionsMixIn(
     @cached_property
     def locations(self) -> list[str]:
         backend = self.params.get("backup_bucket_backend")
-
         region = next(iter(self.params.region_names), '')
-        buckets = self.params.get("backup_bucket_location").format(region=region)
-        if not isinstance(buckets, list):
-            buckets = buckets.split()
+        bucket_locations = self.params.get("backup_bucket_location")
+
+        buckets = (
+            [bucket.format(region=region) for bucket in bucket_locations]
+            if isinstance(bucket_locations, list)
+            else bucket_locations.format(region=region).split()
+        )
 
         # FIXME: Make it works with multiple locations or file a bug for scylla-manager.
         return [f"{backend}:{location}" for location in buckets[:1]]

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -497,14 +497,14 @@ class SnapshotPreparerOperations(ClusterTester):
         The name should include all the parameters important for c-s read verification and can be used to
         recreate such a command based on ks_name.
         """
-        _scylla_version = re.sub(r"[.]", "_", self.params.get_version_based_on_conf()[0].split("-")[0])
+        scylla_version = re.sub(r"[.]", "_", self.db_cluster.nodes[0].scylla_version)
         ks_name = self.ks_name_template.format(
             size=backup_size,
             compaction=self._abbreviate_compaction_strategy_name(cs_cmd_params.get("compaction")),
             cl=cs_cmd_params.get("cl").lower(),
             col_size=cs_cmd_params.get("col_size"),
             col_n=cs_cmd_params.get("col_n"),
-            scylla_version=_scylla_version,
+            scylla_version=scylla_version,
         )
         return ks_name
 


### PR DESCRIPTION
**Change Scylla version getting approach for snapshots preparer**

Since `_build_ks_name` method is used when Scylla cluster is deployed, there is no need to get `scylla_version` from configuration. Instead of this, it can be retrieved directly from Scylla node using node object property `scylla_version`.

It makes the method universal - supports both basic and cloud created clusters. The previous approach with getting version from config does not work for Cloud cluster (Siren clusters).

**Fix locations property to support list-type `backup_bucket_location` parameter**

Previous implementation supported only str-type `backup_bucket_location` and failed the test for list-type objects.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Regression check, [ubuntu22-sanity](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master-clone/job/ubuntu22-sanity-test/6/)
- [x] Backup snapshot preparer, [SCT standard cluster](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master-clone/view/Helpers/job/helper-prepare-backup-snapshot/8/)
- [x] Backup snapshot preparer, [Siren cloud cluster](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master-clone/view/Helpers/job/helper-prepare-backup-snapshot-cloud/4/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code