### PR TITLE
fix(nemesis): increase wait timeout for decommission operation

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4098,7 +4098,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             disrupt_func_kwargs={"target_node": self.target_node, "hard": True, "verify_ssh": True},
             delay=0
         )
-        full_operations_timeout = nodetool_decommission_timeout + 600
+        full_operations_timeout = nodetool_decommission_timeout + 3600
         with contextlib.ExitStack() as stack:
             for expected_start_failed_context in self.target_node.raft.get_severity_change_filters_scylla_start_failed(
                     terminate_pattern.timeout):

--- a/sdcm/utils/raft/__init__.py
+++ b/sdcm/utils/raft/__init__.py
@@ -44,9 +44,9 @@ class MessageTimeout(NamedTuple):
 
 
 BACKEND_TIMEOUTS: dict[str, Mapping[LogPosition, int]] = {
-    "aws": {LogPosition.BEGIN: 300, LogPosition.END: 3600},
-    "gce": {LogPosition.BEGIN: 300, LogPosition.END: 3600},
-    "azure": {LogPosition.BEGIN: 1200, LogPosition.END: 7200},
+    "aws": {LogPosition.BEGIN: 1200, LogPosition.END: 3600},
+    "gce": {LogPosition.BEGIN: 1800, LogPosition.END: 7200},
+    "azure": {LogPosition.BEGIN: 1800, LogPosition.END: 7200},
 }
 
 ABORT_DECOMMISSION_LOG_PATTERNS: Iterable[MessagePosition] = [

--- a/sdcm/utils/topology_ops.py
+++ b/sdcm/utils/topology_ops.py
@@ -46,8 +46,9 @@ class FailedDecommissionOperationMonitoring:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        decommission_in_progress = self.is_node_decommissioning()
         # Do not check decommission status if SCT raise KillNemesis
-        if exc_type and exc_type != KillNemesis:
+        if (exc_type and exc_type != KillNemesis) or decommission_in_progress:
             LOGGER.warning("Decommission failed with error: %s", traceback.format_exception(exc_type, exc_val, exc_tb))
             decommission_in_progress = self.is_node_decommissioning()
             if not decommission_in_progress:


### PR DESCRIPTION
Decommission operation could run longer on different clouds and with enabled/disabled tablets feature.
Nemesis DecommissionStreamingError depend on log messages which could appear in different log places. Increase timeouts to wait log messages and total decommission operation

Fixes: #8855

### Testing
- [Job passed](https://argus.scylladb.com/tests/scylla-cluster-tests/80b7ae35-b5b1-49ba-a127-a610c8cb41ff)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
