### PR TITLE
improvement(latte): add tag or operation type to log filenames

### DIFF
--- a/sdcm/stress/latte_thread.py
+++ b/sdcm/stress/latte_thread.py
@@ -34,6 +34,7 @@ from sdcm.utils.docker_remote import RemoteDocker
 from sdcm.utils.remote_logger import HDRHistogramFileLogger
 
 LATTE_FN_NAME_RE = '(?:-f|--function)[ =]([\w\s\d:,]+)|--functions[ =]([\w\s\d:,]+)'
+LATTE_TAG_RE = r'--tag(?:\s+|=)([\w-]+(?:,[\w-]+)*)\b'
 LOGGER = logging.getLogger(__name__)
 
 
@@ -50,6 +51,18 @@ def find_latte_fn_names(stress_cmd):
                 # 'write' and 'read'
                 fn_names.append(sub_item.split(":")[0].strip())
     return fn_names
+
+
+def find_latte_tags(stress_cmd):
+    tags = []
+    matches = re.findall(LATTE_TAG_RE, stress_cmd)
+    for item in matches:
+        if not item.strip():
+            continue
+        sub_items = item.split(",")
+        for sub_item in sub_items:
+            tags.append(sub_item.strip())
+    return tags
 
 
 def get_latte_operation_type(stress_cmd):
@@ -175,13 +188,15 @@ class LatteStressThread(DockerBasedStressThread):  # pylint: disable=too-many-in
 
         if not os.path.exists(loader.logdir):
             os.makedirs(loader.logdir, exist_ok=True)
+
+        stress_operation = get_latte_operation_type(self.stress_cmd)
+        first_tag_or_op = "-" + (find_latte_tags(self.stress_cmd) or [stress_operation])[0]
         log_file_name = os.path.join(
-            loader.logdir, 'latte-l%s-c%s-%s.log' % (loader_idx, cpu_idx, uuid.uuid4()))
+            loader.logdir, 'latte%s-l%s-c%s-%s.log' % (first_tag_or_op, loader_idx, cpu_idx, uuid.uuid4()))
         LOGGER.debug('latte benchmarking tool local log: %s', log_file_name)
 
         # TODO: fix usage of the "$HOME". Code works when home is "/". It will fail for non-root.
         log_id = self._build_log_file_id(loader_idx, cpu_idx, "")
-        stress_operation = get_latte_operation_type(self.stress_cmd)
         remote_hdr_file_name = f"hdrh-latte-{stress_operation}-{log_id}.hdr"
         LOGGER.debug("latte remote HDR histogram log file: %s", remote_hdr_file_name)
         local_hdr_file_name = os.path.join(loader.logdir, remote_hdr_file_name)

--- a/unit_tests/test_latte_thread.py
+++ b/unit_tests/test_latte_thread.py
@@ -19,6 +19,7 @@ from sdcm import sct_abs_path
 from sdcm.stress.latte_thread import (
     LatteStressThread,
     find_latte_fn_names,
+    find_latte_tags,
     get_latte_operation_type,
 )
 from sdcm.utils.decorators import timeout
@@ -225,3 +226,22 @@ def test_get_latte_operation_type(cmd, expected_operation_type):
     for fn_param in fn_params:
         result = get_latte_operation_type(cmd % fn_param)
         assert expected_operation_type == result
+
+
+@pytest.mark.parametrize(
+    "cmd,items", (
+        ("%s --tag=latte-prepare-01 -q -r 500", ["latte-prepare-01"]),
+        ("%s --tag latte-main-01 -q -r 500", ["latte-main-01"]),
+        ("%s --tag  latte-prepare-01,write  -q -r 500", ["latte-prepare-01", "write"]),
+        ("%s --tag=latte-main-01,read    -q -r 500", ["latte-main-01", "read"]),
+        ("%s  --tag=latte-main-01  --tag   write,table1    -q -r 500", ["latte-main-01", "write", "table1"]),
+        ("%s --tag=latte-main-01,read  --tag table2  -q -r 500", ["latte-main-01", "read", "table2"]),
+        ("%s --tag=latte-main-01,read -q -r 500 --tag table2", ["latte-main-01", "read", "table2"]),
+    )
+)
+def test_find_latte_tags(cmd, items):
+    result = find_latte_tags(cmd % 'latte run /foo/bar.rn')
+    assert len(result) > 0
+    assert len(result) == len(items), f"Expected: {items}, Actual: {result}"
+    for item in items:
+        assert item in result


### PR DESCRIPTION
C-S logic adds operation type to the log filenames like following:
```
  cassandra-stress-counter_write-l1-c0-k1-624f47b6-c312-4858-97a7-00b95be2dca2.log
  cassandra-stress-write-l1-c0-k1-12398f84-08e0-4873-b4b2-6fb0237e03eb.log
```

It allows to distinguish multiple stress logs among each other.

Latte doesn't have such logic.

So, add the following behavior to ease latte logs usage:
- If `--tag foo` param for a latte command is specified then use first tag from all the tags for latte log filenames.
- If no tags are specified then use operation type instead.
  Possible values in this case: `write`, `read`, `mixed` and `user`.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-provision-test#12](https://argus.scylladb.com/tests/scylla-cluster-tests/5507c918-b49d-45ef-a81d-39b8026f3113)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
