### PR TITLE
fix(cluster.py): None type added as returned value in host_id prop

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -487,7 +487,8 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
 
     @property
     def host_id(self) -> str | None:
-        return self.parent_cluster.get_nodetool_info(self, ignore_status=True, publish_event=False).get("ID")
+        info = self.parent_cluster.get_nodetool_info(self, ignore_status=True, publish_event=False) or {}
+        return info.get("ID")
 
     @property
     def db_node_instance_type(self) -> Optional[str]:


### PR DESCRIPTION
to avoid AttributeError: 'NoneType' object has no attribute 'get'
minor fix 
ref: https://github.com/scylladb/scylla-cluster-tests/issues/10314

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
