### PR TITLE
fix(manager): normalize IPv6 addresses received from sctool status

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -39,6 +39,7 @@ import tempfile
 import traceback
 import ctypes
 import shlex
+import ipaddress
 from typing import Iterable, List, Callable, Optional, Dict, Union, Literal, Any, Type
 from urllib.parse import urlparse
 from unittest.mock import Mock
@@ -2023,6 +2024,25 @@ def normalize_ipv6_url(ip_address):
     if ":" in ip_address:  # IPv6
         return "[%s]" % ip_address
     return ip_address
+
+
+def is_ipv6_address(address: str) -> bool:
+    try:
+        ipaddress.IPv6Address(address)
+        return True
+    except ipaddress.AddressValueError:
+        return False
+
+
+def normalize_ipv6_address(address: str) -> str:
+    """Normalize IPv6 address to full form - adding eliminated leading zeroes or zero sequence blocks.
+    For example, 2001:db8:85a3::121:8a2e:0370:7334 -> 2001:0db8:85a3:0000:0121:8a2e:0370:7334
+    """
+    try:
+        ip = ipaddress.IPv6Address(address)
+        return ip.exploded
+    except ipaddress.AddressValueError:
+        raise ValueError(f"Invalid IPv6 address: {address}")
 
 
 def rows_to_list(rows):


### PR DESCRIPTION
Closed https://github.com/scylladb/scylla-manager/issues/4265

Added an option to normalize compressed IPv6 addresses returned by `sctool status` which provides compressed addresses in its output.

The intention is to make it uniformly with the other parts of the framework. For example, test_cluster_healthcheck test might fail because of IPv6 addresses mismatch - the one got from sctool status and the one got from node configuration.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [ubuntu22-sanity-ipv6-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master-clone/job/ubuntu22-sanity-ipv6-test/1) - checks the issue has gone
- [x] [ubuntu24-sanity-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master-clone/job/ubuntu24-sanity-test/2) - regression

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
