### PR TITLE
fix(keep_duration): pass along the keep:duration tags as hours

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -33,6 +33,7 @@ import itertools
 import json
 import ipaddress
 import shlex
+from decimal import Decimal, ROUND_UP
 from importlib import import_module
 from typing import List, Optional, Dict, Union, Set, Iterable, ContextManager, Any, IO, AnyStr, Callable
 from datetime import datetime, timezone
@@ -562,7 +563,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         ContainerManager.set_all_containers_keep_alive(self)
         return True
 
-    def _set_keep_duration(self, duration_in_minutes: int) -> None:
+    def _set_keep_duration(self, duration_in_hours: int) -> None:
         raise NotImplementedError()
 
     def set_keep_alive(self):
@@ -571,7 +572,8 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             self.log.info("Keep this node alive")
         else:
             # same extra time as in getJobTimeouts.groovy (collection + resources cleanup + sending email report)
-            self._set_keep_duration(self.test_config.TEST_DURATION + 125)
+            self._set_keep_duration(
+                int(Decimal((self.test_config.TEST_DURATION + 125) / 60).quantize(Decimal("1"), ROUND_UP)))
 
     @property
     def short_hostname(self):

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -570,9 +570,9 @@ class AWSNode(cluster.BaseNode):
         self._ec2_service.create_tags(Resources=[self._instance.id], Tags=[{"Key": "keep", "Value": "alive"}])
         return super()._set_keep_alive()
 
-    def _set_keep_duration(self, duration_in_minutes: int) -> None:
+    def _set_keep_duration(self, duration_in_hours: int) -> None:
         self._ec2_service.create_tags(Resources=[self._instance.id], Tags=[
-                                      {"Key": "keep", "Value": str(duration_in_minutes)}])
+                                      {"Key": "keep", "Value": str(duration_in_hours)}])
 
     @property
     def vm_region(self):

--- a/sdcm/cluster_azure.py
+++ b/sdcm/cluster_azure.py
@@ -93,8 +93,8 @@ class AzureNode(cluster.BaseNode):
         return super()._set_keep_alive()
 
     @retrying(n=6, sleep_time=1)
-    def _set_keep_duration(self, duration_in_minutes: int) -> None:
-        self._instance.add_tags({"keep": str(duration_in_minutes)})
+    def _set_keep_duration(self, duration_in_hours: int) -> None:
+        self._instance.add_tags({"keep": str(duration_in_hours)})
 
     def _refresh_instance_state(self):
         ip_tuple = ([self._instance.public_ip_address], [self._instance.private_ip_address])

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -86,7 +86,7 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):  # pylint: disable=abstr
             assert int(container.labels["NodeIndex"]) == node_index, "Container labeled with wrong index."
             self._containers["node"] = container
 
-    def _set_keep_duration(self, duration_in_minutes: int) -> None:
+    def _set_keep_duration(self, duration_in_hours: int) -> None:
         pass
 
     def wait_for_cloud_init(self):
@@ -449,7 +449,7 @@ class DockerMonitoringNode(cluster.BaseNode):  # pylint: disable=abstract-method
     def disable_daily_triggered_services(self):
         pass
 
-    def _set_keep_duration(self, duration_in_minutes: int) -> None:
+    def _set_keep_duration(self, duration_in_hours: int) -> None:
         pass
 
 

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -132,11 +132,11 @@ class GCENode(cluster.BaseNode):
                               zone=self.zone) and \
             super()._set_keep_alive()
 
-    def _set_keep_duration(self, duration_in_minutes: int) -> None:
+    def _set_keep_duration(self, duration_in_hours: int) -> None:
         self._refresh_instance_state()
         gce_set_labels(instances_client=self._gce_service,
                        instance=self._instance,
-                       new_labels={"keep": str(duration_in_minutes)},
+                       new_labels={"keep": str(duration_in_hours)},
                        project=self.project,
                        zone=self.zone)
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1796,7 +1796,7 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
     def _init_port_mapping(self):
         pass
 
-    def _set_keep_duration(self, duration_in_minutes: int):
+    def _set_keep_duration(self, duration_in_hours: int):
         pass
 
     @property

--- a/unit_tests/dummy_remote.py
+++ b/unit_tests/dummy_remote.py
@@ -80,7 +80,7 @@ class LocalNode(BaseNode):
     def check_spot_termination(self):
         pass
 
-    def _set_keep_duration(self, duration_in_minutes: int) -> None:
+    def _set_keep_duration(self, duration_in_hours: int) -> None:
         pass
 
     def restart(self):

--- a/unit_tests/test_utils_common.py
+++ b/unit_tests/test_utils_common.py
@@ -126,7 +126,7 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method
         self.remoter.stop()
         self.remoter = Remoter(self.system_log)
 
-    def _set_keep_duration(self, duration_in_minutes: int) -> None:
+    def _set_keep_duration(self, duration_in_hours: int) -> None:
         pass
 
     def _get_private_ip_address(self) -> str:


### PR DESCRIPTION
test duration in SCT is calculated in minutes, while the tags are using hours, updating the implmention to pass hours and rename the functions arguments to match.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
