### PR TITLE
fix(gce): update instance state before labeling it

### DIFF
--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -133,6 +133,7 @@ class GCENode(cluster.BaseNode):
             super()._set_keep_alive()
 
     def _set_keep_duration(self, duration_in_minutes: int) -> None:
+        self._refresh_instance_state()
         gce_set_labels(instances_client=self._gce_service,
                        instance=self._instance,
                        new_labels={"keep": str(duration_in_minutes)},


### PR DESCRIPTION
cause the fingerprinting of the labels might not be up-to-date we load again the instance information before we label the machine

Fixes: #10228

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :clock1: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-10gb-3h-gce-test/58/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
