### PR TITLE
Revert refactor check_nodes_up_and_normal

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4452,26 +4452,23 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         return True
 
     def check_nodes_up_and_normal(self, nodes=None, verification_node=None):
-        """
-        Checks via nodetool that nodes have joined the cluster and reached 'UN' state.
-
-        :param nodes: List of nodes to check. If None, checks all nodes in the cluster.
-        :param verification_node: Node to run the nodetool command on. If None, a random node is chosen.
-        :raises ClusterNodesNotReady: If any node is not in 'UN' state or not found in nodetool status.
-        """
         """Checks via nodetool that node joined the cluster and reached 'UN' state"""
         if not nodes:
             nodes = self.nodes
         status = self.get_nodetool_status(verification_node=verification_node)
+        up_statuses = []
         for node in nodes:
+            found_node_status = False
             for dc_status in status.values():
                 ip_status = dc_status.get(node.ip_address)
-                if not ip_status:
-                    error_message = f"Not all nodes joined the cluster: node {node.ip_address} not found in nodetool status"
-                    raise ClusterNodesNotReady(error_message)
-                if ip_status["state"] != "UN":
-                    error_message = f"Not all nodes joined the cluster: node {node.ip_address} is not in 'UN' state: {ip_status['state']}"
-                    raise ClusterNodesNotReady(error_message)
+                if ip_status:
+                    found_node_status = True
+                    up_statuses.append(ip_status["state"] == "UN")
+                    break
+            if not found_node_status:
+                up_statuses.append(False)
+        if not all(up_statuses):
+            raise ClusterNodesNotReady("Not all nodes joined the cluster")
 
     def get_nodes_up_and_normal(self, verification_node=None):
         """Checks via nodetool that node joined the cluster and reached 'UN' state"""


### PR DESCRIPTION
This reverts commit f1591c2abd2bcdf967799cacb472541e6d395727.

It breaks with multidc scenarios.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
