### PR TITLE
fix(cluster.py): ignore status of SCT actions logging on DB nodes

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3171,8 +3171,13 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         self.remoter.sudo('systemctl stop firewalld', ignore_status=True)
         self.remoter.sudo('systemctl disable firewalld', ignore_status=True)
 
-    def log_message(self, message: str, level: str = 'info', verbose: bool = False) -> None:
-        self.remoter.run(f'logger -p {level} -t scylla-cluster-tests {shlex.quote(message)}', verbose=verbose)
+    def log_message(self, message: str, level: str = 'info') -> None:
+        try:
+            self.remoter.run(
+                f'logger -p {level} -t scylla-cluster-tests {shlex.quote(message)}',
+                ignore_status=True, verbose=False, retry=0, timeout=10)
+        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            pass
 
     def query_metadata(self, url: str, headers: dict = None, token_url: str = None, token_header: str = None,
                        token_ttl_header: str = None, token_ttl: int = 21600) -> str:
@@ -5205,9 +5210,9 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 enabled_features_state.append(feature in enabled_features)
         return all(enabled_features_state)
 
-    def log_message(self, message: str, level: str = 'info', verbose: bool = False) -> None:
+    def log_message(self, message: str, level: str = 'info') -> None:
         for node in self.nodes:
-            node.log_message(message, level, verbose)
+            node.log_message(message, level)
 
 
 class BaseLoaderSet():
@@ -5379,9 +5384,9 @@ class BaseLoaderSet():
             LOGGER.debug("Update rack info in Argus for loader '%s'", loader.name)
             loader.update_rack_info_in_argus(loader.datacenter, loader.node_rack)
 
-    def log_message(self, message: str, level: str = 'info', verbose: bool = False) -> None:
+    def log_message(self, message: str, level: str = 'info') -> None:
         for node in self.nodes:
-            node.log_message(message, level, verbose)
+            node.log_message(message, level)
 
 
 class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instance-attributes


### PR DESCRIPTION
Ignore failures when executing the remote 'logger' command for logging SCT actions in the system log of DB nodes.

A node may sometimes become unavailable (e.g., after a nemesis decommissions it), so we should avoid raising exceptions for such valid cases.
Instead, we should just try to log SCT actions on remote DB nodes and raise no exceptions if it wasn't successful (otherwise this can affect the thread where this kind of
logging is performed, e.g. a nemesis).

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/10424

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :yellow_circle: [longevity-large-partition-200k-pks-4days-gce-test](https://argus.scylladb.com/tests/scylla-cluster-tests/a656378c-576a-4dce-924c-cf623dcbdd6d) (the test run was aborted, which is expected, as the stress timeout was set shorter in Jenkins build parameter than the stress duration defined in the test config)
We should be OK now with attempts to log to nodes and not aborting nemesis thread due to the addressee node is no longer available  - as it is seen from e.g. Jenkins console, there are instances of  errors in logs like below (and these error entries will appear always for similar situations due to the way how notification about connection failures is implemented, e.g. https://github.com/scylladb/scylla-cluster-tests/blob/0884d455ff72a9f87e1b91dc5602e5cc4006d6df/sdcm/remote/remote_libssh_cmd_runner.py#L66 ), but this does not fail the nemesis thread:
```
16:57:40  < t:2025-03-19 15:57:35,541 f:remote_libssh_cmd_runner.py l:66   c:RemoteLibSSH2CmdRunner p:ERROR > Failed to run a command due to exception!
16:57:40  < t:2025-03-19 15:57:35,541 f:remote_libssh_cmd_runner.py l:66   c:RemoteLibSSH2CmdRunner p:ERROR > 
16:57:40  < t:2025-03-19 15:57:35,541 f:remote_libssh_cmd_runner.py l:66   c:RemoteLibSSH2CmdRunner p:ERROR > Command: 'logger -p info -t scylla-cluster-tests \'============ Finished disruption disrupt_add_remove_mv (AddRemoveMv nemesis) with status \'"\'"\'succeeded\'"\'"\' ============\''
16:57:40  < t:2025-03-19 15:57:35,541 f:remote_libssh_cmd_runner.py l:66   c:RemoteLibSSH2CmdRunner p:ERROR > 
16:57:40  < t:2025-03-19 15:57:35,541 f:remote_libssh_cmd_runner.py l:66   c:RemoteLibSSH2CmdRunner p:ERROR > Stdout:
...
16:57:40  < t:2025-03-19 15:57:35,541 f:remote_libssh_cmd_runner.py l:66   c:RemoteLibSSH2CmdRunner p:ERROR >     raise OpenChannelTimeout(f'Failed to open channel in {timeout} seconds')
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
