### PR TITLE
fix(kafka-cdc-connector): create test keyspace with tablets disabled

### DIFF
--- a/test-cases/kafka/longevity-kafka-cdc.yaml
+++ b/test-cases/kafka/longevity-kafka-cdc.yaml
@@ -1,6 +1,8 @@
 test_duration: 60
+# CDC log cannot be created for a table if keyspace uses tablets (issue scylladb/scylladb#16317).
+# Creating keyspace with tablets disabled until the issues is fixed
 pre_create_keyspace: [
-  "CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor': 1 };",
+  "CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor': 1 } AND tablets = {'enabled': false};",
   "CREATE TABLE IF NOT EXISTS keyspace1.standard1 (key blob PRIMARY KEY, \"C0\" blob, \"C1\" blob, \"C2\" blob, \"C3\" blob, \"C4\" blob) WITH  cdc = {'enabled': true, 'preimage': false, 'postimage': true, 'ttl': 600}"
 ]
 


### PR DESCRIPTION
Until CDC is supported with tablets, the kafka cdc connector test should use a test keyspace with tablets disabled.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [longevity-kafka-cdc-aws-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-kafka-cdc-aws-test/3/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
