### PR TITLE
fix(gce): allow using of the CQL shard-aware ports

### DIFF
--- a/sdcm/utils/gce_region.py
+++ b/sdcm/utils/gce_region.py
@@ -99,7 +99,7 @@ class GceRegion:
                      network=self.network.self_link),
             Firewall(name=f'{self.SCT_NETWORK_NAME}-allow-node-cql',
                      direction="INGRESS",
-                     allowed=[compute_v1.Allowed(I_p_protocol="tcp", ports=['9042', '9142'])],
+                     allowed=[compute_v1.Allowed(I_p_protocol="tcp", ports=['9042', '9142', '19042', '19142'])],
                      source_ranges=["0.0.0.0/0"],
                      network=self.network.self_link),
             Firewall(name=f'{self.SCT_NETWORK_NAME}-allow-prometheus',


### PR DESCRIPTION
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
