### PR TITLE
fix(auto backport): trigger with labeled event

### DIFF
--- a/.github/workflows/add-label-when-promoted.yaml
+++ b/.github/workflows/add-label-when-promoted.yaml
@@ -7,9 +7,9 @@ on:
       - branch-*.*
       - branch-perf-v*
       - manager-*.*
-    pull_request_target:
-      types: [labeled]
-      branches: [master]
+  pull_request_target:
+    types: [labeled]
+    branches: [master]
 
 env:
   DEFAULT_BRANCH: 'master'


### PR DESCRIPTION
auto backport doesn't trigger when a PR is closed and the labels are added after. this is because `pull_request_target` was under a push event instead of its own

Fixing it

