### PR TITLE
improvement(logging): Log SCT actions in system log of cluster nodes

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -32,6 +32,7 @@ from sdcm import wait
 from sdcm.mgmt.common import \
     TaskStatus, ScyllaManagerError, HostStatus, HostSsl, HostRestStatus, duration_to_timedelta, DEFAULT_TASK_TIMEOUT
 from sdcm.provision.helpers.certificate import TLSAssets
+from sdcm.utils.context_managers import DbNodeLogger
 from sdcm.wait import WaitForTimeoutError
 
 LOGGER = logging.getLogger(__name__)
@@ -710,7 +711,8 @@ class ManagerCluster(ScyllaManagerBase):
         if cron is not None:
             cmd += " --cron '{}' ".format(" ".join(cron))
 
-        res = self.sctool.run(cmd=cmd, parse_table_res=False)
+        with DbNodeLogger([self.manager_node], f"start scylla-manager task {cmd}", target_node=self.manager_node):
+            res = self.sctool.run(cmd=cmd, parse_table_res=False)
         if not res:
             raise ScyllaManagerError("Unknown failure for sctool {} command".format(cmd))
 


### PR DESCRIPTION
improvement(logging): Log SCT actions in system log of cluster nodes
Adds ability to log SCT actions in the system log of cluster nodes.

Some cluster node operations (mainly the disruptive actions of Nemeses) have
been updated to be logged using this feature.

Closes: https://github.com/scylladb/scylla-cluster-tests/issues/10051

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_apple: [PR-provision-test with RestartThenRepairNodeMonkey nemesis config](https://argus.scylladb.com/tests/scylla-cluster-tests/4cf287ea-a6be-49ec-af8f-df2f8becff65)
Example of log entries on nodes:
```
❯ egrep -r 'scylla-cluster-tests' db-cluster-4cf287ea/longevity-5gb-1h-RestartThenRepairN-db-node-4cf287ea-*/
...
db-cluster-4cf287ea/longevity-5gb-1h-RestartThenRepairN-db-node-4cf287ea-1/messages.log:2025-03-05T09:33:52.019+00:00 longevity-5gb-1h-RestartThenRepairN-db-node-4cf287ea-1     !INFO | scylla-cluster-tests[5738]: executing restart node on longevity-5gb-1h-RestartThenRepairN-db-node-4cf287ea-2 [10.4.3.164]
db-cluster-4cf287ea/longevity-5gb-1h-RestartThenRepairN-db-node-4cf287ea-1/messages.log:2025-03-05T09:34:40.268+00:00 longevity-5gb-1h-RestartThenRepairN-db-node-4cf287ea-1     !INFO | scylla-cluster-tests[5770]: executing nodetool /usr/bin/nodetool  status  on longevity-5gb-1h-RestartThenRepairN-db-node-4cf287ea-1 [10.4.3.231]
db-cluster-4cf287ea/longevity-5gb-1h-RestartThenRepairN-db-node-4cf287ea-1/messages.log:2025-03-05T09:34:40.768+00:00 longevity-5gb-1h-RestartThenRepairN-db-node-4cf287ea-1     !INFO | scylla-cluster-tests[5775]: nodetool /usr/bin/nodetool  status  completed after 0.66s on longevity-5gb-1h-RestartThenRepairN-db-node-4cf287ea-1 [10.4.3.231]
db-cluster-4cf287ea/longevity-5gb-1h-RestartThenRepairN-db-node-4cf287ea-1/messages.log:2025-03-05T09:36:55.519+00:00 longevity-5gb-1h-RestartThenRepairN-db-node-4cf287ea-1     !INFO | scylla-cluster-tests[5809]: restart node completed after 183.69s on longevity-5gb-1h-RestartThenRepairN-db-node-4cf287ea-2 [10.4.3.164]
...
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
