### PR TITLE
feature(cql-stress): add support for hdr histogram

### DIFF
--- a/configurations/performance/cql-stress-650gb-8-col-i4i-80-percent-throughput-ent.yaml
+++ b/configurations/performance/cql-stress-650gb-8-col-i4i-80-percent-throughput-ent.yaml
@@ -8,5 +8,4 @@ instance_type_db: 'i4i.2xlarge'
 stress_cmd_w: "cql-stress-cassandra-stress write no-warmup cl=QUORUM duration=2850m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=27000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
 stress_cmd_r: "cql-stress-cassandra-stress read no-warmup  cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=24000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
 stress_cmd_m: "cql-stress-cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=22000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,6500000)' "
-use_hdrhistogram: false  # https://github.com/scylladb/cql-stress/issues/95
 use_prepared_loaders: false  # no need for that - using docker anyway

--- a/configurations/performance/cql-stress-650gb-8-col-i4i-80-percent-throughput-oss.yaml
+++ b/configurations/performance/cql-stress-650gb-8-col-i4i-80-percent-throughput-oss.yaml
@@ -8,5 +8,4 @@ instance_type_db: 'i4i.2xlarge'
 stress_cmd_w: "cql-stress-cassandra-stress write no-warmup cl=QUORUM duration=2850m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=24000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
 stress_cmd_r: "cql-stress-cassandra-stress read no-warmup  cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=20000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
 stress_cmd_m: "cql-stress-cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=17000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,6500000)' "
-use_hdrhistogram: false  # https://github.com/scylladb/cql-stress/issues/95
 use_prepared_loaders: false  # no need for that - using docker anyway

--- a/configurations/performance/cql-stress-6gb-8-col-i4i-mini-test-throughput.yaml
+++ b/configurations/performance/cql-stress-6gb-8-col-i4i-mini-test-throughput.yaml
@@ -6,7 +6,6 @@ prepare_write_cmd: [ "cql-stress-cassandra-stress write no-warmup cl=ALL n=65000
 stress_cmd_w: "cql-stress-cassandra-stress write no-warmup cl=QUORUM duration=2850m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=6000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..6500000,3250000,97500)' "
 stress_cmd_r: "cql-stress-cassandra-stress read no-warmup  cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=5000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..6500000,3250000,97500)' "
 stress_cmd_m: "cql-stress-cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=4000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..6500000,3250000,65000)' "
-use_hdrhistogram: false  # https://github.com/scylladb/cql-stress/issues/95
 use_prepared_loaders: false  # no need for that - using docker anyway
 n_db_nodes: 3
 n_loaders: 1

--- a/defaults/docker_images/cql-stress-cassandra-stress/values_cql-stress-cassandra-stress.yaml
+++ b/defaults/docker_images/cql-stress-cassandra-stress/values_cql-stress-cassandra-stress.yaml
@@ -1,2 +1,2 @@
 cql-stress-cassandra-stress:
-  image: scylladb/cql-stress:0.1.0
+  image: scylladb/cql-stress:0.2.1

--- a/sdcm/cql_stress_cassandra_stress_thread.py
+++ b/sdcm/cql_stress_cassandra_stress_thread.py
@@ -17,13 +17,13 @@ import os
 import time
 import contextlib
 from typing import Any
-from sdcm.loader import CqlStressCassandraStressExporter
+from sdcm.loader import CqlStressCassandraStressExporter, CqlStressHDRExporter
 from sdcm.prometheus import nemesis_metrics_obj
 from sdcm.sct_events.loaders import CQL_STRESS_CS_ERROR_EVENTS_PATTERNS, CqlStressCassandraStressEvent
 from sdcm.stress_thread import CassandraStressThread
 from sdcm.utils.common import FileFollowerThread, SoftTimeoutContext
 from sdcm.utils.docker_remote import RemoteDocker
-
+from sdcm.utils.remote_logger import HDRHistogramFileLogger
 
 LOGGER = logging.getLogger(__name__)
 
@@ -82,13 +82,6 @@ class CqlStressCassandraStressThread(CassandraStressThread):
             stress_cmd = re.sub(r' (\'?)n=[\s]*fixed\(([0-9]+)\)(\'?)', r' \1n=\2\3',
                                 stress_cmd, flags=re.IGNORECASE)
 
-        if '-rate' in stress_cmd:
-            # In cassandra-stress either '-rate throttle=' or '-rate fixed=' parameter is accepted.
-            # In cql-stress we decided to change it so 'fixed' is a boolean flag
-            # specifying whether the tool should display coordination-omission fixed latencies.
-            stress_cmd = re.sub(r' fixed=[\s]*([0-9]+/s)',
-                                r' throttle=\1 fixed', stress_cmd)
-
         if '-pop' in stress_cmd and "seq=" in stress_cmd:
             # '-pop seq=x..y' syntax is not YET supported by cql-stress.
             # TODO remove when seq=x..y syntax is supported.
@@ -107,7 +100,7 @@ class CqlStressCassandraStressThread(CassandraStressThread):
         stress_cmd = self.adjust_cmd_node_option(stress_cmd, loader, cmd_runner)
         return stress_cmd
 
-    def _run_cs_stress(self, loader, loader_idx, cpu_idx, keyspace_idx):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    def _run_cs_stress(self, loader, loader_idx, cpu_idx, keyspace_idx):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements  # noqa: PLR0914
         # TODO:
         # - Add support for profile yaml once cql-stress supports 'user' command.
         # - Adjust metrics collection once cql-stress displays the metrics grouped by operation (mixed workload).
@@ -122,8 +115,14 @@ class CqlStressCassandraStressThread(CassandraStressThread):
         log_file_name = os.path.join(
             loader.logdir, f'cql-stress-cassandra-stress-{stress_cmd_opt}-{log_id}.log')
 
-        LOGGER.debug('cassandra-stress local log: %s', log_file_name)
-
+        LOGGER.debug('cql-stress-cassandra-stress local log: %s', log_file_name)
+        remote_hdr_file_name = f"hdrh-cscs-{stress_cmd_opt}-{log_id}.hdr"
+        LOGGER.debug("cql-stress-cassandra-stress remote HDR histogram log file: %s", remote_hdr_file_name)
+        local_hdr_file_name = os.path.join(loader.logdir, remote_hdr_file_name)
+        LOGGER.debug("cql-stress-cassandra-stress HDR local file %s", local_hdr_file_name)
+        loader.remoter.run(f"touch $HOME/{remote_hdr_file_name}", ignore_status=False, verbose=False)
+        remote_hdr_file_name_full_path = loader.remoter.run(
+            f"realpath $HOME/{remote_hdr_file_name}", ignore_status=False, verbose=False).stdout.strip()
         cmd_runner_name = loader.ip_address
 
         cpu_options = ""
@@ -136,8 +135,21 @@ class CqlStressCassandraStressThread(CassandraStressThread):
                                                     '--network=host '
                                                     '--security-opt seccomp=unconfined '
                                                     f'--label shell_marker={self.shell_marker}'
-                                                    f' --entrypoint /bin/bash')
+                                                    f' --entrypoint /bin/bash'
+                                                    f' -w /'
+                                                    f' -v {remote_hdr_file_name_full_path}:/{remote_hdr_file_name}'
+                                                    )
         stress_cmd = self.create_stress_cmd(cmd_runner, keyspace_idx, loader)
+
+        if self.params.get("use_hdrhistogram"):
+            stress_cmd = self._add_hdr_log_option(stress_cmd, remote_hdr_file_name)
+            hdrh_logger_context = HDRHistogramFileLogger(
+                node=loader,
+                remote_log_file=remote_hdr_file_name_full_path,
+                target_log_file=os.path.join(loader.logdir, remote_hdr_file_name),
+            )
+        else:
+            hdrh_logger_context = contextlib.nullcontext()
         LOGGER.info('Stress command:\n%s', stress_cmd)
 
         tag = f'TAG: loader_idx:{loader_idx}-cpu_idx:{cpu_idx}-keyspace_idx:{keyspace_idx}'
@@ -157,7 +169,14 @@ class CqlStressCassandraStressThread(CassandraStressThread):
                                                  loader_idx=loader_idx, cpu_idx=cpu_idx), \
                 CqlStressCassandraStressEventsPublisher(node=loader, log_filename=log_file_name) as publisher, \
                 CqlStressCassandraStressEvent(node=loader, stress_cmd=self.stress_cmd,
-                                              log_file_name=log_file_name) as cs_stress_event:
+                                              log_file_name=log_file_name) as cs_stress_event, \
+                CqlStressHDRExporter(instance_name=cmd_runner_name,
+                                     hdr_tags=self.hdr_tags,
+                                     metrics=nemesis_metrics_obj(),
+                                     stress_operation=stress_cmd_opt,
+                                     stress_log_filename=local_hdr_file_name,
+                                     loader_idx=loader_idx, cpu_idx=cpu_idx), \
+                hdrh_logger_context:
             publisher.event_id = cs_stress_event.event_id
             try:
                 # prolong timeout by 5% to avoid killing cassandra-stress process

--- a/sdcm/loader.py
+++ b/sdcm/loader.py
@@ -308,6 +308,17 @@ class LatteHDRExporter(CassandraStressHDRExporter):
         return gauge_name
 
 
+class CqlStressHDRExporter(CassandraStressHDRExporter):
+    def create_metrix_gauge(self):
+        gauge_name = f'collectd_cql_stress_hdr_{self.stress_operation}_gauge'
+        if gauge_name not in self.METRICS_GAUGES:
+            self.METRICS_GAUGES[gauge_name] = self.metrics.create_gauge(
+                gauge_name,
+                'Gauge for cql-stress hdr percentiles',
+                [f'cql_stress_hdr_{self.stress_operation}', 'instance', 'loader_idx', 'cpu_idx', 'type', 'keyspace'])
+        return gauge_name
+
+
 class CqlStressCassandraStressExporter(StressExporter):
     # Lines containing any of these should be skipped. These are the logs emitted by the `tracing` crate.
     TRACING_LOGS = ['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR']


### PR DESCRIPTION
Since cql-stress now supports hdr histogram, it can be enabled. cqlstress thread will respect `use_hdrhistogram` config param.

refs: https://github.com/scylladb/qa-tasks/issues/1861

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [perf upgrade test](https://argus.scylladb.com/tests/scylla-cluster-tests/5eea6056-c024-497c-9cc8-5b44a0406a7b)
- [x] - [small elasticity test](https://argus.scylladb.com/tests/scylla-cluster-tests/db02a215-add1-4c1b-a2a0-5b9037a08e14)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
