### PR TITLE
fix(network interfaces): change network_configuration to be cached

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -477,7 +477,7 @@ class AWSNode(cluster.BaseNode):
             " | %s" % self.ipv6_ip_address if self.test_config.IP_SSH_CONNECTIONS == "ipv6" else "",
             self._dc_info_str())
 
-    @property
+    @cached_property
     def network_configuration(self):
         # Output example:
         #   0a:7b:18:de:f9:71: eth0


### PR DESCRIPTION
With increase of node count in a test cluster we get significant delays among points in time where SCT triggers a DB node startup. Looks like it happens because we connect to the node a lot of time to receive list of interfaces. The interfaces are not changed during the test so it's not needed to be received so many times.
To prevent unnesessary getting of network interfaces, make this cached.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/10217

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
