### PR TITLE
fix(build-docker-image): let renovate[bot] trigger building

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - name: Check user for team affiliation
         uses: tspascoal/get-user-teams-membership@v3
+        if: github.actor != 'renovate[bot]'
         id: teamAffiliation
         with:
           GITHUB_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}
@@ -29,7 +30,7 @@ jobs:
 
   build_image:
     needs: check_org_membership
-    if: needs.check_org_membership.outputs.isTeamMember == 'true' && contains(github.event.pull_request.labels.*.name, 'New Hydra Version')
+    if: github.actor == 'renovate[bot]' || (needs.check_org_membership.outputs.isTeamMember == 'true' && contains(github.event.pull_request.labels.*.name, 'New Hydra Version'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
the check we are doing at the begining of the workflow skips the PRs from renovate bot, which which defetes the whole purpose of that new action.

now we should rebuild any renovate PR that needs rebuilding of the docker image.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested it on dtest pipeline (and applied exact logic here)  

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
