### PR TITLE
fix(latte): detect latte keyspace correctly

### DIFF
--- a/sdcm/loader.py
+++ b/sdcm/loader.py
@@ -176,6 +176,18 @@ class LatteKeyspaceHolder:
     def __str__(self):
         return self._value
 
+    def __repr__(self):
+        return f"LatteKeyspaceHolder({self._value!r})"
+
+    def __getitem__(self, index):
+        return self._value[index]
+
+    def __len__(self):
+        return len(self._value)
+
+    def __iter__(self):
+        return iter(self._value)
+
 
 class LatteExporter(StressExporter):
     def init(self):
@@ -209,8 +221,10 @@ class LatteExporter(StressExporter):
         )
 
     def skip_line(self, line: str) -> bool:
-        if not self.keyspace and 'Keyspace:' in line:
-            self.keyspace.set_value(self.keyspace_regex.match(line).groups()[0])
+        if not self.keyspace and self.keyspace_regex.match(line):
+            ks = self.keyspace_regex.match(line).groups()[0].strip()
+            LOGGER.debug("Found following keyspace in the latte command: '%s'", ks)
+            self.keyspace.set_value(ks)
             return True
 
         # NOTE: all latency data lines consist of digits only.


### PR DESCRIPTION
In latte logic we use special class for handling of the detected keyspaces which is needed to share the data among several data exporters - common stress cmd results and HDR histograms data.

The problem was that having `self._value = ''` the condition for emptiness
was always giving us `False` because we were checking the class instance itself for emptiness.
So fix it by adding additional methods to make it behave like string more closely.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-longevity-gce-custom-d1-workload1-hybrid-raid#34](https://argus.scylladb.com/tests/scylla-cluster-tests/41569477-eb39-4a12-adcd-fdceafad6e4a)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
