### PR TITLE
feature(scale): 2 new scale jobs with large parallel bootstrap number of nodes

### DIFF
--- a/configurations/scale/scale-10-100-90.yaml
+++ b/configurations/scale/scale-10-100-90.yaml
@@ -1,0 +1,29 @@
+test_duration: 1440
+
+prepare_write_cmd:  [ "cassandra-stress write cl=ALL n=500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=1..500000          -col 'n=FIXED(10) size=FIXED(128)' -log interval=5",
+                      "cassandra-stress write cl=ALL n=500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=500001..1000000   -col 'n=FIXED(16) size=FIXED(128)' -log interval=5",
+                    ]
+
+stress_cmd: [ "cassandra-stress mixed cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=1..500000          -col 'n=FIXED(16) size=FIXED(128)' -log interval=5",
+              "cassandra-stress mixed cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=500001..1000000   -col 'n=FIXED(16) size=FIXED(182)' -log interval=5",
+             ]
+
+round_robin: true
+
+
+n_db_nodes: 10
+cluster_target_size: 100
+add_node_cnt: 90
+n_loaders: 2
+
+user_prefix: 'cluster-scale-10-100-90-test'
+
+# Takes too long on big clusters
+cluster_health_check: false
+backtrace_decoding: false
+
+# enable parallel node bootstrap
+parallel_node_operations: true
+
+nemesis_class_name: 'NoOpMonkey' # disable nemesis
+nemesis_during_prepare: false

--- a/configurations/scale/scale-5-100-15.yaml
+++ b/configurations/scale/scale-5-100-15.yaml
@@ -1,0 +1,29 @@
+test_duration: 1440
+
+prepare_write_cmd:  [ "cassandra-stress write cl=ALL n=500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=1..500000          -col 'n=FIXED(10) size=FIXED(128)' -log interval=5",
+                      "cassandra-stress write cl=ALL n=500000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=500001..1000000   -col 'n=FIXED(16) size=FIXED(128)' -log interval=5",
+                    ]
+
+stress_cmd: [ "cassandra-stress mixed cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=1..500000          -col 'n=FIXED(16) size=FIXED(128)' -log interval=5",
+              "cassandra-stress mixed cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=25 -pop seq=500001..1000000   -col 'n=FIXED(16) size=FIXED(182)' -log interval=5",
+             ]
+
+round_robin: true
+
+
+n_db_nodes: 5
+cluster_target_size: 100
+add_node_cnt: 15
+n_loaders: 2
+
+user_prefix: 'cluster-scale-5-100-15-test'
+
+# Takes too long on big clusters
+cluster_health_check: false
+backtrace_decoding: false
+
+# enable parallel node bootstrap
+parallel_node_operations: true
+
+nemesis_class_name: 'NoOpMonkey' # disable nemesis
+nemesis_during_prepare: false

--- a/jenkins-pipelines/oss/scale/scale-10-100-90-cluster-test.jenkinsfile
+++ b/jenkins-pipelines/oss/scale/scale-10-100-90-cluster-test.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    post_behavior_db_nodes: 'destroy',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/scale/scale-cluster.yaml", "configurations/scale/scale-10-100-90.yaml"]'''
+)

--- a/jenkins-pipelines/oss/scale/scale-5-100-15-cluster-test.jenkinsfile
+++ b/jenkins-pipelines/oss/scale/scale-5-100-15-cluster-test.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    post_behavior_db_nodes: 'destroy',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/scale/scale-cluster.yaml", "configurations/scale/scale-5-100-15.yaml"]'''
+)


### PR DESCRIPTION
Raft topology changes feature allow to bootstrap nodes in parallel. Sct supports parallel node operations.
Adding new 2 scale jobs with parallel node bootstrap for building cluster of xl size:
 - cluster start with 5 nodes and reach 100 nodes by bootstrap 15 nodes in parallel
 - cluster start with 10 nodes and reach 100 nodes by bootstrap 90 nodes in parallel

Tests for issue scylladb/scylladb#7039

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
