### PR TITLE
fix(disrupt_terminate_and_replace_node): raise critical event on failure

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -147,3 +147,4 @@ ScrubValidationErrorEvent: ERROR
 PartitionRowsValidationEvent: CRITICAL
 FailedResultEvent: ERROR
 HDRFileMissed: ERROR
+TopologyFailureEvent: CRITICAL

--- a/sdcm/sct_events/system.py
+++ b/sdcm/sct_events/system.py
@@ -334,3 +334,13 @@ class FailedResultEvent(InformationalEvent):
     @property
     def msgfmt(self) -> str:
         return super().msgfmt + ": message={0.message}"
+
+
+class TopologyFailureEvent(SctEvent):
+    def __init__(self, message: str, severity: Severity = Severity.CRITICAL):
+        super().__init__(severity)
+        self.message = message
+
+    @property
+    def msgfmt(self) -> str:
+        return super().msgfmt + ": message={0.message}"


### PR DESCRIPTION
If the nemesis cannot leave the cluster in the topological state it was before it should raise a critical error so the test can be stopped.

Add new event for topology failures `TopologyFailureEvent`.

refs: #9918

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
