### PR TITLE
fix(scylla_doctor.py): Don't try to reinstall curl

### DIFF
--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -64,7 +64,10 @@ class ScyllaDoctor:
         return latest
 
     def download_scylla_doctor(self):
-        self.node.install_package('curl')
+        if self.node.remoter.run("which curl", ignore_status=True).ok:
+            LOGGER.info("curl already installed, proceeding...")
+        else:
+            self.node.install_package('curl')
         latest_package = self.locate_newest_scylla_doctor_package()
         if not latest_package:
             raise ScyllaDoctorException("Unable to find latest scylla-doctor package for offline install")


### PR DESCRIPTION
This commit fixes an issue where some distros might have preinstalled
curl with unexpected dependencies, preventing installing curl using the
package manager.

Fixes #10425

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Jenkins/Amazon2023/Offline](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/artifacts-amazon2023-offline-test/)
- [x] [Jenkins/Centos9/Offline](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/artifacts-centos9-offline-test/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
