### PR TITLE
fix(artifact_test): switch the skip issue for scylla-doctor of non-root

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -490,7 +490,7 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
             return
 
         if self.db_cluster.nodes[0].is_nonroot_install and \
-                SkipPerIssues("https://github.com/scylladb/field-engineering/issues/2254", self.params):
+                SkipPerIssues("https://github.com/scylladb/scylla-cluster-tests/issues/10540", self.params):
             self.log.info("Scylla Doctor test is skipped for non-root test due to issue field-engineering#2254. ")
             return
 


### PR DESCRIPTION
since scylladb/field-engineering#2254 was close/fixed, but not on any scylla-doctor version yet, we'll switch the skip to an SCT issue so we can control better when to enable those checks

Ref: scylladb/field-engineering#2254
Ref: scylladb/scylla-cluster-tests#10540

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
