### PR TITLE
fix(sct.py): Check for null values in store_logs_in_argus

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1294,8 +1294,11 @@ def store_logs_in_argus(test_id: UUID, logs: dict[str, list[list[str] | str]], u
         argus_client = get_argus_client(run_id=test_id)
         log_links = []
         existing_links = [name for [name, _] in argus_client.get_run().get('logs', [])] if update else []
-        for _, s3_links in logs.items():
+        for log_name, s3_links in logs.items():
             for link in s3_links:
+                if not link:
+                    LOGGER.warning("Link is missing for log %s", log_name)
+                    continue
                 file_name = link.split("/")[-1]
                 if update and file_name not in existing_links:
                     LOGGER.info("Adding missing log link %s to Argus...", file_name)


### PR DESCRIPTION
This fixes an issue where logs would not be submitted if link is missing
from the log structure.

Fixes #10244

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
