### PR TITLE
fix(sdcm/cluster.py): Use microdnf on rhel-like docker backend

### DIFF
--- a/docker/scylla-sct/centos/Dockerfile
+++ b/docker/scylla-sct/centos/Dockerfile
@@ -18,7 +18,7 @@ USER root
 
 RUN curl -L https://download.docker.com/linux/centos/docker-ce.repo -o /etc/yum.repos.d/docker-ce.repo
 
-RUN microdnf update && \
+RUN microdnf -y update && \
 	microdnf -y install \
         iproute \
         sudo \

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1871,7 +1871,8 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
                         package_version: str = None,
                         ignore_status: bool = False) -> None:
         if self.distro.is_rhel_like:
-            pkg_cmd = 'yum'
+            pkg_cmd = next(mgr for mgr in ["microdnf", "yum", "dnf"] if self.remoter.run(
+                f"test -e /usr/bin/{mgr}", ignore_status=True).ok)
             package_name = f"{package_name}-{package_version}*" if package_version else package_name
         elif self.distro.is_sles:
             pkg_cmd = 'zypper'

--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -64,7 +64,7 @@ class ScyllaDoctor:
         return latest
 
     def download_scylla_doctor(self):
-        if self.node.remoter.run("which curl", ignore_status=True).ok:
+        if self.node.remoter.run("curl --version", ignore_status=True).ok:
             LOGGER.info("curl already installed, proceeding...")
         else:
             self.node.install_package('curl')
@@ -97,8 +97,9 @@ class ScyllaDoctor:
     def install_scylla_doctor(self):
         if self.node.parent_cluster.cluster_backend == "docker":
             self.node.install_package('ethtool')
+            self.node.install_package('tar')
 
-        if self.offline_install:
+        if self.offline_install or self.node.parent_cluster.cluster_backend == "docker":
             self.download_scylla_doctor()
             if self.node.is_nonroot_install:
                 self.python3_path = self.find_local_python3_binary(self.current_dir)


### PR DESCRIPTION
Since we are now using RHEL UBI9 image for our docker backend, add
additional logic to support using `microdnf` inside
BaseNode.install_package

Fixes #10449

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] [Jenkins/Docker](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/artifacts-docker-test/10/)
- [x] [Jenkins/Centos9](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/artifacts-centos9-test/3/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
