### PR TITLE
fix(event_counter): switch to thread base class

### DIFF
--- a/sdcm/sct_events/event_counter.py
+++ b/sdcm/sct_events/event_counter.py
@@ -13,7 +13,7 @@
 
 import re
 import logging
-import multiprocessing
+import threading
 
 from dataclasses import dataclass
 from pathlib import Path
@@ -99,12 +99,12 @@ EventStatHandleMapper = {
 }
 
 
-class EventsCounter(BaseEventsProcess[Tuple[str, Any], None], multiprocessing.Process):
+class EventsCounter(BaseEventsProcess[Tuple[str, Any], None], threading.Thread):
 
     def __init__(self, _registry: EventsProcessesRegistry):
         base_dir: Path = get_events_main_device(_registry=_registry).events_log_base_dir
         self.events_stat_dir = base_dir / Path(EVENT_COUNTER_DIR)
-        self.counters_register = multiprocessing.Manager().dict()
+        self.counters_register = dict()
         super().__init__(_registry=_registry)
 
     def run(self) -> None:

--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -13,7 +13,6 @@
 
 import json
 import time
-import atexit
 import logging
 from typing import Union, Optional
 from pathlib import Path
@@ -61,8 +60,6 @@ def start_events_device(log_dir: Optional[Union[str, Path]] = None,
     start_events_counter(_registry=_registry)
 
     time.sleep(EVENTS_SUBSCRIBERS_START_DELAY)
-
-    atexit.register(stop_events_device, _registry=_registry)
 
 
 def stop_events_device(_registry: Optional[EventsProcessesRegistry] = None) -> None:


### PR DESCRIPTION
using it as a process is forcing us to use multiprocess sync manager which in turn can leave running processes until the test end

there no real reason for using a process with this one so switching it to the thread base implementation

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] integration tests
- [x] provision tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
