### PR TITLE
fix(performance): run elasticity test with loader on docker

### DIFF
--- a/test-cases/performance/perf-regression-latency-650gb-elasticity.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-elasticity.yaml
@@ -30,7 +30,7 @@ backtrace_decoding: false
 
 store_perf_results: true
 email_recipients: ["scylla-perf-results@scylladb.com"]
-use_prepared_loaders: true
+use_prepared_loaders: false
 use_hdrhistogram: true
 email_subject_postfix: 'elasticity test'
 nemesis_double_load_during_grow_shrink_duration: 30


### PR DESCRIPTION
The latest c-s version is 3.17.3.
This version is defined for elasticity perf test, but actually the loader is created from prepared AMI and not use latest c-s version. Run loader from docker and use latest c-s version

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [scylla-enterprise-perf-regression-latency-650gb-elasticity](https://argus.scylladb.com/tests/scylla-cluster-tests/00bc5952-309b-4b6b-a223-8c6c89ff21a4)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
