### PR TITLE
improvement(scylla-bench): report scylla-bench version info in logs

### DIFF
--- a/sdcm/reporting/tooling_reporter.py
+++ b/sdcm/reporting/tooling_reporter.py
@@ -186,3 +186,42 @@ class LatteRustDriverVersionReporter(ToolReporterBase):
 
     def _collect_version_info(self) -> None:
         pass
+
+
+class ScyllaBenchVersionReporter(ToolReporterBase):
+    """
+    Reports scylla-bench and scylla gocql driver versions used in SCT.
+    """
+    TOOL_NAME = "scylla-bench"
+
+    def _collect_version_info(self) -> None:
+        output = self.runner.run(f"{self.command_prefix} {self.TOOL_NAME} -version-json")
+        LOGGER.debug("%s: Collected scylla-bench version output:\n%s", self, output.stdout)
+        version_info = json.loads(output.stdout)
+        LOGGER.debug("Result:\n%s", version_info)
+
+        s_b_info = version_info.get("scylla-bench", {})
+        self.version = f"{s_b_info.get('version', '#FAILED_CHECK_LOGS')}"
+        self.date = s_b_info.get('commit_date')
+        self.revision_id = s_b_info.get('commit_sha')
+
+        if driver_details := version_info.get("scylla-driver", {}):
+            ScyllaBenchGoCqlDriverVersionReporter(
+                driver_version=driver_details.get('version'),
+                date=driver_details.get("commit_date"),
+                revision_id=driver_details.get("commit_sha"),
+                argus_client=self.argus_client
+            ).report()
+
+
+class ScyllaBenchGoCqlDriverVersionReporter(ToolReporterBase):
+    TOOL_NAME = "scylla-bench-gocql-driver"
+
+    def __init__(self, driver_version: str, date: str, revision_id: str, argus_client: ArgusSCTClient = None) -> None:
+        super().__init__(None, "", argus_client)
+        self.version = driver_version
+        self.date = date
+        self.revision_id = revision_id
+
+    def _collect_version_info(self) -> None:
+        pass


### PR DESCRIPTION
The change implements scylla-bench and scylla-go-cql driver versions reporter.

Closes: https://github.com/scylladb/qa-tasks/issues/1877

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [pr-provision-test](https://argus.scylladb.com/tests/scylla-cluster-tests/f263cae2-ea9e-4906-b224-6ab8a3e13ba0/packages)
The test run was executed against `scylla-bench:0.2.0 image`, which has the support for getting s-b and scylladb-gocql driver versions info. But due to https://github.com/scylladb/scylla-bench/issues/178 the retrieved version data misses the commit date and sha attributes ('unknown' placeholder is used now instead). Still the versions themselves are retrieved and properly set in argus.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
