### PR TITLE
fix(utils/scylla_doctor.py): Remove `apt update` call

### DIFF
--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -93,7 +93,6 @@ class ScyllaDoctor:
 
     def install_scylla_doctor(self):
         if self.node.parent_cluster.cluster_backend == "docker":
-            self.run('apt update')
             self.node.install_package('ethtool')
 
         if self.offline_install:


### PR DESCRIPTION
Since we don't use debian as a base for docker image anymore and have
switched to RHEL UBI9 the call to `apt update` is no longer needed.

Fixes #10436

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
