### PR TITLE
fix(docker_remote.py): login to Dockerhub and pull image under the same context

### DIFF
--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -157,10 +157,9 @@ class RemoteDocker(BaseNode):
     @cache
     def pull_image(node, image):
         # Login docker-hub before pull, in case node authentication is expired or not logged-in.
-        docker_hub_login(remoter=node.remoter)
-        prefix = "sudo" if node.is_docker else ""
-        node.remoter.run(
-            f'{prefix} docker pull {image}', verbose=True, retry=3)
+        docker_hub_login(remoter=node.remoter, use_sudo=node.is_docker)
+        remote_cmd = node.remoter.sudo if node.is_docker else node.remoter.run
+        remote_cmd(f"docker pull {image}", verbose=True, retry=3)
 
     def __enter__(self):
         return self


### PR DESCRIPTION
The change adjusts RemoteDocker.pull_image method to log in to Docker hub and pull an image under the same user context.

This prevents a scenario when the login is performed as a regular user, but the image pull is executed under the root user context, leading to an unauthenticated request from Docker hub perspective.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/10399

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [PR-provision-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/29/)
The logging in to Docker hub and pulling the image is now performed under the same user context (root or a regular user) and should prevent from hitting pull rate limit early:
```
❯ grep -i 'docker ' sct-d9b87b0c.log
< t:2025-03-13 20:24:21,786 f:docker_utils.py l:546  c:RemoteLibSSH2CmdRunner p:DEBUG > Login to Docker Hub as `scyllaqatest'
< t:2025-03-13 20:24:21,786 f:remote_base.py  l:560  c:RemoteLibSSH2CmdRunner p:DEBUG > <10.4.3.200>: Running command "sudo docker login --username scyllaqatest --password-stdin < '/tmp/tmp.5S7pfJaKfl'"...
< t:2025-03-13 20:24:22,833 f:base.py         l:143  c:RemoteLibSSH2CmdRunner p:DEBUG > <10.4.3.200>: Command "sudo docker login --username scyllaqatest --password-stdin < '/tmp/tmp.5S7pfJaKfl'" finished with status 0
< t:2025-03-13 20:24:23,378 f:remote_base.py  l:560  c:RemoteLibSSH2CmdRunner p:DEBUG > <10.4.3.200>: Running command "sudo docker pull scylladb/hydra-loaders:scylla-bench-v0.1.24"...
< t:2025-03-13 20:24:34,441 f:base.py         l:143  c:RemoteLibSSH2CmdRunner p:DEBUG > <10.4.3.200>: Command "sudo docker pull scylladb/hydra-loaders:scylla-bench-v0.1.24" finished with status 0
...
< t:2025-03-13 20:25:20,942 f:base.py         l:143  c:RemoteLibSSH2CmdRunner p:DEBUG > <10.4.3.200>: Command "sudo docker info" finished with status 0
< t:2025-03-13 20:25:20,942 f:docker_utils.py l:534  c:RemoteLibSSH2CmdRunner p:DEBUG > Docker daemon is already logged in as `scyllaqatest'.
< t:2025-03-13 20:25:20,942 f:remote_base.py  l:560  c:RemoteLibSSH2CmdRunner p:DEBUG > <10.4.3.200>: Running command "sudo docker pull scylladb/cassandra-stress:3.17.3"...
< t:2025-03-13 20:25:26,004 f:base.py         l:143  c:RemoteLibSSH2CmdRunner p:DEBUG > <10.4.3.200>: Command "sudo docker pull scylladb/cassandra-stress:3.17.3" finished with status 0
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
