### PR TITLE
fix(wait_for_view_to_be_built) function did not return if only an ind…

### DIFF
--- a/sdcm/utils/nemesis_utils/indexes.py
+++ b/sdcm/utils/nemesis_utils/indexes.py
@@ -74,18 +74,19 @@ def wait_for_index_to_be_built(node: BaseNode, ks, index_name, timeout=300) -> N
 
 
 def wait_for_view_to_be_built(node: BaseNode, ks, view_name, timeout=300) -> None:
-    LOGGER.info('waiting for view/index %s to be built', view_name)
+    LOGGER.info(f"waiting {timeout} seconds for view/index {view_name} to be built")
     start_time = time.time()
     while time.time() - start_time < timeout:
         result = node.run_nodetool(f"viewbuildstatus {ks}.{view_name}",
                                    ignore_status=True, verbose=False, publish_event=False)
         if f"{ks}.{view_name}_index has finished building" in result.stdout:
             InfoEvent(message=f"Index {ks}.{view_name} was built").publish()
+            return
         if f"{ks}.{view_name} has finished building" in result.stdout:
             InfoEvent(message=f"View/index {ks}.{view_name} was built").publish()
             return
         time.sleep(30)
-    raise TimeoutError(f"Timeout error while creating view/index {view_name}. "
+    raise TimeoutError(f"Timeout error ({timeout} seconds) while creating view/index {view_name}.\n"
                        f"stdout\n: {result.stdout}\n"
                        f"stderr\n: {result.stderr}")
 


### PR DESCRIPTION
…ex completed building

It seems that if we are checking that an only index has finished building (which will happen when we call the function from wait_for_index_to_be_built() function), then the code does add an INFO level log - but does not return.

Unrelated, added a more detailed log - of the timeout value.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] None

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

(Unsure if we need to backport this, perhaps)

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
