### PR TITLE
feature(nemesis_selector): support full logical expressions

### DIFF
--- a/configurations/longevity-fips-and-encryptions.yaml
+++ b/configurations/longevity-fips-and-encryptions.yaml
@@ -8,4 +8,4 @@ server_encrypt: true
 internode_encryption: 'all'
 user_prefix: 'longevity-fips'
 test_duration: 400
-nemesis_selector: ["!disruptive"]
+nemesis_selector: "not disruptive"

--- a/configurations/manager/manager_operations.yaml
+++ b/configurations/manager/manager_operations.yaml
@@ -1,2 +1,2 @@
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['manager_operation']
+nemesis_selector: 'manager_operation'

--- a/configurations/operator/1tb-7days-no-tls.yaml
+++ b/configurations/operator/1tb-7days-no-tls.yaml
@@ -1,5 +1,5 @@
 user_prefix: 'longevity-operator-1tb-7d'
-nemesis_selector: ['kubernetes']
+nemesis_selector: 'kubernetes'
 k8s_minio_storage_size: '2048Gi'
 
 # NOTE: operator doesn't support encryption as of January 2022

--- a/configurations/operator/200GB-no-tls.yaml
+++ b/configurations/operator/200GB-no-tls.yaml
@@ -1,5 +1,5 @@
 user_prefix: 'longevity-operator-200gb-48h'
-nemesis_selector: ['kubernetes']
+nemesis_selector: 'kubernetes'
 
 k8s_minio_storage_size: '4608Gi'
 

--- a/configurations/operator/50GB-no-tls.yaml
+++ b/configurations/operator/50GB-no-tls.yaml
@@ -1,5 +1,5 @@
 user_prefix: 'longevity-operator-50gb-3d'
-nemesis_selector: ['kubernetes']
+nemesis_selector: 'kubernetes'
 nemesis_add_node_cnt: 1
 
 k8s_minio_storage_size: '1024Gi'

--- a/configurations/operator/cdc-3d-400gb.yaml
+++ b/configurations/operator/cdc-3d-400gb.yaml
@@ -1,5 +1,5 @@
 user_prefix: 'longevity-operator-cdc-3d-400gb'
-nemesis_selector: ['kubernetes']
+nemesis_selector: 'kubernetes'
 
 k8s_minio_storage_size: '4608Gi'
 

--- a/configurations/operator/large-collections-12h.yaml
+++ b/configurations/operator/large-collections-12h.yaml
@@ -1,5 +1,5 @@
 user_prefix: 'longevity-operator-large-collections-12h'
-nemesis_selector: ['kubernetes']
+nemesis_selector: 'kubernetes'
 
 n_db_nodes: 5
 k8s_n_scylla_pods_per_cluster: 4

--- a/configurations/operator/large-partition-200k-pks-4days.yaml
+++ b/configurations/operator/large-partition-200k-pks-4days.yaml
@@ -1,5 +1,5 @@
 user_prefix: 'long-operator-large-partitions-200k-pks-4d'
-nemesis_selector: ['kubernetes']
+nemesis_selector: 'kubernetes'
 
 k8s_minio_storage_size: '7168Gi'
 

--- a/configurations/operator/lwt-basic-24h.yaml
+++ b/configurations/operator/lwt-basic-24h.yaml
@@ -1,5 +1,5 @@
 user_prefix: 'longevity-operator-lwt-24h'
-nemesis_selector: ['kubernetes']
+nemesis_selector: 'kubernetes'
 
 n_db_nodes: 5
 k8s_n_scylla_pods_per_cluster: 4

--- a/configurations/operator/twcs-basic-48h.yaml
+++ b/configurations/operator/twcs-basic-48h.yaml
@@ -1,5 +1,5 @@
 user_prefix: 'longevity-operator-twcs-48h'
-nemesis_selector: ['kubernetes']
+nemesis_selector: 'kubernetes'
 
 n_db_nodes: 5
 k8s_n_scylla_pods_per_cluster: 4

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -3183,7 +3183,7 @@ Flag for running db node benchmarks before the tests
 
 ## **nemesis_selector** / SCT_NEMESIS_SELECTOR
 
-nemesis_selector gets a list of "nemesis properties" and filters IN all the nemesis that has<br>ALL the properties in that list which are set to true (the intersection of all properties).<br>(In other words filters out all nemesis that doesn't ONE of these properties set to true)<br>IMPORTANT: If a property doesn't exist, ALL the nemesis will be included.
+nemesis_selector gets a list of logical expression based on "nemesis properties" and filters IN all the nemesis that has<br>example of logical expression:<br>```yaml<br>nemesis_selector: ["disruptive and not sla"] # simple one<br>nemesis_selector: ["disruptive and not (sla or limited or manager_operation or config_changes)"] # complex one<br>```
 
 **default:** N/A
 

--- a/internal_test_data/nemesis_selector_list.yaml
+++ b/internal_test_data/nemesis_selector_list.yaml
@@ -1,1 +1,1 @@
-nemesis_selector: ["config_changes", "topology_changes"]
+nemesis_selector: "config_changes and topology_changes"

--- a/internal_test_data/nemesis_selector_list_of_list.yaml
+++ b/internal_test_data/nemesis_selector_list_of_list.yaml
@@ -1,1 +1,1 @@
-nemesis_selector: [["config_changes", "topology_changes"], ["topology_changes"], ["disruptive"]]
+nemesis_selector: ["config_changes and topology_changes", "topology_changes", "disruptive"]

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1611,10 +1611,13 @@ class SCTConfiguration(dict):
              help="Flag for running db node benchmarks before the tests"),
         dict(name="nemesis_selector", env="SCT_NEMESIS_SELECTOR",
              type=str_or_list, k8s_multitenancy_supported=True,
-             help="""nemesis_selector gets a list of "nemesis properties" and filters IN all the nemesis that has
-             ALL the properties in that list which are set to true (the intersection of all properties).
-             (In other words filters out all nemesis that doesn't ONE of these properties set to true)
-             IMPORTANT: If a property doesn't exist, ALL the nemesis will be included."""),
+             help="""nemesis_selector gets a list of logical expression based on "nemesis properties" and filters IN all the nemesis that has
+             example of logical expression:
+             ```yaml
+                nemesis_selector: "disruptive and not sla" # simple one
+                nemesis_selector: "disruptive and not (sla or limited or manager_operation or config_changes)" # complex one
+             ```
+             """),
         dict(name="nemesis_exclude_disabled", env="SCT_NEMESIS_EXCLUDE_DISABLED",
              type=boolean, k8s_multitenancy_supported=True,
              help="""nemesis_exclude_disabled determines whether 'disabled' nemeses are filtered out from list

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1192,8 +1192,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         if nemesis_selectors and isinstance(nemesis_selectors, str):
             nemesis_selectors = [nemesis_selectors]
-        if nemesis_selectors and isinstance(nemesis_selectors[0], str):
-            nemesis_selectors = [nemesis_selectors[:]]
+        if nemesis_selectors and isinstance(nemesis_selectors, list):
+            nemesis_selectors = nemesis_selectors[:]
         if nemesis_seeds and isinstance(nemesis_seeds, int):
             nemesis_seeds = [nemesis_seeds]
         if nemesis_seeds and isinstance(nemesis_seeds, str):
@@ -1213,7 +1213,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 nemesis_class_names.append(nemesis_name)
 
         for i, nemesis_name in enumerate(nemesis_class_names):
-            nemesis_selector = []
+            nemesis_selector = ''
             if nemesis_selectors:
                 try:
                     nemesis_selector = nemesis_selectors[i % len(nemesis_class_names)]

--- a/sdcm/utils/ast_utils.py
+++ b/sdcm/utils/ast_utils.py
@@ -1,0 +1,83 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+import ast
+
+
+class BooleanEvaluator(ast.NodeVisitor):
+    # NOTE: based example from https://stackoverflow.com/a/70889491/459189
+
+    def __init__(self, context: dict = None):
+        """
+        Create a new Boolean Evaluator.
+        If you want to allow named variables, give the constructor a
+        dictionary which maps names to values. Any name not in the
+        dictionary will provoke a NameError exception, but you could
+        use a defaultdict to provide a default value (probably False).
+        You can modify the symbol table after the evaluator is
+        constructed, if you want to evaluate an expression with different
+        values.
+        """
+        self.context = {} if context is None else context
+
+    # Expression is the top-level AST node if you specify mode='eval'.
+    # That's not made very clear in the documentation. It's different
+    # from an Expr node, which represents an expression statement (and
+    # there are no statements in a tree produced with mode='eval').
+    def visit_Expression(self, node):
+        return self.visit(node.body)
+
+    # 'and' and 'or' are BoolOp, and the parser collapses a sequence of
+    # the same operator into a single AST node. The class of the .op
+    # member identifies the operator, and the .values member is a list
+    # of expressions.
+    def visit_BoolOp(self, node):
+        if isinstance(node.op, ast.And):
+            return all(self.visit(c) for c in node.values)
+        elif isinstance(node.op, ast.Or):
+            return any(self.visit(c) for c in node.values)
+        else:
+            # This "shouldn't happen".
+            raise NotImplementedError(node.op.__doc__ + " Operator")
+
+    # 'not' is a UnaryOp. So are a number of other things, like unary '-'.
+    def visit_UnaryOp(self, node):
+        if isinstance(node.op, ast.Not):
+            return not self.visit(node.operand)
+        else:
+            # This error can happen. Try using the `~` operator.
+            raise NotImplementedError(node.op.__doc__ + " Operator")
+
+    # Name is a variable name. Technically, we probably should check the
+    # ctx member, but unless you decide to handle the walrus operator you
+    # should never see anything other than `ast.Load()` as ctx.
+    # I didn't check that the symbol table contains a boolean value,
+    # but you could certainly do that.
+    def visit_Name(self, node):
+        return self.context.get(node.id, False)
+
+    # The only constants we're really interested in are True and False,
+    # but you could extend this to handle other values like 0 and 1
+    # if you wanted to be more liberal
+    def visit_Constant(self, node):
+        if isinstance(node.value, bool):
+            return node.value
+        else:
+            # I avoid calling str on the value in case that executes
+            # a dunder method.
+            raise ValueError("non-boolean value")
+
+    # The `generic_visit` method is called for any AST node for
+    # which a specific visitor method hasn't been provided.
+    def generic_visit(self, node):
+        raise RuntimeError("non-boolean expression")

--- a/test-cases/enterprise-features/workload-prioritization/longevity/longevity-sla-system-24h.yaml
+++ b/test-cases/enterprise-features/workload-prioritization/longevity/longevity-sla-system-24h.yaml
@@ -21,7 +21,7 @@ run_fullscan: ['{"mode": "random", "ks_cf": "keyspace1.standard1", "interval": 5
 nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
 # There are SLA nemeses that uses binary disable/enable workaround that in a test with parallel nemeses can cause to the errors and
 # failures that is not a problem of Scylla. The option "!disruptive" is added to prevent irrelevant failures.
-nemesis_selector: [['sla', '!disruptive'], ['!sla']]
+nemesis_selector: ['sla and not disruptive', 'not sla']
 nemesis_during_prepare: false
 
 stop_test_on_stress_failure: false

--- a/test-cases/features/elasticity/elasticity-90-percent-with-nemesis.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-with-nemesis.yaml
@@ -23,7 +23,7 @@ instance_type_monitor: 't3.large'
 instance_type_db: 'i4i.large'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['supports_high_disk_utilization']
+nemesis_selector: 'supports_high_disk_utilization'
 nemesis_seed: '019'
 nemesis_during_prepare: false
 

--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -9,7 +9,7 @@ instance_type_loader: 'm6i.xlarge'
 user_prefix: 'gemini-1tb-10h'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['run_with_gemini']
+nemesis_selector: 'run_with_gemini'
 nemesis_seed: '041'
 
 gemini_cmd: |

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -8,7 +8,7 @@ instance_type_db: 'i4i.2xlarge'
 user_prefix: 'gemini-with-nemesis-3h-normal'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['run_with_gemini']
+nemesis_selector: 'run_with_gemini'
 nemesis_seed: '032'
 
 gemini_cmd: |

--- a/test-cases/gemini/gemini-8h-large-num-columns.yaml
+++ b/test-cases/gemini/gemini-8h-large-num-columns.yaml
@@ -9,7 +9,7 @@ instance_type_loader: 'c6i.4xlarge'
 user_prefix: 'gemini-8h-large-num-columns'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['run_with_gemini']
+nemesis_selector: 'run_with_gemini'
 nemesis_seed: '023'
 
 gemini_cmd: |

--- a/test-cases/longevity/longevity-100GB-48h-cloud-CloudLimitedChaosMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-100GB-48h-cloud-CloudLimitedChaosMonkey-tls.yaml
@@ -12,7 +12,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i4i.large' # instance type is defined in the jenkins job (with default value in the jenkinsfile for the cloud longevity
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['limited']
+nemesis_selector: 'limited'
 nemesis_interval: 30
 nemesis_during_prepare: false
 

--- a/test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml
+++ b/test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml
@@ -12,7 +12,7 @@ instance_type_db: 'i4i.4xlarge'
 gce_instance_type_db: 'n2-highmem-16'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['limited']
+nemesis_selector: 'limited'
 nemesis_seed: '026'
 nemesis_interval: 30
 nemesis_during_prepare: false

--- a/test-cases/longevity/longevity-200GB-48h-network-monkey.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-network-monkey.yaml
@@ -11,7 +11,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i4i.2xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['networking']
+nemesis_selector: 'networking'
 nemesis_seed: '002'
 nemesis_interval: 10
 nemesis_multiply_factor: 15

--- a/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -19,7 +19,7 @@ azure_instance_type_db: 'Standard_L16s_v3'
 gce_instance_type_db: 'n2-highmem-16'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['limited']
+nemesis_selector: 'limited'
 nemesis_seed: '003'
 nemesis_interval: 30
 nemesis_during_prepare: false

--- a/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -30,7 +30,7 @@ instance_type_runner: 'r6i.2xlarge'
 
 cluster_health_check: false
 nemesis_class_name: 'DisruptiveMonkey:1 NonDisruptiveMonkey:2'
-nemesis_selector: [[],[],["!manager_operation"]]
+nemesis_selector: ["", "", "not manager_operation"]
 nemesis_interval: 30
 nemesis_during_prepare: false
 seeds_num: 3

--- a/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-large-cluster.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-large-cluster.yaml
@@ -13,7 +13,7 @@ region_aware_loader: true
 n_monitor_nodes: 1
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['topology_changes']
+nemesis_selector: 'topology_changes'
 nemesis_seed: '023'
 
 round_robin: true

--- a/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml
@@ -13,7 +13,7 @@ region_aware_loader: true
 n_monitor_nodes: 1
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['topology_changes']
+nemesis_selector: 'topology_changes'
 nemesis_seed: '032'
 nemesis_add_node_cnt: 2
 

--- a/test-cases/longevity/longevity-change-cluster-size-by-2-times.yaml
+++ b/test-cases/longevity/longevity-change-cluster-size-by-2-times.yaml
@@ -17,7 +17,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i3en.xlarge'
 
 nemesis_class_name: 'GrowShrinkClusterNemesis:1 SisyphusMonkey:1'
-nemesis_selector: [[],["!disruptive","schema_changes"]]
+nemesis_selector: ["","schema_changes and not disruptive"]
 nemesis_interval: 10
 
 round_robin: true

--- a/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
@@ -11,7 +11,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i4i.4xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['limited']
+nemesis_selector: 'limited'
 nemesis_seed: '028'
 nemesis_during_prepare: false
 

--- a/test-cases/longevity/longevity-large-partitions-deletions-and-reversed-queries.yaml
+++ b/test-cases/longevity/longevity-large-partitions-deletions-and-reversed-queries.yaml
@@ -42,4 +42,4 @@ data_validation: |
 
 
 run_fullscan: ['{"mode": "random", "ks_cf": "scylla_bench.test", "interval": 3600, "pk_name":"pk", "rows_count": 50000, "validate_data": true}']
-nemesis_selector: [['delete_rows'], ['disruptive']]
+nemesis_selector: ['delete_rows', 'disruptive']

--- a/test-cases/longevity/longevity-large-partitions-with-network-nemesis-1h.yaml
+++ b/test-cases/longevity/longevity-large-partitions-with-network-nemesis-1h.yaml
@@ -30,7 +30,7 @@ instance_type_db: 'i4i.4xlarge'
 instance_type_loader: 'c7i.2xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['!limited','!sla','!manager_operation', '!config_changes', 'disruptive']
+nemesis_selector: 'disruptive and not (sla or limited or manager_operation or config_changes)'
 nemesis_seed: '007'
 nemesis_interval: 3
 nemesis_multiply_factor: 1

--- a/test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml
@@ -10,7 +10,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i4i.2xlarge'
 
 nemesis_class_name: 'DisruptiveMonkey:1 NonDisruptiveMonkey:2'
-nemesis_selector: [[],[],["!manager_operation"]]
+nemesis_selector: ["", "", "not manager_operation"]
 nemesis_during_prepare: false
 space_node_threshold: 64424
 

--- a/test-cases/longevity/longevity-multidc-parallel-network-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-network-schema-changes-12h.yaml
@@ -17,7 +17,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i3en.xlarge'
 
 nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
-nemesis_selector: [["networking"],["!disruptive","schema_changes"]]
+nemesis_selector: ["networking","schema_changes and not disruptive"]
 
 seeds_num: 2
 round_robin: true

--- a/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
@@ -18,7 +18,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i3en.2xlarge'
 
 nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
-nemesis_selector: [["topology_changes"],["!disruptive","schema_changes"]]
+nemesis_selector: ["topology_changes", "schema_changes and not disruptive"]
 nemesis_seed: '253 328'
 nemesis_interval: 10
 nemesis_during_prepare: false

--- a/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
@@ -20,7 +20,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i4i.2xlarge'
 
 nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
-nemesis_selector: [["topology_changes"],["!disruptive","schema_changes"]]
+nemesis_selector: ["topology_changes", "schema_changes and not disruptive"]
 nemesis_interval: 10
 nemesis_during_prepare: false
 

--- a/test-cases/longevity/longevity-schema-changes-3h.yaml
+++ b/test-cases/longevity/longevity-schema-changes-3h.yaml
@@ -14,6 +14,6 @@ round_robin: true
 instance_type_db: 'i3en.large'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['schema_changes']
+nemesis_selector: 'schema_changes'
 
 user_prefix: 'longevity-schemachanges-3h'

--- a/test-cases/longevity/longevity-topology-changes-3h.yaml
+++ b/test-cases/longevity/longevity-topology-changes-3h.yaml
@@ -25,7 +25,7 @@ gce_n_local_ssd_disk_db: 16
 round_robin: true
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['topology_changes']
+nemesis_selector: 'topology_changes'
 
 seeds_num: 3
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h.yaml
@@ -8,7 +8,7 @@ n_loaders: 2
 n_monitor_nodes: 1
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['kubernetes']
+nemesis_selector: 'kubernetes'
 nemesis_seed: '026'
 
 user_prefix: 'longevity-scylla-operator-3h'

--- a/test-cases/scylla-operator/longevity-scylla-operator-basic-12h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-basic-12h.yaml
@@ -20,7 +20,7 @@ instance_type_db: 'i4i.4xlarge'
 gce_instance_type_db: 'n2-highmem-16'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['kubernetes']
+nemesis_selector: 'kubernetes'
 nemesis_seed: '026'
 
 space_node_threshold: 100246000000

--- a/test-cases/scylla-operator/longevity-scylla-operator-multidc-12h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-multidc-12h.yaml
@@ -16,7 +16,7 @@ n_monitor_nodes: 1
 k8s_n_scylla_pods_per_cluster: 3
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['kubernetes']
+nemesis_selector: 'kubernetes'
 nemesis_during_prepare: false
 nemesis_seed: '013'
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-multidc-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-multidc-3h.yaml
@@ -16,7 +16,7 @@ n_monitor_nodes: 1
 k8s_n_scylla_pods_per_cluster: 3
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ['kubernetes']
+nemesis_selector: 'kubernetes'
 nemesis_during_prepare: false
 nemesis_seed: '026'
 

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -682,7 +682,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         val = conf.get(None)
         assert val is None
 
-    def test_23_1_include_nemesis_selector_one_list(self):
+    def test_23_1_include_nemesis_selector(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-dummy'
         os.environ['SCT_CONFIG_FILES'] = '''["internal_test_data/minimal_test_case.yaml", \
@@ -691,23 +691,20 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 
-        self.assertListEqual(conf["nemesis_selector"], ["config_changes", "topology_changes"],
-                             msg=f"Wrong value {conf['nemesis_selector']}")
+        assert conf["nemesis_selector"] == "config_changes and topology_changes"
 
-    def test_23_2_nemesis_include_selector_list_of_list_config_file(self):
+    def test_23_2_nemesis_include_selector_list(self):
 
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_REGION_NAME'] = 'eu-west-1'
         os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-dummy'
         os.environ['SCT_CONFIG_FILES'] = '''["internal_test_data/minimal_test_case.yaml", \
                                              "internal_test_data/nemesis_selector_list_of_list.yaml"]'''
-        os.environ['SCT_NEMESIS_CLASS_NAME'] = "NemesisClass1 NemesisClass2"
+        os.environ['SCT_NEMESIS_CLASS_NAME'] = "NemesisClass:1 NemesisClass:2"
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 
-        self.assertListEqual(conf["nemesis_selector"],
-                             [["config_changes", "topology_changes"], ["topology_changes"], ["disruptive"]],
-                             msg=f"Wrong value {conf['nemesis_selector']}")
+        assert conf["nemesis_selector"] == ["config_changes and topology_changes", "topology_changes", "disruptive"]
 
     def test_26_run_fullscan_params_validtion_positive(self):
         os.environ['SCT_CONFIG_FILES'] = '''["internal_test_data/minimal_test_case.yaml", \

--- a/unit_tests/test_nemesis.py
+++ b/unit_tests/test_nemesis.py
@@ -217,7 +217,7 @@ def test_use_disabled_monkey():
     tester = FakeTester()
 
     tester.params["nemesis_exclude_disabled"] = False
-    tester.params["nemesis_selector"] = []
+    tester.params["nemesis_selector"] = ''
     sisyphus = SisyphusMonkey(tester, None)
 
     collected_disrupt_methods_names = {disrupt.__name__ for disrupt in sisyphus.disruptions_list}
@@ -284,7 +284,7 @@ class TestSisyphusMonkeyNemesisFilter:
 
     def test_list_topology_changes_monkey(self, expected_topology_changes_methods):
         tester = FakeTester()
-        tester.params["nemesis_selector"] = ['topology_changes']
+        tester.params["nemesis_selector"] = 'topology_changes'
         sisyphus_nemesis = SisyphusMonkey(tester, None)
 
         collected_disrupt_methods_names = [disrupt.__name__ for disrupt in sisyphus_nemesis.disruptions_list]
@@ -295,7 +295,7 @@ class TestSisyphusMonkeyNemesisFilter:
 
     def test_list_schema_changes_monkey(self, expected_schema_changes_methods):
         tester = FakeTester()
-        tester.params["nemesis_selector"] = ['schema_changes']
+        tester.params["nemesis_selector"] = 'schema_changes'
         sisyphus_nemesis = SisyphusMonkey(tester, None)
         collected_disrupt_methods_names = [disrupt.__name__ for disrupt in sisyphus_nemesis.disruptions_list]
 
@@ -305,7 +305,7 @@ class TestSisyphusMonkeyNemesisFilter:
 
     def test_list_config_changes_monkey(self, expected_config_changes_methods):
         tester = FakeTester()
-        tester.params["nemesis_selector"] = ['config_changes']
+        tester.params["nemesis_selector"] = 'config_changes'
         sisyphus_nemesis = SisyphusMonkey(tester, None)
         collected_disrupt_methods_names = [disrupt.__name__ for disrupt in sisyphus_nemesis.disruptions_list]
 
@@ -315,8 +315,8 @@ class TestSisyphusMonkeyNemesisFilter:
 
     def test_list_config_and_schema_changes_monkey(self, expected_config_and_schema_changes_methods):
         tester = FakeTester()
-        tester.params["nemesis_selector"] = ['config_changes', 'schema_changes']
-        sisyphus_nemesis = SisyphusMonkey(tester, None, nemesis_selector=['config_changes', 'schema_changes'])
+        tester.params["nemesis_selector"] = 'config_changes and schema_changes'
+        sisyphus_nemesis = SisyphusMonkey(tester, None, nemesis_selector='config_changes and schema_changes')
         collected_disrupt_methods_names = [disrupt.__name__ for disrupt in sisyphus_nemesis.disruptions_list]
 
         for disrupt_method in collected_disrupt_methods_names:
@@ -329,11 +329,14 @@ class TestSisyphusMonkeyNemesisFilter:
         tester.db_cluster = Cluster(nodes=[Node(), Node()])
         tester.db_cluster.params = tester.params
         tester.params["nemesis_class_name"] = "SisyphusMonkey:1 SisyphusMonkey:2"
-        tester.params["nemesis_selector"] = [["topology_changes"], ["schema_changes"], ["schema_changes"]]
+        tester.params["nemesis_selector"] = ["topology_changes",
+                                             "schema_changes and schema_changes",
+                                             "schema_changes and schema_changes"]
         tester.params["nemesis_multiply_factor"] = 1
         nemesises = tester.get_nemesis_class()
 
-        expected_selectors = [["topology_changes"], ["schema_changes"], ["schema_changes"]]
+        expected_selectors = ["topology_changes",
+                              "schema_changes and schema_changes",  "schema_changes and schema_changes"]
         for i, nemesis_settings in enumerate(nemesises):
             assert nemesis_settings['nemesis'] == SisyphusMonkey, \
                 f"Wrong instance of nemesis class {nemesis_settings['nemesis']} expected SisyphusMonkey"


### PR DESCRIPTION
in multiplce cases the current `nemesis_selector` was a limiting factor, and we could express complex requirements with the naive list and the "AND"ing them togther.

this commit introduce a lexiciel parser built on the ast module the can parse full expressions base on the properties of the Nemesis class

examples:
```yaml
nemesis_selector: ["config_changes and topology_changes"]
nemesis_selector: ["not disruptive"] # notice it's replacing the exclamation mark notion we had before "!disruptive"
nemesis_selector: ["topology_changes or disruptive"]
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] covered by unit-tests (that was change to fit it) 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
