### PR TITLE
Backport[perf-v16]: fix(aws-provision): avoid pricing import

### DIFF
--- a/sdcm/sct_provision/aws/cluster.py
+++ b/sdcm/sct_provision/aws/cluster.py
@@ -20,7 +20,7 @@ from sdcm import cluster
 from sdcm.provision.aws.instance_parameters import AWSInstanceParams
 from sdcm.provision.aws.provisioner import AWSInstanceProvisioner
 from sdcm.provision.common.provision_plan import ProvisionPlan
-from sdcm.provision.common.provision_plan_builder import ProvisionPlanBuilder
+from sdcm.provision.common.provision_plan_builder import ProvisionPlanBuilder, ProvisionType
 from sdcm.provision.common.provisioner import TagsType
 from sdcm.provision.network_configuration import network_interfaces_count
 from sdcm.sct_config import SCTConfiguration
@@ -201,7 +201,8 @@ class ClusterBase(BaseModel):
             fallback_provision_on_demand=self.params.get('instance_provision_fallback_on_demand'),
             region_name=self._region(region_id),
             availability_zone=availability_zone,
-            spot_low_price=self._spot_low_price(region_id),
+            spot_low_price=self._spot_low_price(
+                region_id) if self._instance_provision == ProvisionType.SPOT_LOW_PRICE else None,
             provisioner=AWSInstanceProvisioner(),
         ).provision_plan
 


### PR DESCRIPTION
the aws pricing model is suffering from cyclic depedecies this change is a workaround avoid it, if we aren't really gonna use the pricing code

(cherry picked from commit a1d4dc9e21545c74e77e25e5190f0ca1974eb2a6)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] Tested in i7i testing I did in my staging - https://argus.scylladb.com/tests/scylla-cluster-tests/aac5179a-9329-4aea-bf18-5ee6f422ab06

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
