### PR TITLE
fix(artifacts-test): skip scylla-doctor check for docker

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -488,6 +488,10 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
             self.log.info("Scylla Doctor test is skipped for non-root test due to issue field-engineering#2254. ")
             return
 
+        if self.node.parent_cluster.cluster_backend == "docker":
+            self.log.info("Scylla Doctor check in SCT isn't yet support for docker backend")
+            return
+
         for node in self.db_cluster.nodes:
             scylla_doctor = ScyllaDoctor(node, self.test_config, bool(self.params.get('unified_package')))
             scylla_doctor.install_scylla_doctor()


### PR DESCRIPTION
since it's currently broken for docker backend,
and we have more work to fix it, we are disable it for now

Fixes: #10449

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested locally 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
