### PR TITLE
fix(nemesis.py): Prevent static columns for MVs

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5139,7 +5139,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             if not ks_cf_list:
                 raise UnsupportedNemesis("No table found to create index on")
             ks, cf = random.choice(ks_cf_list).split('.')
-            column = get_random_column_name(session, ks, cf)
+            column = get_random_column_name(session, ks, cf, filter_out_static_columns=True)
             if not column:
                 raise UnsupportedNemesis("No column found to create index on")
             try:
@@ -5185,7 +5185,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     session=session, ks=ks_name, cf=base_table_name, is_primary_key=True)
                 # selecting a supported column for creating a materialized-view (not a collection type).
                 column = get_random_column_name(session=session, ks=ks_name,
-                                                cf=base_table_name, filter_out_collections=True)
+                                                cf=base_table_name, filter_out_collections=True, filter_out_static_columns=True)
                 if not column:
                     raise UnsupportedNemesis(
                         'A supported column for creating MV is not found. nemesis can\'t run')

--- a/sdcm/utils/nemesis_utils/indexes.py
+++ b/sdcm/utils/nemesis_utils/indexes.py
@@ -41,8 +41,9 @@ def is_cf_a_view(node: BaseNode, ks, cf) -> bool:
             return False
 
 
-def get_column_names(session, ks, cf, is_primary_key: bool = False, filter_out_collections: bool = False) -> list:
-    filter_kind = " kind in ('static', 'regular')" if not is_primary_key else "kind in ('partition_key', 'clustering')"
+def get_column_names(session, ks, cf, is_primary_key: bool = False, filter_out_collections: bool = False, filter_out_static_columns: bool = False) -> list:
+    column_types = "'regular'" if filter_out_static_columns else "'static', 'regular'"
+    filter_kind = f" kind in ({column_types})" if not is_primary_key else "kind in ('partition_key', 'clustering')"
     res = session.execute(f"SELECT column_name, type FROM system_schema.columns"
                           f" WHERE keyspace_name = '{ks}'"
                           f" AND table_name = '{cf}'"
@@ -56,8 +57,8 @@ def get_column_names(session, ks, cf, is_primary_key: bool = False, filter_out_c
     return column_names
 
 
-def get_random_column_name(session, ks, cf, filter_out_collections: bool = False) -> str | None:
-    if column_names := get_column_names(session=session, ks=ks, cf=cf, filter_out_collections=filter_out_collections):
+def get_random_column_name(session, ks, cf, filter_out_collections: bool = False, filter_out_static_columns: bool = False) -> str | None:
+    if column_names := get_column_names(session=session, ks=ks, cf=cf, filter_out_collections=filter_out_collections, filter_out_static_columns=filter_out_static_columns):
         return random.choice(column_names)
     return None
 


### PR DESCRIPTION
This commit disables disrupt_add_remove_mv from using a static column
inside a materialized view by introducing additional flag to both
get_column_names and get_random_column_name to disable selecting
'static' column types.

Fixes #10202

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
