### PR TITLE
test(collect_diagnosis_data_test): Add ScyllaDiagnosisReport nemesis

### DIFF
--- a/collect_diagnosis_data_test.py
+++ b/collect_diagnosis_data_test.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+from sdcm.tester import ClusterTester
+from sdcm import nemesis
+
+
+class ScyllaDiagnosisReport(ClusterTester):
+
+    def test_diagnosis_data(self):  # pylint: disable=invalid-name
+        current_nemesis = nemesis.ScyllaDiagnosisReport(
+            tester_obj=self, termination_event=self.db_cluster.nemesis_termination_event)
+        current_nemesis.disrupt()

--- a/configurations/nemesis/ScyllaDiagnosisReport.yaml
+++ b/configurations/nemesis/ScyllaDiagnosisReport.yaml
@@ -1,0 +1,2 @@
+nemesis_class_name: 'ScyllaDiagnosisReport'
+user_prefix: 'ScyllaDiagnosisReport'

--- a/data_dir/nemesis_classes.yml
+++ b/data_dir/nemesis_classes.yml
@@ -65,6 +65,7 @@
 - RollingRestartConfigChangeInternodeCompression
 - ScyllaKillMonkey
 - SerialRestartOfElectedTopologyCoordinatorNemesis
+- ScyllaDiagnosisReport
 - SlaDecreaseSharesDuringLoad
 - SlaIncreaseSharesByAttachAnotherSlDuringLoad
 - SlaIncreaseSharesDuringLoad

--- a/jenkins-pipelines/oss/features/sigquit-scylla-test.jenkinsfile
+++ b/jenkins-pipelines/oss/features/sigquit-scylla-test.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    params: params,
+
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'collect_diagnosis_data_test.ScyllaDiagnosisReport.test_diagnosis_data',
+    test_config: 'test-cases/features/diagnosis-report.yaml'
+)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -989,6 +989,10 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         return self.name
 
     @property
+    def is_diagnostics_logged(self):
+        return self.remoter.run("grep 'Diagnostics dump requested via SIGQUIT' /var/log/messages", ignore_status=True).exit_status == 0
+
+    @property
     def is_spot(self):
         return False
 

--- a/test-cases/features/diagnosis-report.yaml
+++ b/test-cases/features/diagnosis-report.yaml
@@ -1,0 +1,13 @@
+test_duration: 30
+stress_cmd: "cassandra-stress write no-warmup cl=QUORUM duration=10m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=60 -pop seq=1..30000000"
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1
+
+instance_type_db: 'i4i.large'
+nemesis_class_name: 'ScyllaDiagnosisReport'
+nemesis_interval: 5
+
+email_recipients: ['qa@scylladb.com']
+stress_image:
+  cassandra-stress: 'scylladb/cassandra-stress:3.13.0'

--- a/unit_tests/test_nemesis_sisyphus.py
+++ b/unit_tests/test_nemesis_sisyphus.py
@@ -80,7 +80,7 @@ def test_list_all_available_nemesis(generate_file=True):
     disruption_list, disruptions_dict, disruption_classes = sisyphus.get_list_of_disrupt_methods(
         subclasses_list=subclasses, export_properties=True)
 
-    assert len(disruption_list) == 92
+    assert len(disruption_list) == 93
 
     if generate_file:
         with open(sct_abs_path('data_dir/nemesis.yml'), 'w', encoding="utf-8") as outfile1:


### PR DESCRIPTION
Adds a new ScyllaDiagnosisReport nemesis to send signal to scylladb to dump diagnostics and verify it.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/9443

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/81aeba13-f6d3-4801-8440-0ba292463abe

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
