### PR TITLE
fix(cluster_aws): make sure we are not picking terminated nodes

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -336,7 +336,7 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         availability_zone = self.params.get('availability_zone').split(",")[az_idx] if az_idx is not None else None
         ec2 = ec2_client.EC2ClientWrapper(region_name=self.region_names[dc_idx],
                                           spot_max_price_percentage=self.params.get('spot_max_price'))
-        results = list_instances_aws(tags_dict={'TestId': test_id, 'NodeType': self.node_type},
+        results = list_instances_aws(tags_dict={'TestId': test_id, 'NodeType': self.node_type}, running=True,
                                      region_name=self.region_names[dc_idx], group_as_region=True, availability_zone=availability_zone)
         instances = results[self.region_names[dc_idx]]
 
@@ -824,6 +824,7 @@ class AWSNode(cluster.BaseNode):
         self.stop_task_threads()
         self.wait_till_tasks_threads_are_stopped()
         self._instance.terminate()
+        self._instance.wait_until_terminated()
         if self.eip_allocation_id:
             self.release_address()
         super().destroy()


### PR DESCRIPTION
Seems like in some situatation we might pick terminated nodes during test time, while we should have created a new node.

this commit introduce two things to help prevent it:
* wait for termination to full execute
* filter only running instances in the logic looking for instances

fixes: #10005

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
