### PR TITLE
fix(list-image): improve handling of rc versions listing

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1141,6 +1141,7 @@ def get_scylla_ami_versions(region_name: str, arch: AwsArchType = 'x86_64', vers
             # if version is not exact version, we need to add the wildcard to the end, to catch all minor versions
             scylla_version_filter = f"*{version.replace('enterprise-', '')}*"
 
+    scylla_version_filter = scylla_version_filter.replace('-', '?').replace('~', '?').replace('.rc', '?rc')
     ec2_resource: EC2ServiceResource = boto3.resource('ec2', region_name=region_name)
     images = []
     for client, owner in zip((ec2_resource, get_scylla_images_ec2_resource(region_name=region_name)),
@@ -1169,7 +1170,7 @@ def get_scylla_gce_images_versions(project: str = SCYLLA_GCE_IMAGES_PROJECT, ver
     #   https://github.com/apache/libcloud/blob/trunk/libcloud/compute/drivers/gce.py#L274
     filters = "(family eq 'scylla(-enterprise)?')( labels.environment eq 'production' )"
     if version and version != "all":
-        filters += f"(labels.scylla_version eq '{version.replace('.', '-')}.*"
+        filters += f"(labels.scylla_version eq '{version.replace('.', '-').replace('~', '-')}.*"
         if 'rc' not in version and len(version.split('.')) < 3:
             filters += "(-\\d)?(\\d)?(\\d)?(-rc)?(\\d)?(\\d)?')"
         else:


### PR DESCRIPTION
since images names and they label tags are not identical in the version format, one had to be exact as the version while what visible is the image name

now all of those variants would work regardless:
* 2025.1.0-rc2
* 2025.1.0~rc2
* 2025.1.0.rc2

for both AWS and GCP, Azure doesn't have rc version uploaded into public gallary yet.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
