### PR TITLE
fix(logcollector): print zstd information that was missing

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1709,7 +1709,7 @@ def check_archive(remoter, path: str) -> bool:
     elif path.endswith(".zip"):
         cmd = f"unzip -qql '{path}'"
     elif path.endswith(".zst"):
-        cmd = f"zstd -t '{path}'"
+        cmd = f"zstd -t '{path}' && zstd -lv '{path}'"
     elif path.endswith(".gz"):
         cmd = f"gzip -t '{path}' && gzip -lv '{path}'"
     else:


### PR DESCRIPTION
8109f84aab95f52f6ff14484105dfd841438b22c add a check, but that check isn't generating and stdout, hence it was failing during checks:
```
Archive `2025_03_01__16_24_19_622.sct-d3da56d3.log.zst' is corrupted:
`zstd -t '2025_03_01__16_24_19_622.sct-d3da56d3.log.zst'' returns 0
```

this commit adds one more command that would output the stats of the zstd compressed file

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
