### PR TITLE
feature(events): introduce Severity.SUPRESS

### DIFF
--- a/sdcm/sct_events/__init__.py
+++ b/sdcm/sct_events/__init__.py
@@ -18,6 +18,7 @@ from typing import Protocol, Optional, Type, runtime_checkable
 
 
 class Severity(enum.Enum):
+    SUPPRESS = -2  # those won't be generating events for
     DEBUG = -1  # this should only be through test case configuration!!!
     UNKNOWN = 0
     NORMAL = 1

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -81,7 +81,7 @@ class ReactorStalledMixin(Generic[T_log_event]):
         return super().add_info(node=node, line=line, line_number=line_number)
 
 
-DatabaseLogEvent.add_subevent_type("WARNING", severity=Severity.WARNING,
+DatabaseLogEvent.add_subevent_type("WARNING", severity=Severity.SUPPRESS,
                                    regex=r"(^WARNING|!\s*?WARNING).*\[shard.*\]")
 DatabaseLogEvent.add_subevent_type("NO_SPACE_ERROR", severity=Severity.ERROR,
                                    regex="No space left on device")


### PR DESCRIPTION
A new severity level, that would help us stop generating some events we need those events for skipping some log line, so we never generate error or critical events from those.

until now we generated an event for each one, and now we'll be able to skip them since for some cases there are too many of those warnings.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
