### PR TITLE
fix(90% utilization with nemesis): opt out DecommissionSeedNode

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5834,7 +5834,7 @@ class DecommissionMonkey(Nemesis):
     disruptive = True
     limited = True
     topology_changes = True
-    supports_high_disk_utilization = False  # Decommissioning a node consumes disk space
+    supports_high_disk_utilization = False  # Decommissioning a node cause increase of disk space across rest of the nodes
 
     def disrupt(self):
         self.disrupt_nodetool_decommission()
@@ -5843,6 +5843,7 @@ class DecommissionMonkey(Nemesis):
 class DecommissionSeedNode(Nemesis):
     disruptive = True
     topology_changes = True
+    supports_high_disk_utilization = False  # Decommissioning a node cause increase of disk space across rest of the nodes
 
     def disrupt(self):
         self.disrupt_nodetool_seed_decommission()


### PR DESCRIPTION
DecommissionSeedNode is not supported with high disk utilization. 
It [fails](https://argus.scylladb.com/tests/scylla-cluster-tests/fad01b0b-d363-4bb4-9cf2-074b3b22c2cf) with "Unable to find new replica for tablet".

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
