### PR TITLE
test(longevity): add test for rack-aware policy

### DIFF
--- a/configurations/longevity-100gb-2h-rackaware-validation.yaml
+++ b/configurations/longevity-100gb-2h-rackaware-validation.yaml
@@ -1,0 +1,15 @@
+# This configuration is created to be run on top of "longevity-100gb-4h.yaml"
+test_duration: 180
+stress_duration: 120
+# One loader per DC is must for RACK validation tests
+n_loaders: 1
+
+# Instance type for DB is decreased due to the RACK validation test is running with one loader only and create less load
+instance_type_db: 'i4i.2xlarge'
+
+rack_aware_loader: true
+
+# teardown validators
+teardown_validators:
+  rackaware:
+    enabled: true

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -249,6 +249,8 @@ teardown_validators:
         event_type: RUNTIME_ERROR
         regex: '.*runtime_error.*'
       - event_class: CoreDumpEvent
+  rackaware:
+    enabled: false
 
 kafka_backend: null
 kafka_connectors: []

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -3457,7 +3457,7 @@ Run commit log check thread if commitlog_use_hard_size_limit is True
 
 Configuration for additional validations executed after the test
 
-**default:** {'scrub': {'enabled': False, 'timeout': 1200, 'keyspace': '', 'table': ''}, 'test_error_events': {'enabled': False, 'failing_events': [{'event_class': 'DatabaseLogEvent', 'event_type': 'RUNTIME_ERROR', 'regex': '.*runtime_error.*'}, {'event_class': 'CoreDumpEvent'}]}}
+**default:** {'scrub': {'enabled': False, 'timeout': 1200, 'keyspace': '', 'table': ''}, 'test_error_events': {'enabled': False, 'failing_events': [{'event_class': 'DatabaseLogEvent', 'event_type': 'RUNTIME_ERROR', 'regex': '.*runtime_error.*'}, {'event_class': 'CoreDumpEvent'}]}, 'rackaware': {'enabled': False}}
 
 **type:** dict_or_str
 

--- a/jenkins-pipelines/oss/longevity/longevity-100gb-2h-rackaware.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-100gb-2h-rackaware.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: """["test-cases/longevity/longevity-100gb-4h.yaml","configurations/longevity-100gb-2h-rackaware-validation.yaml"]""",
+    instance_provision_fallback_on_demand: true
+)

--- a/jenkins-pipelines/oss/longevity/longevity-multi-dc-rackaware-validation.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-multi-dc-rackaware-validation.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: '''["eu-west-1", "eu-west-2"]''',
+    availability_zone: 'a,b,c',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-multi-dc-rackaware-validation.yaml"]''',
+)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2464,6 +2464,10 @@ class SCTConfiguration(dict):
         self._validate_placement_group_required_values()
         self._instance_type_validation()
 
+        if ((teardown_validators := self.get("teardown_validators.rackaware")) and
+                teardown_validators.get("enabled", False)):
+            self._verify_rackaware_configuration()
+
     def _replace_docker_image_latest_tag(self):
         docker_repo = self.get('docker_image')
         scylla_version = self.get('scylla_version')
@@ -2912,6 +2916,24 @@ class SCTConfiguration(dict):
     def _validate_docker_backend_parameters(self):
         if self.get("use_mgmt"):
             raise ValueError("Scylla Manager is not supported for docker backend")
+
+    def _verify_rackaware_configuration(self):
+        if not self.get("rack_aware_loader"):
+            raise ValueError("'rack_aware_loader' must be set to True for rackaware validator.")
+
+        regions = self.get("simulated_regions") or len(self.region_names)
+        availability_zone = self.get("availability_zone")
+        racks_count = simulated_racks if (simulated_racks := self.get("simulated_racks")) else len(
+            availability_zone.split(",")) if availability_zone else 1
+        if racks_count == 1 and regions == 1:
+            raise ValueError(
+                "Rack-aware validation can only be performed in multi-availability zone or multi-region environments.")
+
+        loaders = sum(int(l) for l in n_loaders.split(" ")) if isinstance(
+            (n_loaders := self.get("n_loaders")), str) else n_loaders
+        zones = racks_count * regions
+        if loaders >= zones:
+            raise ValueError("Rack-aware validation requires zones without loaders.")
 
 
 def init_and_verify_sct_config() -> SCTConfiguration:

--- a/sdcm/teardown_validators/__init__.py
+++ b/sdcm/teardown_validators/__init__.py
@@ -1,4 +1,5 @@
 from sdcm.teardown_validators.events import ErrorEventsValidator
+from sdcm.teardown_validators.rackaware import RackawareValidator
 from sdcm.teardown_validators.sstables import SstablesValidator
 
-teardown_validators_list = [SstablesValidator, ErrorEventsValidator]
+teardown_validators_list = [SstablesValidator, ErrorEventsValidator, RackawareValidator]

--- a/sdcm/teardown_validators/rackaware.py
+++ b/sdcm/teardown_validators/rackaware.py
@@ -1,0 +1,172 @@
+import logging
+import time
+
+from sdcm.sct_events import Severity
+from sdcm.sct_events.teardown_validators import ValidatorEvent
+from sdcm.teardown_validators.base import TeardownValidator
+
+LOGGER = logging.getLogger(__name__)
+
+
+class RackawareValidator(TeardownValidator):  # pylint: disable=too-few-public-methods
+    """
+    Rack-aware validation is enabled under these conditions:
+    - A rack-aware policy is configured.
+    - A single loader is employed (due to Scylla rack metric limitation).
+    - The cluster is deployed across multiple availability zones or a simulated rack environment or in multiple regions.
+
+    The validation aims to confirm that no coordination traffic is directed to availability zones where loaders are absent
+    """
+    validator_name = 'rackaware'
+
+    # This variable defines the allowed percentage variation of system CQL reads directed to availability zones without loaders.
+    # These reads, such as those performed by nemeses or non-rack-aware test code, may be routed this way.
+    EXPECTED_NON_SYSTEM_READS_PERC = 10
+
+    def validate(self):
+        """
+        Validates the rack-aware policy by ensuring that no coordination traffic is directed
+        to availability zones without loaders.
+
+        This method:
+        - Checks if the rack-aware policy is enabled.
+        - Retrieves database and loader nodes per region.
+        - Validates traffic distribution for each region.
+        - Updates the test status based on validation results.
+
+        If validation fails, an error event is published.
+
+        Returns:
+            None
+        """
+        if not self.tester.is_rack_aware_policy:
+            LOGGER.info("No workloads were running under the rack-aware policy.")
+            return
+
+        validation_passed = set()
+        # The case: multi-region cluster
+        loaders_per_region = self.tester.loaders.nodes_by_region()
+        db_nodes_per_region = self.tester.db_cluster.nodes_by_region()
+        for region in self.tester.db_cluster.datacenter:
+            (non_rack_db_nodes, rack_db_nodes) = self.map_nodes_per_rack_with_and_without_loader(db_nodes=db_nodes_per_region[region],
+                                                                                                 loader_nodes=loaders_per_region[region])
+
+            LOGGER.debug("Nodes in a loader-less AZ: %s; Region: %s", non_rack_db_nodes, region)
+            LOGGER.debug("Nodes in a loader AZ: %s; Region: %s", rack_db_nodes, region)
+            if not (non_rack_db_nodes or rack_db_nodes):
+                ValidatorEvent(message='Rackaware validation. Unable to retrieve node list filtered by loader AZ, or all nodes '
+                                       'when loader is absent.',
+                               severity=Severity.ERROR).publish()
+                validation_passed.add(False)
+                continue
+
+            validation_passed.add(self.one_region_validate(
+                non_rack_db_nodes=non_rack_db_nodes, rack_db_nodes=rack_db_nodes))
+
+        current_test_status = self.tester.get_test_status
+        self.tester.get_test_status = lambda: 'FAILED' if not validation_passed == {True} else current_test_status()
+
+    def map_nodes_per_rack_with_and_without_loader(self, db_nodes, loader_nodes):
+        """
+        Maps database nodes into two categories:
+        - Nodes in availability zones without loaders.
+        - Nodes in availability zones with loaders.
+
+        Args:
+            db_nodes (list): List of database nodes.
+            loader_nodes (list): List of loader nodes.
+
+        Returns:
+            tuple: A tuple containing two lists:
+                - non_rack_db_nodes: Nodes in loader-less availability zones.
+                - rack_db_nodes: Nodes in availability zones with loaders.
+        """
+        non_rack_db_nodes, rack_db_nodes = [], []
+        db_nodes_per_dc_and_rack_id = self.tester.db_cluster.nodes_by_racks_idx_and_regions(db_nodes)
+        loader_nodes_per_dc_and_rack_id = self.tester.db_cluster.nodes_by_racks_idx_and_regions(loader_nodes)
+        LOGGER.debug("DB nodes per dc and rack: %s", db_nodes_per_dc_and_rack_id)
+        LOGGER.debug("Loader nodes per dc and rack: %s", loader_nodes_per_dc_and_rack_id)
+        for (region, rack) in db_nodes_per_dc_and_rack_id:
+            if (region, rack) not in loader_nodes_per_dc_and_rack_id:
+                non_rack_db_nodes.extend(
+                    [node.external_address for node in db_nodes_per_dc_and_rack_id[(region, rack)]])
+            else:
+                rack_db_nodes.extend([node.external_address for node in db_nodes_per_dc_and_rack_id[(region, rack)]])
+
+        return non_rack_db_nodes, rack_db_nodes
+
+    def one_region_validate(self, non_rack_db_nodes, rack_db_nodes):
+        """
+            Validates rack-aware traffic distribution for a single region.
+
+            This method checks that user-initiated CQL reads are not disproportionately routed
+            to database nodes in availability zones (AZs) without loaders. It calculates the
+            percentage of reads handled by nodes in loader-less AZs and compares it to the
+            expected threshold (`EXPECTED_NON_SYSTEM_READS_PERC`). If the percentage exceeds
+            the threshold, an error event is published.
+
+            Args:
+                non_rack_db_nodes (list): List of database node IPs in AZs without loaders.
+                rack_db_nodes (list): List of database node IPs in AZs with loaders.
+
+            Returns:
+                bool: True if validation passes, False otherwise. If no reads are detected,
+                      returns None after publishing an error event.
+            """
+        validation_passed = True
+        non_rack_user_cql_reads = 0
+        for db_node_ip in non_rack_db_nodes:
+            cql_reads = max(0, self.get_cql_reads(db_node_ip=db_node_ip))
+            LOGGER.debug("Node %s. Non-system CQl read amounts are being routed to a node in a loader-less AZ: %s",
+                         db_node_ip, cql_reads)
+            non_rack_user_cql_reads += cql_reads
+
+        rack_user_cql_reads = 0
+        for db_node_ip in rack_db_nodes:
+            cql_reads = max(0, self.get_cql_reads(db_node_ip=db_node_ip))
+            LOGGER.debug("Node %s. Non-system CQl read amounts are being routed to a node in a loader AZ: %s",
+                         db_node_ip, cql_reads)
+            rack_user_cql_reads += cql_reads
+
+        if not (rack_user_cql_reads or non_rack_user_cql_reads):
+            ValidatorEvent(message='Rackaware validation. Reads (non-system CQL) initiated by the user were not received',
+                           severity=Severity.ERROR).publish()
+            return False
+
+        non_system_cql_reads_perc = 100 * float(non_rack_user_cql_reads) / \
+            (float(rack_user_cql_reads) + float(non_rack_user_cql_reads))
+        LOGGER.debug("Non-system CQl read amounts are being routed to a node in a loader-less AZ: %s",
+                     non_rack_user_cql_reads)
+        LOGGER.debug("Non-system CQl read amounts are being routed to a node in a loader AZ: %s", rack_user_cql_reads)
+        LOGGER.debug("User-initiated CQL reads as a percentage of all CQL reads: %s", non_system_cql_reads_perc)
+        if non_system_cql_reads_perc > self.EXPECTED_NON_SYSTEM_READS_PERC:
+            ValidatorEvent(message=f'Rackaware validation. '
+                                   f'Database nodes in availability zones without loaders received more coordination traffic than the '
+                                   'expected maximum.'
+                                   f'\nUser CQL reads are received on Db nodes in AZ with loaders: {rack_user_cql_reads};'
+                                   f'\nUser CQL reads are received on Db nodes in AZ without loaders: {non_rack_user_cql_reads};\n'
+                                   f'The percent is {non_system_cql_reads_perc}',
+                           severity=Severity.ERROR).publish()
+            validation_passed = False
+
+        return validation_passed
+
+    def get_cql_reads(self, db_node_ip: str):
+        """
+        Retrieves the number of non-system CQL reads for a given database node.
+
+        This method queries Prometheus for the CQL read metrics of the specified node
+        and calculates the total number of non-system reads.
+
+        Args:
+            db_node_ip (str): The IP address of the database node.
+
+        Returns:
+            int: The total number of non-system CQL reads. Returns 0 if no data is available.
+        """
+        query = 'sum(irate(scylla_cql_reads{instance="%s"} [40s]))-sum(irate(scylla_cql_reads_per_ks{instance="%s"} [40s]))' % \
+                (db_node_ip, db_node_ip)
+        # Example of result: [{'metric': {}, 'values': [[1741104987.33, '0'], [1741105007.33, '0'], [1741105027.33, '0']]}]
+        if results := self.tester.prometheus_db.query(query=query, start=self.tester.start_time, end=time.time()):
+            return sum([int(float(value[1])) for value in results[0]["values"]]) if results[0]["values"] else 0
+        return 0

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3899,6 +3899,14 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
                 return True
         return False
 
+    @property
+    def is_rack_aware_validation_enabled(self) -> bool:
+        if not self.is_rack_aware_policy:
+            return False
+
+        count_loaders = sum(len(loaders.nodes) for loaders in self.loaders_multitenant)
+        return count_loaders == 1 and self.db_cluster.racks_count > 1
+
     def get_hdrhistogram(self, hdr_tags: list[str], stress_operation: str,
                          start_time: float, end_time: float) -> dict[str, Any]:
         if not self.params["use_hdrhistogram"]:

--- a/test-cases/longevity/longevity-multi-dc-rackaware-validation.yaml
+++ b/test-cases/longevity/longevity-multi-dc-rackaware-validation.yaml
@@ -1,0 +1,24 @@
+test_duration: 180
+
+prepare_write_cmd:  ["cassandra-stress write cl=LOCAL_QUORUM n=2097152 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..2097152 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+                    ]
+
+stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=120m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..2097152)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5 -errors retries=50",
+             "cassandra-stress read  cl=LOCAL_QUORUM duration=120m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..2097152)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5 -errors retries=50",
+             ]
+rack_aware_loader: true
+n_db_nodes: '6 6'
+n_loaders: '1 1'
+n_monitor_nodes: 1
+
+instance_type_db: 'i4i.2xlarge'
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_interval: 10
+
+user_prefix: 'multi-dc-rackaware-validation'
+
+# teardown validators
+teardown_validators:
+  rackaware:
+    enabled: true


### PR DESCRIPTION
This PR presents 2 changes:

1. add a new longevity test.

2. Add new validation for rack-aware policy.
Rack-aware validation is enabled under these conditions:
- A rack-aware policy is configured.
- A single loader is employed (due to Scylla rack metric limitation).
- The cluster is deployed across multiple availability zones.

The validation aims to confirm that no coordination traffic is directed to availability zones
where loaders are absent or not more then 10% of non-system traffic. These reads, such as those 
performed by nemeses or non-rack-aware test code, may be routed this way.


Task: https://github.com/scylladb/qa-tasks/issues/1819

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-100gb-4h-rackaware](https://argus.scylladb.com/tests/scylla-cluster-tests/aeceb825-55db-4853-af69-9c099f5f2ef9)
```
< t:2025-05-14 15:14:42,607 f:rackaware.py    l:40   c:sdcm.teardown_validators.rackaware p:DEBUG > Nodes in a loader AZ: ['10.12.1.192', '10.12.2.244']; Region: us-east-1
< t:2025-05-14 15:14:42,613 f:rackaware.py    l:73   c:sdcm.teardown_validators.rackaware p:DEBUG > Node 10.12.3.143. Non-system CQl read amounts are being routed to a node in a loader-less AZ: 1294
< t:2025-05-14 15:14:42,619 f:rackaware.py    l:73   c:sdcm.teardown_validators.rackaware p:DEBUG > Node 10.12.2.199. Non-system CQl read amounts are being routed to a node in a loader-less AZ: 2075
< t:2025-05-14 15:14:42,625 f:rackaware.py    l:80   c:sdcm.teardown_validators.rackaware p:DEBUG > Node 10.12.1.192. Non-system CQl read amounts are being routed to a node in a loader AZ: 3240362
< t:2025-05-14 15:14:42,630 f:rackaware.py    l:80   c:sdcm.teardown_validators.rackaware p:DEBUG > Node 10.12.2.244. Non-system CQl read amounts are being routed to a node in a loader AZ: 3253827
< t:2025-05-14 15:14:42,630 f:rackaware.py    l:91   c:sdcm.teardown_validators.rackaware p:DEBUG > Non-system CQl read amounts are being routed to a node in a loader-less AZ: 3369
< t:2025-05-14 15:14:42,630 f:rackaware.py    l:93   c:sdcm.teardown_validators.rackaware p:DEBUG > Non-system CQl read amounts are being routed to a node in a loader AZ: 6494189
< t:2025-05-14 15:14:42,630 f:rackaware.py    l:94   c:sdcm.teardown_validators.rackaware p:DEBUG > User-initiated CQL reads as a percentage of all CQL reads: 0.05185024897045936
```
- [x] [longevity-multi-dc-rackaware-validation](https://argus.scylladb.com/tests/scylla-cluster-tests/242ad734-dbd5-459a-9329-87aa5669f003)
```
eu-west-1:
==================
< t:2025-05-15 12:25:49,963 > DB nodes per dc and rack: defaultdict(<class 'list'>, {('eu-west-1', '0'): [<sdcm.cluster_
aws.AWSNode object at 0x752e3a86f250>, <sdcm.cluster_aws.AWSNode object at 0x752e3bf0f100>], ('eu-west-1', '1'): [<sdcm.cluster_aws.AWSNode object at 0x752e3a86f280>, <sdcm.cluster_aws.AWSNode object at 0x752e4cfb4cd0>], ('eu-west-1', '2'): [<sdcm.cluster_aws.AWSNode object at 0x752e451106d0>, <sdcm.cluster_aws.AWSNode object at 0x752e3ba94e80>]})
< t:2025-05-15 12:25:49,963 f:rackaware.py    l:59   c:sdcm.teardown_validators.rackaware p:DEBUG > Loader nodes per dc and rack: defaultdict(<class 'list'>, {('eu-west-1', '0'): [<sdcm.cluster_aws.AWSNode object at 0x752e447b51b0>]})
< t:2025-05-15 12:25:49,963 > Nodes in a loader-less AZ: ['10.4.6.241', '10.4.7.183', '10.4.11.116', '10.4.10.111']; Region: eu-west-1
< t:2025-05-15 12:25:49,963 f:rackaware.py    l:40   c:sdcm.teardown_validators.rackaware p:DEBUG > Nodes in a loader AZ: ['10.4.3.216', '10.4.0.105']; Region: eu-west-1
< t:2025-05-15 12:25:49,973 > Node 10.4.6.241. Non-system CQl read amounts are being routed to a node in a loader-less AZ: 0
< t:2025-05-15 12:25:49,982 > Node 10.4.7.183. Non-system CQl read amounts are being routed to a node in a loader-less AZ: 0
< t:2025-05-15 12:25:49,989 > Node 10.4.11.116. Non-system CQl read amounts are being routed to a node in a loader-less AZ: 0
< t:2025-05-15 12:25:49,997 > Node 10.4.10.111. Non-system CQl read amounts are being routed to a node in a loader-less AZ: 0
< t:2025-05-15 12:25:50,007 > Node 10.4.3.216. Non-system CQl read amounts are being routed to a node in a loader AZ: 3858786
< t:2025-05-15 12:25:50,016 > Node 10.4.0.105. Non-system CQl read amounts are being routed to a node in a loader AZ: 3859626
< t:2025-05-15 12:25:50,016 > Non-system CQl read amounts are being routed to a node in a loader-less AZ: 0
< t:2025-05-15 12:25:50,016 f:rackaware.py    l:94   c:sdcm.teardown_validators.rackaware p:DEBUG > Non-system CQl read amounts are being routed to a node in a loader AZ: 7718412
< t:2025-05-15 12:25:50,016 User-initiated CQL reads as a percentage of all CQL reads: 0.0

eu-west-2:
==================
< t:2025-05-15 12:25:50,016 > DB nodes per dc and rack: defaultdict(<class 'list'>, {('eu-west-2', '0'): [<sdcm.cluster_aws.AWSNode object at 0x752e446291e0>, <sdcm.cluster_aws.AWSNode object at 0x752e44629090>], ('eu-west-2', '1'): [<sdcm.cluster_aws.AWSNode object at 0x752e3bf1be50>, <sdcm.cluster_aws.AWSNode object at 0x752e46707880>], ('eu-west-2', '2'): [<sdcm.cluster_aws.AWSNode object at 0x752e457c3700>, <sdcm.cluster_aws.AWSNode object at 0x752e45ab47f0>]})
< t:2025-05-15 12:25:50,016 f:rackaware.py    l:59   c:sdcm.teardown_validators.rackaware p:DEBUG > Loader nodes per dc and rack: defaultdict(<class 'list'>, {('eu-west-2', '0'): [<sdcm.cluster_aws.AWSNode object at 0x752e45ae1ba0>]})
< t:2025-05-15 12:25:50,016 > Nodes in a loader-less AZ: ['10.3.5.244', '10.3.6.195', '10.3.9.218', '10.3.8.142']; Region: eu-west-2
< t:2025-05-15 12:25:50,016 f:rackaware.py    l:40   c:sdcm.teardown_validators.rackaware p:DEBUG > Nodes in a loader AZ: ['10.3.2.236', '10.3.1.45']; Region: eu-west-2
< t:2025-05-15 12:25:50,024 > Node 10.3.5.244. Non-system CQl read amounts are being routed to a node in a loader-less AZ: 0
< t:2025-05-15 12:25:50,031 > Node 10.3.6.195. Non-system CQl read amounts are being routed to a node in a loader-less AZ: 0
< t:2025-05-15 12:25:50,039 > Node 10.3.9.218. Non-system CQl read amounts are being routed to a node in a loader-less AZ: 0
< t:2025-05-15 12:25:50,048 > Node 10.3.8.142. Non-system CQl read amounts are being routed to a node in a loader-less AZ: 0
< t:2025-05-15 12:25:50,056 > Node 10.3.2.236. Non-system CQl read amounts are being routed to a node in a loader AZ: 3831099
< t:2025-05-15 12:25:50,066 > Node 10.3.1.45. Non-system CQl read amounts are being routed to a node in a loader AZ: 3828241
< t:2025-05-15 12:25:50,066 > Non-system CQl read amounts are being routed to a node in a loader-less AZ: 0
< t:2025-05-15 12:25:50,066 > Non-system CQl read amounts are being routed to a node in a loader AZ: 7659340
< t:2025-05-15 12:25:50,066 User-initiated CQL reads as a percentage of all CQL reads: 0.0
```
- [x] [longevity-cdc-100gb-4h-test](https://argus.scylladb.com/tests/scylla-cluster-tests/51fc2ef1-d2b6-4cf4-b41f-60d5cceefece) - **rackaware validation is disabled**


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
