### PR TITLE
test(default): set `tablets_initial_scale_factor` scylla config option

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -1,3 +1,9 @@
+# NOTE: set the 'tablets_initial_scale_factor' explicitly while the following
+#       Scylla change is not merged and backported to older scylla branches.
+#       https://github.com/scylladb/scylladb/pull/22522
+append_scylla_yaml:
+  tablets_initial_scale_factor: 10
+
 db_type: "scylla"
 
 test_duration: 60

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -538,7 +538,10 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method,too-many-instance-
             expected_node_yaml = expected_node_yaml.replace(
                 '__SEED_NODE_IPS__', seed_node_ips)
             expected_node_yaml = expected_node_yaml.replace('__NODE_IPV6_ADDRESS__', self.ipv6_ip_address)
-            assert json.loads(expected_node_yaml) == node_yaml.dict(
+            expected_node_yaml_dict = json.loads(expected_node_yaml)
+            if append_scylla_yaml := self.parent_cluster.params.get("append_scylla_yaml"):
+                expected_node_yaml_dict.update(append_scylla_yaml)
+            assert expected_node_yaml_dict == node_yaml.dict(
                 exclude_unset=True, exclude_defaults=True, exclude_none=True)
 
 


### PR DESCRIPTION
Make it be bigger than the current scylla default '1' to avoid load balance issues.

Ref: https://github.com/scylladb/scylladb/pull/22522

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
