### PR TITLE
feature(multidc): scale cluster per dc in multidc config

### DIFF
--- a/jenkins-pipelines/oss/longevity/longevity-scale-5dcs-cluster-xl.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-scale-5dcs-cluster-xl.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: '''["us-west-2", "us-east-1", "eu-west-2", "eu-west-1", "eu-central-1"]''',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/scale/longevity-scale-5dcs-cluster-xl.yaml"]''',
+
+)

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -33,6 +33,7 @@ from sdcm.tester import ClusterTester
 from sdcm.utils import loader_utils
 from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations
 from sdcm.utils.common import skip_optional_stage
+from sdcm.utils.cluster_tools import group_nodes_by_dc_idx
 from sdcm.utils.decorators import optional_stage
 from sdcm.utils.operations_thread import ThreadParams
 from sdcm.sct_events.system import InfoEvent, TestFrameworkEvent
@@ -155,22 +156,38 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
 
         # Grow cluster to target size if requested
         if cluster_target_size := self.params.get('cluster_target_size'):
+            def is_target_reached(current: list[int], target: list[int]) -> bool:
+                return all([x >= y for x, y in zip(current, target)])
+
+            cluster_target_size = list(map(int, cluster_target_size.split())) if isinstance(
+                cluster_target_size, str) else [cluster_target_size]
             add_node_cnt = self.params.get('add_node_cnt')
-            node_cnt = len(self.db_cluster.data_nodes)
+            nodes_by_dcx = group_nodes_by_dc_idx(self.db_cluster.data_nodes)
+            current_cluster_size = [len(nodes_by_dcx[dcx]) for dcx in sorted(nodes_by_dcx)]
 
-            InfoEvent(message=f"Starting to grow cluster from {node_cnt} to {cluster_target_size}").publish()
+            InfoEvent(
+                message=f"Starting to grow cluster from {self.params.get('n_db_nodes')} to {cluster_target_size}").publish()
 
-            while node_cnt < cluster_target_size:
-                InfoEvent(message=f"Adding node number {node_cnt + 1}").publish()
-                new_nodes = self.db_cluster.add_nodes(count=add_node_cnt, enable_auto_bootstrap=True)
+            while not is_target_reached(current_cluster_size, cluster_target_size):
+                added_nodes = []
+                for dcx, target in enumerate(cluster_target_size):
+                    if current_cluster_size[dcx] < target:
+                        add_nodes_num = add_node_cnt if (
+                            target - current_cluster_size[dcx]) >= add_node_cnt else target - current_cluster_size[dcx]
+                        InfoEvent(message=f"Adding next number of nodes {add_nodes_num} to dc_idx {dcx}").publish()
+                        added_nodes.extend(self.db_cluster.add_nodes(
+                            count=add_nodes_num, enable_auto_bootstrap=True, dc_idx=dcx))
+
                 self.monitors.reconfigure_scylla_monitoring()
                 up_timeout = MAX_TIME_WAIT_FOR_NEW_NODE_UP
                 with adaptive_timeout(Operations.NEW_NODE, node=self.db_cluster.data_nodes[0], timeout=up_timeout):
-                    self.db_cluster.wait_for_init(node_list=new_nodes, timeout=up_timeout, check_node_health=False)
-                self.db_cluster.wait_for_nodes_up_and_normal(nodes=new_nodes)
-                node_cnt = len(self.db_cluster.data_nodes)
+                    self.db_cluster.wait_for_init(node_list=added_nodes, timeout=up_timeout, check_node_health=False)
+                self.db_cluster.wait_for_nodes_up_and_normal(nodes=added_nodes)
+                # node_cnt = len(self.db_cluster.data_nodes)
+                nodes_by_dcx = group_nodes_by_dc_idx(self.db_cluster.data_nodes)
+                current_cluster_size = [len(nodes_by_dcx[dcx]) for dcx in sorted(nodes_by_dcx)]
 
-            InfoEvent(message=f"Growing cluster finished, new cluster size is {node_cnt}").publish()
+            InfoEvent(message=f"Growing cluster finished, new cluster size is {current_cluster_size}").publish()
 
         # Collect data about partitions and their rows amount
         if self.partitions_attrs and self.partitions_attrs.validate_partitions:

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5764,7 +5764,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
                     # NOTE: monitoring-4.7 expects that node export metrics are part of exactly the "node_export" job
                     if scrape_config.get("job_name", "unknown") != job_name:
                         continue
-                    if "static_configs" not in base_scrape_configs[i]:
+                    if "static_configs" not in scrape_config:
                         base_scrape_configs[i]["static_configs"] = []
                     base_scrape_configs[i]["static_configs"] += static_config_list
                     break

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -680,7 +680,7 @@ class SCTConfiguration(dict):
              type=_str, k8s_multitenancy_supported=True,
              help="""Instance type to use for adding/removing nodes during GrowShrinkCluster nemesis"""),
 
-        dict(name="cluster_target_size", env="SCT_CLUSTER_TARGET_SIZE", type=int,
+        dict(name="cluster_target_size", env="SCT_CLUSTER_TARGET_SIZE", type=int_or_space_separated_ints,
              help="""Used for scale test: max size of the cluster"""),
 
         dict(name="space_node_threshold", env="SCT_SPACE_NODE_THRESHOLD",

--- a/sdcm/utils/cluster_tools.py
+++ b/sdcm/utils/cluster_tools.py
@@ -1,0 +1,21 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+from collections import defaultdict
+
+
+def group_nodes_by_dc_idx(nodes: list['BaseNode']) -> dict[int, list['BaseNode']]:  # noqa: F821
+    """ Group nodes by dc_idx """
+    nodes_by_dc_idx = defaultdict(list)
+    for node in nodes:
+        nodes_by_dc_idx[node.dc_idx].append(node)
+    return nodes_by_dc_idx

--- a/test-cases/scale/longevity-scale-5dcs-cluster-xl.yaml
+++ b/test-cases/scale/longevity-scale-5dcs-cluster-xl.yaml
@@ -1,0 +1,30 @@
+test_duration: 6000
+
+prepare_write_cmd:  ["cassandra-stress write cl=LOCAL_QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=20 -pop seq=1..20971520 -col 'n=FIXED(5) size=FIXED(64)' -log interval=5",
+                    ]
+
+stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=120m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=10 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(64)' -log interval=5",
+             "cassandra-stress read  cl=LOCAL_QUORUM duration=120m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=10 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(64)' -log interval=5",
+             ]
+
+n_db_nodes: '5 5 5 5 5'
+cluster_target_size: '25 25 25 25 25'
+add_node_cnt: 10
+n_loaders: '1 1 1 1 1'
+region_aware_loader: true
+n_monitor_nodes: 1
+
+instance_type_db: 'i4i.xlarge'
+
+nemesis_class_name: 'NoOpMonkey'
+nemesis_selector: ''
+nemesis_interval: 15
+nemesis_filter_seeds: false
+
+seeds_num: 4
+
+# server_encrypt: false
+# internode_encryption: 'all'
+# intra_node_comm_public: true
+
+user_prefix: 'scale-multidc-xl-cluster'


### PR DESCRIPTION
The scale test allows you to add new nodes to reach the target cluster size only when you have a single data center (DC) cluster configuration. However, if you have a multi-DC configuration, you cannot run scale tests with iterations.

The fix introduces a new feature that allows you to configure a multi-DC cluster and set the target size for it. Then, new nodes can be added to each DC in an iterative process until the target size is reached.

Next config params should be configured:
n_db_nodes: '3 3 3 3 3'
cluster_target_size: '25 25 25 25 25'
add_node_cnt: 10
cluster will start with 5 dc with 3 nodes in each
then on each interation 10 nodes will be added to
each dc while target size in each dc 25 nodes will
not be reached.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [DC: 2, start size: 3 3, add by : 3, finished: 9 9](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/5-multidc/job/multidc-cluster-xl-size-test/4)
- [DC: 1, start size 3, add by 3, finished 10](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/scale-10-100-cluster-test/23/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
