### PR TITLE
fix(nemesis.py): don't wait after rolling restart cluster

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4992,7 +4992,6 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             node.stop_scylla(verify_down=True)
             node.start_scylla(verify_up=True)
             self.log.debug("'%s' restarted.", node.name)
-            self.wait_all_nodes_un()  # wait for all nodes to be up due to issue https://github.com/scylladb/scylladb/issues/18647
 
     @retrying(n=15, sleep_time=5, allowed_exceptions=ClusterNodesNotReady)
     def wait_all_nodes_un(self):


### PR DESCRIPTION
Since the scylla issue 18647 is closed, no need to wait for nodes up-normal status after rolling-restart.
refs: https://github.com/scylladb/scylladb/issues/18647

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [50gb-3days](https://argus.scylladb.com/tests/scylla-cluster-tests/e785da10-5beb-4076-944f-077e477bce28)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
