### PR TITLE
fix(upgrade_tests): skip user profiles with index if tablets enabled

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -3383,7 +3383,7 @@ class FillDatabaseData(ClusterTester):
             session.default_timeout = 60 * 5
             self.run_db_queries(session, session.default_fetch_size)
 
-    def paged_query(self, keyspace='keyspace_complex'):
+    def paged_query(self, keyspace: str):
         # Prepare connection
         def create_table():
             session.execute('CREATE TABLE IF NOT EXISTS paged_query_test (k int PRIMARY KEY, v1 int, v2 int)')

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -32,6 +32,7 @@ from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
 
 from sdcm import wait
 from sdcm.cluster import BaseNode
+from sdcm.utils.issues import SkipPerIssues
 from sdcm.fill_db_data import FillDatabaseData
 from sdcm.sct_events import Severity
 from sdcm.stress_thread import CassandraStressThread
@@ -59,7 +60,7 @@ from sdcm.sct_events.group_common_events import (
     ignore_raft_topology_cmd_failing,
 )
 from sdcm.utils import loader_utils
-from sdcm.utils.features import CONSISTENT_TOPOLOGY_CHANGES_FEATURE
+from sdcm.utils.features import CONSISTENT_TOPOLOGY_CHANGES_FEATURE, is_tablets_feature_enabled
 from sdcm.wait import wait_for
 from sdcm.rest.raft_upgrade_procedure import RaftUpgradeProcedure
 from test_lib.sla import create_sla_auth
@@ -164,6 +165,15 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
     expected_sstable_format_version = 'mc'
 
     system_upgrade_timeout = 6 * 60
+
+    def should_do_complex_profile(self) -> bool:
+        """
+        since tablets doesn't support complex profiles with index, we need to replace them with simple profiles without index
+        """
+        if is_tablets_feature_enabled(self.db_cluster.nodes[0]):
+            if SkipPerIssues('https://github.com/scylladb/scylladb/issues/22677', params=self.params):
+                return False
+        return True
 
     @retrying(n=5)
     def _query_from_one_table(self, session, query, table_name) -> list:
@@ -642,18 +652,25 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         # shuffle it so we will upgrade the nodes in a random order
         random.shuffle(indexes)
 
-        InfoEvent(message='pre-test - Run stress workload before upgrade').publish()
-        # complex workload: prepare write
-        InfoEvent(message='Starting c-s complex workload (5M) to prepare data').publish()
-        stress_cmd_complex_prepare = self.params.get('stress_cmd_complex_prepare')
-        complex_cs_thread_pool = self.run_stress_thread(
-            stress_cmd=stress_cmd_complex_prepare, profile='data_dir/complex_schema.yaml')
+        if self.should_do_complex_profile():
+            keyspace = "keyspace_complex"
+            table = "user_with_ck"
+        else:
+            keyspace = "keyspace_entire_test"
+            table = "standard1"
 
-        # wait for the complex workload to finish
-        self.verify_stress_thread(complex_cs_thread_pool)
+        InfoEvent(message='pre-test - Run stress workload before upgrade').publish()
+        if self.should_do_complex_profile():
+            # complex workload: prepare write
+            InfoEvent(message='Starting c-s complex workload (5M) to prepare data').publish()
+            stress_cmd_complex_prepare = self.params.get('stress_cmd_complex_prepare')
+            complex_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_complex_prepare)
+
+            # wait for the complex workload to finish
+            self.verify_stress_thread(complex_cs_thread_pool)
 
         InfoEvent(message='Will check paged query before upgrading nodes').publish()
-        self.paged_query()
+        self.paged_query(keyspace=keyspace)
         InfoEvent(message='Done checking paged query before upgrading nodes').publish()
 
         # prepare write workload
@@ -784,8 +801,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         # Verify sstabledump / scylla sstable dump-data
         InfoEvent(message='Starting sstabledump to verify correctness of sstables').publish()
         first_node = self.db_cluster.nodes[0]
-        keyspace = "keyspace_complex"
-        table = "user_with_ck"
+
         dump_cmd = get_sstable_data_dump_command(first_node, keyspace, table)
         first_node.remoter.run(
             f'for i in `sudo find /var/lib/scylla/data/{keyspace}/ -type f |grep -v manifest.json |'
@@ -802,16 +818,16 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         verify_stress_cs_thread_pool = self.run_stress_thread(stress_cmd=verify_stress_after_cluster_upgrade)
         self.verify_stress_thread(verify_stress_cs_thread_pool)
 
-        # complex workload: verify data by simple read cl=ALL
-        InfoEvent(message='Starting c-s complex workload to verify data by simple read').publish()
-        stress_cmd_complex_verify_read = self.params.get('stress_cmd_complex_verify_read')
-        complex_cs_thread_pool = self.run_stress_thread(
-            stress_cmd=stress_cmd_complex_verify_read, profile='data_dir/complex_schema.yaml')
-        # wait for the read complex workload to finish
-        self.verify_stress_thread(complex_cs_thread_pool)
+        if self.should_do_complex_profile():
+            # complex workload: verify data by simple read cl=ALL
+            InfoEvent(message='Starting c-s complex workload to verify data by simple read').publish()
+            stress_cmd_complex_verify_read = self.params.get('stress_cmd_complex_verify_read')
+            complex_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_complex_verify_read)
+            # wait for the read complex workload to finish
+            self.verify_stress_thread(complex_cs_thread_pool)
 
         InfoEvent(message='Will check paged query after upgrading all nodes').publish()
-        self.paged_query()
+        self.paged_query(keyspace=keyspace)
         InfoEvent(message='Done checking paged query after upgrading nodes').publish()
 
         # After adjusted the workloads, there is a entire write workload, and it uses a fixed duration for catching
@@ -820,23 +836,23 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         # complex workloads,and comment two complex workloads.
         #
         # TODO: retest commented workloads and decide to enable or delete them.
-        #
-        # complex workload: verify data by multiple ops
-        # self.log.info('Starting c-s complex workload to verify data by multiple ops')
-        # stress_cmd_complex_verify_more = self.params.get('stress_cmd_complex_verify_more')
-        # complex_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_complex_verify_more,
-        #                                                profile='data_dir/complex_schema.yaml')
+        # if self.should_do_complex_profile():
+        #   # complex workload: verify data by multiple ops
+        #   self.log.info('Starting c-s complex workload to verify data by multiple ops')
+        #   stress_cmd_complex_verify_more = self.params.get('stress_cmd_complex_verify_more')
+        #   stress_cmd_complex_verify_more = self.replace_complex_profile_if_needed(stress_cmd_complex_verify_more)
+        #   complex_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_complex_verify_more)
 
-        # wait for the complex workload to finish
-        # self.verify_stress_thread(complex_cs_thread_pool)
+        #   # wait for the complex workload to finish
+        #   self.verify_stress_thread(complex_cs_thread_pool)
 
-        # complex workload: verify data by delete 1/10 data
-        # self.log.info('Starting c-s complex workload to verify data by delete')
-        # stress_cmd_complex_verify_delete = self.params.get('stress_cmd_complex_verify_delete')
-        # complex_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_complex_verify_delete,
-        #                                                profile='data_dir/complex_schema.yaml')
-        # wait for the complex workload to finish
-        # self.verify_stress_thread(complex_cs_thread_pool)
+        #   # complex workload: verify data by delete 1/10 data
+        #   self.log.info('Starting c-s complex workload to verify data by delete')
+        #   stress_cmd_complex_verify_delete = self.params.get('stress_cmd_complex_verify_delete')
+        #   stress_cmd_complex_verify_delete = self.replace_complex_profile_if_needed(stress_cmd_complex_verify_delete)
+        #   complex_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_complex_verify_delete)
+        #   # wait for the complex workload to finish
+        #   self.verify_stress_thread(complex_cs_thread_pool)
 
         # During the test we filter and ignore some specific errors, but we want to allow only certain amount of them
         step = 'Step9 - Search for errors that we filter during the test '


### PR DESCRIPTION
recently that was new addition that was introduced that blocks creation of MV and SI if tablets enabled, so we must drop the usage of indexes in that case.

Fixes: #10169

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🕥 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-ami-test/19/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
