### PR TITLE
improvement(cql-stress): updated to version with driver 1.0.0

### DIFF
--- a/docker/cql-stress-cassandra-stress/Dockerfile
+++ b/docker/cql-stress-cassandra-stress/Dockerfile
@@ -1,14 +1,14 @@
-FROM rust:1.84-bookworm AS builder
+FROM rust:1.85-bookworm AS builder
 
 ARG BRANCH
 ARG REPO
 
 ENV BRANCH=${BRANCH:-master}
 ENV REPO=${REPO:-https://github.com/scylladb/cql-stress.git}
-
+RUN apt-get update && apt-get install -y clang libclang-dev
 RUN git clone ${REPO} -b ${BRANCH}
 
-RUN cd cql-stress && cargo build --release --bin cql-stress-cassandra-stress
+RUN cd cql-stress && RUSTFLAGS="--cfg fetch_extended_version_info" cargo build --release --bin cql-stress-cassandra-stress
 
 FROM debian:bookworm-slim
 RUN apt update && apt -y install \

--- a/docker/cql-stress-cassandra-stress/image
+++ b/docker/cql-stress-cassandra-stress/image
@@ -1,1 +1,1 @@
-scylladb/hydra-loaders:cql-stress-cassandra-stress-20250127
+scylladb/hydra-loaders:cql-stress-cassandra-stress-20250310


### PR DESCRIPTION
Recently updated driver to 1.0.0. Publishing new version so it can be used in SCT.
This version also contains cql-stress with `version` argument support.

refs: https://github.com/scylladb/cql-stress/issues/115

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/longevity-100gb-4h-cql-stress-test/2/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
