### PR TITLE
fix(microbenchmarking): point unittest to index `microbenchmarkingv3`

### DIFF
--- a/sdcm/microbenchmarking.py
+++ b/sdcm/microbenchmarking.py
@@ -98,6 +98,7 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
         query = f"hostname:'{self.hostname}' AND versions.scylla-server.version:{self.db_version[:3]}*"
         if additional_filter:
             query += " AND " + additional_filter
+        print(query)
         output = self._es.search(  # pylint: disable=unexpected-keyword-arg; pylint doesn't understand Elasticsearch code
             index=self._es_index,
             q=query,
@@ -117,7 +118,7 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
             "hits.hits._id",  # '2018-04-02_18:36:47_large-partition-skips_[64-32.1)'
             "hits.hits._source.test_args",  # [64-32.1)
             "hits.hits.test_group_properties.name",  # large-partition-skips
-            "hits.hits._source.hostname",  # 'godzilla.cloudius-systems.com'
+            "hits.hits._source.hostname",  # 'monster'
             "hits.hits._source.test_run_date",
             "hits.hits._source.test_group_properties.name",  # large-partition-skips
             "hits.hits._source.results.stats.aio",
@@ -384,7 +385,7 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
         self.log.info('Exclude testrun {} from results'.format(testrun_id))
         filter_path = (
             "hits.hits._id",  # '2018-04-02_18:36:47_large-partition-skips_[64-32.1)'
-            "hits.hits._source.hostname",  # 'godzilla.cloudius-systems.com'
+            "hits.hits._source.hostname",  # 'monster'
             "hits.hits._source.test_run_date",
         )
 

--- a/unit_tests/test_data/test_microbenchmarking/PFF_with_AVGAIO/perf_fast_forward_output/large-partition-forwarding/large-part-ds1/no.1.json
+++ b/unit_tests/test_data/test_microbenchmarking/PFF_with_AVGAIO/perf_fast_forward_output/large-partition-forwarding/large-part-ds1/no.1.json
@@ -45,7 +45,7 @@
 			"commit_id" : "7d14514b8",
 			"date" : "20190618",
 			"run_date_time" : "2019-06-21 15:00:26",
-			"version" : "3.1.0.rc2"
+			"version" : "6.1.0.rc2"
 		}
 	}
 }

--- a/unit_tests/test_data/test_microbenchmarking/PFF_with_AVGAIO/perf_fast_forward_output/large-partition-forwarding/large-part-ds1/yes.1.json
+++ b/unit_tests/test_data/test_microbenchmarking/PFF_with_AVGAIO/perf_fast_forward_output/large-partition-forwarding/large-part-ds1/yes.1.json
@@ -45,7 +45,7 @@
 			"commit_id" : "7d14514b8",
 			"date" : "20190618",
 			"run_date_time" : "2019-06-21 15:00:26",
-			"version" : "3.1.0.rc2"
+			"version" : "6.1.0.rc2"
 		}
 	}
 }

--- a/unit_tests/test_data/test_microbenchmarking/PFF_with_AVGAIO/perf_fast_forward_output/small-partition-slicing/small-part/0-256.1.json
+++ b/unit_tests/test_data/test_microbenchmarking/PFF_with_AVGAIO/perf_fast_forward_output/small-partition-slicing/small-part/0-256.1.json
@@ -46,7 +46,7 @@
 			"commit_id" : "7d14514b8",
 			"date" : "20190618",
 			"run_date_time" : "2019-06-21 15:00:26",
-			"version" : "3.1.0.rc2"
+			"version" : "6.1.0.rc2"
 		}
 	}
 }

--- a/unit_tests/test_data/test_microbenchmarking/PFF_with_AVGAIO/perf_fast_forward_output/small-partition-slicing/small-part/500000-4096.1.json
+++ b/unit_tests/test_data/test_microbenchmarking/PFF_with_AVGAIO/perf_fast_forward_output/small-partition-slicing/small-part/500000-4096.1.json
@@ -46,7 +46,7 @@
 			"commit_id" : "7d14514b8",
 			"date" : "20190618",
 			"run_date_time" : "2019-06-21 15:00:26",
-			"version" : "3.1.0.rc2"
+			"version" : "6.1.0.rc2"
 		}
 	}
 }

--- a/unit_tests/test_data/test_microbenchmarking/PFF_with_AVGAIO/result_obj
+++ b/unit_tests/test_data/test_microbenchmarking/PFF_with_AVGAIO/result_obj
@@ -40,7 +40,7 @@ V20190618
 p21
 sVversion
 p22
-V3.1.0.rc2
+V6.1.0.rc2
 p23
 sVrun_date_time
 p24
@@ -52,7 +52,7 @@ S'0-256.1'
 p27
 sS'hostname'
 p28
-S'godzilla.cloudius-systems.com'
+S'monster'
 p29
 sVresults
 p30
@@ -187,7 +187,7 @@ V20190618
 p87
 sVversion
 p88
-V3.1.0.rc2
+V6.1.0.rc2
 p89
 sVrun_date_time
 p90
@@ -323,7 +323,7 @@ V20190618
 p144
 sVversion
 p145
-V3.1.0.rc2
+V6.1.0.rc2
 p146
 sVrun_date_time
 p147
@@ -458,7 +458,7 @@ V20190618
 p200
 sVversion
 p201
-V3.1.0.rc2
+V6.1.0.rc2
 p202
 sVrun_date_time
 p203

--- a/unit_tests/test_data/test_microbenchmarking/PFF_with_new_metric/result_obj
+++ b/unit_tests/test_data/test_microbenchmarking/PFF_with_new_metric/result_obj
@@ -52,7 +52,7 @@ S'0-1.1'
 p27
 sS'hostname'
 p28
-S'godzilla.cloudius-systems.com'
+S'monster'
 p29
 sVresults
 p30

--- a/unit_tests/test_data/test_microbenchmarking/PFF_without_AVGAIO/result_obj
+++ b/unit_tests/test_data/test_microbenchmarking/PFF_without_AVGAIO/result_obj
@@ -52,7 +52,7 @@ S'0-4096.1'
 p27
 sS'hostname'
 p28
-S'godzilla.cloudius-systems.com'
+S'monster'
 p29
 sVresults
 p30

--- a/unit_tests/test_microbenchmarking.py
+++ b/unit_tests/test_microbenchmarking.py
@@ -67,10 +67,10 @@ class TestMBM(unittest.TestCase):  # pylint: disable=too-many-public-methods
     def setUp(self):
         self.mbra = MicroBenchmarkingResultsAnalyzerMock(email_recipients=(
             'alex.bykov@scylladb.com', ), es_index="microbenchmarking")
-        self.mbra.hostname = 'godzilla.cloudius-systems.com'
+        self.mbra.hostname = 'monster'
         self.cwd = os.path.join(os.path.dirname(__file__), '..', 'sdcm')
         self.mbra.test_run_date = "2019-06-27_11:39:40"
-        self.es_index = "microbenchmarking"
+        self.es_index = "microbenchmarkingv3"
 
     @staticmethod
     def get_result_obj(path):
@@ -87,7 +87,7 @@ class TestMBM(unittest.TestCase):  # pylint: disable=too-many-public-methods
     def test_object_exists(self):
         # pylint: disable=protected-access
         self.assertIsInstance(self.mbra, MicroBenchmarkingResultsAnalyzer)
-        self.assertEqual(self.mbra.hostname, 'godzilla.cloudius-systems.com')
+        self.assertEqual(self.mbra.hostname, 'monster')
         self.assertEqual(self.mbra._email_recipients, ('alex.bykov@scylladb.com', ))
 
     def test_get_result_with_avg_aio(self):
@@ -95,7 +95,7 @@ class TestMBM(unittest.TestCase):  # pylint: disable=too-many-public-methods
         results = self.mbra.get_results(results_path=result_path, update_db=False)
         self.assertTrue(results)
         expected_obj = self.get_result_obj(result_path)
-        self.assertDictEqual(results, expected_obj)
+        assert results == expected_obj
 
     def test_get_result_without_avg_aio(self):
         result_path = os.path.join(os.path.dirname(__file__), 'test_data/test_microbenchmarking/PFF_without_AVGAIO')


### PR DESCRIPTION
since `microbenchmarking` index was deleted, this commit switch the unittest to work with the latest index `microbenchmarkingv3`, for that some of the version and names of the host were needed to change

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested manually (and in CI)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
