### PR TITLE
improvement(pyproject.toml): Add Argus client to ignores for Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ lint.select = [
     "PIE",
     "B006",
 ]
-
+exclude = ["argus/"]
 lint.ignore = ["E501", "PLR2004"]
 
 target-version = "py310"


### PR DESCRIPTION
Currently, it is ignored in precommit only, so if running manually it will still complain.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
