### PR TITLE
fix(modify_table_compaction): filter_out_table_with_counter is not filtering counter tables

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3709,6 +3709,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
 
         def execute_cmd(cql_session, entity_type):
             result = set()
+            counter_tables = set()
             is_column_type = entity_type == "column"
             column_names = regular_column_names
             if is_column_type:
@@ -3733,6 +3734,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
                     continue
 
                 if is_column_type and (filter_out_table_with_counter and "counter" in row.type):
+                    counter_tables.add(table_name)
                     continue
 
                 if filter_out_cdc_log_tables and getattr(row, column_names[1]).endswith(cdc.options.CDC_LOGTABLE_SUFFIX):
@@ -3763,6 +3765,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
 
             if filter_func is not None:
                 self.get_keyspace_info.cache_clear()  # pylint: disable=no-member
+            result = result - counter_tables
             return result
 
         with self.cql_connection_patient(db_node, connect_timeout=600) as session:

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2748,7 +2748,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         prop_val = random.choice(strategies)
         # max allowed TTL - 49 days (4300000) (to be compatible with default TWCS settings)
         if prop_val['class'] == 'TimeWindowCompactionStrategy':
-            self._modify_table_property(name="default_time_to_live", val=str(4300000))
+            self._modify_table_property(name="default_time_to_live", val=str(4300000),
+                                        filter_out_table_with_counter=True)
 
         self._modify_table_property(name="compaction", val=str(prop_val))
 
@@ -5123,7 +5124,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.set_current_running_nemesis(cql_query_executor_node)
         try:
             ks_cfs = self.cluster.get_non_system_ks_cf_list(db_node=cql_query_executor_node,
-                                                            filter_empty_tables=True, filter_out_mv=True)
+                                                            filter_empty_tables=True, filter_out_mv=True,
+                                                            filter_out_table_with_counter=True)
             if not ks_cfs:
                 raise UnsupportedNemesis(
                     'Non-system keyspace and table are not found. nemesis can\'t be run')


### PR DESCRIPTION
Implementation of `get_any_ks_cf_list` returned incorrect table names when
`filter_out_table_with_counter` was True. If such a table contained one
column whose type is not counter, this table would be added to the final
list and returned.

Fixes https://github.com/scylladb/scylla-cluster-tests/issues/9998

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/jsmolar/job/longevity-counters-3h-test/24/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
