### PR TITLE
fix(cluster_docker): add missing `_set_keep_duration` implementation

### DIFF
--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -86,6 +86,9 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):  # pylint: disable=abstr
             assert int(container.labels["NodeIndex"]) == node_index, "Container labeled with wrong index."
             self._containers["node"] = container
 
+    def _set_keep_duration(self, duration_in_minutes: int) -> None:
+        pass
+
     def wait_for_cloud_init(self):
         pass
 
@@ -444,6 +447,9 @@ class DockerMonitoringNode(cluster.BaseNode):  # pylint: disable=abstract-method
         pass
 
     def disable_daily_triggered_services(self):
+        pass
+
+    def _set_keep_duration(self, duration_in_minutes: int) -> None:
         pass
 
 


### PR DESCRIPTION
b8b20a2 introduced changes in as baseclass that didn't included implementations in all it's users. that can break the docker backend (and even pylint was yelling about it old branches)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
