### PR TITLE
feature(ArtifactsTest): IOTune parameters validation

### DIFF
--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -11,6 +11,7 @@
 #
 # Copyright (c) 2024 ScyllaDB
 import json
+import logging
 import time
 from datetime import timezone, datetime
 
@@ -20,6 +21,9 @@ from argus.client.generic_result import GenericResultTable, ColumnMetadata, Resu
 
 from sdcm.sct_events.event_counter import STALL_INTERVALS
 from sdcm.sct_events.system import FailedResultEvent
+
+
+LOGGER = logging.getLogger(__name__)
 
 LATENCY_ERROR_THRESHOLDS = {
     "replace_node": {
@@ -276,3 +280,55 @@ def send_manager_snapshot_details_to_argus(argus_client: ArgusClient, snapshot_d
     for key, value in snapshot_details.items():
         result_table.add_result(column=key, row="#1", value=value, status=Status.UNSET)
     submit_results_to_argus(argus_client, result_table)
+
+
+def send_iotune_results_to_argus(argus_client: ArgusClient, results: dict, node, params):
+    if not argus_client:
+        LOGGER.warning("Will not submit to argus - no client initialized")
+        return
+
+    class IOPropertiesResultsTable(GenericResultTable):
+        class Meta:
+            name = f"{params.get('cluster_backend')} - {node.db_node_instance_type} - Disk Performance"
+            description = "io_properties.yaml generated from live measured disk"
+            Columns = [
+                ColumnMetadata(name="read_iops", unit="iops", type=ResultType.INTEGER, higher_is_better=True),
+                ColumnMetadata(name="read_bandwidth", unit="bps", type=ResultType.INTEGER, higher_is_better=True),
+                ColumnMetadata(name="write_iops", unit="iops", type=ResultType.INTEGER, higher_is_better=True),
+                ColumnMetadata(name="write_bandwidth", unit="bps", type=ResultType.INTEGER, higher_is_better=True),
+            ]
+
+    class IOPropertiesDeviationResultsTable(GenericResultTable):
+        class Meta:
+            name = f"{params.get('cluster_backend')} - {node.db_node_instance_type} - Disk Performance Percent deviation"
+            description = "io_properties.yaml percent deviation from pre-configured disk"
+            Columns = [
+                ColumnMetadata(name="read_iops_pct_deviation", unit="%",
+                               type=ResultType.INTEGER, higher_is_better=False),
+                ColumnMetadata(name="read_bandwidth_pct_deviation", unit="%",
+                               type=ResultType.INTEGER, higher_is_better=False),
+                ColumnMetadata(name="write_iops_pct_deviation", unit="%",
+                               type=ResultType.INTEGER, higher_is_better=False),
+                ColumnMetadata(name="write_bandwidth_pct_deviation", unit="%",
+                               type=ResultType.INTEGER, higher_is_better=False),
+            ]
+
+            ValidationRules = {
+                "read_iops_pct_deviation": ValidationRule(fixed_limit=15),
+                "read_bandwidth_pct_deviation": ValidationRule(fixed_limit=15),
+                "write_iops_pct_deviation": ValidationRule(fixed_limit=15),
+                "write_bandwidth_pct_deviation": ValidationRule(fixed_limit=15),
+            }
+
+    table = IOPropertiesResultsTable()
+    for key, value in results["active"].items():
+        table.add_result(column=key, row="measured", value=value, status=Status.UNSET)
+        table.add_result(column=key, row="pre-configured", value=results["preset"][key], status=Status.UNSET)
+    submit_results_to_argus(argus_client, table)
+
+    table = IOPropertiesDeviationResultsTable()
+    for key, value in results["deviation_pct"].items():
+        table.add_result(column=f"{key}_pct_deviation", row="deviation_percent",
+                         value=value, status=Status.PASS if value < 15 else Status.WARNING)
+
+    submit_results_to_argus(argus_client, table)

--- a/sdcm/utils/validators/iotune.py
+++ b/sdcm/utils/validators/iotune.py
@@ -1,0 +1,101 @@
+from copy import deepcopy
+import logging
+from typing import TypedDict
+import yaml
+from sdcm.cluster import BaseNode
+from sdcm.remote.remote_file import remote_file
+from sdcm.sct_events import Severity
+from sdcm.sct_events.system import TestFrameworkEvent
+
+LOGGER = logging.getLogger(__name__)
+
+
+class IOTuneDiskParams(TypedDict):
+    mountpoint: str
+    read_iops: int
+    read_bandwidth: int
+    write_iops: int
+    write_bandwidth: int
+
+
+class IOProperties(TypedDict):
+    disks: list[IOTuneDiskParams]
+
+
+class IOTuneException(Exception):
+    pass
+
+
+class IOTuneValidator:
+    def __init__(self, node: BaseNode):
+        self.node = node
+        self.node_io_properties: IOProperties = {}
+        self.preset_io_properties: IOProperties = {}
+        self.results = {
+            "mountpoint": None,
+            "deviation": {},
+            "deviation_pct": {},
+            "active": {},
+            "preset": {},
+            "limits":  {},
+        }
+
+    def validate(self):
+        self._run_io_tune()
+        self._prepare_results_table()
+        self._format_results_to_console()
+
+    def _read_io_properties(self, io_props_path="/etc/scylla.d/io_properties.yaml") -> IOProperties:
+        with remote_file(self.node.remoter, io_props_path) as f:
+            return yaml.safe_load(f)
+
+    def _run_io_tune(self, temp_props_path="/tmp/io_properties.yaml") -> IOProperties:
+        self.node.remoter.sudo(f"iotune  --evaluation-directory /var/lib/scylla --properties-file {temp_props_path}")
+        self.node_io_properties = self._read_io_properties(temp_props_path)
+        self.preset_io_properties = self._read_io_properties()
+
+        preset_disk = next(iter(self.preset_io_properties.get("disks", [])), None)
+        if not preset_disk:
+            LOGGER.error("Unable to continue - node should have io_properties.yaml, but it doesn't.")
+            TestFrameworkEvent(source="send_iotune_results_to_argus",
+                               message="Unable to continue - node should have io_properties.yaml, but it doesn't.",
+                               severity=Severity.ERROR).publish()
+            raise IOTuneException("Unable to continue - node should have io_properties.yaml, but it doesn't.")
+
+        return self.node_io_properties
+
+    @staticmethod
+    def _bottom_limit(metric_val, threshold=0.15):
+        """
+            Determine disk metric deviation threshold and
+            use that as fixed limit
+        """
+        return metric_val * threshold
+
+    def _prepare_results_table(self):
+        preset_disk = next(iter(self.preset_io_properties.get("disks", [])), None)
+        tested_disk = deepcopy(next(iter(self.node_io_properties.get("disks", []))))
+        tested_mountpoint = tested_disk.pop("mountpoint")
+        if tested_mountpoint != preset_disk["mountpoint"]:
+            LOGGER.error("Disks differ - probably a mistake: %s vs %s",
+                         tested_mountpoint, preset_disk["mountpoint"])
+            TestFrameworkEvent(source=self.__class__.__name__,
+                               message=f"Disks differ - probably a mistake: {tested_mountpoint} vs {preset_disk['mountpoint']}",
+                               severity=Severity.ERROR).publish()
+            raise IOTuneException(
+                f"Disks differ - probably a mistake: {tested_mountpoint} vs {preset_disk['mountpoint']}")
+
+        self.results["mountpoint"] = tested_mountpoint
+        for key, value in tested_disk.items():
+            preset_val = preset_disk.get(key)
+            deviation_val = abs(preset_val - value)
+            self.results["deviation"][key] = deviation_val
+            self.results["deviation_pct"][key] = (deviation_val / preset_val) * 100
+            self.results["active"][key] = value
+            self.results["preset"][key] = preset_disk.get(key)
+            self.results["limits"][key] = self._bottom_limit(preset_disk[key])
+
+    def _format_results_to_console(self):
+        LOGGER.info("Disk performance values validation - testing %s", self.results["mountpoint"])
+        for key, val in self.results["active"].items():
+            LOGGER.info("[%s] %s: %s (%.0f%)", self.results["mountpoint"], key, val, self.results["deviation_pct"][key])


### PR DESCRIPTION
This commits adds a new subtest inside Artifacts test, that does the
check of machine image io_properties.yaml by comparing them to the
actual machine values and showing the deviation. The results are both
printed to console with deviation value and submitted to argus as a 
GenericResultTable.

Fixes scylladb/qa-tasks#1787

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Jenkins](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/artifacts-ami-test/)
- [x] [Argus](https://argus.scylladb.com/workspace?state=WyI5MmMwYWZiZS03N2NiLTQ4ZjEtOWMzZi03YThlMzU3NDgzMWUiXQ)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
