### PR TITLE
fix(sct): Dont require Okta for commands which do not need it

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -190,16 +190,19 @@ class SctLoader(unittest.TestLoader):
               type=click.Path(),
               expose_value=False,
               help="Install paths for extra python packages to install, scylla-cluster-plugins for example")
-def cli():
+@click.pass_context
+def cli(ctx):
     disable_loggers_during_startup()
-    try_auth_with_okta()
+    # Ugly way of filtering the few command that do not require OKTA verification
+    if ctx.invoked_subcommand not in ("update-conf-docs", "nemesis-list", "create-nemesis-pipelines"):
+        try_auth_with_okta()
 
-    key_store = KeyStore()
-    # TODO: still leaving old keys, until we'll rebuild runner images - and reconfigure jenkins
-    key_store.sync(keys=['scylla-qa-ec2', 'scylla-test', 'scylla_test_id_ed25519'],
-                   local_path=Path('~/.ssh/').expanduser(), permissions=0o0600)
+        key_store = KeyStore()
+        # TODO: still leaving old keys, until we'll rebuild runner images - and reconfigure jenkins
+        key_store.sync(keys=['scylla-qa-ec2', 'scylla-test', 'scylla_test_id_ed25519'],
+                       local_path=Path('~/.ssh/').expanduser(), permissions=0o0600)
 
-    docker_hub_login(remoter=LOCALRUNNER)
+        docker_hub_login(remoter=LOCALRUNNER)
 
 
 @cli.command('provision-resources', help="Provision resources for the test")


### PR DESCRIPTION
* update-conf-docs, nemesis-list, create-nemesis-pipelines
* This is a hotfix and it is ugly, but for 3 commands no bigger effort is needed
* All the code was actually suggested and written by @fruch in https://github.com/scylladb/scylla-cluster-tests/issues/10534#issuecomment-2767510477

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
