### PR TITLE
fix(wait_no_tablets_migration_running): add soft timeout

### DIFF
--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -72,6 +72,7 @@ class Operations(Enum):
     QUERY = ("query", _get_query_timeout, ("timeout", "query"))
     SERVICE_LEVEL_PROPAGATION = ("service_level_propagation", _get_service_level_propagation_timeout,
                                  ("timeout", "service_level_for_test_step"))
+    TABLET_MIGRATION = ("tablet_migration", _get_soft_timeout, ("timeout",))
 
 
 class TestInfoServices:  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
`wait_no_tablets_migration_running` function was raising exception in case of timeout. This caused to miss info about added node and failing its decommission in tests.

Fix by applying soft timeout to this function (with hard timeout set much higer) and making it not raising exception, but just error event.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/10119

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [grow-shrink nemesis test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/longevity-5gb-1h-GrowShrinkClusterNemesis-aws-test/25/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
