### PR TITLE
fix(unit-tests): drop tests for enterprise:latest branch

### DIFF
--- a/unit_tests/test_config_get_version_based_on_conf.py
+++ b/unit_tests/test_config_get_version_based_on_conf.py
@@ -52,8 +52,6 @@ def function_setup():
                                           (None, False), id='master:latest'),
                              pytest.param('enterprise', 'scylladb/scylla-enterprise-nightly',
                                           (None, True), id='enterprise'),
-                             pytest.param('enterprise:latest', 'scylladb/scylla-enterprise-nightly',
-                                          (None, True), id='enterprise:latest'),
                          ],
                          )
 def test_docker(scylla_version, expected_docker_image, expected_outcome):
@@ -81,7 +79,6 @@ def test_docker(scylla_version, expected_docker_image, expected_outcome):
                              pytest.param('2024.1', ('2024.1', True), id='2024.1'),
                              pytest.param('master:latest', (None, True), id='master'),
                              pytest.param('branch-6.0:latest', (None, False), id='branch-6.0'),
-                             pytest.param('enterprise:latest', (None, True), id='enterprise'),
                              pytest.param('enterprise-2023.1:latest', (None, True), id='enterprise-2023.1'),
                              pytest.param('enterprise-2024.1:latest', (None, True), id='enterprise-2024.1'),
                          ],
@@ -109,7 +106,6 @@ def test_scylla_repo(scylla_version, expected_outcome, distro):
                              pytest.param('2024.2', ('2024.2', True), id='2024.2'),
                              pytest.param('master:latest', (None, True), id='master'),
                              pytest.param('branch-6.2:latest', (None, False), id='branch-6.2'),
-                             pytest.param('enterprise:latest', (None, True), id='enterprise'),
                              pytest.param('branch-2024.1:latest', (None, True), id='branch-2024.1'),
                              pytest.param('branch-2024.2:latest', (None, True), id='branch-2024.2'),
                          ],

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -273,11 +273,11 @@ class ClassWithVersiondMethods:  # pylint: disable=too-few-public-methods
     "2020.1", "2020.1.0", "2020.1.1",
     "2021.1", "2021.1.0", "2021.1.1",
     "2022.1", "2022.1.0", "2022.1.1",
-    "2023:latest", "enterprise:latest",
+    "2023:latest"
 ) for method in ("es_method", "mixed_method")] + [(scylla_version, method) for scylla_version in (
     "4.6.rc1", "4.6", "4.6.0", "4.6.1", "4.7:latest", "master:latest",
 ) for method in ("new_oss_method", "new_mixed_method")] + [(scylla_version, method) for scylla_version in (
-    "2022.1.rc1", "2022.1", "2022.1.0", "2022.1.1", "2023:latest", "enterprise:latest",
+    "2022.1.rc1", "2022.1", "2022.1.0", "2022.1.1", "2023:latest"
 ) for method in ("new_es_method", "new_mixed_method")])
 def test_scylla_versions_decorator_positive(scylla_version, method):
     for nemesis_like_class in (True, False):


### PR DESCRIPTION
Drop unit tests for enterprise:latest branch, as after switching to SA the branch support is not needed.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/10276

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
