### PR TITLE
fix(elastic): remove usage of doc_type

### DIFF
--- a/microbenchmarking_test.py
+++ b/microbenchmarking_test.py
@@ -37,7 +37,7 @@ class PerfSimpleQueryTest(ClusterTester):
                 doc_id_with_timestamp=True)
             if self.create_stats:
                 is_gce = self.params.get('cluster_backend') == 'gce'
-                PerfSimpleQueryAnalyzer(self._test_index, self._es_doc_type).check_regression(
+                PerfSimpleQueryAnalyzer(self._test_index).check_regression(
                     self._test_id, is_gce=is_gce,
                     extra_jobs_to_compare=self.params.get('perf_extra_jobs_to_compare'))
             send_perf_simple_query_result_to_argus(self.test_config.argus_client(), results)

--- a/performance_regression_gradual_grow_throughput.py
+++ b/performance_regression_gradual_grow_throughput.py
@@ -257,7 +257,6 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
     def run_performance_analyzer(self, total_summary):
         perf_analyzer = PredefinedStepsTestPerformanceAnalyzer(
             es_index=self._test_index,
-            es_doc_type=self._es_doc_type,
             email_recipients=self.params.get('email_recipients'))
         # Keep next 2 lines for debug purpose
         self.log.debug("es_index: %s", self._test_index)

--- a/performance_search_max_throughput_test.py
+++ b/performance_search_max_throughput_test.py
@@ -184,7 +184,6 @@ class MaximumPerformanceSearchTest(PerformanceRegressionTest):
         }
 
         analyzer = SearchBestThroughputConfigPerformanceAnalyzer(es_index=self._test_index,
-                                                                 es_doc_type=self._es_doc_type,
                                                                  email_recipients=self.params.get("email_recipients"))
         analyzer.check_regression(test_name, setup_details=setup_details, test_results=raw_results)
 

--- a/sct.py
+++ b/sct.py
@@ -961,7 +961,7 @@ def perf_regression_report(es_id, emails, es_index, extra_jobs_to_compare):
     if not emails:
         LOGGER.warning("No email recipients. Email will not be sent")
         sys.exit(1)
-    results_analyzer = PerformanceResultsAnalyzer(es_index=es_index, es_doc_type="test_stats",
+    results_analyzer = PerformanceResultsAnalyzer(es_index=es_index,
                                                   email_recipients=emails, logger=LOGGER)
     results_analyzer.check_regression(es_id, extra_jobs_to_compare=extra_jobs_to_compare)
 
@@ -1413,7 +1413,7 @@ def send_email(test_id=None, test_status=None, start_time=None, started_by=None,
         # figure out it's a perf tests with multiple emails in single file
         # based on the structure of file
         logs = list_logs_by_test_id(test_results.get('test_id', test_id))
-        reporter = BaseResultsAnalyzer(es_index=test_id, es_doc_type='test_stats',
+        reporter = BaseResultsAnalyzer(es_index=test_id,
                                        email_recipients=email_recipients)
         send_perf_email(reporter, test_results, logs, email_recipients, testrun_dir, start_time)
     else:
@@ -1706,14 +1706,13 @@ def generate_parallel_timelines_report(logdir: str | None, test_id: str | None) 
 
 @cli.command("create-es-index", help="Create ElasticSearch index with mapping ")
 @click.option("-n", "--name", envvar='SCT_ES_INDEX_NAME', required=True, help="ES index name")
-@click.option("-dt", "--doc-type", envvar='SCT_ES_DOC_TYPE', default="")
 @click.option("-f", "--mapping-file", envvar='SCT_MAPPING_FILEPATH', type=click.Path(exists=True),
               required=True, help="Full path to es index mapping file")
-def create_es_index(name: str, doc_type: str, mapping_file: str) -> None:
+def create_es_index(name: str, mapping_file: str) -> None:
     add_file_logger()
 
     mapping_data = get_mapping(mapping_file)
-    create_index(index_name=name, doc_type=doc_type, mappings=mapping_data)
+    create_index(index_name=name, mappings=mapping_data)
 
 
 @cli.command("configure-jenkins-builders", help="Configure all required jenkins builders for SCT")

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -470,7 +470,6 @@ class Stats:
     def __init__(self, *args, **kwargs):
         self._test_index = kwargs.get("test_index")
         self._test_id = kwargs.get("test_id")
-        self._es_doc_type = "test_stats"
         self._stats = {}
         self.test_config = TestConfig()
 
@@ -494,7 +493,6 @@ class Stats:
         try:
             self.elasticsearch.create_doc(
                 index=self._test_index,
-                doc_type=self._es_doc_type,
                 doc_id=self._test_id,
                 body=self._stats,
             )
@@ -509,7 +507,6 @@ class Stats:
         try:
             self.elasticsearch.update_doc(
                 index=self._test_index,
-                doc_type=self._es_doc_type,
                 doc_id=self._test_id,
                 body=data,
             )
@@ -525,7 +522,6 @@ class Stats:
         try:
             return self.elasticsearch.exists(
                 index=self._test_index,
-                doc_type=self._es_doc_type,
                 id=self._test_id,
             )
         except Exception as exc:  # pylint: disable=broad-except
@@ -911,7 +907,6 @@ class TestStatsMixin(Stats):
             try:
                 result = self.elasticsearch.get_doc(
                     index=self._test_index,
-                    doc_type=self._es_doc_type,
                     doc_id=self._test_id,
                 )
             except Exception as exc:  # pylint: disable=broad-except

--- a/sdcm/microbenchmarking.py
+++ b/sdcm/microbenchmarking.py
@@ -84,7 +84,7 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
     def __init__(self, email_recipients, db_version=None, es_index=None):
         if not es_index:
             es_index = MICROBENCHMARK_INDEX_NAME
-        super().__init__(es_index=es_index, es_doc_type="microbenchmark", email_recipients=email_recipients,
+        super().__init__(es_index=es_index, email_recipients=email_recipients,
                          email_template_fp="results_microbenchmark.html", query_limit=10000, logger=LOGGER)
         self.hostname = socket.gethostname()
         self._run_date_pattern = "%Y-%m-%d_%H:%M:%S"
@@ -359,7 +359,7 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
                                           'excluded': False
                                           })
                         if update_db:
-                            self._es.create_doc(index=self._es_index, doc_type=self._es_doc_type,
+                            self._es.create_doc(index=self._es_index,
                                                 doc_id="%s_%s" % (self.test_run_date, test_type), body=datastore)
                         results[test_type] = datastore
             if not results:
@@ -398,7 +398,6 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
             self.log.info(res['_id'])
             self.log.info(res['_source']['test_run_date'])
             self._es.update_doc(index=self._es_index,
-                                doc_type=self._es_doc_type,
                                 doc_id=res['_id'],
                                 body={'excluded': True})
 
@@ -418,7 +417,6 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
         doc = self._es.get_doc(index=self._es_index, doc_id=test_id)
         if doc:
             self._es.update_doc(index=self._es_index,
-                                doc_type=self._es_doc_type,
                                 doc_id=doc['_id'],
                                 body={'excluded': True})
         else:
@@ -472,7 +470,6 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
 
         for res in before_date_results:
             self._es.update_doc(index=self._es_index,
-                                doc_type=self._es_doc_type,
                                 doc_id=res['_id'],
                                 body={'excluded': True})
 
@@ -504,7 +501,6 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
                           doc['_source']['versions']['scylla-server']['commit_id'],
                           doc['_source']['test_run_date'])
             self._es.update_doc(index=self._es_index,
-                                doc_type=self._es_doc_type,
                                 doc_id=doc['_id'],
                                 body={'excluded': True})
 

--- a/sdcm/nemesis_publisher.py
+++ b/sdcm/nemesis_publisher.py
@@ -107,5 +107,5 @@ class NemesisElasticSearchPublisher:
                 failure_message=data['error']
             ))
 
-        res = self.es.index(index=self.index_name, doc_type='nemesis', body=new_nemesis_data)
+        res = self.es.index(index=self.index_name, body=new_nemesis_data)
         LOGGER.debug(res)

--- a/sdcm/reporting/elastic_reporter.py
+++ b/sdcm/reporting/elastic_reporter.py
@@ -49,7 +49,7 @@ class ElasticRunReporter:
             "build_number": build_number,
         }
 
-        self._es.create(index=index, document=document, id=run_id, doc_type="sct_test_run_short_v1")
+        self._es.create(index=index, document=document, id=run_id)
         return True
 
     def _check_index(self, index_name: str):

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -46,12 +46,11 @@ class BaseResultsAnalyzer:  # pylint: disable=too-many-instance-attributes
     PARAMS = TestStatsMixin.STRESS_STATS
 
     # pylint: disable=too-many-arguments
-    def __init__(self, es_index, es_doc_type, email_recipients=(), email_template_fp="", query_limit=1000, logger=None,
+    def __init__(self, es_index, email_recipients=(), email_template_fp="", query_limit=1000, logger=None,
                  events=None):
         self._es = ES()
         self._conf = self._es.conf  # pylint: disable=protected-access
         self._es_index = es_index
-        self._es_doc_type = es_doc_type
         self._limit = query_limit
         self._email_recipients = email_recipients
         self._email_template_fp = email_template_fp
@@ -70,10 +69,10 @@ class BaseResultsAnalyzer:  # pylint: disable=too-many-instance-attributes
         :param test_id: test id created by performance test
         :return: test results in json format
         """
-        if not self._es.exists(index=self._es_index, doc_type=self._es_doc_type, id=test_id):
+        if not self._es.exists(index=self._es_index, id=test_id):
             self.log.error('Test results not found: {}'.format(test_id))
             return None
-        return self._es.get(index=self._es_index, doc_type=self._es_doc_type, id=test_id)
+        return self._es.get(index=self._es_index, id=test_id)
 
     @staticmethod
     def _get_grafana_screenshot(test_doc):
@@ -252,8 +251,8 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
     Get latency during operations performance analyzer
     """
 
-    def __init__(self, es_index, es_doc_type, email_recipients=(), logger=None, events=None):   # pylint: disable=too-many-arguments
-        super().__init__(es_index=es_index, es_doc_type=es_doc_type, email_recipients=email_recipients,
+    def __init__(self, es_index, email_recipients=(), logger=None, events=None):   # pylint: disable=too-many-arguments
+        super().__init__(es_index=es_index, email_recipients=email_recipients,
                          email_template_fp="results_latency_during_ops_short.html", logger=logger, events=events)
         self.percentiles = ['percentile_90', 'percentile_99']
 
@@ -285,7 +284,6 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
         LOGGER.debug("ES QUERY: %s", query)
         test_results = self._es.search(  # pylint: disable=unexpected-keyword-arg; pylint doesn't understand Elasticsearch code
             index=self._es_index,
-            doc_type=self._es_doc_type,
             q=query,
             filter_path=filter_path,
             size=self._limit)
@@ -541,8 +539,8 @@ class SpecifiedStatsPerformanceAnalyzer(BaseResultsAnalyzer):
     Get specified performance test results from elasticsearch DB and analyze it to find a regression
     """
 
-    def __init__(self, es_index, es_doc_type, email_recipients=(), logger=None, events=None):   # pylint: disable=too-many-arguments
-        super().__init__(es_index=es_index, es_doc_type=es_doc_type, email_recipients=email_recipients,
+    def __init__(self, es_index, email_recipients=(), logger=None, events=None):   # pylint: disable=too-many-arguments
+        super().__init__(es_index=es_index, email_recipients=email_recipients,
                          email_template_fp="", logger=logger, events=events)
 
     def _test_stats(self, test_doc):
@@ -674,8 +672,8 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
 
     PARAMS = TestStatsMixin.STRESS_STATS
 
-    def __init__(self, es_index, es_doc_type, email_recipients=(), logger=None, events=None):  # pylint: disable=too-many-arguments
-        super().__init__(es_index=es_index, es_doc_type=es_doc_type, email_recipients=email_recipients,
+    def __init__(self, es_index, email_recipients=(), logger=None, events=None):  # pylint: disable=too-many-arguments
+        super().__init__(es_index=es_index, email_recipients=email_recipients,
                          email_template_fp="results_performance.html", logger=logger, events=events)
 
     @staticmethod
@@ -1512,8 +1510,8 @@ class PredefinedStepsTestPerformanceAnalyzer(LatencyDuringOperationsPerformanceA
     Performance Analyzer for results with throughput and latency of gradual payload increase
     """
 
-    def __init__(self, es_index, es_doc_type, email_recipients=(), logger=None, events=None):   # pylint: disable=too-many-arguments
-        super().__init__(es_index=es_index, es_doc_type=es_doc_type, email_recipients=email_recipients,
+    def __init__(self, es_index, email_recipients=(), logger=None, events=None):   # pylint: disable=too-many-arguments
+        super().__init__(es_index=es_index, email_recipients=email_recipients,
                          logger=logger, events=events)
         self._email_template_fp = "results_performance_predefined_steps.html"
         self.percentiles = ['percentile_95', 'percentile_99']
@@ -1569,8 +1567,8 @@ class SearchBestThroughputConfigPerformanceAnalyzer(BaseResultsAnalyzer):
     Get latency during operations performance analyzer
     """
 
-    def __init__(self, es_index, es_doc_type, email_recipients=(), logger=None, events=None):   # pylint: disable=too-many-arguments
-        super().__init__(es_index=es_index, es_doc_type=es_doc_type, email_recipients=email_recipients,
+    def __init__(self, es_index, email_recipients=(), logger=None, events=None):   # pylint: disable=too-many-arguments
+        super().__init__(es_index=es_index, email_recipients=email_recipients,
                          email_template_fp="results_search_best_throughput_config.html", logger=logger, events=events)
 
     def check_regression(self, test_name, setup_details, test_results) -> None:  # pylint: disable=too-many-locals, too-many-branches, too-many-statements

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3314,7 +3314,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         end_time = time.time()
         analyzer = LatencyDuringOperationsPerformanceAnalyzer
         results_analyzer = analyzer(es_index=self._test_index,
-                                    es_doc_type=self._es_doc_type,
                                     email_recipients=self.params.get(
                                         'email_recipients'),
                                     events=get_events_grouped_by_category(
@@ -3354,7 +3353,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     def check_regression(self):
         results_analyzer = PerformanceResultsAnalyzer(es_index=self._test_index,
-                                                      es_doc_type=self._es_doc_type,
                                                       email_recipients=self.params.get('email_recipients'),
                                                       events=get_events_grouped_by_category(
                                                           _registry=self.events_processes_registry,
@@ -3379,7 +3377,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     def check_regression_with_baseline(self, subtest_baseline):
         results_analyzer = PerformanceResultsAnalyzer(es_index=self._test_index,
-                                                      es_doc_type=self._es_doc_type,
                                                       email_recipients=self.params.get('email_recipients'),
                                                       events=get_events_grouped_by_category(
                                                           _registry=self.events_processes_registry,
@@ -3404,7 +3401,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def check_regression_multi_baseline(self, subtests_info=None,  # pylint: disable=inconsistent-return-statements
                                         metrics=None, email_subject=None):
         results_analyzer = PerformanceResultsAnalyzer(es_index=self._test_index,
-                                                      es_doc_type=self._es_doc_type,
                                                       email_recipients=self.params.get('email_recipients'),
                                                       events=get_events_grouped_by_category(
                                                           _registry=self.events_processes_registry,
@@ -3433,7 +3429,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     def check_specified_stats_regression(self, stats):
         perf_analyzer = SpecifiedStatsPerformanceAnalyzer(es_index=self._test_index,
-                                                          es_doc_type=self._es_doc_type,
                                                           email_recipients=self.params.get('email_recipients'),
                                                           events=get_events_grouped_by_category(
                                                               _registry=self.events_processes_registry))

--- a/sdcm/utils/benchmarks.py
+++ b/sdcm/utils/benchmarks.py
@@ -142,7 +142,7 @@ class ScyllaClusterBenchmarkManager(metaclass=Singleton):
                     **runner.benchmark_results
                 }
                 doc_id = f"{self._test_id}-{runner.node_name.split('-')[-1]}"
-                self._es.create_doc(index=ES_INDEX, doc_type=None, doc_id=doc_id, body=results)
+                self._es.create_doc(index=ES_INDEX, doc_id=doc_id, body=results)
             else:
                 LOGGER.debug("No benchmarks results for node: %s", runner.node_name)
 

--- a/sdcm/utils/es_index.py
+++ b/sdcm/utils/es_index.py
@@ -17,9 +17,8 @@ def create_index(index_name: str, mappings: dict, **kwargs):
     if not mappings:
         raise Exception(f"Mappings configuration is empty {mappings}")
     es_client = ES()
-    doc_type = kwargs.get("doc_type")
     es_client.indices.create(index=index_name)
-    es_client.indices.put_mapping(index=index_name, doc_type=doc_type, body=mappings,  # pylint: disable=unexpected-keyword-arg
+    es_client.indices.put_mapping(index=index_name, body=mappings,  # pylint: disable=unexpected-keyword-arg
                                   include_type_name=True)
 
 

--- a/sdcm/utils/microbenchmarking/perf_simple_query_reporter.py
+++ b/sdcm/utils/microbenchmarking/perf_simple_query_reporter.py
@@ -8,8 +8,6 @@ def keys_exists(element, *keys):
     '''
     Check if *keys (nested) exists in `element` (dict).
     '''
-    if not isinstance(element, dict):
-        raise AttributeError('keys_exists() expects dict as first argument.')
     if len(keys) == 0:
         raise AttributeError('keys_exists() expects at least two arguments, one given.')
 
@@ -26,8 +24,8 @@ class PerfSimpleQueryAnalyzer(BaseResultsAnalyzer):
 
     collect_last_scylla_date_count = 10
 
-    def __init__(self, es_index, es_doc_type):
-        super().__init__(es_index, es_doc_type, query_limit=1000, logger=None)
+    def __init__(self, es_index):
+        super().__init__(es_index, query_limit=1000, logger=None)
 
     def _get_perf_simple_query_result(self, test_doc):
         if not keys_exists(test_doc, "_source", "results", "perf_simple_query_result"):

--- a/sdcm/utils/operator/multitenant_common.py
+++ b/sdcm/utils/operator/multitenant_common.py
@@ -37,7 +37,6 @@ class TenantMixin:  # pylint: disable=too-many-instance-attributes
         self.params = copy.deepcopy(params)
         self.kafka_cluster = None
         self.log = logging.getLogger(self.__class__.__name__)
-        self._es_doc_type = "test_stats"
         self._stats = self._init_stats()
         self.test_config = test_config
         self._init_test_duration()

--- a/sla_per_user_system_test.py
+++ b/sla_per_user_system_test.py
@@ -888,7 +888,7 @@ class SlaPerUserTest(LongevityTest):
                 **self._comparison_results
             }
         }
-        self._es.create_doc(index="workload_types", doc_type="test_stats",
+        self._es.create_doc(index="workload_types",
                             doc_id=self.test_id, body=es_body)
         self.log.info("C-s comparison uploaded to ES.")
 

--- a/utils/migrate_nemesis_data.py
+++ b/utils/migrate_nemesis_data.py
@@ -64,7 +64,7 @@ def migrate(old_index_name, dry_run, new_index, days):  # pylint: disable=too-ma
     def post_to_new(doc):
         if dry_run:
             return
-        elastic_search.index(index=new_index, doc_type='nemesis', body=doc)
+        elastic_search.index(index=new_index, body=doc)
 
     res = scan(elastic_search, index=old_index_name, query={"query": {"range": {
         "test_details.start_time": {

--- a/utils/update_field.py
+++ b/utils/update_field.py
@@ -91,7 +91,7 @@ def update_value(index_name, test_id, new_job_name):
         )
         test_data["test_details"]["job_name"] = new_job_name
         elastic_search.update(   # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
-            index=index_name, id=hit["_id"], doc_type="test_stats", doc=test_data
+            index=index_name, id=hit["_id"], doc=test_data
         )
         click.secho(f"updated {test_data['test_details']['test_id']}", fg="green")
 


### PR DESCRIPTION
this argument was removed in v7 of the elasticsearch client we shouldn't use it anymore

fixes: #10308

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade/6/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
