### PR TITLE
fix(aws_builder): disable java new http max values

### DIFF
--- a/sdcm/utils/aws_builder.py
+++ b/sdcm/utils/aws_builder.py
@@ -59,7 +59,7 @@ EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
   config.labels,  // labels
   "/tmp/jenkins/", // fs root
   new SSHConnector(22,
-                   "user-jenkins_scylla_test_id_ed25519.pem", "", "", "", "", null, 0, 0,
+                   "user-jenkins_scylla_test_id_ed25519.pem", "-Djdk.httpclient.maxLiteralWithIndexing=0 -Djdk.httpclient.maxNonFinalResponses=0", "", "", "", null, 0, 0,
                    new NonVerifyingKeyVerificationStrategy()),
   false, // privateIpUsed
   true, // alwaysReconnect


### PR DESCRIPTION
those value was introduced in recent java updates, and we suspect them to be breaking connections
to long running jenkins agents.

hopfully disabling them, would make the related issue go away.

Ref: #9444

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-ami-test/29

logs showed it's working:
```
[02/25/25 22:55:13] [SSH] Starting agent process: cd "/tmp/jenkins" && java -Djdk.httpclient.maxLiteralWithIndexing=0 -Djdk.httpclient.maxNonFinalResponses=0 -jar remoting.jar -workDir /tmp/jenkins -jar-cache /tmp/jenkins/remoting/jarCache
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
