### PR TITLE
fix(longevity_test): Set ignore 'raft topology connection close' error globally

### DIFF
--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -33,6 +33,7 @@ from sdcm.sct_events.events_processes import \
     EVENTS_GRAFANA_ANNOTATOR_ID, EVENTS_GRAFANA_AGGREGATOR_ID, EVENTS_GRAFANA_POSTMAN_ID, \
     EventsProcessesRegistry, create_default_events_process_registry, get_events_process, EVENTS_HANDLER_ID, EVENTS_COUNTER_ID
 from sdcm.utils.issues import SkipPerIssues
+from sdcm.sct_events.group_common_events import ignore_topology_change_coordinator_errors
 
 
 EVENTS_DEVICE_START_DELAY = 1  # seconds
@@ -147,6 +148,13 @@ def enable_default_filters(sct_config: SCTConfiguration):  # pylint: disable=unu
     EventsSeverityChangerFilter(new_severity=Severity.WARNING,
                                 event_class=DatabaseLogEvent.ABORTING_ON_SHARD,
                                 regex=r'.*Parent connection [\d]+ is aborting on shard').publish()
+
+    # As written in https://github.com/scylladb/scylladb/issues/20950#issuecomment-2411387784
+    # raft error messages with connection close could be ignored during topology operations,
+    # upgrades and any place where the race between raft global barrier and gossipier could
+    # take place. So ignore such messages globally for any sct test.
+    # TODO: this should be removed after gossiper will be removed.
+    ignore_topology_change_coordinator_errors().__enter__()
 
 
 __all__ = ("start_events_device", "stop_events_device", "enable_default_filters")


### PR DESCRIPTION
Error: 'raft_topology - topology change coordinator fiber got error  (connection is closed))' Could appeared in different moment when node/nodes are being restarted. As described in issue: scylladb/scylladb#20950 in comment: https://github.com/scylladb/scylladb/issues/20950#issuecomment-2411387784

the error message could appeared while we have race between raft and gossip. we can ignore this issue while issue will not be fixed on scylla side, gossip mode will be removed from scylla.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- Job https://argus.scylladb.com/tests/scylla-cluster-tests/840673cf-ce9f-4022-95df-a3ad0b7d1d2d currently failed by another issue

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
