### PR TITLE
fix(PR-provision-test): disable tablets in CI docker backend

### DIFF
--- a/test-cases/PR-provision-test-docker.yaml
+++ b/test-cases/PR-provision-test-docker.yaml
@@ -16,3 +16,6 @@ nemesis_filter_seeds: false
 user_prefix: 'PR-provision-docker'
 
 use_mgmt: false
+
+append_scylla_yaml:
+  enable_tablets: false  # counters are not supported with tablets


### PR DESCRIPTION
Tablets are enabled by default and we use most recent Scylla in docker
provision test in CI. Because counters are not supported with tablets it
fails CI with c-s error.

fix by disabling tablets like in cloud based CI.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
