### PR TITLE
improvement(scylla-bench): bump version to v0.2.0

### DIFF
--- a/defaults/docker_images/scylla-bench/values_scylla-bench.yaml
+++ b/defaults/docker_images/scylla-bench/values_scylla-bench.yaml
@@ -1,2 +1,2 @@
 scylla-bench:
-  image: scylladb/hydra-loaders:scylla-bench-v0.1.24
+  image: scylladb/scylla-bench:0.2.0

--- a/docker/scylla-bench/README.md
+++ b/docker/scylla-bench/README.md
@@ -1,19 +1,10 @@
 
-### build release
-```
-export SCYLLA_BENCH_VERSION=tags/v0.1.24
-export NAME=`echo $SCYLLA_BENCH_VERSION | cut -d "/" -f 2`
-export SCYLLA_BENCH_DOCKER_IMAGE=scylladb/hydra-loaders:scylla-bench-${NAME}
-docker build . -t ${SCYLLA_BENCH_DOCKER_IMAGE} --build-arg version=$SCYLLA_BENCH_VERSION
-docker push ${SCYLLA_BENCH_DOCKER_IMAGE}
-```
-
 ### build from fork
 ```
 export SCYLLA_BENCH_BRANCH=heads/some_fixes
 export SCYLLA_BENCH_FORK=fruch/scylla-bench
 export NAME=`echo $SCYLLA_BENCH_BRANCH | cut -d "/" -f 2`
-export SCYLLA_BENCH_DOCKER_IMAGE=scylladb/hydra-loaders:scylla-bench-${NAME}
+export SCYLLA_BENCH_DOCKER_IMAGE=scylladb/scylla-bench:scylla-bench-${NAME}
 docker build . -t ${SCYLLA_BENCH_DOCKER_IMAGE} --build-arg version=${SCYLLA_BENCH_BRANCH} --build-arg fork=${SCYLLA_BENCH_FORK}
 docker push ${SCYLLA_BENCH_DOCKER_IMAGE}
 ```

--- a/docs/docker-loaders.md
+++ b/docs/docker-loaders.md
@@ -41,7 +41,7 @@ We should be able to override the default in the test configuration:
 stress_image:
   ycsb: scylladb/hydra-loaders:ycsb-jdk8-20211104
   cassandra-stress: scylladb/scylla:5.0.0
-  scylla-bench: scylladb/hydra-loaders:scylla-bench-v0.1.8
+  scylla-bench: scylladb/scylla-bench:0.2.0
 ```
 
 or via environment variables :
@@ -49,7 +49,7 @@ or via environment variables :
 ```bash
 export SCT_STRESS_IMAGE='{"ycsb": "scylladb/hydra-loaders:ycsb-jdk8-20211104"}'
 export SCT_STRESS_IMAGE.cassandra-stress="scylladb/scylla:5.0.0"
-export SCT_STRESS_IMAGE.scylla-bench="scylladb/hydra-loaders:scylla-bench-v0.1.8"
+export SCT_STRESS_IMAGE.scylla-bench="scylladb/scylla-bench:0.2.0"
 ```
 
 for using multiple versions, we should be able to define the image as part of the stress command:


### PR DESCRIPTION
Main changes in the new version are following:
- PR#163 - fix(lints): fix all lints and upgrade to go 1.24
- PR#156 - Add extended version info - scylla-bench and gocql driver versions (version, sha, date)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
