### PR TITLE
fix(perf-simple-query): handle 'perf_simple_query_extra_command' param

### DIFF
--- a/microbenchmarking_test.py
+++ b/microbenchmarking_test.py
@@ -27,7 +27,7 @@ class PerfSimpleQueryTest(ClusterTester):
             self._test_index = es_index
 
     def test_perf_simple_query(self):
-        perf_simple_query_extra_command = self.params.get('perf_simple_query_extra_command')
+        perf_simple_query_extra_command = self.params.get('perf_simple_query_extra_command') or ""
         result = self.db_cluster.nodes[0].remoter.run(
             f"scylla perf-simple-query --json-result=perf-simple-query-result.txt --smp 1 -m 1G {perf_simple_query_extra_command}")
         if result.ok:


### PR DESCRIPTION
New parameter 'perf_simple_query_extra_command' was presented in https://github.com/scylladb/scylla-cluster-tests/pull/10331

If the new parameter is not defined for the test, the 'None' is return by get and causes to test failure:
```
Command: 'scylla perf-simple-query --json-result=perf-simple-query-result.txt --smp 1 -m 1G None' error: too many positional options have been specified on the command line
```

Return empty string instead of 'None'.

Example of failed test: https://argus.scylladb.com/tests/scylla-cluster-tests/a7145188-0f42-4f95-ad91-5ce478a13211

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64](https://argus.scylladb.com/tests/scylla-cluster-tests/39461329-ae0a-4034-a930-dda345351027)
- [x] [scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64](https://argus.scylladb.com/tests/scylla-cluster-tests/a7e5e937-1c8b-4547-9e87-6d419a213f68)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
