### PR TITLE
improvement(nemesis): Rework nemesis discovery

### DIFF
--- a/data_dir/nemesis.yml
+++ b/data_dir/nemesis.yml
@@ -1,410 +1,394 @@
-- disrupt_abort_repair:
-  - disruptive = False
-  - kubernetes = True
-  - limited = True
-  - supports_high_disk_utilization = True
-- disrupt_add_drop_column:
-  - disruptive = False
-  - run_with_gemini = False
-  - networking = False
-  - kubernetes = True
-  - limited = True
-  - schema_changes = True
-  - free_tier_set = True
-  - supports_high_disk_utilization = True
-- disrupt_add_remove_dc:
-  - disruptive = True
-  - kubernetes = False
-  - run_with_gemini = False
-  - limited = True
-  - topology_changes = True
-- disrupt_add_remove_mv:
-  - disruptive = True
-  - schema_changes = True
-  - free_tier_set = True
-  - supports_high_disk_utilization = False
-- disrupt_bootstrap_streaming_error:
-  - disruptive = True
-  - topology_changes = True
-  - supports_high_disk_utilization = True
-- disrupt_corrupt_then_scrub:
-  - disruptive = False
-  - supports_high_disk_utilization = False
-- disrupt_create_index:
-  - disruptive = False
-  - schema_changes = True
-  - free_tier_set = True
-  - supports_high_disk_utilization = False
-- disrupt_decommission_streaming_err:
-  - disruptive = True
-  - topology_changes = True
-- disrupt_delete_10_full_partitions:
-  - disruptive = False
-  - kubernetes = True
-  - free_tier_set = True
-  - delete_rows = True
-- disrupt_delete_by_rows_range:
-  - disruptive = False
-  - kubernetes = True
-  - free_tier_set = True
-  - delete_rows = True
-- disrupt_delete_overlapping_row_ranges:
-  - disruptive = False
-  - kubernetes = True
-  - free_tier_set = True
-  - delete_rows = True
-- disrupt_destroy_data_then_rebuild:
-  - disruptive = True
-  - kubernetes = True
-- disrupt_destroy_data_then_repair:
-  - disruptive = True
-  - kubernetes = True
-  - supports_high_disk_utilization = True
-- disrupt_disable_binary_gossip_execute_major_compaction:
-  - disruptive = True
-  - supports_high_disk_utilization = True
-  - kubernetes = True
-- disrupt_disable_enable_ldap_authorization:
-  - disruptive = True
-  - limited = True
-- disrupt_drain_kubernetes_node_then_decommission_and_add_scylla_node:
-  - disruptive = True
-  - kubernetes = True
-- disrupt_drain_kubernetes_node_then_replace_scylla_node:
-  - disruptive = True
-  - kubernetes = True
-- disrupt_enable_disable_table_encryption_aws_kms_provider_with_rotation:
-  - disruptive = True
-  - kubernetes = False
-- disrupt_enable_disable_table_encryption_aws_kms_provider_without_rotation:
-  - disruptive = True
-  - kubernetes = False
-- disrupt_end_of_quota_nemesis:
-  - disruptive = True
-  - config_changes = True
-- disrupt_grow_shrink_cluster:
-  - disruptive = True
-  - kubernetes = True
-  - topology_changes = True
-- disrupt_grow_shrink_new_rack:
-  - disruptive = True
-  - kubernetes = True
-  - config_changes = True
-- disrupt_grow_shrink_zero_nodes:
-  - disruptive = True
-  - schema_changes = False
-  - free_tier_set = False
-  - zero_node_changes = True
-- disrupt_hard_reboot_node:
-  - disruptive = True
-  - supports_high_disk_utilization = True
-  - kubernetes = True
-  - limited = True
-  - free_tier_set = True
-- disrupt_hot_reloading_internode_certificate:
-  - disruptive = False
-  - config_changes = True
-  - supports_high_disk_utilization = True
-- disrupt_increase_shares_by_attach_another_sl_during_load:
-  - disruptive = True
-  - sla = True
-- disrupt_kill_scylla:
-  - disruptive = True
-  - supports_high_disk_utilization = True
-  - kubernetes = True
-  - free_tier_set = True
-- disrupt_ldap_connection_toggle:
-  - disruptive = False
-  - limited = True
-- disrupt_load_and_stream:
-  - disruptive = False
-  - run_with_gemini = False
-  - kubernetes = True
-  - limited = True
-  - supports_high_disk_utilization = True
-- disrupt_major_compaction:
-  - disruptive = False
-  - kubernetes = True
-  - limited = True
-  - supports_high_disk_utilization = True
-- disrupt_maximum_allowed_sls_with_max_shares_during_load:
-  - disruptive = False
-  - sla = True
-- disrupt_memory_stress:
-  - disruptive = True
-  - supports_high_disk_utilization = True
-  - free_tier_set = True
-- disrupt_mgmt_backup:
-  - manager_operation = True
-  - disruptive = False
-  - limited = True
-  - supports_high_disk_utilization = False
-- disrupt_mgmt_backup_specific_keyspaces:
-  - manager_operation = True
-  - disruptive = False
-  - limited = True
-  - supports_high_disk_utilization = False
-- disrupt_mgmt_corrupt_then_repair:
-  - manager_operation = True
-  - disruptive = True
-  - kubernetes = True
-  - supports_high_disk_utilization = True
-- disrupt_mgmt_repair_cli:
-  - manager_operation = True
-  - disruptive = False
-  - kubernetes = True
-  - limited = True
-  - supports_high_disk_utilization = True
-- disrupt_mgmt_restore:
-  - manager_operation = True
-  - disruptive = True
-  - kubernetes = True
-  - limited = True
-  - supports_high_disk_utilization = False
-- disrupt_modify_table:
-  - disruptive = False
-  - kubernetes = True
-  - limited = True
-  - schema_changes = True
-  - free_tier_set = True
-  - supports_high_disk_utilization = True
-- disrupt_multiple_hard_reboot_node:
-  - disruptive = True
-  - supports_high_disk_utilization = True
-  - kubernetes = True
-  - free_tier_set = True
-- disrupt_network_block:
-  - disruptive = True
-  - networking = True
-  - run_with_gemini = False
-  - kubernetes = True
-- disrupt_network_random_interruptions:
-  - disruptive = True
-  - networking = True
-  - run_with_gemini = False
-  - kubernetes = True
-- disrupt_network_reject_inter_node_communication:
-  - disruptive = True
-  - networking = True
-  - run_with_gemini = False
-  - free_tier_set = True
-- disrupt_network_reject_node_exporter:
-  - disruptive = True
-  - networking = True
-  - run_with_gemini = False
-- disrupt_network_reject_thrift:
-  - disruptive = True
-  - networking = True
-  - run_with_gemini = False
-- disrupt_network_start_stop_interface:
-  - disruptive = True
-  - networking = True
-  - run_with_gemini = False
-- disrupt_no_corrupt_repair:
-  - disruptive = False
-  - kubernetes = True
-  - limited = True
-- disrupt_nodetool_cleanup:
-  - disruptive = False
-  - kubernetes = True
-  - limited = True
-  - supports_high_disk_utilization = True
-- disrupt_nodetool_decommission:
-  - disruptive = True
-  - limited = True
-  - topology_changes = True
-  - supports_high_disk_utilization = False
-- disrupt_nodetool_drain:
-  - disruptive = True
-  - kubernetes = True
-  - limited = True
-  - topology_changes = True
-- disrupt_nodetool_enospc:
-  - disruptive = True
-  - kubernetes = True
-  - limited = True
-  - supports_high_disk_utilization = True
-- disrupt_nodetool_enospc:
-  - disruptive = True
-  - kubernetes = True
-  - supports_high_disk_utilization = True
-- disrupt_nodetool_flush_and_reshard_on_kubernetes:
-  - disruptive = True
-  - kubernetes = True
-- disrupt_nodetool_refresh:
-  - disruptive = False
-  - run_with_gemini = False
-  - kubernetes = True
-  - limited = True
-  - supports_high_disk_utilization = True
-- disrupt_nodetool_refresh:
-  - disruptive = False
-  - run_with_gemini = False
-  - kubernetes = True
-  - supports_high_disk_utilization = True
-- disrupt_nodetool_seed_decommission:
-  - disruptive = True
-  - topology_changes = True
-  - supports_high_disk_utilization = False
-- disrupt_rebuild_streaming_err:
-  - disruptive = True
-- disrupt_refuse_connection_with_block_scylla_ports_on_banned_node:
-  - disruptive = True
-  - topology_changes = True
-  - kubernetes = False
-- disrupt_refuse_connection_with_send_sigstop_signal_to_scylla_on_banned_node:
-  - disruptive = True
-  - topology_changes = True
-  - kubernetes = False
-- disrupt_remove_node_then_add_node:
-  - disruptive = True
-  - kubernetes = False
-  - topology_changes = True
-  - supports_high_disk_utilization = False
-- disrupt_remove_service_level_while_load:
-  - disruptive = True
-  - sla = True
-- disrupt_repair_streaming_err:
-  - disruptive = True
-- disrupt_replace_scylla_node_on_kubernetes:
-  - disruptive = True
-  - kubernetes = True
-  - free_tier_set = True
-- disrupt_replace_service_level_using_detach_during_load:
-  - disruptive = True
-  - sla = True
-- disrupt_replace_service_level_using_drop_during_load:
-  - disruptive = True
-  - sla = True
-- disrupt_resetlocalschema:
-  - disruptive = False
-  - config_changes = True
-  - free_tier_set = True
-- disrupt_restart_then_repair_node:
-  - disruptive = True
-  - kubernetes = True
-- disrupt_restart_with_resharding:
-  - disruptive = True
-  - kubernetes = True
-  - topology_changes = True
-  - config_changes = True
-- disrupt_rolling_config_change_internode_compression:
-  - disruptive = True
-  - supports_high_disk_utilization = True
-  - full_cluster_restart = True
-  - config_changes = True
-- disrupt_rolling_restart_cluster:
-  - disruptive = True
-  - supports_high_disk_utilization = True
-  - kubernetes = True
-  - free_tier_set = True
-- disrupt_rolling_restart_cluster:
-  - disruptive = True
-  - supports_high_disk_utilization = True
-  - kubernetes = True
-  - free_tier_set = True
-- disrupt_run_cdcstressor_tool:
-  - disruptive = False
-  - free_tier_set = True
-- disrupt_run_unique_sequence:
-  - disruptive = True
-  - networking = False
-  - run_with_gemini = False
-- disrupt_serial_restart_elected_topology_coordinator:
-  - disruptive = True
-  - topology_changes = True
-  - supports_high_disk_utilization = True
-- disrupt_show_toppartitions:
-  - disruptive = False
-  - kubernetes = True
-  - limited = True
-  - supports_high_disk_utilization = True
-- disrupt_sla_decrease_shares_during_load:
-  - disruptive = False
-  - sla = True
-- disrupt_sla_increase_shares_during_load:
-  - disruptive = False
-  - sla = True
-- disrupt_snapshot_operations:
-  - disruptive = False
-  - kubernetes = True
-  - limited = True
-  - supports_high_disk_utilization = True
-- disrupt_soft_reboot_node:
-  - disruptive = True
-  - supports_high_disk_utilization = True
-  - kubernetes = True
-  - limited = True
-  - free_tier_set = True
-- disrupt_start_stop_cleanup_compaction:
-  - disruptive = False
-  - supports_high_disk_utilization = True
-- disrupt_start_stop_major_compaction:
-  - disruptive = False
-  - supports_high_disk_utilization = True
-- disrupt_start_stop_scrub_compaction:
-  - disruptive = False
-- disrupt_start_stop_validation_compaction:
-  - disruptive = False
-  - supports_high_disk_utilization = False
-- disrupt_stop_start_scylla_server:
-  - disruptive = True
-  - supports_high_disk_utilization = True
-  - kubernetes = True
-  - limited = True
-- disrupt_stop_wait_start_scylla_server:
-  - disruptive = True
-  - supports_high_disk_utilization = True
-  - kubernetes = True
-  - limited = True
-  - zero_node_changes = True
-- disrupt_switch_between_password_authenticator_and_saslauthd_authenticator_and_back:
-  - disruptive = True
-  - config_changes = True
-- disrupt_terminate_and_replace_node:
-  - disruptive = True
-  - kubernetes = False
-  - topology_changes = True
-  - zero_node_changes = True
-- disrupt_terminate_kubernetes_host_then_decommission_and_add_scylla_node:
-  - disruptive = True
-  - kubernetes = True
-- disrupt_terminate_kubernetes_host_then_replace_scylla_node:
-  - disruptive = True
-  - kubernetes = True
-- disrupt_toggle_audit_syslog:
-  - disruptive = True
-  - supports_high_disk_utilization = True
-  - schema_changes = True
-  - config_changes = True
-  - free_tier_set = True
-- disrupt_toggle_cdc_feature_properties_on_table:
-  - disruptive = False
-  - schema_changes = True
-  - config_changes = True
-  - free_tier_set = True
-- disrupt_toggle_table_gc_mode:
-  - kubernetes = True
-  - disruptive = False
-  - schema_changes = True
-  - free_tier_set = True
-  - supports_high_disk_utilization = True
-- disrupt_toggle_table_ics:
-  - kubernetes = True
-  - schema_changes = True
-  - free_tier_set = True
-- disrupt_truncate:
-  - disruptive = False
-  - kubernetes = True
-  - limited = True
-  - free_tier_set = True
-  - supports_high_disk_utilization = True
-- disrupt_truncate_large_partition:
-  - disruptive = False
-  - kubernetes = True
-  - free_tier_set = True
-  - supports_high_disk_utilization = True
-- disrupt_validate_hh_short_downtime:
-  - disruptive = True
-  - kubernetes = True
-  - free_tier_set = True
+disrupt_abort_repair:
+  disruptive: false
+  kubernetes: true
+  limited: true
+  supports_high_disk_utilization: true
+disrupt_add_drop_column:
+  disruptive: false
+  free_tier_set: true
+  kubernetes: true
+  limited: true
+  networking: false
+  run_with_gemini: false
+  schema_changes: true
+  supports_high_disk_utilization: true
+disrupt_add_remove_dc:
+  disruptive: true
+  kubernetes: false
+  limited: true
+  run_with_gemini: false
+  topology_changes: true
+disrupt_add_remove_mv:
+  disruptive: true
+  free_tier_set: true
+  schema_changes: true
+  supports_high_disk_utilization: false
+disrupt_bootstrap_streaming_error:
+  disruptive: true
+  supports_high_disk_utilization: true
+  topology_changes: true
+disrupt_corrupt_then_scrub:
+  disruptive: false
+  supports_high_disk_utilization: false
+disrupt_create_index:
+  disruptive: false
+  free_tier_set: true
+  schema_changes: true
+  supports_high_disk_utilization: false
+disrupt_decommission_streaming_err:
+  disruptive: true
+  topology_changes: true
+disrupt_delete_10_full_partitions:
+  delete_rows: true
+  disruptive: false
+  free_tier_set: true
+  kubernetes: true
+disrupt_delete_by_rows_range:
+  delete_rows: true
+  disruptive: false
+  free_tier_set: true
+  kubernetes: true
+disrupt_delete_overlapping_row_ranges:
+  delete_rows: true
+  disruptive: false
+  free_tier_set: true
+  kubernetes: true
+disrupt_destroy_data_then_rebuild:
+  disruptive: true
+  kubernetes: true
+disrupt_destroy_data_then_repair:
+  disruptive: true
+  kubernetes: true
+  supports_high_disk_utilization: true
+disrupt_disable_binary_gossip_execute_major_compaction:
+  disruptive: true
+  kubernetes: true
+  supports_high_disk_utilization: true
+disrupt_disable_enable_ldap_authorization:
+  disruptive: true
+  limited: true
+disrupt_drain_kubernetes_node_then_decommission_and_add_scylla_node:
+  disruptive: true
+  kubernetes: true
+disrupt_drain_kubernetes_node_then_replace_scylla_node:
+  disruptive: true
+  kubernetes: true
+disrupt_enable_disable_table_encryption_aws_kms_provider_with_rotation:
+  disruptive: true
+  kubernetes: false
+disrupt_enable_disable_table_encryption_aws_kms_provider_without_rotation:
+  disruptive: true
+  kubernetes: false
+disrupt_end_of_quota_nemesis:
+  config_changes: true
+  disruptive: true
+disrupt_grow_shrink_cluster:
+  disruptive: true
+  kubernetes: true
+  topology_changes: true
+disrupt_grow_shrink_new_rack:
+  config_changes: true
+  disruptive: true
+  kubernetes: true
+disrupt_grow_shrink_zero_nodes:
+  disruptive: true
+  free_tier_set: false
+  schema_changes: false
+  zero_node_changes: true
+disrupt_hard_reboot_node:
+  disruptive: true
+  free_tier_set: true
+  kubernetes: true
+  limited: true
+  supports_high_disk_utilization: true
+disrupt_hot_reloading_internode_certificate:
+  config_changes: true
+  disruptive: false
+  supports_high_disk_utilization: true
+disrupt_increase_shares_by_attach_another_sl_during_load:
+  disruptive: true
+  sla: true
+disrupt_kill_scylla:
+  disruptive: true
+  free_tier_set: true
+  kubernetes: true
+  supports_high_disk_utilization: true
+disrupt_ldap_connection_toggle:
+  disruptive: false
+  limited: true
+disrupt_load_and_stream:
+  disruptive: false
+  kubernetes: true
+  limited: true
+  run_with_gemini: false
+  supports_high_disk_utilization: true
+disrupt_major_compaction:
+  disruptive: false
+  kubernetes: true
+  limited: true
+  supports_high_disk_utilization: true
+disrupt_maximum_allowed_sls_with_max_shares_during_load:
+  disruptive: false
+  sla: true
+disrupt_memory_stress:
+  disruptive: true
+  free_tier_set: true
+  supports_high_disk_utilization: true
+disrupt_mgmt_backup:
+  disruptive: false
+  limited: true
+  manager_operation: true
+  supports_high_disk_utilization: false
+disrupt_mgmt_backup_specific_keyspaces:
+  disruptive: false
+  limited: true
+  manager_operation: true
+  supports_high_disk_utilization: false
+disrupt_mgmt_corrupt_then_repair:
+  disruptive: true
+  kubernetes: true
+  manager_operation: true
+  supports_high_disk_utilization: true
+disrupt_mgmt_repair_cli:
+  disruptive: false
+  kubernetes: true
+  limited: true
+  manager_operation: true
+  supports_high_disk_utilization: true
+disrupt_mgmt_restore:
+  disruptive: true
+  kubernetes: true
+  limited: true
+  manager_operation: true
+  supports_high_disk_utilization: false
+disrupt_modify_table:
+  disruptive: false
+  free_tier_set: true
+  kubernetes: true
+  limited: true
+  schema_changes: true
+  supports_high_disk_utilization: true
+disrupt_multiple_hard_reboot_node:
+  disruptive: true
+  free_tier_set: true
+  kubernetes: true
+  supports_high_disk_utilization: true
+disrupt_network_block:
+  disruptive: true
+  kubernetes: true
+  networking: true
+  run_with_gemini: false
+disrupt_network_random_interruptions:
+  disruptive: true
+  kubernetes: true
+  networking: true
+  run_with_gemini: false
+disrupt_network_reject_inter_node_communication:
+  disruptive: true
+  free_tier_set: true
+  networking: true
+  run_with_gemini: false
+disrupt_network_reject_node_exporter:
+  disruptive: true
+  networking: true
+  run_with_gemini: false
+disrupt_network_reject_thrift:
+  disruptive: true
+  networking: true
+  run_with_gemini: false
+disrupt_network_start_stop_interface:
+  disruptive: true
+  networking: true
+  run_with_gemini: false
+disrupt_no_corrupt_repair:
+  disruptive: false
+  kubernetes: true
+  limited: true
+disrupt_nodetool_cleanup:
+  disruptive: false
+  kubernetes: true
+  limited: true
+  supports_high_disk_utilization: true
+disrupt_nodetool_decommission:
+  disruptive: true
+  limited: true
+  supports_high_disk_utilization: false
+  topology_changes: true
+disrupt_nodetool_drain:
+  disruptive: true
+  kubernetes: true
+  limited: true
+  topology_changes: true
+disrupt_nodetool_enospc:
+  disruptive: true
+  kubernetes: true
+  supports_high_disk_utilization: true
+disrupt_nodetool_flush_and_reshard_on_kubernetes:
+  disruptive: true
+  kubernetes: true
+disrupt_nodetool_refresh:
+  disruptive: false
+  kubernetes: true
+  run_with_gemini: false
+  supports_high_disk_utilization: true
+disrupt_nodetool_seed_decommission:
+  disruptive: true
+  supports_high_disk_utilization: false
+  topology_changes: true
+disrupt_rebuild_streaming_err:
+  disruptive: true
+disrupt_refuse_connection_with_block_scylla_ports_on_banned_node:
+  disruptive: true
+  kubernetes: false
+  topology_changes: true
+disrupt_refuse_connection_with_send_sigstop_signal_to_scylla_on_banned_node:
+  disruptive: true
+  kubernetes: false
+  topology_changes: true
+disrupt_remove_node_then_add_node:
+  disruptive: true
+  kubernetes: false
+  supports_high_disk_utilization: false
+  topology_changes: true
+disrupt_remove_service_level_while_load:
+  disruptive: true
+  sla: true
+disrupt_repair_streaming_err:
+  disruptive: true
+disrupt_replace_scylla_node_on_kubernetes:
+  disruptive: true
+  free_tier_set: true
+  kubernetes: true
+disrupt_replace_service_level_using_detach_during_load:
+  disruptive: true
+  sla: true
+disrupt_replace_service_level_using_drop_during_load:
+  disruptive: true
+  sla: true
+disrupt_resetlocalschema:
+  config_changes: true
+  disruptive: false
+  free_tier_set: true
+disrupt_restart_then_repair_node:
+  disruptive: true
+  kubernetes: true
+disrupt_restart_with_resharding:
+  config_changes: true
+  disruptive: true
+  kubernetes: true
+  topology_changes: true
+disrupt_rolling_config_change_internode_compression:
+  config_changes: true
+  disruptive: true
+  full_cluster_restart: true
+  supports_high_disk_utilization: true
+disrupt_rolling_restart_cluster:
+  disruptive: true
+  free_tier_set: true
+  kubernetes: true
+  supports_high_disk_utilization: true
+disrupt_run_cdcstressor_tool:
+  disruptive: false
+  free_tier_set: true
+disrupt_run_unique_sequence:
+  disruptive: true
+  networking: false
+  run_with_gemini: false
+disrupt_serial_restart_elected_topology_coordinator:
+  disruptive: true
+  supports_high_disk_utilization: true
+  topology_changes: true
+disrupt_show_toppartitions:
+  disruptive: false
+  kubernetes: true
+  limited: true
+  supports_high_disk_utilization: true
+disrupt_sla_decrease_shares_during_load:
+  disruptive: false
+  sla: true
+disrupt_sla_increase_shares_during_load:
+  disruptive: false
+  sla: true
+disrupt_snapshot_operations:
+  disruptive: false
+  kubernetes: true
+  limited: true
+  supports_high_disk_utilization: true
+disrupt_soft_reboot_node:
+  disruptive: true
+  free_tier_set: true
+  kubernetes: true
+  limited: true
+  supports_high_disk_utilization: true
+disrupt_start_stop_cleanup_compaction:
+  disruptive: false
+  supports_high_disk_utilization: true
+disrupt_start_stop_major_compaction:
+  disruptive: false
+  supports_high_disk_utilization: true
+disrupt_start_stop_scrub_compaction:
+  disruptive: false
+disrupt_start_stop_validation_compaction:
+  disruptive: false
+  supports_high_disk_utilization: false
+disrupt_stop_start_scylla_server:
+  disruptive: true
+  kubernetes: true
+  limited: true
+  supports_high_disk_utilization: true
+disrupt_stop_wait_start_scylla_server:
+  disruptive: true
+  kubernetes: true
+  limited: true
+  supports_high_disk_utilization: true
+  zero_node_changes: true
+disrupt_switch_between_password_authenticator_and_saslauthd_authenticator_and_back:
+  config_changes: true
+  disruptive: true
+disrupt_terminate_and_replace_node:
+  disruptive: true
+  kubernetes: false
+  topology_changes: true
+  zero_node_changes: true
+disrupt_terminate_kubernetes_host_then_decommission_and_add_scylla_node:
+  disruptive: true
+  kubernetes: true
+disrupt_terminate_kubernetes_host_then_replace_scylla_node:
+  disruptive: true
+  kubernetes: true
+disrupt_toggle_audit_syslog:
+  config_changes: true
+  disruptive: true
+  free_tier_set: true
+  schema_changes: true
+  supports_high_disk_utilization: true
+disrupt_toggle_cdc_feature_properties_on_table:
+  config_changes: true
+  disruptive: false
+  free_tier_set: true
+  schema_changes: true
+disrupt_toggle_table_gc_mode:
+  disruptive: false
+  free_tier_set: true
+  kubernetes: true
+  schema_changes: true
+  supports_high_disk_utilization: true
+disrupt_toggle_table_ics:
+  free_tier_set: true
+  kubernetes: true
+  schema_changes: true
+disrupt_truncate:
+  disruptive: false
+  free_tier_set: true
+  kubernetes: true
+  limited: true
+  supports_high_disk_utilization: true
+disrupt_truncate_large_partition:
+  disruptive: false
+  free_tier_set: true
+  kubernetes: true
+  supports_high_disk_utilization: true
+disrupt_validate_hh_short_downtime:
+  disruptive: true
+  free_tier_set: true
+  kubernetes: true

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -30,14 +30,12 @@ import traceback
 import json
 import itertools
 import enum
-import ast
 from contextlib import ExitStack, contextmanager
-from typing import Any, List, Optional, Type, Tuple, Callable, Dict, Set, Union, Iterable
-from functools import wraps, partial, lru_cache
+from typing import Any, List, Optional, Tuple, Callable, Dict, Set, Union, Iterable
+from functools import wraps, partial
 from collections import defaultdict, Counter, namedtuple
 from concurrent.futures import ThreadPoolExecutor
 from threading import Lock
-from types import MethodType  # pylint: disable=no-name-in-module
 
 from cassandra import ConsistencyLevel, InvalidRequest, Unavailable
 from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
@@ -45,6 +43,7 @@ from cassandra.cluster import NoHostAvailable, OperationTimedOut  # pylint: disa
 from invoke import UnexpectedExit
 from elasticsearch.exceptions import ConnectionTimeout as ElasticSearchConnectionTimeout
 from argus.common.enums import NemesisStatus
+from sdcm.nemesis_registry import NemesisRegistry
 
 from sdcm.utils.cql_utils import cql_unquote_if_needed
 from sdcm import wait
@@ -165,7 +164,6 @@ from test_lib.compaction import CompactionStrategy, get_compaction_strategy, get
 from test_lib.cql_types import CQLTypeBuilder
 from test_lib.sla import ServiceLevel, MAX_ALLOWED_SERVICE_LEVELS
 from sdcm.utils.topology_ops import FailedDecommissionOperationMonitoring
-from sdcm.utils.ast_utils import BooleanEvaluator
 
 
 LOGGER = logging.getLogger(__name__)
@@ -214,7 +212,6 @@ def target_all_nodes(func: Callable) -> Callable:
 
 
 class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-methods
-    DISRUPT_NAME_PREF: str = "disrupt_"
 
     # nemesis flags:
     topology_changes: bool = False  # flag that signal that nemesis is changing cluster topology,
@@ -236,16 +233,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     zero_node_changes: bool = False
 
     def __init__(self, tester_obj, termination_event, *args, nemesis_selector=None, nemesis_seed=None, **kwargs):  # pylint: disable=unused-argument
-        for name, member in inspect.getmembers(self, lambda x: inspect.isfunction(x) or inspect.ismethod(x)):
-            if not name.startswith(self.DISRUPT_NAME_PREF):
-                continue
-            is_exclusive = name in EXCLUSIVE_NEMESIS_NAMES
-            # add "disrupt_method_wrapper" decorator to all methods are started with "disrupt_"
-            setattr(self, name,
-                    MethodType(disrupt_method_wrapper(member, is_exclusive=is_exclusive), self))
-
         # *args -  compatible with CategoricalMonkey
         self.tester = tester_obj  # ClusterTester object
+        self.nemesis_registry = NemesisRegistry(base_class=Nemesis,
+                                                excluded_list=COMPLEX_NEMESIS)
         self.cluster: Union[BaseCluster, BaseScyllaCluster] = tester_obj.db_cluster
         self.loaders = tester_obj.loaders
         self.monitoring_set = tester_obj.monitors
@@ -513,163 +504,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         for operation in self.operation_log:
             self.log.info(operation)
 
-    # pylint: disable=too-many-arguments,unused-argument
-    def get_list_of_methods_compatible_with_backend(
-            self,
-            disruptive: Optional[bool] = None,
-            supports_high_disk_utilization: Optional[bool] = None,
-            run_with_gemini: Optional[bool] = None,
-            networking: Optional[bool] = None,
-            limited: Optional[bool] = None,
-            topology_changes: Optional[bool] = None,
-            schema_changes: Optional[bool] = None,
-            config_changes: Optional[bool] = None,
-            free_tier_set: Optional[bool] = None,
-            manager_operation: Optional[bool] = None,
-            zero_node_changes: Optional[bool] = None,
-    ) -> List[str]:
-        return self.get_list_of_methods_by_flags(
-            disruptive=disruptive,
-            supports_high_disk_utilization=supports_high_disk_utilization,
-            run_with_gemini=run_with_gemini,
-            networking=networking,
-            kubernetes=self._is_it_on_kubernetes() or None,
-            limited=limited,
-            topology_changes=topology_changes,
-            schema_changes=schema_changes,
-            config_changes=config_changes,
-            free_tier_set=free_tier_set,
-            manager_operation=manager_operation,
-            zero_node_changes=zero_node_changes
-        )
-
     def _is_it_on_kubernetes(self) -> bool:
         return isinstance(getattr(self.tester, "db_cluster", None), PodCluster)
-
-    # pylint: disable=too-many-arguments,unused-argument
-    def get_list_of_methods_by_flags(  # pylint: disable=too-many-locals  # noqa: PLR0913
-            self,
-            disruptive: Optional[bool] = None,
-            supports_high_disk_utilization: Optional[bool] = None,
-            run_with_gemini: Optional[bool] = None,
-            networking: Optional[bool] = None,
-            kubernetes: Optional[bool] = None,
-            limited: Optional[bool] = None,
-            topology_changes: Optional[bool] = None,
-            schema_changes: Optional[bool] = None,
-            config_changes: Optional[bool] = None,
-            free_tier_set: Optional[bool] = None,
-            sla: Optional[bool] = None,
-            manager_operation: Optional[bool] = None,
-            zero_node_changes: Optional[bool] = None,
-    ) -> List[str]:
-        args = dict(
-            disruptive=disruptive,
-            supports_high_disk_utilization=supports_high_disk_utilization,
-            run_with_gemini=run_with_gemini,
-            networking=networking,
-            kubernetes=kubernetes,
-            limited=limited,
-            topology_changes=topology_changes,
-            schema_changes=schema_changes,
-            config_changes=config_changes,
-            free_tier_set=free_tier_set,
-            sla=sla,
-            manager_operation=manager_operation,
-            zero_node_changes=zero_node_changes
-        )
-        logical_phrase = " and ".join([key for key, val in args.items() if val])
-        subclasses_list = self._get_subclasses(logical_phrase=logical_phrase)
-
-        disrupt_methods_list = []
-        for subclass in subclasses_list:
-            if method_name := self.get_disrupt_method_from_class(subclass):
-                disrupt_methods_list.append(method_name)
-        self.log.debug("Gathered subclass methods: {}".format(disrupt_methods_list))
-        return disrupt_methods_list
-
-    def get_list_of_subclasses_by_property_name(self, filter_logical_phrase: str | None):
-        subclasses_list = self._get_subclasses(logical_phrase=filter_logical_phrase)
-        return subclasses_list
-
-    @staticmethod
-    @lru_cache
-    def get_disrupt_method_from_class(nemesis_cls):
-        method_name = DISRUPT_METHOD_IDENTIFY_REGEX.search(inspect.getsource(nemesis_cls))
-        if method_name:
-            return method_name.group("method_name")
-
-    def get_list_of_disrupt_methods(self, subclasses_list, export_properties=False):
-        disrupt_methods_objects_list = []
-        disrupt_methods_names_list = []
-        nemesis_classes = []
-        all_methods_with_properties = []
-        for subclass in subclasses_list:
-            properties_list = []
-            per_method_properties = {}
-
-            for attribute in subclass.__dict__.keys():
-                if attribute[:2] != '__':
-                    value = getattr(subclass, attribute)
-                    if not callable(value):
-                        properties_list.append(f"{attribute} = {value}")
-
-            if method_name_str := self.get_disrupt_method_from_class(subclass):
-                disrupt_methods_names_list.append(method_name_str)
-                nemesis_classes.append(subclass.__name__)
-                if export_properties:
-                    per_method_properties[method_name_str] = properties_list
-                    all_methods_with_properties.append(per_method_properties)
-                    all_methods_with_properties = sorted(all_methods_with_properties, key=lambda d: list(d.keys()))
-        nemesis_classes.sort()
-        self.log.debug("list of matching disrupions: {}".format(disrupt_methods_names_list))
-        for _ in disrupt_methods_names_list:
-            disrupt_methods_objects_list = [attr[1] for attr in inspect.getmembers(self) if
-                                            attr[0] in disrupt_methods_names_list and callable(attr[1])]
-        return disrupt_methods_objects_list, all_methods_with_properties, nemesis_classes
-
-    @classmethod
-    def _get_subclasses(cls, logical_phrase: str | None = None) -> List[Type['Nemesis']]:
-        tmp = Nemesis.__subclasses__()
-        subclasses = []
-        while tmp:
-            for nemesis in tmp.copy():
-                subclasses.append(nemesis)
-                tmp.remove(nemesis)
-                tmp.extend(nemesis.__subclasses__())
-        return cls._get_subclasses_from_list(subclasses, logical_phrase=logical_phrase)
-
-    @classmethod
-    def _get_subclasses_from_list(cls,
-                                  list_of_nemesis: List[Type['Nemesis']],
-                                  logical_phrase: str | None) -> List[Type['Nemesis']]:
-        """
-        It apply 'and' logic to filter,
-            if any value in the filter does not match what nemeses have,
-            nemeses will be filtered out.
-        """
-        nemesis_subclasses = []
-        nemesis_to_exclude = COMPLEX_NEMESIS
-
-        evaluator = BooleanEvaluator()
-        if logical_phrase:
-            expression_ast = ast.parse(logical_phrase, mode="eval")
-
-        for nemesis in list_of_nemesis:
-            if nemesis in nemesis_to_exclude:
-                continue
-            evaluator.context = dict(**nemesis.__dict__,
-                                     **{nemesis.__name__: True})
-            if (logical_phrase and 'disrupt_' in logical_phrase and
-                    (method_name := cls.get_disrupt_method_from_class(nemesis))):
-                # if the `logical_phrase` has a method name of any disrupt method
-                # we look it up for the specific class and add it to the context
-                # so we can match on those as well
-                # example: 'disrupt_create_index or disrupt_drop_index'
-                evaluator.context[method_name] = True
-            if (logical_phrase and evaluator.visit(expression_ast)) or not logical_phrase:
-                nemesis_subclasses.append(nemesis)
-        return nemesis_subclasses
 
     def __str__(self):
         try:
@@ -2016,7 +1852,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         disrupt_method_name = disrupt_method.__name__.replace('disrupt_', '')
         self.metrics_srv.event_start(disrupt_method_name)
         try:
-            disrupt_method()
+            disrupt_method(self)
         finally:
             self.metrics_srv.event_stop(disrupt_method_name)
 
@@ -2033,17 +1869,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         more about nemesis_selector behaviour in sct_config.py
         """
         nemesis_selector = nemesis_selector or self.nemesis_selector
-        nemesis_multiply_factor = self.cluster.params.get('nemesis_multiply_factor') or nemesis_multiply_factor
-        if nemesis_selector:
-            subclasses = self.get_list_of_subclasses_by_property_name(
-                filter_logical_phrase=nemesis_selector)
-            if subclasses:
-                disruptions, _, _ = self.get_list_of_disrupt_methods(subclasses_list=subclasses)
+        if self._is_it_on_kubernetes():
+            if nemesis_selector:
+                nemesis_selector = nemesis_selector + " and kubernetes"
             else:
-                disruptions = []
-        else:
-            disruptions = [attr[1] for attr in inspect.getmembers(self)
-                           if attr[0].startswith('disrupt_') and callable(attr[1])]
+                nemesis_selector = "kubernetes"
+        nemesis_multiply_factor = self.cluster.params.get('nemesis_multiply_factor') or nemesis_multiply_factor
+        disruptions = self.nemesis_registry.get_disrupt_methods(nemesis_selector)
 
         if nemesis_multiply_factor:
             disruptions = disruptions * nemesis_multiply_factor
@@ -5686,7 +5518,7 @@ def disrupt_method_wrapper(method, is_exclusive=False):  # pylint: disable=too-m
                 nemesis_info = argus_create_nemesis_info(nemesis=args[0], class_name=class_name,
                                                          method_name=method_name, start_time=start_time)
                 try:
-                    result = method(*args[1:], **kwargs)
+                    result = method(*args, **kwargs)
                 except (UnsupportedNemesis, MethodVersionNotFound) as exp:
                     skip_reason = str(exp)
                     log_info.update({'subtype': 'skipped', 'skip_reason': skip_reason})
@@ -5782,6 +5614,25 @@ def disrupt_method_wrapper(method, is_exclusive=False):  # pylint: disable=too-m
         return result
 
     return wrapper
+
+
+DISRUPT_NAME_PREF = "disrupt_"
+for name, member in inspect.getmembers(Nemesis, lambda x: inspect.isfunction(x) or inspect.ismethod(x)):
+    if not name.startswith(DISRUPT_NAME_PREF):
+        continue
+    is_exclusive = name in EXCLUSIVE_NEMESIS_NAMES
+    # add "disrupt_method_wrapper" decorator to all methods are started with "disrupt_"
+    setattr(Nemesis, name, disrupt_method_wrapper(member, is_exclusive=is_exclusive))
+
+
+class SisyphusMonkey(Nemesis):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.build_list_of_disruptions_to_execute()
+        self.shuffle_list_of_disruptions()
+
+    def disrupt(self):
+        self.call_next_nemesis()
 
 
 class SslHotReloadingNemesis(Nemesis):
@@ -6210,9 +6061,7 @@ class CategoricalMonkey(Nemesis):
         assert len(population) == len(weights) and population
 
         method = random.choices(population, weights=weights)[0]
-        bound_method = method.__get__(self, CategoricalMonkey)
-        self.execute_disrupt_method(bound_method)
-
+        self.execute_disrupt_method(method)
 
 CLOUD_LIMITED_CHAOS_MONKEY = ['disrupt_nodetool_cleanup',
                               'disrupt_nodetool_drain', 'disrupt_nodetool_refresh',
@@ -6657,17 +6506,6 @@ class TerminateAndRemoveNodeMonkey(Nemesis):
 
     def disrupt(self):
         self.disrupt_remove_node_then_add_node()
-
-
-class SisyphusMonkey(Nemesis):
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.build_list_of_disruptions_to_execute()
-        self.shuffle_list_of_disruptions()
-
-    def disrupt(self):
-        self.call_next_nemesis()
 
 
 class ToggleCDCMonkey(Nemesis):

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -32,7 +32,7 @@ import itertools
 import enum
 from contextlib import ExitStack, contextmanager
 from typing import Any, List, Optional, Tuple, Callable, Dict, Set, Union, Iterable
-from functools import wraps, partial
+from functools import wraps, partial, cached_property
 from collections import defaultdict, Counter, namedtuple
 from concurrent.futures import ThreadPoolExecutor
 from threading import Lock
@@ -242,7 +242,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.monitoring_set = tester_obj.monitors
         self.target_node: BaseNode = None
         self.disruptions_list = []
-        self.disruptions_cycle: Iterable[Callable] | None = None
         self.termination_event = termination_event
         self.operation_log = []
         self.current_disruption = None
@@ -264,7 +263,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.task_used_streaming = None
         self.filter_seed = self.cluster.params.get('nemesis_filter_seeds')
         self.nemesis_seed = nemesis_seed or random.randint(0, 1000)
-        self._random_sequence = None
         self._add_drop_column_max_per_drop = 5
         self._add_drop_column_max_per_add = 5
         self._add_drop_column_max_column_name_size = 10
@@ -1808,47 +1806,14 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.log.info('StopStart %s', self.target_node)
         self.target_node.restart()
 
-    def call_random_disrupt_method(self, disrupt_methods=None, predefined_sequence=False):
-        # pylint: disable=too-many-branches
+    # Nemesis running code
 
-        if disrupt_methods is None:
-            disrupt_methods = [attr[1] for attr in inspect.getmembers(self) if
-                               attr[0].startswith('disrupt_') and
-                               callable(attr[1])]
-        else:
-            disrupt_methods = [attr[1] for attr in inspect.getmembers(self) if
-                               attr[0] in disrupt_methods and
-                               callable(attr[1])]
-        if not disrupt_methods:
-            self.log.warning("No monkey to run")
-            return
-        if not predefined_sequence:
-            disrupt_method = random.choice(disrupt_methods)
-        else:
-            if not self._random_sequence:
-                # Generate random sequence, every method has same chance to be called.
-                # Here we use multiple original methods list, it will increase the chance
-                # to call same method continuously.
-                #
-                # Adjust the rate according to the test duration. Try to call more unique
-                # methods and don't wait to long time to meet the balance if the test
-                # duration is short.
-                test_duration = self.cluster.params.get('test_duration')
-                if test_duration < 600:  # less than 10 hours
-                    rate = 1
-                elif test_duration < 4320:  # less than 3 days
-                    rate = 2
-                else:
-                    rate = 3
-                multiple_disrupt_methods = disrupt_methods * rate
-                random.shuffle(multiple_disrupt_methods)
-                self._random_sequence = multiple_disrupt_methods
-            # consume the random sequence
-            disrupt_method = self._random_sequence.pop()
-
-        self.execute_disrupt_method(disrupt_method)
+    @cached_property
+    def all_disrupt_methods(self):
+        return self.nemesis_registry.get_disrupt_methods()
 
     def execute_disrupt_method(self, disrupt_method):
+        """Runs selected disrupt method"""
         disrupt_method_name = disrupt_method.__name__.replace('disrupt_', '')
         self.metrics_srv.event_start(disrupt_method_name)
         try:
@@ -1856,32 +1821,28 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         finally:
             self.metrics_srv.event_stop(disrupt_method_name)
 
-    def build_list_of_disruptions_to_execute(self, nemesis_selector: str | None = None, nemesis_multiply_factor=1):
-        """
-        Builds the list of disruptions that should be excuted during a test.
+    def build_disruptions_by_name(self, disrupt_methods: List[str]):
+        """Builds list of available disruptions according to function names"""
+        filtered = [func for func in self.all_disrupt_methods if func.__name__ in disrupt_methods]
+        names = [func.__name__ for func in filtered]
+        assert names == disrupt_methods, f"Unable to find these disrupt methods: {set(disrupt_methods).difference(names)}"
+        return filtered
 
-        nemesis_selector: should be retrived from the test yaml by using the "nemesis_selector".
-        Here it kept for future usages and unit testing ability.
-        more about nemesis_selector behaviour in sct_config.py
-
-        nemesis_multiply_factor: should be retrived from the test yaml by using the "nemesis_multiply_factor".
-        Here it kept for future usages and unit testing ability.
-        more about nemesis_selector behaviour in sct_config.py
+    def build_disruptions_by_selector(self, nemesis_selector: str | None = None):
         """
-        nemesis_selector = nemesis_selector or self.nemesis_selector
+        Filter available disruptions according to the logical phrase
+
+        nemesis_selector: Logical phrase selector to filter available disruption methods.
+        To be able to be filtered, method needs to have corresponding class.
+        Usually retrieved from the test yaml by using the "nemesis_selector", more about nemesis_selector behaviour in sct_config.py
+        """
         if self._is_it_on_kubernetes():
             if nemesis_selector:
                 nemesis_selector = nemesis_selector + " and kubernetes"
             else:
                 nemesis_selector = "kubernetes"
-        nemesis_multiply_factor = self.cluster.params.get('nemesis_multiply_factor') or nemesis_multiply_factor
         disruptions = self.nemesis_registry.get_disrupt_methods(nemesis_selector)
-
-        if nemesis_multiply_factor:
-            disruptions = disruptions * nemesis_multiply_factor
-
-        self.disruptions_list.extend(disruptions)
-        return self.disruptions_list
+        return disruptions
 
     @property
     def nemesis_selector(self) -> str:
@@ -1905,22 +1866,34 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     @property
     def _disruption_list_names(self):
+        """Returns name of all collected nemesis"""
         return [nemesis.__name__ for nemesis in self.disruptions_list]
 
-    def shuffle_list_of_disruptions(self):
-        self.log.debug(f'nemesis_seed to be used is {self.nemesis_seed}')
+    def shuffle_list_of_disruptions(self, disruption_list: List, nemesis_multiply_factor: int | None = None):
+        """
+        Randomizes list of disruptions
 
+        nemesis_multiply_factor: How many times to multiply the original list before shuffle
+        Useful for increasing probability of the same nemesis twice in a row
+        Usually retrieved from the test yaml by using the "nemesis_selector", more about nemesis_selector behaviour in sct_config.py
+        """
+        self.log.debug(f'nemesis_seed to be used is {self.nemesis_seed}')
         self.log.debug(f"nemesis stack BEFORE SHUFFLE is {self._disruption_list_names}")
-        random.Random(self.nemesis_seed).shuffle(self.disruptions_list)
+        nemesis_multiply_factor = nemesis_multiply_factor or self.cluster.params.get('nemesis_multiply_factor') or 1
+        random.Random(self.nemesis_seed).shuffle(disruption_list * nemesis_multiply_factor)
         self.log.info(f"List of Nemesis to execute: {self._disruption_list_names}")
 
-    def call_next_nemesis(self):
-        assert self.disruptions_list, "no nemesis were selected"
-        if not self.disruptions_cycle:
-            self.disruptions_cycle = itertools.cycle(self.disruptions_list)
-        self.log.debug(f'Selecting the next nemesis out of stack {self._disruption_list_names[10:]}')
-        self.execute_disrupt_method(disrupt_method=next(self.disruptions_cycle))
+    @cached_property
+    def infinite_cycle(self):
+        """Returns infinite cycle of all nemesis"""
+        return itertools.cycle(self.disruptions_list)
 
+    def call_next_nemesis(self):
+        """Calls next nemesis in the order"""
+        assert self.disruptions_list, "no nemesis were selected"
+        self.execute_disrupt_method(disrupt_method=next(self.infinite_cycle))
+
+    # End of Nemesis running code
     @latency_calculator_decorator(legend="Run repair process with nodetool repair")
     def repair_nodetool_repair(self, node=None, publish_event=True):
         node = node if node else self.target_node
@@ -5628,8 +5601,8 @@ for name, member in inspect.getmembers(Nemesis, lambda x: inspect.isfunction(x) 
 class SisyphusMonkey(Nemesis):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.build_list_of_disruptions_to_execute()
-        self.shuffle_list_of_disruptions()
+        self.disruptions_list = self.build_disruptions_by_selector(self.nemesis_selector)
+        self.shuffle_list_of_disruptions(self.disruptions_list)
 
     def disrupt(self):
         self.call_next_nemesis()
@@ -5740,13 +5713,14 @@ class EnableDisableTableEncryptionAwsKmsProviderMonkey(Nemesis):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.disrupt_methods_list = [
+        self.disruptions_list = self.build_disruptions_by_name([
             'disrupt_enable_disable_table_encryption_aws_kms_provider_without_rotation',
             'disrupt_enable_disable_table_encryption_aws_kms_provider_with_rotation',
-        ]
+        ])
+        self.shuffle_list_of_disruptions(self.disruptions_list)
 
     def disrupt(self):
-        self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list, predefined_sequence=True)
+        self.call_next_nemesis()
 
 
 class RestartThenRepairNodeMonkey(Nemesis):
@@ -5974,12 +5948,6 @@ class DeleteOverlappingRowRangesMonkey(Nemesis):
         self.disrupt_delete_overlapping_row_ranges()
 
 
-class ChaosMonkey(Nemesis):
-
-    def disrupt(self):
-        self.call_random_disrupt_method()
-
-
 class CategoricalMonkey(Nemesis):
     """Randomly picks disruptions to execute using the given categorical distribution.
 
@@ -6063,34 +6031,40 @@ class CategoricalMonkey(Nemesis):
         method = random.choices(population, weights=weights)[0]
         self.execute_disrupt_method(method)
 
-CLOUD_LIMITED_CHAOS_MONKEY = ['disrupt_nodetool_cleanup',
-                              'disrupt_nodetool_drain', 'disrupt_nodetool_refresh',
-                              'disrupt_stop_start_scylla_server', 'disrupt_major_compaction',
-                              'disrupt_modify_table', 'disrupt_nodetool_enospc',
-                              'disrupt_stop_wait_start_scylla_server',
-                              'disrupt_soft_reboot_node',
-                              'disrupt_truncate']
-
 
 class ScyllaCloudLimitedChaosMonkey(Nemesis):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.disruptions_list = self.build_disruptions_by_name([
+            'disrupt_nodetool_cleanup',
+            'disrupt_nodetool_drain', 'disrupt_nodetool_refresh',
+            'disrupt_stop_start_scylla_server', 'disrupt_major_compaction',
+            'disrupt_modify_table', 'disrupt_nodetool_enospc',
+            'disrupt_stop_wait_start_scylla_server',
+            'disrupt_soft_reboot_node',
+            'disrupt_truncate'
+        ])
+        self.shuffle_list_of_disruptions(self.disruptions_list)
+
     def disrupt(self):
         # Limit the nemesis scope to only one relevant to scylla cloud, where we defined we don't have AWS api access:
-        self.call_random_disrupt_method(disrupt_methods=CLOUD_LIMITED_CHAOS_MONKEY)
-
-
-class AllMonkey(Nemesis):
-
-    def disrupt(self):
-        self.call_random_disrupt_method(predefined_sequence=True)
+        self.call_next_nemesis()
 
 
 class MdcChaosMonkey(Nemesis):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.disruptions_list = self.build_disruptions_by_name([
+            'disrupt_destroy_data_then_repair',
+            'disrupt_no_corrupt_repair',
+            'disrupt_nodetool_decommission'
+        ])
+        self.shuffle_list_of_disruptions(self.disruptions_list)
+
     def disrupt(self):
-        self.call_random_disrupt_method(
-            disrupt_methods=['disrupt_destroy_data_then_repair', 'disrupt_no_corrupt_repair',
-                             'disrupt_nodetool_decommission'])
+        self.call_next_nemesis()
 
 
 class ModifyTableMonkey(Nemesis):
@@ -6238,13 +6212,14 @@ class DisruptKubernetesNodeThenReplaceScyllaNode(Nemesis):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.disrupt_methods_list = [
+        self.disruptions_list = self.build_disruptions_by_name([
             'disrupt_drain_kubernetes_node_then_replace_scylla_node',
             'disrupt_terminate_kubernetes_host_then_replace_scylla_node',
-        ]
+        ])
+        self.shuffle_list_of_disruptions(self.disruptions_list)
 
     def disrupt(self):
-        self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)
+        self.call_next_nemesis()
 
 
 class DrainKubernetesNodeThenDecommissionAndAddScyllaNode(Nemesis):
@@ -6269,13 +6244,14 @@ class DisruptKubernetesNodeThenDecommissionAndAddScyllaNode(Nemesis):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.disrupt_methods_list = [
+        self.disruptions_list = self.build_disruptions_by_name([
             'disrupt_drain_kubernetes_node_then_decommission_and_add_scylla_node',
             'disrupt_terminate_kubernetes_host_then_decommission_and_add_scylla_node',
-        ]
+        ])
+        self.shuffle_list_of_disruptions(self.disruptions_list)
 
     def disrupt(self):
-        self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)
+        self.call_next_nemesis()
 
 
 class K8sSetMonkey(Nemesis):
@@ -6284,16 +6260,16 @@ class K8sSetMonkey(Nemesis):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.disrupt_methods_list = [
+        self.disruptions_list = self.build_disruptions_by_name([
             'disrupt_drain_kubernetes_node_then_replace_scylla_node',
             'disrupt_terminate_kubernetes_host_then_replace_scylla_node',
             'disrupt_drain_kubernetes_node_then_decommission_and_add_scylla_node',
             'disrupt_terminate_kubernetes_host_then_decommission_and_add_scylla_node',
-        ]
+        ])
+        self.shuffle_list_of_disruptions(self.disruptions_list)
 
     def disrupt(self):
-        self.call_random_disrupt_method(
-            disrupt_methods=self.disrupt_methods_list, predefined_sequence=True)
+        self.call_next_nemesis()
 
 
 class OperatorNodeReplace(Nemesis):
@@ -6465,7 +6441,7 @@ class ScyllaOperatorBasicOperationsMonkey(Nemesis):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.disrupt_methods_list = [
+        self.disruptions_list = self.build_disruptions_by_name([
             'disrupt_nodetool_flush_and_reshard_on_kubernetes',
             'disrupt_rolling_restart_cluster',
             'disrupt_grow_shrink_cluster',
@@ -6480,10 +6456,11 @@ class ScyllaOperatorBasicOperationsMonkey(Nemesis):
             'disrupt_mgmt_repair_cli',
             'disrupt_mgmt_backup_specific_keyspaces',
             'disrupt_mgmt_backup',
-        ]
+        ])
+        self.shuffle_list_of_disruptions(self.disruptions_list)
 
     def disrupt(self):
-        self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list, predefined_sequence=True)
+        self.call_next_nemesis()
 
 
 class NemesisSequence(Nemesis):
@@ -6551,8 +6528,8 @@ class RepairStreamingErrMonkey(Nemesis):
         self.disrupt_repair_streaming_err()
 
 
-COMPLEX_NEMESIS = [NoOpMonkey, ChaosMonkey, ScyllaCloudLimitedChaosMonkey,
-                   AllMonkey, MdcChaosMonkey, SisyphusMonkey,
+COMPLEX_NEMESIS = [NoOpMonkey, ScyllaCloudLimitedChaosMonkey,
+                   MdcChaosMonkey, SisyphusMonkey,
                    DisruptKubernetesNodeThenReplaceScyllaNode,
                    DisruptKubernetesNodeThenDecommissionAndAddScyllaNode,
                    CategoricalMonkey]

--- a/sdcm/nemesis_registry.py
+++ b/sdcm/nemesis_registry.py
@@ -1,0 +1,102 @@
+import ast
+import inspect
+import re
+from functools import lru_cache
+from typing import List, TypeVar, Callable, Dict, Tuple
+
+from sdcm.utils.ast_utils import BooleanEvaluator
+
+DISRUPT_PATTERN = re.compile(r"self\.(?P<method_name>disrupt_[0-9A-Za-z_]+?)\(.*\)", flags=re.MULTILINE)
+SourceType = TypeVar("SourceType")
+DisruptMethod = Callable[[], None]
+
+
+@lru_cache
+def get_disrupt_method_from_class(nemesis_cls):
+    """Returns disrupt method that is called inside the disrupt() method"""
+    method_name = DISRUPT_PATTERN.search(inspect.getsource(nemesis_cls.disrupt))
+    if method_name:
+        return method_name.group("method_name")
+
+
+class NemesisRegistry:
+    """
+    Class, that serves as a Nemesis discovery mechanism.
+    Currently, the disrupt methods are carrier of the code, but the Nemesis subclasses are carriers of flags.
+    This class searches through all subclasses and matches disrupt methods with proper subclass, without initializing them.
+    All searches are done through a logical phrase (e.g. "not disruptive")
+    """
+
+    def __init__(self, base_class: SourceType, excluded_list: List[SourceType] | None = None):
+        super().__init__()
+        self.base_class = base_class
+        self.excluded_list = excluded_list or []
+
+    def filter_subclasses(self, list_of_nemesis: List[SourceType], logical_phrase: str | None = None) -> List[SourceType]:
+        """
+        It applies 'and' logic to filter,
+            if any value in the filter does not match what nemeses have,
+            nemeses will be filtered out.
+        """
+        nemesis_subclasses = []
+
+        evaluator = BooleanEvaluator()
+        if logical_phrase:
+            expression_ast = ast.parse(logical_phrase, mode="eval")
+
+        for nemesis in list_of_nemesis:
+            if nemesis in self.excluded_list:
+                continue
+            evaluator.context = dict(**nemesis.__dict__, **{nemesis.__name__: True})
+            if logical_phrase and "disrupt_" in logical_phrase and (method_name := get_disrupt_method_from_class(nemesis)):
+                # if the `logical_phrase` has a method name of any disrupt method
+                # we look it up for the specific class and add it to the context
+                # so we can match on those as well
+                # example: 'disrupt_create_index or disrupt_drop_index'
+                evaluator.context[method_name] = True
+            if not logical_phrase or evaluator.visit(expression_ast):
+                nemesis_subclasses.append(nemesis)
+        return nemesis_subclasses
+
+    def get_disrupt_methods(self, logical_phrase: str | None = None) -> List[DisruptMethod]:
+        """Return all disrupt methods that satisfy logical phrase"""
+        subclasses = self.filter_subclasses(self.get_subclasses(), logical_phrase)
+        return self.extract_methods(subclasses)
+
+    def get_subclasses(self) -> List[SourceType]:
+        """Collects all known subclasses of Nemesis class"""
+        tmp = self.base_class.__subclasses__()
+        subclasses = []
+        while tmp:
+            for nemesis in tmp.copy():
+                subclasses.append(nemesis)
+                tmp.remove(nemesis)
+                tmp.extend(nemesis.__subclasses__())
+        return subclasses
+
+    def extract_methods(self, subclasses_list: List[SourceType]) -> List[DisruptMethod]:
+        """Transform list of classes into a list of disrupt method to run"""
+        disrupt_methods = []
+        for subclass in subclasses_list:
+            if method_name_str := get_disrupt_method_from_class(subclass):
+                disrupt_methods.append(method_name_str)
+        disrupt_methods_objects_list = [func for name, func in inspect.getmembers(
+            self.base_class) if name in disrupt_methods and callable(func)]
+        return disrupt_methods_objects_list
+
+    def gather_properties(self) -> Tuple[Dict[SourceType, Dict[str, bool]], Dict[str, Dict[str, bool]]]:
+        """Return all properties for all known subclasses and their respective disrupt methods"""
+        class_properties = {}
+        method_properties = {}
+        for subclass in self.get_subclasses():
+            properties_list = {}
+            for attribute in subclass.__dict__.keys():
+                if attribute[:2] != "__":
+                    value = getattr(subclass, attribute)
+                    if not callable(value):
+                        properties_list[attribute] = value
+
+            if method_name_str := get_disrupt_method_from_class(subclass):
+                class_properties[subclass.__name__] = properties_list
+                method_properties[method_name_str] = properties_list
+        return class_properties, method_properties

--- a/test-cases/features/2mv-backpressure-4d.yaml
+++ b/test-cases/features/2mv-backpressure-4d.yaml
@@ -12,5 +12,5 @@ user_prefix: 'longevity-2mv-backpressure-4d'
 instance_type_db: 'i4i.2xlarge'
 instance_type_loader: 'c6i.2xlarge'
 
-nemesis_class_name: 'ChaosMonkey'
+nemesis_class_name: 'SisyphusMonkey'
 nemesis_during_prepare: false

--- a/unit_tests/test_nemesis.py
+++ b/unit_tests/test_nemesis.py
@@ -134,7 +134,8 @@ def test_list_nemesis_of_added_disrupt_methods(capsys):
         nemesis = ChaosMonkey(FakeTester(), None)
         assert 'disrupt_rnd_method' in [
             method.__name__ for method in nemesis.nemesis_registry.get_disrupt_methods()]
-    assert nemesis.call_random_disrupt_method(disrupt_methods=['disrupt_rnd_method']) is None
+    nemesis.disruptions_list = nemesis.build_disruptions_by_name(['disrupt_rnd_method'])
+    nemesis.call_next_nemesis()
     captured = capsys.readouterr()
     assert "It Works!" in captured.out
 

--- a/unit_tests/test_nemesis.py
+++ b/unit_tests/test_nemesis.py
@@ -99,8 +99,8 @@ class FakeCategoricalMonkey(CategoricalMonkey):
         return object.__new__(cls)
 
     def __init__(self, tester_obj, termination_event, dist: dict, default_weight: float = 1):
-        setattr(CategoricalMonkey, 'disrupt_m1', self.disrupt_m1)
-        setattr(CategoricalMonkey, 'disrupt_m2', self.disrupt_m2)
+        setattr(CategoricalMonkey, 'disrupt_m1', FakeCategoricalMonkey.disrupt_m1)
+        setattr(CategoricalMonkey, 'disrupt_m2', FakeCategoricalMonkey.disrupt_m2)
         super().__init__(tester_obj, termination_event, dist, default_weight=default_weight)
 
     def disrupt_m1(self):
@@ -113,7 +113,7 @@ class FakeCategoricalMonkey(CategoricalMonkey):
         return self.runs
 
 
-class AddRemoveDCMonkey(FakeNemesis):
+class AddRemoveDCMonkey(ChaosMonkey):
     @Nemesis.add_disrupt_method
     def disrupt_add_remove_dc(self):  # pylint: disable=no-self-use
         return 'Worked'
@@ -125,7 +125,8 @@ class AddRemoveDCMonkey(FakeNemesis):
 @pytest.mark.usefixtures('events')
 def test_list_nemesis_of_added_disrupt_methods():
     nemesis = ChaosMonkey(FakeTester(), None)
-    assert 'disrupt_add_remove_dc' in nemesis.get_list_of_methods_by_flags(disruptive=False)
+    assert 'disrupt_add_remove_dc' in [
+        method.__name__ for method in nemesis.nemesis_registry.get_disrupt_methods("disruptive")]
     assert nemesis.call_random_disrupt_method(disrupt_methods=['disrupt_add_remove_dc']) is None
 
 

--- a/unit_tests/test_nemesis_sisyphus.py
+++ b/unit_tests/test_nemesis_sisyphus.py
@@ -1,95 +1,26 @@
-from dataclasses import dataclass, field
 import yaml
 
 from sdcm import sct_abs_path
-from sdcm.nemesis import Nemesis, SisyphusMonkey
-from sdcm.cluster import BaseScyllaCluster
-
-PARAMS = dict(nemesis_interval=1, nemesis_filter_seeds=False)
-
-
-@dataclass
-class Node:
-    running_nemesis = None
-    public_ip_address: str = '127.0.0.1'
-    name: str = 'Node1'
-
-    @property
-    def scylla_shards(self):
-        return 8
-
-
-@dataclass
-class Cluster:
-    nodes: list
-    params: dict = field(default_factory=lambda: PARAMS)
-
-    def check_cluster_health(self):
-        pass
-
-    @property
-    def data_nodes(self):
-        return self.nodes
-
-    @property
-    def zero_nodes(self):
-        return self.nodes
-
-
-@dataclass
-class FakeTester:
-    params: dict = field(default_factory=lambda: PARAMS)
-    loaders: list = field(default_factory=list)
-    db_cluster: Cluster | BaseScyllaCluster = field(default_factory=lambda: Cluster(nodes=[Node(), Node()]))
-    monitors: list = field(default_factory=list)
-
-    def __post_init__(self):
-        self.db_cluster.params = self.params
-
-    def create_stats(self):
-        pass
-
-    def update(self, *args, **kwargs):
-        pass
-
-    def get_scylla_versions(self):
-        pass
-
-    def get_test_details(self):
-        pass
-
-    def id(self):  # pylint: disable=invalid-name,no-self-use
-        return 0
-
-
-class FakeNemesis(Nemesis):
-    def __new__(cls, tester_obj, termination_event, *args):  # pylint: disable=unused-argument
-        return object.__new__(cls)
-
-    def disrupt(self):
-        pass
+from sdcm.nemesis import Nemesis, COMPLEX_NEMESIS
+from sdcm.nemesis_registry import NemesisRegistry
 
 
 def test_list_all_available_nemesis(generate_file=True):
-    tester = FakeTester()
-
-    tester.params["nemesis_seed"] = '1'
-    sisyphus = SisyphusMonkey(tester, None)
-
-    subclasses = sisyphus._get_subclasses()  # pylint: disable=protected-access
-    disruption_list, disruptions_dict, disruption_classes = sisyphus.get_list_of_disrupt_methods(
-        subclasses_list=subclasses, export_properties=True)
+    registry = NemesisRegistry(Nemesis, COMPLEX_NEMESIS)
+    disruption_list = registry.get_disrupt_methods()
 
     assert len(disruption_list) == 92
 
+    class_properties, method_properties = registry.gather_properties()
+    sorted_dict = dict(sorted(method_properties.items(), key=lambda d: d[0]))
     if generate_file:
         with open(sct_abs_path('data_dir/nemesis.yml'), 'w', encoding="utf-8") as outfile1:
-            yaml.dump(disruptions_dict, outfile1, default_flow_style=False)
+            yaml.dump(sorted_dict, outfile1, default_flow_style=False)
 
         with open(sct_abs_path('data_dir/nemesis_classes.yml'), 'w', encoding="utf-8") as outfile2:
-            yaml.dump(disruption_classes, outfile2, default_flow_style=False)
+            yaml.dump(sorted(class_properties.keys()), outfile2, default_flow_style=False)
 
     with open(sct_abs_path('data_dir/nemesis.yml'), 'r', encoding="utf-8") as nemesis_file:
         static_nemesis_list = yaml.safe_load(nemesis_file)
 
-    assert static_nemesis_list == disruptions_dict
+    assert static_nemesis_list == method_properties


### PR DESCRIPTION
# Problem statement

Currently, the Nemesis class has too many responsibilities, which causes problems, one of the problems is that it requires parameters to initialize and does a lot of logic in the `init` function and you need to provide those even if you need only part of the class. Problem manifests can be seen in `test_nemesis_sisyphus` which needs to mock Tester, Cluster and Node to filter nemesis, but none of methods used required any of this, we need to provide it because of the aforementioned problem.

# Solution

Extract Nemesis discovery (i.e. Gathering all disrupt method and matching it with subclasses) to a separate class. While doing so, also reduce the nemesis discovery methods needed. Only one method for filtering is now present (`NemesisRegistry.get_disrupt_methods`) and input is a logical phrase. To allow also extracting properties to `nemesis.yaml`/`nemesis_classes.yaml` add `gather_properties`.

`nemesis.yaml` was also changed from list containing strings, to a full on dict. Dict is sorted so the desired output is essentially the same, but it requires less processing to write/read.

All Monkey which only filtered by flags (`LimitedChaosMonkey`, `GeminiNonDisruptiveChaosMonkey`, `GeminiChaosMonkey`, `NetworkMonkey`, `NonDisruptiveMonkey`, `DisruptiveMonkey`, `FreeTierSetMonkey`)
were removed and replaced by `nemesis_selector` usage

# Changelog

* Add `NemesisRegistry` class
  * Responsible for gathering and filtering available disrupt methods
  * Semi-generic, theoretically it could be used on any class that has disrupt method, not only Nemesis
     * Currently only requirement is that is has `disrupt` method
  * Requires no runtime information to initialize
* Limit source code searching to disrupt method
  *  This improvement changes time of  `test_nemesis_sisyphus` from 13 sec to 3 sec, including python env initialization
* Rewrite  `test_nemesis_sisyphus` to demonstrate improvements
* Remove Monkeys that use filtering by flags
* Change `nemesis.yaml` structure into a dict

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/phala/job/longevity-schema-changes-3h-test/40/
   - Based on `test-cases/longevity/longevity-sla-100gb-4h` test, as that is one of the test affected by the changes
   - Failed due to a known issue https://github.com/scylladb/scylla-enterprise/issues/2572, but the nemesis was executed
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/phala/job/longevity-100gb-4h-test/10/
   - General longevity to verify Sisyphus correctness

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
