### PR TITLE
improvement(setup): enable parallel node operations by default

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -73,7 +73,7 @@ email_subject_postfix: ''
 collect_logs: false
 
 hinted_handoff: 'disabled'
-parallel_node_operations: false  # supported from Scylla 6.0
+parallel_node_operations: true  # supported from Scylla 6.0
 
 server_encrypt: false
 client_encrypt: false


### PR DESCRIPTION
Feature is enabled for one longevity and perf elasticity case and we didn't face issues around that.

Enabling this feature by default will speed up cluster provisioning and make test scenarios where we add multiple nodes (`nemesis_add_node_cnt`>1) more appropriate for recent Scylla where we test doubling cluster as fast as possible.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
