### PR TITLE
fix(hydra): bring back the ^ to the regexs

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -185,19 +185,19 @@ fi
 DOCKER_ADD_HOST_ARGS=()
 
 # export all SCT_* env vars into the docker run
-SCT_OPTIONS=$(env | sed -n 's/\(SCT_.*\)=.*/--env \1/p')
+SCT_OPTIONS=$(env | sed -n 's/^\(SCT_.*\)=.*/--env \1/p')
 
 # export all PYTEST_* env vars into the docker run
-PYTEST_OPTIONS=$(env | sed -n 's/\(PYTEST_.*\)=.*/--env \1/p')
+PYTEST_OPTIONS=$(env | sed -n 's/^\(PYTEST_.*\)=.*/--env \1/p')
 
 # export all BUILD_* env vars into the docker run
-BUILD_OPTIONS=$(env | sed -n 's/\(BUILD_.*\)=.*/--env \1/p')
+BUILD_OPTIONS=$(env | sed -n 's/^\(BUILD_.*\)=.*/--env \1/p')
 
 # export all AWS_* env vars into the docker run
-AWS_OPTIONS=$(env | sed -n 's/\(AWS_.*\)=.*/--env \1/p')
+AWS_OPTIONS=$(env | sed -n 's/^\(AWS_.*\)=.*/--env \1/p')
 
 # export all JENKINS_* env vars into the docker run
-JENKINS_OPTIONS=$(env | sed -n 's/\(JENKINS_.*\)=.*/--env \1/p')
+JENKINS_OPTIONS=$(env | sed -n 's/^\(JENKINS_.*\)=.*/--env \1/p')
 
 is_podman="$($tool --help | { grep -o podman || :; })"
 docker_common_args=()


### PR DESCRIPTION
since the cap `^` was dropped, we had situation where the prefix of envs we were looking was in the content of other envirment variables

and that was breaking the hydra command

Fixes: #10480

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
