### PR TITLE
fix(post_behavior_*): set all of them to `destroy`

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -50,10 +50,10 @@ seeds_num: 1
 instance_provision: "spot"
 
 execute_post_behavior: false
-post_behavior_db_nodes: "keep-on-failure"
+post_behavior_db_nodes: "destroy"
 post_behavior_loader_nodes: "destroy"
-post_behavior_monitor_nodes: "keep-on-failure"
-post_behavior_k8s_cluster: "keep-on-failure"
+post_behavior_monitor_nodes: "destroy"
+post_behavior_k8s_cluster: "destroy"
 
 cloud_credentials_path: ''
 use_cloud_manager: false

--- a/jenkins-pipelines/master-triggers/sct_triggers/no_tablets_weekly_trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/no_tablets_weekly_trigger.xml
@@ -20,9 +20,9 @@
               <properties>scylla_version=master:latest
 new_scylla_repo=https://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list
 provision_type=on_demand
-post_behavior_db_nodes=keep-on-failure
+post_behavior_db_nodes=destroy
 post_behavior_loader_nodes=destroy
-post_behavior_monitor_nodes=keep-on-failure
+post_behavior_monitor_nodes=destroy
 email_recipients=qa@scylladb.com,tablets@scylladb.com</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -562,10 +562,16 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         ContainerManager.set_all_containers_keep_alive(self)
         return True
 
+    def _set_keep_duration(self, duration_in_minutes: int) -> None:
+        raise NotImplementedError()
+
     def set_keep_alive(self):
         node_type = None if self.parent_cluster is None else self.parent_cluster.node_type
         if self.test_config.should_keep_alive(node_type) and self._set_keep_alive():
             self.log.info("Keep this node alive")
+        else:
+            # same extra time as in getJobTimeouts.groovy (collection + resources cleanup + sending email report)
+            self._set_keep_duration(self.test_config.TEST_DURATION + 125)
 
     @property
     def short_hostname(self):

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -570,6 +570,10 @@ class AWSNode(cluster.BaseNode):
         self._ec2_service.create_tags(Resources=[self._instance.id], Tags=[{"Key": "keep", "Value": "alive"}])
         return super()._set_keep_alive()
 
+    def _set_keep_duration(self, duration_in_minutes: int) -> None:
+        self._ec2_service.create_tags(Resources=[self._instance.id], Tags=[
+                                      {"Key": "keep", "Value": str(duration_in_minutes)}])
+
     @property
     def vm_region(self):
         return self._ec2_service.meta.client.meta.region_name

--- a/sdcm/cluster_azure.py
+++ b/sdcm/cluster_azure.py
@@ -92,6 +92,10 @@ class AzureNode(cluster.BaseNode):
         self._instance.add_tags({"keep": "alive"})
         return super()._set_keep_alive()
 
+    @retrying(n=6, sleep_time=1)
+    def _set_keep_duration(self, duration: int) -> None:
+        self._instance.add_tags({"keep": str(duration)})
+
     def _refresh_instance_state(self):
         ip_tuple = ([self._instance.public_ip_address], [self._instance.private_ip_address])
         return ip_tuple

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -132,6 +132,13 @@ class GCENode(cluster.BaseNode):
                               zone=self.zone) and \
             super()._set_keep_alive()
 
+    def _set_keep_duration(self, duration_in_minutes: int) -> None:
+        gce_set_labels(instances_client=self._gce_service,
+                       instance=self._instance,
+                       new_labels={"keep": str(duration_in_minutes)},
+                       project=self.project,
+                       zone=self.zone)
+
     def _instance_wait_safe(self, instance_method: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
         try:
             return exponential_retry(func=lambda: instance_method(*args, **kwargs), logger=self.log)

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -155,8 +155,6 @@ class TestConfig(metaclass=Singleton):  # pylint: disable=too-many-public-method
 
     @classmethod
     def should_keep_alive(cls, node_type: Optional[str]) -> bool:
-        if cls.TEST_DURATION >= 11 * 60:
-            return True
         if node_type is None:
             return False
         if "db" in node_type:

--- a/test-cases/PR-provision-test.yaml
+++ b/test-cases/PR-provision-test.yaml
@@ -29,9 +29,5 @@ instance_provision: 'spot'
 
 use_preinstalled_scylla: true
 
-post_behavior_db_nodes: "destroy"
-post_behavior_loader_nodes: "destroy"
-post_behavior_monitor_nodes: "destroy"
-
 append_scylla_yaml:
   enable_tablets: false  # counters are not supported with tablets

--- a/test-cases/longevity/longevity-100GB-48h-cloud-CloudLimitedChaosMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-100GB-48h-cloud-CloudLimitedChaosMonkey-tls.yaml
@@ -11,10 +11,6 @@ n_monitor_nodes: 1
 
 instance_type_db: 'i4i.large' # instance type is defined in the jenkins job (with default value in the jenkinsfile for the cloud longevity
 
-post_behavior_db_nodes: "destroy"
-post_behavior_loader_nodes: "destroy"
-post_behavior_monitor_nodes: "destroy"
-
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_selector: ['limited']
 nemesis_interval: 30

--- a/test-cases/manager/manager-backup-and-restore-4TB-single-node.yaml
+++ b/test-cases/manager/manager-backup-and-restore-4TB-single-node.yaml
@@ -26,9 +26,5 @@ n_db_nodes: 1
 n_loaders: 4
 n_monitor_nodes: 1
 
-post_behavior_db_nodes: "destroy"
-post_behavior_loader_nodes: "destroy"
-post_behavior_monitor_nodes: "destroy"
-
 user_prefix: manager-regression
 space_node_threshold: 6442

--- a/test-cases/manager/manager-multiple-restores-schema-and-data.yaml
+++ b/test-cases/manager/manager-multiple-restores-schema-and-data.yaml
@@ -8,8 +8,4 @@ n_db_nodes: 5
 n_loaders: 1
 n_monitor_nodes: 1
 
-post_behavior_db_nodes: "destroy"
-post_behavior_loader_nodes: "destroy"
-post_behavior_monitor_nodes: "destroy"
-
 user_prefix: manager-regression

--- a/test-cases/manager/manager-regression-azure.yaml
+++ b/test-cases/manager/manager-regression-azure.yaml
@@ -13,9 +13,6 @@ root_disk_size_monitor: 64
 
 client_encrypt: true
 
-post_behavior_db_nodes: "destroy"
-post_behavior_loader_nodes: "destroy"
-post_behavior_monitor_nodes: "destroy"
 use_preinstalled_scylla: true
 
 user_prefix: manager-regression

--- a/test-cases/manager/manager-regression-ipv6.yaml
+++ b/test-cases/manager/manager-regression-ipv6.yaml
@@ -13,10 +13,6 @@ n_monitor_nodes: 1
 
 client_encrypt: true
 
-post_behavior_db_nodes: "destroy"
-post_behavior_loader_nodes: "destroy"
-post_behavior_monitor_nodes: "keep-on-failure"
-
 user_prefix: manager-regression
 space_node_threshold: 6442
 

--- a/test-cases/manager/manager-regression-multiDC-gce.yaml
+++ b/test-cases/manager/manager-regression-multiDC-gce.yaml
@@ -9,9 +9,6 @@ n_monitor_nodes: 1
 
 client_encrypt: true
 
-post_behavior_db_nodes: "destroy"
-post_behavior_loader_nodes: "destroy"
-post_behavior_monitor_nodes: "destroy"
 use_preinstalled_scylla: true
 
 endpoint_snitch: 'GoogleCloudSnitch'

--- a/test-cases/manager/manager-regression-multiDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-multiDC-set-distro.yaml
@@ -13,10 +13,6 @@ n_monitor_nodes: 1
 
 client_encrypt: true
 
-post_behavior_db_nodes: "destroy"
-post_behavior_loader_nodes: "destroy"
-post_behavior_monitor_nodes: "destroy"
-
 user_prefix: manager-regression
 space_node_threshold: 6442
 

--- a/test-cases/upgrades/manager-upgrade.yaml
+++ b/test-cases/upgrades/manager-upgrade.yaml
@@ -13,10 +13,6 @@ n_monitor_nodes: 1
 
 client_encrypt: true
 
-post_behavior_db_nodes: "destroy"
-post_behavior_loader_nodes: "destroy"
-post_behavior_monitor_nodes: "destroy"
-
 user_prefix: manager-upgrade
 space_node_threshold: 6442
 ip_ssh_connections: 'private'

--- a/unit_tests/provisioner/test_azure_region_definition_builder.py
+++ b/unit_tests/provisioner/test_azure_region_definition_builder.py
@@ -58,7 +58,7 @@ def test_can_create_basic_scylla_instance_definition_from_sct_config():
     instance_definition = InstanceDefinition(name=f"{prefix}-db-node-{test_config.test_id()[:8]}-eastus-1",
                                              image_id=env_config.SCT_AZURE_IMAGE_DB,
                                              type="Standard_L8s_v3", user_name="scyllaadm", root_disk_size=30,
-                                             tags=tags | {"NodeType": "scylla-db", "keep_action": "",
+                                             tags=tags | {"NodeType": "scylla-db", "keep_action": "terminate",
                                                           'NodeIndex': '1', "TestId": test_config.test_id()},
                                              ssh_key=ssh_key)
     assert len(region_definitions) == 2

--- a/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.yaml
@@ -33,10 +33,6 @@ scylla_version: 2021.1.15
 scylla_mgmt_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo'
 parallel_node_operations: false  # supported from Scylla 6.0
 
-post_behavior_db_nodes: "destroy"
-post_behavior_loader_nodes: "destroy"
-post_behavior_monitor_nodes: "destroy"
-
 scylla_network_config:
 - address: listen_address  # Address Scylla listens for connections from other nodes. See storage_port and ssl_storage_ports.
   ip_type: ipv4

--- a/unit_tests/test_utils_common.py
+++ b/unit_tests/test_utils_common.py
@@ -126,6 +126,9 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method
         self.remoter.stop()
         self.remoter = Remoter(self.system_log)
 
+    def _set_keep_duration(self, duration_in_minutes: int) -> None:
+        pass
+
     def _get_private_ip_address(self) -> str:
         return '127.0.0.1'
 

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -63,7 +63,7 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('test_config', 'test-cases/artifacts/centos7.yaml')}",
                    description: 'a config file for the artifacts test',
                    name: 'test_config')
-            string(defaultValue: "${pipelineParams.get('post_behavior_db_nodes', 'keep-on-failure')}",
+            string(defaultValue: "${pipelineParams.get('post_behavior_db_nodes', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_db_nodes')
             string(defaultValue: "${pipelineParams.get('ip_ssh_connections', 'private')}",

--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -84,7 +84,7 @@ def call() {
                    description: 'private|public|ipv6',
                    name: 'ip_ssh_connections')
 
-            string(defaultValue: "keep-on-failure",
+            string(defaultValue: "destroy",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_db_nodes')
 
@@ -92,7 +92,7 @@ def call() {
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_loader_nodes')
 
-            string(defaultValue: "keep-on-failure",
+            string(defaultValue: "destroy",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_monitor_nodes')
 

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -67,16 +67,16 @@ def call(Map pipelineParams) {
                    description: 'true|false',
                    name: 'instance_provision_fallback_on_demand')
 
-            string(defaultValue: "${pipelineParams.get('post_behavior_db_nodes', 'keep-on-failure')}",
+            string(defaultValue: "${pipelineParams.get('post_behavior_db_nodes', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_db_nodes')
             string(defaultValue: "${pipelineParams.get('post_behavior_loader_nodes', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_loader_nodes')
-            string(defaultValue: "${pipelineParams.get('post_behavior_monitor_nodes', 'keep-on-failure')}",
+            string(defaultValue: "${pipelineParams.get('post_behavior_monitor_nodes', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_monitor_nodes')
-            string(defaultValue: "${pipelineParams.get('post_behavior_k8s_cluster', 'keep-on-failure')}",
+            string(defaultValue: "${pipelineParams.get('post_behavior_k8s_cluster', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_k8s_cluster')
 

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -92,13 +92,13 @@ def call(Map pipelineParams) {
                    description: 'true|false',
                    name: 'instance_provision_fallback_on_demand')
 
-            string(defaultValue: "${pipelineParams.get('post_behavior_db_nodes', 'keep-on-failure')}",
+            string(defaultValue: "${pipelineParams.get('post_behavior_db_nodes', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_db_nodes')
             string(defaultValue: "${pipelineParams.get('post_behavior_loader_nodes', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_loader_nodes')
-            string(defaultValue: "${pipelineParams.get('post_behavior_monitor_nodes', 'keep-on-failure')}",
+            string(defaultValue: "${pipelineParams.get('post_behavior_monitor_nodes', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_monitor_nodes')
 

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -55,7 +55,7 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('post_behavior_monitor_nodes', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_monitor_nodes')
-            string(defaultValue: "${pipelineParams.get('post_behavior_k8s_cluster', 'keep-on-failure')}",
+            string(defaultValue: "${pipelineParams.get('post_behavior_k8s_cluster', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_k8s_cluster')
             string(defaultValue: "${groovy.json.JsonOutput.toJson(pipelineParams.get('sub_tests'))}",

--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -44,10 +44,10 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('post_behavior_loader_nodes', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_loader_nodes')
-            string(defaultValue: "${pipelineParams.get('post_behavior_monitor_nodes', 'keep-on-failure')}",
+            string(defaultValue: "${pipelineParams.get('post_behavior_monitor_nodes', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_monitor_nodes')
-            string(defaultValue: "${pipelineParams.get('post_behavior_k8s_cluster', 'keep-on-failure')}",
+            string(defaultValue: "${pipelineParams.get('post_behavior_k8s_cluster', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_k8s_cluster')
             string(defaultValue: "${groovy.json.JsonOutput.toJson(pipelineParams.get('sub_tests'))}",


### PR DESCRIPTION
cause we are running into multiple cases of resource left behind unattended, we by default gonna set all pipelines to destroy whom would need to investigate something specific would need to run it with `keep/keep-on-failure`

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/104/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
