### PR TITLE
improvement(latte_cs_alike.rn): support `counter_write` and `counter_read`

### DIFF
--- a/data_dir/latte/latte_cs_alike.rn
+++ b/data_dir/latte/latte_cs_alike.rn
@@ -36,6 +36,7 @@ const COMPRESSION = latte::param!("compression", "");
 const COMPACTION_STRATEGY = latte::param!("compaction_strategy", "");
 const KEYSPACE = latte::param!("keyspace", "keyspace1");
 const TABLE = latte::param!("table", "standard1");
+const COUNTER_TABLE = latte::param!("counter_table", "counter1");
 const KEY_SIZE = latte::param!("key_size", 16);
 const COLUMN_SIZE = latte::param!("column_size", 128);
 const COLUMN_COUNT = latte::param!("column_count", 8);
@@ -44,8 +45,10 @@ const OFFSET = latte::param!("offset", 0);
 const GAUSS_MEAN = latte::param!("gauss_mean", 0);
 const GAUSS_STDDEV = latte::param!("gauss_stddev", 0);
 
-const P_STMT_WRITE = "latte_prep_stmt___write";
+const P_STMT_WRITE = "latte_prep_stmt__write";
 const P_STMT_READ = "latte_prep_stmt__read";
+const P_STMT_COUNTER_WRITE = "latte_prep_stmt__counter_write";
+const P_STMT_COUNTER_READ = "latte_prep_stmt__counter_read";
 
 //////////////////////////////
 // LATTE-SPECIFIC FUNCTIONS //
@@ -58,13 +61,15 @@ pub async fn schema(db) {
         AND durable_writes = true
     `).await?;
 
-    // Create tables
+    // Prepare tables params
     if COLUMN_COUNT < 1 {
         return Err("'column_count' cannot be less than '1'")
     }
     let columns_def = "";
+    let counter_columns_def = "";
     for i in 0..=COLUMN_COUNT-1 {
-        columns_def += ", \"C" + `${i}` + "\" blob"
+        columns_def += ", \"C" + `${i}` + "\" blob";
+        counter_columns_def += ", \"C" + `${i}` + "\" counter";
     }
     let compression = ") WITH compression = {";
     if COMPRESSION.is_empty() { // This is the default like in the C-S case
@@ -79,15 +84,24 @@ pub async fn schema(db) {
         // Result: WITH COMPACTION = { 'class': 'IncrementalCompactionStrategy' }
         compaction += " AND COMPACTION = { 'class' : '" + COMPACTION_STRATEGY + "' }"
     }
+    let comment = " AND comment='Created by latte'";
+
+    // Create blob table
     db.execute(
         `CREATE TABLE IF NOT EXISTS ${KEYSPACE}.${TABLE}` +
-        `(key blob PRIMARY KEY${columns_def}${compression}${compaction}`
+        `(key blob PRIMARY KEY${columns_def}${compression}${compaction}${comment}`
     ).await?;
-    // TODO: add creation of the 'counter1' table?
+
+    // Create counter table
+    db.execute(
+        `CREATE TABLE IF NOT EXISTS ${KEYSPACE}.${COUNTER_TABLE}` +
+        `(key blob PRIMARY KEY${counter_columns_def}${compression}${compaction}${comment}`
+    ).await?;
 }
 
 pub async fn erase(db) {
     db.execute(`TRUNCATE TABLE ${KEYSPACE}.${TABLE}`).await?;
+    db.execute(`TRUNCATE TABLE ${KEYSPACE}.${COUNTER_TABLE}`).await?;
 }
 
 pub async fn prepare(db) {
@@ -99,15 +113,30 @@ pub async fn prepare(db) {
 
     let columns_keys = "";
     let columns_values = "";
+    let counter_columns = "";
     for i in 0..=COLUMN_COUNT-1 {
         columns_keys += ", \"C" + `${i}` + "\"";
         columns_values += `, :C${i}`;
+        let counter_prefix = "";
+        if i > 0 {
+            counter_prefix = ", ";
+        }
+        counter_columns += `${counter_prefix}` + "\"C" + `${i}` + "\" = \"C" + `${i}` + "\" + " + `:C${i}`;
     }
+
     db.prepare(
         P_STMT_WRITE,
         `INSERT INTO ${KEYSPACE}.${TABLE}(key${columns_keys}) VALUES (:key${columns_values})`
     ).await?;
     db.prepare(P_STMT_READ, `SELECT * FROM ${KEYSPACE}.${TABLE} WHERE key = :key`).await?;
+
+    db.prepare(
+        P_STMT_COUNTER_WRITE,
+        `UPDATE ${KEYSPACE}.${COUNTER_TABLE}` +
+        ` SET ${counter_columns}` +
+        " WHERE key = :key"
+    ).await?;
+    db.prepare(P_STMT_COUNTER_READ, `SELECT * FROM ${KEYSPACE}.${COUNTER_TABLE} WHERE key = :key`).await?;
 
     prepare_gauss_distribution(db).await
 }
@@ -152,11 +181,21 @@ async fn get_partition_idx(db, i) {
 }
 
 /// Utility function to be used by the 'write' public function
-async fn get_columns_data(key, idx) {
+async fn get_blob_columns_data(key, idx) {
     let columns = [key];
     for current_column_idx in 0..=COLUMN_COUNT-1 {
         columns.push(blob(idx + current_column_idx * ROW_COUNT, COLUMN_SIZE));
     }
+    return columns
+}
+
+/// Utility function to be used by the 'counter_write' public function
+async fn get_counter_columns_data(key, idx) {
+    let columns = [];
+    for current_column_idx in 0..=COLUMN_COUNT-1 {
+        columns.push(1);
+    }
+    columns.push(key);
     return columns
 }
 
@@ -167,11 +206,23 @@ async fn get_columns_data(key, idx) {
 pub async fn write(db, i) {
     let partition_idx = get_partition_idx(db, i).await;
     let key = blob(partition_idx, KEY_SIZE);
-    db.execute_prepared(P_STMT_WRITE, get_columns_data(key, partition_idx).await).await?
+    db.execute_prepared(P_STMT_WRITE, get_blob_columns_data(key, partition_idx).await).await?
 }
 
 pub async fn read(db, i) {
     let partition_idx = get_partition_idx(db, i).await;
     let key = blob(partition_idx, KEY_SIZE);
     db.execute_prepared(P_STMT_READ, [key]).await?
+}
+
+pub async fn counter_write(db, i) {
+    let partition_idx = get_partition_idx(db, i).await;
+    let key = blob(partition_idx, KEY_SIZE);
+    db.execute_prepared(P_STMT_COUNTER_WRITE, get_counter_columns_data(key, partition_idx).await).await?
+}
+
+pub async fn counter_read(db, i) {
+    let partition_idx = get_partition_idx(db, i).await;
+    let key = blob(partition_idx, KEY_SIZE);
+    db.execute_prepared(P_STMT_COUNTER_READ, [key]).await?
 }

--- a/data_dir/monitoring-dash-template.json
+++ b/data_dir/monitoring-dash-template.json
@@ -186,18 +186,25 @@
                             "refId": "C"
                         },
                         {
-                            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
+                            "expr": "sct_latte_counter_write_gauge{type=\"lat_perc_95\"}",
                             "format": "time_series",
                             "interval": "15s",
                             "intervalFactor": 1,
                             "refId": "D"
                         },
                         {
-                            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
+                            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
                             "format": "time_series",
                             "interval": "15s",
                             "intervalFactor": 1,
                             "refId": "E"
+                        },
+                        {
+                            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
+                            "format": "time_series",
+                            "interval": "15s",
+                            "intervalFactor": 1,
+                            "refId": "F"
                         }
                     ],
                     "title": "WRITE P95 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
@@ -244,18 +251,25 @@
                             "refId": "C"
                         },
                         {
-                            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
+                            "expr": "sct_latte_counter_write_gauge{type=\"lat_perc_95\"}",
                             "format": "time_series",
                             "interval": "15s",
                             "intervalFactor": 1,
                             "refId": "D"
                         },
                         {
-                            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
+                            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
                             "format": "time_series",
                             "interval": "15s",
                             "intervalFactor": 1,
                             "refId": "E"
+                        },
+                        {
+                            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
+                            "format": "time_series",
+                            "interval": "15s",
+                            "intervalFactor": 1,
+                            "refId": "F"
                         }
                     ],
                     "title": "WRITE P95 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",
@@ -550,18 +564,25 @@
                             "refId": "C"
                         },
                         {
-                            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_99\"}",
+                            "expr": "sct_latte_counter_write_gauge{type=\"lat_perc_99\"}",
                             "format": "time_series",
                             "interval": "15s",
                             "intervalFactor": 1,
                             "refId": "D"
                         },
                         {
-                            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}",
+                            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_99\"}",
                             "format": "time_series",
                             "interval": "15s",
                             "intervalFactor": 1,
                             "refId": "E"
+                        },
+                        {
+                            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}",
+                            "format": "time_series",
+                            "interval": "15s",
+                            "intervalFactor": 1,
+                            "refId": "F"
                         }
                     ],
                     "title": "WRITE P99 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
@@ -608,18 +629,25 @@
                             "refId": "C"
                         },
                         {
-                            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_99\"}",
+                            "expr": "sct_latte_counter_write_gauge{type=\"lat_perc_99\"}",
                             "format": "time_series",
                             "interval": "15s",
                             "intervalFactor": 1,
                             "refId": "D"
                         },
                         {
-                            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}",
+                            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_99\"}",
                             "format": "time_series",
                             "interval": "15s",
                             "intervalFactor": 1,
                             "refId": "E"
+                        },
+                        {
+                            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}",
+                            "format": "time_series",
+                            "interval": "15s",
+                            "intervalFactor": 1,
+                            "refId": "F"
                         }
                     ],
                     "title": "WRITE P99 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",

--- a/data_dir/scylla-dash-per-server-nemesis.master.json
+++ b/data_dir/scylla-dash-per-server-nemesis.master.json
@@ -822,18 +822,25 @@
             "refId": "C"
           },
           {
-            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
+            "expr": "sct_latte_counter_write_gauge{type=\"lat_perc_95\"}",
             "format": "time_series",
             "interval": "15s",
             "intervalFactor": 1,
             "refId": "D"
           },
           {
-            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
+            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
             "format": "time_series",
             "interval": "15s",
             "intervalFactor": 1,
             "refId": "E"
+          },
+          {
+            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "F"
           }
         ],
         "title": "WRITE P95 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
@@ -914,18 +921,25 @@
             "refId": "C"
           },
           {
-            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
+            "expr": "sct_latte_counter_write_gauge{type=\"lat_perc_95\"}",
             "format": "time_series",
             "interval": "15s",
             "intervalFactor": 1,
             "refId": "D"
           },
           {
-            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
+            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
             "format": "time_series",
             "interval": "15s",
             "intervalFactor": 1,
             "refId": "E"
+          },
+          {
+            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "F"
           }
         ],
         "title": "WRITE P95 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",
@@ -1616,18 +1630,25 @@
             "refId": "C"
           },
           {
-            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_99\"}",
+            "expr": "sct_latte_counter_write_gauge{type=\"lat_perc_99\"}",
             "format": "time_series",
             "interval": "15s",
             "intervalFactor": 1,
             "refId": "D"
           },
           {
-            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}",
+            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_99\"}",
             "format": "time_series",
             "interval": "15s",
             "intervalFactor": 1,
             "refId": "E"
+          },
+          {
+            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "F"
           }
         ],
         "title": "WRITE P99 latency | C-S and/or CQL-stress and/or Latte benchmarking tools",
@@ -1708,18 +1729,25 @@
             "refId": "C"
           },
           {
-            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_99\"}",
+            "expr": "sct_latte_counter_write_gauge{type=\"lat_perc_99\"}",
             "format": "time_series",
             "interval": "15s",
             "intervalFactor": 1,
             "refId": "D"
           },
           {
-            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}",
+            "expr": "sct_cql_stress_cassandra_stress_write_gauge{type=\"lat_perc_99\"}",
             "format": "time_series",
             "interval": "15s",
             "intervalFactor": 1,
             "refId": "E"
+          },
+          {
+            "expr": "sct_cql_stress_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "F"
           }
         ],
         "title": "WRITE P99 latency histogram | C-S and/or CQL-stress and/or Latte benchmarking tools",

--- a/sdcm/stress/latte_thread.py
+++ b/sdcm/stress/latte_thread.py
@@ -53,20 +53,28 @@ def find_latte_fn_names(stress_cmd):
 
 
 def get_latte_operation_type(stress_cmd):
-    write_found, read_found = False, False
+    write_found, counter_write, read_found, counter_read = False, False, False, False
     for fn in find_latte_fn_names(stress_cmd):
-        if re.findall(r"(?:^|_)(write|insert|update|delete)(?:_|$)", fn):
+        if fn == "counter_write":
+            counter_write = True
+        elif fn == "counter_read":
+            counter_read = True
+        elif re.findall(r"(?:^|_)(write|insert|update|delete)(?:_|$)", fn):
             write_found = True
         elif re.findall(r"(?:^|_)(read|select|get|count)(?:_|$)", fn):
             read_found = True
         else:
             return "user"
-    if write_found and read_found:
-        return "mixed"
-    elif write_found:
+    if write_found and not (counter_write or counter_read or read_found):
         return "write"
-    else:
+    elif read_found and not (counter_write or counter_read or write_found):
         return "read"
+    elif counter_write and not (write_found or read_found or counter_read):
+        return "counter_write"
+    elif counter_read and not (write_found or read_found or counter_write):
+        return "counter_read"
+    else:
+        return "mixed"
 
 
 class LatteStressThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes

--- a/unit_tests/test_latte_thread.py
+++ b/unit_tests/test_latte_thread.py
@@ -194,6 +194,7 @@ def test_find_latte_fn_names(cmd, items):
         ("latte run /foo/bar.rn %sdelete -q -r 500", "write"),
         ("latte run /foo/bar.rn %sinsert_delete -q -r 500", "write"),
         ("latte run /foo/bar.rn %sinsert_delete_by_one -q -r 500", "write"),
+        ("latte run /foo/bar.rn %scounter_write -q -r 500", "counter_write"),
 
         ("latte run /foo/bar.rn %sread -q -r 500", "read"),
         ("latte run /foo/bar.rn %sread_all -q -r 500", "read"),
@@ -209,10 +210,15 @@ def test_find_latte_fn_names(cmd, items):
         ("latte run /foo/bar.rn %smulti_get -q -r 500", "read"),
         ("latte run /foo/bar.rn %sdo_get_all -q -r 500", "read"),
         ("latte run /foo/bar.rn %sget_all,get_single -q -r 500", "read"),
+        ("latte run /foo/bar.rn %scounter_read -q -r 500", "counter_read"),
 
         ("latte run /foo/bar.rn %sread,write -q -r 500", "mixed"),
         ("latte run /foo/bar.rn %swrite:1,read:2 -q -r 500", "mixed"),
         ("latte run /foo/bar.rn %sbatch_insert:1,read_all:2,get_bar:0.5 -q -r 500", "mixed"),
+        ("latte run /foo/bar.rn %sread,counter_write -q -r 500", "mixed"),
+        ("latte run /foo/bar.rn %sread,counter_read -q -r 500", "mixed"),
+        ("latte run /foo/bar.rn %swrite,counter_read -q -r 500", "mixed"),
+        ("latte run /foo/bar.rn %swrite,counter_write -q -r 500", "mixed"),
 
         ("latte run /foo/bar.rn %scustom -q -r 500", "user"),
         ("latte run /foo/bar.rn %suser_profile -q -r 500", "user"),


### PR DESCRIPTION
Add support of the `counter_write` and `counter_read` operations
to the `data_dir/latte/latte_cs_alike.rn` rune script which aims to mimic the C-S behavior.

Also, update the Grafana dashboards to distinguish these new operation metrics
from common `write` and `read` ones.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-provision-test#12](https://argus.scylladb.com/tests/scylla-cluster-tests/5507c918-b49d-45ef-a81d-39b8026f3113)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
