### PR TITLE
fix(upgrade_test): use `node.is_product_enterprise`

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -277,7 +277,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             node.stop_scylla_server(verify_down=False)
             InfoEvent(message='upgrade_node - ended to "stop_scylla_server"').publish()
 
-            orig_is_enterprise = node.is_enterprise
+            orig_is_enterprise = node.is_product_enterprise
             if node.distro.is_rhel_like:
                 result = node.remoter.run("sudo yum search scylla-enterprise 2>&1", ignore_status=True)
                 new_is_enterprise = bool('scylla-enterprise.x86_64' in result.stdout or

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -140,7 +140,7 @@ class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
 
     def filter_rc_only_version(self, base_version_list: list) -> list:
         LOGGER.info("Filtering rc versions from base version list...")
-        base_version_list = sorted(list(set(base_version_list)))
+        base_version_list = sorted(list(set(base_version_list)), key=ComparableScyllaVersion)
         if base_version_list and self.scylla_version not in ('enterprise', 'master'):
             filter_rc = [v for v in get_all_versions(self.repo_maps[base_version_list[-1]]) if 'rc' not in v]
             if not filter_rc:


### PR DESCRIPTION
baa8624a648ff3e14bc729be6300d83b12e59929 change the logic of `node.is_enterprise` and missed to update a small part in `upgrade_test` that was counting on the old logic based on packaging

cause of it we failed to configure `reinstall` for the rollback

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-centos9-test/13/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-ami-test/11/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
