### PR TITLE
fix(hdr_tags): fix getting of HDR tags in the perf predefined steps test

### DIFF
--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -165,11 +165,16 @@ def _find_hdr_tags(*args):
         elif hasattr(input_arg, "hdr_tags"):
             # NOTE: case of 'stress_queue.hdr_tags' and 'nemesis.hdr_tags'
             return input_arg.hdr_tags
-        elif isinstance(input_arg, tuple):
-            # NOTE: case when 'stress_queue' is part of a returned tuple
-            for input_subarg in input_arg:
-                if hasattr(input_subarg, "hdr_tags"):
-                    return input_subarg.hdr_tags
+        elif isinstance(input_arg, (list, tuple)):
+            # NOTE: case when 'stress_queue' is part of a returned tuple/(tuple of lists)
+            hdr_tags = []
+            for subinput_arg in input_arg:
+                try:
+                    hdr_tags = _find_hdr_tags(subinput_arg)
+                    if hdr_tags:
+                        return hdr_tags
+                except ValueError:
+                    continue
     raise ValueError("Failed to find 'hdr_tags'")
 
 

--- a/unit_tests/test_utils_decorators.py
+++ b/unit_tests/test_utils_decorators.py
@@ -1,0 +1,39 @@
+from sdcm.utils.decorators import _find_hdr_tags
+
+
+HDR_TAGS1 = ["foohdr1", "foohdr2"]
+HDR_TAGS2 = ["barhdr1", "barhdr2"]
+
+
+def test__find_hdr_tags_in_dict():
+    assert _find_hdr_tags({"foo": HDR_TAGS1, "hdr_tags": HDR_TAGS2}) == HDR_TAGS2
+
+
+def test__find_hdr_tags_in_object_attr():
+    obj_with_hdr_tags = type("FakeStressQueue", (), {"fake_hdr_tags": HDR_TAGS1, "hdr_tags": HDR_TAGS2})
+    res = _find_hdr_tags(obj_with_hdr_tags)
+    assert res == HDR_TAGS2
+
+
+def test__find_hdr_tags_in_tuple():
+    obj_with_hdr_tags = type("FakeStressQueue", (), {"hdr_tags": HDR_TAGS1})
+    params = ("foo", 5, obj_with_hdr_tags)
+    res = _find_hdr_tags(params)
+    assert res == HDR_TAGS1
+
+
+def test__find_hdr_tags_in_tuple_of_lists():
+    obj_with_hdr_tags1 = type("FakeStressQueue", (), {"hdr_tags": HDR_TAGS1})
+    obj_with_hdr_tags2 = type("FakeStressQueue", (), {"hdr_tags": HDR_TAGS2})
+    params = ("foo", 5, (["a", "b"], [obj_with_hdr_tags1, obj_with_hdr_tags2]))
+    res = _find_hdr_tags(params)
+    assert res == HDR_TAGS1
+
+
+def test__find_hdr_tags_error():
+    try:
+        _find_hdr_tags({"no_hdr_tags": ["foo"]})
+    except ValueError:
+        pass
+    else:
+        assert False, "Expected 'ValueError'"


### PR DESCRIPTION
Closes: https://github.com/scylladb/scylla-cluster-tests/issues/10128

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-scylla-enterprise-perf-regression-predefined-throughput-steps-vnodes#7](https://argus.scylladb.com/tests/scylla-cluster-tests/321a60b6-1cc0-4d02-8963-b27c7b1688ab)
- [scylla-staging/valerii/vp-perf-regression-latency-650gb-during-rolling-upgrade#28](https://argus.scylladb.com/tests/scylla-cluster-tests/fe626fe7-91af-43f7-97a3-f7c02c8a5c51)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
