### PR TITLE
fix(DataCenterTopologyRfControl): decrease RF to 0 before decommission

### DIFF
--- a/sdcm/utils/replication_strategy_utils.py
+++ b/sdcm/utils/replication_strategy_utils.py
@@ -156,7 +156,7 @@ class DataCenterTopologyRfControl:
 
     def _get_original_nodes_number(self, node: 'BaseNode') -> int:
         # Get the original number of nodes in the data center
-        return len([n for n in self.cluster.data_nodes if n.dc_idx == node.dc_idx])
+        return len([n for n in self.cluster.data_nodes if n.datacenter == node.datacenter])
 
     def _get_keyspaces_to_decrease_rf(self, session) -> list:
         """
@@ -225,8 +225,8 @@ class DataCenterTopologyRfControl:
             replication-factor value.
         """
         node = self.target_node
-        # Ensure that nodes_num is 2 or greater
-        if self.original_nodes_number > 1:
+
+        if self.original_nodes_number > 0:
             with self.cluster.cql_connection_patient(node) as session:
                 decreased_rf_keyspaces = self._get_keyspaces_to_decrease_rf(session=session)
             if decreased_rf_keyspaces:
@@ -242,6 +242,8 @@ class DataCenterTopologyRfControl:
                     LOGGER.error(
                         f"Decreasing keyspace replication factor failed with: ({error}), aborting operation")
                     raise error
+            else:
+                LOGGER.debug("No keyspaces found to decrease the replication factor")
         else:
             LOGGER.error(
                 f"DC {self.datacenter} has {self.original_nodes_number} nodes. Cannot alter replication factor")


### PR DESCRIPTION
Alternative PR to https://github.com/scylladb/scylla-cluster-tests/pull/10028#issuecomment-2659216366
Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9861

When `self.original_nodes_number` was 1 (which is in the case of decommission of single node in DC), the whole process is skipped. Which means no RF=0 for decommissioned data-center: https://opensource.docs.scylladb.com/master/operating-scylla/procedures/cluster-management/decommissioning-data-center.html

In addition `_get_original_nodes_number` was returning keyspaces where node was not present as two DCs had same `dc_idx` 

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/jsmolar/job/ongevity-5gb-1h-AddRemoveDcNemesis-aws-test/69/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
