### PR TITLE
fix(shutdown): stop argus heartbeat thread quicker

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -367,10 +367,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                     break
                 try:
                     client.sct_heartbeat()
+                    fail_count = 0  # Reset fail_count on success
                 except Exception:  # pylint: disable=broad-except  # noqa: BLE001
                     self.log.warning("Failed to submit heartbeat to argus, Try #%s", fail_count + 1)
                     fail_count += 1
-                time.sleep(30.0)
+                stop_signal.wait(timeout=30.0)
 
         thread_stop_signal = threading.Event()
         thread = threading.Thread(name="argus-heartbeat",


### PR DESCRIPTION
We face issues with python coredumping upon SCT shutdown. One of the reason might be running argus heartbeat thread which is not awaited to complete (and it may take up to 30 secs to end).

Fix by quittin it as soon as shutdown is initiated without waiting for sleep to end.

refs: https://github.com/scylladb/scylla-cluster-tests/issues/9784

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - provision test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
