### PR TITLE
fix(tester): add traceback logging when checking regressions

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -21,6 +21,7 @@ import random
 import logging
 import os
 import re
+import sys
 import time
 import traceback
 import unittest
@@ -3345,6 +3346,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             except Exception as exc:  # noqa: BLE001
                 TestFrameworkEvent(
                     message='Failed to check regression',
+                    trace=sys._getframe().f_back,
                     source=self.__class__.__name__,
                     source_method='check_regression',
                     exception=exc
@@ -3369,6 +3371,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         except Exception as exc:  # noqa: BLE001
             TestFrameworkEvent(
                 message='Failed to check regression',
+                trace=sys._getframe().f_back,
                 source=self.__class__.__name__,
                 source_method='check_regression',
                 exception=exc
@@ -3392,6 +3395,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         except Exception as exc:  # noqa: BLE001
             TestFrameworkEvent(
                 message='Failed to check regression',
+                trace=sys._getframe().f_back,
                 source=self.__class__.__name__,
                 source_method='check_regression',
                 exception=exc
@@ -3421,6 +3425,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         except Exception as exc:  # noqa: BLE001
             TestFrameworkEvent(
                 message='Failed to check regression',
+                trace=sys._getframe().f_back,
                 source=self.__class__.__name__,
                 source_method='check_regression',
                 exception=exc
@@ -3437,6 +3442,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         except Exception as exc:  # noqa: BLE001
             TestFrameworkEvent(
                 message='Failed to check regression',
+                trace=sys._getframe().f_back,
                 source=self.__class__.__name__,
                 source_method='check_regression',
                 exception=exc


### PR DESCRIPTION
If checking regression fails, this makes it easier to debug, especially errors related to the email templates.


For example, if a test does not have `use_hdrhistogram: true`, then the error would be 
> 2025-03-02 13:55:20.759: (TestFrameworkEvent Severity.ERROR) period_type=one-time event_id=f0a49a5c-6891-43c3-8f99-85b5798e090f, source=PerformanceRegressionTest.check_regression() message=Failed to check regression
exception='NoneType' object is not iterable

which is not useful at all

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/1ca06f64-8d81-4da6-af33-73e14cafd2f7

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code


