### PR TITLE
fix(artifacts_test): Skip IOTuneValidator on unsupported instances

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -16,6 +16,7 @@ import re
 import typing
 from functools import cached_property
 import json
+from unittest import SkipTest
 
 import yaml
 import requests
@@ -331,6 +332,9 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
         if backend in ["gce", "aws", "azure"] and self.params.get("use_preinstalled_scylla"):
             with self.subTest("check Scylla IO Params"):
                 try:
+                    if self.node.db_node_instance_type in ["t3.micro"]:
+                        self.skipTest(
+                            f"{self.node.db_node_instance_type} is not a supported instance - skipping this test.")
                     validator = IOTuneValidator(self.node)
                     validator.validate()
                     send_iotune_results_to_argus(
@@ -339,6 +343,8 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
                         self.node,
                         self.params
                     )
+                except SkipTest as exc:
+                    self.log.info("Skipping IOTuneValidation due to %s", exc.args)
                 except Exception:  # pylint: disable=broad-except # noqa: BLE001
                     self.log.error("IOTuneValidator failed", exc_info=True)
                     TestFrameworkEvent(source={self.__class__.__name__},


### PR DESCRIPTION
This commit adds a check for unsupported instances and skips the subtest
if an instance is found to be unsupported.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
