### PR TITLE
fix(test_classes): switch from `__init__` to `setUp`

### DIFF
--- a/longevity_lwt_test.py
+++ b/longevity_lwt_test.py
@@ -30,8 +30,8 @@ from sdcm.sct_events.group_common_events import ignore_mutation_write_errors
 class LWTLongevityTest(LongevityTest):
     BASE_TABLE_PARTITION_KEYS = ['domain', 'published_date']
 
-    def __init__(self, *args):
-        super().__init__(*args)
+    def setUp(self):
+        super().setUp()
         self.data_validator = None
 
     def run_prepare_write_cmd(self):

--- a/longevity_sla_test.py
+++ b/longevity_sla_test.py
@@ -22,8 +22,8 @@ from test_lib.sla import create_sla_auth
 class LongevitySlaTest(LongevityTest, loader_utils.LoaderUtilsMixin):
     FULLSCAN_SERVICE_LEVEL_SHARES = 600
 
-    def __init__(self, *args):
-        super().__init__(*args)
+    def setUp(self):
+        super().setUp()
         self.service_level_shares = self.params.get("service_level_shares")
         self.fullscan_role = None
         self.roles = []

--- a/longevity_tombstone_gc_test.py
+++ b/longevity_tombstone_gc_test.py
@@ -15,8 +15,8 @@ class TombstoneGcLongevityTest(TWCSLongevityTest):
     repair_date = None
     db_node = None
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def setUp(self):
+        super().setUp()
         post_prepare_cql_cmds = self.params.get('post_prepare_cql_cmds')
         self.ttl = int(re.search(r'default_time_to_live = (\d+)', post_prepare_cql_cmds).group(1))
         self.propagation_delay = int(

--- a/performance_regression_alternator_test.py
+++ b/performance_regression_alternator_test.py
@@ -20,8 +20,8 @@ from sdcm.utils.decorators import optional_stage
 
 
 class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
-    def __init__(self, *args):
-        super().__init__(*args)
+    def setUp(self):
+        super().setUp()
 
         # suppress YCSB client error and timeout to warnings for all the test in this class
         self.stack = contextlib.ExitStack()

--- a/performance_regression_gradual_grow_throughput.py
+++ b/performance_regression_gradual_grow_throughput.py
@@ -41,8 +41,8 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
     Latency for every step is received from cassandra-stress HDR file and reported in Argus and email.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def setUp(self):
+        super().setUp()
         self.CLUSTER_SIZE = self.params.get("n_db_nodes")  # pylint: disable=invalid-name
         self.REPLICATION_FACTOR = 3  # pylint: disable=invalid-name
 

--- a/sla_per_user_system_test.py
+++ b/sla_per_user_system_test.py
@@ -57,8 +57,8 @@ class SlaPerUserTest(LongevityTest):
     MIXED_LOAD = 'mixed'
     WORKLOAD_TYPES_INDEX = "workload_tests"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def setUp(self):
+        super().setUp()
         self.prometheus_stats = None
         self.num_of_partitions = 50000000
         self.backgroud_task = None

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -139,8 +139,8 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
     Test a Scylla cluster upgrade.
     """
 
-    def __init__(self, *args):
-        super().__init__(*args)
+    def setUp(self):
+        super().setUp()
 
         self.stack = contextlib.ExitStack()
         # ignoring those unsuppressed exceptions, till both ends of the upgrade would have https://github.com/scylladb/scylladb/pull/14681

--- a/ycsb_performance_regression_test.py
+++ b/ycsb_performance_regression_test.py
@@ -48,8 +48,8 @@ class BaseYCSBPerformanceRegressionTest(PerformanceRegressionTest):
     ]
     records_size: int = 1_000_000
 
-    def __init__(self, *args):
-        super().__init__(*args)
+    def setUp(self):
+        super().setUp()
         self._create_prepare_cmds(self.ycsb_workloads[0])
 
     def _create_prepare_cmds(self, workload: YcsbWorkload):


### PR DESCRIPTION
following 32ebb721422788c0978f202c9494669ab3aee101, seems like we didn't changed all of the test classes using this pattern.

this commit cover all of this class that still were using `__init__`

one that did, was failing like the following:
```
AttributeError: 'TombstoneGcLongevityTest' object has no attribute 'params'
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
