### PR TITLE
fix(upgrade_test): make rollback reinstall option work for centos

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -413,7 +413,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         if re.findall(r'\d+.\d+', self.orig_ver)[0] == re.findall(r'\d+.\d+', self.new_ver)[0]:
             self.upgrade_rollback_mode = 'minor_release'
 
-        if self.upgrade_rollback_mode == 'reinstall' or not node.distro.is_rhel_like:
+        if self.upgrade_rollback_mode == 'reinstall':
             scylla_pkg_ver = node.scylla_pkg()
 
             if self.params.get('use_preinstalled_scylla'):


### PR DESCRIPTION
seem like by mistake we left some logic that skip the `reinstall` option for the rollback, hence code would try to do `yum downgrade` and would fail to uninstall the new 2025.1 version during rollback.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-centos9-test/14/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
