### PR TITLE
fix(double_cluster): stress command was waited incorrectly

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4366,8 +4366,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.log.info("Doubling the load on the cluster for %s minutes", duration)
         stress_queue = self.tester.run_stress_thread(
             stress_cmd=self.tester.stress_cmd, stress_num=1, stats_aggregate_cmds=False, duration=duration)
-        results, errors = stress_queue.parse_results()
-        self._nemesis_stress_failure_handler(results, errors)
+        results = self.tester.verify_stress_thread(thread_pool=stress_queue,
+                                                   error_handler=self._nemesis_stress_failure_handler)
         self.log.info(f"Double load results: {results}")
 
     @target_data_nodes


### PR DESCRIPTION
nemesis case was calling `_nemesis_stress_failure_handler` with the wrong arguments, hence failing like:

```
Traceback (most recent call last):
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 5688, in wrapper
result = method(*args[1:], **kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 4384, in disrupt_grow_shrink_cluster
self._double_cluster_load(duration)
File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/decorators.py", line 224, in wrapped
res = func(*args, **kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 4370, in _double_cluster_load
self._nemesis_stress_failure_handler(results, errors)
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 2139, in _nemesis_stress_failure_handler
if len(errors) == len(stress_pool.get_results()):
AttributeError: 'list' object has no attribute 'get_results'
```

this commit change it to be used as a callback to `verify_stress_thread` call. as `_nemesis_stress_failure_handler` was designed.

Ref: #10335

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
