### PR TITLE
fix(NodeBase): add missing `_set_keep_duration` implementations

### DIFF
--- a/sdcm/cluster_azure.py
+++ b/sdcm/cluster_azure.py
@@ -93,8 +93,8 @@ class AzureNode(cluster.BaseNode):
         return super()._set_keep_alive()
 
     @retrying(n=6, sleep_time=1)
-    def _set_keep_duration(self, duration: int) -> None:
-        self._instance.add_tags({"keep": str(duration)})
+    def _set_keep_duration(self, duration_in_minutes: int) -> None:
+        self._instance.add_tags({"keep": str(duration_in_minutes)})
 
     def _refresh_instance_state(self):
         ip_tuple = ([self._instance.public_ip_address], [self._instance.private_ip_address])

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1796,6 +1796,9 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
     def _init_port_mapping(self):
         pass
 
+    def _set_keep_duration(self, duration_in_minutes: int):
+        pass
+
     @property
     def system_log(self):
         return os.path.join(self.logdir, "system.log")

--- a/unit_tests/dummy_remote.py
+++ b/unit_tests/dummy_remote.py
@@ -80,6 +80,9 @@ class LocalNode(BaseNode):
     def check_spot_termination(self):
         pass
 
+    def _set_keep_duration(self, duration_in_minutes: int) -> None:
+        pass
+
     def restart(self):
         pass
 


### PR DESCRIPTION
b8b20a2 introducde changes in as baseclass that didn't included implemetions in all it's users.

that can break the EKS/GKE flows (and pylint was yelling at it in backports to old branches)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
