### PR TITLE
Revert "Monitoring 4.9.0"

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -9,7 +9,7 @@ instance_type_monitor: 't3.large'
 # manual on creating loader AMI's: see docs/new_loader_ami.md
 ami_id_loader: 'scylla-qa-loader-ami-v22-ubuntu22'  # versions: c-s 2024.2.0-rc0, s-b 0.1.21
 # manual on updating monitor images see: docs/monitoring-images.md
-ami_id_monitor: 'scylladb-monitor-4-9-0-2025-02-26t11-45-48z'
+ami_id_monitor: 'scylladb-monitor-4-8-0-2024-08-06t03-34-43z'
 
 availability_zone: 'a'
 root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -6,7 +6,7 @@ gce_project: '' # empty mean default one, can be overwritten to use different on
 gce_image_db: '' # so we can use `scylla_version` as needed
 gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts'
 # manual on updating monitor images see: docs/monitoring-images.md
-gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-9-0-2025-02-26t11-45-48z'
+gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-8-0-2024-08-06t03-34-43z'
 gce_image_username: 'scylla-test'
 
 gce_instance_type_loader: 'e2-standard-2'

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -28,7 +28,7 @@ scylla_linux_distro: 'ubuntu-focal'
 scylla_linux_distro_loader: 'ubuntu-jammy'
 ssh_transport: 'libssh2'
 
-monitor_branch: 'branch-4.9'
+monitor_branch: 'branch-4.8'
 
 space_node_threshold: 0
 


### PR DESCRIPTION
Reverts scylladb/scylla-cluster-tests#10006

seems like we are hitting this issue:
https://github.com/grafana/grafana/issues/82958

at least on GCP
reverting it for now