### PR TITLE
feature(gemini): logs compression by default using ZSTD

### DIFF
--- a/defaults/docker_images/gemini/values_gemini.yaml
+++ b/defaults/docker_images/gemini/values_gemini.yaml
@@ -1,2 +1,2 @@
 gemini:
-  image: scylladb/gemini:1.8.10
+  image: scylladb/gemini:1.8.11

--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -98,6 +98,7 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
             # These two are used to control the memory usage of Gemini
             "token-range-slices": 512,  # Number of partitions
             "partition-key-buffer-reuse-size": 100,  # Internal Channel Size per parittion value generation
+            "statement-log-file-compression": "zstd",
         }
 
         self.gemini_oracle_statements_file = f"gemini_oracle_statements_{self.unique_id}.log"


### PR DESCRIPTION
When gemini is run with --test-statement-log-file and --oracle-statement-log-file, after running the program for a longer periods of time, e.g 3h or 10h case, these files are extremly large, to the point that can kill loader instance in SCT. This sometimes happenes after 10 minutes, as having both of these flags, have identical data in them (same size), thats a double the storage needed.

After this change, everything thats logged in the statements files will be compress while it's being written (power of Go's `io.Writer` magic)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
1. Running without log compression
- [x] 🟢 [Argus Run](https://argus.scylladb.com/tests/scylla-cluster-tests/a160e9f6-726f-4375-bbaa-3603a60467f9)
- Log Size: 2.9GB * 2 (Since we have Oracle and Cluster under test statements) 

2. Running with log compression (ZSTD Compression)
- [x] 🟢 [Argus Run](https://argus.scylladb.com/tests/scylla-cluster-tests/11fefefb-59ff-4f01-81ec-a04703c4fb64) 
- Log Size: 432MB * 2 (Since we have Oracle and Cluster under test statements)


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
