### PR TITLE
fix(loader stress): Introduce "rack_aware_loader" parameter

### DIFF
--- a/configurations/tablets_multidc_multirack.yaml
+++ b/configurations/tablets_multidc_multirack.yaml
@@ -1,2 +1,3 @@
 n_db_nodes: '4 4'
 simulated_racks: 4
+rack_aware_loader: true

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -223,7 +223,7 @@ run_fullscan: []
 stress_step_duration: '15m'
 simulated_regions: 0
 simulated_racks: 0
-
+rack_aware_loader: false
 use_dns_names: false
 
 use_placement_group: false

--- a/internal_test_data/multi_region_dc_test_case.yaml
+++ b/internal_test_data/multi_region_dc_test_case.yaml
@@ -1,6 +1,7 @@
 stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(strategy=NetworkTopologyStrategy,us-eastscylla_node_east=2,us-west-2scylla_node_west=1)' -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
 region_name: 'eu-west-1 us-east-1'
 n_db_nodes: '2 1'
+rack_aware_loader: true
 n_loaders: 1
 n_monitor_nodes: 1
 monitor_branch: 'branch-2.1'

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1700,6 +1700,8 @@ class SCTConfiguration(dict):
         dict(name="simulated_racks", env="SCT_SIMULATED_RACKS", type=int,
              help="""Forces GossipingPropertyFileSnitch (regardless `endpoint_snitch`) to simulate racks.
              Provide number of racks to simulate."""),
+        dict(name="rack_aware_loader", env="SCT_RACK_AWARE_LOADER", type=boolean,
+             help="When enabled, loaders will look for nodes on the same rack."),
 
         dict(name="use_dns_names", env="SCT_USE_DNS_NAMES", type=boolean,
              help="""Use dns names instead of ip addresses for nodes in cluster"""),

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -135,14 +135,15 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
                     LOGGER.error("Not found datacenter for loader region '%s'. Datacenter per loader dict: %s",
                                  loader.region, datacenter_name_per_region)
 
-            # if there are multiple rack/AZs configured, we'll try to configue c-s to pin to them
-            rack_names = self.loader_set.get_rack_names_per_datacenter_and_rack_idx(db_nodes=self.node_list)
             node_list = self.node_list
-            if len(set(rack_names.values())) > 1 and 'rack' in self._get_available_suboptions(cmd_runner, '-node'):
-                if loader_rack := rack_names.get((str(loader.region), str(loader.rack))):
-                    stress_cmd += f"rack={loader_rack} "
-                    node_list = self.loader_set.get_nodes_per_datacenter_and_rack_idx(
-                        db_nodes=self.node_list).get((str(loader.region), str(loader.rack)))
+            if self.params.get("rack_aware_loader"):
+                # if there are multiple rack/AZs configured, we'll try to configue c-s to pin to them
+                rack_names = self.loader_set.get_rack_names_per_datacenter_and_rack_idx(db_nodes=self.node_list)
+                if len(set(rack_names.values())) > 1 and 'rack' in self._get_available_suboptions(cmd_runner, '-node'):
+                    if loader_rack := rack_names.get((str(loader.region), str(loader.rack))):
+                        stress_cmd += f"rack={loader_rack} "
+                        node_list = self.loader_set.get_nodes_per_datacenter_and_rack_idx(
+                            db_nodes=self.node_list).get((str(loader.region), str(loader.rack)))
 
             node_ip_list = [n.cql_address for n in node_list]
 

--- a/test-cases/longevity/longevity-alternator-3h-multidc.yaml
+++ b/test-cases/longevity/longevity-alternator-3h-multidc.yaml
@@ -28,7 +28,7 @@ stress_cmd: [
 ]
 
 round_robin: true
-
+rack_aware_loader: true
 n_db_nodes: '3 3'
 instance_type_db: 'i4i.4xlarge'
 n_loaders: '2 2'

--- a/test-cases/longevity/longevity-aws-custom-d2-workload1-3dcs.yaml
+++ b/test-cases/longevity/longevity-aws-custom-d2-workload1-3dcs.yaml
@@ -2,7 +2,7 @@ test_duration: 255
 n_monitor_nodes: 1
 n_db_nodes: '3 3 3'
 n_loaders: '3 1 1'
-
+rack_aware_loader: true
 instance_type_db: 'i4i.2xlarge'
 instance_type_loader: 'c6i.xlarge'
 

--- a/test-cases/longevity/longevity-aws-custom-d2-workload1-5dcs.yaml
+++ b/test-cases/longevity/longevity-aws-custom-d2-workload1-5dcs.yaml
@@ -2,7 +2,7 @@ test_duration: 1440
 n_monitor_nodes: 1
 n_db_nodes: '12 12 12 12 12'
 n_loaders: '5 1 1 1 1'
-
+rack_aware_loader: true
 instance_type_db: 'i3en.large'
 instance_type_loader: 'c6i.2xlarge'
 

--- a/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-large-cluster.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-large-cluster.yaml
@@ -6,6 +6,7 @@ stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc.
               "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc_preimage_postimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=180m -mode cql3 native -rate threads=50"
             ]
 
+rack_aware_loader: true
 n_db_nodes: '15 15 15'
 instance_type_db: 'i4i.large'
 n_loaders: '2 2 2'

--- a/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml
@@ -6,6 +6,7 @@ stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc.
               "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc_preimage_postimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=480m -mode cql3 native -rate threads=75"
              ]
 
+rack_aware_loader: true
 n_db_nodes: '4 4'
 instance_type_db: 'i4i.4xlarge'
 n_loaders: '2 2'

--- a/test-cases/longevity/longevity-counters-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-multidc.yaml
@@ -4,6 +4,7 @@ pre_create_keyspace: "CREATE KEYSPACE scylla_bench WITH replication = {'class': 
 stress_cmd:      "scylla-bench -workload=uniform -mode=counter_update -replication-factor=3 -partition-count=1000 -clustering-row-count=10 -concurrency 1024 -duration 360m -validate-data"
 stress_read_cmd: "scylla-bench -workload=uniform -mode=counter_read   -replication-factor=3 -partition-count=1000 -clustering-row-count=10 -concurrency 512 -duration 360m -validate-data"
 
+rack_aware_loader: true
 availability_zone: 'a,b,c'
 n_db_nodes: '3 3 3'
 n_loaders:  '1 1 1'

--- a/test-cases/longevity/longevity-encryption-at-rest-20GB-6h-multidc.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-20GB-6h-multidc.yaml
@@ -9,7 +9,7 @@ stress_cmd: [
   "cassandra-stress read  cl=QUORUM duration=360m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=30 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
 ]
 round_robin: true
-
+rack_aware_loader: true
 n_db_nodes: '3 3'
 n_loaders: '1 1'
 n_monitor_nodes: 1

--- a/test-cases/longevity/longevity-gce-custom-d1-workload2-hybrid-raid.yaml
+++ b/test-cases/longevity/longevity-gce-custom-d1-workload2-hybrid-raid.yaml
@@ -3,7 +3,7 @@ n_monitor_nodes: 1
 n_db_nodes: '5 5'
 n_loaders: '1 1'
 simulated_regions: 2
-
+rack_aware_loader: true
 gce_instance_type_db: 'n2-highmem-32'
 gce_instance_type_loader: 'e2-highcpu-32'
 

--- a/test-cases/longevity/longevity-lwt-24h-multidc.yaml
+++ b/test-cases/longevity/longevity-lwt-24h-multidc.yaml
@@ -3,6 +3,7 @@ prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc
 stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=LOCAL_QUORUM serial-cl=LOCAL_SERIAL duration=1350m -mode native cql3 -rate threads=800" ]
 stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml ops'(select=1)' cl=LOCAL_QUORUM serial-cl=LOCAL_SERIAL duration=1350m -mode native cql3 -rate threads=800" ]
 
+rack_aware_loader: true
 n_db_nodes: '4 3 2'
 n_loaders: '1 1 1'
 n_monitor_nodes: 1

--- a/test-cases/longevity/longevity-multi-dc-rack-aware-with-znode-in-diff_dc.yaml
+++ b/test-cases/longevity/longevity-multi-dc-rack-aware-with-znode-in-diff_dc.yaml
@@ -6,7 +6,7 @@ prepare_write_cmd:  ["cassandra-stress write cl=LOCAL_QUORUM n=20971520 -schema 
 stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3,eu-northscylla_node_north=0) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5 -errors retries=50",
              "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3,eu-northscylla_node_north=0) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5 -errors retries=50",
              ]
-
+rack_aware_loader: true
 n_db_nodes: '4 4 0'
 n_loaders: '1 1'
 n_monitor_nodes: 1

--- a/test-cases/longevity/longevity-multi-dc-rack-aware.yaml
+++ b/test-cases/longevity/longevity-multi-dc-rack-aware.yaml
@@ -6,7 +6,7 @@ prepare_write_cmd:  ["cassandra-stress write cl=LOCAL_QUORUM n=20971520 -schema 
 stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5 -errors retries=50",
              "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5 -errors retries=50",
              ]
-
+rack_aware_loader: true
 n_db_nodes: '3 3'
 n_loaders: '1 1'
 n_monitor_nodes: 1

--- a/test-cases/longevity/longevity-multidc-parallel-network-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-network-schema-changes-12h.yaml
@@ -8,7 +8,7 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=720m -schema 'replicatio
              "cassandra-stress read  cl=QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
              "cassandra-stress user profile=/tmp/cs_multidc_mv_lcs.yaml ops'(write=1,read=1,mv_read1=1,mv_read2=1)' -port jmx=6868 -mode cql3 native -rate threads=40 duration=700m -log interval=5",
              ]
-
+rack_aware_loader: true
 n_db_nodes: '4 4'
 n_loaders: '2 1'
 region_aware_loader: true

--- a/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
@@ -9,6 +9,7 @@ stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'repl
              "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(insert=1,read=1,si_read1=1,si_read2=1)' cl=LOCAL_QUORUM duration=700m -mode cql3 native -rate threads=40 -log interval=5",
              ]
 
+rack_aware_loader: true
 availability_zone: 'a,b,c'
 n_db_nodes: '6 6'
 n_loaders: '2 1'

--- a/test-cases/longevity/longevity-ndbench-12-nodes-multidc-4h.yaml
+++ b/test-cases/longevity/longevity-ndbench-12-nodes-multidc-4h.yaml
@@ -10,6 +10,7 @@ stress_cmd: >-
   readEnabled=true; numReaders=100; numWriters=100 ; cass.writeConsistencyLevel=LOCAL_QUORUM ; generateChecksum=true;
   cli.timeoutMillis=14400000; writeRateLimit=1350 ; readRateLimit=12000
 
+rack_aware_loader: true
 region_name: 'us-east-1 eu-west-1'
 n_db_nodes: '6 6'
 n_loaders: '2 2'

--- a/test-cases/longevity/longevity-ndbench-192-nodes-multidc-4h.yaml
+++ b/test-cases/longevity/longevity-ndbench-192-nodes-multidc-4h.yaml
@@ -10,6 +10,7 @@ stress_cmd: >-
   readEnabled=true; numReaders=60; numWriters=60 ; cass.writeConsistencyLevel=LOCAL_QUORUM ; generateChecksum=true;
   cli.timeoutMillis=14400000; writeRateLimit=18000 ; readRateLimit=1350
 
+rack_aware_loader: true
 region_name: 'us-east-1 eu-west-1'
 n_db_nodes: '96 96'
 n_loaders: '32 32'

--- a/test-cases/manager/manager-regression-multiDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-multiDC-set-distro.yaml
@@ -6,6 +6,7 @@ stress_read_cmd: "cassandra-stress read cl=QUORUM n=4000000 -schema 'replication
 instance_type_db: 'i4i.large'
 instance_type_loader: 'c6i.large'
 
+rack_aware_loader: true
 region_name: 'us-east-1 us-west-2'
 n_db_nodes: '2 1'
 n_loaders: 1

--- a/test-cases/scale/longevity-scale-5dcs-cluster-xl.yaml
+++ b/test-cases/scale/longevity-scale-5dcs-cluster-xl.yaml
@@ -6,7 +6,7 @@ prepare_write_cmd:  ["cassandra-stress write cl=LOCAL_QUORUM n=20971520 -schema 
 stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=120m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=10 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(64)' -log interval=5",
              "cassandra-stress read  cl=LOCAL_QUORUM duration=120m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=IncrementalCompactionStrategy)' -mode cql3 native -rate threads=10 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(64)' -log interval=5",
              ]
-
+rack_aware_loader: true
 n_db_nodes: '5 5 5 5 5'
 cluster_target_size: '25 25 25 25 25'
 add_node_cnt: 10

--- a/test-cases/upgrades/multi-dc-rolling-upgrade.yaml
+++ b/test-cases/upgrades/multi-dc-rolling-upgrade.yaml
@@ -5,6 +5,7 @@ stress_during_entire_upgrade: cassandra-stress write no-warmup cl=QUORUM n=20100
 stress_after_cluster_upgrade: cassandra-stress read no-warmup cl=QUORUM n=30200400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compression=LZ4Compressor' -mode cql3 native compression=lz4 -rate threads=1000 -pop seq=1..30200400 -log interval=5
 
 instance_type_db: 'i4i.2xlarge'
+rack_aware_loader: true
 n_db_nodes: '3 3'
 n_loaders: '1 1'
 n_monitor_nodes: 1


### PR DESCRIPTION
The rack aware logic of loader should not apply in case of simulated rack (where not enough loaders configured).
It should only apply in case where real multi racks are configured as in multi-dc case.
Fixes: #10402

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [longevity-10gb-3h-azure-test](https://argus.scylladb.com/tests/scylla-cluster-tests/385ef408-7a08-4f19-8d8c-59d0cd430c19)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
