### PR TITLE
improvement(events): add DB event type for raft topology sending error

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -51,6 +51,7 @@ DatabaseLogEvent.RPC_CONNECTION: WARNING
 DatabaseLogEvent.DATABASE_ERROR: ERROR
 DatabaseLogEvent.STACKTRACE: ERROR
 DatabaseLogEvent.RAFT_TRANSFER_SNAPSHOT_ERROR: WARNING
+DatabaseLogEvent.RAFT_TOPOLOGY_SENDING_ERROR: WARNING
 IndexSpecialColumnErrorEvent: ERROR
 CassandraHarryEvent.failure: CRITICAL
 CassandraHarryEvent.error: ERROR


### PR DESCRIPTION
Scylla `2025.1.0` started producing following error in DB logs:

```
  Feb 20 21:15:35.887314 long-5000-tables-2025-1-db-node-acc227de-2 scylla[5730]:  \
    [shard  0: gms] raft_topology - send_raft_topology_cmd(stream_ranges) failed \
    with exception (node state is bootstrapping): raft::request_aborted \
    (Request aborted while performing action on leader, \
    current leader: fccd43b5-4024-4c2a-853d-88bba7df9fd4, previous leader: unknown)
```

This error is not critical and we should reduce it's severity in SCT while it is not fixed.

Ref: https://github.com/scylladb/scylladb/issues/22980

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
