### PR TITLE
fix(ipv6_format): as string in format of inet_ntop

### DIFF
--- a/sdcm/utils/net.py
+++ b/sdcm/utils/net.py
@@ -47,3 +47,14 @@ def resolve_ip_to_dns(ip_address: str) -> str:
         return socket.gethostbyaddr(ip_address)[0]
     except socket.herror as e:
         raise ValueError(f"Unable to resolve IP: {e}")
+
+
+def to_inet_ntop_format(ip_address: str) -> str:
+    """Converts an IP address to a inet_ntop format if it is a valid IPv6 address.
+    Otherwise, it returns the input address.
+    """
+    try:
+        packed_ipv6 = ipaddress.IPv6Address(ip_address).packed
+        return socket.inet_ntop(socket.AF_INET6, packed_ipv6)
+    except ipaddress.AddressValueError:
+        return ip_address

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -600,11 +600,11 @@ class TestNodetoolStatus(unittest.TestCase):
         status = db_cluster.get_nodetool_status()
 
         assert status == {'eu-north':
-                          {'2a05:d016:0cf8:de00:e07d:5832:c5c0:36a0':
+                          {'2a05:d016:cf8:de00:e07d:5832:c5c0:36a0':
                            {'state': 'UN', 'load': '774KB', 'tokens': '256', 'owns': '?',
                             'host_id': 'e2ed6943', 'rack': '1a'},
-                           '2a05:d016:0cf8:de00:339e:0d0d:9446:1980': {'state': 'UN', 'load': '1.04MB', 'tokens': '256', 'owns': '?',
-                                                                       'host_id': 'd67e8502', 'rack': '1a'}}}
+                           '2a05:d016:cf8:de00:339e:d0d:9446:1980': {'state': 'UN', 'load': '1.04MB', 'tokens': '256', 'owns': '?',
+                                                                     'host_id': 'd67e8502', 'rack': '1a'}}}
 
     def test_can_get_nodetool_status_azure(self):  # pylint: disable=no-self-use
         resp = "\n".join(["Datacenter: eastus",


### PR DESCRIPTION
Because scylla logs show it in this format we want to align it with SCT so it's not failing comparisons or eases searching.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/8910

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [manager ipv6 test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/ubuntu22-sanity-ipv6-test/2/)
- [x] - [provision test with encryption and ipv6](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/provision-test/32/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
