### PR TITLE
fix(longevity-large-partitions-deletions-and-reversed-queries.yaml): split to multi nemesis

### DIFF
--- a/test-cases/longevity/longevity-large-partitions-deletions-and-reversed-queries.yaml
+++ b/test-cases/longevity/longevity-large-partitions-deletions-and-reversed-queries.yaml
@@ -22,7 +22,7 @@ n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
 
-nemesis_class_name: 'SisyphusMonkey'
+nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
 nemesis_seed: '156'
 instance_type_loader: 'c5n.4xlarge'
 round_robin: true
@@ -42,4 +42,4 @@ data_validation: |
 
 
 run_fullscan: ['{"mode": "random", "ks_cf": "scylla_bench.test", "interval": 3600, "pk_name":"pk", "rows_count": 50000, "validate_data": true}']
-nemesis_selector: ["delete_rows", "disruptive"]
+nemesis_selector: [['delete_rows'], ['disruptive']]


### PR DESCRIPTION

Fix nemesis selector values and set multi nemesis. One with "delete_rows" and the other with "disruptive".
So the test will have intensive deletions while also having disruptive operations.
Fixes: #10256

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
