### PR TITLE
fix(certificate_builder): Add ssl factory entrypoint for cqlshrc

### DIFF
--- a/sdcm/provision/helpers/certificate.py
+++ b/sdcm/provision/helpers/certificate.py
@@ -83,6 +83,9 @@ def install_client_certificate(remoter, node_identifier):
     setup_script = dedent(f"""
         mkdir -p ~/.cassandra/
         cp /tmp/ssl_conf/client/cqlshrc ~/.cassandra/
+        sed -i '/ssl = true/a hostname = {node_identifier}' ~/.cassandra/cqlshrc
+        sudo mkdir -p /root/.cassandra
+        sudo cp ~/.cassandra/cqlshrc /root/.cassandra
         sudo mkdir -p /etc/scylla/
         sudo rm -rf {SCYLLA_SSL_CONF_DIR}
         sudo mv -f /tmp/ssl_conf/ /etc/scylla/

--- a/sdcm/provision/scylla_yaml/certificate_builder.py
+++ b/sdcm/provision/scylla_yaml/certificate_builder.py
@@ -31,6 +31,10 @@ CQLSHRC_FILE = get_data_dir_path('ssl_conf', 'client', 'cqlshrc')
 def update_cqlshrc(cqlshrc_file: str = CQLSHRC_FILE, client_encrypt: bool = False) -> None:
     config = configparser.ConfigParser()
     config.read(cqlshrc_file)
+    if client_encrypt:
+        if not config['connection']:
+            config['connection'] = {}
+        config['connection']['ssl'] = 'true'
     config['ssl'] = {
         'validate': 'true' if client_encrypt else 'false',
         'certfile': f'{SCYLLA_SSL_CONF_DIR / CA_CERT_FILE.name}',


### PR DESCRIPTION
This commit allows scylla-doctor to use correct certificates when
checking CQLsh liveliness.

Fixes #10490

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Jenkins/UbuntuFIPS](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/artifacts-ubuntu2004-fips-test/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
