### PR TITLE
fix(nemesis.py): make node unselection and selection atomic in set_target_node

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -447,10 +447,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if is_seed is DefaultValue - if self.filter_seed is True it act as if is_seed=False,
           otherwise it will act as if is_seed is None
         """
-        # first give up the current target node
-        self.unset_current_running_nemesis(self.target_node)
-
         with NEMESIS_TARGET_SELECTION_LOCK:
+            # first give up the current target node
+            if self.target_node:
+                self.target_node.running_nemesis = None
+
             nodes = self._get_target_nodes(is_seed=is_seed, dc_idx=dc_idx, rack=rack)
             if not nodes:
                 dc_str = '' if dc_idx is None else f'dc {dc_idx} '


### PR DESCRIPTION
Makes unselection and then selection an atomic operation in `set_target_node`.
Previously unselection and then selection were performed not in the same lock scope, leading to a potential situation when 2 threads could pick up the same node for parallel nemeses.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/10426

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [longevity-schema-topology-changes-12h-test - the run executes disrupt_nodetool_decommission and disrupt_create_index 10 times in  parallel](https://argus.scylladb.com/tests/scylla-cluster-tests/e74cf286-edb4-4007-8d0e-31059fcafe28)
The test run was executed on branch-2024.1 as the `disrupt_create_index` nemesis (one of 2 parallel nemeses, which were causing the failure in the original issue) is skipped in SCT master due SkipPerIssues condition.
But the fix is applicable to master as well.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
