### PR TITLE
fix(logcollector): introduce correct check to zstd only file

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1708,6 +1708,8 @@ def check_archive(remoter, path: str) -> bool:
         cmd = f"tar --zstd -tf '{path}'"
     elif path.endswith(".zip"):
         cmd = f"unzip -qql '{path}'"
+    elif path.endswith(".zst"):
+        cmd = f"zstd -t '{path}'"
     elif path.endswith(".gz"):
         cmd = f"gzip -t '{path}' && gzip -lv '{path}'"
     else:


### PR DESCRIPTION
check existing for tarball compressed with zstd, but not for zstd compressed file (as the case when splitting big sct log)

Fixes: #10167

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
