### PR TITLE
fix(90% utilization): Use simulated racks

### DIFF
--- a/test-cases/features/elasticity/elasticity-90-percent-with-nemesis.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-with-nemesis.yaml
@@ -13,6 +13,7 @@ stress_cmd:
 pre_create_keyspace: "CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 64};"
 
 n_db_nodes: 3
+simulated_racks: 3
 nemesis_add_node_cnt: 3
 n_loaders: 4
 n_monitor_nodes: 1

--- a/test-cases/features/elasticity/longevity-elasticity-many-small-tables.yaml
+++ b/test-cases/features/elasticity/longevity-elasticity-many-small-tables.yaml
@@ -20,6 +20,7 @@ cs_duration: ''
 n_loaders: 4
 n_monitor_nodes: 1
 n_db_nodes: 3
+simulated_racks: 3
 add_node_cnt: 0
 
 instance_type_db: 'i4i.xlarge'


### PR DESCRIPTION
Added a usage of simulated_racks to the 90%-utilizations tests of nemesis and of many-small-tables.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [elasticity-90-percent-with-nemesis-simulate-rack](https://argus.scylladb.com/tests/scylla-cluster-tests/fad01b0b-d363-4bb4-9cf2-074b3b22c2cf)
- [scale-elasticity-many-small-tables-simulated-rack](https://argus.scylladb.com/tests/scylla-cluster-tests/782f0151-e35c-4088-99ea-703d0e60c0df)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
