### PR TITLE
fix(latte): handle duration update properly

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2191,7 +2191,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         elif self._stress_duration and (' --duration' in stress_cmd or ' -d' in stress_cmd):
             timeout = self.get_duration(self._stress_duration)
             stress_cmd = re.sub(
-                r'\s(?:--duration|-d)[ =]\d+[mhd]?\s',
+                r'\s(?:--duration|-d)[ =]\d+[smhd]\s',
                 f' --duration {self._stress_duration}m ', stress_cmd)
         else:
             timeout = get_timeout_from_stress_cmd(stress_cmd) or self.get_duration(duration)


### PR DESCRIPTION
One of the recently merged PRs (https://github.com/scylladb/scylla-cluster-tests/pull/10073) introduced a bug for latte commands.
The bug is if we explicitly define the duration for main latte stress commands
then it gets also applied to the `preload` ones
which have specific number of operations to be performed, not real duration.

So, update the appropriate regex to make it work as expected again.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-longevity-gce-custom-d1-workload1-hybrid-raid#34](https://argus.scylladb.com/tests/scylla-cluster-tests/41569477-eb39-4a12-adcd-fdceafad6e4a)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
