### PR TITLE
fix(manager): update path to test for rocky9 installation test

### DIFF
--- a/jenkins-pipelines/manager/rocky9-manager-install.jenkinsfile
+++ b/jenkins-pipelines/manager/rocky9-manager-install.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
-    test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_installed_and_functional',
+    test_name: 'mgmt_cli_test.ManagerInstallationTests.test_manager_installed_and_functional',
     test_config: '''["test-cases/manager/manager-installation-set-distro.yaml", "configurations/manager/rocky9.yaml"]''',
 
     post_behavior_db_nodes: 'destroy',


### PR DESCRIPTION
This .jenkinsfile didn't get an update when the refactoring for Manager test files (classes reorganization, renamings) were done.

Fixing here updating test_name parameter to the valid one.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] not required

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code