### PR TITLE
fix(build_n_push.sh): add a missing dot

### DIFF
--- a/docker/env/build_n_push.sh
+++ b/docker/env/build_n_push.sh
@@ -25,7 +25,7 @@ else
     echo "Hydra image with version $VERSION not found locally. Building..."
     cd "${DOCKER_ENV_DIR}"
     REQUIREMENTS_IN=$(realpath --relative-to=${DOCKER_ENV_DIR} ${SCT_DIR}/requirements.in)
-    uv pip compile $REQUIREMENTS_IN --generate-hashes --python-version=$(cat ${SCT_DIR}/python-version) > ${SCT_DIR}/${PY_PREREQS_FILE}
+    uv pip compile $REQUIREMENTS_IN --generate-hashes --python-version=$(cat ${SCT_DIR}/.python-version) > ${SCT_DIR}/${PY_PREREQS_FILE}
     sed 's|\.\./\.\./requirements.in|requirements.in|' -i  ${SCT_DIR}/requirements.txt
     cp -f ${SCT_DIR}/${PY_PREREQS_FILE} .
     docker build --network=host -t scylladb/hydra:${VERSION} .


### PR DESCRIPTION
`python-version` doesn't exist in the code, while `.python-version` does...

this commit should fix the ability to build hydra docker images

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] test locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
