### PR TITLE
improvement(latte): collect latte and rust driver versions

### DIFF
--- a/sdcm/stress/latte_thread.py
+++ b/sdcm/stress/latte_thread.py
@@ -26,6 +26,7 @@ from sdcm.loader import (
 from sdcm.prometheus import nemesis_metrics_obj
 from sdcm.provision.helpers.certificate import SCYLLA_SSL_CONF_DIR, TLSAssets
 from sdcm.remote.libssh2_client.exceptions import Failure
+from sdcm.reporting.tooling_reporter import LatteVersionReporter
 from sdcm.sct_events.loaders import LatteStressEvent
 from sdcm.sct_events import Severity
 from sdcm.stress.base import DockerBasedStressThread
@@ -236,8 +237,16 @@ class LatteStressThread(DockerBasedStressThread):  # pylint: disable=too-many-in
             hdrh_logger_context = contextlib.nullcontext()
         stress_cmd += f" -- {hosts} "
 
-        LOGGER.debug("running: %s", stress_cmd)
+        try:
+            LatteVersionReporter(
+                runner=cmd_runner,
+                command_prefix=stress_cmd.split("latte", maxsplit=1)[0],
+                argus_client=loader.parent_cluster.test_config.argus_client(),
+            ).report()
+        except Exception:  # noqa: BLE001
+            LOGGER.info("Failed to collect latte version information", exc_info=True)
 
+        LOGGER.debug("running: %s", stress_cmd)
         result, keyspace_holder = {}, LatteKeyspaceHolder()
         with cleanup_context, \
                 hdrh_logger_context, \

--- a/unit_tests/test_latte_thread.py
+++ b/unit_tests/test_latte_thread.py
@@ -32,6 +32,7 @@ pytestmark = [
 
 @pytest.mark.integration
 def test_01_latte_schema(request, docker_scylla, params):
+    params['enable_argus'] = False
     loader_set = LocalLoaderSetDummy(params=params)
 
     cmd = ("latte schema docker/latte/workloads/workload.rn")
@@ -52,8 +53,8 @@ def test_01_latte_schema(request, docker_scylla, params):
 
 @pytest.mark.integration
 def test_02_latte_load(request, docker_scylla, params):
-    loader_set = LocalLoaderSetDummy()
-    loader_set.params = params
+    params['enable_argus'] = False
+    loader_set = LocalLoaderSetDummy(params=params)
 
     cmd = ("latte load docker/latte/workloads/workload.rn")
 
@@ -73,6 +74,7 @@ def test_02_latte_load(request, docker_scylla, params):
 
 @pytest.mark.integration
 def test_03_latte_run(request, docker_scylla, prom_address, params):
+    params['enable_argus'] = False
     loader_set = LocalLoaderSetDummy(params=params)
 
     cmd = ("latte run --function run -d 10s docker/latte/workloads/workload.rn --generate-report")
@@ -114,6 +116,7 @@ def test_03_latte_run(request, docker_scylla, prom_address, params):
 @pytest.mark.docker_scylla_args(ssl=True)
 def test_04_latte_run_client_encrypt(request, docker_scylla, params):
     params['client_encrypt'] = True
+    params['enable_argus'] = False
 
     loader_set = LocalLoaderSetDummy(params=params)
 


### PR DESCRIPTION
With this change SCT will send `latte`
and its `scylla rust driver` versions to Argus.

Ref: https://github.com/scylladb/qa-tasks/issues/1829

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-provision-test#15](https://argus.scylladb.com/tests/scylla-cluster-tests/1ae98407-1b0d-4a24-9e60-27126071513a)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
