### PR TITLE
fix(tearDown): Close DECODING_QUEUE

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3050,6 +3050,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.stop_resources()
         self.get_test_failures()
 
+        with silence(parent=self, name='closing decoding queue as needed'):
+            if self.test_config.BACKTRACE_DECODING:
+                self.test_config.DECODING_QUEUE.close()
+
         # NOTE: running on K8S we need to gather logs otherwise a lot of
         # debugging info is lost
         if self.k8s_clusters:


### PR DESCRIPTION
if we don't close it, there a left thread `QueueFeederThread` at the end of the test, we want to eliminate of the threads/proccess left at the end of the test, to avoid any deadlock of other issue that seem to be coredump the end of the end from time to time

Ref: https://github.com/scylladb/scylla-cluster-tests/issues/9784

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
