### PR TITLE
fix(argus): do not validate cpu_cycles_per_op

### DIFF
--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -250,7 +250,6 @@ def send_perf_simple_query_result_to_argus(argus_client: ArgusClient, result: di
 
             ValidationRules = {
                 "allocs_per_op": ValidationRule(best_pct=5),
-                "cpu_cycles_per_op": ValidationRule(best_pct=5),
                 "instructions_per_op": ValidationRule(best_pct=5),
             }
 


### PR DESCRIPTION
According to Avi, we should not validate cpu_cycles_per_op and fail the test on it. This metrics is not stable

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
