### PR TITLE
feature(events): new event for catching oversized allocation

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -18,6 +18,7 @@ FullPartitionScanReversedOrderEvent: ERROR
 FullPartitionScanEvent: ERROR
 TombstoneGcVerificationEvent: ERROR
 FullScanAggregateEvent: ERROR
+DatabaseLogEvent.OVERSIZED_ALLOCATION: ERROR
 DatabaseLogEvent.WARNING: WARNING
 DatabaseLogEvent.NO_SPACE_ERROR: ERROR
 DatabaseLogEvent.UNKNOWN_VERB: WARNING

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -29,6 +29,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class DatabaseLogEvent(LogEvent, abstract=True):
+    OVERSIZED_ALLOCATION: Type[LogEventProtocol]
     WARNING: Type[LogEventProtocol]
     NO_SPACE_ERROR: Type[LogEventProtocol]
     UNKNOWN_VERB: Type[LogEventProtocol]
@@ -82,6 +83,9 @@ class ReactorStalledMixin(Generic[T_log_event]):
         return super().add_info(node=node, line=line, line_number=line_number)
 
 
+# cause this is warning level, it's need to be before WARNING being suppressed
+DatabaseLogEvent.add_subevent_type("OVERSIZED_ALLOCATION", severity=Severity.ERROR,
+                                   regex="seastar_memory - oversized allocation:")
 DatabaseLogEvent.add_subevent_type("WARNING", severity=Severity.SUPPRESS,
                                    regex=r"(^WARNING|!\s*?WARNING).*\[shard.*\]")
 DatabaseLogEvent.add_subevent_type("NO_SPACE_ERROR", severity=Severity.ERROR,
@@ -173,6 +177,7 @@ DatabaseLogEvent.add_subevent_type("DATABASE_ERROR", severity=Severity.ERROR,
 DatabaseLogEvent.add_subevent_type("BACKTRACE", severity=Severity.ERROR,
                                    regex="^(?!.*audit:).*backtrace")
 SYSTEM_ERROR_EVENTS = (
+    DatabaseLogEvent.OVERSIZED_ALLOCATION(),
     DatabaseLogEvent.WARNING(),
     DatabaseLogEvent.NO_SPACE_ERROR(),
     DatabaseLogEvent.UNKNOWN_VERB(),


### PR DESCRIPTION
new everytime we'll have those we'll have an error event for it

```
2025-03-24T12:58:48.953+00:00 rolling-upgrade--ubuntu-focal-db-node-1b73896e-eastus-4  !WARNING |
scylla[13320]:  [shard 0:strm] seastar_memory - oversized allocation: 1409024 bytes.
This is non-fatal, but could lead to latency and/or fragmentation issues.
Please report: at 0x26f152e 0x26f0fc0 0x26f0f98 0x518d2fc 0x176c134 0x15c0a44 0x271fe5c
0x2fb90dd 0x1d3c4c6 0x30d3df7 0x30d2b0c 0x2cb3099 0x2cb2a72 0x29526de
0x295a78d /opt/scylladb/libreloc/libc.so.6+0x2a087 /opt/scylladb/libreloc/libc.so.6+0x2a14a
0x319a844
```

Ref: https://github.com/scylladb/scylladb/issues/23446#issuecomment-2772291495

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
