### PR TITLE
fix(Nemesis): is_tablets_feature_enabled wrong keyword argument

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1491,10 +1491,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if not self._is_it_on_kubernetes():
             raise UnsupportedNemesis('It is supported only on kubernetes')
         # If tablets in use, skipping resharding since it is not supported.
-        with self.cluster.cql_connection_patient(self.target_node) as session:
-            if is_tablets_feature_enabled(session=session):
-                if SkipPerIssues('https://github.com/scylladb/scylladb/issues/16739', params=self.tester.params):
-                    raise UnsupportedNemesis('https://github.com/scylladb/scylladb/issues/16739')
+        if is_tablets_feature_enabled(self.target_node):
+            if SkipPerIssues('https://github.com/scylladb/scylladb/issues/16739', params=self.tester.params):
+                raise UnsupportedNemesis('https://github.com/scylladb/scylladb/issues/16739')
 
         dc_idx = 0
         for node in self.cluster.nodes:
@@ -1790,10 +1789,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 # NOTE: resharding happens only if we have more than 1 core.
                 #       We may have 1 core in a K8S multitenant setup.
                 # If tablets in use, skipping resharding validation since it doesn't work the same as vnodes
-                with self.cluster.cql_connection_patient(self.cluster.data_nodes[0]) as session:
-                    if shards_num > 1 and not is_tablets_feature_enabled(session=session):
-                        SstableLoadUtils.validate_resharding_after_refresh(
-                            node=node, system_log_follower=system_log_follower)
+                if shards_num > 1 and not is_tablets_feature_enabled(self.cluster.data_nodes[0]):
+                    SstableLoadUtils.validate_resharding_after_refresh(
+                        node=node, system_log_follower=system_log_follower)
 
             # Verify that the special key is loaded by SELECT query
             result = self.target_node.run_cqlsh(query_verify)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1153,9 +1153,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                     (self.params.get('alternator_access_key_id'),
                                      self.params.get('alternator_secret_access_key')))
 
-            with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
-                # is tablets feature enabled in Scylla configuration.
-                tablets_enabled = is_tablets_feature_enabled(session)
+            tablets_enabled = is_tablets_feature_enabled(self.db_cluster.nodes[0])
             prepare_cmd = self.params.get('prepare_write_cmd')
             stress_cmd = self.params.get('stress_cmd')
             is_ttl_in_workload = any('dynamodb.ttlKey' in str(cmd) for cmd in [prepare_cmd, stress_cmd])


### PR DESCRIPTION
When updating `is_tablets_feature_enabled` session argument was changed to node. This change was not reflected in few places.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/jsmolar/job/longevity-5gb-1h-RefreshMonkey-aws-test/4/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
