### PR TITLE
fix(cleanup): fix cleaning CRs when no region provided

### DIFF
--- a/sdcm/provision/aws/capacity_reservation.py
+++ b/sdcm/provision/aws/capacity_reservation.py
@@ -21,6 +21,7 @@ from botocore.exceptions import ClientError
 import boto3
 
 from sdcm.exceptions import CapacityReservationError
+from sdcm.utils.common import all_aws_regions, ParallelObject
 from sdcm.utils.get_username import get_username
 
 LOGGER = logging.getLogger(__name__)
@@ -259,3 +260,42 @@ class SCTCapacityReservation:
                     LOGGER.info("Capacity reservation %s for %s cancelled successfully.", cr_id, instance_type)
                 except ClientError as exp:
                     LOGGER.error("Failed to cancel capacity reservation %s. Error: %s", cr_id, exp)
+
+    @classmethod
+    def cancel_all_regions(cls, test_id) -> None:
+        """Finds and cancels capacity reservations for all regions in parallel."""
+        regions = all_aws_regions()
+        if not test_id:
+            LOGGER.warning("No test_id provided. Skipping capacity reservation cancellation.")
+            return
+
+        def cancel_region(region):
+            ec2 = boto3.client('ec2', region_name=region)
+            try:
+                reservations = ec2.describe_capacity_reservations(
+                    Filters=[
+                        {
+                            'Name': 'tag:test_id',
+                            'Values': [test_id]
+                        },
+                        {
+                            'Name': 'state',
+                            'Values': ['active']
+                        }
+                    ]
+                )
+                if not reservations['CapacityReservations']:
+                    LOGGER.info("There are no CRs to remove in region %s.", region)
+                for reservation in reservations['CapacityReservations']:
+                    try:
+                        ec2.cancel_capacity_reservation(CapacityReservationId=reservation['CapacityReservationId'])
+                        LOGGER.info("Capacity reservation %s in region %s cancelled successfully.",
+                                    reservation['CapacityReservationId'], region)
+                    except ClientError as exp:
+                        LOGGER.error("Failed to cancel capacity reservation %s in region %s. Error: %s",
+                                     reservation['CapacityReservationId'], region, exp)
+
+            except ClientError as exp:
+                LOGGER.error("Failed to describe capacity reservations in region %s. Error: %s", region, exp)
+
+        ParallelObject(regions, timeout=60, num_workers=len(regions)).run(cancel_region, ignore_exceptions=True)

--- a/sdcm/utils/resources_cleanup.py
+++ b/sdcm/utils/resources_cleanup.py
@@ -88,8 +88,11 @@ def clean_cloud_resources(tags_dict, config=None, dry_run=False):
 
     if cluster_backend in ('aws', 'k8s-eks', ''):
         clean_instances_aws(tags_dict, regions=aws_regions, dry_run=dry_run)
-        SCTCapacityReservation.get_cr_from_aws(config, force_fetch=True)
-        SCTCapacityReservation.cancel(config)
+        if config.region_names:
+            SCTCapacityReservation.get_cr_from_aws(config, force_fetch=True)
+            SCTCapacityReservation.cancel(config)
+        else:
+            SCTCapacityReservation.cancel_all_regions(config.get("test_id"))
         clean_elastic_ips_aws(tags_dict, regions=aws_regions, dry_run=dry_run)
         clean_test_security_groups(tags_dict, regions=aws_regions, dry_run=dry_run)
         clean_placement_groups_aws(tags_dict, regions=aws_regions, dry_run=dry_run)


### PR DESCRIPTION
In case region is not provided we should search all regions for active CR's for given test id instead of failing.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/10131

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] - tested running locally (also without region)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
