### PR TITLE
fix(nemesis): TTL setter workaround added for non TWCS tables

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2840,7 +2840,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 compaction_properties = get_table_compaction_info(
                     keyspace=keyspace, table=table, session=session
                 )
-        ttl_to_set = calculate_allowed_twcs_ttl(compaction_properties, default_min_ttl, default_max_ttl)
+            ttl_to_set = calculate_allowed_twcs_ttl(compaction_properties, default_min_ttl, default_max_ttl)
+        else:
+            ttl_to_set = default_max_ttl
 
         InfoEvent(f'New default time to live to be set: {ttl_to_set}, for table: {keyspace_table}').publish()
         self._modify_table_property(name="default_time_to_live", val=ttl_to_set,


### PR DESCRIPTION
This commit should fix unexpected python error:
```
Traceback (most recent call last):
  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 5559, in wrapper
    result = method(*args[1:], **kwargs)
  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 3027, in disrupt_modify_table
    disrupt_func()
  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 2839, in modify_table_default_time_to_live
    ttl_to_set = calculate_allowed_twcs_ttl(compaction_properties, default_min_ttl, default_max_ttl)
UnboundLocalError: local variable 'compaction_properties' referenced before assignment
```

### Testing
https://argus.scylladb.com/tests/scylla-cluster-tests/24ba3271-f770-4512-b72f-e09888871140

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
