### PR TITLE
fix(performance_regression_test): Move super.setUp() to be called first

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -61,14 +61,13 @@ class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):  
     @teardown_on_exception
     @log_run_info
     def setUp(self):
+        super().setUp()
         if es_index := self.params.get("custom_es_index"):
             self._test_index = es_index
 
         # need to remove the email_data.json file, as in the builders, it will accumulate and it will send multiple
         # emails for each test. When we move to use SCT Runners, it won't be necessary.
         self._clean_email_data()
-
-        super().setUp()
         if self.params.get("run_db_node_benchmarks"):
             self.log.info("Validate node benchmarks results")
             compare_results = self.db_cluster.get_node_benchmarks_results() or {}


### PR DESCRIPTION
Parameters are not initialized before that and it kept failing on `self.params`

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/phala/job/perf-regression-throughput-125gb-perf-fix/4/
    - Failed due to #10360, but passed otherwise. I did not want to edit testcase just for this PR 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
