### PR TITLE
fix(rack_aware_loader): remove from non c-s tests

### DIFF
--- a/test-cases/longevity/longevity-alternator-3h-multidc.yaml
+++ b/test-cases/longevity/longevity-alternator-3h-multidc.yaml
@@ -28,7 +28,6 @@ stress_cmd: [
 ]
 
 round_robin: true
-rack_aware_loader: true
 n_db_nodes: '3 3'
 instance_type_db: 'i4i.4xlarge'
 n_loaders: '2 2'

--- a/test-cases/longevity/longevity-aws-custom-d2-workload1-3dcs.yaml
+++ b/test-cases/longevity/longevity-aws-custom-d2-workload1-3dcs.yaml
@@ -2,7 +2,6 @@ test_duration: 255
 n_monitor_nodes: 1
 n_db_nodes: '3 3 3'
 n_loaders: '3 1 1'
-rack_aware_loader: true
 instance_type_db: 'i4i.2xlarge'
 instance_type_loader: 'c6i.xlarge'
 

--- a/test-cases/longevity/longevity-aws-custom-d2-workload1-5dcs.yaml
+++ b/test-cases/longevity/longevity-aws-custom-d2-workload1-5dcs.yaml
@@ -2,7 +2,6 @@ test_duration: 1440
 n_monitor_nodes: 1
 n_db_nodes: '12 12 12 12 12'
 n_loaders: '5 1 1 1 1'
-rack_aware_loader: true
 instance_type_db: 'i3en.large'
 instance_type_loader: 'c6i.2xlarge'
 

--- a/test-cases/longevity/longevity-counters-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-multidc.yaml
@@ -4,7 +4,6 @@ pre_create_keyspace: "CREATE KEYSPACE scylla_bench WITH replication = {'class': 
 stress_cmd:      "scylla-bench -workload=uniform -mode=counter_update -replication-factor=3 -partition-count=1000 -clustering-row-count=10 -concurrency 1024 -duration 360m -validate-data"
 stress_read_cmd: "scylla-bench -workload=uniform -mode=counter_read   -replication-factor=3 -partition-count=1000 -clustering-row-count=10 -concurrency 512 -duration 360m -validate-data"
 
-rack_aware_loader: true
 availability_zone: 'a,b,c'
 n_db_nodes: '3 3 3'
 n_loaders:  '1 1 1'

--- a/test-cases/longevity/longevity-gce-custom-d1-workload2-hybrid-raid.yaml
+++ b/test-cases/longevity/longevity-gce-custom-d1-workload2-hybrid-raid.yaml
@@ -3,7 +3,6 @@ n_monitor_nodes: 1
 n_db_nodes: '5 5'
 n_loaders: '1 1'
 simulated_regions: 2
-rack_aware_loader: true
 gce_instance_type_db: 'n2-highmem-32'
 gce_instance_type_loader: 'e2-highcpu-32'
 

--- a/test-cases/longevity/longevity-ndbench-12-nodes-multidc-4h.yaml
+++ b/test-cases/longevity/longevity-ndbench-12-nodes-multidc-4h.yaml
@@ -10,7 +10,6 @@ stress_cmd: >-
   readEnabled=true; numReaders=100; numWriters=100 ; cass.writeConsistencyLevel=LOCAL_QUORUM ; generateChecksum=true;
   cli.timeoutMillis=14400000; writeRateLimit=1350 ; readRateLimit=12000
 
-rack_aware_loader: true
 region_name: 'us-east-1 eu-west-1'
 n_db_nodes: '6 6'
 n_loaders: '2 2'

--- a/test-cases/longevity/longevity-ndbench-192-nodes-multidc-4h.yaml
+++ b/test-cases/longevity/longevity-ndbench-192-nodes-multidc-4h.yaml
@@ -10,7 +10,6 @@ stress_cmd: >-
   readEnabled=true; numReaders=60; numWriters=60 ; cass.writeConsistencyLevel=LOCAL_QUORUM ; generateChecksum=true;
   cli.timeoutMillis=14400000; writeRateLimit=18000 ; readRateLimit=1350
 
-rack_aware_loader: true
 region_name: 'us-east-1 eu-west-1'
 n_db_nodes: '96 96'
 n_loaders: '32 32'


### PR DESCRIPTION
The rack aware logic only apply to c-s. remove it from yamls that only use other stress tools.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
