### PR TITLE
test(add_remove_dc): write more data and flush

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4792,19 +4792,22 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def _write_read_data_to_multi_dc_keyspace(self, datacenters: List[str]) -> None:
         InfoEvent(message='Writing and reading data with new dc').publish()
-        write_cmd = f"cassandra-stress write no-warmup cl=ALL n=10000 -schema 'keyspace=keyspace_new_dc " \
+        write_cmd = f"cassandra-stress write no-warmup cl=ALL n=100000 -schema 'keyspace=keyspace_new_dc " \
                     f"replication(strategy=NetworkTopologyStrategy,{datacenters[0]}=3,{datacenters[1]}=1) " \
                     f"compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)' " \
-                    f"-mode cql3 native compression=lz4 -rate threads=5 -pop seq=1..10000 -log interval=5"
+                    f"-mode cql3 native compression=lz4 -rate threads=5 -pop seq=1..100000 -log interval=5"
         write_thread = self.tester.run_stress_thread(stress_cmd=write_cmd, round_robin=True, stop_test_on_failure=False)
         self.tester.verify_stress_thread(cs_thread_pool=write_thread)
         self.stop_nemesis_on_stress_errors(write_thread)
         self._verify_multi_dc_keyspace_data(consistency_level="ALL")
+        # flush data to ensure it is seen in monitoring
+        for node in self.cluster.nodes:
+            node.run_nodetool("flush keyspace_new_dc")
 
     def _verify_multi_dc_keyspace_data(self, consistency_level: str = "ALL"):
-        read_cmd = f"cassandra-stress read no-warmup cl={consistency_level} n=10000 -schema 'keyspace=keyspace_new_dc " \
+        read_cmd = f"cassandra-stress read no-warmup cl={consistency_level} n=100000 -schema 'keyspace=keyspace_new_dc " \
                    f"compression=LZ4Compressor' -mode cql3 native compression=lz4 -rate threads=5 " \
-                   f"-pop seq=1..10000 -log interval=5"
+                   f"-pop seq=1..100000 -log interval=5"
         read_thread = self.tester.run_stress_thread(stress_cmd=read_cmd, round_robin=True, stop_test_on_failure=False)
         self.tester.verify_stress_thread(cs_thread_pool=read_thread)
         self.stop_nemesis_on_stress_errors(read_thread)


### PR DESCRIPTION
With the old ammount of data, it was never flushed to disk and because it gets dropped at the end of the nemesis, it looks like nothing was written to the new DC.
By writting more and flushing, we can see it in Grafana.

closes: #9923

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/02f2ecc0-0c5b-42c2-b74f-315cf7c91c69
  Test fails due to a different issue later, it also fails without this, I am creating a different issue for that.

![Screenshot 2025-02-24 162051](https://github.com/user-attachments/assets/0d54444b-c02a-4ad1-b6b7-14771b390fe0)


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
