### PR TITLE
improvement(tier1): Use virtual racks

### DIFF
--- a/test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml
+++ b/test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml
@@ -4,11 +4,12 @@ prepare_write_cmd: "cassandra-stress write cl=ALL n=50050075  -schema 'replicati
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=11h  -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=400200300..600200300 -log interval=15"]
 stress_read_cmd: ["cassandra-stress read cl=ONE duration=11h -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..50050075 -log interval=5"]
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 5}']
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 1
 n_monitor_nodes: 1
+simulated_racks: 3
 
-instance_type_db: 'i4i.4xlarge'
+instance_type_db: 'i4i.2xlarge'
 gce_instance_type_db: 'n2-highmem-16'
 
 nemesis_class_name: 'SisyphusMonkey'

--- a/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
@@ -12,10 +12,11 @@ stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=6800m -schema 'replicati
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "random", "interval": 120}']
 round_robin: true
 
-n_db_nodes: 4
+n_db_nodes: 3
 n_loaders: 4
 n_monitor_nodes: 1
 seeds_num: 2
+simulated_racks: 3
 
 instance_type_db: 'i4i.4xlarge'
 gce_instance_type_db: 'n2-highmem-16'

--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -39,9 +39,10 @@ post_prepare_cql_cmds: ["CREATE MATERIALIZED VIEW scylla_bench.view_test AS SELE
                         "ALTER TABLE scylla_bench.test with tombstone_gc = {'mode': 'repair', 'propagation_delay_in_seconds':'300'};"
                        ]
 
-n_db_nodes: 5
+n_db_nodes: 6
 n_loaders: 5 # Each loader will have 1 scylla-bench process at every step of the test (prepare, verify, stress & stress_read)
 n_monitor_nodes: 1
+simulated_racks: 3
 
 round_robin: true
 

--- a/test-cases/longevity/longevity-mv-si-4days.yaml
+++ b/test-cases/longevity/longevity-mv-si-4days.yaml
@@ -10,9 +10,10 @@ stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_profile_4mv_5queries.y
                  ]
 run_fullscan: ['{"mode": "table", "ks_cf": "random", "interval": 15}']
 
-n_db_nodes: 5
+n_db_nodes: 6
 n_loaders: 2
 n_monitor_nodes: 1
+simulated_racks: 3
 
 instance_type_db: 'i4i.8xlarge'
 gce_instance_type_db: 'n2-highmem-64'

--- a/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
@@ -13,9 +13,10 @@ stress_cmd: [
 
              ]
 
-n_db_nodes: 5
+n_db_nodes: 6
 n_loaders: 2
 n_monitor_nodes: 1
+simulated_racks: 3
 
 instance_type_db: 'i4i.2xlarge'
 

--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -10,9 +10,10 @@ stress_read_cmd: [
     ]
 
 
-n_db_nodes: 4
+n_db_nodes: 3
 n_loaders: 3
 n_monitor_nodes: 1
+simulated_racks: 3
 
 instance_type_db: 'i3en.2xlarge'
 


### PR DESCRIPTION
Needs to be retuned to increased number of nodes, which will be done after we see it in action.

* Increased number of nodes to multiples of 3
* Left out jobs which already have AZs in the configs
   * `longevity-multidc-schema-topology-changes-12h` and `longevity-50gb-3days` already have real AZs in their configuration files, followup PR will be made to run them with AZs weekly (I think they are currently reduced to a single AZ via trigger)

Part of #10241 
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/ef3ff586-9498-4a55-a653-55e7fc3f3c01
    * Failed due to https://github.com/scylladb/scylla-cluster-tests/issues/9986, not caused by this PR, ran for 13hours

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
