### PR TITLE
improvement(treewide): Remove pylint

### DIFF
--- a/.github/scripts/search_commits.py
+++ b/.github/scripts/search_commits.py
@@ -24,7 +24,7 @@ def get_parser():
     return parser.parse_args()
 
 
-def main():  # pylint: disable=too-many-locals  # noqa: PLR0914
+def main():  # noqa: PLR0914
     args = get_parser()
     github = Github(github_token)
     repo = github.get_repo(args.repository, lazy=False)
@@ -44,7 +44,7 @@ def main():  # pylint: disable=too-many-locals  # noqa: PLR0914
         }
         response = requests.get(search_url, headers=headers, params=params)
         prs = response.json().get("items", [])
-        for pr in prs:  # pylint: disable=invalid-name
+        for pr in prs:
             match = re.findall(r'Parent PR: #(\d+)', pr["body"])
             if match:
                 pr_number = int(match[0])

--- a/add_new_dc_test.py
+++ b/add_new_dc_test.py
@@ -2,7 +2,7 @@ import warnings
 from typing import Tuple, List
 
 from cassandra import ConsistencyLevel
-from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
+from cassandra.query import SimpleStatement
 
 from longevity_test import LongevityTest
 from sdcm.cluster import BaseNode
@@ -19,7 +19,7 @@ class TestAddNewDc(LongevityTest):
      https://docs.scylladb.com/operating-scylla/procedures/cluster-management/add-dc-to-existing-dc/
      """
 
-    def test_add_new_dc(self) -> None:  # pylint: disable=too-many-locals
+    def test_add_new_dc(self) -> None:
 
         self.log.info("Starting add new DC test...")
         assert self.params.get('n_db_nodes').endswith(" 0"), "n_db_nodes must be a list and last dc must equal 0"

--- a/argus/client/base.py
+++ b/argus/client/base.py
@@ -22,7 +22,7 @@ class ArgusClient:
     schema_version: str | None = None
 
     class Routes():
-        # pylint: disable=too-few-public-methods
+        
         SUBMIT = "/testrun/$type/submit"
         GET = "/testrun/$type/$id/get"
         HEARTBEAT = "/testrun/$type/$id/heartbeat"

--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -48,7 +48,7 @@ BACKENDS = {
 }
 
 
-class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
+class ArtifactsTest(ClusterTester):
     REPO_TABLE = "housekeeping.repo"
     CHECK_VERSION_TABLE = "housekeeping.checkversion"
 
@@ -329,7 +329,6 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
                                   scylla_encryption_options=scylla_encryption_options,
                                   compaction=compaction_strategy, sstable_size=sstable_size)
 
-    # pylint: disable=too-many-statements,too-many-branches
     def test_scylla_service(self):  # noqa: PLR0915
 
         self.run_pre_create_schema()
@@ -357,7 +356,7 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
                 except SkipTest as exc:
                     self.log.info("Skipping IOTuneValidation due to %s", exc.args)
                     self.actions_log.info("Skipped IOTuneValidation", target=self.node.name)
-                except Exception:  # pylint: disable=broad-except # noqa: BLE001
+                except Exception:  # noqa: BLE001
                     self.log.error("IOTuneValidator failed", exc_info=True)
                     TestFrameworkEvent(source={self.__class__.__name__},
                                        message="Error during IOTune params validation.",

--- a/big_cluster_test.py
+++ b/big_cluster_test.py
@@ -13,8 +13,7 @@
 #
 # Copyright (c) 2016 ScyllaDB
 
-# TODO: this test seem to totally unused, hence disabling all pylint checks
-# pylint: disable=all
+# TODO: this test seem to totally unused
 
 import logging
 

--- a/cdc_replication_test.py
+++ b/cdc_replication_test.py
@@ -23,7 +23,7 @@ from textwrap import dedent
 from typing import Optional, Tuple
 
 from cassandra import ConsistencyLevel
-from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
+from cassandra.query import SimpleStatement
 
 from sdcm import cluster
 from sdcm.tester import ClusterTester
@@ -132,7 +132,6 @@ class CDCReplicationTest(ClusterTester):
         self.start_replicator(Mode.DELTA)
 
         self.consistency_ok = True
-        # pylint: disable=unexpected-keyword-arg
         self.db_cluster.nemesis.append(CategoricalMonkey(
             tester_obj=self, termination_event=self.db_cluster.nemesis_termination_event,
             dist={
@@ -224,8 +223,6 @@ class CDCReplicationTest(ClusterTester):
             # If the test fails, one should connect to the cluster manually and investigate there,
             # or try to reproduce based on the logs in a smaller test.
             self.fail('Consistency check failed.')
-
-    # pylint: disable=too-many-statements,too-many-branches,too-many-locals
 
     def test_replication(self, is_gemini_test: bool, mode: Mode) -> None:
         assert is_gemini_test or (mode == Mode.DELTA), "cassandra-stress doesn't work with preimage/postimage modes"

--- a/cql_test.py
+++ b/cql_test.py
@@ -31,7 +31,6 @@ class CQLExampleTest(ClusterTester):
         node = self.db_cluster.nodes[0]
         with self.db_cluster.cql_connection_patient(node) as session:
             self.create_keyspace(keyspace_name='ks', replication_factor=1)
-            # pylint: disable=no-member
             session.execute("""
                 CREATE TABLE ks.test1 (
                     k int,

--- a/destroy_data_then_repair_test.py
+++ b/destroy_data_then_repair_test.py
@@ -19,7 +19,7 @@ from sdcm import nemesis
 
 class CorruptThenRepair(ClusterTester):
 
-    def test_destroy_data_then_repair_test_nodes(self):  # pylint: disable=invalid-name
+    def test_destroy_data_then_repair_test_nodes(self):
         # populates 100GB
         write_queue = self.populate_data_parallel(100, blocking=False)
 

--- a/docker/alternator-dns/dns_server.py
+++ b/docker/alternator-dns/dns_server.py
@@ -34,7 +34,7 @@ def livenodes_update():
             # If we're successful, replace livenodes by the new list
             livenodes = a
             print(livenodes)
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             # TODO: contacting this ip was unsuccessful, maybe we should
             # remove it from the list of live nodes.
             pass

--- a/functional_tests/scylla_operator/conftest.py
+++ b/functional_tests/scylla_operator/conftest.py
@@ -43,17 +43,17 @@ LOGGER = logging.getLogger(__name__)
 # TODO: add support for multiDC setups
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
-def pytest_runtest_makereport(item, call):  # pylint: disable=unused-argument
+def pytest_runtest_makereport(item, call):
     # Populate test result to test function instance
     outcome = yield
     rep = outcome.get_result()
     if rep.skipped:
-        item._test_result = ('SKIPPED', rep.longrepr[2])  # pylint: disable=protected-access
-        TESTER.update_test_status(item.nodeid, *item._test_result)  # pylint: disable=protected-access
+        item._test_result = ('SKIPPED', rep.longrepr[2])
+        TESTER.update_test_status(item.nodeid, *item._test_result)
     elif rep.passed:
-        item._test_result = ('SUCCESS', None)  # pylint: disable=protected-access
+        item._test_result = ('SUCCESS', None)
     elif not rep.passed:
-        item._test_result = ('FAILED', str(rep.longrepr))  # pylint: disable=protected-access
+        item._test_result = ('FAILED', str(rep.longrepr))
 
 
 @pytest.fixture(autouse=True, name="harvest_test_results")
@@ -63,14 +63,14 @@ def fixture_harvest_test_results(request, tester: ScyllaOperatorFunctionalCluste
     def publish_test_result():
         tester.update_test_status(
             request.node.nodeid,
-            *request.node._test_result)  # pylint: disable=protected-access
+            *request.node._test_result)
 
     request.addfinalizer(publish_test_result)
 
 
 @pytest.fixture(autouse=True, scope='package', name="tester")
 def fixture_tester() -> ScyllaOperatorFunctionalClusterTester:
-    global TESTER  # pylint: disable=global-statement  # noqa: PLW0603
+    global TESTER  # noqa: PLW0603
     os.chdir(sct_abs_path())
     tester_inst = ScyllaOperatorFunctionalClusterTester()
     TESTER = tester_inst  # putting tester global, so we can report skipped test (one with mark.skip)
@@ -175,7 +175,7 @@ def _bring_cluster_back_to_original_state(
             db_cluster.restart_scylla()
         db_cluster.wait_for_nodes_up_and_normal(
             nodes=db_cluster.nodes, verification_node=db_cluster.nodes[0])
-    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         tester.healthy_flag = False
         pytest.fail("Failed to bring cluster nodes back to original state due to :\n" +
                     "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)))

--- a/functional_tests/scylla_operator/libs/helpers.py
+++ b/functional_tests/scylla_operator/libs/helpers.py
@@ -100,7 +100,7 @@ def scylla_services_names(db_cluster: ScyllaPodCluster) -> list:
             if name not in ('NAME', f"{scylla_cluster_name}-client")]
 
 
-def wait_for_resource_absence(db_cluster: ScyllaPodCluster,  # pylint: disable=too-many-arguments
+def wait_for_resource_absence(db_cluster: ScyllaPodCluster,
                               resource_type: str, resource_name: str,
                               namespace: str = SCYLLA_NAMESPACE,
                               step: int = 2, timeout: int = 60) -> None:
@@ -198,7 +198,7 @@ def verify_resharding_on_k8s(db_cluster: ScyllaPodCluster, cpus: Union[str, int,
     # One resharding with 100Gb+ may take about 3-4 minutes. So, set 5 minutes timeout per node.
     for node, liveness_probe_failures, resharding_start, resharding_finish in nodes_data:
         assert wait_for(
-            func=lambda: list(resharding_start),  # pylint: disable=cell-var-from-loop
+            func=lambda: list(resharding_start),
             step=1, timeout=600, throw_exc=False,
             text=f"Waiting for the start of resharding on the '{node.name}' node.",
         ), f"Start of resharding hasn't been detected on the '{node.name}' node."
@@ -207,7 +207,7 @@ def verify_resharding_on_k8s(db_cluster: ScyllaPodCluster, cpus: Union[str, int,
 
         # Wait for the end of resharding
         assert wait_for(
-            func=lambda: list(resharding_finish),  # pylint: disable=cell-var-from-loop
+            func=lambda: list(resharding_finish),
             step=3, timeout=600, throw_exc=False,
             text=f"Waiting for the finish of resharding on the '{node.name}' node.",
         ), f"Finish of the resharding hasn't been detected on the '{node.name}' node."

--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -13,7 +13,6 @@
 #
 # Copyright (c) 2021 ScyllaDB
 
-#  pylint: disable=too-many-lines
 import logging
 import os
 import random
@@ -26,7 +25,7 @@ import path
 
 import pytest
 import yaml
-from cassandra.cluster import (  # pylint: disable=no-name-in-module
+from cassandra.cluster import (
     Cluster,
     ExecutionProfile,
     EXEC_PROFILE_DEFAULT,
@@ -95,7 +94,7 @@ def test_single_operator_image_tag_is_everywhere(db_cluster):
 
 
 @pytest.mark.required_operator("v1.11.0")
-def test_deploy_quasi_multidc_db_cluster(db_cluster: ScyllaPodCluster):  # pylint: disable=too-many-locals,too-many-statements,too-many-branches  # noqa: PLR0914
+def test_deploy_quasi_multidc_db_cluster(db_cluster: ScyllaPodCluster):  # noqa: PLR0914
     """
     Deploy 2 'ScyllaCluster' K8S objects in 2 different namespaces in the single K8S cluster
     and combine them into a single DB cluster.
@@ -322,7 +321,7 @@ def test_add_new_node_and_check_old_nodes_are_cleaned_up(db_cluster):
                 time.sleep(4)
                 db_cluster.nodes[0].run_cqlsh(cmd=f"DROP KEYSPACE IF EXISTS {current_ks_name}", timeout=60)
                 time.sleep(4)
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 # NOTE: we don't care if some of the queries fail.
                 #       At first, there are redundant ones and, at second, they are utilitary.
                 log.warning("Utilitary CQL query has failed: %s", exc)
@@ -647,7 +646,7 @@ def test_ha_update_spec_while_rollout_restart(db_cluster: ScyllaPodCluster):
                 # NOTE: increase the value only when the sysctl spec update is successful
                 #       to avoid false negative results in further assertions
                 expected_aio_max_nr_value += 1
-            except Exception as error:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as error:  # noqa: BLE001
                 str_error = str(error)
                 log.debug("Change /spec/sysctls value to %d failed. Error: %s",
                           expected_aio_max_nr_value, str_error)
@@ -853,7 +852,7 @@ def test_rolling_config_change_internode_compression(db_cluster, scylla_yaml):
 
 
 @pytest.mark.restart_is_used
-def test_scylla_yaml_override(db_cluster, scylla_yaml):  # pylint: disable=too-many-branches
+def test_scylla_yaml_override(db_cluster, scylla_yaml):
     """
     Test of applying scylla.yaml via configmap
     - update parameter that exists in scylla.yaml
@@ -958,7 +957,6 @@ def test_default_dns_policy(db_cluster: ScyllaPodCluster):
 @pytest.mark.required_operator("v1.8.0")
 @pytest.mark.requires_tls_and_sni
 def test_operator_managed_tls(db_cluster: ScyllaPodCluster, tmp_path: path.Path):
-    # pylint: disable=too-many-locals
 
     cluster_name = db_cluster.k8s_cluster.k8s_scylla_cluster_name
 
@@ -990,7 +988,7 @@ def test_operator_managed_tls(db_cluster: ScyllaPodCluster, tmp_path: path.Path)
     cluster = Cluster(contact_points=[db_cluster.nodes[0].cql_address], port=db_cluster.nodes[0].CQL_SSL_PORT,
                       execution_profiles={EXEC_PROFILE_DEFAULT: execution_profile})
     ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_SSLv23)
-    ssl_context.verify_mode = ssl.VerifyMode.CERT_REQUIRED  # pylint: disable=no-member
+    ssl_context.verify_mode = ssl.VerifyMode.CERT_REQUIRED
 
     ssl_context.load_verify_locations(cadata=ca_filename.read_text())
     ssl_context.load_cert_chain(keyfile=key_filename, certfile=crt_filename)

--- a/grow_cluster_test.py
+++ b/grow_cluster_test.py
@@ -122,7 +122,7 @@ class GrowClusterTest(ClusterTester):
         self.grow_cluster(cluster_target_size=self._cluster_target_size,
                           stress_cmd=self.get_stress_cmd())
 
-    def test_grow_3_to_4_large_partition(self):  # pylint: disable=invalid-name
+    def test_grow_3_to_4_large_partition(self):
         """
         Shorter version of the cluster growth test.
 

--- a/ics_space_amplification_goal_test.py
+++ b/ics_space_amplification_goal_test.py
@@ -135,7 +135,7 @@ class IcsSpaceAmplificationTest(LongevityTest):
             node.stop_scylla_server()
             node.start_scylla_server()
 
-    def test_ics_space_amplification_goal(self):  # pylint: disable=too-many-locals  # noqa: PLR0914
+    def test_ics_space_amplification_goal(self):  # noqa: PLR0914
         """
         (1) writing new data. wait for compactions to finish.
         (2) over-writing existing data.

--- a/longevity_alternator_ttl_test.py
+++ b/longevity_alternator_ttl_test.py
@@ -100,7 +100,6 @@ class AlternatorTtlLongevityTest(LongevityTest):
         4. Wait for TTL-scan intervals to run
         5. Run a background read stress while data is being expired.
         """
-        # pylint: disable=too-many-locals,too-many-branches,too-many-statements
 
         self.db_cluster.add_nemesis(nemesis=self.get_nemesis_class(),
                                     tester_obj=self)

--- a/longevity_large_partition_test.py
+++ b/longevity_large_partition_test.py
@@ -14,7 +14,6 @@ class LargePartitionLongevityTest(LongevityTest):
         node = self.db_cluster.nodes[0]
         create_table_query = create_scylla_bench_table_query(compaction_strategy=compaction_strategy)
         with self.db_cluster.cql_connection_patient(node) as session:
-            # pylint: disable=no-member
             session.execute("""
                     CREATE KEYSPACE IF NOT EXISTS scylla_bench WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}
             """)

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -23,7 +23,7 @@ from typing import List, Dict
 
 import yaml
 from cassandra import AlreadyExists, InvalidRequest
-from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
+from cassandra.query import SimpleStatement
 
 from sdcm import sct_abs_path
 from sdcm.sct_events.group_common_events import \
@@ -126,7 +126,6 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
         """
         Run cassandra-stress with params defined in data_dir/scylla.yaml
         """
-        # pylint: disable=too-many-locals,too-many-branches,too-many-statements
 
         self.db_cluster.add_nemesis(nemesis=self.get_nemesis_class(),
                                     tester_obj=self)
@@ -206,7 +205,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
                 profile_dst = os.path.join('/tmp', os.path.basename(cs_profile))
                 with open(cs_profile, encoding="utf-8") as pconf:
                     cont = pconf.readlines()
-                    user_profile_table_count = self.params.get(  # pylint: disable=invalid-name
+                    user_profile_table_count = self.params.get(
                         'user_profile_table_count')
                     for _ in range(user_profile_table_count):
                         for cmd in [line.lstrip('#').strip() for line in cont if line.find('cassandra-stress') > 0]:
@@ -295,7 +294,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
         self.db_cluster.add_nemesis(nemesis=self.get_nemesis_class(), tester_obj=self)
 
         batch_size = self.params.get('batch_size')
-        user_profile_table_count = self.params.get('user_profile_table_count')  # pylint: disable=invalid-name
+        user_profile_table_count = self.params.get('user_profile_table_count')
         if not self.params.get('reuse_cluster'):
             self._pre_create_templated_user_schema()
 
@@ -347,7 +346,6 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
         :param stress_params_list: the list of all stress commands
         :return:
         """
-        # pylint: disable=too-many-locals
 
         def chunks(_list, chunk_size):
             """Yield successive n-sized chunks from _list."""
@@ -457,8 +455,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
                               compaction=compaction_strategy, sstable_size=sstable_size)
 
     def _pre_create_templated_user_schema(self, batch_start=None, batch_end=None):
-        # pylint: disable=too-many-locals
-        user_profile_table_count = self.params.get(  # pylint: disable=invalid-name
+        user_profile_table_count = self.params.get(
             'user_profile_table_count') or 0
         cs_user_profiles = self.params.get('cs_user_profiles')
         # read user-profile
@@ -524,8 +521,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
         })
         return email_data
 
-    def create_templated_user_stress_params(self, idx, cs_profile) -> List[Dict]:  # pylint: disable=invalid-name
-        # pylint: disable=too-many-locals
+    def create_templated_user_stress_params(self, idx, cs_profile) -> List[Dict]:
         params_list = []
         cs_duration = self.params.get('cs_duration')
 

--- a/longevity_tombstone_gc_test.py
+++ b/longevity_tombstone_gc_test.py
@@ -64,7 +64,6 @@ class TombstoneGcLongevityTest(TWCSLongevityTest):
         Run a major compaction.
         Verify no tombstones.
         """
-        # pylint: disable=too-many-locals,too-many-statements
 
         self.create_tables_for_scylla_bench()
         self.db_node = self.db_cluster.nodes[0]

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -12,9 +12,7 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2016 ScyllaDB
-# pylint: disable=too-many-lines
 
-# pylint: disable=too-many-lines
 import random
 import threading
 from enum import Enum
@@ -677,7 +675,6 @@ class ManagerTestFunctionsMixIn(
         else:
             return None
 
-    # pylint: disable=too-many-arguments
     def verify_backup_success(self, mgr_cluster, backup_task, ks_names: list = None, tables_names: list = None,
                               truncate=True, restore_data_with_task=False, timeout=None):
         if ks_names is None:
@@ -800,7 +797,7 @@ class ManagerTestFunctionsMixIn(
 
 class ManagerRestoreTests(ManagerTestFunctionsMixIn):
 
-    def test_restore_multiple_backup_snapshots(self):  # pylint: disable=too-many-locals  # noqa: PLR0914
+    def test_restore_multiple_backup_snapshots(self):  # noqa: PLR0914
         manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
         mgr_cluster = self.ensure_and_get_cluster(manager_tool)
         cluster_backend = self.params.get('cluster_backend')
@@ -1132,7 +1129,7 @@ class ManagerRepairTests(ManagerTestFunctionsMixIn):
         load_results = stress_read_thread.get_results()
         self.log.info('load={}'.format(load_results))
 
-    def test_repair_multiple_keyspace_types(self):  # pylint: disable=invalid-name
+    def test_repair_multiple_keyspace_types(self):
         self.log.info('starting test_repair_multiple_keyspace_types')
         manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
         mgr_cluster = self.ensure_and_get_cluster(manager_tool)

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -52,7 +52,7 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
                                                auth_token=self.monitors.mgmt_auth_token)
         return mgr_cluster, current_manager_version
 
-    def test_upgrade(self):  # pylint: disable=too-many-locals,too-many-statements  # noqa: PLR0914
+    def test_upgrade(self):  # noqa: PLR0914
         manager_node = self.monitors.nodes[0]
 
         target_upgrade_server_version = self.params.get('target_scylla_mgmt_server_address')

--- a/multiple_dc_test.py
+++ b/multiple_dc_test.py
@@ -13,8 +13,7 @@
 #
 # Copyright (c) 2017 ScyllaDB
 
-# TODO: this test seem to be broken, hence disabling all pylint checks
-# pylint: disable=all
+# TODO: this test seem to be broken, hence disabling all ruff checks
 # ruff: noqa: F821
 
 from sdcm.tester import ClusterTester

--- a/performance_regression_alternator_test.py
+++ b/performance_regression_alternator_test.py
@@ -28,7 +28,7 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
         self.stack.enter_context(ignore_alternator_client_errors())
         self.stack.enter_context(ignore_operation_errors())
 
-    def _workload(self, stress_cmd, stress_num, test_name=None, sub_type=None, keyspace_num=1, prefix='', debug_message='',  # pylint: disable=too-many-arguments,arguments-differ
+    def _workload(self, stress_cmd, stress_num, test_name=None, sub_type=None, keyspace_num=1, prefix='', debug_message='',
                   save_stats=True, is_alternator=True):
         if not is_alternator:
             stress_cmd = stress_cmd.replace('dynamodb', 'cassandra-cql')

--- a/performance_regression_cdc_test.py
+++ b/performance_regression_cdc_test.py
@@ -62,7 +62,7 @@ class PerformanceRegressionCDCTest(PerformanceRegressionTest):
         write_cmd = self.params.get("stress_cmd_w")
 
         self._workload_cdc(write_cmd,
-                           stress_num=2,  # pylint: disable=unused-variable
+                           stress_num=2,
                            test_name="test_write",
                            sub_type="cdc_disabled")
         node1: BaseNode = self.db_cluster.nodes[0]
@@ -71,7 +71,7 @@ class PerformanceRegressionCDCTest(PerformanceRegressionTest):
         node1.run_cqlsh(f"ALTER TABLE {self.keyspace}.{self.table} WITH cdc = {{'enabled': true, 'postimage': true}}")
 
         self._workload_cdc(write_cmd,
-                           stress_num=2,  # pylint: disable=unused-variable
+                           stress_num=2,
                            test_name="test_write",
                            sub_type="cdc_preimage_enabled")
 
@@ -90,7 +90,7 @@ class PerformanceRegressionCDCTest(PerformanceRegressionTest):
     def test_mixed_latency(self):
         self.cdc_workflow(use_cdclog_reader=True)
 
-    def cdc_workflow(self, use_cdclog_reader=False):  # pylint: disable=unused-variable
+    def cdc_workflow(self, use_cdclog_reader=False):
         self.keyspace = "keyspace1"
         self.table = "standard1"
         write_cmd = self.params.get("stress_cmd_w")
@@ -152,7 +152,7 @@ class PerformanceRegressionCDCTest(PerformanceRegressionTest):
 
         self.check_regression_with_baseline(subtest_baseline="cdc_disabled")
 
-    def _workload_cdc(self, stress_cmd, stress_num, test_name, sub_type=None,  # pylint: disable=too-many-arguments
+    def _workload_cdc(self, stress_cmd, stress_num, test_name, sub_type=None,
                       save_stats=True, read_cdclog_cmd=None, update_cdclog_stats=False, enable_batching=True):
         cdc_stress_queue = None
 

--- a/performance_regression_gradual_grow_throughput.py
+++ b/performance_regression_gradual_grow_throughput.py
@@ -32,7 +32,7 @@ class Workload(NamedTuple):
     step_duration: str
 
 
-class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # pylint: disable=too-many-instance-attributes
+class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
     """
     This class presents new performance test that run gradual increased throughput steps.
     The test run steps with different throughput.
@@ -43,8 +43,8 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
 
     def setUp(self):
         super().setUp()
-        self.CLUSTER_SIZE = self.params.get("n_db_nodes")  # pylint: disable=invalid-name
-        self.REPLICATION_FACTOR = 3  # pylint: disable=invalid-name
+        self.CLUSTER_SIZE = self.params.get("n_db_nodes")
+        self.REPLICATION_FACTOR = 3
 
     def throttle_steps(self, workload_type):
         throttle_steps = self.params["perf_gradual_throttle_steps"]
@@ -64,7 +64,7 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
                                severity=Severity.CRITICAL).publish()
         return step_duration[workload_type]
 
-    def test_mixed_gradual_increase_load(self):  # pylint: disable=too-many-locals
+    def test_mixed_gradual_increase_load(self):
         """
         Test steps:
 
@@ -84,7 +84,7 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
         self._base_test_workflow(workload=workload,
                                  test_name="test_mixed_gradual_increase_load (read:50%,write:50%)")
 
-    def test_write_gradual_increase_load(self):  # pylint: disable=too-many-locals
+    def test_write_gradual_increase_load(self):
         """
         Test steps:
 
@@ -104,7 +104,7 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
         self._base_test_workflow(workload=workload,
                                  test_name="test_write_gradual_increase_load (100% writes)")
 
-    def test_read_gradual_increase_load(self):  # pylint: disable=too-many-locals
+    def test_read_gradual_increase_load(self):
         """
         Test steps:
 
@@ -211,7 +211,6 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
         with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
             session.execute(f'DROP KEYSPACE IF EXISTS {"keyspace1"};')
 
-    # pylint: disable=too-many-arguments,too-many-locals
     def run_gradual_increase_load(self, workload: Workload, stress_num, num_loaders, test_name):  # noqa: PLR0914
         if workload.cs_cmd_warm_up is not None:
             self.warmup_cache(workload.cs_cmd_warm_up, workload.num_threads)

--- a/performance_regression_operator_multi_tenant_test.py
+++ b/performance_regression_operator_multi_tenant_test.py
@@ -18,11 +18,10 @@ from sdcm.utils.common import ParallelObject
 from sdcm.utils.operator.multitenant_common import MultiTenantTestMixin
 
 
-# pylint: disable=too-many-public-methods
 class PerformanceRegressionOperatorMultiTenantTest(MultiTenantTestMixin, PerformanceRegressionTest):
     load_iteration_timeout_sec = 7200
 
-    def create_test_stats(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def create_test_stats(self, *args, **kwargs):
         self.log.info(
             "Suppress the test class stats creation. "
             "Leave it for the per-DB classes.")

--- a/performance_regression_row_level_repair_test.py
+++ b/performance_regression_row_level_repair_test.py
@@ -138,7 +138,6 @@ class PerformanceRegressionRowLevelRepairTest(ClusterTester):
     def _pre_create_schema_scylla_bench(self):
         node = self.db_cluster.nodes[0]
         create_table_query = create_scylla_bench_table_query()
-        # pylint: disable=no-member
         with self.db_cluster.cql_connection_patient(node) as session:
             session.execute("""
                     CREATE KEYSPACE IF NOT EXISTS scylla_bench WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}
@@ -190,7 +189,7 @@ class PerformanceRegressionRowLevelRepairTest(ClusterTester):
                 "Node {} used capacity after pre-load data is: {}".format(node.public_ip_address, used_capacity))
 
         self.log.info('Run Repair on node: {} , 0% synced'.format(node1.name))
-        repair_time = self._run_repair(node=node1)[0]  # pylint: disable=unsubscriptable-object
+        repair_time = self._run_repair(node=node1)[0]
         self.log.info('Repair (0% synced) time on node: {} is: {}'.format(node1.name, repair_time))
 
         stats['repair_runtime_all_diff'] = repair_time
@@ -198,7 +197,7 @@ class PerformanceRegressionRowLevelRepairTest(ClusterTester):
         self.wait_no_compactions_running()
 
         self.log.info('Run Repair on node: {} , 100% synced'.format(node1.name))
-        repair_time = self._run_repair(node=node1)[0]  # pylint: disable=unsubscriptable-object
+        repair_time = self._run_repair(node=node1)[0]
         self.log.info('Repair (100% synced) time on node: {} is: {}'.format(node1.name, repair_time))
 
         stats['repair_runtime_no_diff'] = repair_time
@@ -248,7 +247,7 @@ class PerformanceRegressionRowLevelRepairTest(ClusterTester):
         self.print_nodes_used_capacity()
 
         self.log.info('Run Repair on node: {} , 99.8% synced'.format(node3.name))
-        repair_time = self._run_repair(node=node3)[0]  # pylint: disable=unsubscriptable-object
+        repair_time = self._run_repair(node=node3)[0]
 
         self.log.debug("Nodes total used capacity after repair end is:")
         self.print_nodes_used_capacity()
@@ -327,7 +326,7 @@ class PerformanceRegressionRowLevelRepairTest(ClusterTester):
         self.print_nodes_used_capacity()
 
         self.log.info('Run Repair on node: {}'.format(node3.name))
-        repair_time = self._run_repair(node=node3)[0]  # pylint: disable=unsubscriptable-object
+        repair_time = self._run_repair(node=node3)[0]
 
         self.log.debug("Nodes total used capacity after repair end is:")
         self.print_nodes_used_capacity()
@@ -378,7 +377,7 @@ class PerformanceRegressionRowLevelRepairTest(ClusterTester):
             stress_queue.append(self.run_stress_thread(**params))
 
         self.log.info('Run Repair on node: {} , during r/w load'.format(node1.name))
-        repair_time = self._run_repair(node=node1)[0]  # pylint: disable=unsubscriptable-object
+        repair_time = self._run_repair(node=node1)[0]
 
         self.log.debug("Nodes total used capacity after repair end is:")
         self.print_nodes_used_capacity()

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -18,7 +18,7 @@ import os
 import time
 
 import yaml
-from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
+from cassandra.query import SimpleStatement
 
 from sdcm.utils import loader_utils
 from upgrade_test import UpgradeTest
@@ -34,7 +34,7 @@ from sdcm.utils.nemesis_utils.indexes import wait_for_view_to_be_built
 KB = 1024
 
 
-class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):  # pylint: disable=too-many-public-methods
+class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):
 
     """
     Test Scylla performance regression with cassandra-stress.
@@ -162,11 +162,11 @@ class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):  
             with open(os.path.join(self.logdir, 'jenkins_perf_PerfPublisher.xml'), 'w', encoding="utf-8") as pref_file:
                 content = """<report name="%s report" categ="none">%s</report>""" % (test_name, test_xml)
                 pref_file.write(content)
-        except Exception as ex:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as ex:  # noqa: BLE001
             self.log.debug('Failed to display results: {0}'.format(results))
             self.log.debug('Exception: {0}'.format(ex))
 
-    def _workload(self, stress_cmd, stress_num, test_name, sub_type=None, keyspace_num=1, prefix='', debug_message='',  # pylint: disable=too-many-arguments
+    def _workload(self, stress_cmd, stress_num, test_name, sub_type=None, keyspace_num=1, prefix='', debug_message='',
                   save_stats=True):
         if debug_message:
             self.log.debug(debug_message)
@@ -266,7 +266,7 @@ class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):  
             cmds = [cmds]
 
         for cmd in cmds:
-            # pylint: disable=no-member
+
             with self.db_cluster.cql_connection_patient(node) as session:
                 session.execute(cmd)
 
@@ -783,7 +783,7 @@ class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):  
         self._mixed_with_mv(on_populated=False)
 
     # Counter Tests
-    def test_uniform_counter_update_bench(self):  # pylint: disable=invalid-name
+    def test_uniform_counter_update_bench(self):
         """
         Test steps:
 
@@ -849,8 +849,8 @@ class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):  
                                   histogram_data=histogram_data_by_interval)
 
 
-class PerformanceRegressionUpgradeTest(PerformanceRegressionTest, UpgradeTest):  # pylint: disable=too-many-ancestors
-    def get_email_data(self):  # pylint: disable=no-self-use
+class PerformanceRegressionUpgradeTest(PerformanceRegressionTest, UpgradeTest):
+    def get_email_data(self):
         return PerformanceRegressionTest.get_email_data(self)
 
     @latency_calculator_decorator(legend="Upgrade Node")
@@ -858,7 +858,7 @@ class PerformanceRegressionUpgradeTest(PerformanceRegressionTest, UpgradeTest): 
         # NOTE: 'hdr_tags' will be used by the 'latency_calculator_decorator' decorator
         self._upgrade_node(node)
 
-    def _stop_stress_when_finished(self):  # pylint: disable=no-self-use
+    def _stop_stress_when_finished(self):
         with EventsSeverityChangerFilter(new_severity=Severity.NORMAL,  # killing stress creates Critical error
                                          event_class=CassandraStressEvent,
                                          extra_time_to_expiration=60):
@@ -883,9 +883,9 @@ class PerformanceRegressionUpgradeTest(PerformanceRegressionTest, UpgradeTest): 
 
     def run_workload_and_upgrade(self, stress_cmd, sub_type=None):
         # next 3 lines, is a workaround to have it working inside `latency_calculator_decorator`
-        self.cluster = self.db_cluster  # pylint: disable=attribute-defined-outside-init
-        self.tester = self  # pylint: disable=attribute-defined-outside-init
-        self.monitoring_set = self.monitors  # pylint: disable=attribute-defined-outside-init
+        self.cluster = self.db_cluster
+        self.tester = self
+        self.monitoring_set = self.monitors
 
         if sub_type is None:
             sub_type = 'read' if ' read ' in stress_cmd else 'write' if ' write ' in stress_cmd else 'mixed'

--- a/performance_regression_user_profiles_test.py
+++ b/performance_regression_user_profiles_test.py
@@ -27,13 +27,13 @@ class PerformanceRegressionUserProfilesTest(ClusterTester):
         super().setUp()
         self.create_stats = False
 
-    def _clean_keyspace(self, cs_profile):  # pylint: disable=invalid-name
+    def _clean_keyspace(self, cs_profile):
         with open(cs_profile, encoding="utf-8") as fdr:
             key_space = [line.split(':')[-1].strip() for line in fdr.readlines() if line.startswith('keyspace:')]
         if key_space:
             self.log.debug('Drop keyspace {}'.format(key_space[0]))
             with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
-                # pylint: disable=no-member
+
                 session.execute('DROP KEYSPACE IF EXISTS {};'.format(key_space[0]))
 
     def test_user_profiles(self):

--- a/performance_scale_up_test.py
+++ b/performance_scale_up_test.py
@@ -57,7 +57,7 @@ class ScaleUpTest(ClusterTester):
 
         try:
             email_data = self._get_common_email_data()
-        except Exception as error:  # pylint: disable=broad-except
+        except Exception as error:
             self.log.exception("Error in gathering common email data: Error:\n%s", error, exc_info=error)
 
         email_data.update({

--- a/performance_search_max_throughput_test.py
+++ b/performance_search_max_throughput_test.py
@@ -12,7 +12,7 @@ from sdcm.utils.common import format_timestamp
 
 class MaximumPerformanceSearchTest(PerformanceRegressionTest):
 
-    def test_search_best_read_throughput(self):  # pylint: disable=too-many-locals
+    def test_search_best_read_throughput(self):
         stress_params = {"stress_cmd_tmpl":  self.params.get('stress_cmd_r'),
                          "test_name": "Test read"}
         stress_params.update(**self._get_stress_parameters())
@@ -25,7 +25,7 @@ class MaximumPerformanceSearchTest(PerformanceRegressionTest):
 
         self.run_search_best_performance(**stress_params)
 
-    def test_search_best_write_throughput(self):  # pylint: disable=too-many-locals
+    def test_search_best_write_throughput(self):
         stress_params = {"stress_cmd_tmpl":  self.params.get('stress_cmd_w'),
                          "test_name": "Test write"}
         stress_params.update(**self._get_stress_parameters())
@@ -36,7 +36,7 @@ class MaximumPerformanceSearchTest(PerformanceRegressionTest):
 
         self.run_search_best_performance(**stress_params)
 
-    def test_search_best_mixed_throughput(self):  # pylint: disable=too-many-locals
+    def test_search_best_mixed_throughput(self):
         stress_params = {"stress_cmd_tmpl":  self.params.get('stress_cmd_m'),
                          "test_name": "Test mixed"}
         stress_params.update(**self._get_stress_parameters())
@@ -47,7 +47,7 @@ class MaximumPerformanceSearchTest(PerformanceRegressionTest):
 
         self.run_search_best_performance(**stress_params)
 
-    def run_search_best_performance(self, stress_cmd_tmpl: str,  # pylint: disable=too-many-arguments,too-many-locals,too-many-statements  # noqa: PLR0914
+    def run_search_best_performance(self, stress_cmd_tmpl: str,  # noqa: PLR0914
                                     stress_num: int,
                                     stress_num_step: int,
                                     stress_step_duration: str,

--- a/query_limits_test.py
+++ b/query_limits_test.py
@@ -53,7 +53,7 @@ class QueryLimitsTest(ClusterTester):
         self.db_cluster.wait_for_init()
         nodes_monitored = [node.private_ip_address for node in self.db_cluster.nodes]
         nodes_monitored += [node.private_ip_address for node in self.loaders.nodes]
-        self.monitors.wait_for_init(targets=nodes_monitored)  # pylint: disable=unexpected-keyword-arg
+        self.monitors.wait_for_init(targets=nodes_monitored)
         self.stress_thread = None
 
         self.payload = "/tmp/payload"

--- a/sct.py
+++ b/sct.py
@@ -13,7 +13,6 @@
 #
 # Copyright (c) 2021 ScyllaDB
 
-# pylint: disable=too-many-lines
 from collections import defaultdict
 from datetime import datetime, timezone, timedelta
 import os
@@ -116,8 +115,8 @@ from sdcm.cluster_k8s import mini_k8s
 from sdcm.utils.es_index import create_index, get_mapping
 from sdcm.utils.version_utils import get_s3_scylla_repos_mapping
 import sdcm.provision.azure.utils as azure_utils
-from utils.build_system.create_test_release_jobs import JenkinsPipelines  # pylint: disable=no-name-in-module,import-error
-from utils.get_supported_scylla_base_versions import UpgradeBaseVersion  # pylint: disable=no-name-in-module,import-error
+from utils.build_system.create_test_release_jobs import JenkinsPipelines
+from utils.get_supported_scylla_base_versions import UpgradeBaseVersion
 
 
 SUPPORTED_CLOUDS = ("aws", "gce", "azure",)
@@ -153,7 +152,7 @@ def install_package_from_dir(ctx, _, directories):
 
 
 def cloud_provider_option(function=None, default: str | None = DEFAULT_CLOUD,
-                          required: bool = True, help: str = "Cloud provider"):  # pylint:disable=redefined-builtin
+                          required: bool = True, help: str = "Cloud provider"):
     def actual_decorator(func):
         return click.option(
             "-c", "--cloud-provider",
@@ -266,7 +265,7 @@ def clean_aws_kms_aliases(ctx, regions, time_delta_h, dry_run):
 @click.option('--dry-run', is_flag=True, default=False, help='dry run')
 @click.option('-b', '--backend', type=click.Choice(SCTConfiguration.available_backends), help="Backend to use")
 @click.pass_context
-def clean_resources(ctx, post_behavior, user, test_id, logdir, dry_run, backend):  # pylint: disable=too-many-arguments,too-many-branches
+def clean_resources(ctx, post_behavior, user, test_id, logdir, dry_run, backend):
     """Clean cloud resources.
 
     There are different options how to run clean up:
@@ -346,7 +345,6 @@ def clean_resources(ctx, post_behavior, user, test_id, logdir, dry_run, backend)
 @click.option('-b', '--backend', 'backend_type', type=click.Choice(SCTConfiguration.available_backends + ['all']), default='all', help="use specific backend")
 @click.pass_context
 def list_resources(ctx, user, test_id, get_all, get_all_running, verbose, backend_type):  # noqa: PLR0912, PLR0914, PLR0915
-    # pylint: disable=too-many-locals,too-many-arguments,too-many-branches,too-many-statements
 
     add_file_logger()
 
@@ -655,7 +653,7 @@ def list_resources(ctx, user, test_id, get_all, get_all_running, verbose, backen
 @click.option('-a', '--arch',
               type=click.Choice(AwsArchType.__args__),
               default='x86_64',
-              help="architecture of the AMI (default: x86_64)")  # pylint: disable=too-many-locals
+              help="architecture of the AMI (default: x86_64)")
 def list_images(cloud_provider: str, branch: str, version: str, region: str, arch: AwsArchType):
     add_file_logger()
     version_fields = ["Backend", "Name", "ImageId", "CreationDate"]
@@ -772,7 +770,7 @@ def list_repos(dist_type, dist_version):
 @click.option('-d', '--linux-distro', type=str, help='Linux Distribution type')
 @click.option('-o', '--only-print-versions', type=bool, default=False, required=False, help='')
 @click.option('-b', '--backend', type=click.Choice(SCTConfiguration.available_backends), help="Backend to use")
-def get_scylla_base_versions(scylla_version, scylla_repo, linux_distro, only_print_versions, backend):  # pylint: disable=too-many-locals
+def get_scylla_base_versions(scylla_version, scylla_repo, linux_distro, only_print_versions, backend):
     """
     Upgrade test try to upgrade from multiple supported base versions, this command is used to
     get the base versions according to the scylla repo and distro type, then we don't need to hardcode
@@ -842,7 +840,7 @@ def _run_yaml_test(backend, full_path, env):
         config = SCTConfiguration()
         config.verify_configuration()
         config.check_required_files()
-    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         output.append(''.join(traceback.format_exception(type(exc), exc, exc.__traceback__)))
         error = True
     return error, output
@@ -852,7 +850,7 @@ def _run_yaml_test(backend, full_path, env):
 @click.option('-b', '--backend', type=click.Choice(SCTConfiguration.available_backends), default='aws')
 @click.option('-i', '--include', type=str, default='')
 @click.option('-e', '--exclude', type=str, default='')
-def lint_yamls(backend, exclude: str, include: str):  # pylint: disable=too-many-locals,too-many-branches
+def lint_yamls(backend, exclude: str, include: str):
     if not include:
         raise ValueError('You did not provide include filters')
 
@@ -862,7 +860,7 @@ def lint_yamls(backend, exclude: str, include: str):  # pylint: disable=too-many
             continue
         try:
             exclude_filters.append(re.compile(flt))
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             raise ValueError(f'Exclude filter "{flt}" compiling failed with: {exc}') from exc
 
     include_filters = []
@@ -871,11 +869,11 @@ def lint_yamls(backend, exclude: str, include: str):  # pylint: disable=too-many
             continue
         try:
             include_filters.append(re.compile(flt))
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             raise ValueError(f'Include filter "{flt}" compiling failed with: {exc}') from exc
 
     original_env = {**os.environ}
-    process_pool = ProcessPoolExecutor(max_workers=5)  # pylint: disable=consider-using-with
+    process_pool = ProcessPoolExecutor(max_workers=5)
 
     features = []
     for root, _, files in os.walk('./test-cases'):
@@ -913,7 +911,7 @@ def conf(config_file, backend):
     try:
         config.verify_configuration()
         config.check_required_files()
-    except Exception as ex:  # pylint: disable=broad-except
+    except Exception as ex:
         logging.exception(str(ex))
         click.secho(str(ex), fg='red')
         sys.exit(1)
@@ -994,7 +992,7 @@ def show_log(test_id, output_format, update_argus: bool):
         try:
             store_logs_in_argus(test_id=test_id, logs=reduce(lambda acc, log: acc[log["type"]].append(
                 log["link"]) or acc, files, defaultdict(list)), update=True)
-        except Exception:  # pylint: disable=broad-except # noqa: BLE001
+        except Exception:  # noqa: BLE001
             LOGGER.error("Error updating logs in argus.", exc_info=True)
 
 
@@ -1010,7 +1008,7 @@ def show_monitor(test_id, date_time, kill, cluster_name):
     containers = {}
     try:
         containers = restore_monitoring_stack(test_id, date_time)
-    except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as details:  # noqa: BLE001
         LOGGER.error(details)
 
     if not containers:
@@ -1148,7 +1146,7 @@ def pre_commit():
 class OutputLogger():
     def __init__(self, filename, terminal):
         self.terminal = terminal
-        self.log = open(filename, "a", encoding="utf-8")  # pylint: disable=consider-using-with
+        self.log = open(filename, "a", encoding="utf-8")
 
     def write(self, message):
         self.terminal.write(message)
@@ -1158,7 +1156,7 @@ class OutputLogger():
         self.terminal.flush()
         self.log.flush()
 
-    def isatty(self):  # pylint: disable=no-self-use
+    def isatty(self):
         return False
 
 
@@ -1237,10 +1235,10 @@ def cloud_usage_report(emails, report_type, user):
 @click.option('--backend', help='Cloud where search nodes', default=None)
 @click.option('--config-file', type=str, help='config test file path')
 def collect_logs(test_id=None, logdir=None, backend=None, config_file=None):
-    # pylint: disable=too-many-nested-blocks,too-many-branches
+
     add_file_logger()
 
-    from sdcm.logcollector import Collector  # pylint: disable=import-outside-toplevel
+    from sdcm.logcollector import Collector
     logging.getLogger("paramiko").setLevel(logging.CRITICAL)
     if backend is None:
         if os.environ.get('SCT_CLUSTER_BACKEND', None) is None:
@@ -1300,7 +1298,7 @@ def store_logs_in_argus(test_id: UUID, logs: dict[str, list[list[str] | str]], u
 
         if not argus_client.get_run().get("events"):
             argus_offline_collect_events(client=argus_client)
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         LOGGER.error("Error saving logs to argus", exc_info=True)
 
 
@@ -1317,7 +1315,6 @@ def get_test_results_for_failed_test(test_status, start_time):
     }
 
 
-# pylint: disable=too-many-arguments,too-many-branches,too-many-statements
 @cli.command('send-email', help='Send email with results for testrun')
 @click.option('--test-id', help='Test-id of run')
 @click.option('--test-status', help='Override test status FAILED|ABORTED')
@@ -1392,7 +1389,7 @@ def send_email(test_id=None, test_status=None, start_time=None, started_by=None,
             sys.exit(1)
         try:
             reporter.send_report(test_results)
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             LOGGER.error("Failed to create email due to the following error:\n%s", traceback.format_exc())
             build_reporter("TestAborted", email_recipients, testrun_dir).send_report({
                 "job_url": os.environ.get("BUILD_URL"),
@@ -1567,7 +1564,6 @@ def create_runner_image(cloud_provider, region, availability_zone):
 @click.option("-p", "--address-pool", required=False, type=str, help="ElasticIP pool to use")
 def create_runner_instance(cloud_provider, region, availability_zone, instance_type, root_disk_size_gb,
                            test_id, test_name, duration, restore_monitor=False, restored_test_id="", address_pool=None):
-    # pylint: disable=too-many-locals
 
     if cloud_provider == "aws":
         assert len(availability_zone) == 1, f"Invalid AZ: {availability_zone}, availability-zone is one-letter a-z."
@@ -1703,7 +1699,7 @@ def get_nemesis_list(backend, config):
 
     # NOTE: this import messes up logging for the test, since it's importing tester.py
     # directly down the line
-    from unit_tests.test_nemesis import FakeTester  # pylint: disable=import-outside-toplevel
+    from unit_tests.test_nemesis import FakeTester
 
     add_file_logger()
     logging.basicConfig(level=logging.WARNING)

--- a/sct_ssh.py
+++ b/sct_ssh.py
@@ -364,7 +364,6 @@ def select_instance_group(region: str = None, backends: list | None = None, **ta
     return question.ask()
 
 
-# pylint: disable=too-many-arguments
 @click.command("ssh", help="Connect to any SCT machine on AWS")
 @click.option("-u", "--user", default=None,
               help="User to search for (RunByUser tag)")
@@ -596,7 +595,6 @@ class ScyllaDBCluster(BaseScyllaCluster, BaseCluster):
     """
     nodes: list[BaseNode]
 
-    # pylint: disable=super-init-not-called
     def __init__(self, test_id, *args, **kwargs):
         self.uuid = test_id
         self.nodes = []

--- a/sdcm/audit.py
+++ b/sdcm/audit.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from datetime import datetime, date
 from typing import Literal, Optional, List
 
-from cassandra.util import uuid_from_time, datetime_from_uuid1  # pylint: disable=no-name-in-module
+from cassandra.util import uuid_from_time, datetime_from_uuid1
 
 from sdcm.sct_events import Severity
 from sdcm.sct_events.group_common_events import decorate_with_context, ignore_ycsb_connection_refused
@@ -45,7 +45,7 @@ class AuditConfiguration:
 
 
 @dataclass
-class AuditLogRow:  # pylint: disable=too-many-instance-attributes
+class AuditLogRow:
     date: date
     node: str
     event_time: datetime
@@ -59,7 +59,7 @@ class AuditLogRow:  # pylint: disable=too-many-instance-attributes
     username: str
 
 
-class AuditLogReader:  # pylint: disable=too-few-public-methods
+class AuditLogReader:
 
     def __init__(self, cluster):
         self._cluster = cluster
@@ -72,7 +72,7 @@ class AuditLogReader:  # pylint: disable=too-few-public-methods
         raise NotImplementedError()
 
 
-class TableAuditLogReader(AuditLogReader):  # pylint: disable=too-few-public-methods
+class TableAuditLogReader(AuditLogReader):
 
     def read(self, from_datetime: Optional[datetime] = None,
              category: Optional[AuditCategory] = None,
@@ -109,7 +109,7 @@ class TableAuditLogReader(AuditLogReader):  # pylint: disable=too-few-public-met
         return rows
 
 
-def get_audit_log_rows(node,  # pylint: disable=too-many-locals
+def get_audit_log_rows(node,
                        from_datetime: Optional[datetime] = None,
                        category: Optional[AuditCategory] = None,
                        operation: Optional[str] = None,
@@ -153,7 +153,7 @@ def get_audit_log_rows(node,  # pylint: disable=too-many-locals
                     break
 
 
-class SyslogAuditLogReader(AuditLogReader):  # pylint: disable=too-few-public-methods
+class SyslogAuditLogReader(AuditLogReader):
 
     def read(self, from_datetime: Optional[datetime] = None, category: Optional[AuditCategory] = None,
              operation: Optional[str] = None,

--- a/sdcm/cassandra_harry_thread.py
+++ b/sdcm/cassandra_harry_thread.py
@@ -50,12 +50,10 @@ class CassandraHarryStressEventsPublisher(FileFollowerThread):
                         event.add_info(node=self.node, line=line, line_number=line_number).publish()
 
 
-#  pylint: disable=too-many-instance-attributes
 class CassandraHarryThread(DockerBasedStressThread):
 
     DOCKER_IMAGE_PARAM_NAME = "stress_image.harry"
 
-    #  pylint: disable=too-many-arguments
     def __init__(self, *args, **kwargs):
         credentials = kwargs.pop('credentials', None)
 
@@ -105,7 +103,7 @@ class CassandraHarryThread(DockerBasedStressThread):
                                                retry=0,
                                                )
                 result = self._parse_harry_summary(docker_run_result.stdout.splitlines())
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 errors_str = format_stress_cmd_error(exc)
                 if "timeout" in errors_str:
                     harry_failure_event = CassandraHarryEvent.timeout
@@ -127,7 +125,7 @@ class CassandraHarryThread(DockerBasedStressThread):
         return loader, result, harry_failure_event or harry_finish_event
 
     @staticmethod
-    def _parse_harry_summary(lines):  # pylint: disable=too-many-branches
+    def _parse_harry_summary(lines):
         """
         Currently we only check if it succeeds or not.
         succeed sample:
@@ -135,7 +133,7 @@ class CassandraHarryThread(DockerBasedStressThread):
         INFO  [pool-6-thread-1] instance_id_IS_UNDEFINED 2021-01-19 13:46:49,835 Runner.java:255 - Completed
         """
         results = {}
-        if any(['Runner.java:255 - Completed' in line for line in lines]):  # pylint: disable=use-a-generator
+        if any(['Runner.java:255 - Completed' in line for line in lines]):
             results['status'] = 'completed'
         else:
             results['status'] = 'failed'

--- a/sdcm/cdclog_reader_thread.py
+++ b/sdcm/cdclog_reader_thread.py
@@ -64,7 +64,7 @@ class CDCLogReaderThread(DockerBasedStressThread):
                                                               *(self.loaders[loader_idx], loader_idx, cpu_idx))]
         return self
 
-    def _run_stress(self, loader, loader_idx, cpu_idx):  # pylint: disable=unused-argument
+    def _run_stress(self, loader, loader_idx, cpu_idx):
         loader_node_logdir = Path(loader.logdir)
         if not loader_node_logdir.exists():
             loader_node_logdir.mkdir()
@@ -98,7 +98,7 @@ class CDCLogReaderThread(DockerBasedStressThread):
                                                stress_cmd=self.stress_cmd,
                                                errors=result.stderr.split("\n")).publish()
                 return result
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             CDCReaderStressEvent.failure(node=loader,
                                          stress_cmd=self.stress_cmd,
                                          errors=[format_stress_cmd_error(exc), ]).publish()

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -11,8 +11,6 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
-# pylint: disable=too-many-arguments
-# pylint: disable=too-many-lines
 
 from __future__ import annotations
 
@@ -96,7 +94,7 @@ from sdcm.wait import wait_for
 from sdcm.cluster_k8s.operator_monitoring import ScyllaOperatorLogMonitoring
 
 
-ANY_KUBERNETES_RESOURCE = Union[  # pylint: disable=invalid-name
+ANY_KUBERNETES_RESOURCE = Union[
     Resource, ResourceField, ResourceInstance, ResourceList, Subresource,
 ]
 NAMESPACE_CREATION_LOCK = Lock()
@@ -159,7 +157,7 @@ SCYLLA_MANAGER_AGENT_RESOURCES = {
 LOGGER = logging.getLogger(__name__)
 
 
-class CloudK8sNodePool(metaclass=abc.ABCMeta):  # pylint: disable=too-many-instance-attributes
+class CloudK8sNodePool(metaclass=abc.ABCMeta):
     def __init__(
             self,
             k8s_cluster: 'KubernetesCluster',
@@ -246,7 +244,7 @@ class CloudK8sNodePool(metaclass=abc.ABCMeta):  # pylint: disable=too-many-insta
     def nodes(self):
         try:
             return self.k8s_cluster.k8s_core_v1_api.list_node(label_selector=f'{self.pool_label_name}={self.name}')
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             self.k8s_cluster.log.debug("Failed to get nodes list: %s", str(details))
             return {}
 
@@ -271,7 +269,7 @@ class CloudK8sNodePool(metaclass=abc.ABCMeta):  # pylint: disable=too-many-insta
         wait_nodes_are_ready()
 
 
-class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-public-methods,too-many-instance-attributes
+class KubernetesCluster(metaclass=abc.ABCMeta):
     AUXILIARY_POOL_NAME = 'auxiliary-pool'
     SCYLLA_POOL_NAME = 'scylla-pool'
     MONITORING_POOL_NAME = 'monitoring-pool'
@@ -819,7 +817,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
                             continue
                         self.apply_file(
                             os.path.join(crd_basedir, current_file), modifiers=[], envsubst=False)
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 self.log.debug("Upgrade Scylla Operator CRDs: Exception: %s", exc)
             self.log.info("Upgrade Scylla Operator CRDs: END")
 
@@ -1378,7 +1376,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
     def prometheus_port(self) -> int:
         return 9090
 
-    def register_sct_grafana_dashboard(self, cluster_name: str, namespace: str) -> str:  # pylint: disable=too-many-locals
+    def register_sct_grafana_dashboard(self, cluster_name: str, namespace: str) -> str:
         # TODO: make it work for EKS by using ingress LB IP when it is enabled
         sct_dashboard_file = sct_abs_path("data_dir/scylla-dash-per-server-nemesis.master.json")
         sct_dashboard_file_data_str = ""
@@ -1655,7 +1653,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
                 config_map = self.k8s_core_v1_api.read_namespaced_config_map(
                     name=SCYLLA_CONFIG_NAME, namespace=namespace).data or {}
                 exists = True
-            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 config_map = {}
                 exists = False
             original_config_map = deepcopy(config_map)
@@ -1738,7 +1736,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
                 self.log.warning("K8S SCYLLA_YAML, not applied options: %s", kwargs)
 
 
-class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-methods
+class BasePodContainer(cluster.BaseNode):
     parent_cluster: PodCluster
 
     pod_readiness_delay = 30  # seconds
@@ -1898,7 +1896,7 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
     def k8s_pod_uid(self) -> str:
         try:
             return str(self._pod.metadata.uid)
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             return ''
 
     @property
@@ -2022,7 +2020,7 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
         return True
 
 
-class BaseScyllaPodContainer(BasePodContainer):  # pylint: disable=abstract-method,too-many-public-methods
+class BaseScyllaPodContainer(BasePodContainer):
     @cached_property
     def node_type(self) -> str:
         return 'db'
@@ -2108,7 +2106,7 @@ class BaseScyllaPodContainer(BasePodContainer):  # pylint: disable=abstract-meth
         self.stop_scylla_server(verify_up=verify_up, verify_down=verify_down, timeout=timeout)
 
     @property
-    def node_name(self) -> str:  # pylint: disable=invalid-overridden-method
+    def node_name(self) -> str:
         return self._pod.spec.node_name
 
     def restart_scylla_server(self, verify_up_before=False, verify_up_after=True, timeout=1800,
@@ -2175,7 +2173,7 @@ class BaseScyllaPodContainer(BasePodContainer):  # pylint: disable=abstract-meth
     def is_seed(self) -> bool:
         try:
             return 'scylla/seed' in self._svc.metadata.labels
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             return False
 
     @is_seed.setter
@@ -2428,7 +2426,7 @@ class PodCluster(cluster.BaseCluster):
     def get_node_ips_param(self, public_ip=True):
         raise NotImplementedError("Derived class must implement 'get_node_ips_param' method!")
 
-    def wait_for_init(self, *_, node_list=None, verbose=False, timeout=None, **__):  # pylint: disable=arguments-differ
+    def wait_for_init(self, *_, node_list=None, verbose=False, timeout=None, **__):
         raise NotImplementedError("Derived class must implement 'wait_for_init' method!")
 
     def wait_sts_rollout_restart(self, pods_to_wait: int, dc_idx: int = 0):
@@ -2494,7 +2492,7 @@ class PodCluster(cluster.BaseCluster):
         raise RuntimeError("No available namespace was found")
 
 
-class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disable=too-many-public-methods
+class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):
     def __init__(self,
                  k8s_clusters: List[KubernetesCluster],
                  scylla_cluster_name: Optional[str] = None,
@@ -2563,7 +2561,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         return 'app=scylla'
 
     def wait_for_nodes_up_and_normal(self, nodes=None, verification_node=None, iterations=None,
-                                     sleep_time=None, timeout=None):  # pylint: disable=too-many-arguments
+                                     sleep_time=None, timeout=None):
         dc_node_mapping, nodes = {}, (nodes or self.nodes)
         for node in nodes:
             dc_idx = node.dc_idx
@@ -2582,7 +2580,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         super().check_nodes_up_and_normal(nodes=nodes, verification_node=verification_node)
 
     @cluster.wait_for_init_wrap
-    def wait_for_init(self, *_, node_list=None, verbose=False, timeout=None, wait_for_db_logs=False, **__):  # pylint: disable=arguments-differ
+    def wait_for_init(self, *_, node_list=None, verbose=False, timeout=None, wait_for_db_logs=False, **__):
         node_list = node_list if node_list else self.nodes
         self.wait_for_nodes_up_and_normal(nodes=node_list, timeout=timeout)
         if wait_for_db_logs:
@@ -2739,7 +2737,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         pass
 
     @cached_property
-    def scylla_manager_cluster_name(self):  # pylint: disable=invalid-overridden-method
+    def scylla_manager_cluster_name(self):
         return f"{self.namespace}/{self.scylla_cluster_name}"
 
     @property
@@ -2757,7 +2755,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         raise NotImplementedError('Scylla manager should not be manipulated on kubernetes manually')
 
     def node_config_setup(self,
-                          client_encrypt=None):  # pylint: disable=too-many-arguments,invalid-name
+                          client_encrypt=None):
         if client_encrypt is None:
             client_encrypt = self.params.get("client_encrypt")
 
@@ -2789,7 +2787,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         return sorted(
             [node for node in self.nodes if node.rack == rack and node.dc_idx == dc_idx], key=lambda n: n.name)
 
-    def add_nodes(self,  # pylint: disable=too-many-locals,too-many-branches  noqa: PLR0913
+    def add_nodes(self,
                   count: int,
                   ec2_user_data: str = "",
                   # NOTE: 'dc_idx=None' means 'create %count% nodes on each K8S cluster'
@@ -2967,7 +2965,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
                         cluster_name=self.scylla_cluster_name, namespace=self.namespace)
                     PrometheusDBStats(host=prometheus_ip, port=k8s_cluster.prometheus_port, protocol='https')
                     kmh_event.message = "Kubernetes monitoring health checks have successfully been finished"
-                except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+                except Exception as exc:  # noqa: BLE001
                     ClusterHealthValidatorEvent.MonitoringStatus(
                         error=f'Failed to connect to K8S prometheus server (namespace={self.namespace}) at '
                               f'{prometheus_ip}:{k8s_cluster.prometheus_port}, due to the: \n'
@@ -3018,7 +3016,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         node = self.nodes[0]
         test_keyspaces = self.get_test_keyspaces()
         # If 'keyspace1' does not exist, create a schema and load a data.
-        create_schema = not (test_keyspace_name in test_keyspaces)  # pylint: disable=superfluous-parens
+        create_schema = not (test_keyspace_name in test_keyspaces)
         if not create_schema:
             # NOTE: if keyspace exists and has data then just exit
             if int(SstableLoadUtils.validate_data_count_after_upload(node=node)) > 0:
@@ -3042,7 +3040,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         assert int(result) == test_data[0].keys_num, "Data was not inserted"
 
 
-class ManagerPodCluser(PodCluster):  # pylint: disable=abstract-method
+class ManagerPodCluser(PodCluster):
     @property
     def pod_selector(self):
         return 'app.kubernetes.io/name=scylla-manager'
@@ -3067,9 +3065,9 @@ class LoaderPodCluster(cluster.BaseLoaderSet, PodCluster):
         cluster.BaseLoaderSet.__init__(self, params=params)
         self.k8s_loader_run_type = self.params.get("k8s_loader_run_type")
         if self.k8s_loader_run_type == "static":
-            self.PodContainerClass = LoaderStsContainer  # pylint: disable=invalid-name
+            self.PodContainerClass = LoaderStsContainer
         elif self.k8s_loader_run_type == "dynamic":
-            self.PodContainerClass = LoaderPodContainer  # pylint: disable=invalid-name
+            self.PodContainerClass = LoaderPodContainer
         else:
             raise ValueError(
                 "'k8s_loader_run_type' has unexpected value: %s" % self.k8s_loader_run_type)

--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -50,8 +50,8 @@ from sdcm.utils.aws_utils import (
 )
 
 
-P = ParamSpec("P")  # pylint: disable=invalid-name
-R = TypeVar("R")  # pylint: disable=invalid-name
+P = ParamSpec("P")
+R = TypeVar("R")
 
 # we didn't add configuration for all the rest 'io1', 'io2', 'gp2', 'sc1', 'st1'
 SUPPORTED_EBS_STORAGE_CLASSES = ['gp3', ]
@@ -156,12 +156,10 @@ def deploy_k8s_eks_cluster(k8s_cluster) -> None:
     return k8s_cluster
 
 
-# pylint: disable=too-many-instance-attributes
 class EksNodePool(CloudK8sNodePool):
     k8s_cluster: 'EksCluster'
     disk_type: Literal["standard", "io1", "io2", "gp2", "gp3", "sc1", "st1"]
 
-    # pylint: disable=too-many-arguments,too-many-locals
     def __init__(  # noqa: PLR0913
             self,
             k8s_cluster: 'EksCluster',
@@ -312,7 +310,7 @@ class EksNodePool(CloudK8sNodePool):
             self.k8s_cluster.eks_client.delete_nodegroup(
                 clusterName=self.k8s_cluster.short_cluster_name,
                 nodegroupName=self.name)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             self.k8s_cluster.log.debug(
                 "Failed to delete nodegroup %s/%s, due to the following error:\n%s",
                 self.k8s_cluster.short_cluster_name, self.name, exc)
@@ -329,8 +327,7 @@ class EksTokenUpdateThread(TokenUpdateThread):
         return LOCALRUNNER.run(self._aws_cmd).stdout
 
 
-# pylint: disable=too-many-instance-attributes
-class EksCluster(KubernetesCluster, EksClusterCleanupMixin):  # pylint: disable=too-many-public-methods
+class EksCluster(KubernetesCluster, EksClusterCleanupMixin):
     POOL_LABEL_NAME = 'eks.amazonaws.com/nodegroup'
     IS_NODE_TUNING_SUPPORTED = True
     NODE_PREPARE_FILE = sct_abs_path("sdcm/k8s_configs/eks/scylla-node-prepare.yaml")
@@ -339,7 +336,6 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):  # pylint: disable=
     pools: Dict[str, EksNodePool]
     short_cluster_name: str
 
-    # pylint: disable=too-many-arguments
     def __init__(self,  # noqa: PLR0913
                  eks_cluster_version,
                  ec2_security_group_ids,
@@ -586,7 +582,7 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):  # pylint: disable=
         cmd = "get node --no-headers -o custom-columns=:.spec.providerID"
         return [name.split("/")[-1] for name in self.kubectl(cmd).stdout.split()]
 
-    def set_tags(self, instance_ids, memo={}):  # pylint: disable=dangerous-default-value  # noqa: B006
+    def set_tags(self, instance_ids, memo={}):  # noqa: B006
         if not instance_ids:
             return
         if isinstance(instance_ids, str):
@@ -609,7 +605,7 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):  # pylint: disable=
         # So, we add it for each node explicitly.
         self.set_tags(self._get_all_instance_ids())
 
-    def set_security_groups(self, instance_id, memo={}):  # pylint: disable=dangerous-default-value  # noqa: B006
+    def set_security_groups(self, instance_id, memo={}):  # noqa: B006
         if not instance_id or instance_id in memo:
             return
         with EC2_INSTANCE_UPDATE_LOCK:
@@ -632,7 +628,7 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):  # pylint: disable=
         for instance_id in self._get_all_instance_ids():
             self.set_security_groups(instance_id)
 
-    def deploy_scylla_cluster(self, *args, **kwargs) -> None:  # pylint: disable=signature-differs
+    def deploy_scylla_cluster(self, *args, **kwargs) -> None:
         super().deploy_scylla_cluster(*args, **kwargs)
         self.set_security_groups_on_all_instances()
         self.set_tags_on_all_instances()
@@ -791,7 +787,6 @@ class EksScyllaPodCluster(ScyllaPodCluster):
     PodContainerClass = EksScyllaPodContainer
     nodes: List[EksScyllaPodContainer]
 
-    # pylint: disable=too-many-arguments
     def add_nodes(self,
                   count: int,
                   ec2_user_data: str = "",
@@ -847,7 +842,7 @@ class MonitorSetEKS(MonitorSetAWS):
         instances = sorted(instances, key=sort_by_index)
         return [ec2.get_instance(instance['InstanceId']) for instance in instances]
 
-    def _create_instances(self, count, ec2_user_data='', dc_idx=0, az_idx=0, instance_type=None, is_zero_node=False):  # pylint: disable=too-many-arguments
+    def _create_instances(self, count, ec2_user_data='', dc_idx=0, az_idx=0, instance_type=None, is_zero_node=False):
         instances = super()._create_instances(count=count, ec2_user_data=ec2_user_data, dc_idx=dc_idx,
                                               az_idx=az_idx, instance_type=instance_type, is_zero_node=is_zero_node)
         for instance in instances:

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -46,8 +46,8 @@ GKE_API_CALL_QUEUE_SIZE = 1000  # ops
 GKE_URLLIB_RETRY = 5  # How many times api request is retried before reporting failure
 GKE_URLLIB_BACKOFF_FACTOR = 0.1
 
-P = ParamSpec("P")  # pylint: disable=invalid-name
-R = TypeVar("R")  # pylint: disable=invalid-name
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 def init_k8s_gke_cluster(gce_datacenter: str, availability_zone: str, params: dict,
@@ -141,7 +141,6 @@ def deploy_k8s_gke_cluster(k8s_cluster) -> None:
 class GkeNodePool(CloudK8sNodePool):
     k8s_cluster: 'GkeCluster'
 
-    # pylint: disable=too-many-arguments
     def __init__(  # noqa: PLR0913
             self,
             k8s_cluster: 'KubernetesCluster',
@@ -256,7 +255,6 @@ class GcloudException(Exception):
     ...
 
 
-# pylint: disable=too-many-instance-attributes
 class GkeCluster(KubernetesCluster):
     AUXILIARY_POOL_NAME = 'default-pool'  # This is default pool that is deployed with the cluster
     POOL_LABEL_NAME = 'cloud.google.com/gke-nodepool'
@@ -266,7 +264,6 @@ class GkeCluster(KubernetesCluster):
     TOKEN_UPDATE_NEEDED = False
     pools: Dict[str, GkeNodePool]
 
-    # pylint: disable=too-many-arguments,too-many-locals
     def __init__(self,  # noqa: PLR0913
                  gke_cluster_version,
                  gke_k8s_release_channel,
@@ -591,7 +588,6 @@ class GkeScyllaPodCluster(ScyllaPodCluster):
     node_pool: 'GkeNodePool'
     PodContainerClass = GkeScyllaPodContainer
 
-    # pylint: disable=too-many-arguments
     def add_nodes(self,
                   count: int,
                   ec2_user_data: str = "",

--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -178,10 +178,9 @@ class MinimalK8SOps:
         node.remoter.sudo(f'bash -cxe "{script}"')
 
 
-class MinimalClusterBase(KubernetesCluster, metaclass=abc.ABCMeta):  # pylint: disable=too-many-public-methods
+class MinimalClusterBase(KubernetesCluster, metaclass=abc.ABCMeta):
     POOL_LABEL_NAME = POOL_LABEL_NAME
 
-    # pylint: disable=too-many-arguments
     def __init__(self, mini_k8s_version, params: dict, user_prefix: str = '', region_name: str = None,
                  cluster_uuid: str = None, **_):
         self.software_version = mini_k8s_version
@@ -252,7 +251,7 @@ class MinimalClusterBase(KubernetesCluster, metaclass=abc.ABCMeta):  # pylint: d
         self._mini_k8s_version = value
 
     @cached_property
-    def local_kubectl_version(self):  # pylint: disable=no-self-use
+    def local_kubectl_version(self):
         # Example of kubectl command output:
         #   $ kubectl version --client --short
         #   Client Version: v1.18.5
@@ -345,7 +344,7 @@ class MinimalClusterBase(KubernetesCluster, metaclass=abc.ABCMeta):  # pylint: d
                     continue
                 try:
                     return doc["spec"]["template"]["spec"]["containers"][0]["image"]
-                except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+                except Exception as exc:  # noqa: BLE001
                     self.log.warning(
                         "Could not read the static local volume provisioner image: %s", exc)
         return ""
@@ -377,7 +376,7 @@ class MinimalClusterBase(KubernetesCluster, metaclass=abc.ABCMeta):  # pylint: d
                         for container in doc["spec"]["template"]["spec"]["containers"]:
                             try:
                                 ingress_images.add(container["image"])
-                            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+                            except Exception as exc:  # noqa: BLE001
                                 self.log.warning(
                                     "Could not read the ingress controller related image: %s", exc)
         return ingress_images
@@ -424,7 +423,6 @@ class LocalMinimalClusterBase(MinimalClusterBase):
             region_name="local-dc-1",
             params=params)
 
-    # pylint: disable=invalid-overridden-method
     @cached_property
     def host_node(self):
         node = LocalK8SHostNode(
@@ -589,7 +587,7 @@ class LocalKindCluster(LocalMinimalClusterBase):
             self.host_node.remoter.run(
                 f"/var/tmp/kind load docker-image {image}", ignore_status=True)
 
-    def on_deploy_completed(self):  # pylint: disable=too-many-branches
+    def on_deploy_completed(self):
         images_to_cache, images_to_retag, new_scylla_image_tag = [], {}, ""
 
         # first setup CNI plugin, otherwise everything else might get broken
@@ -688,7 +686,7 @@ class LocalKindCluster(LocalMinimalClusterBase):
                     f"docker cp kind-control-plane:{src_container_path} {self.logdir} "
                     f"&& mkdir -p {self.logdir}/{dst_subdir} "
                     f"&& mv {self.logdir}/*/{log_prefix}* {self.logdir}/{dst_subdir}")
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 self.log.warning(
                     "Failed to copy K8S apiserver audit logs located at '%s'. Exception: \n%s",
                     src_container_path, exc)
@@ -722,22 +720,21 @@ class LocalMinimalScyllaPodContainer(BaseScyllaPodContainer):
         raise NotImplementedError("Not supported on local K8S backends")
 
 
-# pylint: disable=too-many-ancestors
 class LocalMinimalScyllaPodCluster(ScyllaPodCluster):
     """Represents scylla cluster hosted on locally running minimal k8s clusters such as k3d, minikube or kind"""
     PodContainerClass = LocalMinimalScyllaPodContainer
 
-    def wait_for_nodes_up_and_normal(self, nodes=None, verification_node=None, iterations=20, sleep_time=60, timeout=0):  # pylint: disable=too-many-arguments
+    def wait_for_nodes_up_and_normal(self, nodes=None, verification_node=None, iterations=20, sleep_time=60, timeout=0):
         @retrying(n=iterations, sleep_time=sleep_time,
                   allowed_exceptions=(cluster.ClusterNodesNotReady, UnexpectedExit),
                   message="Waiting for nodes to join the cluster", timeout=timeout)
-        def _wait_for_nodes_up_and_normal(self):  # pylint: disable=unused-argument
+        def _wait_for_nodes_up_and_normal(self):
             super().check_nodes_up_and_normal(nodes=nodes, verification_node=verification_node)
 
         _wait_for_nodes_up_and_normal(self)
 
     @cluster.wait_for_init_wrap
-    def wait_for_init(self, *_, node_list=None, verbose=False, timeout=None, **__):  # pylint: disable=unused-argument
+    def wait_for_init(self, *_, node_list=None, verbose=False, timeout=None, **__):
         node_list = node_list if node_list else self.nodes
         self.wait_for_nodes_up_and_normal(nodes=node_list)
 

--- a/sdcm/commit_log_check_thread.py
+++ b/sdcm/commit_log_check_thread.py
@@ -114,7 +114,6 @@ class PrometheusQueries:
     """
 
 
-# pylint: disable=too-many-instance-attributes
 class CommitLogCheckThread:
     """
         if commitlog-use-hard-size-limit is enabled,
@@ -174,7 +173,7 @@ class CommitLogCheckThread:
                 self.zero_free_segments_checker(self.start_time, interval_end_time)
 
                 self.start_time = interval_end_time
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             trace = traceback.format_exc()
             CommitLogCheckErrorEvent(
                 message=f"CommitLogCheckThread failed: {exc.__repr__()} with traceback {trace}").publish()
@@ -234,7 +233,7 @@ class CommitLogCheckThread:
 
         try:
             thread = CommitLogCheckThread(custer_tester, duration)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             trace = traceback.format_exc()
             CommitLogCheckErrorEvent(
                 message=f"CommitLogCheckThread.__init__ failed with unexpected exception:"
@@ -242,7 +241,7 @@ class CommitLogCheckThread:
         else:
             try:
                 thread.start()
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 trace = traceback.format_exc()
                 CommitLogCheckErrorEvent(
                     message=f"CommitLogCheckThread.start failed with unexpected exception:"

--- a/sdcm/cql_stress_cassandra_stress_thread.py
+++ b/sdcm/cql_stress_cassandra_stress_thread.py
@@ -58,16 +58,16 @@ class CqlStressCassandraStressEventsPublisher(FileFollowerThread):
 class CqlStressCassandraStressThread(CassandraStressThread):
     DOCKER_IMAGE_PARAM_NAME = 'stress_image.cql-stress-cassandra-stress'
 
-    def __init__(self, loader_set, stress_cmd, timeout, stress_num=1, keyspace_num=1, keyspace_name='', compaction_strategy='',  # pylint: disable=too-many-arguments  # noqa: PLR0913
+    def __init__(self, loader_set, stress_cmd, timeout, stress_num=1, keyspace_num=1, keyspace_name='', compaction_strategy='',  # noqa: PLR0913
                  profile=None, node_list=None, round_robin=False, client_encrypt=False, stop_test_on_failure=True,
                  params=None):
         super().__init__(loader_set=loader_set, stress_cmd=stress_cmd, timeout=timeout,
-                         stress_num=stress_num, node_list=node_list,  # pylint: disable=too-many-arguments
+                         stress_num=stress_num, node_list=node_list,
                          round_robin=round_robin, stop_test_on_failure=stop_test_on_failure, params=params,
                          keyspace_num=keyspace_num, keyspace_name=keyspace_name, profile=profile,
                          client_encrypt=client_encrypt, compaction_strategy=compaction_strategy)
 
-    def create_stress_cmd(self, cmd_runner, keyspace_idx, loader):  # pylint: disable=too-many-branches
+    def create_stress_cmd(self, cmd_runner, keyspace_idx, loader):
         stress_cmd = self.stress_cmd
 
         stress_cmd = self.append_no_warmup_to_cmd(stress_cmd)
@@ -101,7 +101,7 @@ class CqlStressCassandraStressThread(CassandraStressThread):
         stress_cmd = self.adjust_cmd_node_option(stress_cmd, loader, cmd_runner)
         return stress_cmd
 
-    def _run_cs_stress(self, loader, loader_idx, cpu_idx, keyspace_idx):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements  # noqa: PLR0914
+    def _run_cs_stress(self, loader, loader_idx, cpu_idx, keyspace_idx):  # noqa: PLR0914
         # TODO:
         # - Add support for profile yaml once cql-stress supports 'user' command.
         # - Adjust metrics collection once cql-stress displays the metrics grouped by operation (mixed workload).
@@ -166,7 +166,7 @@ class CqlStressCassandraStressThread(CassandraStressThread):
             reporter = CqlStressCassandraStressVersionReporter(
                 cmd_runner, prefix, loader.parent_cluster.test_config.argus_client())
             reporter.report()
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             LOGGER.info("Failed to collect cql-stress-cassandra-stress version information", exc_info=True)
         result = None
         with cleanup_context, \
@@ -192,7 +192,7 @@ class CqlStressCassandraStressThread(CassandraStressThread):
                 with SoftTimeoutContext(timeout=self.timeout, operation="cql-stress-cassandra-stress"):
                     result = cmd_runner.run(
                         cmd=node_cmd, timeout=hard_timeout, log_file=log_file_name, retry=0)
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 self.configure_event_on_failure(
                     stress_event=cs_stress_event, exc=exc)
 

--- a/sdcm/db_log_reader.py
+++ b/sdcm/db_log_reader.py
@@ -11,7 +11,6 @@
 #
 # Copyright (c) 2021 ScyllaDB
 
-# pylint: disable=too-many-lines
 
 import json
 import logging
@@ -37,7 +36,7 @@ LOG_LINE_MAX_PROCESSING_SIZE = 1024 * 5
 
 
 class DbLogReader(Process):
-    # pylint: disable=too-many-instance-attributes
+
     EXCLUDE_FROM_LOGGING = [
         ' | sshd[',
         ' | systemd:',
@@ -54,7 +53,7 @@ class DbLogReader(Process):
         '] stream_session - [Stream ',
         '] storage_proxy - Exception when communicating with',
     ]
-    # pylint: disable=too-many-arguments
+
     BUILD_ID_REGEX = re.compile(r'build-id\s(.*?)\sstarting\s\.\.\.')
 
     def __init__(self,
@@ -87,8 +86,6 @@ class DbLogReader(Process):
     def _read_and_publish_events(self) -> None:  # noqa: PLR0912
         """Search for all known patterns listed in `sdcm.sct_events.database.SYSTEM_ERROR_EVENTS'."""
 
-        # pylint: disable=too-many-branches,too-many-locals,too-many-statements
-
         backtraces = []
         index = 0
 
@@ -114,7 +111,7 @@ class DbLogReader(Process):
                     if line[0] == '{':
                         try:
                             json_log = json.loads(line)
-                        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+                        except Exception:  # noqa: BLE001
                             pass
 
                     if self._log_lines:
@@ -175,7 +172,7 @@ class DbLogReader(Process):
 
                     if one_line_backtrace and backtraces:
                         backtraces[-1]['backtrace'] = one_line_backtrace
-                except Exception:  # pylint: disable=broad-except
+                except Exception:
                     LOGGER.exception('Processing of %s line of %s failed, line content:\n%s',
                                      index, self._system_log, line)
 
@@ -204,7 +201,7 @@ class DbLogReader(Process):
                     "build_id": self._build_id,
                     "event": backtrace["event"],
                 })
-            except Exception:  # pylint: disable=broad-except
+            except Exception:
                 backtrace["event"].publish()
                 raise
 
@@ -222,7 +219,7 @@ class DbLogReader(Process):
                 self._read_and_publish_events()
             except (SystemExit, KeyboardInterrupt) as ex:
                 LOGGER.debug("db_log_reader_thread() stopped by %s", ex.__class__.__name__)
-            except Exception:  # pylint: disable=broad-except
+            except Exception:
                 LOGGER.exception("failed to read db log")
 
     def filter_backtraces(self, backtrace):

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -76,7 +76,6 @@ def get_stress_cmd_params(cmd):
     :return: dict with params
     """
 
-    # pylint: disable=too-many-branches
     cmd_params = {
         "raw_cmd": cmd
     }
@@ -353,7 +352,7 @@ class PrometheusDBStats:
                                                     [float(runtime[1]) for runtime in item['values']]})
         return res
 
-    def get_scylla_scheduler_shares_per_sla(self, start_time, end_time, node_ip):  # pylint: disable=invalid-name
+    def get_scylla_scheduler_shares_per_sla(self, start_time, end_time, node_ip):
         """
         Get scylla_scheduler_shares from PrometheusDB
 
@@ -368,13 +367,13 @@ class PrometheusDBStats:
         for item in results:
             try:
                 res[item['metric']['group']] = {int(i[1]) for i in item['values']}
-            except Exception as error:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as error:  # noqa: BLE001
                 # average value may be returned not integer. Ignore it
                 LOGGER.error("Failed to analyze results of query: %s\nResults: %s\nError: %s", query, results, error)
         return res
 
     def get_scylla_storage_proxy_replica_cross_shard_ops(self, start_time, end_time):
-        query = """sum(irate(scylla_storage_proxy_replica_cross_shard_ops{instance=~".+[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.+",shard=~"[0-9]+"}[1m])) by (dc)"""  # pylint: disable=line-too-long
+        query = """sum(irate(scylla_storage_proxy_replica_cross_shard_ops{instance=~".+[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.+",shard=~"[0-9]+"}[1m])) by (dc)"""
         query = urllib.parse.quote(query)
         results = self.query(query, start_time, end_time)
         cross_shards_ops_per_node_shard_by_dc = []
@@ -410,7 +409,7 @@ class PrometheusDBStats:
     def generate_node_capacity_query_postfix(node):
         return f'{{mountpoint="{SCYLLA_DIR}", instance=~".*?{node.private_ip_address}.*?"}}'
 
-    def get_used_capacity_gb(self, node):  # pylint: disable=too-many-locals
+    def get_used_capacity_gb(self, node):
         #  example: node_filesystem_size_bytes{mountpoint="/var/lib/scylla",
         #  instance=~".*?10.0.79.46.*?"}-node_filesystem_avail_bytes{mountpoint="/var/lib/scylla",
         #  instance=~".*?10.0.79.46.*?"}
@@ -481,7 +480,7 @@ class Stats:
     def elasticsearch(self) -> Optional[ES]:
         try:
             return ES()
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc:
             LOGGER.exception("Failed to create ES connection (doc_id=%s)", self._test_id)
             ElasticsearchEvent(doc_id=self._test_id, error=str(exc)).publish()
             return None
@@ -496,7 +495,7 @@ class Stats:
                 doc_id=self._test_id,
                 body=self._stats,
             )
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc:
             LOGGER.exception("Failed to create test stats (doc_id=%s)", self._test_id)
             ElasticsearchEvent(doc_id=self._test_id, error=str(exc)).publish()
 
@@ -510,7 +509,7 @@ class Stats:
                 doc_id=self._test_id,
                 body=data,
             )
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc:
             LOGGER.exception("Failed to update test stats (doc_id=%s)", self._test_id)
             ElasticsearchEvent(doc_id=self._test_id, error=str(exc)).publish()
 
@@ -524,7 +523,7 @@ class Stats:
                 index=self._test_index,
                 id=self._test_id,
             )
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc:
             LOGGER.exception("Failed to check for test stats existence (doc_id=%s)", self._test_id)
             ElasticsearchEvent(doc_id=self._test_id, error=str(exc)).publish()
         return None
@@ -604,7 +603,7 @@ class TestStatsMixin(Stats):
                                                                             'date': match.group(4),
                                                                             'commit_id': match.group(5),
                                                                             'build_id': build_id if build_id else ''}
-        except Exception as ex:  # pylint: disable=broad-except
+        except Exception as ex:
             LOGGER.exception('Failed getting scylla versions: %s', ex)
 
         # append Scylla build mode in scylla_versions
@@ -620,10 +619,10 @@ class TestStatsMixin(Stats):
         test_params = self.params.items()
 
         for key, value in test_params:
-            if key in exclude_details or (isinstance(key, str) and key.startswith('stress_cmd')):  # pylint: disable=no-else-continue
+            if key in exclude_details or (isinstance(key, str) and key.startswith('stress_cmd')):
                 continue
             elif is_gce and key in \
-                    ['instance_type_loader',  # pylint: disable=no-else-continue
+                    ['instance_type_loader',
                      'instance_type_monitor',
                      'instance_type_db']:
                 # exclude these params from gce run
@@ -645,10 +644,10 @@ class TestStatsMixin(Stats):
         setup_details['packages_updated'] = bool(new_scylla_packages and os.listdir(new_scylla_packages))
         setup_details['cpu_platform'] = 'UNKNOWN'
         if is_gce and self.db_cluster:
-            if hasattr(self.db_cluster.nodes[0]._instance, "cpu_platform"):  # pylint: disable=protected-access
-                setup_details['cpu_platform'] = self.db_cluster.nodes[0]._instance.cpu_platform  # pylint: disable=protected-access
+            if hasattr(self.db_cluster.nodes[0]._instance, "cpu_platform"):
+                setup_details['cpu_platform'] = self.db_cluster.nodes[0]._instance.cpu_platform
             else:
-                setup_details['cpu_platform'] = self.db_cluster.nodes[0]._instance.extra.get(  # pylint: disable=protected-access
+                setup_details['cpu_platform'] = self.db_cluster.nodes[0]._instance.extra.get(
                     'cpuPlatform', 'UNKNOWN')
 
         setup_details['db_cluster_node_details'] = {}
@@ -671,7 +670,7 @@ class TestStatsMixin(Stats):
         test_details['log_files'] = {}
         return test_details
 
-    def create_test_stats(self, sub_type=None, specific_tested_stats=None,  # pylint: disable=too-many-arguments
+    def create_test_stats(self, sub_type=None, specific_tested_stats=None,
                           doc_id_with_timestamp=False, append_sub_test_to_name=True, test_name=None, test_index=None):
 
         if not self.create_stats:
@@ -742,7 +741,7 @@ class TestStatsMixin(Stats):
             stat["stdev"] = stddev(ops_filtered)
             self.log.debug("Stats: %s", stat)
             return stat
-        except Exception as ex:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as ex:  # noqa: BLE001
             self.log.error("Exception when calculating PrometheusDB stats: %s" % ex)
             return {}
 
@@ -788,7 +787,7 @@ class TestStatsMixin(Stats):
             return 0
         try:
             return float(stress_result[stat])
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             self.log.warning("Error in conversion of '%s' for stat '%s': '%s'"
                              "Discarding stat." % (stress_result[stat], stat, details))
         return 0
@@ -821,7 +820,6 @@ class TestStatsMixin(Stats):
                 total_stats[stat] = total
         self._stats['results']['stats_total'] = total_stats
 
-    # pylint: disable=too-many-arguments,too-many-locals
     def update_test_details(self, errors=None, coredumps=None, scylla_conf=False, extra_stats=None, alternator=False,
                             scrap_metrics_step=None):
         if not self.create_stats:
@@ -909,7 +907,7 @@ class TestStatsMixin(Stats):
                     index=self._test_index,
                     doc_id=self._test_id,
                 )
-            except Exception as exc:  # pylint: disable=broad-except
+            except Exception as exc:
                 LOGGER.exception("Failed to get test stats (doc_id=%s)", self._test_id)
                 ElasticsearchEvent(doc_id=self._test_id, error=str(exc)).publish()
             else:

--- a/sdcm/ec2_client.py
+++ b/sdcm/ec2_client.py
@@ -69,7 +69,7 @@ class EC2ClientWrapper():
             boto3.setup_default_session(region_name=region_name)
             return self._get_ec2_client()
 
-    def _request_spot_instance(self, instance_type, image_id, region_name, network_if, spot_price, key_pair='',  # pylint: disable=too-many-arguments  # noqa: PLR0913
+    def _request_spot_instance(self, instance_type, image_id, region_name, network_if, spot_price, key_pair='',  # noqa: PLR0913
                                user_data='', count=1, duration=0, request_type='one-time', block_device_mappings=None,
                                aws_instance_profile=None, placement_group_name=None):
         """
@@ -77,7 +77,6 @@ class EC2ClientWrapper():
         :return: list of request id-s
         """
 
-        # pylint: disable=too-many-locals
         params = dict(DryRun=False,
                       InstanceCount=count,
                       Type=request_type,
@@ -108,7 +107,7 @@ class EC2ClientWrapper():
         LOGGER.debug('Spot requests: %s', request_ids)
         return request_ids
 
-    def _request_spot_fleet(self, instance_type, image_id, region_name, network_if, key_pair='', user_data='', count=3,  # pylint: disable=too-many-arguments
+    def _request_spot_fleet(self, instance_type, image_id, region_name, network_if, key_pair='', user_data='', count=3,
                             block_device_mappings=None, aws_instance_profile=None, placement_group_name=None):
 
         spot_price = self._get_spot_price(instance_type)
@@ -147,7 +146,7 @@ class EC2ClientWrapper():
         :return: spot bid price
         """
         LOGGER.info('Calculating spot price based on OnDemand price')
-        from sdcm.utils.pricing import AWSPricing  # pylint: disable=import-outside-toplevel
+        from sdcm.utils.pricing import AWSPricing
         aws_pricing = AWSPricing()
         on_demand_price = float(aws_pricing.get_on_demand_instance_price(self.region_name, instance_type))
 
@@ -259,7 +258,7 @@ class EC2ClientWrapper():
         tags += tags_as_ec2_tags(TestConfig().common_tags())
         self._client.create_tags(Resources=instance_ids, Tags=tags)
 
-    def create_spot_instances(self, instance_type, image_id, region_name, network_if, key_pair='', user_data='',  # pylint: disable=too-many-arguments
+    def create_spot_instances(self, instance_type, image_id, region_name, network_if, key_pair='', user_data='',
                               count=1, duration=0, block_device_mappings=None, aws_instance_profile=None, placement_group_name=None):
         """
         Create spot instances
@@ -277,8 +276,6 @@ class EC2ClientWrapper():
 
         :return: list of instance id-s
         """
-
-        # pylint: disable=too-many-locals
 
         spot_price = self._get_spot_price(instance_type)
 
@@ -301,7 +298,7 @@ class EC2ClientWrapper():
         instances = [self.get_instance(instance_id) for instance_id in instance_ids]
         return instances
 
-    def create_spot_fleet(self, instance_type, image_id, region_name, network_if, key_pair='', user_data='', count=3,  # pylint: disable=too-many-arguments
+    def create_spot_fleet(self, instance_type, image_id, region_name, network_if, key_pair='', user_data='', count=3,
                           block_device_mappings=None, aws_instance_profile=None, placement_group_name=None):
         """
         Create spot fleet
@@ -318,7 +315,6 @@ class EC2ClientWrapper():
 
         :return: list of instance id-s
         """
-        # pylint: disable=too-many-locals
 
         request_id = self._request_spot_fleet(instance_type, image_id, region_name, network_if, key_pair,
                                               user_data, count, block_device_mappings=block_device_mappings,

--- a/sdcm/es.py
+++ b/sdcm/es.py
@@ -21,7 +21,7 @@ class ES(elasticsearch.Elasticsearch):
         return KeyStore().get_elasticsearch_token()
 
     def _create_index(self, index):
-        self.indices.create(index=index, ignore=400)  # pylint: disable=unexpected-keyword-arg
+        self.indices.create(index=index, ignore=400)
 
     def create_doc(self, index, doc_id, body):
         """
@@ -48,13 +48,13 @@ class ES(elasticsearch.Elasticsearch):
         """
         Search for documents for the certain index
         """
-        return self.search(index=index, size=limit)  # pylint: disable=unexpected-keyword-arg
+        return self.search(index=index, size=limit)
 
     def get_doc(self, index, doc_id):
         """
         Get document by id
         """
-        doc = self.get(index=index, id=doc_id, ignore=[  # pylint: disable=unexpected-keyword-arg
+        doc = self.get(index=index, id=doc_id, ignore=[
                        400, 404])
         if not doc['found']:
             LOGGER.warning('Document not found: %s', doc_id)

--- a/sdcm/exceptions.py
+++ b/sdcm/exceptions.py
@@ -56,7 +56,7 @@ class AuditLogTestFailure(Exception):
     """
 
 
-class BootstrapStreamErrorFailure(Exception):  # pylint: disable=too-few-public-methods
+class BootstrapStreamErrorFailure(Exception):
     """ raised if node was not boostrapped after bootstrap
     streaming was aborted """
 

--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -15,7 +15,6 @@ __author__ = 'Roy Dahan'
 #
 # Copyright (c) 2016 ScyllaDB
 
-# pylint: disable=too-many-lines,eval-used, line-too-long
 import contextlib
 import logging
 import random
@@ -26,9 +25,9 @@ from collections import OrderedDict
 from uuid import UUID
 
 from cassandra import InvalidRequest
-from cassandra.util import sortedset, SortedSet  # pylint: disable=no-name-in-module
+from cassandra.util import sortedset, SortedSet
 from cassandra import ConsistencyLevel
-from cassandra.protocol import ProtocolException  # pylint: disable=no-name-in-module
+from cassandra.protocol import ProtocolException
 
 from sdcm.tester import ClusterTester
 from sdcm.utils.database_query_utils import fetch_all_rows
@@ -3044,11 +3043,11 @@ class FillDatabaseData(ClusterTester):
             time.sleep(15)
 
     @staticmethod
-    def cql_insert_data_to_simple_tables(session, rows):  # pylint: disable=invalid-name
+    def cql_insert_data_to_simple_tables(session, rows):
         def insert_query():
             return f'INSERT INTO truncate_table{i} (my_id, col1, value) VALUES ( {k}, {k}, {k})'
-        for i in range(rows):  # pylint: disable=unused-variable
-            for k in range(100):  # pylint: disable=unused-variable
+        for i in range(rows):
+            for k in range(100):
                 session.execute(insert_query())
 
     @staticmethod
@@ -3198,7 +3197,7 @@ class FillDatabaseData(ClusterTester):
         return is_tablets_feature_enabled(self.db_cluster.nodes[0])
 
     @retrying(n=3, sleep_time=20, allowed_exceptions=ProtocolException)
-    def truncate_table(self, session, truncate):  # pylint: disable=no-self-use
+    def truncate_table(self, session, truncate):
         LOGGER.debug(truncate)
         session.execute(truncate)
 
@@ -3220,7 +3219,7 @@ class FillDatabaseData(ClusterTester):
 
     def cql_insert_data_to_tables(self, session, default_fetch_size):
         self.log.info('Start to populate data into tables')
-        # pylint: disable=too-many-nested-blocks
+
         for test_num, item in enumerate(self.all_verification_items):
             test_name = item.get('name', 'Test #' + str(test_num))
             # TODO: fix following condition to make "skip_condition" really skip stuff
@@ -3297,7 +3296,7 @@ class FillDatabaseData(ClusterTester):
 
     def run_db_queries(self, session, default_fetch_size):
         self.log.info('Start to running queries')
-        # pylint: disable=too-many-branches,too-many-nested-blocks
+
         for test_num, item in enumerate(self.all_verification_items):
             test_name = item.get('name', 'Test #' + str(test_num))
             # Some queries contains statement of switch keyspace, reset keyspace at the beginning
@@ -3338,14 +3337,14 @@ class FillDatabaseData(ClusterTester):
         node = self.db_cluster.nodes[0]
 
         with self.db_cluster.cql_connection_patient(node) as session:
-            # pylint: disable=no-member
+
             # override driver consistency level
             session.default_consistency_level = ConsistencyLevel.QUORUM
             # clean original test data by truncate
             try:
                 session.set_keyspace(self.base_ks)
                 self.truncate_tables(session)
-            except Exception as ex:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as ex:  # noqa: BLE001
                 LOGGER.debug("Found error in truncate tables: '%s'", ex)
 
             # Insert data to the tables according to the "inserts" and flush to disk in several cases (nodetool flush)

--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -29,7 +29,7 @@ from sdcm.utils.docker_remote import RemoteDocker
 LOGGER = logging.getLogger(__name__)
 
 
-class NotGeminiErrorResult:  # pylint: disable=too-few-public-methods
+class NotGeminiErrorResult:
     def __init__(self, error):
         self.exited = 1
         self.stdout = "n/a"
@@ -59,10 +59,10 @@ class GeminiEventsPublisher(FileFollowerThread):
                     break
 
 
-class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes
+class GeminiStressThread(DockerBasedStressThread):
     DOCKER_IMAGE_PARAM_NAME = "stress_image.gemini"
 
-    def __init__(self, test_cluster: BaseCluster | BaseScyllaCluster, oracle_cluster: ScyllaAWSCluster | CassandraAWSCluster | None, loaders, stress_cmd: str, timeout=None, params=None):  # pylint: disable=too-many-arguments
+    def __init__(self, test_cluster: BaseCluster | BaseScyllaCluster, oracle_cluster: ScyllaAWSCluster | CassandraAWSCluster | None, loaders, stress_cmd: str, timeout=None, params=None):
         super().__init__(loader_set=loaders, stress_cmd=stress_cmd, timeout=timeout, params=params)
         self.test_cluster = test_cluster
         self.oracle_cluster = oracle_cluster
@@ -186,7 +186,7 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
                 )
                 # sleep to gather all latest log messages
                 time.sleep(5)
-            except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as details:  # noqa: BLE001
                 LOGGER.error(details)
                 result = getattr(details, "result", NotGeminiErrorResult(details))
 
@@ -249,7 +249,7 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
         try:
             results = json.loads(json_str)
 
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             LOGGER.error("Invalid json document {}".format(details))
 
         return results.get("result")

--- a/sdcm/kafka/kafka_cluster.py
+++ b/sdcm/kafka/kafka_cluster.py
@@ -173,5 +173,5 @@ class LocalKafkaCluster(cluster.BaseCluster):
         rack=0,
         enable_auto_bootstrap=False,
         instance_type=None,
-    ):  # pylint: disable=too-many-arguments
+    ):
         raise NotImplementedError

--- a/sdcm/kafka/kafka_config.py
+++ b/sdcm/kafka/kafka_config.py
@@ -1,8 +1,6 @@
 from typing import Optional
 
-from pydantic import Field, BaseModel, ConfigDict  # pylint: disable=no-name-in-module
-
-# pylint: disable=too-few-public-methods
+from pydantic import Field, BaseModel, ConfigDict
 
 
 class ConnectorConfiguration(BaseModel):

--- a/sdcm/kafka/kafka_consumer.py
+++ b/sdcm/kafka/kafka_consumer.py
@@ -29,13 +29,13 @@ from sdcm.wait import wait_for
 LOGGER = logging.getLogger(__name__)
 
 
-class KafkaCDCReaderThread(Thread):  # pylint: disable=too-many-instance-attributes
+class KafkaCDCReaderThread(Thread):
     """
     thread that listen on kafka topic, and list all the unique key
     received, so we can validate how many unique key we got
     """
 
-    def __init__(self, tester, params: SCTConfiguration, kafka_addresses: list | None = None,  # pylint: disable=too-many-arguments
+    def __init__(self, tester, params: SCTConfiguration, kafka_addresses: list | None = None,
                  connector_index: int = 0, group_id: str = None, duration: int | None = None, **kwargs):
         self.keys = set()
         self.termination_event = Event()

--- a/sdcm/kcl_thread.py
+++ b/sdcm/kcl_thread.py
@@ -32,7 +32,7 @@ from sdcm.sct_events.loaders import KclStressEvent
 LOGGER = logging.getLogger(__name__)
 
 
-class KclStressThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes
+class KclStressThread(DockerBasedStressThread):
 
     DOCKER_IMAGE_PARAM_NAME = "stress_image.kcl"
 
@@ -82,7 +82,7 @@ class KclStressThread(DockerBasedStressThread):  # pylint: disable=too-many-inst
                                     log_file=log_file_name,
                                     retry=0,
                                     )
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc:
             errors_str = format_stress_cmd_error(exc)
             kcl_failure_event = KclStressEvent.failure(
                 node=loader,
@@ -99,7 +99,7 @@ class KclStressThread(DockerBasedStressThread):  # pylint: disable=too-many-inst
         return loader, result, kcl_failure_event or kcl_finish_event
 
 
-class CompareTablesSizesThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes
+class CompareTablesSizesThread(DockerBasedStressThread):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._stop_event = threading.Event()
@@ -153,7 +153,7 @@ class CompareTablesSizesThread(DockerBasedStressThread):  # pylint: disable=too-
                 time.sleep(self._interval)
             return None
 
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc:
             KclStressEvent.failure(
                 node=loader,
                 stress_cmd=self.stress_cmd,

--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -31,7 +31,7 @@ SSHKey = namedtuple("SSHKey", ["name", "public_key", "private_key"])
 BOTO3_CLIENT_CREATION_LOCK = threading.Lock()
 
 
-class KeyStore:  # pylint: disable=too-many-public-methods
+class KeyStore:
     @property
     def s3(self) -> S3ServiceResource:
         return boto3.resource("s3")

--- a/sdcm/loader.py
+++ b/sdcm/loader.py
@@ -46,12 +46,10 @@ class HDRPositions(NamedTuple):
     lat_perc_9999: int
 
 
-# pylint: disable=too-many-instance-attributes
 class StressExporter(FileFollowerThread, metaclass=ABCMeta):
     METRICS_GAUGES = {}
     METRIC_NAMES = ['lat_mean', 'lat_med', 'lat_perc_95', 'lat_perc_99', 'lat_perc_999', 'lat_max']
 
-    # pylint: disable=too-many-arguments
     def __init__(self, instance_name: str, metrics: NemesisMetrics, stress_operation: str,
                  stress_log_filename: str, loader_idx: int, cpu_idx: int = 1, keyspace: str = ''):
         super().__init__()
@@ -323,8 +321,6 @@ class CqlStressCassandraStressExporter(StressExporter):
     # Lines containing any of these should be skipped. These are the logs emitted by the `tracing` crate.
     TRACING_LOGS = ['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR']
 
-    # pylint: disable=too-many-arguments
-
     def __init__(self, instance_name: str, metrics: NemesisMetrics, stress_operation: str, stress_log_filename: str,
                  loader_idx: int, cpu_idx: int = 1):
 
@@ -388,7 +384,6 @@ class ScyllaBenchStressExporter(StressExporter):
                 [f'scylla_bench_stress_{self.stress_operation}', 'instance', 'loader_idx', 'cpu_idx', 'type', 'keyspace'])
         return gauge_name
 
-    # pylint: disable=line-too-long
     def metrics_position_in_log(self) -> MetricsPosition:
         # Enumerate stress metric position in the log. Example:
         # time  operations/s    rows/s   errors  max   99.9th   99th      95th     90th       median        mean
@@ -397,7 +392,6 @@ class ScyllaBenchStressExporter(StressExporter):
         return MetricsPosition(ops=1, lat_mean=10, lat_med=9, lat_perc_95=7, lat_perc_99=6, lat_perc_999=5,
                                lat_max=4, errors=3)
 
-    # pylint: disable=line-too-long
     def skip_line(self, line) -> bool:
         # If line is not starts with numeric ended by "s" - skip this line.
         # Example:
@@ -421,7 +415,6 @@ class ScyllaBenchStressExporter(StressExporter):
 
 class CassandraHarryStressExporter(StressExporter):
 
-    # pylint: disable=too-many-arguments,useless-super-delegation
     def __init__(self, instance_name: str, metrics: NemesisMetrics, stress_operation: str, stress_log_filename: str,
                  loader_idx: int, cpu_idx: int = 1):
 

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -11,7 +11,6 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
-#  pylint: disable=too-many-lines
 import os
 import json
 import re
@@ -68,10 +67,9 @@ LOGGER = logging.getLogger(__name__)
 
 
 class CollectingNode:
-    # pylint: disable=too-few-public-methods,too-many-instance-attributes
     logdir = None
 
-    def __init__(self, name, ssh_login_info=None, instance=None, global_ip=None, grafana_ip=None, tags=None, logdir=None):  # pylint: disable=too-many-arguments
+    def __init__(self, name, ssh_login_info=None, instance=None, global_ip=None, grafana_ip=None, tags=None, logdir=None):
         if logdir:
             self.logdir = logdir
         self._containers = {}
@@ -126,7 +124,7 @@ class PrometheusSnapshotErrorException(Exception):
     pass
 
 
-class BaseLogEntity:  # pylint: disable=too-few-public-methods
+class BaseLogEntity:
     """Base class for log entity
 
     LogEntity any file, command, operation, complex actions
@@ -151,7 +149,7 @@ class BaseLogEntity:  # pylint: disable=too-few-public-methods
     def set_params(self, params):
         self._params = params
 
-    def collect(self, node, local_dst, remote_dst=None, local_search_path=None):  # pylint: disable=unused-argument,no-self-use
+    def collect(self, node, local_dst, remote_dst=None, local_search_path=None):
         raise Exception('Should be implemented in child class')
 
 
@@ -165,18 +163,18 @@ class BaseMonitoringEntity(BaseLogEntity):
     @staticmethod
     def get_monitoring_stack(backend):
         if backend == 'aws':
-            from sdcm.cluster_aws import MonitorSetAWS  # pylint: disable=import-outside-toplevel
+            from sdcm.cluster_aws import MonitorSetAWS
             return MonitorSetAWS
         elif backend == 'docker':
-            from sdcm.cluster_docker import MonitorSetDocker  # pylint: disable=import-outside-toplevel
+            from sdcm.cluster_docker import MonitorSetDocker
             return MonitorSetDocker
         elif backend == 'gce':
-            from sdcm.cluster_gce import MonitorSetGCE  # pylint: disable=import-outside-toplevel
+            from sdcm.cluster_gce import MonitorSetGCE
             return MonitorSetGCE
         elif backend == 'baremetal':
-            from sdcm.cluster_baremetal import MonitorSetPhysical  # pylint: disable=import-outside-toplevel
+            from sdcm.cluster_baremetal import MonitorSetPhysical
             return MonitorSetPhysical
-        from sdcm.cluster import BaseMonitorSet  # pylint: disable=import-outside-toplevel
+        from sdcm.cluster import BaseMonitorSet
         return BaseMonitorSet
 
     def get_monitoring_version(self, node):
@@ -191,7 +189,7 @@ class BaseMonitoringEntity(BaseLogEntity):
                 return None, None, None
             result = node.remoter.run(
                 f"cat {basedir}/{name}/monitor_version", ignore_status=True, verbose=False)
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             LOGGER.error("Failed to get monitoring version: %s", details)
             return None, None, None
 
@@ -203,7 +201,7 @@ class BaseMonitoringEntity(BaseLogEntity):
         return name, monitor_version, scylla_version
 
 
-class CommandLog(BaseLogEntity):  # pylint: disable=too-few-public-methods
+class CommandLog(BaseLogEntity):
     """Command to get log and save output result to file on remote host
 
     CommandLog which allow to save the output (usually log output)
@@ -244,7 +242,7 @@ class FileLog(CommandLog):
     def find_local_files(search_in_dir, search_pattern, except_patterns="collected_logs"):
         local_files = []
         for root, _, files in os.walk(search_in_dir):
-            for f in files:  # pylint: disable=invalid-name
+            for f in files:
                 full_path = os.path.join(root, f)
                 if except_patterns in full_path:
                     continue
@@ -255,7 +253,7 @@ class FileLog(CommandLog):
         return local_files
 
     @staticmethod
-    def find_on_builder(builder, file_name, search_in_dir="/"):  # pylint: disable=unused-argument
+    def find_on_builder(builder, file_name, search_in_dir="/"):
         result = builder.remoter.run('find {search_in_dir} -name {file_name}'.format(**locals()),
                                      ignore_status=True)
         if not result.exited and not result.stderr:
@@ -355,7 +353,7 @@ class PrometheusSnapshots(BaseMonitoringEntity):
     def get_prometheus_snapshot_remote(self, node) -> Optional[str]:
         try:
             snapshot_dir = self.create_prometheus_snapshot(node)
-        except (PrometheusSnapshotErrorException, Exception) as details:  # pylint: disable=broad-except
+        except (PrometheusSnapshotErrorException, Exception) as details:
             LOGGER.warning("Create prometheus snapshot failed %s.\nUse prometheus data directory", details)
             node.remoter.run('docker stop aprom', ignore_status=True)
             snapshot_dir = self.monitoring_data_dir
@@ -434,7 +432,7 @@ class MonitoringStack(BaseMonitoringEntity):
             res = requests.get(f"http://{grafana_ip}:{self.grafana_port}/api/annotations")
             if res.ok:
                 return res.text
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             LOGGER.warning("Unable to get Grafana annotations [%s]", details)
         return ""
 
@@ -463,7 +461,7 @@ class MonitoringStack(BaseMonitoringEntity):
         return local_archive
 
 
-class GrafanaEntity(BaseMonitoringEntity):  # pylint: disable=too-few-public-methods
+class GrafanaEntity(BaseMonitoringEntity):
     """Base Gragana log entity
 
     Base class to support various Grafana log entity
@@ -554,12 +552,12 @@ class GrafanaScreenShot(GrafanaEntity):
                             for chunk in response.iter_content(chunk_size=8192):
                                 output_file.write(chunk)
                     screenshots.append(screenshot_path)
-                except Exception as details:  # pylint: disable=broad-except
+                except Exception as details:
                     LOGGER.error("Error get screenshot %s: %s", dashboard.name, details, exc_info=True)
 
             return screenshots
 
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             LOGGER.error("Error taking monitor screenshot: %s, traceback: %s", details, traceback.format_exc())
             return []
 
@@ -625,7 +623,7 @@ class LogCollector:
                     'Remote storing folder not created.\n{}'.format(result))
                 remote_dir = self.node_remote_dir
 
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             LOGGER.error("Error during creating remote directory %s", details)
             remote_dir = self.node_remote_dir
 
@@ -675,7 +673,7 @@ class LogCollector:
                                        local_dst=local_parent_dir if log_entity.collect_from_parent else local_node_dir,
                                        remote_dst=remote_node_dir,
                                        local_search_path=local_search_path)
-                except Exception as details:  # pylint: disable=unused-variable, broad-except  # noqa: BLE001
+                except Exception as details:  # noqa: BLE001
                     LOGGER.error("Error occured during collecting of %s on host: %s\n%s",
                                  log_entity.name, node.name, details)
 
@@ -689,7 +687,7 @@ class LogCollector:
             try:
                 ParallelObject(self.nodes, num_workers=workers_number, timeout=self.collect_timeout).run(
                     collect_logs_per_node, ignore_exceptions=True)
-            except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as details:  # noqa: BLE001
                 LOGGER.error('Error occured during collecting logs %s', details)
 
         if not os.listdir(self.local_dir):
@@ -724,7 +722,7 @@ class LogCollector:
     def update_db_info(self):
         pass
 
-    def _compress_file(self, src_path: str, src_name: str) -> str:  # pylint: disable=no-self-use
+    def _compress_file(self, src_path: str, src_name: str) -> str:
         archive_name = f"{src_name}.tar.zst"
         archive_dir, log_filename = os.path.split(src_path)
 
@@ -742,7 +740,7 @@ class LogCollector:
                 src_name = src_name.replace(extension, f"-{self.test_id.split('-')[0]}{extension}")
         try:
             return self._compress_file(src_path, src_name)
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             LOGGER.error("Error during archive creation. Details: \n%s", details)
             return None
 
@@ -850,7 +848,7 @@ def save_kallsyms_map(node):
 
         try:
             log_entity.collect(node, node.logdir, remote_node_dir)
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             LOGGER.error("Error occurred during collecting kallsyms on host: %s\n%s", node.name, details)
 
 
@@ -877,7 +875,7 @@ def collect_log_entities(node, log_entities: List[BaseLogEntity]):
             try:
                 log_entity.collect(node, node.logdir, remote_node_dir)
                 LOGGER.debug("Diagnostic file '%s' collected", log_entity.name)
-            except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as details:  # noqa: BLE001
                 LOGGER.error("Error occurred during collecting diagnostics data on host: %s\n%s", node.name, details)
 
 
@@ -1163,7 +1161,7 @@ class KubernetesAPIServerLogCollector(BaseSCTLogCollector):
             self.generate_apiserver_call_stats_file(apiserver_logdir)
             return self.create_single_archive_and_upload()
 
-    def generate_apiserver_call_stats_file(self, apiserver_logdir: str) -> None:  # pylint: disable=no-self-use
+    def generate_apiserver_call_stats_file(self, apiserver_logdir: str) -> None:
         dst_file_path = f"{apiserver_logdir}/{self.api_call_stats_filename}"
         results, results_list = {}, []
 
@@ -1266,7 +1264,7 @@ class KubernetesLogCollector(BaseSCTLogCollector):
                                     k8s_logdir, '.kube', current_k8s_logdir_sub_file)):
                                 KubernetesOps.gather_k8s_logs(k8s_logdir)
                                 break
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.warning("Got following failure processing the K8S logs: %s", exc)
         return super().collect_logs(local_search_path=local_search_path)
 
@@ -1331,7 +1329,7 @@ class SSTablesCollector(BaseSCTLogCollector):
         data_path, keyspace, table_dir, sstable_name = sstable_path.rsplit("/", 3)
         return f"{data_path}/{keyspace}/{table_dir}", keyspace, table_dir.split("-")[0], sstable_name
 
-    def collect_logs(self, local_search_path: Optional[str] = None) -> list[str]:  # pylint: disable=too-many-locals
+    def collect_logs(self, local_search_path: Optional[str] = None) -> list[str]:
         try:
             raw_events_file_path = Path(self.local_dir).parent.parent.parent / EVENTS_LOG_DIR / RAW_EVENTS_LOG
             with open(raw_events_file_path, "r", encoding="utf-8") as events_file:
@@ -1371,7 +1369,7 @@ class SSTablesCollector(BaseSCTLogCollector):
                     s3_bucket=S3Storage.bucket_name,
                     s3_key=f"{self.test_id}/{self.current_run}/corrupted-sstables-{keyspace}-{table_name}.tar.gz",
                     max_size_gb=80, public_read_acl=True)
-        except Exception as error:  # pylint: disable=broad-except
+        except Exception as error:
             LOGGER.exception("failed collecting malformed sstables:\n%s", error, exc_info=error)
             return []
         return [s3_link]
@@ -1393,7 +1391,7 @@ class SSLConfCollector(BaseSCTLogCollector):
     cluster_log_type = 'ssl-conf'
 
 
-class Collector:  # pylint: disable=too-many-instance-attributes,
+class Collector:
     """Collector instance
 
     Collector instance which should be run to collect logs and additional info
@@ -1467,7 +1465,7 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
 
     def find_and_append_cloud_manager_instance_to_collecting_nodes(self):
         try:
-            from cluster_cloud import get_manager_instance_by_cluster_id  # pylint: disable=import-outside-toplevel
+            from cluster_cloud import get_manager_instance_by_cluster_id
         except ImportError:
             LOGGER.error("Couldn't collect Siren manager logs, cluster_cloud module isn't installed")
             return
@@ -1481,7 +1479,7 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
             instance = get_manager_instance_by_cluster_id(cluster_id=cloud_cluster_id)
             if not instance:
                 raise ValueError(f"Cloud manager for the cluster {cloud_cluster_id} not found")
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.error("Failed to get cloud manager instance. Error: %s", exc)
             return
 
@@ -1695,7 +1693,7 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
                     LOGGER.info("collected data for %s\n%s\n", log_collector.cluster_log_type, result)
                 else:
                     LOGGER.warning("There are no logs collected for %s", log_collector.cluster_log_type)
-            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 LOGGER.warning(
                     "%s is not able to collect logs. Moving to the next log collector",
                     log_collector.__class__.__name__, exc_info=True)
@@ -1707,7 +1705,7 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
         self.storage_dir = os.path.join(self.sct_result_dir, log_dir, 'collected_logs')
         os.makedirs(self.storage_dir, exist_ok=True)
         if not os.path.exists(os.path.join(os.path.dirname(self.storage_dir), "test_id")):
-            with open(os.path.join(os.path.dirname(self.storage_dir), "test_id"), "w", encoding="utf-8") as f:  # pylint: disable=invalid-name
+            with open(os.path.join(os.path.dirname(self.storage_dir), "test_id"), "w", encoding="utf-8") as f:
                 f.write(self.test_id)
 
 

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -11,7 +11,7 @@
 #
 # Copyright (c) 2021 ScyllaDB
 
-# pylint: disable=too-many-lines
+
 import json
 import time
 import logging
@@ -51,10 +51,10 @@ forcing_tls_minimum_version = LooseVersion("3.2.6")
 # TODO: remove these checks once manager 2.6 is no longer supported
 
 
-class ScyllaManagerBase:  # pylint: disable=too-few-public-methods
+class ScyllaManagerBase:
 
-    def __init__(self, id, manager_node):  # pylint: disable=redefined-builtin
-        self.id = id  # pylint: disable=invalid-name
+    def __init__(self, id, manager_node):
+        self.id = id
         self.manager_node = manager_node
         self.sctool = SCTool(manager_node=manager_node)
 
@@ -67,7 +67,7 @@ class ManagerTask:
     def __init__(self, task_id, cluster_id, manager_node):
         self.manager_node = manager_node
         self.sctool = SCTool(manager_node=manager_node)
-        self.id = task_id  # pylint: disable=invalid-name
+        self.id = task_id
         self.cluster_id = cluster_id
 
     def get_property(self, parsed_table, column_name):
@@ -395,7 +395,7 @@ class ManagerTask:
         # * check that progress command works on various task statuses (that was how manager bug #856 found).
         # * print the progress to log in cases needed for failures/performance analysis.
         ###
-        progress = self.progress  # pylint: disable=unused-variable  # noqa: F841
+        progress = self.progress  # noqa: F841
         return self.status in list_status
 
     def wait_for_status(self, list_status, check_task_progress=True, timeout=3600, step=120):
@@ -627,7 +627,7 @@ class ManagerCluster(ScyllaManagerBase):
         LOGGER.debug("Created task id is: {}".format(task_id))
         return RestoreTask(task_id=task_id, cluster_id=self.id, manager_node=self.manager_node)
 
-    def create_backup_task(self, dc_list=None,  # pylint: disable=too-many-arguments,too-many-locals,too-many-branches  # noqa: PLR0913
+    def create_backup_task(self, dc_list=None,  # noqa: PLR0913
                            dry_run=None, interval=None, keyspace_list=None, cron=None,
                            location_list=None, num_retries=None, rate_limit_list=None, retention=None, show_tables=None,
                            snapshot_parallel_list=None, start_date=None, upload_parallel_list=None, transfers=None,
@@ -679,7 +679,7 @@ class ManagerCluster(ScyllaManagerBase):
         LOGGER.debug("Created task id is: {}".format(task_id))
         return BackupTask(task_id=task_id, cluster_id=self.id, manager_node=self.manager_node)
 
-    def create_repair_task(self, dc_list=None,  # pylint: disable=too-many-arguments
+    def create_repair_task(self, dc_list=None,
                            keyspace=None, interval=None, num_retries=None, fail_fast=None,
                            intensity=None, parallel=None, cron=None, start_date=None):
         # the interval string:
@@ -779,7 +779,7 @@ class ManagerCluster(ScyllaManagerBase):
         cmd = "cluster delete -c {}".format(self.id)
         self.sctool.run(cmd=cmd, is_verify_errorless_result=True)
 
-    def update(self, name=None, host=None, client_encrypt=None, force_non_ssl_session_port=False):  # pylint: disable=too-many-arguments
+    def update(self, name=None, host=None, client_encrypt=None, force_non_ssl_session_port=False):
         """
         $ sctool cluster update --help
         Modify a cluster
@@ -883,7 +883,6 @@ class ManagerCluster(ScyllaManagerBase):
         """
         Gets the Manager's Cluster Nodes status
         """
-        # pylint: disable=too-many-locals
 
         # $ sctool status -c bla
         # Datacenter: dc1
@@ -941,8 +940,8 @@ class ManagerCluster(ScyllaManagerBase):
                                                          health.rest_status, health.rest_rtt, health.ssl))
         return dict_hosts_health
 
-    class _HostHealth():  # pylint: disable=too-few-public-methods
-        def __init__(self, status, rtt, ssl, rest_status, rest_rtt, rest_http_status_code=None):  # pylint: disable=too-many-arguments
+    class _HostHealth():
+        def __init__(self, status, rtt, ssl, rest_status, rest_rtt, rest_http_status_code=None):
             self.status = status
             self.rtt = rtt
             self.rest_status = rest_status
@@ -1042,7 +1041,7 @@ class ScyllaManagerTool(ScyllaManagerBase):
     def get_cluster_hosts_with_ips(db_cluster):
         return [[n, n.ip_address] for n in db_cluster.nodes]
 
-    def add_cluster(self, name, host=None, db_cluster=None, client_encrypt=None, disable_automatic_repair=True,  # pylint: disable=too-many-arguments
+    def add_cluster(self, name, host=None, db_cluster=None, client_encrypt=None, disable_automatic_repair=True,
                     auth_token=None, credentials=None, force_non_ssl_session_port=False):
         """
         :param name: cluster name
@@ -1065,7 +1064,7 @@ class ScyllaManagerTool(ScyllaManagerBase):
           https://manager.docs.scylladb.com/stable/add-a-cluster.html
           https://manager.docs.scylladb.com/stable/sctool#cluster-add
         """
-        # pylint: disable=too-many-locals
+
         if not any([host, db_cluster]):
             raise ScyllaManagerError("Neither host or db_cluster parameter were given to Manager add_cluster")
 
@@ -1199,7 +1198,7 @@ class SCTool:
     def __init__(self, manager_node):
         self.manager_node = manager_node
 
-    def run(self,  # pylint: disable=too-many-arguments
+    def run(self,
             cmd,
             is_verify_errorless_result=False,
             parse_table_res=True,
@@ -1413,7 +1412,7 @@ class ScyllaMgmt:
             raise Exception(err_msg)
         try:
             return json.loads(resp.content)
-        except Exception as ex:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as ex:  # noqa: BLE001
             LOGGER.error('Failed load data from json %s, error: %s', resp.content, ex)
         return resp.content
 
@@ -1517,7 +1516,7 @@ class ScyllaMgmt:
     def get_task_progress(self, cluster_id, repair_unit):
         try:
             return self.get(path='cluster/{}/repair/unit/{}/progress'.format(cluster_id, repair_unit))
-        except Exception as ex:  # pylint: disable=broad-except
+        except Exception as ex:
             LOGGER.exception('Failed to get repair progress: %s', ex)
         return None
 

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -147,7 +147,7 @@ class HostRestStatus(Enum):
             raise ScyllaManagerError("Could not recognize returned host rest status: {}".format(output_str)) from err
 
 
-class TaskStatus:  # pylint: disable=too-few-public-methods
+class TaskStatus:
     NEW = "NEW"
     RUNNING = "RUNNING"
     DONE = "DONE"

--- a/sdcm/mgmt/operator.py
+++ b/sdcm/mgmt/operator.py
@@ -89,7 +89,6 @@ class ScyllaOperatorRepairTask(ScyllaOperatorTaskBaseClass):
     small_table_threshold: str = None
 
 
-# pylint: disable=invalid-name,too-many-instance-attributes,too-many-arguments
 @dataclass
 class ScyllaOperatorRepairTaskStatus(ScyllaOperatorRepairTask):
     # These statuses are not available at scylla-operator 1.0
@@ -248,12 +247,11 @@ class OperatorManagerCluster(ManagerCluster):
         )
         try:
             self.scylla_cluster.add_scylla_cluster_value('/spec/backups', so_backup_task.to_dict())
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc:
             LOGGER.error('Failed to submit repair task:\n%s\ndue to the %s', so_backup_task.to_dict(), exc)
             raise
         return so_backup_task
 
-    # pylint: disable=too-many-locals
     def create_backup_task(  # noqa: PLR0913
             self,
             dc_list=None,
@@ -307,12 +305,12 @@ class OperatorManagerCluster(ManagerCluster):
         )
         try:
             self.scylla_cluster.add_scylla_cluster_value('/spec/repairs', so_repair_task.to_dict())
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc:
             LOGGER.error('Failed to submit repair task:\n%s\ndue to the %s', so_repair_task.to_dict(), exc)
             raise
         return so_repair_task
 
-    def create_repair_task(self, dc_list=None,  # pylint: disable=too-many-arguments,arguments-differ
+    def create_repair_task(self, dc_list=None,
                            keyspace=None, interval=None, num_retries=None, fail_fast=None,
                            intensity=None, parallel=None, name=None) -> RepairTask:
         # NOTE: wait for the 'healthcheck' tasks be 'DONE' before starting the repair one.
@@ -409,8 +407,8 @@ class ScyllaManagerToolOperator(ScyllaManagerTool):
             cluster = self.clusterClass(
                 manager_node=self.manager_node, cluster_name=cluster_name, scylla_cluster=self.scylla_cluster)
         else:
-            cluster.set_scylla_cluster(self.scylla_cluster)  # pylint: disable=no-member
-            cluster.set_cluster_name(cluster_name)  # pylint: disable=no-member
+            cluster.set_scylla_cluster(self.scylla_cluster)
+            cluster.set_cluster_name(cluster_name)
         return cluster
 
     def __init__(self, manager_node, scylla_cluster):

--- a/sdcm/microbenchmarking.py
+++ b/sdcm/microbenchmarking.py
@@ -34,8 +34,8 @@ from cryptography.utils import CryptographyDeprecationWarning
 warnings.filterwarnings(action='ignore', category=CryptographyDeprecationWarning)
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-from sdcm.results_analyze import BaseResultsAnalyzer  # pylint: disable=wrong-import-position
-from sdcm.utils.log import setup_stdout_logger  # pylint: disable=wrong-import-position
+from sdcm.results_analyze import BaseResultsAnalyzer
+from sdcm.utils.log import setup_stdout_logger
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 setup_stdout_logger()
@@ -75,7 +75,7 @@ class EmptyResultFolder(Exception):
         return "MBM: {0.message}".format(self)
 
 
-class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=too-many-instance-attributes
+class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):
     allowed_stats = ('Current', 'Stats', 'Last, commit, date', 'Diff last [%]', 'Best, commit, date', 'Diff best [%]')
     higher_better = ('frag/s',)
     lower_better = ('avg aio',)
@@ -99,7 +99,7 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
         if additional_filter:
             query += " AND " + additional_filter
         print(query)
-        output = self._es.search(  # pylint: disable=unexpected-keyword-arg; pylint doesn't understand Elasticsearch code
+        output = self._es.search(
             index=self._es_index,
             q=query,
             size=self._limit,
@@ -107,9 +107,7 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
         )
         return output
 
-    def check_regression(self, current_results):  # pylint: disable=arguments-differ
-        # pylint: disable=too-many-locals, too-many-statements
-
+    def check_regression(self, current_results):
         if not current_results:
             return {}
 
@@ -325,7 +323,6 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
         return self.send_email(subject, summary_html, files=files)
 
     def get_results(self, results_path, update_db):
-        # pylint: disable=too-many-locals
 
         bad_chars = " "
         with chdir(os.path.join(results_path, "perf_fast_forward_output")):
@@ -455,7 +452,7 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
             "hits.hits._source.versions.scylla-server.run_date_time"
         )
         self.log.info('Exclude tests before date {}'.format(date))
-        results = self._es.search(index=self._es_index, filter_path=filter_path, size=self._limit,  # pylint: disable=unexpected-keyword-arg
+        results = self._es.search(index=self._es_index, filter_path=filter_path, size=self._limit,
                                   q="hostname:'%s' AND versions.scylla-server.version:%s*" %
                                   (self.hostname, self.db_version[:3]))
         if not results:
@@ -488,7 +485,7 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):  # pylint: disable=
 
         self.log.info('Exclude tests by commit id #{}'.format(commit_id))
 
-        results = self._es.search(index=self._es_index, filter_path=filter_path, size=self._limit,  # pylint: disable=unexpected-keyword-arg
+        results = self._es.search(index=self._es_index, filter_path=filter_path, size=self._limit,
                                   q="hostname:'{}' \
                                   AND versions.scylla-server.version:{}*\
                                   AND versions.scylla-server.commit_id:'{}'".format(self.hostname, self.db_version[:3], commit_id))

--- a/sdcm/monitorstack/__init__.py
+++ b/sdcm/monitorstack/__init__.py
@@ -37,7 +37,7 @@ class ErrorUploadAnnotations(Exception):
     pass
 
 
-def restore_monitoring_stack(test_id, date_time=None):  # pylint: disable=too-many-return-statements,too-many-locals  # noqa: PLR0911
+def restore_monitoring_stack(test_id, date_time=None):  # noqa: PLR0911
     if not is_docker_available():
         return False
 
@@ -317,7 +317,7 @@ def get_monitoring_stack_dir(base_dir):
 
 def get_monitoring_stack_scylla_version(monitoring_stack_dir):
     try:
-        with open(os.path.join(monitoring_stack_dir, 'monitor_version'), encoding="utf-8") as f:  # pylint: disable=invalid-name
+        with open(os.path.join(monitoring_stack_dir, 'monitor_version'), encoding="utf-8") as f:
             versions = f.read().strip()
         monitoring_version, scylla_version = versions.split(':')
         if not requests.head(f'https://github.com/scylladb/scylla-monitoring/tree/{monitoring_version}'
@@ -325,7 +325,7 @@ def get_monitoring_stack_scylla_version(monitoring_stack_dir):
             scylla_version = 'master'
 
         return monitoring_version, scylla_version
-    except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception:  # noqa: BLE001
         return 'branch-3.0', 'master'
 
 
@@ -335,7 +335,7 @@ def restore_grafana_dashboards_and_annotations(monitoring_dockers_dir, grafana_d
         status.append(restore_sct_dashboards(grafana_docker_port=grafana_docker_port,
                                              sct_dashboard_file=sct_dashboard_file))
         status.append(restore_annotations_data(monitoring_dockers_dir, grafana_docker_port=grafana_docker_port))
-    except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as details:  # noqa: BLE001
         LOGGER.error("Error during uploading sct monitoring data %s", details)
         status.append(False)
 
@@ -345,7 +345,7 @@ def restore_grafana_dashboards_and_annotations(monitoring_dockers_dir, grafana_d
 def run_monitoring_stack_containers(monitoring_stack_dir, monitoring_data_dir, scylla_version, tenants_number=1):
     try:
         return start_dockers(monitoring_stack_dir, monitoring_data_dir, scylla_version, tenants_number)
-    except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as details:  # noqa: BLE001
         LOGGER.error("Dockers are not started. Error: %s", details)
         return {}
 
@@ -358,7 +358,7 @@ def restore_sct_dashboards(grafana_docker_port, sct_dashboard_file):
         sct_dashboard_file = [Path(__file__).parent.parent.parent / 'data_dir' / sct_dashboard_file_name]
 
     dashboard_url = f'http://localhost:{grafana_docker_port}/api/dashboards/db'
-    with open(sct_dashboard_file, encoding="utf-8") as f:  # pylint: disable=invalid-name
+    with open(sct_dashboard_file, encoding="utf-8") as f:
         dashboard_config = json.load(f)
         # NOTE: remove value from the 'dashboard.id' field to avoid following error:
         #
@@ -381,7 +381,7 @@ def restore_sct_dashboards(grafana_docker_port, sct_dashboard_file):
                 res.text))
         LOGGER.info('Dashboard %s loaded successfully', sct_dashboard_file)
         return True
-    except Exception as details:  # pylint: disable=broad-except
+    except Exception as details:
         LOGGER.error('Error uploading dashboard %s. Error message %s', sct_dashboard_file, details)
         raise
 
@@ -396,11 +396,11 @@ def restore_annotations_data(monitoring_stack_dir, grafana_docker_port):
         LOGGER.info('There is no annotations file.Skip loading annotations')
         return False
     try:
-        with open(annotations_file, encoding="utf-8") as f:  # pylint: disable=invalid-name
+        with open(annotations_file, encoding="utf-8") as f:
             annotations = json.load(f)
 
         annotations_url = f"http://localhost:{grafana_docker_port}/api/annotations"
-        for an in annotations:  # pylint: disable=invalid-name
+        for an in annotations:
             res = requests.post(annotations_url, data=json.dumps(an), headers={'Content-Type': 'application/json'})
             if res.status_code != 200:
                 LOGGER.info('Error during uploading annotation %s. Error message %s', an, res.text)
@@ -408,18 +408,18 @@ def restore_annotations_data(monitoring_stack_dir, grafana_docker_port):
                                                                                                              res.text))
         LOGGER.info('Annotations loaded successfully')
         return True
-    except Exception as details:  # pylint: disable=broad-except
+    except Exception as details:
         LOGGER.error("Error during annotations data upload %s", details)
         raise
 
 
 @retrying(n=3, sleep_time=5, message='Start docker containers')
-def start_dockers(monitoring_dockers_dir, monitoring_stack_data_dir, scylla_version, tenants_number):  # pylint: disable=unused-argument
+def start_dockers(monitoring_dockers_dir, monitoring_stack_data_dir, scylla_version, tenants_number):
     graf_port = get_free_port(ports_to_try=[GRAFANA_DOCKER_PORT + i for i in range(tenants_number)] + [0])
     alert_port = get_free_port(ports_to_try=[ALERT_DOCKER_PORT + i for i in range(tenants_number)] + [0])
     prom_port = get_free_port(ports_to_try=[PROMETHEUS_DOCKER_PORT + i for i in range(tenants_number)] + [0])
 
-    lr = LocalCmdRunner()  # pylint: disable=invalid-name
+    lr = LocalCmdRunner()
     lr.run('cd {monitoring_dockers_dir}; ./kill-all.sh -g {graf_port} -m {alert_port} -p {prom_port}'.format(**locals()),
            ignore_status=True, verbose=False)
 
@@ -500,9 +500,9 @@ def verify_monitoring_stack(containers_ports):
 
 
 def verify_dockers_are_running(containers_ports):
-    result = LocalCmdRunner().run("docker ps --format '{{.Names}}'", ignore_status=True)  # pylint: disable=invalid-name
+    result = LocalCmdRunner().run("docker ps --format '{{.Names}}'", ignore_status=True)
     docker_names = result.stdout.strip().split()
-    result = LocalCmdRunner().run("docker ps --format '{{.Names}}'", ignore_status=True)  # pylint: disable=invalid-name
+    result = LocalCmdRunner().run("docker ps --format '{{.Names}}'", ignore_status=True)
     grafana_docker_port = containers_ports["grafana_docker_port"]
     prometheus_docker_port = containers_ports["prometheus_docker_port"]
     if result.ok and docker_names:
@@ -515,7 +515,7 @@ def verify_dockers_are_running(containers_ports):
 
 
 def verify_grafana_is_available(grafana_docker_port=GRAFANA_DOCKER_PORT):
-    # pylint: disable=import-outside-toplevel
+
     from sdcm.logcollector import GrafanaEntity, MonitoringStack
     grafana_statuses = []
     for dashboard in GrafanaEntity.base_grafana_dashboards:
@@ -526,7 +526,7 @@ def verify_grafana_is_available(grafana_docker_port=GRAFANA_DOCKER_PORT):
                                                             title=dashboard.title)
             grafana_statuses.append(result)
             LOGGER.info("Dashboard {} is available".format(dashboard.title))
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             LOGGER.error("Dashboard %s is not available. Error: %s", dashboard.title, details)
             grafana_statuses.append(False)
 
@@ -546,7 +546,6 @@ def verify_prometheus_is_available(prometheus_docker_port=PROMETHEUS_DOCKER_PORT
     :rtype: {bool}
     """
 
-    # pylint: disable=import-outside-toplevel
     from sdcm.db_stats import PrometheusDBStats
 
     time_end = time.time()
@@ -557,7 +556,7 @@ def verify_prometheus_is_available(prometheus_docker_port=PROMETHEUS_DOCKER_PORT
         prom_client.get_throughput(time_start, time_end)
         LOGGER.info("Prometheus is up")
         return True
-    except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as details:  # noqa: BLE001
         LOGGER.error("Error requesting prometheus %s", details)
         return False
 
@@ -573,7 +572,7 @@ def kill_running_monitoring_stack_services(ports=None):
                               "prometheus_docker_port": PROMETHEUS_DOCKER_PORT,
                               "alert_docker_port": ALERT_DOCKER_PORT}
 
-    lr = LocalCmdRunner()  # pylint: disable=invalid-name
+    lr = LocalCmdRunner()
     for docker in get_monitoring_stack_services(ports=dockers_ports):
         LOGGER.info("Killing %s", docker['service'])
         lr.run('docker rm -f {name}-{port}'.format(name=docker['name'], port=docker['port']),

--- a/sdcm/monitorstack/ui.py
+++ b/sdcm/monitorstack/ui.py
@@ -1,7 +1,5 @@
 from sdcm.utils.ci_tools import get_test_name
 
-# pylint: disable=too-few-public-methods
-
 
 class Dashboard:
     name: str

--- a/sdcm/ndbench_thread.py
+++ b/sdcm/ndbench_thread.py
@@ -106,11 +106,11 @@ class NdBenchStatsPublisher(FileFollowerThread):
                             operation, name = key.split('_', 1)
                             self.set_metric(operation, name, float(value))
 
-                except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+                except Exception as exc:  # noqa: BLE001
                     LOGGER.warning("Failed to send metric. Failed with exception {exc}".format(exc=exc))
 
 
-class NdBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes
+class NdBenchStressThread(DockerBasedStressThread):
 
     DOCKER_IMAGE_PARAM_NAME = "stress_image.ndbench"
 
@@ -160,7 +160,7 @@ class NdBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-many-
                                     log_file=log_file_name,
                                     verbose=True,
                                     retry=0)
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 ndbench_failure_event = NdBenchStressEvent.failure(
                     node=str(loader),
                     stress_cmd=self.stress_cmd,

--- a/sdcm/node_exporter_setup.py
+++ b/sdcm/node_exporter_setup.py
@@ -4,7 +4,7 @@ from sdcm.remote import shell_script_cmd
 NODE_EXPORTER_VERSION = '1.8.2'
 
 
-class NodeExporterSetup:  # pylint: disable=too-few-public-methods
+class NodeExporterSetup:
     @staticmethod
     def install(node: "BaseNode | None" = None, remoter: "Remoter | None" = None):  # noqa: F821
         assert node or remoter, "node or remoter much be pass to this function"

--- a/sdcm/nosql_thread.py
+++ b/sdcm/nosql_thread.py
@@ -46,7 +46,7 @@ class NoSQLBenchEventsPublisher(FileFollowerThread):
                         event.clone().add_info(node=self.node, line=line, line_number=line_number).publish()
 
 
-class NoSQLBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes
+class NoSQLBenchStressThread(DockerBasedStressThread):
     """
     A stress thread that is running NoSQLBench docker on remote loader and getting results back
     If you have questions regarding NoSQLBench command line please checkout following documentation:
@@ -114,7 +114,7 @@ class NoSQLBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-ma
                                             f'{self.docker_image_name} '
                                             f'{stress_cmd} --report-graphite-to graphite-exporter:9109',
                                             timeout=self.timeout + self.shutdown_timeout, log_file=log_file_name)
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 self.configure_event_on_failure(stress_event=stress_event, exc=exc)
 
             return loader, result, stress_event

--- a/sdcm/parallel_timeline_report/generate_pt_report.py
+++ b/sdcm/parallel_timeline_report/generate_pt_report.py
@@ -41,7 +41,6 @@ class EventGroup(Enum):
     STRESS_EVENTS = ["CassandraStressEvent", "CassandraStressLogEvent"]
 
 
-# pylint: disable=too-many-instance-attributes
 @dataclass
 class Event:
     event_dict: dict
@@ -149,7 +148,6 @@ class Event:
         return label_string
 
 
-# pylint: disable=too-many-instance-attributes
 class ParallelTimelinesReportGenerator:
     def __init__(self, events_file):
         self.events_file = Path(events_file)

--- a/sdcm/prometheus.py
+++ b/sdcm/prometheus.py
@@ -61,14 +61,14 @@ def start_metrics_server():
         ip = get_my_ip()
         LOGGER.info('prometheus API server running on port: %s', port)
         return '{}:{}'.format(ip, port)
-    except Exception as ex:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as ex:  # noqa: BLE001
         LOGGER.error('Cannot start local http metrics server: %s', ex)
 
     return None
 
 
 def nemesis_metrics_obj(metric_name_suffix=''):
-    global NM_OBJ  # pylint: disable=global-statement,global-variable-not-assigned  # noqa: PLW0602
+    global NM_OBJ  # noqa: PLW0602
     if not NM_OBJ.get(metric_name_suffix):
         NM_OBJ[metric_name_suffix] = NemesisMetrics(metric_name_suffix)
     return NM_OBJ[metric_name_suffix]
@@ -97,7 +97,7 @@ class NemesisMetrics:
     def create_counter(name, desc, param_list):
         try:
             return prometheus_client.Counter(name, desc, param_list)
-        except Exception as ex:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as ex:  # noqa: BLE001
             LOGGER.error('Cannot create metrics counter: %s', ex)
         return None
 
@@ -105,22 +105,22 @@ class NemesisMetrics:
     def create_gauge(name, desc, param_list):
         try:
             return prometheus_client.Gauge(name, desc, param_list)
-        except Exception as ex:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as ex:  # noqa: BLE001
             LOGGER.error('Cannot create metrics gauge: %s', ex)
         return None
 
     def event_start(self, disrupt):
         try:
-            self._disrupt_counter.labels(disrupt, START).inc()  # pylint: disable=no-member
-            self._disrupt_gauge.labels(disrupt).inc()  # pylint: disable=no-member
-        except Exception as ex:  # pylint: disable=broad-except
+            self._disrupt_counter.labels(disrupt, START).inc()
+            self._disrupt_gauge.labels(disrupt).inc()
+        except Exception as ex:
             LOGGER.exception('Cannot start metrics event: %s', ex)
 
     def event_stop(self, disrupt):
         try:
-            self._disrupt_counter.labels(disrupt, STOP).inc()  # pylint: disable=no-member
-            self._disrupt_gauge.labels(disrupt).dec()  # pylint: disable=no-member
-        except Exception as ex:  # pylint: disable=broad-except
+            self._disrupt_counter.labels(disrupt, STOP).inc()
+            self._disrupt_gauge.labels(disrupt).dec()
+        except Exception as ex:
             LOGGER.exception('Cannot stop metrics event: %s', ex)
 
 
@@ -138,7 +138,7 @@ class PrometheusAlertManagerListener(threading.Thread):
     def is_alert_manager_up(self):
         try:
             return requests.get(f"{self._alert_manager_url}/status", timeout=3).json()['cluster']['status'] == 'ready'
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             return False
 
     @log_run_info
@@ -168,7 +168,7 @@ class PrometheusAlertManagerListener(threading.Thread):
             return response.json()
         return None
 
-    def _publish_new_alerts(self, alerts: dict):  # pylint: disable=no-self-use
+    def _publish_new_alerts(self, alerts: dict):
         for alert in alerts.values():
             PrometheusAlertManagerEvent(raw_alert=alert).begin_event()
 
@@ -284,7 +284,7 @@ class PrometheusAlertManagerListener(threading.Thread):
 
 
 class AlertSilencer:
-    # pylint: disable=too-many-arguments
+
     def __init__(self,
                  alert_manager: PrometheusAlertManagerListener,
                  alert_name: str,

--- a/sdcm/provision/aws/capacity_reservation.py
+++ b/sdcm/provision/aws/capacity_reservation.py
@@ -198,7 +198,6 @@ class SCTCapacityReservation:
         return cls.reservations[availability_zone][instance_type]
 
     @staticmethod
-    # pylint: disable=too-many-arguments
     def _create(ec2, test_id, availability_zone, instance_type, instance_count, duration, placement_group_arn=None) -> str | None:
         additional_params = {}
         if placement_group_arn:
@@ -236,7 +235,7 @@ class SCTCapacityReservation:
                 **additional_params
             )
             return response['CapacityReservation']['CapacityReservationId']
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.info("Failed to create capacity reservation for %s. Error: %s", instance_type, exc)
             return None
 

--- a/sdcm/provision/aws/configuration_script.py
+++ b/sdcm/provision/aws/configuration_script.py
@@ -15,7 +15,7 @@ from sdcm.provision.aws.utils import network_config_ipv6_workaround_script
 from sdcm.provision.common.configuration_script import ConfigurationScriptBuilder
 
 
-class AWSConfigurationScriptBuilder(ConfigurationScriptBuilder):  # pylint: disable=too-few-public-methods
+class AWSConfigurationScriptBuilder(ConfigurationScriptBuilder):
     """
     A class that builds instance initialization script from parameters
     """

--- a/sdcm/provision/aws/instance_parameters.py
+++ b/sdcm/provision/aws/instance_parameters.py
@@ -55,7 +55,7 @@ class AWSPlacementInfo(BaseModel):
 
 
 class AWSInstanceParams(InstanceParamsBase):
-    # pylint: disable=invalid-name
+
     ImageId: str
     KeyName: str
     InstanceType: str
@@ -69,7 +69,6 @@ class AWSInstanceParams(InstanceParamsBase):
     AddressingType: str = None
     EbsOptimized: bool = None
 
-    # pylint: disable=arguments-differ
     def model_dump(
         self,
         *,

--- a/sdcm/provision/aws/instance_parameters_builder.py
+++ b/sdcm/provision/aws/instance_parameters_builder.py
@@ -22,35 +22,35 @@ from sdcm.provision.common.builders import AttrBuilder
 class AWSInstanceParamsBuilderBase(AttrBuilder, metaclass=abc.ABCMeta):
     @property
     @abc.abstractmethod
-    def BlockDeviceMappings(self) -> List[AWSDiskMapping]:  # pylint: disable=invalid-name
+    def BlockDeviceMappings(self) -> List[AWSDiskMapping]:
         pass
 
     @property
     @abc.abstractmethod
-    def ImageId(self) -> Optional[str]:  # pylint: disable=invalid-name
+    def ImageId(self) -> Optional[str]:
         pass
 
     @property
     @abc.abstractmethod
-    def KeyName(self) -> str:  # pylint: disable=invalid-name
+    def KeyName(self) -> str:
         pass
 
     @property
     @abc.abstractmethod
-    def NetworkInterfaces(self) -> List[dict]:  # pylint: disable=invalid-name
+    def NetworkInterfaces(self) -> List[dict]:
         pass
 
     @property
     @abc.abstractmethod
-    def IamInstanceProfile(self):  # pylint: disable=invalid-name
+    def IamInstanceProfile(self):
         pass
 
     @property
     @abc.abstractmethod
-    def InstanceType(self) -> str:  # pylint: disable=invalid-name
+    def InstanceType(self) -> str:
         pass
 
     @property
     @abc.abstractmethod
-    def Placement(self) -> Optional[AWSPlacementInfo]:  # pylint: disable=invalid-name
+    def Placement(self) -> Optional[AWSPlacementInfo]:
         pass

--- a/sdcm/provision/aws/provisioner.py
+++ b/sdcm/provision/aws/provisioner.py
@@ -32,12 +32,12 @@ from sdcm.provision.common.provisioner import TagsType, ProvisionParameters, Ins
 LOGGER = logging.getLogger(__name__)
 
 
-class AWSInstanceProvisioner(InstanceProvisionerBase):  # pylint: disable=too-few-public-methods
+class AWSInstanceProvisioner(InstanceProvisionerBase):
     # TODO: Make them configurable
     _wait_interval = 5
     _iam_fleet_role = 'arn:aws:iam::797456418907:role/aws-ec2-spot-fleet-role'
 
-    def provision(  # pylint: disable=too-many-arguments
+    def provision(
             self,
             provision_parameters: ProvisionParameters,
             instance_parameters: AWSInstanceParams,
@@ -208,7 +208,7 @@ class AWSInstanceProvisioner(InstanceProvisionerBase):  # pylint: disable=too-fe
         try:
             resp = self._ec2_client(provision_parameters).describe_spot_fleet_requests(SpotFleetRequestIds=request_ids)
             LOGGER.info("%s: - %s", request_ids, resp)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.info("%s: - failed to get status: %s", request_ids, exc)
             return []
         for req in resp['SpotFleetRequestConfigs']:

--- a/sdcm/provision/aws/utils.py
+++ b/sdcm/provision/aws/utils.py
@@ -108,14 +108,14 @@ def find_instances_by_tags(region_name: str, tags: TagsType, states: List[str] =
 
 
 def find_instance_by_id(region_name: str, instance_id: str) -> Instance:
-    return ec2_resources[region_name].Instance(id=instance_id)  # pylint: disable=no-member
+    return ec2_resources[region_name].Instance(id=instance_id)
 
 
 def set_tags_on_instances(region_name: str, instance_ids: List[str], tags: TagsType):
     end_time = time.perf_counter() + 20
     while end_time > time.perf_counter():
         with contextlib.suppress(ClientError):
-            ec2_clients[region_name].create_tags(  # pylint: disable=no-member
+            ec2_clients[region_name].create_tags(
                 Resources=instance_ids,
                 Tags=convert_tags_to_aws_format(tags))
             return True
@@ -145,7 +145,7 @@ def wait_for_provision_request_done(
 def get_provisioned_fleet_instance_ids(region_name: str, request_ids: List[str]) -> Optional[List[str]]:
     try:
         resp = ec2_clients[region_name].describe_spot_fleet_requests(SpotFleetRequestIds=request_ids)
-    except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception:  # noqa: BLE001
         return []
     for req in resp['SpotFleetRequestConfigs']:
         if req['SpotFleetRequestState'] == 'active' and req.get('ActivityStatus', None) == STATUS_FULFILLED:
@@ -168,7 +168,7 @@ def get_provisioned_fleet_instance_ids(region_name: str, request_ids: List[str])
     for request_id in request_ids:
         try:
             resp = ec2_clients[region_name].describe_spot_fleet_instances(SpotFleetRequestId=request_id)
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             return None
         provisioned_instances.extend([inst['InstanceId'] for inst in resp['ActiveInstances']])
     return provisioned_instances
@@ -182,7 +182,7 @@ def get_provisioned_spot_instance_ids(region_name: str, request_ids: List[str]) 
     """
     try:
         resp = ec2_clients[region_name].describe_spot_instance_requests(SpotInstanceRequestIds=request_ids)
-    except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception:  # noqa: BLE001
         return []
     provisioned = []
     for req in resp['SpotInstanceRequests']:
@@ -196,7 +196,6 @@ def get_provisioned_spot_instance_ids(region_name: str, request_ids: List[str]) 
     return provisioned
 
 
-#  pylint: disable=too-many-arguments
 def create_spot_fleet_instance_request(
         region_name: str,
         count: int,
@@ -216,7 +215,6 @@ def create_spot_fleet_instance_request(
     return resp['SpotFleetRequestId']
 
 
-#  pylint: disable=too-many-arguments
 def create_spot_instance_request(
         region_name: str,
         count: int,

--- a/sdcm/provision/azure/provisioner.py
+++ b/sdcm/provision/azure/provisioner.py
@@ -34,7 +34,7 @@ from sdcm.utils.azure_utils import AzureService
 LOGGER = logging.getLogger(__name__)
 
 
-class AzureProvisioner(Provisioner):  # pylint: disable=too-many-instance-attributes
+class AzureProvisioner(Provisioner):
     """Provides api for VM provisioning in Azure cloud, tuned for Scylla QA. """
 
     def __init__(self, test_id: str, region: str, availability_zone: str,
@@ -88,7 +88,6 @@ class AzureProvisioner(Provisioner):  # pylint: disable=too-many-instance-attrib
     @classmethod
     def discover_regions(cls, test_id: str = "", regions: list = None,
                          azure_service: AzureService = AzureService(), **kwargs) -> List["AzureProvisioner"]:
-        # pylint: disable=arguments-differ,unused-argument
         """Discovers provisioners for in each region for given test id.
 
         If test_id is not provided, it discovers all related to SCT provisioners."""

--- a/sdcm/provision/azure/utils.py
+++ b/sdcm/provision/azure/utils.py
@@ -29,7 +29,7 @@ from sdcm.utils.version_utils import (
 LOGGER = logging.getLogger(__name__)
 
 
-def get_scylla_images(  # pylint: disable=too-many-branches,too-many-locals
+def get_scylla_images(
         scylla_version: str,
         region_name: str,
         arch: VmArch = VmArch.X86,
@@ -91,7 +91,7 @@ def get_scylla_images(  # pylint: disable=too-many-branches,too-many-locals
     return output[::-1]
 
 
-def get_released_scylla_images(  # pylint: disable=unused-argument
+def get_released_scylla_images(
         scylla_version: str,
         region_name: str,
         arch: VmArch = VmArch.X86,

--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -52,7 +52,7 @@ class VirtualMachineProvider:
 
     def get_or_create(self, definitions: List[InstanceDefinition], nics_ids: List[str], pricing_model: PricingModel
                       ) -> List[VirtualMachine]:
-        # pylint: disable=too-many-locals
+
         v_ms = []
         pollers = []
         error_to_raise = None

--- a/sdcm/provision/common/builders.py
+++ b/sdcm/provision/common/builders.py
@@ -13,7 +13,7 @@
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict  # pylint: disable=no-name-in-module
+from pydantic import BaseModel, ConfigDict
 
 
 class AttrBuilder(BaseModel):

--- a/sdcm/provision/common/provisioner.py
+++ b/sdcm/provision/common/provisioner.py
@@ -2,13 +2,13 @@
 import abc
 from typing import Dict, Any, List, Union
 
-from pydantic import BaseModel  # pylint: disable=no-name-in-module
+from pydantic import BaseModel
 
 
 TagsType = Dict[str, str]
 
 
-class ProvisionParameters(BaseModel):  # pylint: disable=too-few-public-methods
+class ProvisionParameters(BaseModel):
     name: str  # Name of the parameter needed only to make distinction between the parameter instances
     region_name: str
     availability_zone: str
@@ -17,18 +17,18 @@ class ProvisionParameters(BaseModel):  # pylint: disable=too-few-public-methods
     price: float = None  # Requested price for instance
 
 
-class InstanceParamsBase(BaseModel):  # pylint: disable=too-few-public-methods
+class InstanceParamsBase(BaseModel):
     """
     Base class for instance parameters
     """
 
 
-class InstanceProvisionerBase(BaseModel, metaclass=abc.ABCMeta):  # pylint: disable=too-few-public-methods
+class InstanceProvisionerBase(BaseModel, metaclass=abc.ABCMeta):
     """
     Base class for provisioner - a class that provide API to provision instances
     """
     @abc.abstractmethod
-    def provision(  # pylint: disable=too-many-arguments
+    def provision(
             self,
             provision_parameters: ProvisionParameters,
             instance_parameters: InstanceParamsBase | List[InstanceParamsBase],

--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -14,8 +14,6 @@
 from textwrap import dedent
 
 
-# pylint: disable=anomalous-backslash-in-string
-
 def configure_syslogng_target_script(hostname: str = "") -> str:
     return dedent("""
         source_name=`cat /etc/syslog-ng/syslog-ng.conf | tr -d "\\n" | tr -d "\\r" | sed -r "s/\\}};/\\}};\\n/g; \

--- a/sdcm/provision/helpers/certificate.py
+++ b/sdcm/provision/helpers/certificate.py
@@ -79,7 +79,7 @@ def install_client_certificate(remoter, node_identifier):
     dst = '/tmp/ssl_conf'
     remoter.run(f'mkdir -p {dst}')
     remoter.send_files(src=str(Path(get_data_dir_path('ssl_conf')) / node_identifier) + '/', dst=dst)
-    remoter.send_files(src=str(Path(get_data_dir_path('ssl_conf')) / 'client'), dst=dst)  # pylint: disable=not-callable
+    remoter.send_files(src=str(Path(get_data_dir_path('ssl_conf')) / 'client'), dst=dst)
     setup_script = dedent(f"""
         mkdir -p ~/.cassandra/
         cp /tmp/ssl_conf/client/cqlshrc ~/.cassandra/
@@ -148,7 +148,6 @@ def _create_ca(cname: str = 'scylladb.com', valid_days: int = 365) -> None:
         )
 
 
-# pylint: disable=too-many-arguments,too-many-locals
 def create_certificate(
         cert_file: Path, key_file: Path, cname: str, ca_cert_file: Path = None, ca_key_file: Path = None,
         server_csr_file: Path = None, ip_addresses: list = None, dns_names: list = None, valid_days: int = 365) -> None:

--- a/sdcm/provision/network_configuration.py
+++ b/sdcm/provision/network_configuration.py
@@ -7,7 +7,7 @@ class NetworkInterfaceNotFound(Exception):
 
 
 @dataclass
-class NetworkInterface:  # pylint: disable=too-many-instance-attributes
+class NetworkInterface:
     ipv4_public_address: Optional[str]
     # AWS allows to have a few public IPv6 addresses per interface.
     ipv6_public_addresses: [str]

--- a/sdcm/provision/provisioner.py
+++ b/sdcm/provision/provisioner.py
@@ -36,7 +36,7 @@ class DataDisk:
 
 
 @dataclass
-class InstanceDefinition:  # pylint: disable=too-many-instance-attributes
+class InstanceDefinition:
     name: str
     image_id: str
     type: str   # instance_type from yaml
@@ -70,7 +70,7 @@ class PricingModel(Enum):
 
 
 @dataclass
-class VmInstance:  # pylint: disable=too-many-instance-attributes
+class VmInstance:
     name: str
     region: str
     user_name: str

--- a/sdcm/provision/scylla_yaml/auxiliaries.py
+++ b/sdcm/provision/scylla_yaml/auxiliaries.py
@@ -15,7 +15,7 @@
 import logging
 from typing import Literal, List, Union, Optional
 
-from pydantic import Field, validator, BaseModel  # pylint: disable=no-name-in-module
+from pydantic import Field, validator, BaseModel
 
 from sdcm.provision.common.builders import AttrBuilder
 from sdcm.sct_config import SCTConfiguration
@@ -39,7 +39,7 @@ SASLAUTHD_AUTHENTICATOR = 'com.scylladb.auth.SaslauthdAuthenticator'
 LOGGER = logging.getLogger(__file__)
 
 
-class SeedProvider(BaseModel):  # pylint: disable=too-few-public-methods
+class SeedProvider(BaseModel):
     class_name: Literal[
         'org.apache.cassandra.locator.SimpleSeedProvider',
         'org.apache.cassandra.locator.GossipingPropertyFileSnitch',
@@ -56,7 +56,6 @@ class SeedProvider(BaseModel):  # pylint: disable=too-few-public-methods
     ]
     parameters: List[dict] = None
 
-    # pylint: disable=no-self-argument,no-self-use
     @validator("class_name", pre=True, always=True)
     def set_class_name(cls, class_name: str):
         if class_name.startswith('org.apache.cassandra.locator.'):
@@ -64,7 +63,7 @@ class SeedProvider(BaseModel):  # pylint: disable=too-few-public-methods
         return 'org.apache.cassandra.locator.' + class_name
 
 
-class ServerEncryptionOptions(BaseModel):  # pylint: disable=too-few-public-methods
+class ServerEncryptionOptions(BaseModel):
     internode_encryption: Literal['all', 'none', 'dc', 'rack'] = 'none'
     certificate: str = 'conf/scylla.crt'
     keyfile: str = 'conf/scylla.key'
@@ -73,7 +72,7 @@ class ServerEncryptionOptions(BaseModel):  # pylint: disable=too-few-public-meth
     require_client_auth: bool = False
 
 
-class ClientEncryptionOptions(BaseModel):  # pylint: disable=too-few-public-methods
+class ClientEncryptionOptions(BaseModel):
     enabled: bool = False
     certificate: str = 'conf/scylla.crt'
     keyfile: str = 'conf/scylla.key'
@@ -82,7 +81,7 @@ class ClientEncryptionOptions(BaseModel):  # pylint: disable=too-few-public-meth
     require_client_auth: bool = False
 
 
-class RequestSchedulerOptions(BaseModel):  # pylint: disable=too-few-public-methods
+class RequestSchedulerOptions(BaseModel):
     throttle_limit: int = None
     default_weight: int = 1
     weights: int = 1
@@ -150,7 +149,7 @@ class ScyllaYamlAttrBuilderBase(AttrBuilder):
         """
         if not self._regions:
             return False
-        return len(self._regions) > 1  # pylint: disable=no-member
+        return len(self._regions) > 1
 
     @property
     def _intra_node_comm_public(self) -> bool:

--- a/sdcm/provision/scylla_yaml/certificate_builder.py
+++ b/sdcm/provision/scylla_yaml/certificate_builder.py
@@ -46,7 +46,7 @@ def update_cqlshrc(cqlshrc_file: str = CQLSHRC_FILE, client_encrypt: bool = Fals
 
 
 # Disabling no-member since can't import BaseNode from 'sdcm.cluster' due to a circular import
-# pylint: disable=no-member
+
 class ScyllaYamlCertificateAttrBuilder(ScyllaYamlAttrBuilderBase):
     """
     Builds scylla yaml attributes regarding encryption

--- a/sdcm/provision/scylla_yaml/node_builder.py
+++ b/sdcm/provision/scylla_yaml/node_builder.py
@@ -20,7 +20,7 @@ from sdcm.provision.scylla_yaml.auxiliaries import ScyllaYamlAttrBuilderBase, Se
 
 
 # Disabling no-member since can't import BaseNode from 'sdcm.cluster' due to a circular import
-# pylint: disable=no-member
+
 class ScyllaYamlNodeAttrBuilder(ScyllaYamlAttrBuilderBase):
     """
     Builds scylla yaml attributes that are needed to keep node connected to the other nodes in the cluster

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -15,7 +15,7 @@ from typing import List, Literal, Union, Any
 
 import logging
 import yaml
-from pydantic import validator, BaseModel, ConfigDict  # pylint: disable=no-name-in-module
+from pydantic import validator, BaseModel, ConfigDict
 
 from sdcm.provision.scylla_yaml.auxiliaries import RequestSchedulerOptions, EndPointSnitchType, SeedProvider, \
     ServerEncryptionOptions, ClientEncryptionOptions
@@ -24,7 +24,7 @@ from sdcm.provision.scylla_yaml.auxiliaries import RequestSchedulerOptions, EndP
 logger = logging.getLogger(__name__)
 
 
-class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods,too-many-instance-attributes
+class ScyllaYaml(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -50,7 +50,6 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods,too-many-
     disk_failure_policy: Literal["die", "stop_paranoid", "stop", "best_effort", "ignore"] = None  # "stop"
     endpoint_snitch: EndPointSnitchType | None = None
 
-    # pylint: disable=no-self-argument,no-self-use
     @validator("endpoint_snitch", pre=True, always=True)
     def set_endpoint_snitch(cls, endpoint_snitch: str):
         if endpoint_snitch is None:
@@ -189,7 +188,6 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods,too-many-
     ] | None = None
     stream_io_throughput_mb_per_sec: int = None  # 0
 
-    # pylint: disable=no-self-argument,no-self-use
     @validator("request_scheduler", pre=True, always=True)
     def set_request_scheduler(cls, request_scheduler: str):
         if request_scheduler is None:
@@ -209,7 +207,6 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods,too-many-
         "com.scylladb.auth.SaslauthdAuthenticator"
     ] | None = None  # "org.apache.cassandra.auth.AllowAllAuthenticator"
 
-    # pylint: disable=no-self-argument,no-self-use
     @validator("authenticator", pre=True, always=True)
     def set_authenticator(cls, authenticator: str):
         if authenticator is None:
@@ -230,7 +227,6 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods,too-many-
         "com.scylladb.auth.SaslauthdAuthorizer"
     ] | None = None  # "org.apache.cassandra.auth.AllowAllAuthorizer"
 
-    # pylint: disable=no-self-argument,no-self-use
     @validator("authorizer", pre=True, always=True)
     def set_authorizer(cls, authorizer: str):
         if authorizer is None:
@@ -359,7 +355,7 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods,too-many-
 
     reader_concurrency_semaphore_cpu_concurrency: int = None
 
-    def model_dump(  # pylint: disable=arguments-differ
+    def model_dump(
         self,
         *,
         explicit: List[str] = None,

--- a/sdcm/remote/base.py
+++ b/sdcm/remote/base.py
@@ -89,7 +89,6 @@ class CommandRunner(metaclass=ABCMeta):
             watchers.append(LogWriteWatcher(log_file))
         return watchers
 
-    # pylint: disable=too-many-arguments
     @abstractmethod
     def run(self,
             cmd: str,
@@ -104,7 +103,6 @@ class CommandRunner(metaclass=ABCMeta):
             ) -> Result:
         pass
 
-    # pylint: disable=too-many-arguments
     def sudo(self,
              cmd: str,
              timeout: Optional[float] = None,
@@ -191,7 +189,7 @@ class CommandRunner(metaclass=ABCMeta):
         return shlex.quote("".join(new_name))
 
     @staticmethod
-    def _make_ssh_command(user: str = "root",  # pylint: disable=too-many-arguments
+    def _make_ssh_command(user: str = "root",
                           port: int = 22, opts: str = '', hosts_file: str = '/dev/null',
                           key_file: str = None, connect_timeout: float = 300, alive_interval: float = 300,
                           extra_ssh_options: str = '', proxy_cmd: str = None) -> str:
@@ -210,7 +208,7 @@ class CommandRunner(metaclass=ABCMeta):
                                alive_interval, user, port, proxy_cmd)
 
 
-class OutputWatcher(StreamWatcher):  # pylint: disable=too-few-public-methods
+class OutputWatcher(StreamWatcher):
     def __init__(self, log: logging.Logger, hostname: str):
         super().__init__()
         self.hostname = hostname
@@ -231,13 +229,13 @@ class OutputWatcher(StreamWatcher):  # pylint: disable=too-few-public-methods
         self.log.debug("<%s>: %s", self.hostname, line.rstrip('\n'))
 
 
-class LogWriteWatcher(StreamWatcher):  # pylint: disable=too-few-public-methods
+class LogWriteWatcher(StreamWatcher):
     def __init__(self, log_file: str):
         super().__init__()
         self.len = 0
         self.log_file = log_file
         # open fail with line buffering, so prom stats would be as accuracte as possible
-        # pylint: disable=consider-using-with
+
         self.file_object = open(self.log_file, "a+", encoding="utf-8", buffering=1)
 
     def submit(self, stream: str) -> list:

--- a/sdcm/remote/kubernetes_cmd_runner.py
+++ b/sdcm/remote/kubernetes_cmd_runner.py
@@ -133,7 +133,7 @@ class KubernetesCmdRunner(RemoteCmdRunnerBase):
     exception_retryable = (ConnectionError, MaxRetryError, ThreadException)
     default_run_retry = 8
 
-    def __init__(self, kluster, pod_image: str,  # pylint: disable=too-many-arguments
+    def __init__(self, kluster, pod_image: str,
                  pod_name: str, container: Optional[str] = None,
                  namespace: str = "default") -> None:
         self.kluster = kluster
@@ -162,7 +162,7 @@ class KubernetesCmdRunner(RemoteCmdRunnerBase):
             },
         )
 
-    def run(self, cmd, **kwargs):  # pylint: disable=arguments-differ
+    def run(self, cmd, **kwargs):
         if hasattr(self, "dynamic_remoter") and hasattr(self, "pod_image"):
             if is_scylla_bench_command(cmd) and "scylla-bench" not in self.pod_image:
                 LOGGER.info(
@@ -194,8 +194,7 @@ class KubernetesCmdRunner(RemoteCmdRunnerBase):
                                                           "k8s_container": self.container,
                                                           "k8s_namespace": self.namespace, })))
 
-    # pylint: disable=too-many-arguments
-    def _run_execute(self, cmd: str, timeout: Optional[float] = None,  # pylint: disable=too-many-arguments
+    def _run_execute(self, cmd: str, timeout: Optional[float] = None,
                      ignore_status: bool = False, verbose: bool = True, new_session: bool = False,
                      watchers: Optional[List[StreamWatcher]] = None):
         # TODO: This should be removed than sudo calls will be done in more organized way.
@@ -213,14 +212,12 @@ class KubernetesCmdRunner(RemoteCmdRunnerBase):
         return super()._run_execute(cmd, timeout=timeout, ignore_status=ignore_status, verbose=verbose,
                                     new_session=True, watchers=watchers)
 
-    # pylint: disable=too-many-arguments,unused-argument
     @retrying(n=3, sleep_time=5, allowed_exceptions=(RetryableNetworkException, ))
     def receive_files(self, src, dst, delete_dst=False, preserve_perm=True, preserve_symlinks=False, timeout=300):
         KubernetesOps.copy_file(self.kluster, f"{self.namespace}/{self.pod_name}:{src}", dst,
                                 container=self.container, timeout=timeout)
         return True
 
-    # pylint: disable=too-many-arguments,unused-argument
     @retrying(n=3, sleep_time=5, allowed_exceptions=(RetryableNetworkException, ))
     def send_files(self, src, dst, delete_dst=False, preserve_symlinks=False, verbose=False):
         with KEY_BASED_LOCKS.get_lock(f"k8s--{self.kluster.name}--{self.namespace}--{self.pod_name}"):
@@ -405,7 +402,7 @@ class KubernetesPodWatcher(KubernetesRunner):
             namespace=self.context.config.k8s_namespace).stdout.strip()
         return yaml.safe_load(result_raw) or {}
 
-    def returncode(self, status: dict | None = None) -> Optional[int]:  # pylint: disable=arguments-differ
+    def returncode(self, status: dict | None = None) -> Optional[int]:
         if status is None:
             status = self._get_pod_status()
         # NOTE: logic is based on the following conditions:
@@ -440,7 +437,7 @@ class KubernetesPodWatcher(KubernetesRunner):
             pod_name, result)
         return result
 
-    def _is_pod_failed_or_completed(self, _cache={}) -> bool:  # pylint: disable=dangerous-default-value  # noqa: B006
+    def _is_pod_failed_or_completed(self, _cache={}) -> bool:  # noqa: B006
         last_call_at = _cache.get('last_call_at')
         if last_call_at and time.time() - last_call_at < 3:
             time.sleep(3)
@@ -566,9 +563,8 @@ class KubernetesPodWatcher(KubernetesRunner):
         return super().run(command, **kwargs)
 
 
-# pylint: disable=too-many-instance-attributes
 class KubernetesPodRunner(KubernetesCmdRunner):
-    def __init__(self, kluster,  # pylint: disable=too-many-arguments,super-init-not-called
+    def __init__(self, kluster,
                  template_path: str,
                  template_modifiers: list,
                  pod_name_template: str,
@@ -580,7 +576,7 @@ class KubernetesPodRunner(KubernetesCmdRunner):
         self.pod_name_template = pod_name_template
         self.namespace = namespace
         self.environ = environ
-        RemoteCmdRunnerBase.__init__(  # pylint: disable=non-parent-init-called
+        RemoteCmdRunnerBase.__init__(
             self=self, hostname=f"pod/{pod_name_template}")
         self._pod_counter = -1
         self._connections = []
@@ -629,7 +625,6 @@ class KubernetesPodRunner(KubernetesCmdRunner):
         self._connections.append(connection)
         return connection
 
-    # pylint: disable=too-many-arguments,unused-argument
     def receive_files(self, src, dst, delete_dst=False,
                       preserve_perm=True, preserve_symlinks=False, timeout=300):
         # TODO: may be implemented if we want to copy files which exist in the image
@@ -637,7 +632,6 @@ class KubernetesPodRunner(KubernetesCmdRunner):
         #       running pod.
         raise NotImplementedError()
 
-    # pylint: disable=too-many-arguments,unused-argument
     def send_files(self, src, dst, delete_dst=False, preserve_symlinks=False, verbose=False):
         """Mount single files to a 'dynamic'aly created pods.
 

--- a/sdcm/remote/libssh2_client/__init__.py
+++ b/sdcm/remote/libssh2_client/__init__.py
@@ -23,9 +23,9 @@ from abc import abstractmethod, ABC
 from queue import SimpleQueue as Queue
 import ipaddress
 
-from ssh2.channel import Channel  # pylint: disable=no-name-in-module
-from ssh2.exceptions import AuthenticationError  # pylint: disable=no-name-in-module
-from ssh2.error_codes import LIBSSH2_ERROR_EAGAIN  # pylint: disable=no-name-in-module
+from ssh2.channel import Channel
+from ssh2.exceptions import AuthenticationError
+from ssh2.error_codes import LIBSSH2_ERROR_EAGAIN
 
 from .exceptions import AuthenticationException, UnknownHostException, ConnectError, PKeyFileError, UnexpectedExit, \
     CommandTimedOut, FailedToReadCommandOutput, ConnectTimeout, FailedToRunCommand, OpenChannelTimeout
@@ -40,17 +40,17 @@ __all__ = ['Session', 'Timings', 'Client', 'Channel', 'FailedToRunCommand']
 LINESEP = b'\n'
 
 
-class __DEFAULT__:  # pylint: disable=invalid-name, too-few-public-methods
+class __DEFAULT__:
     """ Default value for function attribute when None is not an option """
 
 
-class StreamWatcher(ABC):  # pylint: disable=too-few-public-methods
+class StreamWatcher(ABC):
     @abstractmethod
     def submit_line(self, line: str):
         pass
 
 
-class SSHReaderThread(Thread):  # pylint: disable=too-many-instance-attributes
+class SSHReaderThread(Thread):
     """
     Thread that reads data from ssh session socket and forwards it to Queue.
     It is needed because socket buffer gets overflowed if data is sent faster than watchers can process it, so
@@ -76,16 +76,16 @@ class SSHReaderThread(Thread):  # pylint: disable=too-many-instance-attributes
         try:
             self._read_output(self._session, self._channel, self._timeout,
                               self._timeout_read_data, self.stdout, self.stderr)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             self.raised = exc
 
-    def _read_output(  # pylint: disable=too-many-arguments,too-many-branches
+    def _read_output(
             self, session: Session, channel: Channel, timeout: NullableTiming, timeout_read_data: NullableTiming,
             stdout_stream: Queue, stderr_stream: Queue):
         """Reads data from ssh session, split it into lines and forward lines into stderr ad stdout pipes
         It is required for it to be fast, that is why there is code duplications and non-pythonic code
         """
-        # pylint: disable=too-many-locals
+
         stdout_remainder = stderr_remainder = b''
         if timeout is None:
             end_time = float_info.max
@@ -93,14 +93,14 @@ class SSHReaderThread(Thread):  # pylint: disable=too-many-instance-attributes
             end_time = perf_counter() + timeout
         eof_result = stdout_size = stderr_size = 1
         while eof_result == LIBSSH2_ERROR_EAGAIN or stdout_size == LIBSSH2_ERROR_EAGAIN or \
-                stdout_size > 0 or stderr_size == LIBSSH2_ERROR_EAGAIN or stderr_size > 0:  # pylint: disable=consider-using-in
+                stdout_size > 0 or stderr_size == LIBSSH2_ERROR_EAGAIN or stderr_size > 0:
             if perf_counter() > end_time:
                 self.timeout_reached = True
                 break
             if not self._can_run.is_set():
                 break
             with session.lock:
-                if stdout_size == LIBSSH2_ERROR_EAGAIN and stderr_size == LIBSSH2_ERROR_EAGAIN:  # pylint: disable=consider-using-in
+                if stdout_size == LIBSSH2_ERROR_EAGAIN and stderr_size == LIBSSH2_ERROR_EAGAIN:
                     session.simple_select(timeout=timeout_read_data)
                 stdout_size, stdout_chunk = channel.read()
                 stderr_size, stderr_chunk = channel.read_stderr()
@@ -150,7 +150,7 @@ class KeepAliveThread(Thread):
             try:
                 time_to_wait = self._session.eagain(
                     self._session.keepalive_send, timeout=self._keepalive_timeout)
-            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 time_to_wait = self._keepalive_timeout
             sleep(time_to_wait)
 
@@ -233,7 +233,7 @@ class FloodPreventingFacility(dict):
 DEFAULT_FLOOD_PREVENTING = FloodPreventingFacility(hash_items='host', limit=2)
 
 
-class Client:  # pylint: disable=too-many-instance-attributes
+class Client:
     """
     SSH2 Client, partially imitates invoke interface.
     It is not thread safe, so make sure that any given instance is not used by multiple threads.
@@ -284,7 +284,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
     timings: Timings = Timings()
     flood_preventing: FloodPreventingFacility = DEFAULT_FLOOD_PREVENTING
 
-    def __init__(self, host: str, user: str, password: str = None,  # pylint: disable=too-many-arguments
+    def __init__(self, host: str, user: str, password: str = None,
                  port: int = None, pkey: str = None, allow_agent: bool = None, forward_ssh_agent: bool = None,
                  proxy_host: str = None, keepalive_seconds: int = None, timings: Timings = None,
                  flood_preventing: FloodPreventingFacility = None):
@@ -356,7 +356,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
                 with self.session.lock:
                     self.session.agent_auth(self.user)
                 return
-            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 pass
         self._password_auth()
 
@@ -386,7 +386,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
             self.session.eagain(
                 self.session.userauth_password,
                 args=(self.user, self.password), timeout=self.timings.auth_timeout)
-        except Exception as error:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as error:  # noqa: BLE001
             raise AuthenticationException("Password authentication failed") from error
 
     @staticmethod
@@ -403,7 +403,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
         if self.sock:
             try:
                 self.sock.close()
-            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 pass
         family = self._get_socket_family(host)
         if family is None:
@@ -422,9 +422,8 @@ class Client:  # pylint: disable=too-many-instance-attributes
             raise ConnectError("Error connecting to host '%s:%s' - %s" % (host, port, str(error_type))) from ex
 
     @staticmethod
-    def _process_output(  # pylint: disable=too-many-arguments, too-many-branches
-            watchers: List[StreamWatcher], encoding: str, stdout_stream: StringIO, stderr_stream: StringIO,
-            reader: SSHReaderThread, timeout: NullableTiming, timeout_read_data_chunk: NullableTiming):
+    def _process_output(watchers: List[StreamWatcher], encoding: str, stdout_stream: StringIO, stderr_stream: StringIO,
+                        reader: SSHReaderThread, timeout: NullableTiming, timeout_read_data_chunk: NullableTiming):
         """Separate different approach for the case when watchers are present, since watchers are slow,
           we can loose data due to the socket buffer limit, if endpoint sending it faster than watchers can read it.
         To avoid that we run `SSHReaderThread` thread that picks data up from the socket, splits it into lines
@@ -450,7 +449,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
                     for watcher in watchers:
                         watcher.submit_line(data)
                     data_processed = True
-                except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+                except Exception:  # noqa: BLE001
                     pass
             if stderr_stream is not None and reader.stderr.qsize():
                 try:
@@ -460,14 +459,14 @@ class Client:  # pylint: disable=too-many-instance-attributes
                     for watcher in watchers:
                         watcher.submit_line(data)
                     data_processed = True
-                except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+                except Exception:  # noqa: BLE001
                     pass
             if not data_processed:  # prevent unbounded loop in case no data on the streams
                 sleep(timeout_read_data_chunk or 0.5)
         return True
 
     @staticmethod
-    def _process_output_no_watchers(  # pylint: disable=too-many-arguments
+    def _process_output_no_watchers(
             session: Session, channel: Channel, encoding: str, stdout_stream: StringIO,
             stderr_stream: StringIO, timeout: NullableTiming, timeout_read_data_chunk: NullableTiming) -> bool:
         eof_result = stdout_size = stderr_size = LIBSSH2_ERROR_EAGAIN
@@ -476,11 +475,11 @@ class Client:  # pylint: disable=too-many-instance-attributes
         else:
             end_time = float_info.max
         while eof_result == LIBSSH2_ERROR_EAGAIN or stdout_size == LIBSSH2_ERROR_EAGAIN or stdout_size > 0 or \
-                stderr_size == LIBSSH2_ERROR_EAGAIN or stderr_size > 0:  # pylint: disable=consider-using-in
+                stderr_size == LIBSSH2_ERROR_EAGAIN or stderr_size > 0:
             if perf_counter() > end_time:
                 return False
             with session.lock:
-                if stdout_size == LIBSSH2_ERROR_EAGAIN and stderr_size == LIBSSH2_ERROR_EAGAIN:  # pylint: disable=consider-using-in
+                if stdout_size == LIBSSH2_ERROR_EAGAIN and stderr_size == LIBSSH2_ERROR_EAGAIN:
                     session.simple_select(timeout=timeout_read_data_chunk)
                 eof_result = channel.wait_eof()
                 stdout_size, stdout_chunk = channel.read()
@@ -521,8 +520,8 @@ class Client:  # pylint: disable=too-many-instance-attributes
                     break
                 except AuthenticationError:
                     self.disconnect()
-                    raise  # pylint: disable=broad-except
-                except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+                    raise
+                except Exception as exc:  # noqa: BLE001
                     self.disconnect()
                     if perf_counter() > end_time:
                         ex_msg = f'Failed to connect in {timeout} seconds, last error: ({type(exc).__name__}){str(exc)}'
@@ -545,19 +544,19 @@ class Client:  # pylint: disable=too-many-instance-attributes
         if self.session is not None:
             try:
                 self.session.eagain(self.session.disconnect)
-            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 pass
             del self.session
             self.session = None
         if self.sock is not None:
             try:
                 self.sock.close()
-            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 pass
             self.sock = None
 
-    def run(  # pylint: disable=unused-argument,too-many-arguments,too-many-locals
-            self, command: str, warn: bool = False, encoding: str = 'utf-8',  # pylint: disable=redefined-outer-name
+    def run(
+            self, command: str, warn: bool = False, encoding: str = 'utf-8',
             hide=True, watchers=None, env=None, replace_env=False, in_stream=False, timeout=None) -> Result:
         """Run command, wait till it ends and return result in Result class.
         If `watchers` are defined it runs `SSHReaderThread` that reads data from the socket and forwards it to Queue.
@@ -592,12 +591,12 @@ class Client:  # pylint: disable=too-many-instance-attributes
             if self.session is None:
                 self.connect()
             channel = self.open_channel()
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             return self._complete_run(
                 channel, FailedToRunCommand(result, exc), timeout_reached, timeout, result, warn, stdout, stderr)
         try:
             self._apply_env(channel, env)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             return self._complete_run(
                 channel, FailedToRunCommand(result, exc), timeout_reached, timeout, result, warn, stdout, stderr)
         if watchers:
@@ -607,7 +606,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
                 self.execute(command, channel=channel, use_pty=False)
                 self._process_output(watchers, encoding, stdout, stderr, reader, timeout,
                                      self.timings.interactive_read_data_chunk_timeout)
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 exception = FailedToReadCommandOutput(result, exc)
             if reader.is_alive():
                 reader.stop()
@@ -620,7 +619,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
                 timeout_reached = not self._process_output_no_watchers(
                     self.session, channel, encoding, stdout, stderr, timeout,
                     self.timings.read_data_chunk_timeout)
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 exception = FailedToReadCommandOutput(result, exc)
         return self._complete_run(channel, exception, timeout_reached, timeout, result, warn, stdout, stderr)
 
@@ -630,8 +629,8 @@ class Client:  # pylint: disable=too-many-instance-attributes
             for var, val in env.items():
                 channel.setenv(str(var), str(val))
 
-    def _complete_run(self, channel: Channel, exception: Exception,  # pylint: disable=too-many-arguments
-                      timeout_reached: NullableTiming, timeout: NullableTiming, result: Result, warn,  # pylint: disable=redefined-outer-name
+    def _complete_run(self, channel: Channel, exception: Exception,
+                      timeout_reached: NullableTiming, timeout: NullableTiming, result: Result, warn,
                       stdout: StringIO, stderr: StringIO) -> Result:
         """Complete executing command and return result, no matter what had happened.
         """
@@ -642,11 +641,11 @@ class Client:  # pylint: disable=too-many-instance-attributes
             try:
                 with self.session.lock:
                     channel.close()
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 print(f'Failed to close channel due to the following error: {exc}')
             try:
                 self.session.eagain(channel.wait_closed, timeout=self.timings.channel_close_timeout)
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 print(f'Failed to close channel due to the following error: {exc}')
             exit_status = channel.get_exit_status()
             self.session.drop_channel(channel)
@@ -684,7 +683,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
                 chan = self.session.eagain(self.session.open_session)
                 if chan != LIBSSH2_ERROR_EAGAIN:
                     break
-            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 pass
             delay = next(delay_iter, delay)
             sleep(delay)

--- a/sdcm/remote/libssh2_client/exceptions.py
+++ b/sdcm/remote/libssh2_client/exceptions.py
@@ -13,7 +13,7 @@
 
 import traceback
 
-from ssh2.exceptions import SocketRecvError  # pylint: disable=no-name-in-module
+from ssh2.exceptions import SocketRecvError
 
 from .result import Result
 
@@ -75,7 +75,7 @@ class Failure(Exception):
     .. versionadded:: 1.0
     """
 
-    def __init__(self, result: Result, reason: str = None):  # pylint: disable=super-init-not-called
+    def __init__(self, result: Result, reason: str = None):
         self.result = result
         self.reason = reason
 

--- a/sdcm/remote/libssh2_client/result.py
+++ b/sdcm/remote/libssh2_client/result.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 
 
 @dataclass
-class Result:  # pylint: disable=too-many-instance-attributes
+class Result:
     """
     A copy-cat from invoke.runners.Result
 

--- a/sdcm/remote/libssh2_client/session.py
+++ b/sdcm/remote/libssh2_client/session.py
@@ -15,15 +15,15 @@ from gc import collect as gc_collect
 from select import select
 from threading import Lock
 
-from ssh2.session import Session as LibSSH2Session, LIBSSH2_SESSION_BLOCK_INBOUND, LIBSSH2_SESSION_BLOCK_OUTBOUND  # pylint: disable=no-name-in-module
-from ssh2.exceptions import SocketRecvError  # pylint: disable=no-name-in-module
-from ssh2.error_codes import LIBSSH2_ERROR_EAGAIN  # pylint: disable=no-name-in-module
-from ssh2.channel import Channel  # pylint: disable=no-name-in-module
+from ssh2.session import Session as LibSSH2Session, LIBSSH2_SESSION_BLOCK_INBOUND, LIBSSH2_SESSION_BLOCK_OUTBOUND
+from ssh2.exceptions import SocketRecvError
+from ssh2.error_codes import LIBSSH2_ERROR_EAGAIN
+from ssh2.channel import Channel
 
 from .timings import NullableTiming
 
 
-class Session(LibSSH2Session):  # pylint: disable=too-few-public-methods
+class Session(LibSSH2Session):
     """Custom SSH2 Session class with Lock in it, to make it thread safe where it is needed """
 
     # Libssh2 is currently not thread safe, we have work it around by having separete session for each thread
@@ -53,7 +53,7 @@ class Session(LibSSH2Session):  # pylint: disable=too-few-public-methods
         except (ValueError, SocketRecvError):  # under high load it can throw these errors, on next try it will be ok
             pass
 
-    def eagain(self, func, args=(), kwargs={},  # pylint: disable=dangerous-default-value  # noqa: B006
+    def eagain(self, func, args=(), kwargs={},  # noqa: B006
                timeout: NullableTiming = None) -> int:
         """Running function followed by simple_select up until it return anything but `LIBSSH2_ERROR_EAGAIN`"""
         with self.lock:
@@ -74,11 +74,11 @@ class Session(LibSSH2Session):  # pylint: disable=too-few-public-methods
             self.channels.remove(channel)
         try:
             channel.close()
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             pass
         try:
             channel.wait_closed()
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             pass
         del channel
 

--- a/sdcm/remote/libssh2_client/timings.py
+++ b/sdcm/remote/libssh2_client/timings.py
@@ -21,7 +21,7 @@ Delays = Iterable[float]
 
 
 @dataclass
-class Timings:  # pylint: disable=too-many-instance-attributes
+class Timings:
     """A store for timeouts and delays
     """
     keepalive_timeout: Timing = 30

--- a/sdcm/remote/local_cmd_runner.py
+++ b/sdcm/remote/local_cmd_runner.py
@@ -24,7 +24,7 @@ from sdcm.utils.decorators import retrying
 from .base import CommandRunner, RetryableNetworkException
 
 
-class LocalCmdRunner(CommandRunner):  # pylint: disable=too-few-public-methods
+class LocalCmdRunner(CommandRunner):
     def __init__(self, hostname: str = None, user: str = None):
         if hostname is None:
             hostname = socket.gethostname()
@@ -41,10 +41,10 @@ class LocalCmdRunner(CommandRunner):  # pylint: disable=too-few-public-methods
     def _create_connection(self) -> Connection:
         return Connection(host=self.hostname, user=self.user)
 
-    def is_up(self, timeout: float = None) -> bool:  # pylint: disable=no-self-use
+    def is_up(self, timeout: float = None) -> bool:
         return True
 
-    def run(self, cmd: str, timeout: Optional[float] = None, ignore_status: bool = False,  # pylint: disable=too-many-arguments
+    def run(self, cmd: str, timeout: Optional[float] = None, ignore_status: bool = False,
             verbose: bool = True, new_session: bool = False, log_file: Optional[str] = None, retry: int = 1,
             watchers: Optional[List[StreamWatcher]] = None, change_context: bool = False) -> Result:
 
@@ -89,17 +89,17 @@ class LocalCmdRunner(CommandRunner):  # pylint: disable=too-few-public-methods
         return result
 
     @retrying(n=3, sleep_time=5, allowed_exceptions=(RetryableNetworkException,))
-    def receive_files(  # pylint: disable=too-many-arguments,unused-argument
+    def receive_files(
             self, src: str, dst: str, delete_dst: bool = False, preserve_perm: bool = True,
-            preserve_symlinks: bool = False, timeout: float = 300) -> bool:  # pylint: disable=too-many-arguments,unused-argument
+            preserve_symlinks: bool = False, timeout: float = 300) -> bool:
         if src == dst:
             return True
         return self.run(f'cp {src} {dst}', timeout=timeout).ok
 
     @retrying(n=3, sleep_time=5, allowed_exceptions=(RetryableNetworkException,))
-    def send_files(  # pylint: disable=too-many-arguments,unused-argument
+    def send_files(
             self, src: str, dst: str, delete_dst: bool = False, preserve_symlinks: bool = False, verbose: bool = False,
-            timeout: float = 300) -> bool:  # pylint: disable=unused-argument
+            timeout: float = 300) -> bool:
         if src == dst:
             return True
         return self.run(f'cp {src} {dst}', timeout=timeout).ok

--- a/sdcm/remote/remote_base.py
+++ b/sdcm/remote/remote_base.py
@@ -30,7 +30,7 @@ from .base import RetryableNetworkException, CommandRunner
 from .local_cmd_runner import LocalCmdRunner
 
 
-class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-attributes
+class RemoteCmdRunnerBase(CommandRunner):
     port: int = 22
     connect_timeout: int = 60
     key_file: str = ""
@@ -51,7 +51,7 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
     connection_thread_map = threading.local()
     default_run_retry = 3
 
-    def __init__(self, hostname: str, user: str = 'root',  # pylint: disable=too-many-arguments  # noqa: PLR0913
+    def __init__(self, hostname: str, user: str = 'root',  # noqa: PLR0913
                  password: str = None, port: int = None, connect_timeout: int = None, key_file: str = None,
                  extra_ssh_options: str = None, auth_sleep_time: float = None,
                  proxy_host: str = None, proxy_port: int = 22, proxy_user: str = None, proxy_password: str = None,
@@ -115,13 +115,13 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
             cls.remoter_classes[ssh_transport] = cls
 
     @classmethod
-    def create_remoter(cls, *args, **kwargs) -> 'RemoteCmdRunnerBase':  # pylint: disable=unused-argument
+    def create_remoter(cls, *args, **kwargs) -> 'RemoteCmdRunnerBase':
         """
         Use this function to create remote runner of the default type
         """
         if cls.default_remoter_class is None:
             raise RuntimeError("Can't create remoter, no default remoter class found")
-        return cls.default_remoter_class(*args, **kwargs)  # pylint: disable=not-callable
+        return cls.default_remoter_class(*args, **kwargs)
 
     @classmethod
     def set_default_ssh_transport(cls, ssh_transport: str):
@@ -183,7 +183,7 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
         pass
 
     @retrying(n=3, sleep_time=5, allowed_exceptions=(RetryableNetworkException,))
-    def receive_files(self, src: str, dst: str, delete_dst: bool = False,  # pylint: disable=too-many-arguments
+    def receive_files(self, src: str, dst: str, delete_dst: bool = False,
                       preserve_perm: bool = True, preserve_symlinks: bool = False, timeout: float = 300):
         """
         Copy files from the remote host to a local path.
@@ -272,7 +272,7 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
         return files_received
 
     @retrying(n=3, sleep_time=5, allowed_exceptions=(RetryableNetworkException,))
-    def send_files(self, src: str,  # pylint: disable=too-many-arguments,too-many-statements
+    def send_files(self, src: str,
                    dst: str, delete_dst: bool = False, preserve_symlinks: bool = False, verbose: bool = False) -> bool:
         """
         Copy files from a local path to the remote host.
@@ -300,7 +300,6 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
         :raises: invoke.exceptions.UnexpectedExit, invoke.exceptions.Failure if the remote copy command failed
         """
 
-        # pylint: disable=too-many-branches,too-many-locals
         self.log.debug('<%s>: Send files (src) %s -> (dst) %s', self.hostname, src, dst)
         # Start a master SSH connection if necessary.
         source_is_dir = False
@@ -515,7 +514,7 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
         else:
             set_file_privs(dest)
 
-    def _make_rsync_cmd(  # pylint: disable=too-many-arguments
+    def _make_rsync_cmd(
             self, src: list, dst: str, delete_dst: bool, preserve_symlinks: bool, timeout: int = 300) -> str:
         """
         Given a list of source paths and a destination path, produces the
@@ -553,7 +552,7 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
             f'{self.proxy_user}@{self.proxy_host}"')
         return proxy_command
 
-    def _run_execute(self, cmd: str, timeout: Optional[float] = None,  # pylint: disable=too-many-arguments
+    def _run_execute(self, cmd: str, timeout: Optional[float] = None,
                      ignore_status: bool = False, verbose: bool = True, new_session: bool = False,
                      watchers: Optional[List[StreamWatcher]] = None):
         if verbose:
@@ -579,7 +578,7 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
         result.exit_status = result.exited
         return result
 
-    def _run_pre_run(self, cmd: str, timeout: Optional[float] = None,  # pylint: disable=too-many-arguments
+    def _run_pre_run(self, cmd: str, timeout: Optional[float] = None,
                      ignore_status: bool = False, verbose: bool = True, new_session: bool = False,
                      log_file: Optional[str] = None, retry: int = 1, watchers: Optional[List[StreamWatcher]] = None):
         pass
@@ -590,7 +589,7 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
 
     def _run_on_exception(self, exc: Exception, verbose: bool, ignore_status: bool) -> bool:
         if hasattr(exc, "result"):
-            self._print_command_results(exc.result, verbose, ignore_status)  # pylint: disable=no-member
+            self._print_command_results(exc.result, verbose, ignore_status)
         return True
 
     def _get_retry_params(self, retry: int = 1) -> dict:
@@ -607,7 +606,6 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
             allowed_exceptions = (Exception, )
         return {'n': retry, 'sleep_time': 5, 'allowed_exceptions': allowed_exceptions}
 
-    # pylint: disable=too-many-arguments
     def run(self,
             cmd: str,
             timeout: float | None = None,
@@ -645,7 +643,7 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
             except self.exception_retryable as exc:
                 if self._run_on_retryable_exception(exc, new_session):
                     raise
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 if self._run_on_exception(exc, verbose, ignore_status):
                     raise
             return None

--- a/sdcm/remote/remote_cmd_runner.py
+++ b/sdcm/remote/remote_cmd_runner.py
@@ -25,7 +25,7 @@ from .base import RetryableNetworkException, SSHConnectTimeoutError
 from .remote_base import RemoteCmdRunnerBase
 
 
-class RemoteCmdRunner(RemoteCmdRunnerBase, ssh_transport='fabric', default=True):  # pylint: disable=too-many-instance-attributes
+class RemoteCmdRunner(RemoteCmdRunnerBase, ssh_transport='fabric', default=True):
     connection: Connection
     ssh_config: Config = None
     ssh_is_up: threading.Event = None
@@ -65,7 +65,7 @@ class RemoteCmdRunner(RemoteCmdRunnerBase, ssh_transport='fabric', default=True)
             self.log.debug("%s: sleeping %s seconds before next retry", auth_exception, self.auth_sleep_time)
             self.ssh_up_thread_termination.wait(self.auth_sleep_time)
             return False
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             self.log.debug(details)
             return False
 
@@ -97,7 +97,7 @@ class RemoteCmdRunner(RemoteCmdRunnerBase, ssh_transport='fabric', default=True)
         self.stop_ssh_up_thread()
         super().stop()
 
-    def _run_pre_run(self, cmd: str, timeout: Optional[float] = None,  # pylint: disable=too-many-arguments
+    def _run_pre_run(self, cmd: str, timeout: Optional[float] = None,
                      ignore_status: bool = False, verbose: bool = True, new_session: bool = False,
                      log_file: Optional[str] = None, retry: int = 1, watchers: Optional[List[StreamWatcher]] = None):
         if not self.is_up(timeout=self.connect_timeout):

--- a/sdcm/remote/remote_file.py
+++ b/sdcm/remote/remote_file.py
@@ -31,7 +31,6 @@ def read_to_stringio(fobj):
     return StringIO(fobj.read())
 
 
-# pylint: disable=too-many-locals,too-many-arguments
 @contextlib.contextmanager
 def remote_file(remoter, remote_path: str | Path, serializer=StringIO.getvalue, deserializer=read_to_stringio, sudo=False,
                 preserve_ownership=True, preserve_permissions=True, log_change=True):

--- a/sdcm/remote/remote_libssh_cmd_runner.py
+++ b/sdcm/remote/remote_libssh_cmd_runner.py
@@ -23,7 +23,7 @@ from .base import RetryableNetworkException
 from .remote_base import RemoteCmdRunnerBase
 
 
-class RemoteLibSSH2CmdRunner(RemoteCmdRunnerBase, ssh_transport='libssh2'):  # pylint: disable=too-many-instance-attributes
+class RemoteLibSSH2CmdRunner(RemoteCmdRunnerBase, ssh_transport='libssh2'):
     """Remoter that mimic RemoteCmdRunner, under the hood it runs libssh2 client, instead of paramiko
     Main problem in libssh2 - is that it is not thread safe, we mitigate this problem by having
       _connection_thread_map - a dictionary in which we bind thread to the libssh2 session.
@@ -54,11 +54,11 @@ class RemoteLibSSH2CmdRunner(RemoteCmdRunnerBase, ssh_transport='libssh2'):  # p
             try:
                 if self.connection.check_if_alive(timeout):
                     return True
-            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 try:
                     self.connection.close()
                     self.connection.open(timeout)
-                except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+                except Exception:  # noqa: BLE001
                     pass
         return False
 
@@ -68,11 +68,11 @@ class RemoteLibSSH2CmdRunner(RemoteCmdRunnerBase, ssh_transport='libssh2'):  # p
             self.log.debug('Reestablish the session...')
             try:
                 self.connection.disconnect()
-            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 pass
             try:
                 self.connection.connect()
-            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 pass
         if self._is_error_retryable(str(exc)) or isinstance(exc, self.exception_retryable):
             raise RetryableNetworkException(str(exc), original=exc)

--- a/sdcm/remote/remote_long_running.py
+++ b/sdcm/remote/remote_long_running.py
@@ -11,7 +11,7 @@ from sdcm.remote.libssh2_client.exceptions import UnexpectedExit
 logger = logging.getLogger(__name__)
 
 
-def run_long_running_cmd(remoter: RemoteCmdRunnerBase,  # pylint: disable=too-many-arguments
+def run_long_running_cmd(remoter: RemoteCmdRunnerBase,
                          cmd: str,
                          timeout: float | None = None,
                          ignore_status: bool = False,

--- a/sdcm/reporting/tooling_reporter.py
+++ b/sdcm/reporting/tooling_reporter.py
@@ -44,7 +44,7 @@ class ToolReporterBase():
         try:
             report_package_to_argus(client=self.argus_client, tool_name=self.TOOL_NAME, package_version=self.version,
                                     additional_data=self.additional_data, date=self.date, revision_id=self.revision_id)
-        except Exception:  # pylint: disable=broad-except # noqa: BLE001
+        except Exception:  # noqa: BLE001
             LOGGER.warning("Failed reporting tool version to Argus", exc_info=True)
 
     def _collect_version_info(self) -> None:
@@ -60,7 +60,7 @@ class ToolReporterBase():
 
 
 class PythonDriverReporter(ToolReporterBase):
-    # pylint: disable=too-few-public-methods
+
     """
         Reports python-driver version used for SCT operations.
     """
@@ -75,7 +75,7 @@ class PythonDriverReporter(ToolReporterBase):
 
 
 class CassandraStressVersionReporter(ToolReporterBase):
-    # pylint: disable=too-few-public-methods
+
     TOOL_NAME = "cassandra-stress"
 
     def _collect_version_info(self) -> None:
@@ -103,7 +103,7 @@ class CassandraStressVersionReporter(ToolReporterBase):
 
 
 class CqlStressCassandraStressVersionReporter(ToolReporterBase):
-    # pylint: disable=too-few-public-methods
+
     TOOL_NAME = "cql-stress-cassandra-stress"
 
     def _collect_version_info(self) -> None:
@@ -148,7 +148,7 @@ class LatteVersionReporter(ToolReporterBase):
 
 
 class CassandraStressJavaDriverVersionReporter(ToolReporterBase):
-    # pylint: disable=too-few-public-methods
+
     TOOL_NAME = "java-driver"
 
     def __init__(self, driver_version: str, runner: CommandRunner, command_prefix: str = None, argus_client: ArgusSCTClient = None) -> None:
@@ -160,7 +160,7 @@ class CassandraStressJavaDriverVersionReporter(ToolReporterBase):
 
 
 class CqlStressRustDriverVersionReporter(ToolReporterBase):
-    # pylint: disable=too-few-public-methods
+
     TOOL_NAME = "cql-stress-rust-driver"
 
     def __init__(self, driver_version: str, date: str, revision_id: str, runner: CommandRunner, command_prefix: str = None,

--- a/sdcm/rest/remote_curl_client.py
+++ b/sdcm/rest/remote_curl_client.py
@@ -28,7 +28,7 @@ class RemoteCurlClient(RestClient):
         self._node = node
         self._remoter = self._node.remoter
 
-    def run_remoter_curl(self, method: Literal["GET", "POST"],  # pylint: disable=too-many-arguments
+    def run_remoter_curl(self, method: Literal["GET", "POST"],
                          path: str,
                          params: dict[str, str] | None,
                          timeout: int = 120,

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -11,7 +11,6 @@
 #
 # Copyright (c) 2021 ScyllaDB
 
-# pylint: disable=too-many-lines
 import json
 import os
 import math
@@ -42,14 +41,13 @@ LOGGER = logging.getLogger(__name__)
 PP = pprint.PrettyPrinter(indent=2)
 
 
-class BaseResultsAnalyzer:  # pylint: disable=too-many-instance-attributes
+class BaseResultsAnalyzer:
     PARAMS = TestStatsMixin.STRESS_STATS
 
-    # pylint: disable=too-many-arguments
     def __init__(self, es_index, email_recipients=(), email_template_fp="", query_limit=1000, logger=None,
                  events=None):
         self._es = ES()
-        self._conf = self._es.conf  # pylint: disable=protected-access
+        self._conf = self._es.conf
         self._es_index = es_index
         self._limit = query_limit
         self._email_recipients = email_recipients
@@ -61,7 +59,7 @@ class BaseResultsAnalyzer:  # pylint: disable=too-many-instance-attributes
         """
         Get all the test results in json format
         """
-        return self._es.search(index=self._es_index, size=self._limit)  # pylint: disable=unexpected-keyword-arg
+        return self._es.search(index=self._es_index, size=self._limit)
 
     def get_test_by_id(self, test_id):
         """
@@ -251,7 +249,7 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
     Get latency during operations performance analyzer
     """
 
-    def __init__(self, es_index, email_recipients=(), logger=None, events=None):   # pylint: disable=too-many-arguments
+    def __init__(self, es_index, email_recipients=(), logger=None, events=None):
         super().__init__(es_index=es_index, email_recipients=email_recipients,
                          email_template_fp="results_latency_during_ops_short.html", logger=logger, events=events)
         self.percentiles = ['percentile_90', 'percentile_99']
@@ -282,7 +280,7 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
         query = LatencyWithNemesisQueryFilter(test_doc, is_gce, use_wide_query=True, lastyear=True)()
 
         LOGGER.debug("ES QUERY: %s", query)
-        test_results = self._es.search(  # pylint: disable=unexpected-keyword-arg; pylint doesn't understand Elasticsearch code
+        test_results = self._es.search(
             index=self._es_index,
             q=query,
             filter_path=filter_path,
@@ -323,7 +321,7 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
                      "average_time_operation_in_sec": int(operation_time_average)
                      })
 
-    def _get_best_per_nemesis_for_each_version(self, test_doc, is_gce):  # pylint: disable=too-many-branches,too-many-locals
+    def _get_best_per_nemesis_for_each_version(self, test_doc, is_gce):
         try:
             if not test_doc["_source"].get("latency_during_ops"):
                 LOGGER.error("Document with id=%s doesn't have 'latency_during_ops' statistics", test_doc['_id'])
@@ -384,7 +382,7 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
                                                                    key=lambda version: version,
                                                                    reverse=True)}
             return best_results
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.error("Search best results per version failed. Error: %s", exc)
             return {}
 
@@ -438,10 +436,10 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
                     best['average_time_operation_in_sec_diff'] = _calculate_relative_change_magnitude(
                         current_result[nemesis]['average_time_operation_in_sec'],
                         best['average_time_operation_in_sec'])
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.error("Compare results failed: %s", exc)
 
-    def check_regression(self, test_id, data, is_gce=False, node_benchmarks=None, email_subject_postfix=None):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements, too-many-arguments  # noqa: PLR0914
+    def check_regression(self, test_id, data, is_gce=False, node_benchmarks=None, email_subject_postfix=None):  # noqa: PLR0914
         doc = self.get_test_by_id(test_id)
         if not doc:
             raise ValueError(f'Cannot find test by id: {test_id}!')
@@ -542,7 +540,7 @@ class SpecifiedStatsPerformanceAnalyzer(BaseResultsAnalyzer):
     Get specified performance test results from elasticsearch DB and analyze it to find a regression
     """
 
-    def __init__(self, es_index, email_recipients=(), logger=None, events=None):   # pylint: disable=too-many-arguments
+    def __init__(self, es_index, email_recipients=(), logger=None, events=None):
         super().__init__(es_index=es_index, email_recipients=email_recipients,
                          email_template_fp="", logger=logger, events=events)
 
@@ -553,7 +551,7 @@ class SpecifiedStatsPerformanceAnalyzer(BaseResultsAnalyzer):
             return None
         return test_doc['_source']['results']
 
-    def check_regression(self, test_id, stats):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements  # noqa: PLR0914
+    def check_regression(self, test_id, stats):  # noqa: PLR0914
         """
         Get test results by id, filter similar results and calculate DB values for each version,
         then compare with max-allowed in the tested version (and report all the found versions).
@@ -581,7 +579,7 @@ class SpecifiedStatsPerformanceAnalyzer(BaseResultsAnalyzer):
             stat_path = '.'.join([es_source_path, stat])
             filter_path.append(stat_path)
 
-        tests_filtered = self._es.search(  # pylint: disable=unexpected-keyword-arg; pylint doesn't understand Elasticsearch code
+        tests_filtered = self._es.search(
             index=self._es_index,
             size=self._limit,
             filter_path=filter_path,
@@ -675,7 +673,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
 
     PARAMS = TestStatsMixin.STRESS_STATS
 
-    def __init__(self, es_index, email_recipients=(), logger=None, events=None):  # pylint: disable=too-many-arguments
+    def __init__(self, es_index, email_recipients=(), logger=None, events=None):
         super().__init__(es_index=es_index, email_recipients=email_recipients,
                          email_template_fp="results_performance.html", logger=logger, events=events)
 
@@ -755,7 +753,6 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
                     param, src[param], dst[param], version_dst))
         return cmp_res
 
-    # pylint: disable=too-many-arguments
     def check_regression(self, test_id, is_gce=False, email_subject_postfix=None,  # noqa: PLR0914
                          use_wide_query=False, lastyear=False,
                          node_benchmarks=None, extra_jobs_to_compare=None) -> None:
@@ -767,7 +764,6 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
         :param is_gce: is gce instance
         :return: True/False
         """
-        # pylint: disable=too-many-locals,too-many-branches,too-many-statements
 
         # get test res
         doc = self.get_test_by_id(test_id)
@@ -790,7 +786,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
                        'hits.hits._source.results.stats_total',
                        'hits.hits._source.results.throughput',
                        'hits.hits._source.versions']
-        tests_filtered = self._es.search(index=self._es_index, q=query, filter_path=filter_path,  # pylint: disable=unexpected-keyword-arg
+        tests_filtered = self._es.search(index=self._es_index, q=query, filter_path=filter_path,
                                          size=self._limit, request_timeout=30)
 
         if not tests_filtered:
@@ -945,7 +941,6 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
         :param is_gce: is gce instance
         :return: True/False
         """
-        # pylint: disable=too-many-locals,too-many-branches,too-many-statements
 
         doc = self.get_test_by_id(test_id)
         if not doc:
@@ -970,7 +965,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
                        'hits.hits._source.results',
                        'hits.hits._source.versions',
                        'hits.hits._source.test_details']
-        tests_filtered = self._es.search(  # pylint: disable=unexpected-keyword-arg; pylint doesn't understand Elasticsearch code
+        tests_filtered = self._es.search(
             index=self._es_index,
             q=query,
             size=self._limit,
@@ -1249,7 +1244,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
         return output
 
     @staticmethod
-    def _cleanup_not_complete_main_tests(prior_main_tests: list, prior_subtests: dict, expected_subtests_count):  # pylint: disable=too-many-branches
+    def _cleanup_not_complete_main_tests(prior_main_tests: list, prior_subtests: dict, expected_subtests_count):
         is_test_complete = {}
         for subtest, prior_tests in prior_subtests.items():
             for prior_test_id, _ in prior_tests.group_by('main_test_id').items():
@@ -1282,7 +1277,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
             subtests_info: list = None,
             metrics: list = None,
             subject: str = None,
-    ) -> None:  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    ) -> None:
         """
         Build regression report for subtests.
         test_id: Main test id
@@ -1395,7 +1390,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
 
         tmp_subtest_by_name = rp_subtests_of_current_test.group_by('subtest_name')
 
-        for group_name, group_substest_infos in subtests_groups.items():  # pylint: disable=too-many-nested-blocks
+        for group_name, group_substest_infos in subtests_groups.items():
             rp_metrics_table[group_name] = rp_metrics_table_l1 = collections.OrderedDict()
             grouped_subtests = []
             subtest_info_grouped_by_baseline = group_substest_infos.group_by('baseline', '', sort_keys=1)
@@ -1513,7 +1508,7 @@ class PredefinedStepsTestPerformanceAnalyzer(LatencyDuringOperationsPerformanceA
     Performance Analyzer for results with throughput and latency of gradual payload increase
     """
 
-    def __init__(self, es_index, email_recipients=(), logger=None, events=None):   # pylint: disable=too-many-arguments
+    def __init__(self, es_index, email_recipients=(), logger=None, events=None):
         super().__init__(es_index=es_index, email_recipients=email_recipients,
                          logger=logger, events=events)
         self._email_template_fp = "results_performance_predefined_steps.html"
@@ -1570,11 +1565,11 @@ class SearchBestThroughputConfigPerformanceAnalyzer(BaseResultsAnalyzer):
     Get latency during operations performance analyzer
     """
 
-    def __init__(self, es_index, email_recipients=(), logger=None, events=None):   # pylint: disable=too-many-arguments
+    def __init__(self, es_index, email_recipients=(), logger=None, events=None):
         super().__init__(es_index=es_index, email_recipients=email_recipients,
                          email_template_fp="results_search_best_throughput_config.html", logger=logger, events=events)
 
-    def check_regression(self, test_name, setup_details, test_results) -> None:  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
+    def check_regression(self, test_name, setup_details, test_results) -> None:
         subject = f"Performance Regression Best throughput with configuation - {test_name} - {setup_details['start_time']}"
         results = {
             "test_id": setup_details.get("test_id", ""),

--- a/sdcm/results_analyze/base.py
+++ b/sdcm/results_analyze/base.py
@@ -1,7 +1,7 @@
 from test_lib.utils import get_data_by_path
 
 
-class __DEFAULT__:  # pylint: disable=invalid-name,too-few-public-methods
+class __DEFAULT__:
     pass
 
 
@@ -21,7 +21,7 @@ class ClassBase:
     def load_kwargs(self, kwargs):
         errors = []
         for data_name, value in kwargs.items():
-            data_type = self.__annotations__.get(data_name, None)  # pylint: disable=no-member
+            data_type = self.__annotations__.get(data_name, None)
             if data_type is None:
                 errors.append(f'Wrong {data_name} attribute was provided')
                 continue
@@ -42,7 +42,7 @@ class ClassBase:
         if not isinstance(es_data, dict):
             raise ValueError(f"Class {self.__class__.__name__} can be loaded only from dict")
         data_mapping = self._es_data_mapping
-        for data_name, data_type in self.__annotations__.items():  # pylint: disable=no-member
+        for data_name, data_type in self.__annotations__.items():
             data_path = data_mapping.get(data_name, __DEFAULT__)
             if data_path is __DEFAULT__:
                 value = es_data.get(data_name, __DEFAULT__)
@@ -74,7 +74,7 @@ class ClassBase:
         setattr(self, data_name, data_type(value))
 
     def is_valid(self):
-        for data_name in self.__annotations__.keys():  # pylint: disable=no-member
+        for data_name in self.__annotations__.keys():
             default = getattr(self.__class__, data_name)
             value = getattr(self, data_name, None)
             if value is default:
@@ -93,7 +93,7 @@ class ClassBase:
         if max_level == 0:
             return {}
         output = {}
-        for data_name, data_type in cls.__annotations__.items():  # pylint: disable=no-member
+        for data_name, data_type in cls.__annotations__.items():
             data_path = cls._es_data_mapping.get(data_name, __DEFAULT__)
             if data_path is __DEFAULT__:
                 data_path = data_name
@@ -103,7 +103,7 @@ class ClassBase:
                     # No mapping if custom loader defined
                     child_data_mapping = {}
                 else:
-                    child_data_mapping = data_type._get_all_es_data_mapping(  # pylint: disable=protected-access
+                    child_data_mapping = data_type._get_all_es_data_mapping(
                         max_level=max_level-1)
                 if not child_data_mapping:
                     output[data_name] = data_path
@@ -129,9 +129,9 @@ class ClassBase:
         while instances:
             current_instance, data_path, es_data_path = instances.pop()
             for data_name, data_instance in current_instance.__dict__.items():
-                if current_instance.__annotations__.get(data_name, None) is None:  # pylint: disable=no-member
+                if current_instance.__annotations__.get(data_name, None) is None:
                     continue
-                es_data_name = current_instance._es_data_mapping.get(  # pylint: disable=protected-access
+                es_data_name = current_instance._es_data_mapping.get(
                     data_name, None)
                 if es_data_name is None:
                     es_data_name = es_data_path + [data_name]
@@ -158,7 +158,7 @@ class ClassBase:
 
         output = {}
 
-        def data_cb(data_instance, current_instance, data_path, es_data_path, is_edge):  # pylint: disable=too-many-branches, too-many-locals
+        def data_cb(data_instance, current_instance, data_path, es_data_path, is_edge):
             final_return = False
             for data_pattern_split in data_patterns_split:
                 to_add = len(data_pattern_split) == len(data_path)

--- a/sdcm/results_analyze/test.py
+++ b/sdcm/results_analyze/test.py
@@ -243,7 +243,7 @@ class SoftwareVersions(ClassBase):
         return self.scylla_server if self.scylla_server else self.scylla_enterprise_server
 
     def is_valid(self):
-        for data_name in self.__annotations__.keys():  # pylint: disable=no-member
+        for data_name in self.__annotations__.keys():
             default = getattr(self.__class__, data_name)
             value = getattr(self, data_name, None)
             if value is default:
@@ -487,13 +487,13 @@ class TestResultClass(ClassBase):
         es_query = cls._get_es_query_from_instance_data(params)
         filter_path = cls._get_es_filters()
         try:
-            es_data = ES().search(  # pylint: disable=unexpected-keyword-arg; pylint doesn't understand Elasticsearch code
+            es_data = ES().search(
                 index=es_index,
                 q=es_query,
                 size=10000,
                 filter_path=filter_path,
             )
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.warning("Unable to find ES data: %s", exc)
             es_data = None
 
@@ -518,7 +518,7 @@ class TestResultClass(ClassBase):
     def gen_kibana_dashboard_url(
             dashboard_path="app/kibana#/dashboard/03414b70-0e89-11e9-a976-2fe0f5890cd0?_g=()"
     ):
-        return "%s/%s" % (ES().conf.get('kibana_url'), dashboard_path)  # pylint: disable=protected-access
+        return "%s/%s" % (ES().conf.get('kibana_url'), dashboard_path)
 
     def get_subtests(self):
         return self.get_by_params(es_index=self.es_index, main_test_id=self.test_id, subtest_name='*')
@@ -557,20 +557,20 @@ class TestResultClass(ClassBase):
         output = []
         try:
             es_query = self.get_same_tests_query()
-            es_result = ES().search(  # pylint: disable=unexpected-keyword-arg; pylint doesn't understand Elasticsearch code
+            es_result = ES().search(
                 index=self._es_data['_index'],
                 q=es_query,
                 size=10000,
                 filter_path=filter_path,
             )
             es_result = es_result.get('hits', {}).get('hits', None) if es_result else None
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.warning("Unable to find ES data: %s", exc)
             es_result = None
 
         if not es_result:
             return output
-        for es_data in es_result:  # pylint: disable=not-an-iterable
+        for es_data in es_result:
             test = TestResultClass(es_data)
             output.append(test)
         return output

--- a/sdcm/scan_operation_thread.py
+++ b/sdcm/scan_operation_thread.py
@@ -15,8 +15,8 @@ from contextlib import contextmanager
 
 from pytz import utc
 from cassandra import ConsistencyLevel
-from cassandra.cluster import ResponseFuture, ResultSet  # pylint: disable=no-name-in-module
-from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
+from cassandra.cluster import ResponseFuture, ResultSet
+from cassandra.query import SimpleStatement
 from cassandra.policies import ExponentialBackoffRetryPolicy
 
 from sdcm.remote import LocalCmdRunner
@@ -52,7 +52,6 @@ class FullscanException(Exception):
     """ Exception during running a fullscan"""
 
 
-# pylint: disable=too-many-instance-attributes
 class ScanOperationThread(OperationThread):
     """
     Runs fullscan operations according to the parameters specified in the test
@@ -125,7 +124,6 @@ class FullscanOperationBase:
             self, session, cmd: str,
             event: Type[FullScanEvent | FullPartitionScanEvent
                         | FullPartitionScanReversedOrderEvent]) -> ResultSet:
-        # pylint: disable=unused-argument
         self.log.debug('Will run command %s', cmd)
         return session.execute(SimpleStatement(
             cmd,
@@ -157,7 +155,7 @@ class FullscanOperationBase:
                         self.fetch_result_pages(result=result, read_pages=self.fullscan_stats.read_pages)
                     if not scan_op_event.message:
                         scan_op_event.message = f"{type(self).__name__} operation ended successfully"
-                except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+                except Exception as exc:  # noqa: BLE001
                     self.log.error(traceback.format_exc())
                     msg = repr(exc)
                     self.current_operation_stat.exceptions.append(repr(exc))
@@ -178,7 +176,7 @@ class FullscanOperationBase:
                     # success is True if there were no exceptions
                     self.current_operation_stat.success = not bool(self.current_operation_stat.exceptions)
                     self.update_stats(self.current_operation_stat)
-                    return self.current_operation_stat  # pylint: disable=lost-exception
+                    return self.current_operation_stat
 
     def update_stats(self, new_stat):
         self.fullscan_stats.stats.append(new_stat)
@@ -246,9 +244,9 @@ class FullPartitionScanOperation(FullscanOperationBase):
                                                'no_filter': {'count': 0, 'total_scan_duration': 0}}
         self.ck_filter = ''
         self.limit = ''
-        self.reversed_query_output = tempfile.NamedTemporaryFile(mode='w+', delete=False,  # pylint: disable=consider-using-with
+        self.reversed_query_output = tempfile.NamedTemporaryFile(mode='w+', delete=False,
                                                                  encoding='utf-8')
-        self.normal_query_output = tempfile.NamedTemporaryFile(mode='w+', delete=False,  # pylint: disable=consider-using-with
+        self.normal_query_output = tempfile.NamedTemporaryFile(mode='w+', delete=False,
                                                                encoding='utf-8')
 
     def get_table_clustering_order(self) -> str:
@@ -259,14 +257,14 @@ class FullPartitionScanOperation(FullscanOperationBase):
                 session.default_consistency_level = ConsistencyLevel.ONE
                 return get_table_clustering_order(ks_cf=self.fullscan_params.ks_cf,
                                                   ck_name=self.fullscan_params.ck_name, session=session)
-        except Exception as error:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as error:  # noqa: BLE001
             self.log.error(traceback.format_exc())
             self.log.error('Failed getting table %s clustering order through node %s : %s',
                            self.fullscan_params.ks_cf, node.name,
                            error)
         raise Exception('Failed getting table clustering order from all db nodes')
 
-    def randomly_form_cql_statement(self) -> Optional[tuple[str, str]]:  # pylint: disable=too-many-branches
+    def randomly_form_cql_statement(self) -> Optional[tuple[str, str]]:
         """
         The purpose of this method is to form a random reversed-query out of all options, like:
             select * from scylla_bench.test where pk = 1234 and ck < 4721 and ck > 2549 order by ck desc
@@ -370,9 +368,9 @@ class FullPartitionScanOperation(FullscanOperationBase):
     def reset_output_files(self):
         self.normal_query_output.close()
         self.reversed_query_output.close()
-        self.reversed_query_output = tempfile.NamedTemporaryFile(mode='w+', delete=False,  # pylint: disable=consider-using-with
+        self.reversed_query_output = tempfile.NamedTemporaryFile(mode='w+', delete=False,
                                                                  encoding='utf-8')
-        self.normal_query_output = tempfile.NamedTemporaryFile(mode='w+', delete=False,  # pylint: disable=consider-using-with
+        self.normal_query_output = tempfile.NamedTemporaryFile(mode='w+', delete=False,
                                                                encoding='utf-8')
 
     def _compare_output_files(self) -> bool:
@@ -420,7 +418,7 @@ class FullPartitionScanOperation(FullscanOperationBase):
         self.reset_output_files()
         return result
 
-    def run_scan_operation(self, cmd: str = None):  # pylint: disable=too-many-locals
+    def run_scan_operation(self, cmd: str = None):
         self.table_clustering_order = self.get_table_clustering_order()
         queries = self.randomly_form_cql_statement()
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -14,7 +14,7 @@
 """
 Handling Scylla-cluster-test configuration loading
 """
-# pylint: disable=too-many-lines
+
 import os
 import re
 import ast
@@ -108,7 +108,7 @@ def str_or_list_or_eval(value: Union[str, List[str]]) -> List[str]:
     if isinstance(value, str):
         try:
             return ast.literal_eval(value)
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             pass
         return [str(value), ] if str(value) else []
 
@@ -117,7 +117,7 @@ def str_or_list_or_eval(value: Union[str, List[str]]) -> List[str]:
         for val in value:
             try:
                 ret_values += [ast.literal_eval(val)]
-            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 ret_values += [str(val)]
         return ret_values
 
@@ -128,15 +128,15 @@ def int_or_space_separated_ints(value):
     try:
         value = int(value)
         return value
-    except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception:  # noqa: BLE001
         pass
 
     if isinstance(value, str):
         try:
             values = value.split()
-            [int(v) for v in values]  # pylint: disable=expression-not-assigned
+            [int(v) for v in values]
             return value
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             pass
 
     raise ValueError("{} isn't int or list".format(value))
@@ -146,14 +146,14 @@ def dict_or_str(value):
     if isinstance(value, str):
         try:
             return ast.literal_eval(value)
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             pass
 
         # ast.literal_eval() can fail on some strings (e.g. which contain lowercased booleans), try parsing such strings
         # using yaml.safe_load()
         try:
             return yaml.safe_load(value)
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             pass
 
     if isinstance(value, dict):
@@ -166,7 +166,7 @@ def dict_or_str_or_pydantic(value):
     if isinstance(value, str):
         try:
             return ast.literal_eval(value)
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             pass
 
     if isinstance(value, (dict, BaseModel)):
@@ -1872,7 +1872,7 @@ class SCTConfiguration(dict):
     aws_supported_regions = ['eu-west-1', 'eu-west-2', 'us-west-2', 'us-east-1', 'eu-north-1', 'eu-central-1']
 
     def __init__(self):  # noqa: PLR0912, PLR0914, PLR0915
-        # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+
         super().__init__()
         self.scylla_version = None
         self.scylla_version_upgrade_target = None
@@ -1951,7 +1951,7 @@ class SCTConfiguration(dict):
         dist_type = scylla_linux_distro.split('-')[0]
         dist_version = scylla_linux_distro.split('-')[-1]
 
-        if scylla_version := self.get('scylla_version'):  # pylint: disable=too-many-nested-blocks
+        if scylla_version := self.get('scylla_version'):
             if not self.get('docker_image'):
                 self['docker_image'] = get_scylla_docker_repo_from_version(scylla_version)
             if self.get("cluster_backend") in (
@@ -2034,7 +2034,7 @@ class SCTConfiguration(dict):
 
         # 6.1) handle oracle_scylla_version if exists
         if (oracle_scylla_version := self.get('oracle_scylla_version')) \
-           and self.get("db_type") == "mixed_scylla":  # pylint: disable=too-many-nested-blocks
+           and self.get("db_type") == "mixed_scylla":
             if not self.get('ami_id_db_oracle') and self.get('cluster_backend') == 'aws':
                 ami_list = []
                 for region in region_names:
@@ -2060,7 +2060,7 @@ class SCTConfiguration(dict):
         # 7) support lookup of repos for upgrade test
         new_scylla_version = self.get('new_version')
         if new_scylla_version and not 'k8s' in cluster_backend:
-            if not self.get('ami_id_db_scylla') and cluster_backend == 'aws':  # pylint: disable=no-else-raise
+            if not self.get('ami_id_db_scylla') and cluster_backend == 'aws':
                 raise ValueError("'new_version' isn't supported for AWS AMIs")
 
             elif not self.get('new_scylla_repo'):
@@ -2286,7 +2286,7 @@ class SCTConfiguration(dict):
             if opt['env'] in os.environ:
                 try:
                     environment_vars[opt['name']] = opt['type'](os.environ[opt['env']])
-                except Exception as ex:  # pylint: disable=broad-except  # noqa: BLE001
+                except Exception as ex:  # noqa: BLE001
                     raise ValueError(
                         "failed to parse {} from environment variable".format(opt['env'])) from ex
             nested_keys = [key for key in os.environ if key.startswith(opt['env'] + '.')]
@@ -2339,7 +2339,7 @@ class SCTConfiguration(dict):
         opt['is_k8s_multitenant_value'] = False
         try:
             opt['type'](self.get(opt['name']))
-        except Exception as ex:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as ex:  # noqa: BLE001
             if not (self.get("cluster_backend").startswith("k8s")
                     and self.get("k8s_tenants_num") > 1
                     and opt.get("k8s_multitenancy_supported")
@@ -2351,7 +2351,7 @@ class SCTConfiguration(dict):
             for list_element in self.get(opt['name']):
                 try:
                     opt['type'](list_element)
-                except Exception as ex:  # pylint: disable=broad-except  # noqa: BLE001
+                except Exception as ex:  # noqa: BLE001
                     raise ValueError("failed to validate {}".format(opt['name'])) from ex
             opt['is_k8s_multitenant_value'] = True
 
@@ -2386,8 +2386,7 @@ class SCTConfiguration(dict):
         return stress_tools
 
     def check_required_files(self):
-        # pylint: disable=too-many-nested-blocks
-        # pylint: disable=too-many-branches
+
         for param_name in self.stress_cmd_params:
             stress_cmds = self.get(param_name)
             if stress_cmds is None:
@@ -2654,7 +2653,7 @@ class SCTConfiguration(dict):
     def _validate_zero_token_backend_support(backend: str):
         assert backend == "aws", "Only AWS supports zero nodes configuration"
 
-    def verify_configuration_urls_validity(self):  # pylint: disable=too-many-branches
+    def verify_configuration_urls_validity(self):
         """
         Check if ami_id and repo urls are valid
         """
@@ -2718,7 +2717,7 @@ class SCTConfiguration(dict):
         get_branch_version_for_multiple_repositories(
             urls=(self.get(url) for url in repos_to_validate if self.get(url)))
 
-    def get_version_based_on_conf(self):  # pylint: disable=too-many-locals
+    def get_version_based_on_conf(self):
         """
         figure out which version and if it's enterprise version
         base on configuration only, before nodes are up and running
@@ -2789,7 +2788,7 @@ class SCTConfiguration(dict):
                 test_config.init_argus_client(params=self, test_id=self.get("reuse_cluster") or self.get("test_id"))
                 test_config.argus_client().submit_packages([package])
                 test_config.argus_client().update_scylla_version(version_info["short"])
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc:
             self.log.exception("Failed to save target Scylla version in Argus", exc_info=exc)
 
     def update_config_based_on_version(self):
@@ -2889,7 +2888,7 @@ class SCTConfiguration(dict):
             raise ValueError('Data volume configuration requires: data_volume_disk_type, data_volume_disk_size')
 
     def _verify_scylla_bench_mode_and_workload_parameters(self):
-        # pylint: disable=too-many-nested-blocks
+
         for param_name in self.stress_cmd_params:
             stress_cmds = self.get(param_name)
             if stress_cmds is None:

--- a/sdcm/sct_events/__init__.py
+++ b/sdcm/sct_events/__init__.py
@@ -35,7 +35,6 @@ class SctEventProtocol(Protocol):
     event_timestamp: Optional[float]
     severity: Severity
 
-    # pylint: disable=super-init-not-called
     def __init__(self, *args, **kwargs):
         ...
 
@@ -74,7 +73,7 @@ class SctEventProtocol(Protocol):
 _SAVED_DEFAULT = json.JSONEncoder().default  # save default method.
 
 
-def _new_default(self, obj):  # pylint: disable=unused-argument
+def _new_default(self, obj):
     if isinstance(obj, enum.Enum):
         return obj.name  # could also be obj.value
     else:

--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -11,8 +11,6 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
-# pylint: disable=too-many-instance-attributes, broad-except, protected-access
-
 from __future__ import annotations
 
 import json
@@ -23,7 +21,7 @@ import fnmatch
 import logging
 from enum import Enum
 from json import JSONEncoder
-from types import new_class  # pylint: disable=no-name-in-module
+from types import new_class
 from typing import \
     Any, Optional, Type, Dict, List, Tuple, Callable, Generic, TypeVar, Protocol, runtime_checkable
 from keyword import iskeyword
@@ -45,7 +43,7 @@ LOGGER = logging.getLogger(__name__)
 ACTION_LOGGER = get_action_logger("event")
 
 
-class SctEventTypesRegistry(Dict[str, Type["SctEvent"]]):  # pylint: disable=too-few-public-methods
+class SctEventTypesRegistry(Dict[str, Type["SctEvent"]]):
     def __init__(self, severities_conf: str = DEFAULT_SEVERITIES):
         super().__init__()
         with open(severities_conf, encoding="utf-8") as fobj:
@@ -55,13 +53,12 @@ class SctEventTypesRegistry(Dict[str, Type["SctEvent"]]):  # pylint: disable=too
     def __setitem__(self, key: str, value: Type[SctEvent]):
         if not value.is_abstract() and key not in self.max_severities:
             raise ValueError(f"There is no max severity configured for {key}")
-        super().__setitem__(key, weakproxy(value))  # pylint: disable=no-member; pylint doesn't know about Dict
+        super().__setitem__(key, weakproxy(value))
 
     def __set_name__(self, owner: Type[SctEvent], name: str) -> None:
         self[owner.__name__] = owner  # add owner class to the registry.
 
 
-# pylint: disable=invalid-name
 class EventPeriod(Enum):
     BEGIN = "begin"
     END = "end"
@@ -102,7 +99,6 @@ class SctEvent:
     save_to_files: bool = True
 
     def __init_subclass__(cls, abstract: bool = False):
-        # pylint: disable=unsupported-membership-test; pylint doesn't know about Dict
         if cls.__name__ in cls._sct_event_types_registry:
             raise TypeError(f"Name {cls.__name__} is already used")
         cls.base = cls.__name__.split(".", 1)[0]
@@ -216,7 +212,6 @@ class SctEvent:
         return fmt
 
     def add_subcontext(self):
-        # pylint: disable=import-outside-toplevel; to avoid cyclic imports
         from sdcm.sct_events.continuous_event import ContinuousEventsRegistry
         # Add subcontext for event with ERROR and CRITICAL severity only
         if self.severity.value < 3:
@@ -245,7 +240,6 @@ class SctEvent:
                     self.subcontext.append(nemesis)
 
     def publish(self, warn_not_ready: bool = True) -> None:
-        # pylint: disable=import-outside-toplevel; to avoid cyclic imports
         from sdcm.sct_events.events_device import get_events_main_device
 
         if not self._ready_to_publish:
@@ -268,7 +262,6 @@ class SctEvent:
         self._ready_to_publish = False
 
     def publish_or_dump(self, default_logger: Optional[logging.Logger] = None, warn_not_ready: bool = True) -> None:
-        # pylint: disable=import-outside-toplevel; to avoid cyclic imports
         from sdcm.sct_events.events_device import get_events_main_device
 
         if not self._ready_to_publish:
@@ -337,7 +330,7 @@ class SctEvent:
             warning = f"[SCT internal warning] {self} has not been published or dumped, maybe you missed .publish()"
             try:
                 LOGGER.warning(warning)
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 print(f"Exception while printing {warning}. Full exception: {exc}")
 
 
@@ -426,7 +419,7 @@ class BaseFilter(SystemEvent, abstract=True):
         raise NotImplementedError()
 
 
-T_log_event = TypeVar("T_log_event", bound="LogEvent")  # pylint: disable=invalid-name
+T_log_event = TypeVar("T_log_event", bound="LogEvent")
 
 
 @runtime_checkable

--- a/sdcm/sct_events/continuous_event.py
+++ b/sdcm/sct_events/continuous_event.py
@@ -76,7 +76,6 @@ class ContinuousEventsRegistry(metaclass=Singleton):
         return running_nemesis_events
 
 
-# pylint: disable=too-many-instance-attributes
 class ContinuousEvent(SctEvent, abstract=True):
     # Event filter does not create object of the class (not initialize it), so "_duration" attribute should
     # exist without initialization

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -69,7 +69,6 @@ class DatabaseLogEvent(LogEvent, abstract=True):
 MILLI_RE = re.compile(r"(\d+) ms")
 
 
-# pylint: disable=too-few-public-methods
 class ReactorStalledMixin(Generic[T_log_event]):
     tolerable_reactor_stall: int = TOLERABLE_REACTOR_STALL
 
@@ -426,7 +425,7 @@ class CompactionEvent(ScyllaDatabaseContinuousEvent):
     save_to_files = False
     continuous_hash_fields = ('node', 'shard', 'table', 'compaction_process_id')
 
-    def __init__(self, node: str, shard: int, table: str, compaction_process_id: str,  # pylint: disable=too-many-arguments
+    def __init__(self, node: str, shard: int, table: str, compaction_process_id: str,
                  severity=Severity.NORMAL, **__):
         self.table = table
         self.compaction_process_id = compaction_process_id

--- a/sdcm/sct_events/decorators.py
+++ b/sdcm/sct_events/decorators.py
@@ -24,7 +24,7 @@ def raise_event_on_failure(func):
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             ThreadFailedEvent(message=str(exc), traceback=format_exc()).publish()
         return None
 

--- a/sdcm/sct_events/event_counter.py
+++ b/sdcm/sct_events/event_counter.py
@@ -42,7 +42,7 @@ class EventStatData:
     stats: dict
 
 
-class EventStatHandler:  # pylint: disable=too-few-public-methods
+class EventStatHandler:
     def __init__(self, event: T_log_event, save_dir: str | Path):
         self._event = event
         self._event_name = self._event.__class__.__name__
@@ -66,7 +66,7 @@ class EventStatHandler:  # pylint: disable=too-few-public-methods
             event_writer.write(str(self._event.line) + "\n")
 
 
-class ReactorStallEventStatHandler(EventStatHandler):  # pylint: disable=too-few-public-methods
+class ReactorStallEventStatHandler(EventStatHandler):
     intervals = STALL_INTERVALS
 
     def _get_interval(self, stall_ms: int):

--- a/sdcm/sct_events/event_handler.py
+++ b/sdcm/sct_events/event_handler.py
@@ -53,7 +53,7 @@ class EventsHandler(BaseEventsProcess[Tuple[str, Any], None], threading.Thread):
                     LOGGER.debug("Found handler %s for %s event. Running it.",
                                  handler.__class__.__name__, full_class_name)
                     handler.handle(event=event, tester_obj=tester_obj)
-                except Exception as exc:  # pylint: disable=broad-except
+                except Exception as exc:
                     LOGGER.exception("failed to handle event using event handler: %s", exc)
 
 

--- a/sdcm/sct_events/events_analyzer.py
+++ b/sdcm/sct_events/events_analyzer.py
@@ -51,7 +51,7 @@ class EventsAnalyzer(BaseEventsProcess[Tuple[str, Any], None], threading.Thread)
                 except TestFailure:
                     self.kill_test(sys.exc_info())
 
-    def kill_test(self, backtrace_with_reason, memo={}) -> None:  # pylint: disable=dangerous-default-value  # noqa: B006
+    def kill_test(self, backtrace_with_reason, memo={}) -> None:  # noqa: B006
         self.terminate()
         if tester := TestConfig().tester_obj():
             if memo:

--- a/sdcm/sct_events/events_device.py
+++ b/sdcm/sct_events/events_device.py
@@ -11,8 +11,6 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
-# pylint: disable=no-member; disable `no-member' messages because of zmq.
-
 import time
 import queue
 import ctypes
@@ -140,7 +138,6 @@ class EventsDevice(multiprocessing.Process):
                 if sub.poll(timeout=self.sub_polling_timeout):
                     yield sub.recv_pyobj(flags=zmq.NOBLOCK)
 
-    # pylint: disable=import-outside-toplevel
     def outbound_events(self,
                         stop_event: StopEvent,
                         events_counter: multiprocessing.Value) -> Generator[Tuple[str, Any], None, None]:

--- a/sdcm/sct_events/events_processes.py
+++ b/sdcm/sct_events/events_processes.py
@@ -43,15 +43,14 @@ LOGGER = logging.getLogger(__name__)
 
 StopEvent = Union[multiprocessing.Event, threading.Event]
 
-T_inbound_event = TypeVar("T_inbound_event")  # pylint: disable=invalid-name
-T_outbound_event = TypeVar("T_outbound_event")  # pylint: disable=invalid-name
-T_outbound_events_protocol = TypeVar("T_outbound_events_protocol")  # pylint: disable=invalid-name
+T_inbound_event = TypeVar("T_inbound_event")
+T_outbound_event = TypeVar("T_outbound_event")
+T_outbound_events_protocol = TypeVar("T_outbound_events_protocol")
 
 InboundEventsGenerator = Generator[T_inbound_event, None, None]
 OutboundEventsGenerator = Generator[T_outbound_event, None, None]
 
 
-# pylint: disable=too-few-public-methods
 class OutboundEventsProtocol(Protocol[T_outbound_events_protocol]):
     def outbound_events(self,
                         stop_event: StopEvent,
@@ -85,7 +84,6 @@ class BaseEventsProcess(Generic[T_inbound_event, T_outbound_event], abc.ABC):
                         get_events_process(name=self.inbound_events_process, _registry=self._registry)) \
             .outbound_events(stop_event=self.stop_event, events_counter=self._events_counter)
 
-    # pylint: disable=unused-argument,no-self-use
     def outbound_events(self, stop_event: StopEvent,
                         events_counter: multiprocessing.Value) -> OutboundEventsGenerator:
         yield from []
@@ -98,8 +96,8 @@ class BaseEventsProcess(Generic[T_inbound_event, T_outbound_event], abc.ABC):
         LOGGER.debug("Stopping events process %s", events_process_class_name)
         self.terminate()
         LOGGER.debug("Waiting for events process %s to stop", events_process_class_name)
-        self.join(timeout)  # pylint: disable=no-member; both threading.Thread and multiprocessing.Process have it
-        if self.is_alive():  # pylint: disable=no-member;
+        self.join(timeout)
+        if self.is_alive():
             LOGGER.error("Events process %s is still alive after timeout", events_process_class_name)
             assert False, f"Events process {events_process_class_name} is still alive after timeout"
         else:
@@ -166,7 +164,7 @@ _EVENTS_PROCESSES: Optional[EventsProcessesRegistry] = None
 
 
 def create_default_events_process_registry(log_dir: Union[str, Path]):
-    global _EVENTS_PROCESSES  # pylint: disable=global-statement  # noqa: PLW0603
+    global _EVENTS_PROCESSES  # noqa: PLW0603
 
     with _EVENTS_PROCESSES_LOCK:
         if _EVENTS_PROCESSES is None:
@@ -197,7 +195,7 @@ def get_events_process(name: str, _registry: Optional[EventsProcessesRegistry] =
 def verbose_suppress(*args, **kwargs):
     try:
         yield
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         LOGGER.exception(*args, **kwargs)
 
 

--- a/sdcm/sct_events/file_logger.py
+++ b/sdcm/sct_events/file_logger.py
@@ -44,7 +44,7 @@ LINE_START_RE = re.compile(r"^\d{4}-\d{2}-\d{2} ")  # date in YYYY-MM-DD format
 LOGGER = logging.getLogger(__name__)
 
 
-class head(list):  # pylint: disable=invalid-name
+class head(list):
     def __init__(self, maxlen: Optional[int] = None):
         super().__init__()
         if maxlen is None:
@@ -134,7 +134,7 @@ class EventsFileLogger(BaseEventsProcess[Tuple[str, Any], None], multiprocessing
                             event.append(line)
                 if event:
                     events_bucket.append("\n".join(event))
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 error_msg = f"{self}: failed to read {log_file}: {exc}"
                 LOGGER.error(error_msg)
                 if not events_bucket:

--- a/sdcm/sct_events/grafana.py
+++ b/sdcm/sct_events/grafana.py
@@ -41,7 +41,7 @@ AnnotationKey = NewType("AnnotationKey", Tuple[str, ...])
 
 class GrafanaAnnotator(EventsProcessPipe[Tuple[str, Any], Annotation]):
     def run(self) -> None:
-        for event_tuple in self.inbound_events():  # pylint: disable=no-member; pylint doesn't understand generics
+        for event_tuple in self.inbound_events():
             with verbose_suppress("GrafanaAnnotator failed to process %s", event_tuple):
                 event_class, event = event_tuple  # try to unpack event from EventsDevice
                 if not event.publish_to_grafana:
@@ -70,7 +70,7 @@ class GrafanaEventAggregator(EventsProcessPipe[Annotation, Annotation]):
         time_window_counters: Dict[AnnotationKey, int] = defaultdict(int)
         time_window_end = time.perf_counter()
 
-        for annotation in self.inbound_events():  # pylint: disable=no-member; pylint doesn't understand generics
+        for annotation in self.inbound_events():
             with verbose_suppress("GrafanaEventAggregator failed to process an annotation %s", annotation):
                 annotation_key = self.unique_key(annotation)
                 time_diff = time.perf_counter() - time_window_end

--- a/sdcm/sct_events/handlers/__init__.py
+++ b/sdcm/sct_events/handlers/__init__.py
@@ -16,7 +16,6 @@ import abc
 from sdcm.sct_events.base import SctEvent
 
 
-# pylint: disable=too-few-public-methods
 class EventHandler(abc.ABC):
 
     def __init__(self):

--- a/sdcm/sct_events/handlers/schema_disagreement.py
+++ b/sdcm/sct_events/handlers/schema_disagreement.py
@@ -22,7 +22,6 @@ from sdcm.utils.sstable.s3_uploader import upload_sstables_to_s3
 LOGGER = logging.getLogger(__name__)
 
 
-# pylint: disable=too-few-public-methods
 class SchemaDisagreementHandler(EventHandler):
     """Collects relevant data for schema mismatch investigation."""
 
@@ -48,7 +47,7 @@ class SchemaDisagreementHandler(EventHandler):
                 try:
                     link = upload_sstables_to_s3(node, keyspace='system_schema', test_id=tester_obj.test_id)
                     event.add_sstable_link(link)
-                except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+                except Exception as exc:  # noqa: BLE001
                     LOGGER.error("failed to upload system_schema sstables for node %s: %s", node.name, exc)
             event.add_gossip_info(gossip_info)
             event.add_peers_info(peers_info)

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -28,7 +28,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 class GeminiStressEvent(BaseStressEvent):
-    # pylint: disable=too-many-arguments, too-many-instance-attributes
     def __init__(self, node: Any,
                  cmd: str,
                  log_file_name: Optional[str] = None,
@@ -298,7 +297,7 @@ CASSANDRA_HARRY_ERROR_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]]
     [(re.compile(event.regex), event) for event in CASSANDRA_HARRY_ERROR_EVENTS]
 
 
-class GeminiStressLogEvent(LogEvent[T_log_event], abstract=True):  # pylint: disable=too-many-instance-attributes
+class GeminiStressLogEvent(LogEvent[T_log_event], abstract=True):
     SEVERITY_MAPPING = {
         "INFO": "NORMAL",
         "DEBUG": "NORMAL",

--- a/sdcm/sct_events/monitors.py
+++ b/sdcm/sct_events/monitors.py
@@ -15,7 +15,7 @@ from sdcm.sct_events import Severity
 from sdcm.sct_events.continuous_event import ContinuousEvent
 
 
-class PrometheusAlertManagerEvent(ContinuousEvent):  # pylint: disable=too-many-instance-attributes
+class PrometheusAlertManagerEvent(ContinuousEvent):
     _eq_attrs = (
         "type",
         "starts_at",

--- a/sdcm/sct_events/nemesis.py
+++ b/sdcm/sct_events/nemesis.py
@@ -21,7 +21,7 @@ class DisruptionEvent(ContinuousEvent):
                  nemesis_name,
                  node,
                  severity=Severity.NORMAL,
-                 publish_event=True):  # pylint: disable=redefined-builtin,too-many-arguments
+                 publish_event=True):
         self.nemesis_name = nemesis_name
         self.node = str(node)
         self.duration = None

--- a/sdcm/sct_events/nodetool.py
+++ b/sdcm/sct_events/nodetool.py
@@ -39,9 +39,8 @@ class NodetoolEventEncoder(JSONEncoder):
             return super().default(o)
 
 
-# pylint: disable=too-many-instance-attributes
 class NodetoolEvent(ContinuousEvent):
-    def __init__(self,  # pylint: disable=too-many-arguments
+    def __init__(self,
                  nodetool_command,
                  severity=Severity.NORMAL,
                  node=None,

--- a/sdcm/sct_events/operator.py
+++ b/sdcm/sct_events/operator.py
@@ -35,7 +35,6 @@ class ScyllaOperatorLogEvent(LogEvent):
         super().__init__(regex=regex, severity=severity)
         self.line_number = None
 
-    # pylint: disable=too-many-locals
     def add_info(self: T_log_event, node, line: str, line_number: int) -> T_log_event:
         # I0628 15:53:02.269804       1 operator/operator.go:133] <message>
         # I - Log level = INFO
@@ -54,7 +53,7 @@ class ScyllaOperatorLogEvent(LogEvent):
             self.source_timestamp = datetime.datetime(
                 year=year, month=month, day=day, hour=int(hour), minute=int(minute), second=int(second),
                 microsecond=int(milliseconds), tzinfo=datetime.timezone.utc).timestamp()
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             pass
         self.event_timestamp = time.time()
         self.node = str(node)

--- a/sdcm/sct_events/prometheus.py
+++ b/sdcm/sct_events/prometheus.py
@@ -39,7 +39,7 @@ class PrometheusDumper(BaseEventsProcess[Tuple[str, Any], None], threading.Threa
         for event_tuple in self.inbound_events():
             with verbose_suppress("PrometheusDumper failed to process %s", event_tuple):
                 event_class, event = event_tuple  # try to unpack event from EventsDevice
-                events_gauge.labels(event_class,  # pylint: disable=no-member
+                events_gauge.labels(event_class,
                                     getattr(event, "type", ""),
                                     getattr(event, "subtype", ""),
                                     event.severity,

--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -79,14 +79,14 @@ def stop_events_device(_registry: Optional[EventsProcessesRegistry] = None) -> N
         if (proc := get_events_process(name, _registry=_registry)) and proc.is_alive():
             LOGGER.debug("Signaling %s to terminate and wait for finish...", name)
             proc.stop(timeout=EVENTS_PROCESS_STOP_TIMEOUT)
-            events_stat[f"{proc._registry}[{name}]"] = proc.events_counter  # pylint: disable=protected-access
+            events_stat[f"{proc._registry}[{name}]"] = proc.events_counter
     LOGGER.debug("All events consumers stopped.")
 
     if events_stat:
         LOGGER.info("Statistics of sent/received events (by device): %s", json.dumps(events_stat, indent=4))
 
 
-def enable_default_filters(sct_config: SCTConfiguration):  # pylint: disable=unused-argument
+def enable_default_filters(sct_config: SCTConfiguration):
 
     # Default filters.
     if SkipPerIssues('scylladb/scylla-enterprise#1272', params=sct_config):

--- a/sdcm/sct_events/stress_events.py
+++ b/sdcm/sct_events/stress_events.py
@@ -17,7 +17,7 @@ from sdcm.sct_events.continuous_event import ContinuousEvent
 
 
 class BaseStressEvent(ContinuousEvent, abstract=True):
-    # pylint: disable=too-many-arguments
+
     @classmethod
     def add_stress_subevents(cls,
                              failure: Optional[Severity] = None,
@@ -52,7 +52,7 @@ class StressEventProtocol(SctEventProtocol, Protocol):
 
 
 class StressEvent(BaseStressEvent, abstract=True):
-    # pylint: disable=too-many-arguments
+
     def __init__(self,
                  node: Any,
                  stress_cmd: Optional[str] = None,

--- a/sdcm/sct_events/system.py
+++ b/sdcm/sct_events/system.py
@@ -49,10 +49,9 @@ class HWPerforanceEvent(SctEvent):
         return super().msgfmt + ": message={0.message}"
 
 
-class TestFrameworkEvent(InformationalEvent):  # pylint: disable=too-many-instance-attributes
+class TestFrameworkEvent(InformationalEvent):
     __test__ = False  # Mark this class to be not collected by pytest.
 
-    # pylint: disable=too-many-arguments
     def __init__(self,
                  source: Any,
                  source_method: Optional = None,
@@ -162,7 +161,7 @@ class TestStepEvent(ContinuousEvent):
     def __init__(self,
                  step,
                  severity=Severity.NORMAL,
-                 publish_event=True):  # pylint: disable=redefined-builtin,too-many-arguments
+                 publish_event=True):
         self.step = step
         self.duration = None
         self.full_traceback = ""
@@ -221,7 +220,7 @@ class AwsKmsEvent(ThreadFailedEvent):
 
 
 class CoreDumpEvent(InformationalEvent):
-    # pylint: disable=too-many-arguments
+
     def __init__(self,
                  node: Any,
                  corefile_url: str,

--- a/sdcm/sct_provision/aws/instance_parameters_builder.py
+++ b/sdcm/sct_provision/aws/instance_parameters_builder.py
@@ -43,7 +43,7 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
 
     @computed_field
     @property
-    def BlockDeviceMappings(self) -> List[AWSDiskMapping]:  # pylint: disable=invalid-name
+    def BlockDeviceMappings(self) -> List[AWSDiskMapping]:
         if not self.ImageId:
             return []
         device_mappings = []
@@ -61,19 +61,19 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
 
     @computed_field
     @property
-    def ImageId(self) -> Optional[str]:  # pylint: disable=invalid-name
+    def ImageId(self) -> Optional[str]:
         if not self._image_ids:
             return None
         return self._image_ids[self.region_id]
 
     @computed_field
     @property
-    def KeyName(self) -> str:  # pylint: disable=invalid-name
+    def KeyName(self) -> str:
         return self._credentials[self.region_id].key_pair_name
 
     @computed_field
     @property
-    def NetworkInterfaces(self) -> List[dict]:  # pylint: disable=invalid-name
+    def NetworkInterfaces(self) -> List[dict]:
         output = []
         for index in range(network_interfaces_count(self.params)):
             output.append({'DeviceIndex': index, **self._network_interface_params(interface_index=index)})
@@ -81,26 +81,26 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
 
     @computed_field
     @property
-    def IamInstanceProfile(self) -> dict | None:  # pylint: disable=invalid-name
+    def IamInstanceProfile(self) -> dict | None:
         if profile := self.params.get(self._INSTANCE_PROFILE_PARAM_NAME):
             return {'Name': profile}
         return None
 
     @computed_field
     @property
-    def InstanceType(self) -> str:  # pylint: disable=invalid-name
+    def InstanceType(self) -> str:
         return self.params.get(self._INSTANCE_TYPE_PARAM_NAME)
 
     @computed_field
     @property
-    def Placement(self) -> Optional[AWSPlacementInfo]:  # pylint: disable=invalid-name
+    def Placement(self) -> Optional[AWSPlacementInfo]:
         return AWSPlacementInfo(
             AvailabilityZone=self._region_name + self._availability_zones[self.availability_zone],
             GroupName=self.placement_group)
 
     @computed_field
     @property
-    def UserData(self) -> Optional[str]:  # pylint: disable=invalid-name
+    def UserData(self) -> Optional[str]:
         if not self.user_data_raw:
             return None
         if isinstance(self.user_data_raw, UserDataBuilderBase):
@@ -142,8 +142,8 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
         LOGGER.debug("ec2_subnet_ids: %s; availability_zone: %s, interface_index: %s",
                      self._ec2_subnet_ids, self.availability_zone, interface_index)
         return {
-            'SubnetId': self._ec2_subnet_ids[self.region_id][self.availability_zone][interface_index],  # pylint: disable=invalid-sequence-index
-            'Groups': self._ec2_security_group_ids[self.region_id],  # pylint: disable=invalid-sequence-index
+            'SubnetId': self._ec2_subnet_ids[self.region_id][self.availability_zone][interface_index],
+            'Groups': self._ec2_security_group_ids[self.region_id],
         }
 
     @property

--- a/sdcm/sct_provision/common/layout.py
+++ b/sdcm/sct_provision/common/layout.py
@@ -42,22 +42,22 @@ class SCTProvisionLayout:
         return self._params.get('db_type') == 'mixed_scylla'
 
     @property
-    def db_cluster(self):  # pylint: disable=no-self-use
+    def db_cluster(self):
         return None
 
     @property
-    def loader_cluster(self):  # pylint: disable=no-self-use
+    def loader_cluster(self):
         return None
 
     @property
-    def monitoring_cluster(self):  # pylint: disable=no-self-use
+    def monitoring_cluster(self):
         return None
 
     @property
-    def cs_db_cluster(self):  # pylint: disable=no-self-use
+    def cs_db_cluster(self):
         return None
 
-    def provision(self):  # pylint: disable=no-self-use
+    def provision(self):
         raise RuntimeError("This backend is not supported yet")
 
 

--- a/sdcm/sct_provision/region_definition_builder.py
+++ b/sdcm/sct_provision/region_definition_builder.py
@@ -96,7 +96,7 @@ class DefinitionBuilder(abc.ABC):
                                   use_public_ip=use_public_ip,
                                   )
 
-    def build_region_definition(self, region: str, availability_zone: str, n_db_nodes: int,  # pylint: disable=too-many-arguments
+    def build_region_definition(self, region: str, availability_zone: str, n_db_nodes: int,
                                 n_loader_nodes: int, n_monitor_nodes: int) -> RegionDefinition:
         """Builds instances definitions for given region"""
         definitions = []

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -11,7 +11,7 @@
 #
 # Copyright (c) 2021 ScyllaDB
 
-# pylint: disable=too-many-lines
+
 from __future__ import annotations
 
 import logging
@@ -72,7 +72,7 @@ from sdcm.test_config import TestConfig
 from sdcm.node_exporter_setup import NodeExporterSetup
 
 if TYPE_CHECKING:
-    # pylint: disable=ungrouped-imports
+
     from typing import Optional, Any, Type
 
     from mypy_boto3_ec2.literals import InstanceTypeType
@@ -100,7 +100,7 @@ def datetime_from_formatted(date_string: str) -> datetime.datetime:
 
 
 @dataclass
-class SctRunnerInfo:  # pylint: disable=too-many-instance-attributes
+class SctRunnerInfo:
     sct_runner_class: Type[SctRunner] = field(repr=False)
     cloud_service_instance: EC2Client | AzureService | None = field(repr=False)
     region_az: str
@@ -186,14 +186,14 @@ class SctRunner(ABC):
         ...
 
     def get_remoter(self, host, connect_timeout: Optional[float] = None) -> RemoteCmdRunnerBase:
-        self._ssh_pkey_file = tempfile.NamedTemporaryFile(mode="w", delete=False)  # pylint: disable=consider-using-with
+        self._ssh_pkey_file = tempfile.NamedTemporaryFile(mode="w", delete=False)
         self._ssh_pkey_file.write(self.key_pair.private_key.decode())
         self._ssh_pkey_file.flush()
         return RemoteCmdRunnerBase.create_remoter(hostname=host, user=self.LOGIN_USER,
                                                   key_file=self._ssh_pkey_file.name, connect_timeout=connect_timeout)
 
     def install_prereqs(self, public_ip: str, connect_timeout: Optional[int] = None) -> None:
-        from sdcm.cluster_docker import AIO_MAX_NR_RECOMMENDED_VALUE  # pylint: disable=import-outside-toplevel
+        from sdcm.cluster_docker import AIO_MAX_NR_RECOMMENDED_VALUE
 
         LOGGER.info("Connecting instance...")
         remoter = self.get_remoter(host=public_ip, connect_timeout=connect_timeout)
@@ -293,7 +293,6 @@ class SctRunner(ABC):
         ...
 
     @abstractmethod
-    # pylint: disable=too-many-arguments
     def _create_instance(self,
                          instance_type: str,
                          base_image: Any,
@@ -376,7 +375,7 @@ class SctRunner(ABC):
             try:
                 LOGGER.info("Terminating SCT Image Builder instance `%s'...", builder_instance_id)
                 self._terminate_image_builder_instance(instance=instance)
-            except Exception as ex:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as ex:  # noqa: BLE001
                 LOGGER.warning("Was not able to terminate `%s': %s\nPlease terminate manually!!!",
                                builder_instance_id, ex)
         else:
@@ -395,7 +394,7 @@ class SctRunner(ABC):
     def _get_base_image(self, image: Optional[Any] = None) -> Any:
         ...
 
-    def create_instance(self,  # pylint: disable=too-many-arguments
+    def create_instance(self,
                         test_id: str,
                         test_name: str,
                         test_duration: int,
@@ -513,7 +512,6 @@ class AwsSctRunner(SctRunner):
 
         return aws_region.resource.Image(existing_amis[0]["ImageId"])
 
-    # pylint: disable=too-many-arguments,too-many-locals,too-many-statements
     def _create_instance(self,
                          instance_type: InstanceTypeType,
                          base_image: Any,
@@ -713,7 +711,7 @@ class AwsSctRunner(SctRunner):
         return image.image_id
 
     def _copy_source_image_to_region(self) -> None:
-        result = self.aws_region.client.copy_image(  # pylint: disable=no-member
+        result = self.aws_region.client.copy_image(
             Description=self.IMAGE_DESCRIPTION,
             Name=self.image_name,
             SourceImageId=self.source_image.image_id,
@@ -774,7 +772,7 @@ class AwsSctRunner(SctRunner):
         LOGGER.info("Updated SCT Runner %s with tags: %s successfully.", cloud_instance_name, tags_to_create)
 
 
-class GceSctRunner(SctRunner):  # pylint: disable=too-many-instance-attributes
+class GceSctRunner(SctRunner):
     """Provision and configure the SCT runner on GCE."""
 
     CLOUD_PROVIDER = "gce"
@@ -850,7 +848,6 @@ class GceSctRunner(SctRunner):  # pylint: disable=too-many-instance-attributes
     def tags_to_labels(tags: dict[str, str]) -> dict[str, str]:
         return {key.lower(): value.lower().replace(".", "_") for key, value in tags.items()}
 
-    # pylint: disable=too-many-arguments,too-many-locals
     def _create_instance(self,
                          instance_type: str,
                          base_image: Any,
@@ -1044,7 +1041,7 @@ class AzureSctRunner(SctRunner):
                         return gallery_image_version
         return None
 
-    def _create_instance(self,  # pylint: disable=too-many-arguments
+    def _create_instance(self,
                          instance_type: str,
                          base_image: Any,
                          tags: dict[str, str],
@@ -1176,7 +1173,7 @@ class AzureSctRunner(SctRunner):
         tags_to_create = {str(k): str(v) for k, v in tags.items()}
         params = TagsPatchResource.from_dict(
             {
-                "operation": TagsPatchOperation.MERGE.value,  # pylint:disable=no-member
+                "operation": TagsPatchOperation.MERGE.value,
                 "properties": {
                     "tags": tags_to_create,
                 }
@@ -1250,7 +1247,7 @@ def update_sct_runner_tags(backend: str = None, test_runner_ip: str = None, test
         runner_to_update = runner_to_update[0]
         runner_to_update.sct_runner_class.set_tags(runner_to_update, tags=tags)
         LOGGER.info("Tags on SCT runner updated with: %s", tags)
-    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         LOGGER.warning("Could not set SCT runner tags to: %s due to exc:\n%s", tags, exc)
 
 
@@ -1290,7 +1287,7 @@ def clean_sct_runners(test_status: str,
                       backend: str = None,
                       dry_run: bool = False,
                       force: bool = False) -> None:
-    # pylint: disable=too-many-branches,too-many-statements
+
     sct_runners_list = list_sct_runners(backend=backend, test_runner_ip=test_runner_ip)
     timeout_flag = False
     runners_terminated = 0
@@ -1352,7 +1349,7 @@ def clean_sct_runners(test_status: str,
             sct_runner_info.terminate()
             runners_terminated += 1
             end_message = f"Number of cleaned runners: {runners_terminated}"
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.warning("Exception raised during termination of %s: %s", sct_runner_info, exc)
             end_message = "No runners have been terminated"
 

--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -75,7 +75,7 @@ class ScyllaBenchStressEventsPublisher(FileFollowerThread):
                         event.add_info(node=self.node, line=line, line_number=line_number).publish()
 
 
-class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes
+class ScyllaBenchThread(DockerBasedStressThread):
 
     DOCKER_IMAGE_PARAM_NAME = "stress_image.scylla-bench"
     _SB_STATS_MAPPING = {
@@ -116,7 +116,6 @@ class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-in
         'mean': (int, 'latency mean'),
     }
 
-    # pylint: disable=too-many-arguments
     def __init__(self, stress_cmd, loader_set, timeout, node_list=None, round_robin=False,
                  stop_test_on_failure=False, stress_num=1, credentials=None, params=None):
         super().__init__(loader_set=loader_set, stress_cmd=stress_cmd, timeout=timeout, stress_num=stress_num,
@@ -168,7 +167,7 @@ class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-in
 
         return stress_cmd
 
-    def _run_stress(self, loader, loader_idx, cpu_idx):  # pylint: disable=too-many-locals
+    def _run_stress(self, loader, loader_idx, cpu_idx):
         cmd_runner = None
         if "k8s" in self.params.get("cluster_backend"):
             cmd_runner = loader.remoter
@@ -214,7 +213,7 @@ class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-in
             prefix, *_ = stress_cmd.split("scylla-bench", maxsplit=1)
             reporter = ScyllaBenchVersionReporter(cmd_runner, prefix, loader.parent_cluster.test_config.argus_client())
             reporter.report()
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             LOGGER.info("Failed to collect scylla-bench version information", exc_info=True)
 
         with ScyllaBenchStressExporter(instance_name=cmd_runner_name,
@@ -235,7 +234,7 @@ class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-in
                     log_file=log_file_name,
                     retry=0,
                 )
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 self.configure_event_on_failure(stress_event=scylla_bench_event, exc=exc)
 
         return loader, result, scylla_bench_event
@@ -253,7 +252,7 @@ class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-in
         for line in lines:
             line.strip()
             # Parse load params
-            # pylint: disable=too-many-boolean-expressions
+
             if line.startswith('Results'):
                 continue
             if 'c-o fixed latency' in line:

--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -49,7 +49,6 @@ class BodySizeExceeded(Exception):
 
 
 class Email():
-    #  pylint: disable=too-many-instance-attributes
     """
     Responsible for sending emails
     """
@@ -78,7 +77,7 @@ class Email():
         self.conn.starttls()
         self.conn.login(user=self._user, password=self._password)
 
-    def prepare_email(self, subject, content, recipients, html=True, files=()):  # pylint: disable=too-many-arguments
+    def prepare_email(self, subject, content, recipients, html=True, files=()):
         msg = MIMEMultipart()
         msg['subject'] = subject
         msg['from'] = self.sender
@@ -106,7 +105,7 @@ class Email():
             raise BodySizeExceeded(current_size=len(email), limit=self._body_size_limit)
         return email
 
-    def send(self, subject, content, recipients, html=True, files=()):  # pylint: disable=too-many-arguments
+    def send(self, subject, content, recipients, html=True, files=()):
         """
         :param subject: text
         :param content: text/html
@@ -219,7 +218,7 @@ class BaseEmailReporter:
             return
         try:
             Email().send_email(recipients=self.email_recipients, email=email)
-        except Exception as details:  # pylint: disable=broad-except
+        except Exception as details:
             self.log.error("Error during sending email: %s", details, exc_info=True)
         finally:
             self.log.info('Send email with results to %s', self.email_recipients)
@@ -283,11 +282,11 @@ class BaseEmailReporter:
         return self.render_to_html(report_data)
 
     @staticmethod
-    def build_report_attachments(attachments_data, template_str=None):  # pylint: disable=unused-argument
+    def build_report_attachments(attachments_data, template_str=None):
         return ()
 
     @staticmethod
-    def cut_report_data(report_data, attachments_data, reason):  # pylint: disable=unused-argument
+    def cut_report_data(report_data, attachments_data, reason):
         if attachments_data is not None:
             return report_data, None
         return None, None
@@ -540,7 +539,7 @@ class JepsenEmailReporter(BaseEmailReporter):
     email_template_file = "results_jepsen.html"
 
     @staticmethod
-    def build_report_attachments(attachments_data, template_str=None):  # pylint: disable=unused-argument
+    def build_report_attachments(attachments_data, template_str=None):
         return (attachments_data["jepsen_report"], )
 
 
@@ -582,7 +581,7 @@ class PerfSimpleQueryReporter(BaseEmailReporter):
 def build_reporter(name: str,  # noqa: PLR0911
                    email_recipients: Sequence[str] = (),
                    logdir: Optional[str] = None) -> Optional[BaseEmailReporter]:
-    # pylint: disable=too-many-return-statements,too-many-branches
+
     if "Gemini" in name:
         return GeminiEmailReporter(email_recipients=email_recipients, logdir=logdir)
     elif "Longevity" in name:
@@ -617,7 +616,7 @@ def build_reporter(name: str,  # noqa: PLR0911
         return None
 
 
-def get_running_instances_for_email_report(test_id: str, ip_filter: str = None):  # pylint: disable=too-many-locals
+def get_running_instances_for_email_report(test_id: str, ip_filter: str = None):
     """Get running instances left after testrun
 
     Get all running instances leff after testrun is done.
@@ -683,7 +682,7 @@ def get_running_instances_for_email_report(test_id: str, ip_filter: str = None):
     return nodes
 
 
-def send_perf_email(reporter, test_results, logs, email_recipients, testrun_dir, start_time):  # pylint: disable=too-many-arguments
+def send_perf_email(reporter, test_results, logs, email_recipients, testrun_dir, start_time):
     for subject, content in test_results.items():
         if 'email_body' not in content:
             content['email_body'] = {}
@@ -697,7 +696,7 @@ def send_perf_email(reporter, test_results, logs, email_recipients, testrun_dir,
                                        template=email_content['template'])
         try:
             reporter.send_email(subject=subject, content=html, files=email_content['attachments'])
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             LOGGER.error("Failed to create email due to the following error:\n%s", traceback.format_exc())
             build_reporter("TestAborted", email_recipients, testrun_dir).send_report({
                 "job_url": os.environ.get("BUILD_URL"),
@@ -721,7 +720,7 @@ def read_email_data_from_file(filename):
             with open(filename, encoding="utf-8") as file:
                 data = file.read().strip()
                 email_data = json.loads(data or '{}')
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             LOGGER.warning("Error during read email data file %s: %s", filename, details)
     return email_data
 
@@ -739,5 +738,5 @@ def save_email_data_to_file(email_data, filepath):
         if email_data:
             with open(filepath, "w", encoding="utf-8") as json_file:
                 json.dump(email_data, json_file)
-    except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as details:  # noqa: BLE001
         LOGGER.warning("Error during collecting data for email %s", details)

--- a/sdcm/sla/libs/sla_utils.py
+++ b/sdcm/sla/libs/sla_utils.py
@@ -34,7 +34,6 @@ class SlaUtils:
     VALID_DEVIATION_PRC = 10
 
     @staticmethod
-    # pylint: disable=too-many-arguments, too-many-locals
     def define_read_cassandra_stress_command(role: Role,
                                              load_type: str,
                                              c_s_workload_type: str,
@@ -56,10 +55,10 @@ class SlaUtils:
         def latency():
             return '%d throttle=%d/s' % (threads, throttle)
 
-        def throughput():  # pylint: disable=unused-variable
+        def throughput():
             return threads
 
-        def cache_only(max_rows_for_read):  # pylint: disable=unused-variable
+        def cache_only(max_rows_for_read):
             # Select part of the records to warm the cache (that was read before start this stress command) and all this
             # data exists in the cache (rows from 1 to max_rows_for_read).
             # This data will be read during the test from cache
@@ -68,7 +67,7 @@ class SlaUtils:
             return 'seq=1..%d' % max_rows_for_read
 
         # Read from cache and disk
-        def mixed(max_rows_for_read):  # pylint: disable=unused-variable
+        def mixed(max_rows_for_read):
             # Select part of the records (rows from 1 to max_rows_for_read) for the test.
             # This amount of data will be read during the test. Part of this will be read from a cache (during run the
             # data will be loaded into a cache) and part - from a disk
@@ -78,7 +77,7 @@ class SlaUtils:
                                                     int(max_rows_for_read / 2),
                                                     int(max_rows_for_read * 0.05))
 
-        def disk_only(max_rows_for_read):  # pylint: disable=unused-variable
+        def disk_only(max_rows_for_read):
             # Select part of the record to warm the cache (that was read before start this stress command) -
             # from 1 to max_rows_for_read - all this data will be in the cache.
             # cassandra-stress "-pop" parameter will start from more than "max_key_for_cache" row number -
@@ -139,7 +138,6 @@ class SlaUtils:
 
         return results
 
-    # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
     def validate_io_queue_operations(self, start_time, end_time, read_users, prometheus_stats, db_cluster,
                                      expected_ratio=None, load_high_enough=None, publish_wp_error_event=False,
                                      possible_issue=None):
@@ -234,7 +232,6 @@ class SlaUtils:
                 result.insert(0, "\nProbably the issue https://github.com/scylladb/scylla-enterprise/issues/2572")
             raise SchedulerRuntimeUnexpectedValue("".join(result))
 
-    # pylint: disable=too-many-branches
     @staticmethod
     def validate_io_queue_operations_relatively_to_share(roles_full_info: dict, node_ip: str,
                                                          load_high_enough: bool = None, node_cpu: float = None,
@@ -330,7 +327,7 @@ class SlaUtils:
         return error_message
 
     @staticmethod
-    def calculate_metrics_ratio_per_user(two_users_list, metrics=None):  # pylint: disable=invalid-name
+    def calculate_metrics_ratio_per_user(two_users_list, metrics=None):
         """
         :param metrics: calculate ratio for specific Scylla or cassandra-stress metrics (ops for example).
                         If metrics name is not defined - ration will be calculated for service_shares
@@ -383,7 +380,7 @@ class SlaUtils:
                 if auth:
                     try:
                         auth.drop()
-                    except Exception as error:  # pylint: disable=broad-except  # noqa: BLE001
+                    except Exception as error:  # noqa: BLE001
                         LOGGER.error("Failed to drop '%s'. Error: %s", auth.name, error)
 
     @staticmethod

--- a/sdcm/sla/sla_tests.py
+++ b/sdcm/sla/sla_tests.py
@@ -16,14 +16,14 @@ LOGGER = logging.getLogger(__name__)
 
 
 class Steps(SlaUtils):
-    # pylint: disable=too-many-arguments
+
     def run_stress_and_validate_scheduler_io_queue_operations_during_load(self, tester, read_cmds, prometheus_stats, read_roles,
                                                                           stress_queue, sleep=600):
-        # pylint: disable=not-context-manager
+
         with TestStepEvent(step="Run stress command and validate io_queue_operations during load") as wp_event:
             try:
                 start_time = time.time() + 60
-                # pylint: disable=protected-access
+
                 tester._run_all_stress_cmds(stress_queue, params={'stress_cmd': read_cmds, 'round_robin': True})
                 time.sleep(sleep)
                 end_time = time.time()
@@ -36,16 +36,15 @@ class Steps(SlaUtils):
                                                   possible_issue={'less resources': 'scylla-enterprise#2717'}
                                                   )
                 return None
-            except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as details:  # noqa: BLE001
                 wp_event.add_error([str(details)])
                 wp_event.full_traceback = traceback.format_exc()
                 wp_event.severity = Severity.ERROR
                 return wp_event
 
-    # pylint: disable=too-many-arguments
     def alter_sl_and_validate_io_queue_operations(self, tester, service_level, new_shares, read_roles, prometheus_stats,
                                                   sleep=600):
-        # pylint: disable=not-context-manager
+
         with TestStepEvent(step=f"Alter shares from {service_level.shares} to {new_shares} Service "
                                 f"Level {service_level.name} and validate io_queue_operations "
                                 f"during load") as wp_event:
@@ -66,45 +65,42 @@ class Steps(SlaUtils):
                                                   db_cluster=tester.db_cluster,
                                                   possible_issue={'less resources': "scylla-enterprise#949"})
                 return None
-            except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as details:  # noqa: BLE001
                 wp_event.add_error([str(details)])
                 wp_event.full_traceback = traceback.format_exc()
                 wp_event.severity = Severity.ERROR
                 return wp_event
 
-    # pylint: disable=too-many-arguments
     @staticmethod
     def detach_service_level_and_run_load(sl_for_detach, role_with_sl_to_detach, sleep=600):
-        # pylint: disable=not-context-manager
+
         with TestStepEvent(step=f"Detach service level {sl_for_detach.name} with {sl_for_detach.shares} shares from "
                                 f"{role_with_sl_to_detach.name}.") as wp_event:
             try:
                 role_with_sl_to_detach.detach_service_level()
                 time.sleep(sleep)
                 return None
-            except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as details:  # noqa: BLE001
                 wp_event.add_error([str(details)])
                 wp_event.full_traceback = traceback.format_exc()
                 wp_event.severity = Severity.ERROR
                 return wp_event
 
-    # pylint: disable=too-many-arguments
     @staticmethod
     def drop_service_level_and_run_load(sl_for_drop, role_with_sl_to_drop, sleep=600):
-        # pylint: disable=not-context-manager
+
         with TestStepEvent(step=f"Drop service level {sl_for_drop.name} with {role_with_sl_to_drop.name}.") as wp_event:
             try:
                 sl_for_drop.drop()
                 role_with_sl_to_drop.reset_service_level()
                 time.sleep(sleep)
                 return None
-            except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as details:  # noqa: BLE001
                 wp_event.add_error([str(details)])
                 wp_event.full_traceback = traceback.format_exc()
                 wp_event.severity = Severity.ERROR
                 return wp_event
 
-    # pylint: disable=too-many-arguments
     def attach_sl_and_validate_io_queue_operations(self, tester, new_service_level, role_for_attach,
                                                    read_roles, prometheus_stats, sleep=600):
         @retrying(n=15, sleep_time=1, message="Wait for service level has been attached to the role",
@@ -112,7 +108,6 @@ class Steps(SlaUtils):
         def validate_role_service_level_attributes_against_db():
             role_for_attach.validate_role_service_level_attributes_against_db()
 
-        # pylint: disable=not-context-manager
         with TestStepEvent(step=f"Attach service level {new_service_level.name} with "
                                 f"{new_service_level.shares} shares to {role_for_attach.name}. "
                                 f"Validate io_queue_operations during load") as wp_event:
@@ -158,7 +153,7 @@ class Steps(SlaUtils):
                                                                   'scylla-enterprise#2572 or scylla-enterprise#2717'}
                                                   )
                 return None
-            except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as details:  # noqa: BLE001
                 wp_event.add_error([str(details)])
                 wp_event.full_traceback = traceback.format_exc()
                 wp_event.severity = Severity.ERROR
@@ -173,7 +168,6 @@ class SlaTests(Steps):
     def unique_subsrtr_for_name():
         return str(uuid.uuid1()).split("-", maxsplit=1)[0]
 
-    # pylint: disable=too-many-arguments
     def _create_sla_auth(self, session, db_cluster, shares: int, index: str, superuser: bool = True) -> Role:
         role = None
         try:
@@ -182,14 +176,13 @@ class SlaTests(Steps):
                                   service_level_for_test_step="INITIAL_FOR_TEST"):
                 self.wait_for_service_level_propagated(cluster=db_cluster, service_level=role.attached_service_level)
             return role
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             if role and role.attached_service_level:
                 role.attached_service_level.drop()
             if role:
                 role.drop()
             raise
 
-    # pylint: disable=too-many-arguments
     def _create_new_service_level(self, session, auth_entity_name_index, shares, db_cluster, service_level_for_test_step: str = None):
         new_sl = ServiceLevel(session=session,
                               name=SERVICE_LEVEL_NAME_TEMPLATE % (shares, auth_entity_name_index),
@@ -204,7 +197,7 @@ class SlaTests(Steps):
         for stress in stress_queue:
             try:
                 tester.verify_stress_thread(stress)
-            except Exception as error:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as error:  # noqa: BLE001
                 LOGGER.error("Stress verifying failed. Error: %s", error)
 
     @staticmethod
@@ -213,7 +206,6 @@ class SlaTests(Steps):
             if role["role"] == role_to_refresh:
                 read_roles[i]["service_level"] = role_to_refresh.attached_service_level
 
-    # pylint: disable=too-many-locals
     def test_increase_shares_by_attach_another_sl_during_load(self, tester, prometheus_stats, num_of_partitions,
                                                               cassandra_stress_column_definition=None):
         low_share = 20
@@ -278,9 +270,8 @@ class SlaTests(Steps):
                 self.clean_auth(entities_list_of_dict=read_roles)
                 if new_sl:
                     new_sl.drop()
-                return error_events  # pylint: disable=lost-exception
+                return error_events
 
-    # pylint: disable=too-many-locals
     def test_increase_shares_during_load(self, tester, prometheus_stats, num_of_partitions,
                                          cassandra_stress_column_definition=None):
         low_share = 20
@@ -331,9 +322,8 @@ class SlaTests(Steps):
             finally:
                 self.verify_stress_threads(tester=tester, stress_queue=stress_queue)
                 self.clean_auth(entities_list_of_dict=read_roles)
-                return error_events  # pylint: disable=lost-exception
+                return error_events
 
-    # pylint: disable=too-many-locals
     def test_decrease_shares_during_load(self, tester, prometheus_stats, num_of_partitions,
                                          cassandra_stress_column_definition=None):
         low_share = 800
@@ -385,9 +375,8 @@ class SlaTests(Steps):
             finally:
                 self.verify_stress_threads(tester=tester, stress_queue=stress_queue)
                 self.clean_auth(entities_list_of_dict=read_roles)
-                return error_events  # pylint: disable=lost-exception
+                return error_events
 
-    # pylint: disable=too-many-locals
     def test_replace_service_level_using_detach_during_load(self, tester, prometheus_stats, num_of_partitions,
                                                             cassandra_stress_column_definition=None):
         low_share = 250
@@ -460,9 +449,8 @@ class SlaTests(Steps):
                 self.clean_auth(entities_list_of_dict=read_roles)
                 if new_sl:
                     new_sl.drop()
-                return error_events  # pylint: disable=lost-exception
+                return error_events
 
-    # pylint: disable=too-many-locals
     def test_replace_service_level_using_drop_during_load(self, tester, prometheus_stats, num_of_partitions,
                                                           cassandra_stress_column_definition=None):
         low_share = 250
@@ -536,9 +524,8 @@ class SlaTests(Steps):
                 self.clean_auth(entities_list_of_dict=read_roles)
                 if new_sl:
                     new_sl.drop()
-                return error_events  # pylint: disable=lost-exception
+                return error_events
 
-    # pylint: disable=too-many-locals,too-many-arguments
     def test_maximum_allowed_sls_with_max_shares_during_load(self, tester, prometheus_stats, num_of_partitions,
                                                              cassandra_stress_column_definition=None,
                                                              service_levels_amount=7):
@@ -581,4 +568,4 @@ class SlaTests(Steps):
             finally:
                 self.verify_stress_threads(tester=tester, stress_queue=stress_queue)
                 self.clean_auth(entities_list_of_dict=read_roles)
-                return error_events  # pylint: disable=lost-exception
+                return error_events

--- a/sdcm/snitch_configuration.py
+++ b/sdcm/snitch_configuration.py
@@ -15,7 +15,7 @@ import re
 from typing import List
 
 
-class SnitchConfig:  # pylint: disable=too-few-public-methods
+class SnitchConfig:
     """Keeps all cassandra-rackdc.properties settings and function to apply them"""
 
     def __init__(self, node: "sdcm.cluster.BaseNode", datacenters: List[str]):  # noqa: F821

--- a/sdcm/stress/base.py
+++ b/sdcm/stress/base.py
@@ -27,10 +27,10 @@ from sdcm.remote.libssh2_client.exceptions import Failure
 LOGGER = logging.getLogger(__name__)
 
 
-class DockerBasedStressThread:  # pylint: disable=too-many-instance-attributes
+class DockerBasedStressThread:
     DOCKER_IMAGE_PARAM_NAME = ""  # test yaml param that stores image
 
-    def __init__(self, loader_set, stress_cmd, timeout, stress_num=1, node_list=None,  # pylint: disable=too-many-arguments
+    def __init__(self, loader_set, stress_cmd, timeout, stress_num=1, node_list=None,
                  round_robin=False, params=None, stop_test_on_failure=True):
         self.loader_set: BaseLoaderSet = loader_set
         self.stress_cmd = stress_cmd
@@ -78,7 +78,7 @@ class DockerBasedStressThread:  # pylint: disable=too-many-instance-attributes
 
         self.max_workers = len(loaders) * self.stress_num
         LOGGER.debug("Starting %d %s Worker threads", self.max_workers, self.__class__.__name__)
-        self.executor = concurrent.futures.ThreadPoolExecutor(  # pylint: disable=consider-using-with
+        self.executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=self.max_workers)
 
     def run(self):

--- a/sdcm/stress/latte_thread.py
+++ b/sdcm/stress/latte_thread.py
@@ -91,14 +91,14 @@ def get_latte_operation_type(stress_cmd):
         return "mixed"
 
 
-class LatteStressThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes
+class LatteStressThread(DockerBasedStressThread):
 
     DOCKER_IMAGE_PARAM_NAME = "stress_image.latte"
 
     def set_stress_operation(self, stress_cmd):
         return get_latte_operation_type(self.stress_cmd)
 
-    def build_stress_cmd(self, cmd_runner, loader, hosts):  # pylint: disable=too-many-locals
+    def build_stress_cmd(self, cmd_runner, loader, hosts):
         # extract the script so we know which files to mount into the docker image
         script_name_regx = re.compile(r'([/\w-]*\.rn)')
         script_name = script_name_regx.search(self.stress_cmd).group(0)
@@ -144,7 +144,7 @@ class LatteStressThread(DockerBasedStressThread):  # pylint: disable=too-many-in
                 processed_v = v
                 try:
                     processed_v = int(v)
-                except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+                except Exception:  # noqa: BLE001
                     if v not in ('true', 'false'):
                         processed_v = r"\"%s\"" % v
                 custom_schema_params += " -P {k}={v}".format(k=k, v=processed_v)
@@ -285,7 +285,7 @@ class LatteStressThread(DockerBasedStressThread):  # pylint: disable=too-many-in
                     retry=0,
                 )
                 result = self.parse_final_output(result)
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 self.configure_event_on_failure(stress_event=latte_stress_event, exc=exc)
 
         return loader, result, latte_stress_event

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -69,14 +69,14 @@ class CassandraStressEventsPublisher(FileFollowerThread):
                         break  # Stop iterating patterns to avoid creating two events for one line of the log
 
 
-class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes
+class CassandraStressThread(DockerBasedStressThread):
     DOCKER_IMAGE_PARAM_NAME = 'stress_image.cassandra-stress'
 
-    def __init__(self, loader_set, stress_cmd, timeout, stress_num=1, keyspace_num=1, keyspace_name='', compaction_strategy='',  # pylint: disable=too-many-arguments  # noqa: PLR0913
+    def __init__(self, loader_set, stress_cmd, timeout, stress_num=1, keyspace_num=1, keyspace_name='', compaction_strategy='',  # noqa: PLR0913
                  profile=None, node_list=None, round_robin=False, client_encrypt=False, stop_test_on_failure=True,
                  params=None):
         super().__init__(loader_set=loader_set, stress_cmd=stress_cmd, timeout=timeout,
-                         stress_num=stress_num, node_list=node_list,  # pylint: disable=too-many-arguments
+                         stress_num=stress_num, node_list=node_list,
                          round_robin=round_robin, stop_test_on_failure=stop_test_on_failure, params=params)
         self.keyspace_num = keyspace_num
         self.keyspace_name = keyspace_name
@@ -175,7 +175,7 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
             stress_cmd = self.adjust_cmd_node_option(stress_cmd, loader, cmd_runner)
         return stress_cmd
 
-    def create_stress_cmd(self, cmd_runner, keyspace_idx, loader):  # pylint: disable=too-many-branches
+    def create_stress_cmd(self, cmd_runner, keyspace_idx, loader):
         stress_cmd = self.stress_cmd
 
         stress_cmd = self.append_no_warmup_to_cmd(stress_cmd)
@@ -223,7 +223,7 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
             return stress_cmd
         return stress_cmd.replace(current_error_option, 'errors ' + ' '.join(new_error_suboptions))
 
-    def _get_available_suboptions(self, loader, option, _cache={}):  # pylint: disable=dangerous-default-value  # noqa: B006
+    def _get_available_suboptions(self, loader, option, _cache={}):  # noqa: B006
         if cached_value := _cache.get(option):
             return cached_value
         try:
@@ -231,14 +231,14 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
                 cmd=f'cassandra-stress help {option} | grep "^Usage:"',
                 timeout=self.timeout,
                 ignore_status=True).stdout
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             return []
         findings = re.findall(r' *\[([\w-]+?)[=?]*] *', result)
         _cache[option] = findings
         return findings
 
     @staticmethod
-    def _disable_logging_for_cs(node, cmd_runner, _cache={}):  # pylint: disable=dangerous-default-value  # noqa: B006
+    def _disable_logging_for_cs(node, cmd_runner, _cache={}):  # noqa: B006
         if not (node.is_kubernetes() or node.name in _cache):
             cmd_runner.run("cp /etc/scylla/cassandra/logback-tools.xml .", ignore_status=True)
             _cache[node.name] = 'done'
@@ -262,7 +262,7 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
     def _run_stress(self, loader, loader_idx, cpu_idx):
         pass
 
-    def _run_cs_stress(self, loader, loader_idx, cpu_idx, keyspace_idx):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements  # noqa: PLR0914
+    def _run_cs_stress(self, loader, loader_idx, cpu_idx, keyspace_idx):  # noqa: PLR0914
         cleanup_context = contextlib.nullcontext()
         os.makedirs(loader.logdir, exist_ok=True)
 
@@ -355,7 +355,7 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
             reporter = CassandraStressVersionReporter(
                 cmd_runner, prefix, loader.parent_cluster.test_config.argus_client())
             reporter.report()
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             LOGGER.info("Failed to collect cassandra-stress version information", exc_info=True)
         with cleanup_context, \
                 CassandraStressExporter(instance_name=cmd_runner_name,
@@ -378,7 +378,7 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
             try:
                 with SoftTimeoutContext(timeout=self.soft_timeout, operation="cassandra-stress"):
                     result = cmd_runner.run(cmd=node_cmd, timeout=self.hard_timeout, log_file=log_file_name, retry=0)
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 self.configure_event_on_failure(stress_event=cs_stress_event, exc=exc)
 
         return loader, result, cs_stress_event

--- a/sdcm/teardown_validators/base.py
+++ b/sdcm/teardown_validators/base.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
-class TeardownValidator:  # pylint: disable=too-few-public-methods
+class TeardownValidator:
     validator_name = None  # must be defined by child classes
 
     def __init__(self, params: SCTConfiguration, tester: ClusterTester):
@@ -21,5 +21,5 @@ class TeardownValidator:  # pylint: disable=too-few-public-methods
         if not self.is_enabled:
             self.validate = lambda: LOGGER.info("%s validator is disabled", self.validator_name)
 
-    def validate(self):  # pylint: disable=method-hidden
+    def validate(self):
         raise NotImplementedError()

--- a/sdcm/teardown_validators/events.py
+++ b/sdcm/teardown_validators/events.py
@@ -39,7 +39,7 @@ class FailingEventsFilter:
         return match
 
 
-class ErrorEventsValidator(TeardownValidator):  # pylint: disable=too-few-public-methods
+class ErrorEventsValidator(TeardownValidator):
     """
     A teardown validator that checks test events log for presence of specific error events and critical-level events.
     If the test doesn't have any of the defined failing error events or critical events, its status

--- a/sdcm/teardown_validators/sstables.py
+++ b/sdcm/teardown_validators/sstables.py
@@ -16,14 +16,14 @@ from sdcm.utils.s3_remote_uploader import upload_remote_files_directly_to_s3
 LOGGER = logging.getLogger(__name__)
 
 
-class SstablesValidator(TeardownValidator):  # pylint: disable=too-few-public-methods
+class SstablesValidator(TeardownValidator):
     validator_name = 'scrub'
 
     @staticmethod
     def _upload_corrupted_files(node: BaseNode, invalid_sstables_lines):
         # get corrupted sstables from lines:
-        # INFO  2024-04-02 12:40:24,787 [shard 0:stre] sstable - Moving sstable /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/me-3gey_0z3c_2h5vl2ogebmg26ku9t-big-Data.db to "/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/quarantine"  # pylint: disable=line-too-long
-        # scylla[5976]:  [shard 6:strm] compaction - Finished scrubbing in validate mode /var/lib/scylla/data/keyspace1/standard1-01b9f260d55311ef8caf5992914eabbe/me-3gn1_0bxv_16fs02rr7ufpbjejzy-big-Data.db - sstable is invalid"  # pylint: disable=line-too-long
+        # INFO  2024-04-02 12:40:24,787 [shard 0:stre] sstable - Moving sstable /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/me-3gey_0z3c_2h5vl2ogebmg26ku9t-big-Data.db to "/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/quarantine"
+        # scylla[5976]:  [shard 6:strm] compaction - Finished scrubbing in validate mode /var/lib/scylla/data/keyspace1/standard1-01b9f260d55311ef8caf5992914eabbe/me-3gn1_0bxv_16fs02rr7ufpbjejzy-big-Data.db - sstable is invalid"
         corrupted_sstables = []
         sstable_path_regexp = re.compile(r'[./\w\-]+(\.db|quarantine)')
         for line in invalid_sstables_lines:
@@ -82,7 +82,7 @@ class SstablesValidator(TeardownValidator):  # pylint: disable=too-few-public-me
                                                  extra_time_to_expiration=60):
                     parallel_obj.run(run_scrub, ignore_exceptions=False, unpack_objects=True)
                 LOGGER.info("Nodetool scrub validation finished")
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 LOGGER.error("Error during nodetool scrub validation: %s", exc)
                 ValidatorEvent(
                     message=f'Error during nodetool scrub validation: {exc}', severity=Severity.ERROR).publish()

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -26,7 +26,7 @@ from sdcm.utils.metaclasses import Singleton
 LOGGER = logging.getLogger(__name__)
 
 
-class TestConfig(metaclass=Singleton):  # pylint: disable=too-many-public-methods
+class TestConfig(metaclass=Singleton):
     TEST_DURATION = 60
     TEST_WARMUP_TEARDOWN = 60
     SYSLOGNG_LOG_THROTTLE_PER_SECOND = 10000
@@ -240,7 +240,7 @@ class TestConfig(metaclass=Singleton):  # pylint: disable=too-many-public-method
             syslogng_host = "127.0.0.1"
             syslogng_port = cls.SYSLOGNG_SSH_TUNNEL_LOCAL_PORT
         else:
-            syslogng_host, syslogng_port = cls.SYSLOGNG_ADDRESS  # pylint: disable=unpacking-non-sequence
+            syslogng_host, syslogng_port = cls.SYSLOGNG_ADDRESS
         return syslogng_host, syslogng_port
 
     @classmethod

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -10,7 +10,6 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2016 ScyllaDB
-# pylint: disable=too-many-lines
 import shutil
 from collections import defaultdict
 from copy import deepcopy
@@ -38,9 +37,9 @@ import botocore
 import yaml
 from invoke.exceptions import UnexpectedExit, Failure
 
-from cassandra.concurrent import execute_concurrent_with_args  # pylint: disable=no-name-in-module
+from cassandra.concurrent import execute_concurrent_with_args
 from cassandra import ConsistencyLevel
-from cassandra.cluster import Session  # pylint: disable=no-name-in-module
+from cassandra.cluster import Session
 
 from argus.client.sct.client import ArgusSCTClient
 from argus.client.base import ArgusClientError
@@ -206,7 +205,7 @@ def teardown_on_exception(method):
     return wrapper
 
 
-class silence:  # pylint: disable=invalid-name
+class silence:
     """
     A decorator and context manager that catch, log and store any exception that
         happened within wrapped function or within context clause.
@@ -249,7 +248,7 @@ class silence:  # pylint: disable=invalid-name
                 self.log.debug("Silently running '%s'", name)
                 result = funct(*args, **kwargs)
                 self.log.debug("Finished '%s'. No errors were silenced.", name)
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 self.log.debug("Finished '%s'. %s exception was silenced.", name, str(type(exc)))
                 self._store_test_result(args[0], exc, exc.__traceback__, name)
             return result
@@ -282,14 +281,14 @@ class CriticalTestFailure(BaseException):
     pass
 
 
-def critical_failure_handler(signum, frame):  # pylint: disable=unused-argument
+def critical_failure_handler(signum, frame):
     try:
         if TestConfig().tester_obj().teardown_started:
             TEST_LOG.info("A critical event happened during tearDown")
             return
-    except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception:  # noqa: BLE001
         pass
-    raise CriticalTestFailure("Critical Error has failed the test")  # pylint: disable=raise-missing-from
+    raise CriticalTestFailure("Critical Error has failed the test")
 
 
 signal.signal(signal.SIGUSR2, critical_failure_handler)
@@ -307,7 +306,7 @@ class ClusterInformation(NamedTuple):
     schema_versions: List[SchemaVersion]
 
 
-class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disable=too-many-instance-attributes,too-many-public-methods
+class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
     log = None
     actions_log = None
     localhost = None
@@ -320,7 +319,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def k8s_cluster(self):
         return self.k8s_clusters[0] if getattr(self, 'k8s_clusters', None) else None
 
-    def __init__(self, methodName='runTest'):  # pylint: disable=too-many-statements,too-many-locals,too-many-branches
+    def __init__(self, methodName='runTest'):
         self.result = None
         super().__init__(methodName=methodName)
 
@@ -370,7 +369,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 try:
                     client.sct_heartbeat()
                     fail_count = 0  # Reset fail_count on success
-                except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+                except Exception:  # noqa: BLE001
                     self.log.warning("Failed to submit heartbeat to argus, Try #%s", fail_count + 1)
                     fail_count += 1
                 stop_signal.wait(timeout=30.0)
@@ -387,7 +386,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def argus_update_status(self, status: TestStatus):
         try:
             self.test_config.argus_client().set_sct_run_status(new_status=status)
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             self.log.error("Error saving test status to Argus", exc_info=True)
 
     def generate_scylla_server_package(self) -> Package:
@@ -395,7 +394,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             Used for offline tests for tracking scylla versions in Argus.
         """
         scylla_version = self.db_cluster.nodes[0].scylla_version_detailed
-        # pylint: disable=line-too-long
+
         expr = re.compile(
             r'(?P<version>(?P<main>[\w.~]+)-(0.)?(?P<date>[0-9]{8,8}).(?P<commit>\w+).) with build-id (?P<build_id>[\dabcdef]+)')
         version_dict = expr.match(scylla_version).groupdict()
@@ -429,7 +428,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
             self.log.info("Saving collected packages...")
             self.test_config.argus_client().submit_packages(packages_to_submit)
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             self.log.error("Unable to collect package versions for Argus - skipping...", exc_info=True)
 
     def argus_collect_manager_version(self):
@@ -475,7 +474,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 version = match.group(2)
                 self.test_config.argus_client().update_scylla_version(version=version)
                 return
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             self.log.error("Error getting scylla version for argus", exc_info=True)
 
         TestFrameworkEvent(
@@ -531,7 +530,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.argus_update_status(test_status)
 
             self.test_config.argus_client().finalize_sct_run()
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             self.log.error("Error committing test events to Argus", exc_info=True)
 
     def argus_collect_logs(self, log_links: dict[str, list[str] | str]):
@@ -541,12 +540,12 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 argus_link = LogLink(log_name=name, log_link=link)
                 logs_to_save.append(argus_link)
             self.test_config.argus_client().submit_sct_logs(logs_to_save)
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             self.log.error("Error saving logs to Argus", exc_info=True)
 
     def argus_collect_gemini_results(self):
         try:
-            # pylint: disable=no-member
+
             if not hasattr(self, "gemini_results"):
                 return
 
@@ -585,7 +584,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 "oracle_node_scylla_version": self.cs_db_cluster.nodes[0].scylla_version if self.cs_db_cluster else "N/A",
                 "oracle_nodes_count": self.params.get("n_test_oracle_db_nodes"),
             })
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             self.log.warning("Error submitting gemini results to argus", exc_info=True)
 
     def collect_ssl_conf(self):
@@ -793,7 +792,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         # download rpms for update_db_packages
         self.params['update_db_packages'] = download_dir_from_cloud(self.params.get('update_db_packages'))
 
-    def download_encrypt_keys(self):  # pylint: disable=no-self-use
+    def download_encrypt_keys(self):
         download_encrypt_keys()
 
     @property
@@ -818,7 +817,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                              not self.params.get('enterprise_disable_kms'))
 
         if should_enable_kms:
-            self.params['scylla_encryption_options'] = "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'KmsKeyProviderFactory', 'kms_host': 'auto'}"  # pylint: disable=line-too-long
+            self.params['scylla_encryption_options'] = "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'KmsKeyProviderFactory', 'kms_host': 'auto'}"
         if not (scylla_encryption_options := self.params.get("scylla_encryption_options") or ''):
             return None
         kms_host = (yaml.safe_load(scylla_encryption_options) or {}).get("kms_host") or ''
@@ -867,7 +866,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     @teardown_on_exception
     @log_run_info
-    def setUp(self):  # pylint: disable=too-many-branches,too-many-statements  # noqa: PLR0912, PLR0915
+    def setUp(self):  # noqa: PLR0912, PLR0915
         self._results = []
         self.status = "RUNNING"
         self.start_time = time.time()
@@ -1233,7 +1232,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         return nemesis_threads
 
     def get_cluster_gce(self, loader_info, db_info, monitor_info):  # noqa: PLR0912, PLR0914
-        # pylint: disable=too-many-locals,too-many-statements,too-many-branches
+
         if loader_info['n_nodes'] is None:
             n_loader_nodes = self.params.get('n_loaders')
             if isinstance(n_loader_nodes, int):
@@ -1356,7 +1355,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.monitors = NoMonitorSet()
 
     def get_cluster_azure(self, loader_info, db_info, monitor_info):
-        # pylint: disable=too-many-branches,too-many-statements,too-many-locals
+
         regions = self.params.get('azure_region_name')
         test_id = str(TestConfig().test_id())
         provisioners: List[AzureProvisioner] = []
@@ -1424,7 +1423,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.monitors = NoMonitorSet()
 
     def get_cluster_aws(self, loader_info, db_info, monitor_info):
-        # pylint: disable=too-many-locals,too-many-statements,too-many-branches
+
         regions = self.params.get('region_name').split()
 
         if loader_info['n_nodes'] is None:
@@ -1603,7 +1602,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                                         **common_params)
 
     def get_cluster_baremetal(self):
-        # pylint: disable=too-many-locals,too-many-statements,too-many-branches
+
         baremetal_info: cluster_baremetal.BareMetalCredentials = KeyStore(
         ).get_baremetal_config(self.params.get("s3_baremetal_config"))
         user_credentials = self.params.get('user_credentials_path')
@@ -1852,7 +1851,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.monitors = NoMonitorSet()
             self.monitors_multitenant = [self.monitors]
 
-    def get_cluster_k8s_eks(self, n_k8s_clusters: int):  # pylint: disable=too-many-branches
+    def get_cluster_k8s_eks(self, n_k8s_clusters: int):
         region_names = self.params.region_names
         availability_zones = self.params.get('availability_zone').split(',')
         for _ in range(n_k8s_clusters):
@@ -1952,7 +1951,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     def init_resources(self, loader_info=None, db_info=None,
                        monitor_info=None):
-        # pylint: disable=too-many-locals,too-many-statements,too-many-branches
+
         if loader_info is None:
             loader_info = {'n_nodes': None, 'type': None, 'disk_size': None, 'disk_type': None, 'n_local_ssd': None,
                            'device_mappings': None}
@@ -2009,8 +2008,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                                 duration=duration)
         self.verify_stress_thread(cs_thread_pool)
 
-    # pylint: disable=too-many-arguments,too-many-return-statements
-    def run_stress_thread(self, stress_cmd, duration=None, stress_num=1, keyspace_num=1, profile=None, prefix='',  # pylint: disable=too-many-arguments  # noqa: PLR0911, PLR0913
+    def run_stress_thread(self, stress_cmd, duration=None, stress_num=1, keyspace_num=1, profile=None, prefix='',  # noqa: PLR0911, PLR0913
                           round_robin=False, stats_aggregate_cmds=True, keyspace_name=None, compaction_strategy='',
                           use_single_loader=False,
                           stop_test_on_failure=True):
@@ -2051,11 +2049,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         else:
             raise ValueError(f'Unsupported stress command: "{stress_cmd[:50]}..."')
 
-    # pylint: disable=too-many-arguments
     def run_stress_cassandra_thread(  # noqa: PLR0913
             self, stress_cmd, duration=None, stress_num=1, keyspace_num=1, profile=None, prefix='', round_robin=False,
             stats_aggregate_cmds=True, keyspace_name=None, compaction_strategy='', stop_test_on_failure=True, params=None, **_):
-        # pylint: disable=too-many-locals
+
         # stress_cmd = self._cs_add_node_flag(stress_cmd)
         if duration:
             timeout = self.get_duration(duration)
@@ -2087,11 +2084,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.alter_test_tables_encryption(stress_command=stress_cmd)
         return cs_thread
 
-    # pylint: disable=too-many-arguments
     def run_cql_stress_cassandra_thread(  # noqa: PLR0913
             self, stress_cmd, duration=None, stress_num=1, keyspace_num=1, profile=None, prefix='', round_robin=False,
             stats_aggregate_cmds=True, keyspace_name=None, compaction_strategy='', stop_test_on_failure=True, params=None, **_):
-        # pylint: disable=too-many-locals
+
         if duration:
             timeout = self.get_duration(duration)
             if ' duration' in stress_cmd:
@@ -2122,7 +2118,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.alter_test_tables_encryption(stress_command=stress_cmd)
         return cs_thread
 
-    # pylint: disable=too-many-arguments,unused-argument
     def run_stress_thread_bench(self, stress_cmd, duration=None, round_robin=False, stats_aggregate_cmds=True,
                                 stop_test_on_failure=True, **_):
 
@@ -2150,9 +2145,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         return bench_thread
 
     def run_stress_thread_harry(self, stress_cmd, duration=None,
-                                # pylint: disable=too-many-arguments,unused-argument
+
                                 round_robin=False, stats_aggregate_cmds=True,
-                                stop_test_on_failure=True, **_):  # pylint: disable=too-many-arguments,unused-argument
+                                stop_test_on_failure=True, **_):
 
         timeout = self.get_duration(duration)
 
@@ -2174,7 +2169,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         harry_thread.run()
         return harry_thread
 
-    # pylint: disable=too-many-arguments
     def run_ycsb_thread(self, stress_cmd, duration=None, stress_num=1, prefix='',
                         round_robin=False, stats_aggregate_cmds=True, **_):
 
@@ -2215,7 +2209,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                  stop_test_on_failure=stop_test_on_failure,
                                  params=self.params).run()
 
-    # pylint: disable=too-many-arguments
     def run_hydra_kcl_thread(self, stress_cmd, duration=None, stress_num=1, prefix='',
                              round_robin=False, stats_aggregate_cmds=True, **_):
 
@@ -2231,7 +2224,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                node_list=self.db_cluster.nodes,
                                round_robin=round_robin, params=self.params).run()
 
-    # pylint: disable=too-many-arguments
     def run_nosqlbench_thread(self, stress_cmd, duration=None, stress_num=1, prefix='', round_robin=False,
                               stats_aggregate_cmds=True, stop_test_on_failure=True, **_):
 
@@ -2251,7 +2243,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             stop_test_on_failure=stop_test_on_failure,
             params=self.params).run()
 
-    # pylint: disable=too-many-arguments
     def run_table_compare_thread(self, stress_cmd, duration=None, stress_num=1, round_robin=False, **_):
 
         timeout = self.get_duration(duration)
@@ -2263,7 +2254,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                         node_list=self.db_cluster.nodes,
                                         round_robin=round_robin, params=self.params).run()
 
-    # pylint: disable=too-many-arguments
     def run_ndbench_thread(self, stress_cmd, duration=None, stress_num=1, prefix='',
                            round_robin=False, stats_aggregate_cmds=True, **_):
 
@@ -2279,7 +2269,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                    node_list=self.db_cluster.nodes,
                                    round_robin=round_robin, params=self.params).run()
 
-    # pylint: disable=too-many-arguments
     def run_cdclog_reader_thread(self, stress_cmd, duration=None, stress_num=1, prefix='',
                                  round_robin=False, stats_aggregate_cmds=True, enable_batching=True,
                                  keyspace_name=None, base_table_name=None):
@@ -2316,7 +2305,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                   timeout=timeout,
                                   params=self.params).run()
 
-    # pylint: disable=too-many-arguments
     def run_python_thread(self, stress_cmd, duration=None, **_):
         timeout = self.get_duration(duration)
 
@@ -2458,7 +2446,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         return keyspace_name.lower() in keyspace_list
 
     def wait_validate_keyspace_existence(self, session, keyspace_name, timeout=180,
-                                         step=5):  # pylint: disable=invalid-name
+                                         step=5):
         text = 'waiting for the keyspace "{}" to be created in the cluster'.format(keyspace_name)
         does_keyspace_exist = wait.wait_for(func=self.is_keyspace_in_cluster, step=step, text=text, timeout=timeout,
                                             session=session, keyspace_name=keyspace_name, throw_exc=False)
@@ -2494,13 +2482,12 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             does_keyspace_exist = self.wait_validate_keyspace_existence(session, keyspace_name)
         return does_keyspace_exist
 
-    def create_table(self, name, key_type="varchar",  # pylint: disable=too-many-arguments,too-many-branches  # noqa: PLR0913
+    def create_table(self, name, key_type="varchar",  # noqa: PLR0913
                      speculative_retry=None, read_repair=None, compression=None,
                      gc_grace=None, columns=None, compaction=None,
                      compact_storage=False, scylla_encryption_options=None, keyspace_name=None,
                      sstable_size=None):
 
-        # pylint: disable=too-many-locals
         additional_columns = ""
         if columns is not None:
             for key, value in columns.items():
@@ -2553,15 +2540,14 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         try:
             timeout = f" USING TIMEOUT {truncate_timeout_sec}s" if truncate_timeout_sec else ""
             session.execute('TRUNCATE TABLE {0}.{1}{2}'.format(ks_name, table_name, timeout))
-        except Exception as ex:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as ex:  # noqa: BLE001
             self.log.debug('Failed to truncate base table {0}.{1}. Error: {2}'.format(ks_name, table_name, str(ex)))
 
     def create_materialized_view(self, ks_name, base_table_name, mv_name, mv_partition_key, mv_clustering_key, session,  # noqa: PLR0913
-                                 # pylint: disable=too-many-arguments
+
                                  mv_columns='*', speculative_retry=None, read_repair=None, compression=None,
                                  gc_grace=None, compact_storage=False):
 
-        # pylint: disable=too-many-locals
         mv_columns_str = mv_columns
         if isinstance(mv_columns, list):
             mv_columns_str = ', '.join(c for c in mv_columns)
@@ -2570,7 +2556,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         mv_partition_key = mv_partition_key if isinstance(mv_partition_key, list) else list(mv_partition_key)
         mv_clustering_key = mv_clustering_key if isinstance(mv_clustering_key, list) else list(mv_clustering_key)
 
-        for kc in mv_partition_key + mv_clustering_key:  # pylint: disable=invalid-name
+        for kc in mv_partition_key + mv_clustering_key:
             where_clause.append('{} is not null'.format(kc))
 
         pk_clause = ', '.join(pk for pk in mv_partition_key)
@@ -2649,7 +2635,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def rows_to_list(rows):
         return [list(row) for row in rows]
 
-    def copy_table(self, node, src_keyspace, src_table, dest_keyspace,  # pylint: disable=too-many-arguments
+    def copy_table(self, node, src_keyspace, src_table, dest_keyspace,
                    dest_table, columns_list=None, copy_data=False):
         """
         Create table with same structure as <src_keyspace>.<src_table>.
@@ -2667,14 +2653,14 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             try:
                 result = self.copy_data_between_tables(node, src_keyspace, src_table,
                                                        dest_keyspace, dest_table, columns_list)
-            except Exception as error:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as error:  # noqa: BLE001
                 self.log.error('Copying data from %s to %s failed with error: %s',
                                src_table, dest_table, error)
                 return False
 
         return result
 
-    def copy_view(self, node, src_keyspace, src_view, dest_keyspace,  # pylint: disable=too-many-arguments
+    def copy_view(self, node, src_keyspace, src_view, dest_keyspace,
                   dest_table, columns_list=None, copy_data=False):
         """
         Create table with same structure as <src_keyspace>.<src_view>.
@@ -2693,7 +2679,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             try:
                 result = self.copy_data_between_tables(node, src_keyspace, src_view,
                                                        dest_keyspace, dest_table, columns_list)
-            except Exception as error:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as error:  # noqa: BLE001
                 self.log.error('Copying data from %s to %s failed with error %s',
                                src_view, dest_table, error)
                 return False
@@ -2701,7 +2687,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         return result
 
     def create_table_as(self, node, src_keyspace, src_table,
-                        # pylint: disable=too-many-arguments,too-many-locals,inconsistent-return-statements
+
                         dest_keyspace, dest_table, create_statement,
                         columns_list=None):
         """ Create table with same structure as another table or view
@@ -2754,7 +2740,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             return False
 
     def copy_data_between_tables(self, node, src_keyspace, src_table, dest_keyspace,
-                                 # pylint: disable=too-many-arguments,too-many-locals
+
                                  dest_table, columns_list=None):
         """ Copy all data from one table/view to another table
             Structure of the tables has to be same
@@ -2809,7 +2795,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                      'Actually inserted rows: %s.',
                                      len(source_table_rows), succeeded_rows)
                     return False
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 self.log.warning('Problem during copying data: %s', exc)
                 return False
 
@@ -2834,17 +2820,17 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         table_id = self.rows_to_list(session.execute(query))
         return table_id[0]
 
-    def get_truncated_time_from_system_local(self, session):  # pylint: disable=invalid-name
+    def get_truncated_time_from_system_local(self, session):
         query = "SELECT truncated_at FROM system.local"
         truncated_time = self.rows_to_list(session.execute(query))
         return truncated_time
 
-    def get_truncated_time_from_system_truncated(self, session, table_id):  # pylint: disable=invalid-name
+    def get_truncated_time_from_system_truncated(self, session, table_id):
         query = "SELECT truncated_at FROM system.truncated WHERE table_uuid={}".format(table_id)
         truncated_time = self.rows_to_list(session.execute(query))
         return truncated_time[0]
 
-    def get_describecluster_info(self) -> Optional[ClusterInformation]:  # pylint: disable=too-many-locals
+    def get_describecluster_info(self) -> Optional[ClusterInformation]:
         """
         Runs the 'nodetool describecluster' command on a node.
 
@@ -2867,12 +2853,12 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         if describecluster_output.ok:
             desc_stdout = describecluster_output.stdout
-            name_pattern = re.compile("((?<=Name: )[\w _-]*)")  # pylint: disable=anomalous-backslash-in-string
-            snitch_pattern = re.compile("((?<=Snitch: )[\w.]*)")  # pylint: disable=anomalous-backslash-in-string
+            name_pattern = re.compile("((?<=Name: )[\w _-]*)")
+            snitch_pattern = re.compile("((?<=Snitch: )[\w.]*)")
             partitioner_pattern = re.compile(
-                "((?<=Partitioner: )[\w.]*)")  # pylint: disable=anomalous-backslash-in-string
+                "((?<=Partitioner: )[\w.]*)")
             schema_versions_pattern = re.compile(
-                "([a-z0-9-]{36}: \[[\d., ]*\])")  # pylint: disable=anomalous-backslash-in-string
+                "([a-z0-9-]{36}: \[[\d., ]*\])")
 
             name = name_pattern.search(desc_stdout).group()
             snitch = snitch_pattern.search(desc_stdout).group()
@@ -2901,11 +2887,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 current_nemesis.report()
 
     @silence()
-    def stop_nemesis(self, cluster):  # pylint: disable=no-self-use
+    def stop_nemesis(self, cluster):
         cluster.stop_nemesis(timeout=1800)
 
     @silence()
-    def stop_resources_stop_tasks_threads(self, cluster):  # pylint: disable=no-self-use
+    def stop_resources_stop_tasks_threads(self, cluster):
         # TODO: this should be run in parallel
         for node in cluster.nodes:
             node.stop_task_threads()
@@ -2914,11 +2900,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 node.wait_till_tasks_threads_are_stopped()
 
     @silence()
-    def get_backtraces(self, cluster):  # pylint: disable=no-self-use
+    def get_backtraces(self, cluster):
         cluster.get_backtraces()
 
     @silence()
-    def stop_resources(self):  # pylint: disable=no-self-use
+    def stop_resources(self):
         self.log.debug('Stopping all resources')
         SCTCapacityReservation.cancel(self.params)
         with silence(parent=self, name="Kill Stress Threads"):
@@ -2940,15 +2926,15 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.stop_resources_stop_tasks_threads(self.monitors)
 
     @silence()
-    def destroy_cluster(self, cluster):  # pylint: disable=no-self-use
+    def destroy_cluster(self, cluster):
         cluster.destroy()
 
     @silence()
-    def set_keep_alive_on_failure(self, cluster):  # pylint: disable=no-self-use
+    def set_keep_alive_on_failure(self, cluster):
         cluster.set_keep_alive_on_failure()
 
     @silence()
-    def destroy_credentials(self):  # pylint: disable=no-self-use
+    def destroy_credentials(self):
         if self.credentials is not None:
             for credential in self.credentials:
                 credential.destroy()
@@ -2964,7 +2950,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     @silence()
     def clean_resources(self):
-        # pylint: disable=too-many-branches
+
         if not self.params.get('execute_post_behavior'):
             self.log.info('Resources will continue to run')
             return
@@ -3098,7 +3084,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.argus_finalize_test_run()
         try:
             ElasticRunReporter().report_run(run_id=self.test_config.test_id(), status=self.get_test_status())
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             pass
         self.argus_heartbeat_stop_signal.set()
 
@@ -3108,7 +3094,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.remove_python_exit_hooks()
 
     @silence()
-    def remove_python_exit_hooks(self):  # pylint: disable=no-self-use
+    def remove_python_exit_hooks(self):
         clear_out_all_exit_hooks()
 
     @silence()
@@ -3164,7 +3150,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.localhost.destroy()
 
     @silence()
-    def stop_event_analyzer(self):  # pylint: disable=no-self-use
+    def stop_event_analyzer(self):
         stop_events_analyzer(_registry=self.events_processes_registry)
 
     @silence()
@@ -3187,7 +3173,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 self.update({'test_details': {'log_files': {'job_log': s3_link}}})
 
     @silence()
-    def stop_event_device(self):  # pylint: disable=no-self-use
+    def stop_event_device(self):
         stop_events_device(_registry=self.events_processes_registry)
 
     @silence()
@@ -3202,7 +3188,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     def populate_data_parallel(self, size_in_gb: int, replication_factor: int = 3, blocking=True, read=False):
 
-        # pylint: disable=too-many-locals
         base_cmd = "cassandra-stress write cl=QUORUM "
         if read:
             base_cmd = "cassandra-stress read cl=ONE "
@@ -3312,17 +3297,17 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 "drops" if "dropped" in query else "errors")
             assert any((float(v[1]) for v in results[0]["values"])) is False, err_msg
 
-    def get_data_set_size(self, cs_cmd):  # pylint: disable=inconsistent-return-statements
+    def get_data_set_size(self, cs_cmd):
         """:returns value of n in stress comand, that is approximation and currently doesn't take in consideration
             column size definitions if they present in the command
         """
         try:
             return int(re.search(r"n=(\d+) ", cs_cmd).group(1))
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             self.fail("Unable to get data set size from cassandra-stress command: %s" % cs_cmd)
             return None
 
-    def get_c_s_column_definition(self, cs_cmd):  # pylint: disable=inconsistent-return-statements
+    def get_c_s_column_definition(self, cs_cmd):
         """:returns value of -col in stress comand, that is approximation and currently doesn't take in consideration
             column definitions if they present in the command
         """
@@ -3331,7 +3316,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             if search_res := re.search(r".* -col ('.*') .*", cs_cmd):
                 return search_res.group(1)
             return None
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             self.fail("Unable to get column definition from cassandra-stress command: %s" % cs_cmd)
             return None
 
@@ -3435,7 +3420,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 exception=exc
             ).publish_or_dump()
 
-    def check_regression_multi_baseline(self, subtests_info=None,  # pylint: disable=inconsistent-return-statements
+    def check_regression_multi_baseline(self, subtests_info=None,
                                         metrics=None, email_subject=None):
         results_analyzer = PerformanceResultsAnalyzer(es_index=self._test_index,
                                                       email_recipients=self.params.get('email_recipients'),
@@ -3490,7 +3475,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         # if any result values is not zero - there are running compactions.
         return any((float(v[1]) for v in results[0]["values"]))
 
-    def wait_compactions_are_running(self, n=20, sleep_time=60):  # pylint: disable=invalid-name
+    def wait_compactions_are_running(self, n=20, sleep_time=60):
         # Wait until there are running compactions
         @retrying(n=n, sleep_time=sleep_time, allowed_exceptions=(AssertionError,))
         def _is_compaction_running():
@@ -3498,14 +3483,14 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         _is_compaction_running()
 
     @measure_time
-    def wait_no_compactions_running(self, n=80, sleep_time=60):  # pylint: disable=invalid-name
+    def wait_no_compactions_running(self, n=80, sleep_time=60):
         # Wait until there are no running compactions
         @retrying(n=n, sleep_time=sleep_time, allowed_exceptions=(AssertionError,))
         def _is_no_compaction_running():
             assert not self.is_compaction_running, "Waiting until all compactions settle down"
         _is_no_compaction_running()
 
-    def metric_has_data(self, metric_query, n=80, sleep_time=60, ):  # pylint: disable=invalid-name
+    def metric_has_data(self, metric_query, n=80, sleep_time=60, ):
         """
         wait for any prometheus metric to have data in it
 
@@ -3615,9 +3600,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         """
         if hasattr(self, '_outcome'):  # Python 3.4+
             result = self.defaultTestResult()  # these 2 methods have no side effects
-            self._feedErrorsToResult(result, self._outcome.errors)  # pylint: disable=no-member
+            self._feedErrorsToResult(result, self._outcome.errors)
         else:  # Python 3.2 - 3.3 or 3.0 - 3.1 and 2.7
-            result = getattr(self, '_outcomeForDoCleanups', self._resultForDoCleanups)  # pylint: disable=no-member
+            result = getattr(self, '_outcomeForDoCleanups', self._resultForDoCleanups)
         for error in result.errors + result.failures:
             if len(error) > 1 and error[1]:
                 TestFrameworkEvent(
@@ -3661,7 +3646,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         node.wait_db_up()
 
-    def get_used_capacity(self, node) -> float:  # pylint: disable=too-many-locals
+    def get_used_capacity(self, node) -> float:
         # node_filesystem_size_bytes{
         #     mountpoint="/var/lib/scylla", instance=~".*?10.0.79.46.*?"}-node_filesystem_avail_bytes{
         #         mountpoint="/var/lib/scylla", instance=~".*?10.0.79.46.*?"}
@@ -3740,7 +3725,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         try:
             email_data = self.get_email_data()
             self._argus_add_relocatable_pkg(email_data)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             self.log.error("Error while saving email data. Error: %s\nTraceback: %s", exc, traceback.format_exc())
 
         grafana_screenshots = []
@@ -3748,7 +3733,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             grafana_screenshots = self.monitors.get_grafana_screenshots_from_all_monitors(
                 self.start_time) if self.monitors else {}
             self.argus_collect_screenshots(grafana_screenshots)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             self.log.exception("Error while collecting screenshots:", exc_info=exc)
 
         json_file_path = os.path.join(self.logdir, "email_data.json")
@@ -3774,7 +3759,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.test_config.argus_client().submit_packages(
                 [Package(name="relocatable_pkg", date="", version=relocatable_pkg, revision_id="", build_id="")])
 
-    def get_email_data(self):  # pylint: disable=no-self-use
+    def get_email_data(self):
         """prepare data to generate and send via email
 
         Have to return the dict which is used to build the
@@ -3879,7 +3864,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             output.append(result['message'])
         return output
 
-    def _get_live_node(self) -> Optional[BaseNode]:  # pylint: disable=inconsistent-return-statements
+    def _get_live_node(self) -> Optional[BaseNode]:
         if not self.db_cluster or not self.db_cluster.nodes:
             self.log.error("Cluster object was not initialized")
             return None

--- a/sdcm/tombstone_gc_verification_thread.py
+++ b/sdcm/tombstone_gc_verification_thread.py
@@ -14,10 +14,7 @@ LOCAL_CMD_RUNNER = LocalCmdRunner()
 ERROR_SUBSTRINGS = ("timed out", "timeout")
 
 
-# pylint: disable=too-many-instance-attributes
 class TombstoneGcVerificationThread:
-
-    # pylint: disable=too-many-arguments
 
     def __init__(self, db_cluster: [BaseScyllaCluster, BaseCluster], duration: int, interval: int,
                  termination_event: threading.Event, **kwargs):
@@ -81,7 +78,7 @@ class TombstoneGcVerificationThread:
             try:
                 self.tombstone_gc_verification()
                 tombstone_event.message = "Tombstone GC verification ended successfully"
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 msg = str(exc)
                 msg = f"{msg} while running Nemesis: {db_node.running_nemesis}" if db_node.running_nemesis else msg
                 tombstone_event.message = msg

--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -29,7 +29,7 @@ def _get_decommission_timeout(node_info_service: NodeLoadInfoService,
         # rough estimation from previous runs almost 9h for 1TB
         timeout = max(int(node_info_service.node_data_size_mb * 0.03), 7200)  # 2 hours minimum
         return (timeout, None), node_info
-    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         LOGGER.warning("Failed to calculate decommission timeout: \n%s \nDefaulting to 6 hours", exc)
         return (6*60*60, None), {}
 
@@ -54,7 +54,7 @@ def _get_soft_timeout(node_info_service: NodeLoadInfoService, timeout: int | flo
     # no timeout calculation - just return the timeout passed as argument along with node load info
     try:
         return timeout, node_info_service.as_dict()
-    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         LOGGER.warning("Failed to get node info for timeout: \n%s", exc)
         return timeout, {}
 
@@ -102,7 +102,7 @@ class Operations(Enum):
     TABLET_MIGRATION = ("tablet_migration", _get_soft_timeout, ("timeout",))
 
 
-class TestInfoServices:  # pylint: disable=too-few-public-methods
+class TestInfoServices:
     @staticmethod
     def get(node: "BaseNode") -> dict:  # noqa: F821
         return dict(
@@ -188,7 +188,7 @@ def adaptive_timeout(operation: Operations, node: "BaseNode",  # noqa: PLR0914, 
     try:
         with monitor_ctx:
             yield hard_timeout or soft_timeout
-    except Exception as exc:  # pylint: disable=broad-except
+    except Exception as exc:
         exc_name = exc.__class__.__name__
         if "timeout" in exc_name.lower() or "timed out" in str(exc):
             timeout_occurred = True
@@ -205,5 +205,5 @@ def adaptive_timeout(operation: Operations, node: "BaseNode",  # noqa: PLR0914, 
             if load_metrics:
                 stats_storage.store(metrics=load_metrics, operation=operation.name, duration=duration,
                                     timeout=soft_timeout, timeout_occurred=timeout_occurred)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.warning("Failed to store adaptive timeout stats: \n%s", exc)

--- a/sdcm/utils/adaptive_timeouts/load_info_store.py
+++ b/sdcm/utils/adaptive_timeouts/load_info_store.py
@@ -81,7 +81,7 @@ class NodeLoadInfoService:
             load_5 = float(metrics['node_load5'])
             load_15 = float(metrics['node_load15'])
             return load_1, load_5, load_15
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.debug("Couldn't get node load from prometheus metrics. Error: %s", exc)
             # fallback to uptime
             load_1, load_5, load_15 = self.remoter.run('uptime').stdout.split("load average: ")[1].split(",")
@@ -188,7 +188,6 @@ class AdaptiveTimeoutStore(metaclass=Singleton):
 
     Used for future reference/node operations time tracking and calculations optimization."""
 
-    # pylint: disable=too-many-arguments
     def store(self, metrics: dict[str, Any], operation: str, duration: int | float, timeout: int,
               timeout_occurred: bool) -> None:
         pass
@@ -207,7 +206,6 @@ class ESAdaptiveTimeoutStore(AdaptiveTimeoutStore):
     def _es(self):
         return ES()
 
-    # pylint: disable=too-many-arguments
     def store(self, metrics: dict[str, Any], operation: str, duration: float, timeout: float,
               timeout_occurred: bool):
         body = metrics
@@ -222,7 +220,7 @@ class ESAdaptiveTimeoutStore(AdaptiveTimeoutStore):
         if not self._es:
             LOGGER.debug("ESAdaptiveTimeoutStore is not initialized, skipping store")
             return
-        # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
+
         self._es.create(index=self._index, id=load_id, document=body)
 
     def get(self, operation: str | None, timeout_occurred: bool | None = None):
@@ -251,7 +249,7 @@ class ESAdaptiveTimeoutStore(AdaptiveTimeoutStore):
         return [hit["_source"] for hit in res["hits"]["hits"]]
 
 
-class NodeLoadInfoServices(metaclass=Singleton):  # pylint: disable=too-few-public-methods
+class NodeLoadInfoServices(metaclass=Singleton):
     """Cache for NodeLoadInfoService instances."""
 
     def __init__(self):

--- a/sdcm/utils/alternator/api.py
+++ b/sdcm/utils/alternator/api.py
@@ -94,7 +94,7 @@ class Alternator:
         ]
         dynamodb_api.client.tag_resource(ResourceArn=arn, Tags=tags)
 
-    def create_table(self, node,  # pylint: disable=too-many-arguments
+    def create_table(self, node,
                      schema=enums.YCSBSchemaTypes.HASH_AND_RANGE, isolation=None, table_name=consts.TABLE_NAME,
                      wait_until_table_exists=True, tablets_enabled: bool = False, **kwargs) -> Table:
         if isinstance(schema, enums.YCSBSchemaTypes):
@@ -158,7 +158,7 @@ class Alternator:
             return list(chain(*scan_result)) if len(scan_result) > 1 else scan_result
         return _scan_table()
 
-    def batch_write_actions(self, node,  # pylint:disable=too-many-arguments,dangerous-default-value
+    def batch_write_actions(self, node,
                             table_name=consts.TABLE_NAME, new_items=None, delete_items=None,
                             schema=schemas.HASH_SCHEMA):
         dynamodb_api = self.get_dynamodb_api(node=node)

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -123,7 +123,7 @@ class EksClusterCleanupMixin:
                 if attachment_id := attachment.get('AttachmentId'):
                     try:
                         self.ec2_client.detach_network_interface(AttachmentId=attachment_id, Force=True)
-                    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+                    except Exception as exc:  # noqa: BLE001
                         LOGGER.debug("Failed to detach network interface (%s) attachment %s:\n%s",
                                      network_interface_id, attachment_id, exc)
 
@@ -133,7 +133,7 @@ class EksClusterCleanupMixin:
             network_interface_id = interface_description['NetworkInterfaceId']
             try:
                 self.ec2_client.delete_network_interface(NetworkInterfaceId=network_interface_id)
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 LOGGER.debug("Failed to delete network interface %s :\n%s", network_interface_id, exc)
 
     def destroy_attached_security_groups(self):
@@ -141,7 +141,7 @@ class EksClusterCleanupMixin:
         # even when cluster is gone
         try:
             sg_list = self.attached_security_group_ids
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.debug("Failed to get list of security groups:\n%s", exc)
             return
 
@@ -151,12 +151,12 @@ class EksClusterCleanupMixin:
             # In this case you need to forcefully detach interfaces and delete them to make nodegroup deletion possible.
             try:
                 self.delete_network_interfaces_of_sg(security_group_id)
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 LOGGER.debug("destroy_attached_security_groups: %s", exc)
 
             try:
                 self.ec2_client.delete_security_group(GroupId=security_group_id)
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 LOGGER.debug("Failed to delete security groups %s, due to the following error:\n%s",
                              security_group_id, exc)
 
@@ -166,7 +166,7 @@ class EksClusterCleanupMixin:
             for node_group_name in self._get_attached_nodegroup_names(status=status):
                 try:
                     self.eks_client.delete_nodegroup(clusterName=self.short_cluster_name, nodegroupName=node_group_name)
-                except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+                except Exception as exc:  # noqa: BLE001
                     LOGGER.debug("Failed to delete nodegroup %s/%s, due to the following error:\n%s",
                                  self.short_cluster_name, node_group_name, exc)
             time.sleep(10)
@@ -181,7 +181,7 @@ class EksClusterCleanupMixin:
     def destroy_cluster(self):
         try:
             self.eks_client.delete_cluster(name=self.short_cluster_name)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.debug("Failed to delete cluster %s, due to the following error:\n%s",
                          self.short_cluster_name, exc)
 
@@ -205,7 +205,7 @@ class EksClusterCleanupMixin:
                 LOGGER.warning(
                     "Couldn't find any OIDC provider associated with the '%s' EKS cluster",
                     self.short_cluster_name)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.warning(
                 "Failed to delete OIDC provider for the '%s' cluster due to "
                 "the following error:\n%s",

--- a/sdcm/utils/azure_region.py
+++ b/sdcm/utils/azure_region.py
@@ -27,7 +27,7 @@ from azure.mgmt.compute.models import TargetRegion
 from sdcm.utils.azure_utils import AzureService
 
 if TYPE_CHECKING:
-    # pylint: disable=ungrouped-imports
+
     from typing import Optional
 
     from azure.mgmt.compute.models import Gallery, GalleryImageVersion, VirtualMachine
@@ -80,7 +80,7 @@ def region_name_to_location(region_name: str) -> str:
 # [3] https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-manage-subnet
 # [4] https://docs.microsoft.com/en-us/azure/virtual-network/network-security-groups-overview#network-security-groups
 # [5] https://docs.microsoft.com/en-us/azure/virtual-machines/shared-image-galleries
-class AzureRegion:  # pylint: disable=too-many-public-methods
+class AzureRegion:
     SCT_GALLERY_REGION = "eastus"
     SCT_RESOURCE_GROUP_NAME_PREFIX = "SCT_IMAGES"
 
@@ -94,7 +94,7 @@ class AzureRegion:  # pylint: disable=too-many-public-methods
         self.region_name = region_name
 
     @cached_property
-    def azure_service(self) -> AzureService:  # pylint: disable=no-self-use; pylint doesn't now about cached_property
+    def azure_service(self) -> AzureService:
         return AzureService()
 
     @cached_property
@@ -126,7 +126,7 @@ class AzureRegion:  # pylint: disable=too-many-public-methods
         return f"{self.sct_resource_group_name}-{self.VIRTUAL_NETWORK_NAME_SUFFIX}"
 
     @cached_property
-    def sct_subnet_name(self) -> str:  # pylint: disable=no-self-use; pylint doesn't now about cached_property
+    def sct_subnet_name(self) -> str:
         return "default"
 
     def common_parameters(self, location: Optional[str] = None, tags: Optional[dict] = None) -> dict:
@@ -289,7 +289,7 @@ class AzureRegion:  # pylint: disable=too-many-public-methods
             parameters=parameters,
         ).result()
 
-    def create_virtual_machine(self,  # pylint: disable=too-many-arguments
+    def create_virtual_machine(self,
                                vm_name: str,
                                vm_size: str,
                                image: dict[str, str],

--- a/sdcm/utils/azure_utils.py
+++ b/sdcm/utils/azure_utils.py
@@ -34,7 +34,7 @@ from sdcm.utils.decorators import retrying
 from sdcm.utils.metaclasses import Singleton
 
 if TYPE_CHECKING:
-    # pylint: disable=ungrouped-imports
+
     from typing import Optional, Callable, Iterator
 
     from azure.core.credentials import TokenCredential
@@ -68,7 +68,7 @@ class VirtualMachineIPs(NamedTuple):
 
 class AzureService(metaclass=Singleton):
     @cached_property
-    def azure_credentials(self) -> dict[str, str]:  # pylint: disable=no-self-use; pylint doesn't now about cached_property
+    def azure_credentials(self) -> dict[str, str]:
         return KeyStore().get_azure_credentials()
 
     @cached_property

--- a/sdcm/utils/benchmarks.py
+++ b/sdcm/utils/benchmarks.py
@@ -47,7 +47,6 @@ class Averages(ComparableResult):
 
 @dataclass
 class ScyllaNodeBenchmarkSysbenchResult:
-    # pylint:disable=too-many-instance-attributes
     cmd_output: str = field(repr=False)
     sysbench_events_per_second: float = field(init=False)
     sysbench_latency_min: float = field(init=False)
@@ -164,7 +163,7 @@ class ScyllaClusterBenchmarkManager(metaclass=Singleton):
 
         @retrying(n=3, sleep_time=1, message="Get hw performance nodes result...", raise_on_exceeded=False)
         def search_results():
-            results = self._es.search(index=ES_INDEX,  # pylint: disable=unexpected-keyword-arg
+            results = self._es.search(index=ES_INDEX,
                                       q=query,
                                       filter_path=filter_path,
                                       size=1000)
@@ -202,7 +201,7 @@ class ScyllaClusterBenchmarkManager(metaclass=Singleton):
                                         margins=Margins(sysbench_eps=0.03,
                                                         cassandra_fio_read_bw=0.01,
                                                         cassandra_fio_write_bw=0.01)))
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 LOGGER.warning(
                     "Failed to generate comparable result for the following item:\n%s"
                     "\nException:%s", runner.benchmark_results, exc)
@@ -236,7 +235,7 @@ class ScyllaClusterBenchmarkManager(metaclass=Singleton):
                     cassandra_fio_read_bw=item["cassandra_fio_lcs_64k_read"]["read"]["bw"],
                     cassandra_fio_write_bw=item["cassandra_fio_lcs_64k_write"]["write"]["bw"]
                 ))
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 LOGGER.warning(
                     "Failed to generate comparable result for the following item:\n%s"
                     "\nException:%s", item, exc)
@@ -250,7 +249,7 @@ class ScyllaClusterBenchmarkManager(metaclass=Singleton):
 
 
 class ScyllaNodeBenchmarkRunner:
-    # pylint: disable=broad-except
+
     """
     ScyllaNodeBenchmarkRunner installs and runs benchmarking
     tools on given cluster nodes and collects the output.

--- a/sdcm/utils/bisect_test.py
+++ b/sdcm/utils/bisect_test.py
@@ -44,7 +44,7 @@ def get_repo_urls(start_date: datetime, end_date: datetime, is_enterprise: bool 
     return repos
 
 
-def bisect_test(test_func):  # pylint: disable=too-many-statements
+def bisect_test(test_func):
     """
     decorator for bisecting tests.
 
@@ -57,7 +57,7 @@ def bisect_test(test_func):  # pylint: disable=too-many-statements
     """
 
     @wraps(test_func)
-    def wrapper(*args, **kwargs):  # pylint: disable=too-many-locals, too-many-statements  # noqa: PLR0914
+    def wrapper(*args, **kwargs):  # noqa: PLR0914
         tester_obj = args[0]
         start_date = tester_obj.params.get('bisect_start_date')
         test_func(*args, **kwargs)
@@ -69,7 +69,7 @@ def bisect_test(test_func):  # pylint: disable=too-many-statements
 
         def update_binaries(node):
             node.stop_scylla()
-            cluster._scylla_install(node)  # pylint: disable=protected-access
+            cluster._scylla_install(node)
 
         end_date = tester_obj.params.get('bisect_end_date')
         bisect_start_date = datetime.strptime(start_date, '%Y-%m-%d')
@@ -82,7 +82,7 @@ def bisect_test(test_func):  # pylint: disable=too-many-statements
         version = 'unknown'
         while low <= high:
             tester_obj.stop_timeout_thread()
-            tester_obj._init_test_timeout_thread()  # pylint: disable=protected-access
+            tester_obj._init_test_timeout_thread()
             mid = (low + high) // 2
             repo_url = repo_urls[mid]
             tester_obj.params['scylla_repo'] = repo_url
@@ -111,7 +111,7 @@ def bisect_test(test_func):  # pylint: disable=too-many-statements
                         raise ValueError('failed to get version from node: ', node.name)
                     logger.info('successfully updated binaries to version: %s', version)
 
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 logger.warning('error during upgrade: %s \n verifying next closest version.', exc)
                 del repo_urls[mid]
                 high -= 1

--- a/sdcm/utils/cloud_monitor/resources/__init__.py
+++ b/sdcm/utils/cloud_monitor/resources/__init__.py
@@ -4,10 +4,10 @@ from math import ceil
 CLOUD_PROVIDERS = ("aws", "gce", "azure")
 
 
-class CloudInstance:  # pylint: disable=too-few-public-methods,too-many-instance-attributes
+class CloudInstance:
     pricing = None  # need to be set in the child class
 
-    def __init__(self, cloud, name, instance_id, region_az, state, lifecycle, instance_type, owner, create_time, keep, project='N/A'):  # pylint: disable=too-many-arguments
+    def __init__(self, cloud, name, instance_id, region_az, state, lifecycle, instance_type, owner, create_time, keep, project='N/A'):
         self.cloud = cloud
         self.name = name
         self.instance_id = instance_id
@@ -23,7 +23,7 @@ class CloudInstance:  # pylint: disable=too-few-public-methods,too-many-instance
         try:
             self.price = self.pricing.get_instance_price(region=self.region, instance_type=self.instance_type,
                                                          state=self.state, lifecycle=self.lifecycle)
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             self.price = -0.0  # to indicate in the report that we were unable to get the price.
 
     @property

--- a/sdcm/utils/cloud_monitor/resources/instances.py
+++ b/sdcm/utils/cloud_monitor/resources/instances.py
@@ -47,7 +47,7 @@ class AWSInstance(CloudInstance):
             for event in result["Events"]:
                 if event['EventName'] == 'RunInstances':
                     return event["Username"]
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.warning("Error occurred when trying to find an owner for '%s' in CloudTrail: %s",
                            self._instance['InstanceId'], exc)
         return None

--- a/sdcm/utils/cloud_monitor/resources/static_ips.py
+++ b/sdcm/utils/cloud_monitor/resources/static_ips.py
@@ -10,8 +10,8 @@ from sdcm.utils.common import list_elastic_ips_aws, aws_tags_to_dict, list_stati
 LOGGER = getLogger(__name__)
 
 
-class StaticIP:  # pylint: disable=too-few-public-methods
-    def __init__(self, cloud, name, address, region, used_by, owner):  # pylint: disable=too-many-arguments
+class StaticIP:
+    def __init__(self, cloud, name, address, region, used_by, owner):
         self.cloud = cloud
         self.name = name
         self.address = address
@@ -26,7 +26,7 @@ class StaticIP:  # pylint: disable=too-few-public-methods
         return False
 
 
-class AwsElasticIP(StaticIP):  # pylint: disable=too-few-public-methods
+class AwsElasticIP(StaticIP):
     def __init__(self, eip, region):
         tags = eip.get('Tags')
         tags_dict = {}
@@ -42,7 +42,7 @@ class AwsElasticIP(StaticIP):  # pylint: disable=too-few-public-methods
         )
 
 
-class GceStaticIP(StaticIP):  # pylint: disable=too-few-public-methods
+class GceStaticIP(StaticIP):
     def __init__(self, static_ip: compute_v1.Address):
         used_by = static_ip.users
         super().__init__(
@@ -55,7 +55,7 @@ class GceStaticIP(StaticIP):  # pylint: disable=too-few-public-methods
         )
 
 
-class AzureStaticIP(StaticIP):  # pylint: disable=too-few-public-methods
+class AzureStaticIP(StaticIP):
     def __init__(self, static_ip, resource_group):
         super().__init__(
             cloud="azure",

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -11,7 +11,6 @@
 #
 # Copyright (c) 2017 ScyllaDB
 
-# pylint: disable=too-many-lines
 
 from __future__ import absolute_import, annotations
 
@@ -58,7 +57,7 @@ from invoke import UnexpectedExit
 from mypy_boto3_s3 import S3Client, S3ServiceResource
 from mypy_boto3_ec2 import EC2Client, EC2ServiceResource
 from mypy_boto3_ec2.service_resource import Image as EC2Image
-import docker  # pylint: disable=wrong-import-order; false warning because of docker import (local file vs. package)
+import docker
 from google.cloud.storage import Blob as GceBlob
 from google.cloud.compute_v1.types import Metadata as GceMetadata, Instance as GceInstance
 from google.cloud.compute_v1 import ListImagesRequest, Image as GceImage
@@ -102,7 +101,7 @@ SCYLLA_AMI_OWNER_ID_LIST = ["797456418907", "158855661827"]
 SCYLLA_GCE_IMAGES_PROJECT = "scylla-images"
 
 
-class KeyBasedLock():  # pylint: disable=too-few-public-methods
+class KeyBasedLock():
     """Class designed for creating locks based on hashable keys."""
 
     def __init__(self):
@@ -124,7 +123,7 @@ def _remote_get_hash(remoter, file_path):
     try:
         result = remoter.run('md5sum {}'.format(file_path), verbose=True)
         return result.stdout.strip().split()[0]
-    except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as details:  # noqa: BLE001
         LOGGER.error(str(details))
         return None
 
@@ -136,7 +135,7 @@ def _remote_get_file(remoter, src, dst, user_agent=None):
     return remoter.run(cmd, ignore_status=True)
 
 
-def remote_get_file(remoter, src, dst, hash_expected=None, retries=1, user_agent=None):  # pylint: disable=too-many-arguments
+def remote_get_file(remoter, src, dst, hash_expected=None, retries=1, user_agent=None):
     _remote_get_file(remoter, src, dst, user_agent)
     if not hash_expected:
         return
@@ -204,7 +203,7 @@ def get_data_dir_path(*args):
 
 
 def get_sct_root_path():
-    import sdcm  # pylint: disable=import-outside-toplevel
+    import sdcm
     sdcm_path = os.path.realpath(sdcm.__path__[0])
     sct_root_dir = os.path.join(sdcm_path, "..")
     return os.path.abspath(sct_root_dir)
@@ -291,7 +290,7 @@ class S3Storage():
             LOGGER.info("Set public read access")
             self.set_public_access(key=s3_obj)
             return s3_url
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             LOGGER.debug("Unable to upload to S3: %s", details)
             return ""
 
@@ -320,7 +319,7 @@ class S3Storage():
             LOGGER.info("Downloaded finished")
             return os.path.join(os.path.abspath(dst_dir), file_name)
 
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             LOGGER.warning("File {} is not downloaded by reason: {}".format(key_name, details))
             return ""
 
@@ -407,7 +406,7 @@ class ParallelObject:
         Run function in with supplied args in parallel using thread.
     """
 
-    def __init__(self, objects: Iterable, timeout: int = 6,  # pylint: disable=redefined-outer-name
+    def __init__(self, objects: Iterable, timeout: int = 6,
                  num_workers: int = None, disable_logging: bool = False):
         """Constructor for ParallelObject
 
@@ -427,7 +426,7 @@ class ParallelObject:
         self.timeout = timeout
         self.num_workers = num_workers
         self.disable_logging = disable_logging
-        self._thread_pool = ThreadPoolExecutor(max_workers=self.num_workers)  # pylint: disable=consider-using-with
+        self._thread_pool = ThreadPoolExecutor(max_workers=self.num_workers)
 
     def run(self, func: Callable, ignore_exceptions=False, unpack_objects: bool = False) -> List[ParallelObjectResult]:
         """Run callable object "disrupt_func" in parallel
@@ -488,7 +487,7 @@ class ParallelObject:
             except FuturesTimeoutError as exception:
                 results.append(ParallelObjectResult(obj=target_obj, exc=exception, result=None))
                 time_out = 0.001  # if there was a timeout on one of the futures there is no need to wait for all
-            except Exception as exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exception:  # noqa: BLE001
                 results.append(ParallelObjectResult(obj=target_obj, exc=exception, result=None))
             else:
                 results.append(ParallelObjectResult(obj=target_obj, exc=None, result=result))
@@ -573,7 +572,7 @@ class ParallelObject:
         return results_map
 
 
-class ParallelObjectResult:  # pylint: disable=too-few-public-methods
+class ParallelObjectResult:
     """Object for result of future in ParallelObject
 
     Return as a result of ParallelObject.run method
@@ -626,7 +625,7 @@ def list_clients_docker(builder_name: Optional[str] = None, verbose: bool = Fals
                     base_url=f"ssh://{builder['user']}@{normalize_ipv6_url(builder['public_ip'])}:22")
             client.ping()
             log.info("%(name)s: connected via SSH (%(user)s@%(public_ip)s)", builder)
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             log.error("%(name)s: failed to connect to Docker via SSH", builder)
             raise
         docker_clients[builder["name"]] = client
@@ -712,8 +711,6 @@ def aws_tags_to_dict(tags_list):
         for item in tags_list:
             tags_dict[item["Key"]] = item["Value"]
     return tags_dict
-
-# pylint: disable=too-many-arguments
 
 
 def list_instances_aws(tags_dict=None, region_name=None, running=False, group_as_region=False, verbose=False, availability_zone=None):
@@ -1090,21 +1087,21 @@ def list_clusters_eks(tags_dict: Optional[dict] = None, regions: list = None,
         tags = {}
 
         @cached_property
-        def eks_client(self):  # pylint: disable=no-self-use
+        def eks_client(self):
             return
 
-        def list_clusters(self) -> list:  # pylint: disable=no-self-use
+        def list_clusters(self) -> list:
             eks_clusters = []
             for aws_region in regions or all_aws_regions():
                 try:
                     cluster_names = boto3.client('eks', region_name=aws_region).list_clusters()['clusters']
-                except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+                except Exception as exc:  # noqa: BLE001
                     LOGGER.error("Failed to get list of EKS clusters in the '%s' region: %s", aws_region, exc)
                     return []
                 for cluster_name in cluster_names:
                     try:
                         eks_clusters.append(EksClusterForCleaner(cluster_name, aws_region))
-                    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+                    except Exception as exc:  # noqa: BLE001
                         LOGGER.error("Failed to get body of cluster on EKS: %s", exc)
             return eks_clusters
 
@@ -1240,11 +1237,11 @@ def safe_kill(pid, signal):
     try:
         os.kill(pid, signal)
         return True
-    except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception:  # noqa: BLE001
         return False
 
 
-class FileFollowerIterator():  # pylint: disable=too-few-public-methods
+class FileFollowerIterator():
     def __init__(self, filename, thread_obj):
         self.filename = filename
         self.thread_obj = thread_obj
@@ -1252,11 +1249,11 @@ class FileFollowerIterator():  # pylint: disable=too-few-public-methods
     def __iter__(self):
         with open(self.filename, encoding="utf-8") as input_file:
             line = ''
-            poller = select.poll()  # pylint: disable=no-member
+            poller = select.poll()
             registered = False
             while not self.thread_obj.stopped():
                 if not registered:
-                    poller.register(input_file, select.POLLIN)  # pylint: disable=no-member
+                    poller.register(input_file, select.POLLIN)
                     registered = True
                 if poller.poll(100):
                     line += input_file.readline()
@@ -1272,7 +1269,7 @@ class FileFollowerIterator():  # pylint: disable=too-few-public-methods
 
 class FileFollowerThread():
     def __init__(self):
-        self.executor = concurrent.futures.ThreadPoolExecutor(1)  # pylint: disable=consider-using-with
+        self.executor = concurrent.futures.ThreadPoolExecutor(1)
         self._stop_event = threading.Event()
         self.future = None
 
@@ -1639,7 +1636,7 @@ def remove_files(path):
             shutil.rmtree(path=path, ignore_errors=True)
         if os.path.isfile(path):
             os.remove(path)
-    except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as details:  # noqa: BLE001
         LOGGER.error("Error during remove archived logs %s", details)
         LOGGER.info("Remove temporary data manually: \"%s\"", path)
 
@@ -1657,7 +1654,7 @@ def create_remote_storage_dir(node, path='') -> Optional[str, None]:
                 'Remote storing folder not created.\n %s', result)
             remote_dir = node_remote_dir
 
-    except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as details:  # noqa: BLE001
         LOGGER.error("Error during creating remote directory %s", details)
         return None
 
@@ -2030,7 +2027,7 @@ def rows_to_list(rows):
 
 
 # Copied from dtest
-class Page:  # pylint: disable=too-few-public-methods
+class Page:
     data = None
 
     def __init__(self):
@@ -2211,7 +2208,7 @@ def reach_enospc_on_node(target_node):
         LOGGER.debug('Cost 90% free space on /var/lib/scylla/ by {}'.format(occupy_space_cmd))
         try:
             target_node.remoter.sudo(occupy_space_cmd, verbose=True)
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             LOGGER.warning(str(details))
         return bool(list(no_space_log_reader))
 
@@ -2298,7 +2295,7 @@ def convert_metric_to_ms(metric: str) -> float:
             metric_converted += _convert_to_ms(parsed_values['units'], parsed_values['sec'])
         else:
             metric_converted = float(metric)
-    except ValueError as ve:  # pylint: disable=invalid-name
+    except ValueError as ve:
         metric_converted = metric
         LOGGER.error("Value %s can't be converted to float. Exception: %s", metric, ve)
     return metric_converted
@@ -2412,7 +2409,7 @@ def walk_thru_data(data, path: str, separator: str = '/') -> Any:
         if name.isalnum() and isinstance(current_value, (list, tuple, set)):
             try:
                 current_value = current_value[int(name)]
-            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 current_value = None
             continue
         current_value = current_value.get(name, None)
@@ -2485,7 +2482,7 @@ def make_threads_be_daemonic_by_default():
     @return:
     @rtype:
     """
-    threading.current_thread()._daemonic = True  # pylint: disable=protected-access
+    threading.current_thread()._daemonic = True
 
 
 def clear_out_all_exit_hooks():
@@ -2495,7 +2492,7 @@ def clear_out_all_exit_hooks():
     To avoid that we clear it out to be sure that nothing is hooked and test is terminated right after
       teardown.
     """
-    threading._threading_atexits.clear()  # pylint: disable=protected-access
+    threading._threading_atexits.clear()
 
 
 def validate_if_scylla_load_high_enough(start_time, wait_cpu_utilization, prometheus_stats,
@@ -2589,7 +2586,7 @@ def describering_parsing(describering_output):
 
 
 @contextmanager
-def SoftTimeoutContext(timeout: int, operation: str):  # pylint: disable=invalid-name
+def SoftTimeoutContext(timeout: int, operation: str):
     """Publish SoftTimeoutEvent with operation info in case of duration > timeout"""
     start_time = time.time()
     yield

--- a/sdcm/utils/data_validator.py
+++ b/sdcm/utils/data_validator.py
@@ -157,7 +157,6 @@ class DataForValidation(NamedTuple):
     after_update_rows: Optional[list]
 
 
-# pylint: disable=too-many-instance-attributes, too-many-public-methods
 class LongevityDataValidator:
     SUFFIX_FOR_VIEW_AFTER_UPDATE = '_after_update'
     SUFFIX_EXPECTED_DATA_TABLE = '_expect'
@@ -572,7 +571,6 @@ class LongevityDataValidator:
 
         return logdir
 
-    # pylint: disable=too-many-locals,too-many-branches
     def analyze_updated_data_and_save_in_file(self, data_for_validation: DataForValidation, session, logdir: str):
         actual_data_set = {tuple(item) for item in sorted(data_for_validation.actual_data)}
         expected_data_set = {tuple(item) for item in sorted(data_for_validation.expected_data)}
@@ -619,7 +617,7 @@ class LongevityDataValidator:
 
                 try:
                     row_data.update({key: list(session.execute(query % (select_columns, table)))})
-                except Exception as error:  # pylint: disable=broad-except  # noqa: BLE001
+                except Exception as error:  # noqa: BLE001
                     LOGGER.error("Query %s failed. Error: %s", query % table, error)
 
             row_data.update({'source_all_columns': list(session.execute(query % (columns_for_validation,
@@ -647,7 +645,7 @@ class LongevityDataValidator:
                       encoding='utf8') as json_file:
                 try:
                     json.dump(result, json_file)
-                except:   # pylint: disable=bare-except
+                except:
                     json_file.write(str(result))
                 LOGGER.info("analyze_result_debug json: %s", json_file.name)
 

--- a/sdcm/utils/database_query_utils.py
+++ b/sdcm/utils/database_query_utils.py
@@ -11,7 +11,6 @@
 #
 # Copyright (c) 2023 ScyllaDB
 
-# pylint: disable=too-many-lines
 
 from __future__ import absolute_import, annotations
 
@@ -31,7 +30,7 @@ from sdcm.utils.decorators import retrying, optional_stage
 LOGGER = logging.getLogger(__name__)
 
 
-class PartitionsValidationAttributes:  # pylint: disable=too-few-public-methods,too-many-instance-attributes
+class PartitionsValidationAttributes:
     """
     A class that gathers all data related to partitions-validation.
     It helps Longevity tests that uses "validate_partitions" to
@@ -40,7 +39,7 @@ class PartitionsValidationAttributes:  # pylint: disable=too-few-public-methods,
     PARTITIONS_ROWS_BEFORE = "partitions_rows_before"
     PARTITIONS_ROWS_AFTER = "partitions_rows_after"
 
-    def __init__(self, tester, table_name: str, primary_key_column: str, limit_rows_number: int = 0,  # pylint: disable=too-many-arguments
+    def __init__(self, tester, table_name: str, primary_key_column: str, limit_rows_number: int = 0,
                  max_partitions_in_test_table: str | None = None,
                  partition_range_with_data_validation: str | None = None, validate_partitions: bool = False):
         """
@@ -94,7 +93,7 @@ class PartitionsValidationAttributes:  # pylint: disable=too-few-public-methods,
                 session.default_consistency_level = ConsistencyLevel.QUORUM
                 pk_list = sorted(get_partition_keys(ks_cf=self.table_name, session=session,
                                                     pk_name=self.primary_key_column))
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             TestFrameworkEvent(source=self.__class__.__name__, message=error_message.format(exc),
                                severity=Severity.ERROR).publish()
             return None
@@ -121,7 +120,7 @@ class PartitionsValidationAttributes:  # pylint: disable=too-few-public-methods,
                                                                   statement=count_pk_rows_cmd, retries=1, timeout=600,
                                                                   raise_on_exceeded=True, verbose=False)
                         pk_rows_num_result = pk_rows_num_query_result[0].count
-                except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+                except Exception as exc:  # noqa: BLE001
                     TestFrameworkEvent(source=self.__class__.__name__, message=error_message.format(exc),
                                        severity=Severity.ERROR).publish()
                     return None
@@ -225,7 +224,7 @@ def get_partition_keys(ks_cf: str, session, pk_name: str = 'pk', limit: int = No
     return pks_list
 
 
-def fetch_all_rows(session, default_fetch_size, statement, retries: int = 4, timeout: int = None,  # pylint: disable=too-many-arguments
+def fetch_all_rows(session, default_fetch_size, statement, retries: int = 4, timeout: int = None,
                    raise_on_exceeded: bool = False, verbose=True):
     """
     ******* Caution *******

--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -34,17 +34,16 @@ class Retry(Exception):
     pass
 
 
-class retrying:  # pylint: disable=invalid-name,too-few-public-methods
+class retrying:
     """
         Used as a decorator to retry function run that can possibly fail with allowed exceptions list
     """
 
-    # pylint: disable=too-many-arguments,redefined-outer-name
     def __init__(self, n=3, sleep_time=1,
                  allowed_exceptions=(Exception,), message="", timeout=0,
                  raise_on_exceeded=True):
         if n:
-            self.n = n  # number of times to retry  # pylint: disable=invalid-name
+            self.n = n  # number of times to retry
         else:
             self.n = sys.maxsize * 2 + 1
         self.sleep_time = sleep_time  # number seconds to sleep between retries
@@ -82,7 +81,7 @@ class retrying:  # pylint: disable=invalid-name,too-few-public-methods
         return inner
 
 
-timeout = partial(retrying, n=0)  # pylint: disable=invalid-name
+timeout = partial(retrying, n=0)
 
 
 def log_run_info(arg):
@@ -191,7 +190,7 @@ def latency_calculator_decorator(original_function: Optional[Callable] = None, *
     :return: Wrapped method.
     """
     # calling this import here, because of circular import
-    from sdcm.utils import latency  # pylint: disable=import-outside-toplevel
+    from sdcm.utils import latency
 
     def wrapper(func):
 
@@ -333,7 +332,7 @@ class NoValue(Exception):
     ...
 
 
-class optional_cached_property(cached_property):  # pylint: disable=invalid-name,too-few-public-methods
+class optional_cached_property(cached_property):
     """Extension for cached_property from Lib/functools.py with ability to ignore calculated result.
 
     To make it to not cache a value on a property call raise NoValue exception: it will be ignored and

--- a/sdcm/utils/distro.py
+++ b/sdcm/utils/distro.py
@@ -13,7 +13,7 @@
 
 import enum
 import logging
-from sdcm.utils.decorators import static_init  # pylint: disable=unused-import
+from sdcm.utils.decorators import static_init
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -15,9 +15,8 @@ from sdcm.utils.net import resolve_ip_to_dns
 LOGGER = logging.getLogger(__name__)
 
 
-# pylint: disable=too-many-public-methods
 class RemoteDocker(BaseNode):
-    def __init__(self, node, image_name, ports=None, command_line="tail -f /dev/null", extra_docker_opts="", docker_network=None):  # pylint: disable=too-many-arguments
+    def __init__(self, node, image_name, ports=None, command_line="tail -f /dev/null", extra_docker_opts="", docker_network=None):
         self.node = node
         self._internal_ip_address = None
         self.log = LOGGER
@@ -128,7 +127,7 @@ class RemoteDocker(BaseNode):
                                         verbose=kwargs.get('verbose'), ignore_status=True).ok
         return result
 
-    def receive_files(self, src, dst, **kwargs):  # pylint: disable=unused-argument
+    def receive_files(self, src, dst, **kwargs):
         remote_tempfile = self.node.remoter.run("mktemp").stdout.strip()
 
         result = self.node.remoter.run(f"{self.sudo_needed} docker cp {self.docker_id}:{src} {remote_tempfile}",

--- a/sdcm/utils/docker_utils.py
+++ b/sdcm/utils/docker_utils.py
@@ -16,7 +16,7 @@ import re
 import logging
 import warnings
 from pprint import pformat
-from types import SimpleNamespace  # pylint: disable=no-name-in-module
+from types import SimpleNamespace
 from typing import List, Optional, Union, Any, Tuple, Protocol
 from functools import cache
 import itertools
@@ -63,11 +63,10 @@ class DockerClient(docker.DockerClient):
         return res
 
 
-_docker = DockerClient.from_env(timeout=DOCKER_API_CALL_TIMEOUT)  # pylint: disable=invalid-name
+_docker = DockerClient.from_env(timeout=DOCKER_API_CALL_TIMEOUT)
 
 
 class _Name(SimpleNamespace):
-    # pylint: disable=too-few-public-methods
 
     def __init__(self, name: Optional[str]) -> None:
         family, *member = (None, ) if name is None else name.split(":", 1)
@@ -81,13 +80,13 @@ class _Name(SimpleNamespace):
 
 
 class INodeWithContainerManager(Protocol):
-    # pylint: disable=too-few-public-methods
+
     _containers: dict[str, Container]
     tags: dict[str, str]
     parent_cluster: Any
 
 
-class ContainerManager:  # pylint: disable=too-many-public-methods)
+class ContainerManager:
     """A set of methods for manipulating containers associated with a node.
 
     This manager expects that node instance has two dicts: `_containers' and `tags'.
@@ -143,8 +142,6 @@ class ContainerManager:  # pylint: disable=too-many-public-methods)
 
     where `name' is a key for `_containers' dict.
     """
-
-    # pylint: disable=protected-access
 
     keep_alive_suffix = "---KEEPALIVE"
     default_docker_client = _docker
@@ -251,7 +248,7 @@ class ContainerManager:  # pylint: disable=too-many-public-methods)
             try:
                 with open(logfile, "ab") as log:
                     log.write(container.logs())
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 LOGGER.error("Unable to write container logs to %s", logfile, exc_info=exc)
             else:
                 LOGGER.debug("Container %s logs written to %s", container, logfile)
@@ -268,7 +265,7 @@ class ContainerManager:  # pylint: disable=too-many-public-methods)
         for name in tuple(instance._containers.keys()):
             try:
                 cls.destroy_container(instance, name, ignore_keepalive=ignore_keepalive)
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 LOGGER.error("%s: some exception raised during container `%s' destroying", instance, name, exc_info=exc)
 
     @classmethod
@@ -289,7 +286,7 @@ class ContainerManager:  # pylint: disable=too-many-public-methods)
             cls.set_container_keep_alive(instance, name)
 
     @classmethod
-    def ssh_copy_id(cls,  # pylint: disable=too-many-arguments
+    def ssh_copy_id(cls,
                     instance: INodeWithContainerManager,
                     name: str,
                     user: str,

--- a/sdcm/utils/es_index.py
+++ b/sdcm/utils/es_index.py
@@ -18,7 +18,7 @@ def create_index(index_name: str, mappings: dict, **kwargs):
         raise Exception(f"Mappings configuration is empty {mappings}")
     es_client = ES()
     es_client.indices.create(index=index_name)
-    es_client.indices.put_mapping(index=index_name, body=mappings,  # pylint: disable=unexpected-keyword-arg
+    es_client.indices.put_mapping(index=index_name, body=mappings,
                                   include_type_name=True)
 
 

--- a/sdcm/utils/features.py
+++ b/sdcm/utils/features.py
@@ -12,7 +12,7 @@
 #
 import logging
 
-from cassandra.cluster import Session  # pylint: disable=no-name-in-module
+from cassandra.cluster import Session
 
 CONSISTENT_TOPOLOGY_CHANGES_FEATURE = "SUPPORTS_CONSISTENT_TOPOLOGY_CHANGES"
 CONSISTENT_CLUSTER_MANAGEMENT_FEATURE = "SUPPORTS_RAFT_CLUSTER_MANAGEMENT"

--- a/sdcm/utils/file.py
+++ b/sdcm/utils/file.py
@@ -15,7 +15,6 @@ from typing import Optional, TextIO, List, Union, AnyStr, Iterable
 from re import Pattern
 
 
-# pylint: disable=too-few-public-methods
 class ReiterableGenerator:
     def __init__(self, generator):
         self._generator = generator
@@ -24,7 +23,6 @@ class ReiterableGenerator:
         return self._generator()
 
 
-# pylint: disable=too-many-instance-attributes
 class File:
     """
     File object that support chaining and context managing
@@ -34,7 +32,6 @@ class File:
         >>> ).move_to_beginning().readlines() == ['someline\\n', 'someline #1\\n', 'someline #2\\n']
     """
 
-    # pylint: disable=too-many-arguments
     def __init__(self, path: str, mode: str = 'r', buffering: Optional[int] = None,
                  encoding: Optional[str] = None, errors: Optional[str] = None, newline: Optional[str] = None,
                  closefd: bool = True):
@@ -63,7 +60,7 @@ class File:
     def _open(self) -> TextIO:
         kwargs = {attr_name: getattr(self, attr_name) for attr_name in
                   ['mode', 'buffering', 'encoding', 'errors', 'closefd'] if getattr(self, attr_name, None) is not None}
-        return open(self.path, **kwargs)  # pylint: disable=consider-using-with,unspecified-encoding
+        return open(self.path, **kwargs)
 
     def move_to(self, pos) -> 'File':
         self._io.seek(pos)

--- a/sdcm/utils/gce_region.py
+++ b/sdcm/utils/gce_region.py
@@ -168,7 +168,7 @@ class GceRegion:
         backup_service_account = None
 
         try:
-            backup_service_account = self.iam.projects().serviceAccounts().create(  # pylint: disable=no-member
+            backup_service_account = self.iam.projects().serviceAccounts().create(
                 name='projects/' + self.project,
                 body={
                     'accountId': self.SCT_BACKUP_SERVICE_ACCOUNT,
@@ -180,7 +180,7 @@ class GceRegion:
         except googleapiclient.errors.HttpError as exc:
             if not exc.status_code == 409:
                 raise
-            service_accounts = self.iam.projects().serviceAccounts().list(  # pylint: disable=no-member
+            service_accounts = self.iam.projects().serviceAccounts().list(
                 name=f'projects/{self.project}', pageSize=100).execute()
             for service in service_accounts['accounts']:
                 if self.SCT_BACKUP_SERVICE_ACCOUNT in service['name']:

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -151,11 +151,11 @@ class GcloudContextManager:
         if self._container:
             return
         try:
-            self._container = self._instance._get_gcloud_container()  # pylint: disable=protected-access
+            self._container = self._instance._get_gcloud_container()
         except Exception as exc:  # noqa: BLE001
             try:
                 ContainerManager.destroy_container(self._instance, self._name)
-            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 pass
             raise exc from None
 
@@ -165,7 +165,7 @@ class GcloudContextManager:
             return
         try:
             ContainerManager.destroy_container(self._instance, self._name)
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             pass
         self._container = None
 
@@ -277,7 +277,7 @@ class GkeCleaner(GcloudContainerMixin):
     def list_gke_clusters(self) -> list:
         try:
             output = self.gcloud.run("container clusters list --format json")
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.error("`gcloud container clusters list --format json' failed to run: %s", exc)
         else:
             try:
@@ -294,7 +294,7 @@ class GkeCleaner(GcloudContainerMixin):
             disks = json.loads(self.gcloud.run(
                 'compute disks list --format="json(name,zone)" --filter="(name~^gke-.*-pvc-.* OR name~^pvc-.*) '
                 'AND -users:*"'))
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.error("`gcloud compute disks list' failed to run: %s", exc)
         else:
             for disk in disks:
@@ -311,7 +311,7 @@ class GkeCleaner(GcloudContainerMixin):
         ContainerManager.destroy_all_containers(self)
 
 
-class GceLoggingClient:  # pylint: disable=too-few-public-methods
+class GceLoggingClient:
 
     def __init__(self, instance_name: str, zone: str):
         credentials = KeyStore().get_gcp_credentials()
@@ -392,7 +392,7 @@ def wait_for_extended_operation(
     return result
 
 
-def disk_from_image(  # pylint: disable=too-many-arguments
+def disk_from_image(
     disk_type: str,
     boot: bool,
     disk_size_gb: int = None,
@@ -444,7 +444,7 @@ def disk_from_image(  # pylint: disable=too-many-arguments
     return boot_disk
 
 
-def create_instance(  # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements  # noqa: PLR0913
+def create_instance(  # noqa: PLR0913
     project_id: str,
     zone: str,
     instance_name: str,

--- a/sdcm/utils/get_username.py
+++ b/sdcm/utils/get_username.py
@@ -24,7 +24,7 @@ def get_email_user(email_addr: str) -> str:
     return email_addr.strip().split("@")[0]
 
 
-def get_username() -> str:  # pylint: disable=too-many-return-statements  # noqa: PLR0911
+def get_username() -> str:  # noqa: PLR0911
     # First we check if user is being impersonated by an api call
     actual_user_from_request = os.environ.get('BUILD_USER_REQUESTED_BY')
     if actual_user_from_request:

--- a/sdcm/utils/git.py
+++ b/sdcm/utils/git.py
@@ -31,7 +31,7 @@ def get_git_current_branch() -> str:
 
 
 def get_git_status_info() -> GitStatus:
-    # pylint: disable=too-many-locals
+
     try:
         #    Example output:
         #    # branch.oid 0748e3a512b7e698bc4b2e3e8ec8d46d0b3244ae
@@ -90,7 +90,7 @@ def get_git_status_info() -> GitStatus:
 
 
 def clone_repo(remoter, repo_url: str, destination_dir_name: str = "", clone_as_root=True, branch=None):
-    # pylint: disable=broad-except
+
     try:
         LOGGER.debug("Cloning from %s...", repo_url)
         rm_cmd = f"rm -rf ./{repo_url.split('/')[-1].split('.')[0]}"

--- a/sdcm/utils/issues.py
+++ b/sdcm/utils/issues.py
@@ -113,7 +113,7 @@ class SkipPerIssues:
             TestFrameworkEvent(source=self.__class__.__name__,
                                message=f"couldn't parse issue: {issue}",
                                severity=Severity.WARNING,
-                               trace=sys._getframe().f_back).publish()  # pylint: disable=protected-access
+                               trace=sys._getframe().f_back).publish()
             return None
         try:
             if issue_details := self.cache.get_issue(owner=issue_parsed.user_id, repo_id=issue_parsed.repo_id, issue_id=issue_parsed.issue_id):
@@ -139,7 +139,7 @@ class SkipPerIssues:
             TestFrameworkEvent(source=self.__class__.__name__,
                                message=f"couldn't find issue: {issue}",
                                severity=Severity.WARNING,
-                               trace=sys._getframe().f_back).publish()  # pylint: disable=protected-access
+                               trace=sys._getframe().f_back).publish()
             return None
         except RateLimitExceededException as exc:
             logging.debug('RateLimitExceededException raise: %s', str(exc))
@@ -147,7 +147,7 @@ class SkipPerIssues:
             # this would mean that we would assume issue is open, and enable the skips needed, without having the
             # actual data of the issue
             return github.Issue.Issue(requester=None, headers={}, attributes=dict(state='open'), completed=True)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             logging.warning("failed to get issue: %s", issue)
             TestFrameworkEvent(source=self.__class__.__name__,
                                message=f"failed to get issue {issue}",

--- a/sdcm/utils/issues_by_keyword/find_known_issue.py
+++ b/sdcm/utils/issues_by_keyword/find_known_issue.py
@@ -15,7 +15,6 @@ class MapKeywords(NamedTuple):
     issue: str
 
 
-# pylint: disable=too-few-public-methods
 class FindIssuePerBacktrace(metaclass=Singleton):
 
     MAPPING_FILE = Path(__file__).parent / "issue_by_keyword.yaml"

--- a/sdcm/utils/java.py
+++ b/sdcm/utils/java.py
@@ -6,7 +6,7 @@ from sdcm import sct_abs_path
 JAVA_DOCKER_IMAGE = 'openjdk:23-slim'
 
 
-class JavaContainerMixin:  # pylint: disable=too-few-public-methods
+class JavaContainerMixin:
     def java_container_run_args(self) -> dict:
         user_home = os.path.expanduser("~")
         volumes = {

--- a/sdcm/utils/k8s/chaos_mesh.py
+++ b/sdcm/utils/k8s/chaos_mesh.py
@@ -51,7 +51,7 @@ class ChaosMeshTimeout(ChaosMeshExperimentException):
     pass
 
 
-class ChaosMesh:  # pylint: disable=too-few-public-methods
+class ChaosMesh:
     NAMESPACE = "chaos-mesh"
     VERSION = "2.5.0"
     HELM_SETTINGS = {
@@ -164,7 +164,6 @@ class ChaosMeshExperiment:
         self.log.info("'%s' experiment '%s' has started", self.CHAOS_KIND, self._name)
         self._end_time = time.time() + self._timeout
 
-    # pylint: disable=too-many-return-statements
     def get_status(self) -> ExperimentStatus:  # noqa: PLR0911
         """Gets status of chaos-mesh experiment."""
         result = self._k8s_cluster.kubectl(
@@ -241,7 +240,6 @@ class MemoryStressExperiment(ChaosMeshExperiment):
     """
     CHAOS_KIND = "StressChaos"
 
-    # pylint: disable=too-many-arguments
     def __init__(self, pod: "sdcm.cluster_k8s.BasePodContainer", duration: str,  # noqa: F821
                  workers: int, size: str, time_to_reach: str | None = None):
         """Stresses memory on scylla pod using https://github.com/chaos-mesh/memStress
@@ -306,7 +304,6 @@ class IOFaultChaosExperiment(ChaosMeshExperiment):
     """
     CHAOS_KIND = "IOChaos"
 
-    # pylint: disable=too-many-arguments
     def __init__(self, pod: "sdcm.cluster_k8s.BasePodContainer", duration: str, error: DiskError,  # noqa: F821
                  error_probability: int, methods: list[DiskMethod], volume_path: str, path: str | None = None):
         """Induces disk fault (programatically) using IOChaos: https://chaos-mesh.org/docs/simulate-io-chaos-on-kubernetes/
@@ -410,7 +407,6 @@ class NetworkDelayExperiment(ChaosMeshExperiment):
     """
     CHAOS_KIND = "NetworkChaos"
 
-    # pylint: disable=too-many-arguments
     def __init__(self, pod: "sdcm.cluster_k8s.BasePodContainer", duration: str, latency: str,  # noqa: F821
                  correlation: int = 0, jitter: str = "0"):
         """Simulate network delay fault into a specified Pod for a period of time.
@@ -444,7 +440,6 @@ class NetworkBandwidthLimitExperiment(ChaosMeshExperiment):
     """
     CHAOS_KIND = "NetworkChaos"
 
-    # pylint: disable=too-many-arguments
     def __init__(self, pod: "sdcm.cluster_k8s.BasePodContainer", duration: str,  # noqa: F821
                  rate: str, limit: int, buffer: int):
         """Simulate network bandwidth limit fault into a specified Pod for a period of time.

--- a/sdcm/utils/latency.py
+++ b/sdcm/utils/latency.py
@@ -21,7 +21,6 @@ def avg(values):
     return sum(values)/len(values)
 
 
-# pylint: disable=too-many-arguments,too-many-locals,too-many-nested-blocks,too-many-branches
 def collect_latency(monitor_node, start, end, load_type, cluster, nodes_list):  # noqa: PLR0914
     res = {}
     prometheus = PrometheusDBStats(host=monitor_node.external_address)

--- a/sdcm/utils/ldap.py
+++ b/sdcm/utils/ldap.py
@@ -51,7 +51,7 @@ class LdapServerType(str, Enum):
     OPENLDAP = "openldap"
 
 
-class LdapContainerMixin:  # pylint: disable=too-few-public-methods
+class LdapContainerMixin:
     ldap_server = None
     ldap_conn = None
     ldap_server_port = None

--- a/sdcm/utils/loader_utils.py
+++ b/sdcm/utils/loader_utils.py
@@ -166,7 +166,7 @@ class LoaderUtilsMixin:
         duration_per_cs_profile = None if len(user_profiles_def) == 1 else list(user_profiles_def[1])
         return user_profiles, duration_per_cs_profile
 
-    def run_cs_user_profiles(self, cs_profiles: str | int | list, duration_per_cs_profile: str | list = None, stress_queue: list = None):  # pylint: disable=too-many-locals
+    def run_cs_user_profiles(self, cs_profiles: str | int | list, duration_per_cs_profile: str | list = None, stress_queue: list = None):
         """
          :param duration_per_cs_profile: if duration of cassandra-stress command is parameterized, it is expected to get needed value for
                                          duration
@@ -227,7 +227,6 @@ class LoaderUtilsMixin:
             cmds = [cmds]
 
         for cmd in cmds:
-            # pylint: disable=no-member
             with self.db_cluster.cql_connection_patient(node) as session:
                 session.execute(cmd)
 

--- a/sdcm/utils/log.py
+++ b/sdcm/utils/log.py
@@ -98,7 +98,7 @@ class JSONLFormatter(logging.Formatter):
         return json.dumps(log_entry, ensure_ascii=False)
 
 
-class FilterRemote(logging.Filter):  # pylint: disable=too-few-public-methods
+class FilterRemote(logging.Filter):
     def filter(self, record):
         return not record.name == 'sdcm.remote'
 
@@ -128,7 +128,7 @@ def replace_vars(obj, variables, obj_type=None):
     return obj
 
 
-def configure_logging(exception_handler=None,  # pylint: disable=too-many-arguments
+def configure_logging(exception_handler=None,
                       formatters=None, filters=None, handlers=None, loggers=None, config=None, variables=None):
     urllib3.disable_warnings()
     warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)

--- a/sdcm/utils/log_time_consistency.py
+++ b/sdcm/utils/log_time_consistency.py
@@ -17,7 +17,7 @@ import re
 from pathlib import Path
 
 
-class LogTimeConsistencyAnalyzerBase:  # pylint: disable=too-few-public-methods
+class LogTimeConsistencyAnalyzerBase:
     times = {
         '<1min': 60,
         '<5min': 60 * 5,
@@ -81,7 +81,7 @@ class LogTimeConsistencyAnalyzerBase:  # pylint: disable=too-few-public-methods
                 output[name].append('There are more messages, total number is ' + str(value))
 
 
-class DbLogTimeConsistencyAnalyzer(LogTimeConsistencyAnalyzerBase):  # pylint: disable=too-few-public-methods
+class DbLogTimeConsistencyAnalyzer(LogTimeConsistencyAnalyzerBase):
     files_pattern = '**/*db-node*/messages.log'
 
     @classmethod
@@ -96,7 +96,7 @@ class DbLogTimeConsistencyAnalyzer(LogTimeConsistencyAnalyzerBase):  # pylint: d
                     continue
             try:
                 current_time = datetime.datetime.fromisoformat(line.split()[0]).timestamp()
-            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 continue
             current_time_shift = prior_time - current_time
             if bucket_name := cls._get_timeshift_bucket_name(current_time_shift):
@@ -110,7 +110,7 @@ class DbLogTimeConsistencyAnalyzer(LogTimeConsistencyAnalyzerBase):  # pylint: d
         return output, counters
 
 
-class SctLogTimeConsistencyAnalyzer(LogTimeConsistencyAnalyzerBase):  # pylint: disable=too-few-public-methods
+class SctLogTimeConsistencyAnalyzer(LogTimeConsistencyAnalyzerBase):
     files_pattern = '**/sct.log'
     sct_scylla_log_re = re.compile(
         r'< t:([0-9-]+ [0-9:]+),[0-9]+[ \t]+f:cluster.py[ \t]+l:[0-9]+[ \t]+c:sdcm.cluster[ \t]+p:[A-Z]+ > ([0-9T:-]+)')
@@ -132,7 +132,7 @@ class SctLogTimeConsistencyAnalyzer(LogTimeConsistencyAnalyzerBase):  # pylint: 
                 sct_time, event_time = match.groups()
                 sct_time = datetime.datetime.fromisoformat(sct_time).timestamp()
                 event_time = datetime.datetime.fromisoformat(event_time).timestamp()
-            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 continue
             current_time_shift = sct_time - event_time
             if bucket_name := cls._get_timeshift_bucket_name(time_shift=current_time_shift):

--- a/sdcm/utils/microbenchmarking/perf_simple_query_reporter.py
+++ b/sdcm/utils/microbenchmarking/perf_simple_query_reporter.py
@@ -45,7 +45,7 @@ class PerfSimpleQueryAnalyzer(BaseResultsAnalyzer):
         keys.sort(reverse=True)
         return [results[key] for key in keys]
 
-    def check_regression(self, test_id, mad_deviation_limit=0.02, regression_limit=0.05, is_gce=False, extra_jobs_to_compare=None  # pylint: disable=too-many-locals,too-many-statements  # noqa: PLR0914
+    def check_regression(self, test_id, mad_deviation_limit=0.02, regression_limit=0.05, is_gce=False, extra_jobs_to_compare=None  # noqa: PLR0914
                          ) -> dict:
         doc = self.get_test_by_id(test_id)
         if not doc:
@@ -71,7 +71,7 @@ class PerfSimpleQueryAnalyzer(BaseResultsAnalyzer):
                        '.'.join([es_source_path, 'test_details']),
                        '.'.join([es_source_path, 'versions'])]
 
-        tests_filtered = self._es.search(  # pylint: disable=unexpected-keyword-arg; pylint doesn't understand Elasticsearch code
+        tests_filtered = self._es.search(
             index=self._es_index,
 
             size=self._limit,

--- a/sdcm/utils/nemesis_utils/indexes.py
+++ b/sdcm/utils/nemesis_utils/indexes.py
@@ -15,7 +15,7 @@ import logging
 import random
 import time
 
-from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
+from cassandra.query import SimpleStatement
 
 from sdcm.cluster import BaseNode
 from sdcm.sct_events import Severity
@@ -36,7 +36,7 @@ def is_cf_a_view(node: BaseNode, ks, cf) -> bool:
                                      f" WHERE keyspace_name = '{ks}'"
                                      f" AND view_name = '{cf}'")
             return result and bool(len(result.one()))
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.debug('Got no result from system_schema.views for %s.%s table. Error: %s', ks, cf, exc)
             return False
 
@@ -105,7 +105,7 @@ def verify_query_by_index_works(session, ks, cf, column) -> None:
         query = SimpleStatement(f'SELECT * FROM {ks}.{cf} WHERE "{column}" = %s LIMIT 100', fetch_size=100)
         LOGGER.debug("Verifying query by index works: %s", query)
         result = session.execute(query, parameters=(value,))
-    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         InfoEvent(message=f"Index {ks}.{cf}({column}) does not work in query: {query}. Reason: {exc}",
                   severity=Severity.ERROR).publish()
     if len(list(result)) == 0:

--- a/sdcm/utils/operations_thread.py
+++ b/sdcm/utils/operations_thread.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from sdcm.cluster import BaseScyllaCluster, BaseCluster
 
 
-# pylint: disable=too-many-instance-attributes
 @dataclass
 class ConfigParams:
     mode: Literal['random', 'table', 'partition', 'aggregate', 'table_and_aggregate']
@@ -95,8 +94,6 @@ class OneOperationStat:
     success: bool = None
     cmd: str = None
 
-# pylint: disable=too-many-instance-attributes
-
 
 class OperationThread:
     """
@@ -153,7 +150,7 @@ class OperationThread:
 
             self.log.debug("Thread operations queue depleted.")
 
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             self.log.error(traceback.format_exc())
             self.log.error("Encountered exception while performing a operation:\n%s", exc)
 

--- a/sdcm/utils/operator/multitenant_common.py
+++ b/sdcm/utils/operator/multitenant_common.py
@@ -24,11 +24,10 @@ from sdcm.utils.database_query_utils import PartitionsValidationAttributes
 LOGGER = logging.getLogger(__name__)
 
 
-class TenantMixin:  # pylint: disable=too-many-instance-attributes
+class TenantMixin:
     _testMethodName = "runTest"
 
-    # pylint: disable=too-many-instance-attributes
-    def __init__(self, db_cluster, loaders, monitors,  # pylint: disable=too-many-arguments
+    def __init__(self, db_cluster, loaders, monitors,
                  prometheus_db, params, test_config, cluster_index):
         self.db_cluster = db_cluster
         self.loaders = loaders
@@ -55,7 +54,7 @@ class TenantMixin:  # pylint: disable=too-many-instance-attributes
     def get_str_index(self):
         return f"{self.get_str_index_prefix}-{self.db_cluster.k8s_clusters[0].tenants_number}-tenants"
 
-    def id(self):  # pylint: disable=invalid-name
+    def id(self):
         if "Longevity" in self.__class__.__name__:
             return f"{self.test_config.test_id()}-{self._test_index}"
         # NOTE: performance results should not have unique IDs to be able to be used in comparisons
@@ -68,7 +67,7 @@ class TenantMixin:  # pylint: disable=too-many-instance-attributes
         return self.__str__()
 
 
-def get_tenants(test_class_instance):  # pylint: disable=too-many-branches,too-many-locals
+def get_tenants(test_class_instance):
     parent_test_class = None
     for base in test_class_instance.__class__.__bases__:
         if base.__name__.endswith("Test"):
@@ -135,7 +134,7 @@ def get_tenants(test_class_instance):  # pylint: disable=too-many-branches,too-m
 class MultiTenantTestMixin:
     tenants = None
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         super().setUp()
         self.tenants = get_tenants(self)
 

--- a/sdcm/utils/perftune_validator.py
+++ b/sdcm/utils/perftune_validator.py
@@ -101,11 +101,11 @@ class PerftuneExecutor:
 
     def create_temp_perftune_yaml(self, yaml_dict) -> None:
         self.node.remoter.run(f"touch {TEMP_PERFTUNE_YAML_PATH}")
-        with self.node._remote_yaml(path=TEMP_PERFTUNE_YAML_PATH, sudo=False) as temp_yaml:  # pylint: disable=protected-access
+        with self.node._remote_yaml(path=TEMP_PERFTUNE_YAML_PATH, sudo=False) as temp_yaml:
             temp_yaml.update(yaml_dict)
 
 
-class PerftuneOutputChecker:  # pylint: disable=too-few-public-methods
+class PerftuneOutputChecker:
     def __init__(self, node):
         self.log = logging.getLogger(self.__class__.__name__)
         self.node = node
@@ -121,7 +121,7 @@ class PerftuneOutputChecker:  # pylint: disable=too-few-public-methods
         try:
             systemd_version = get_systemd_version(self.node.remoter.run(
                 "systemctl --version", ignore_status=True).stdout)
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             self.log.warning("failed to get systemd version:", exc_info=True)
         return systemd_version
 
@@ -232,7 +232,7 @@ class PerftuneOutputChecker:  # pylint: disable=too-few-public-methods
                 self.executor.create_temp_perftune_yaml(yaml_dict=option_file_dict)
                 self.compare_option_file_yaml_with_temp_yaml_copy(option_file_dict)
                 self.compare_option_file_with_overridden_irq_cpu_mask_param(option_file_dict)
-        except Exception as error:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as error:  # noqa: BLE001
             PerftuneResultEvent(
                 message=f"Unexpected error when verifying the output of Perftune: {error}",
                 severity=Severity.ERROR, trace=traceback.format_exc()).publish()

--- a/sdcm/utils/pricing.py
+++ b/sdcm/utils/pricing.py
@@ -101,7 +101,7 @@ class AWSPricing:
             return 0
 
 
-class GCEPricing:  # pylint: disable=too-few-public-methods
+class GCEPricing:
     # TODO: use https://github.com/googleapis/python-billing
     prices = {
         InstanceLifecycle.ON_DEMAND: {
@@ -252,7 +252,7 @@ class GCEPricing:  # pylint: disable=too-few-public-methods
         },
     }
 
-    def get_instance_price(self, region, instance_type, state, lifecycle):  # pylint: disable=unused-argument
+    def get_instance_price(self, region, instance_type, state, lifecycle):
         """Using us-east1 to estimate"""
         if state == "running":
             price = self.prices[lifecycle].get(instance_type, 0)
@@ -264,7 +264,7 @@ class GCEPricing:  # pylint: disable=too-few-public-methods
             return 0
 
 
-class AzurePricing:  # pylint: disable=too-few-public-methods
+class AzurePricing:
 
     def get_instance_price(self, region, instance_type, state, lifecycle):
         if state == "running":

--- a/sdcm/utils/profiler.py
+++ b/sdcm/utils/profiler.py
@@ -67,10 +67,10 @@ class ProfileableProcess(multiprocessing.Process):
             if profile:
                 profile = profile.fork()
                 profile.set_global_main_profile(profile)
-                profile.enable()  # pylint: disable=protected-access
+                profile.enable()
             original_run_method()
             if profile:
-                profile.create_stats()  # pylint: disable=protected-access
+                profile.create_stats()
         setattr(obj, 'run', modified_run)
 
     def _bind_profile(self, group_name):
@@ -96,11 +96,11 @@ class ProfileableProcess(multiprocessing.Process):
 
     @staticmethod
     def deactivate():
-        multiprocessing.Process._bootstrap_inner = REAL_PROCESS_BOOTSTRAP  # pylint: disable=protected-access
+        multiprocessing.Process._bootstrap_inner = REAL_PROCESS_BOOTSTRAP
         multiprocessing.Process.start = REAL_PROCESS_START
 
 
-REAL_PROCESS_BOOTSTRAP = multiprocessing.Process._bootstrap  # pylint: disable=protected-access
+REAL_PROCESS_BOOTSTRAP = multiprocessing.Process._bootstrap
 REAL_PROCESS_START = multiprocessing.Process.start
 
 
@@ -142,10 +142,10 @@ class ProfileableThread(threading.Thread):
         def modified_run():
             profile = getattr(obj, '_profile', None)
             if profile:
-                profile.enable()  # pylint: disable=protected-access
+                profile.enable()
             original_run_method()
             if profile:
-                profile.create_stats()  # pylint: disable=protected-access
+                profile.create_stats()
         setattr(obj, 'run', modified_run)
 
     def _bootstrap_inner(self):
@@ -155,7 +155,7 @@ class ProfileableThread(threading.Thread):
     @staticmethod
     def init_profile(obj):
         if obj.__class__.__name__ == '_DummyThread':
-            profile_group_name = multiprocessing.current_process()._name  # pylint: disable=protected-access
+            profile_group_name = multiprocessing.current_process()._name
         else:
             profile_group_name = getattr(obj, '_name', 'UnknownThread')
         ProfileableThread._bind_profile(obj, profile_group_name)
@@ -178,17 +178,17 @@ class ProfileableThread(threading.Thread):
 
     @staticmethod
     def deactivate():
-        threading.Thread._bootstrap_inner = REAL_BOOTSTRAP_INNER  # pylint: disable=protected-access
+        threading.Thread._bootstrap_inner = REAL_BOOTSTRAP_INNER
 
 
-REAL_BOOTSTRAP_INNER = threading.Thread._bootstrap_inner  # pylint: disable=protected-access
+REAL_BOOTSTRAP_INNER = threading.Thread._bootstrap_inner
 
 
 def _get_timer_from_str(timer_name):
     return TIMERS.get(timer_name, None)
 
 
-class StatsHolder:  # pylint: disable=too-few-public-methods
+class StatsHolder:
     """ A class that is designed to hold stats that could be fed to pstats.Stats
     """
 

--- a/sdcm/utils/quota.py
+++ b/sdcm/utils/quota.py
@@ -104,7 +104,7 @@ def write_data_to_reach_end_of_quota(node, quota_size):
         try:
             LOGGER.debug('Cost 90% free space on /var/lib/scylla/ by {}'.format(occupy_space_cmd))
             node.remoter.sudo(occupy_space_cmd, Verbose=True)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.warning("We should have reached the expected I/O error and quota has exceeded\n"
                            "Message: {}".format(str(exc)))
         return bool(list(quota_exceeded_appearances))

--- a/sdcm/utils/raft/__init__.py
+++ b/sdcm/utils/raft/__init__.py
@@ -185,7 +185,7 @@ class RaftFeature(RaftFeatureOperations):
         try:
             row = session.execute("select value from system.scylla_local where key = 'raft_group0_id'").one()
             return row.value
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             err_msg = f"Get group0 members failed with error: {exc}"
             LOGGER.error(err_msg)
             return ""
@@ -202,7 +202,7 @@ class RaftFeature(RaftFeatureOperations):
                 for row in rows:
                     group0_members.append({"host_id": str(row.server_id),
                                            "voter": row.can_vote})
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             err_msg = f"Get group0 members failed with error: {exc}"
             LOGGER.error(err_msg)
 
@@ -378,7 +378,7 @@ class RaftFeature(RaftFeatureOperations):
             api = RaftApi(self._node)
             result = api.read_barrier(group_id=raft_group0_id)
             LOGGER.debug("Api response %s", result)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.error("Trigger read-barrier via rest api failed %s", exc)
 
     def search_inconsistent_host_ids(self) -> list[str]:

--- a/sdcm/utils/raft/common.py
+++ b/sdcm/utils/raft/common.py
@@ -111,7 +111,7 @@ class NodeBootstrapAbortManager:
             self.bootstrap_node.parent_cluster.node_setup(self.bootstrap_node, verbose=True)
             self.bootstrap_node.parent_cluster.node_startup(self.bootstrap_node, verbose=True)
             LOGGER.debug("Node %s was bootstrapped", self.bootstrap_node.name)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.error("Setup failed for node %s with err %s", self.bootstrap_node.name, exc)
         finally:
             self._set_wait_stop_event()
@@ -130,7 +130,7 @@ class NodeBootstrapAbortManager:
                 return
             abort_action()
             LOGGER.info("Scylla was stopped successfully on node %s", self.bootstrap_node.name)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.warning("Abort was failed on node %s with error %s", self.bootstrap_node.name, exc)
         finally:
             self._set_wait_stop_event()
@@ -243,7 +243,7 @@ class NodeBootstrapAbortManager:
                 LOGGER.info("Clean node")
                 self.clean_unbootstrapped_node()
 
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.error("Scylla service restart failed: %s", exc)
             self.clean_unbootstrapped_node()
             raise BootstrapStreamErrorFailure(f"Rebootstrap failed with error: {exc}") from exc

--- a/sdcm/utils/remote_logger.py
+++ b/sdcm/utils/remote_logger.py
@@ -89,7 +89,7 @@ class SSHLoggerBase(LoggerBase):
         self._child_process.terminate()
         self._child_process.join(timeout=timeout)
         if self._child_process.is_alive():
-            self._child_process.kill()  # pylint: disable=no-member
+            self._child_process.kill()
 
     @raise_event_on_failure
     def _journal_thread(self) -> None:
@@ -113,7 +113,7 @@ class SSHLoggerBase(LoggerBase):
                 ignore_status=True,
                 log_file=self._target_log_file,
             )
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             self._log.error("Error retrieving remote node DB service log: %s", details)
 
     @cached_property
@@ -163,7 +163,7 @@ class HDRHistogramFileLogger(SSHLoggerBase):
             LOGGER.debug("Is thread shutdown?: %s, target_log_file: %s", self._thread.running(), self.target_log_file)
             self._started = False
             if self._thread.running():
-                self._thread.cancel()  # pylint: disable=no-member
+                self._thread.cancel()
 
     @cached_property
     def _logger_cmd_template(self) -> str:
@@ -303,7 +303,7 @@ class SSHGeneralFileLogger(SSHLoggerBase):
     def _is_file_exist(self, file_path: str) -> bool:
         try:
             return self._remoter.run(cmd=f"sudo test -e {file_path}", ignore_status=True).ok
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             self._log.error("Error checking if file %s exists: %s", file_path, details)
         return False
 
@@ -338,7 +338,7 @@ class CommandLoggerBase(LoggerBase):
     def _thread_body(self):
         while not self._termination_event.wait(self.restart_delay):
             try:
-                # pylint: disable=consider-using-with
+
                 self._child_process = subprocess.Popen(self._logger_cmd, shell=True)
                 started = False
                 try:
@@ -350,7 +350,7 @@ class CommandLoggerBase(LoggerBase):
                 if started:
                     # Update last time only if command successfully started
                     self._last_time_completed = time.time()
-            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 pass
 
     def start(self):
@@ -381,7 +381,7 @@ class CommandNodeLoggerBase(CommandLoggerBase, metaclass=ABCMeta):
 
 
 class DockerGeneralLogger(CommandNodeLoggerBase):
-    # pylint: disable=invalid-overridden-method
+
     @cached_property
     def _logger_cmd(self) -> str:
         return f'docker logs -f {self._node.name} >>{self._target_log_file} 2>&1'
@@ -396,10 +396,10 @@ class KubectlGeneralLogger(CommandNodeLoggerBase):
         cmd = self._node.k8s_cluster.kubectl_cmd(
             f"logs --previous=false -f --since={int(self.time_delta)}s", self._node.name, "-c",
             parent_cluster.container, namespace=parent_cluster.namespace)
-        return f"{cmd} >> {self._target_log_file} 2>&1"  # pylint: disable=protected-access
+        return f"{cmd} >> {self._target_log_file} 2>&1"
 
 
-class K8sClientLogger(LoggerBase):  # pylint: disable=too-many-instance-attributes
+class K8sClientLogger(LoggerBase):
     READ_REQUEST_TIMEOUT = 1200  # 20 minutes
     RECONNECT_DELAY = 30
     CHUNK_SIZE = 64
@@ -418,7 +418,7 @@ class K8sClientLogger(LoggerBase):  # pylint: disable=too-many-instance-attribut
         self._last_read_timestamp = None
         self._k8s_core_v1_api = KubernetesOps.core_v1_api(self._k8s_cluster.get_api_client())
         self._termination_event = ThreadEvent()
-        self._file_object = open(self._target_log_file, "a", encoding="utf-8")  # pylint: disable=consider-using-with
+        self._file_object = open(self._target_log_file, "a", encoding="utf-8")
         self._log_reader = None
         self._stream = None
         self._thread = Thread(target=self._log_loop)
@@ -565,7 +565,7 @@ class K8sClientLogger(LoggerBase):  # pylint: disable=too-many-instance-attribut
                 self._log.debug(
                     "'_read_log_line()': failed to read from pod %s log stream:%s", self._pod_name, exc)
                 self._open_stream()
-            except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 self._log.error(
                     "'_read_log_line()': failed to read from pod %s log stream:%s", self._pod_name, exc)
                 self._open_stream()
@@ -599,7 +599,7 @@ class CertManagerLogger(CommandClusterLoggerBase):
             f"logs --previous=false -f --since={int(self.time_delta)}s --all-containers=true "
             "-l app.kubernetes.io/instance=cert-manager",
             namespace="cert-manager")
-        return f"{cmd} >> {self._target_log_file} 2>&1"  # pylint: disable=protected-access
+        return f"{cmd} >> {self._target_log_file} 2>&1"
 
 
 class ScyllaManagerLogger(CommandClusterLoggerBase):
@@ -610,7 +610,7 @@ class ScyllaManagerLogger(CommandClusterLoggerBase):
         cmd = self._cluster.kubectl_cmd(
             f"logs --previous=false -f --since={int(self.time_delta)}s --all-containers=true "
             "-l app.kubernetes.io/instance=scylla-manager",
-            namespace=self._cluster._scylla_manager_namespace)  # pylint: disable=protected-access
+            namespace=self._cluster._scylla_manager_namespace)
         return f"{cmd} >> {self._target_log_file} 2>&1"
 
 
@@ -622,7 +622,7 @@ class ScyllaOperatorLogger(CommandClusterLoggerBase):
         cmd = self._cluster.kubectl_cmd(
             f"logs --previous=false -f --since={int(self.time_delta)}s --all-containers=true "
             "-l app.kubernetes.io/instance=scylla-operator",
-            namespace=self._cluster._scylla_operator_namespace)  # pylint: disable=protected-access
+            namespace=self._cluster._scylla_operator_namespace)
         return f"{cmd} >> {self._target_log_file} 2>&1"
 
 
@@ -635,7 +635,7 @@ class HaproxyIngressLogger(CommandClusterLoggerBase):
             f"logs --previous=false -f --since={int(self.time_delta)}s --all-containers=true "
             "-l app.kubernetes.io/name=haproxy-ingress",
             namespace="haproxy-controller")
-        return f"{cmd} >> {self._target_log_file} 2>&1"  # pylint: disable=protected-access
+        return f"{cmd} >> {self._target_log_file} 2>&1"
 
 
 class KubernetesWrongSchedulingLogger(CommandClusterLoggerBase):
@@ -667,7 +667,7 @@ class KubernetesWrongSchedulingLogger(CommandClusterLoggerBase):
                 else:
                     wrong_scheduled_pods_on_scylla_node.append(
                         f"{pod.metadata.name} ({pod.spec.node_name} node)")
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             self._log.warning("Failed to get pods list: %s", str(details))
 
         if not wrong_scheduled_pods_on_scylla_node:
@@ -678,7 +678,7 @@ class KubernetesWrongSchedulingLogger(CommandClusterLoggerBase):
         return f"echo \"I`date -u +\"%m%d %H:%M:%S\"`              {message}\" >> {self._target_log_file} 2>&1"
 
 
-def get_system_logging_thread(logs_transport, node, target_log_file):  # pylint: disable=too-many-return-statements  # noqa: PLR0911
+def get_system_logging_thread(logs_transport, node, target_log_file):  # noqa: PLR0911
     if logs_transport == 'docker':
         return DockerGeneralLogger(node, target_log_file)
     if logs_transport == 'kubectl':
@@ -699,8 +699,8 @@ def get_system_logging_thread(logs_transport, node, target_log_file):  # pylint:
     return None
 
 
-class DockerComposeLogger(CommandClusterLoggerBase):  # pylint: disable=too-few-public-methods
-    # pylint: disable=invalid-overridden-method
+class DockerComposeLogger(CommandClusterLoggerBase):
+
     @cached_property
     def _logger_cmd(self) -> str:
         return f"{self._cluster.compose_context} logs --no-color --tail=1000 >>{self._target_log_file}"

--- a/sdcm/utils/replication_strategy_utils.py
+++ b/sdcm/utils/replication_strategy_utils.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
-class ReplicationStrategy:  # pylint: disable=too-few-public-methods
+class ReplicationStrategy:
 
     @classmethod
     def from_string(cls, replication_string):
@@ -47,7 +47,7 @@ class ReplicationStrategy:  # pylint: disable=too-few-public-methods
             session.execute(cql, timeout=300)
 
     @property
-    def replication_factors(self) -> list:  # pylint: disable=no-self-use
+    def replication_factors(self) -> list:
         return [0]
 
 
@@ -99,7 +99,7 @@ class LocalReplicationStrategy(ReplicationStrategy):
 replication_strategies = [SimpleReplicationStrategy, NetworkTopologyReplicationStrategy, LocalReplicationStrategy]
 
 
-class temporary_replication_strategy_setter(ContextDecorator):  # pylint: disable=invalid-name
+class temporary_replication_strategy_setter(ContextDecorator):
     """Context manager that allows to set replication strategy
      and preserves all modified keyspaces for automatic rollback on exit."""
 

--- a/sdcm/utils/resources_cleanup.py
+++ b/sdcm/utils/resources_cleanup.py
@@ -559,6 +559,6 @@ def clean_placement_groups_aws(tags_dict: dict, regions=None, dry_run=False):
                 try:
                     response = client.delete_placement_group(GroupName=name)
                     LOGGER.info("Placement group deleted: %s\n", response)
-                except Exception as ex:  # pylint: disable=broad-except
+                except Exception as ex:
                     LOGGER.debug("Failed to delete placement group: %s", str(ex))
                     raise

--- a/sdcm/utils/s3_remote_uploader.py
+++ b/sdcm/utils/s3_remote_uploader.py
@@ -17,7 +17,7 @@ from typing import List
 
 import boto3
 from botocore.response import StreamingBody
-from ssh2.session import Session  # pylint: disable=no-name-in-module
+from ssh2.session import Session
 
 LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ LOGGER = logging.getLogger(__name__)
 class SshOutAsFile(StreamingBody):
     """Wraps channel stream around file-like object for use by s3.upload_fileobj"""
 
-    def __init__(self, channel):  # pylint: disable=super-init-not-called
+    def __init__(self, channel):
         self._chan = channel
 
     def read(self, amt=1024):
@@ -43,7 +43,7 @@ class SshOutAsFile(StreamingBody):
         return True
 
 
-def upload_remote_files_directly_to_s3(ssh_info: dict[str, str], files: List[str],  # pylint: disable=too-many-arguments
+def upload_remote_files_directly_to_s3(ssh_info: dict[str, str], files: List[str],
                                        s3_bucket: str, s3_key: str, max_size_gb: int = 80, public_read_acl: bool = False):
     """Streams given remote files/directories straight to S3 as tar.gz file. Returns download link."""
 

--- a/sdcm/utils/scylla_metrics_ctrl.py
+++ b/sdcm/utils/scylla_metrics_ctrl.py
@@ -3,10 +3,10 @@ from typing import Literal
 from sdcm.cluster import BaseNode
 
 
-class ScyllaMetricsController:  # pylint: disable=too-few-public-methods
+class ScyllaMetricsController:
     """Class to control Scylla metrics using API. Ref: https://github.com/scylladb/scylladb/pull/12670
     issue about missing docs: https://github.com/scylladb/scylla-monitoring/issues/2196"""
-    curl_cmd = "curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json'"  # pylint: disable=line-too-long
+    curl_cmd = "curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json'"
     endpoint = "http://localhost:10000/v2/metrics-config/"
 
     @classmethod

--- a/sdcm/utils/sstable/load_utils.py
+++ b/sdcm/utils/sstable/load_utils.py
@@ -57,7 +57,6 @@ class SstableLoadUtils:
         return map_files_to_node
 
     @staticmethod
-    # pylint: disable=too-many-arguments,too-many-locals
     def upload_sstables(node, test_data: TestDataInventory, keyspace_name: str = 'keyspace1', table_name=None,
                         create_schema: bool = False, is_cloud_cluster=False, **kwargs):
         key_store = KeyStore()
@@ -106,7 +105,7 @@ class SstableLoadUtils:
         node.remoter.sudo(f'rm -f {table_folder}/upload/manifest.json')
 
     @classmethod
-    def run_load_and_stream(cls, node,  # pylint: disable=too-many-arguments
+    def run_load_and_stream(cls, node,
                             keyspace_name: str = 'keyspace1', table_name: str = 'standard1',
                             start_timeout=60, end_timeout=300):
         """runs load and stream using API request and waits for it to finish"""

--- a/sdcm/utils/sstable/s3_uploader.py
+++ b/sdcm/utils/sstable/s3_uploader.py
@@ -31,7 +31,7 @@ def upload_sstables_to_s3(node: CollectingNode | BaseNode, keyspace: str, test_i
         if s3_link:
             LOGGER.info("Successfully uploaded sstables on node %s for keyspace %s", node.name, keyspace)
         node.remoter.run(f"nodetool clearsnapshot -t {snapshot_tag} {keyspace}")
-    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         LOGGER.warning("Error while getting and uploading sstables: %s", exc, exc_info=exc)
         s3_link = ""
     return s3_link

--- a/sdcm/utils/sstable/sstable_utils.py
+++ b/sdcm/utils/sstable/sstable_utils.py
@@ -21,7 +21,6 @@ class SstableUtils:
     """
 
     REMOTE_SSTABLEDUMP_PATH = "/tmp/sstabledump.json"
-    # pylint: disable=too-many-instance-attributes
 
     def __init__(self, propagation_delay_in_seconds: int = 0, ks_cf: str = None,
                  db_node: 'BaseNode' = None,  # noqa: F821
@@ -59,7 +58,7 @@ class SstableUtils:
         self.log.debug('Got %s sstables %s', len(selected_sstables), message)
         return selected_sstables
 
-    def check_that_sstables_are_encrypted(self, sstables=None,  # pylint: disable=too-many-branches
+    def check_that_sstables_are_encrypted(self, sstables=None,
                                           expected_bool_value: bool = True) -> list:
 
         if not sstables:
@@ -192,7 +191,7 @@ class SstableUtils:
                 self.log.debug('Number of rows in repair_time results: %d', output_length)
                 self.log.debug('Last row in repair_time results: %s', output[-1])
                 return str(output[-1].repair_time)
-            except Exception as exc:  # pylint: disable=broad-except
+            except Exception as exc:
                 self.log.error('Failed to get repair date of %s.%s. Error: %s', self.keyspace, self.table, exc)
                 raise
 

--- a/sdcm/utils/syslogng.py
+++ b/sdcm/utils/syslogng.py
@@ -28,7 +28,7 @@ SYSLOGNG_PORT = 49153  # Non-root
 LOGGER = logging.getLogger(__name__)
 
 
-class SyslogNGContainerMixin:  # pylint: disable=too-few-public-methods
+class SyslogNGContainerMixin:
     @cached_property
     def syslogng_confpath(self) -> str:
         return generate_syslogng_conf_file()

--- a/sdcm/utils/tablets/common.py
+++ b/sdcm/utils/tablets/common.py
@@ -48,6 +48,6 @@ def wait_no_tablets_migration_running(node, timeout: int = 3600):
             client.run_remoter_curl(method="POST", path="storage_service/quiesce_topology",
                                     params={}, timeout=4*3600)
         LOGGER.info("All ongoing tablets topology operations are done")
-    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         InfoEvent(f"Failed to wait for having no ongoing tablets topology operations. Exception: {exc.__repr__()}",
                   severity=Severity.ERROR).publish()

--- a/sdcm/utils/threads_and_processes_alive.py
+++ b/sdcm/utils/threads_and_processes_alive.py
@@ -10,9 +10,9 @@ from typing import Any
 LOGGER = logging.getLogger(__name__)
 
 
-def get_thread_stacktrace(thread):  # pylint: disable=no-self-use
+def get_thread_stacktrace(thread):
     try:
-        frame = sys._current_frames().get(thread.ident, None)  # pylint: disable=protected-access
+        frame = sys._current_frames().get(thread.ident, None)
         output = []
         for filename, lineno, name, line in traceback.extract_stack(frame):
             output.append('File: "%s", line %d, in %s' % (filename,
@@ -20,7 +20,7 @@ def get_thread_stacktrace(thread):  # pylint: disable=no-self-use
             if line:
                 output.append("  %s" % (line.strip()))
         return '\n'.join(output)
-    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         LOGGER.error('Failed to get stack trace due to the: %s', exc)
         return 'FAILED TO GET STACKTRACE'
 
@@ -28,7 +28,7 @@ def get_thread_stacktrace(thread):  # pylint: disable=no-self-use
 def get_source(source: Any):
     try:
         return inspect.getsource(source)
-    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         LOGGER.error('Failed to source due to the: %s', exc)
         return 'NO SOURCE AVAILABLE'
 
@@ -50,8 +50,8 @@ def gather_live_threads_and_dump_to_file(dump_file_path: str) -> bool:
                     module = thread.run.__module__
                     source = get_source(thread.run)
                 elif getattr(thread, '_target', None):
-                    module = thread._target.__module__  # pylint: disable=protected-access
-                    source = get_source(thread._target)  # pylint: disable=protected-access
+                    module = thread._target.__module__
+                    source = get_source(thread._target)
             else:
                 module = thread.__module__
                 source = get_source(thread.__class__)

--- a/sdcm/utils/toppartition_util.py
+++ b/sdcm/utils/toppartition_util.py
@@ -65,7 +65,7 @@ class TopPartitionCmd(ABC):
         Returns:
             dict -- result of parsing
         """
-        pattern1 = r"(?P<sampler>[A-Z]+)\sSampler:\W+Cardinality:\s~(?P<cardinality>[0-9]+)\s\((?P<capacity>[0-9]+)\scapacity\)\W+Top\s(?P<toppartitions>[0-9]+)\spartitions:"  # pylint: disable=line-too-long
+        pattern1 = r"(?P<sampler>[A-Z]+)\sSampler:\W+Cardinality:\s~(?P<cardinality>[0-9]+)\s\((?P<capacity>[0-9]+)\scapacity\)\W+Top\s(?P<toppartitions>[0-9]+)\spartitions:"
         pattern2 = r"(?P<partition>\([\w:]+\)\s[\w:]+)\s+(?P<count>[\d]+)\s+(?P<margin>[\d]+)"
         toppartitions = {}
         for out in output.strip().split('\n\n'):

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -516,7 +516,6 @@ def resolve_latest_repo_symlink(url: str) -> str:
 
     Can raise ValueError if `url' is not a valid URL that points to a repo file stored in S3.
     """
-    # pylint: disable=too-many-branches
     base, sep, rest = url.partition(LATEST_SYMLINK_NAME)
     if sep != LATEST_SYMLINK_NAME:
         LOGGER.debug("%s doesn't contain `%s' substring, use URL as is", url, LATEST_SYMLINK_NAME)
@@ -657,7 +656,7 @@ class MethodVersionNotFound(Exception):
     pass
 
 
-class scylla_versions:  # pylint: disable=invalid-name,too-few-public-methods
+class scylla_versions:
     """Runs a versioned method that is suitable for the configured scylla version.
 
     Limitations:
@@ -738,7 +737,7 @@ def get_relocatable_pkg_url(scylla_version: str) -> str:
             get_pkgs_cmd = f'curl -s -X POST http://backtrace.scylladb.com/index.html -d "build_id={scylla_build_id}&backtrace="'
             res = LOCALRUNNER.run(get_pkgs_cmd)
             relocatable_pkg = re.findall(fr"{scylla_build_id}.+(http:[/\w.:-]*\.tar\.gz)", res.stdout)[0]
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.warning("Couldn't get relocatable_pkg link due to: %s", exc)
     return relocatable_pkg
 
@@ -815,7 +814,6 @@ def find_scylla_repo(scylla_version, dist_type='centos', dist_version=None):
 
     repo_map = get_s3_scylla_repos_mapping(dist_type, dist_version)
 
-    # pylint: disable=useless-else-on-loop
     for key in repo_map:
         if scylla_version.startswith(key):
             return repo_map[key]

--- a/sdcm/wait.py
+++ b/sdcm/wait.py
@@ -26,10 +26,10 @@ from sdcm.exceptions import WaitForTimeoutError, ExitByEventError
 
 LOGGER = logging.getLogger("sdcm.wait")
 
-R = TypeVar("R")  # pylint: disable=invalid-name
+R = TypeVar("R")
 
 
-def wait_for(func, step=1, text=None, timeout=None, throw_exc=True, stop_event=None, **kwargs):  # pylint: disable=too-many-arguments
+def wait_for(func, step=1, text=None, timeout=None, throw_exc=True, stop_event=None, **kwargs):
     """
     Wrapper function to wait with timeout option.
 
@@ -48,7 +48,7 @@ def wait_for(func, step=1, text=None, timeout=None, throw_exc=True, stop_event=N
     res = None
 
     def retry_logger(retry_state):
-        # pylint: disable=protected-access
+
         LOGGER.debug(
             'wait_for: Retrying %s: attempt %s ended with: %s',
             text or retry_state.fn.__name__,
@@ -69,7 +69,7 @@ def wait_for(func, step=1, text=None, timeout=None, throw_exc=True, stop_event=N
         )
         res = retry(func, **kwargs)
 
-    except Exception as ex:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as ex:  # noqa: BLE001
         err = f"Wait for: {text or func.__name__}: timeout - {timeout} seconds - expired"
         raising_exc = WaitForTimeoutError(err)
         if stop_event and stop_event.is_set():
@@ -77,12 +77,12 @@ def wait_for(func, step=1, text=None, timeout=None, throw_exc=True, stop_event=N
             raising_exc = ExitByEventError(err)
 
         LOGGER.error(err)
-        if hasattr(ex, 'last_attempt') and ex.last_attempt.exception() is not None:  # pylint: disable=no-member
-            LOGGER.error("last error: %r", ex.last_attempt.exception())  # pylint: disable=no-member
+        if hasattr(ex, 'last_attempt') and ex.last_attempt.exception() is not None:
+            LOGGER.error("last error: %r", ex.last_attempt.exception())
         else:
             LOGGER.error("last error: %r", ex)
         if throw_exc:
-            if hasattr(ex, 'last_attempt') and not ex.last_attempt._result:  # pylint: disable=protected-access,no-member
+            if hasattr(ex, 'last_attempt') and not ex.last_attempt._result:
                 raise raising_exc from ex
             raise
 

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -67,7 +67,6 @@ class YcsbStatsPublisher(FileFollowerThread):
             self.set_metric('verify', stat['status'], float(stat['value']))
 
     def run(self):
-        # pylint: disable=too-many-nested-blocks
 
         # 729.39 current ops/sec;
         # [READ: Count=510, Max=195327, Min=2011, Avg=4598.69, 90=5743, 99=12583, 99.9=194815, 99.99=195327]
@@ -108,15 +107,15 @@ class YcsbStatsPublisher(FileFollowerThread):
                                         value = float(0)  # noqa: PLW2901
                                 self.set_metric(operation, key, float(value))
 
-                except Exception:  # pylint: disable=broad-except
+                except Exception:
                     LOGGER.exception("fail to send metric")
 
 
-class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes
+class YcsbStressThread(DockerBasedStressThread):
 
     DOCKER_IMAGE_PARAM_NAME = "stress_image.ycsb"
 
-    def copy_template(self, cmd_runner, loader_name, memo={}):  # pylint: disable=dangerous-default-value,too-many-branches  # noqa: B006
+    def copy_template(self, cmd_runner, loader_name, memo={}):  # noqa: B006
         if loader_name in memo:
             return None
         web_protocol = "http"
@@ -243,7 +242,7 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
         output = {k: str(v) for k, v in output.items()}
         return output
 
-    def _run_stress(self, loader, loader_idx, cpu_idx):  # pylint: disable=too-many-locals
+    def _run_stress(self, loader, loader_idx, cpu_idx):
         if "k8s" in self.params.get("cluster_backend"):
             cmd_runner = loader.remoter
             cmd_runner_name = loader.name
@@ -279,7 +278,7 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
             loader.logdir, 'ycsb-l%s-c%s-%s.log' % (loader_idx, cpu_idx, uuid.uuid4()))
         LOGGER.debug('ycsb-stress local log: %s', log_file_name)
 
-        def raise_event_callback(sentinel, line):  # pylint: disable=unused-argument
+        def raise_event_callback(sentinel, line):
             if line:
                 YcsbStressEvent.error(node=cmd_runner_name, stress_cmd=stress_cmd, errors=[line, ]).publish()
 

--- a/sla_per_user_system_test.py
+++ b/sla_per_user_system_test.py
@@ -26,7 +26,6 @@ from test_lib.sla import ServiceLevel, Role, User
 from sdcm.utils.features import is_tablets_feature_enabled
 
 
-# pylint: disable=too-many-public-methods
 class SlaPerUserTest(LongevityTest):
     """
     Test SLA per user feature using cassandra-stress.
@@ -190,7 +189,7 @@ class SlaPerUserTest(LongevityTest):
         return None
 
     @staticmethod
-    def calculate_metrics_ratio_per_user(two_users_list, metrics=None):  # pylint: disable=invalid-name
+    def calculate_metrics_ratio_per_user(two_users_list, metrics=None):
         """
         :param metrics: calculate ratio for specific Scylla or cassandra-stress metrics (ops, scheduler_runtime etc..).
                         If metrics name is not defined - ration will be calculated for service_shares
@@ -254,7 +253,7 @@ class SlaPerUserTest(LongevityTest):
 
         return results
 
-    def validate_if_scylla_load_high_enough(self, start_time, wait_cpu_utilization):  # pylint: disable=invalid-name
+    def validate_if_scylla_load_high_enough(self, start_time, wait_cpu_utilization):
         end_time = int(time.time())
         scylla_load = self.prometheus_stats.get_scylla_reactor_utilization(start_time=start_time, end_time=end_time)
 
@@ -290,7 +289,6 @@ class SlaPerUserTest(LongevityTest):
                      ]
         self.run_stress_and_verify_threads(params={'stress_cmd': read_cmds})
 
-    # pylint: disable=too-many-arguments, too-many-locals
     def define_read_cassandra_stress_command(self,
                                              role: Role, load_type: str,
                                              c_s_workload_type: str,
@@ -308,23 +306,23 @@ class SlaPerUserTest(LongevityTest):
         def latency():
             return '%d throttle=%d/s' % (threads, throttle)
 
-        def throughput():  # pylint: disable=unused-variable
+        def throughput():
             return threads
 
-        def cache_only(max_rows_for_read):  # pylint: disable=unused-variable
+        def cache_only(max_rows_for_read):
             if not max_rows_for_read:
                 max_rows_for_read = int(self.num_of_partitions * 0.3)
             return 'seq=1..%d' % max_rows_for_read
 
         # Read from cache and disk
-        def mixed(max_rows_for_read):  # pylint: disable=unused-variable
+        def mixed(max_rows_for_read):
             if not max_rows_for_read:
                 max_rows_for_read = self.num_of_partitions
             return "'dist=gauss(1..%d, %d, %d)'" % (max_rows_for_read,
                                                     int(max_rows_for_read / 2),
                                                     int(max_rows_for_read * 0.05))
 
-        def disk_only(max_rows_for_read):  # pylint: disable=unused-variable
+        def disk_only(max_rows_for_read):
             if not max_rows_for_read:
                 max_rows_for_read = int(self.num_of_partitions * 0.3)
             return 'seq=%d..%d' % (max_rows_for_read, max_rows_for_read+int(self.num_of_partitions*0.25))
@@ -438,7 +436,7 @@ class SlaPerUserTest(LongevityTest):
         finally:
             self.clean_auth(entities_list_of_dict=read_users)
 
-    def test_read_throughput_vs_latency_cache_and_disk(self):  # pylint: disable=invalid-name
+    def test_read_throughput_vs_latency_cache_and_disk(self):
         """
         Test when one user run load with high latency and another  - with high througput
         The load is run on the full data set (that is read from both the cache and the disk)
@@ -503,7 +501,7 @@ class SlaPerUserTest(LongevityTest):
         self._throughput_latency_tests_run(read_users=read_users, read_cmds=read_cmds,
                                            latency_user=read_users[1], improvement_expected=improvement_expected)
 
-    def test_read_throughput_vs_latency_cache_only(self):  # pylint: disable=invalid-name
+    def test_read_throughput_vs_latency_cache_only(self):
         """
         Test when one user run load with high latency and another  - with high througput
         The load is run on the data set that fully exists in the cache
@@ -569,7 +567,7 @@ class SlaPerUserTest(LongevityTest):
         self._throughput_latency_tests_run(read_users=read_users, read_cmds=read_cmds,
                                            latency_user=read_users[1], improvement_expected=improvement_expected)
 
-    def test_read_throughput_vs_latency_disk_only(self):  # pylint: disable=invalid-name
+    def test_read_throughput_vs_latency_disk_only(self):
         """
         Test when one user run load with high latency and another  - with high througput
         The load is run on the data set that fully exists in the cache
@@ -717,7 +715,6 @@ class SlaPerUserTest(LongevityTest):
                                            latency_user=read_users[1], improvement_expected=improvement_expected)
 
     def _throughput_latency_tests_run(self, read_cmds, read_users, latency_user, improvement_expected):
-        # pylint: disable=too-many-locals
 
         # Wait that service levels are propagated to all nodes
         time.sleep(10)
@@ -898,7 +895,7 @@ class SlaPerUserTest(LongevityTest):
 
         try:
             email_data = self._get_common_email_data()
-        except Exception as error:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as error:  # noqa: BLE001
             self.log.error("Error in gathering common email data: Error:\n%s", error)
 
         email_data.update({
@@ -909,7 +906,6 @@ class SlaPerUserTest(LongevityTest):
 
         return email_data
 
-    # pylint: disable=inconsistent-return-statements
     def get_test_status(self) -> str:
         if self._comparison_results:
             try:

--- a/snitch_test.py
+++ b/snitch_test.py
@@ -30,7 +30,6 @@ class SnitchTest(ClusterTester):
         assert 'GoogleCloudSnitch' in result.stdout, "Cluster doesn't use GoogleCloudSnitch"
 
         with self.db_cluster.cql_connection_patient_exclusive(self.db_cluster.nodes[0]) as session:
-            # pylint: disable=no-member
             result = list(session.execute('select * from system.peers'))
 
         self.log.debug(result)

--- a/stop_compaction_test.py
+++ b/stop_compaction_test.py
@@ -38,7 +38,7 @@ def record_sub_test_result(func: Callable):
         try:
             func(*args, **kwargs)
             return {test_name: ["SUCCESS", []]}
-        except Exception as exc:  # pylint:disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.error(exc)
             return {test_name: ["FAILURE", [exc]]}
     return wrapper
@@ -243,7 +243,7 @@ class StopCompactionTest(ClusterTester):
             ParallelObject(objects=[trigger_func, watch_func], timeout=timeout).call_objects()
             self._grep_log_and_assert(self.node)
             self.test_statuses.update({"StartStopUpgradeCompaction": ["SUCCESS", []]})
-        except self.failureException as exc:  # pylint:disable=broad-except
+        except self.failureException as exc:
             self.test_statuses.update({"StartStopUpgradeCompaction": ["FAILURE", [exc]]})
             raise exc
         finally:
@@ -316,7 +316,7 @@ class StopCompactionTest(ClusterTester):
         try:
             ParallelObject(objects=[trigger_func, watch_func], timeout=timeout).call_objects()
             self.test_statuses.update({"StartStopReshapeCompaction": ["SUCCESS", []]})
-        except self.failureException as exc:  # pylint:disable=broad-except
+        except self.failureException as exc:
             self.test_statuses.update({"StartStopReshapeCompaction": ["FAILURE", [exc]]})
             raise exc
         finally:
@@ -375,7 +375,7 @@ class StopCompactionTest(ClusterTester):
 
         try:
             email_data = self._get_common_email_data()
-        except Exception as error:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as error:  # noqa: BLE001
             self.log.error("Error in gathering common email data: Error:\n%s", error)
 
         email_data.update({"test_statuses": self.test_statuses,

--- a/test_add_remove_ldap_role_permission.py
+++ b/test_add_remove_ldap_role_permission.py
@@ -11,7 +11,7 @@ from sdcm.utils.ldap import LdapServerType, LDAP_USERS, LDAP_PASSWORD, LdapUtils
 
 class AddRemoveLdapRolePermissionTest(LongevityTest, LdapUtilsMixin):
 
-    def test_add_remove_ldap_role_permission(self):  # pylint: disable=too-many-statements
+    def test_add_remove_ldap_role_permission(self):
         """
         Test adding a new user with Ldap permissions,
         and run some load for it.

--- a/test_lib/cql_types.py
+++ b/test_lib/cql_types.py
@@ -33,7 +33,7 @@ class CQLTypeBuilder:
         return target_class(self_type, *args, **kwargs)
 
     @classmethod
-    def get_random(cls, already_created_info: dict, avoid_types: list = None,  # pylint: disable=too-many-arguments
+    def get_random(cls, already_created_info: dict, avoid_types: list = None,
                    allow_levels: int = 1, allowed_types: list = None, forget_on_exhaust=False) -> 'CQLColumnType':
         return CQLColumnType.get_random(
             already_created_info,
@@ -50,7 +50,7 @@ class CQLColumnType:
     def __init_subclass__(cls, **__):
         if cls.self_type is None:
             raise ValueError(f"<{str(cls)}> self_type should be defined")
-        CQLTypeBuilder._register_class(cls)  # pylint: disable=protected-access
+        CQLTypeBuilder._register_class(cls)
 
     def __init__(self, self_type=None):
         self.self_type = self_type
@@ -71,7 +71,7 @@ class CQLColumnType:
         return [e for e in allowed_types if e not in excluded_types]
 
     @classmethod
-    def get_random(cls, already_created_info: dict, avoid_types: list = None,  # pylint: disable=too-many-arguments
+    def get_random(cls, already_created_info: dict, avoid_types: list = None,
                    allow_levels: int = 1, allowed_types: list = None, forget_on_exhaust=False):
         """
         Randomly generates CQLColumnType instance
@@ -85,7 +85,7 @@ class CQLColumnType:
         return:
             Will return randomly generated instance of CQLColumnType
         """
-        # pylint: disable=protected-access
+
         while True:
             calculated_available_types = cls._get_available_variants(already_created_info, avoid_types, allowed_types,
                                                                      allow_levels)
@@ -93,7 +93,7 @@ class CQLColumnType:
                 self_type = random.choice(calculated_available_types)
                 self_bucket = already_created_info.get(self_type, {})
                 instance = CQLTypeBuilder._create_instance(self_type)
-                if instance._get_random_embedded(self_bucket, avoid_types, allow_levels,  # pylint: disable=protected-access
+                if instance._get_random_embedded(self_bucket, avoid_types, allow_levels,
                                                  allowed_types):
                     return instance
                 #  It could reach this point only if collection type ran out of choice for subtypes
@@ -103,8 +103,8 @@ class CQLColumnType:
                 return None
             already_created_info.clear()
 
-    def _get_random_embedded(self,  # pylint: disable=no-self-use
-                             already_created_info: dict, avoid_types: list, allow_levels: int, allowed_types: list):  # pylint: disable=unused-argument
+    def _get_random_embedded(self,
+                             already_created_info: dict, avoid_types: list, allow_levels: int, allowed_types: list):
         return True
 
     def remember_variant(self, stored_variants):
@@ -128,7 +128,6 @@ class CQLColumnType:
 
 class CQLColumnTypeMap(CQLColumnType):
     self_type = 'map'
-    # pylint: disable=unused-argument
 
     def __new__(cls, self_type=None, key_type=None, value_type=None):
         return super().__new__(cls)
@@ -200,7 +199,7 @@ class CQLColumnTypeMap(CQLColumnType):
 class CQLColumnTypeList(CQLColumnType):
     self_type = 'list'
 
-    def __new__(cls, self_type=None, element_type=None):  # pylint: disable=unused-argument
+    def __new__(cls, self_type=None, element_type=None):
         return super().__new__(cls)
 
     def __init__(self, self_type=None, element_type=None):

--- a/test_lib/sla.py
+++ b/test_lib/sla.py
@@ -59,10 +59,9 @@ class ServiceLevelAttributes:
         self.query_string = "".join(attr_strings)
 
 
-# pylint: disable=too-many-instance-attributes
 class ServiceLevel:
     # The class provide interface to manage SERVICE LEVEL
-    # pylint: disable=too-many-arguments
+
     def __init__(self, session,
                  name: str,
                  shares: Optional[int] = 1000,
@@ -197,8 +196,6 @@ class ServiceLevel:
         for res in res_list:
             output.append(ServiceLevel.from_row(self.session, res))
         return output
-
-# pylint: disable=too-many-arguments, too-many-instance-attributes, unused-argument
 
 
 class UserRoleBase:

--- a/test_lib/utils.py
+++ b/test_lib/utils.py
@@ -3,11 +3,11 @@ import functools
 import collections
 
 
-class __DEFAULT__:  # pylint: disable=invalid-name,too-few-public-methods
+class __DEFAULT__:
     pass
 
 
-class __DEFAULT2__:  # pylint: disable=invalid-name,too-few-public-methods
+class __DEFAULT2__:
     pass
 
 

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -57,7 +57,7 @@ def prom_address():
 
 
 @pytest.fixture(name='docker_scylla', scope='function')
-def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # pylint: disable=too-many-locals
+def fixture_docker_scylla(request: pytest.FixtureRequest, params):
     docker_scylla_args = {}
     if test_marker := request.node.get_closest_marker("docker_scylla_args"):
         docker_scylla_args = test_marker.kwargs
@@ -107,14 +107,14 @@ def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # pylint: di
     def db_up():
         try:
             return scylla.is_port_used(port=BaseNode.CQL_PORT, service_name="scylla-server")
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             logging.error("Error checking for scylla up normal: %s", details)
             return False
 
     def db_alternator_up():
         try:
             return scylla.is_port_used(port=ALTERNATOR_PORT, service_name="scylla-server")
-        except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as details:  # noqa: BLE001
             logging.error("Error checking for scylla up normal: %s", details)
             return False
 
@@ -133,12 +133,12 @@ def fake_remoter():
 
 
 @pytest.fixture(scope='session', autouse=True)
-def fake_provisioner():  # pylint: disable=no-self-use
+def fake_provisioner():
     provisioner_factory.register_provisioner(backend="fake", provisioner_class=FakeProvisioner)
 
 
 @pytest.fixture(scope='session', autouse=True)
-def fake_region_definition_builder():  # pylint: disable=no-self-use
+def fake_region_definition_builder():
     region_definition_builder.register_builder(backend="fake", builder_class=FakeDefinitionBuilder)
 
 
@@ -149,7 +149,7 @@ def fixture_params(request: pytest.FixtureRequest):
         os.environ['SCT_CONFIG_FILES'] = config_files
 
     os.environ['SCT_CLUSTER_BACKEND'] = 'docker'
-    params = sct_config.SCTConfiguration()  # pylint: disable=attribute-defined-outside-init
+    params = sct_config.SCTConfiguration()
     params.update(dict(
         authenticator='PasswordAuthenticator',
         authenticator_user='cassandra',

--- a/unit_tests/dummy_remote.py
+++ b/unit_tests/dummy_remote.py
@@ -11,7 +11,6 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
-# pylint: disable=too-few-public-methods
 
 import os
 import shutil
@@ -46,7 +45,7 @@ class DummyRemote:
 
 
 class LocalNode(BaseNode):
-    # pylint: disable=too-many-arguments
+
     def __init__(self, name, parent_cluster, ssh_login_info=None, base_logdir=None, node_prefix=None, dc_idx=0, node_index=1):
         super().__init__(name, parent_cluster)
         self.node_index = node_index
@@ -92,7 +91,7 @@ class LocalNode(BaseNode):
 
 
 class LocalLoaderSetDummy(BaseCluster):
-    # pylint: disable=super-init-not-called,abstract-method
+
     def __init__(self, nodes=None, params=None):
         self.name = "LocalLoaderSetDummy"
         self.params = params or {}
@@ -114,7 +113,7 @@ class LocalLoaderSetDummy(BaseCluster):
 
 
 class LocalScyllaClusterDummy(BaseScyllaCluster, BaseCluster):
-    # pylint: disable=super-init-not-called
+
     def __init__(self, params=None):
         self.name = "LocalScyllaClusterDummy"
         self.params = params or {}

--- a/unit_tests/lib/data_pickle.py
+++ b/unit_tests/lib/data_pickle.py
@@ -16,7 +16,6 @@ import json
 import enum
 
 
-# pylint: disable=too-few-public-methods
 class DefaultValue:
     pass
 

--- a/unit_tests/lib/events_utils.py
+++ b/unit_tests/lib/events_utils.py
@@ -56,7 +56,7 @@ class EventsUtilsMixin:
         shutil.rmtree(cls.temp_dir)
 
     @contextmanager
-    def wait_for_n_events(self, subscriber, count: int, timeout: float = 1,  # pylint: disable=no-self-use
+    def wait_for_n_events(self, subscriber, count: int, timeout: float = 1,
                           last_event_processing_delay: float = 1):
         last_event_n = subscriber.events_counter + count
         end_time = time.perf_counter() + timeout

--- a/unit_tests/lib/fake_provisioner.py
+++ b/unit_tests/lib/fake_provisioner.py
@@ -76,8 +76,8 @@ class FakeProvisioner(Provisioner):
 
     def run_command(self, name: str, command: str) -> Result:
         """Runs command on instance."""
-        return subprocess.run(command, shell=True, capture_output=True, text=True, check=False)  # pylint: disable=subprocess-run-check
+        return subprocess.run(command, shell=True, capture_output=True, text=True, check=False)
 
     @classmethod
-    def discover_regions(cls, test_id: str, **kwargs) -> List[Provisioner]:  # pylint: disable=unused-argument
+    def discover_regions(cls, test_id: str, **kwargs) -> List[Provisioner]:
         return list(cls._provisioners.get(test_id, {}).values())

--- a/unit_tests/lib/fake_remoter.py
+++ b/unit_tests/lib/fake_remoter.py
@@ -24,7 +24,7 @@ class FakeRemoter(RemoteCmdRunnerBase):
 
     result_map: Dict[Pattern, Result] = {}
 
-    def run(self,  # pylint: disable=too-many-arguments
+    def run(self,
             cmd: str,
             timeout=None,
             ignore_status=False,

--- a/unit_tests/lib/mock_remoter.py
+++ b/unit_tests/lib/mock_remoter.py
@@ -37,17 +37,16 @@ class MockRemoter:
         elif isinstance(responses, dict):
             self.responses = responses
 
-    def is_up(self, timeout=None):  # pylint: disable=unused-argument,no-self-use
+    def is_up(self, timeout=None):
         return True
 
-    def _process_response(self, response):  # pylint: disable=no-self-use
+    def _process_response(self, response):
         if isinstance(response, Result):
             return response
         elif isinstance(response, Exception):
             raise response
         return None
 
-    # pylint: disable=too-many-arguments,unused-argument
     def run(self, cmd: str, timeout: Optional[float] = None,
             ignore_status: bool = False, verbose: bool = True, new_session: bool = False,
             log_file: Optional[str] = None, retry: int = 1, watchers: Optional[List[StreamWatcher]] = None,

--- a/unit_tests/lib/remoter_recorder.py
+++ b/unit_tests/lib/remoter_recorder.py
@@ -29,7 +29,7 @@ class RemoterRecorder(RemoteCmdRunner):
     """
     responses = {}
 
-    def run(self, cmd: str, timeout: Optional[float] = None,  # pylint: disable=too-many-arguments
+    def run(self, cmd: str, timeout: Optional[float] = None,
             ignore_status: bool = False, verbose: bool = True, new_session: bool = False,
             log_file: Optional[str] = None, retry: int = 1, watchers: Optional[List[StreamWatcher]] = None,
             change_context: bool = False) -> Result:

--- a/unit_tests/lib/test_profiler/lib.py
+++ b/unit_tests/lib/test_profiler/lib.py
@@ -15,10 +15,10 @@
 import time
 import threading
 from threading import Thread as LibThread
-from threading import Thread  # pylint: disable=reimported
+from threading import Thread
 import multiprocessing
 from multiprocessing import Process as LibProcess
-from multiprocessing import Process  # pylint: disable=reimported
+from multiprocessing import Process
 
 
 __all__ = [

--- a/unit_tests/provisioner/conftest.py
+++ b/unit_tests/provisioner/conftest.py
@@ -10,7 +10,7 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2022 ScyllaDB
-# pylint: disable=redefined-outer-name
+
 import os
 import uuid
 from collections import namedtuple
@@ -21,12 +21,12 @@ import pytest
 from sdcm.utils.sct_cmd_helpers import get_test_config
 from sdcm.sct_config import SCTConfiguration
 from sdcm.test_config import TestConfig
-from sdcm.utils.azure_utils import AzureService  # pylint: disable=import-error
-from unit_tests.provisioner.fake_azure_service import FakeAzureService  # pylint: disable=import-error
+from sdcm.utils.azure_utils import AzureService
+from unit_tests.provisioner.fake_azure_service import FakeAzureService
 
 
 @pytest.fixture(scope="session")
-def azure_service(tmp_path_factory) -> AzureService:  # pylint: disable=no-self-use
+def azure_service(tmp_path_factory) -> AzureService:
     run_on_real_azure = False   # make it True to test with real Azure
     if run_on_real_azure:
         # When true this becomes e2e test - takes around 8 minutes (2m provisioning, 6 min cleanup with wait=True)
@@ -68,7 +68,7 @@ def params():
 
 
 @pytest.fixture
-def test_config(params):  # pylint: disable=unused-argument,redefined-outer-name
+def test_config(params):
     config = get_test_config()
     config.set_test_id("12345678-87654321")
     TestConfig.SYSLOGNG_ADDRESS = ("localhost", 12345)

--- a/unit_tests/provisioner/fake_azure_service.py
+++ b/unit_tests/provisioner/fake_azure_service.py
@@ -37,13 +37,13 @@ def dict_keys_to_camel_case(dct):
             else b for a, b in dct.items()}
 
 
-class WaitableObject:  # pylint: disable=too-few-public-methods
+class WaitableObject:
 
     def wait(self):
         pass
 
 
-class ResultableObject:  # pylint: disable=too-few-public-methods
+class ResultableObject:
 
     def __init__(self, stdout, stderr):
         self.stdout = stdout
@@ -428,7 +428,7 @@ class FakeNetworkInterface:
         return WaitableObject()
 
 
-class FakeNetwork:  # pylint: disable=too-few-public-methods
+class FakeNetwork:
 
     def __init__(self, path) -> None:
         self.path: Path = path
@@ -575,18 +575,16 @@ class FakeVirtualMachines:
         except FileNotFoundError:
             raise ResourceNotFoundError("Virtual Machine not found") from None
 
-    def begin_restart(self, resource_group_name, vm_name  # pylint: disable=unused-argument, no-self-use
-                      ) -> WaitableObject:
+    def begin_restart(self, resource_group_name, vm_name) -> WaitableObject:
         return WaitableObject()
 
-    # pylint: disable=unused-argument,no-self-use
     def begin_run_command(self, resource_group_name, vm_name, parameters) -> ResultableObject:
-        result = subprocess.run(parameters.script[0], shell=True, capture_output=True,  # pylint: disable=subprocess-run-check
+        result = subprocess.run(parameters.script[0], shell=True, capture_output=True,
                                 text=True, check=False)
         return ResultableObject(result.stdout, result.stderr)
 
 
-class FakeImages:  # pylint: disable=too-few-public-methods
+class FakeImages:
     def __init__(self, path: Path) -> None:
         self.path = path
 
@@ -595,7 +593,7 @@ class FakeImages:  # pylint: disable=too-few-public-methods
             return [Image.deserialize(image) for image in json.load(file)]
 
 
-class Compute:  # pylint: disable=too-few-public-methods
+class Compute:
 
     def __init__(self, path) -> None:
         self.path: Path = path
@@ -603,7 +601,7 @@ class Compute:  # pylint: disable=too-few-public-methods
         self.images = FakeImages(self.path)
 
 
-class FakeResourceManagementClient:  # pylint: disable=too-few-public-methods
+class FakeResourceManagementClient:
 
     def __init__(self, path: Path) -> None:
         self.path = path

--- a/unit_tests/provisioner/test_azure_get_scylla_images.py
+++ b/unit_tests/provisioner/test_azure_get_scylla_images.py
@@ -10,7 +10,7 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2022 ScyllaDB
-# pylint: disable=redefined-outer-name
+
 
 import json
 import logging
@@ -24,7 +24,7 @@ from unit_tests.provisioner.fake_azure_service import FakeAzureService
 
 
 @pytest.fixture
-def azure_service():  # pytest: disable=redefined-outer-name
+def azure_service():
     return FakeAzureService(Path(__file__).parent / "test_data")
 
 

--- a/unit_tests/provisioner/test_provision_sct_resources.py
+++ b/unit_tests/provisioner/test_provision_sct_resources.py
@@ -56,7 +56,7 @@ def test_can_provision_instances_according_to_sct_configuration(params, test_con
 
 
 def test_fallback_on_demand_when_spot_fails(fallback_on_demand, params, test_config, azure_service, fake_remoter):
-    # pylint: disable=unused-argument
+
     fake_remoter.result_map = {r"sudo cloud-init status --wait": Result(stdout="..... \n status: done", stderr="nic", exited=0),
                                r"sudo cloud-init --version": Result(stdout="/bin/ 19.2-amzn", stderr="", exited=0),
                                r"ls /var/lib/sct/cloud-init": Result(stdout="done", exited=0)}

--- a/unit_tests/provisioner/test_provisioner.py
+++ b/unit_tests/provisioner/test_provisioner.py
@@ -10,7 +10,7 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2022 ScyllaDB
-# pylint: disable=redefined-outer-name
+
 import uuid
 from datetime import datetime, timezone
 
@@ -106,7 +106,7 @@ def test_can_provision_scylla_vm(region, definition, provisioner, backend, provi
     assert v_m is v_m_2, 'provisioner should not not recreate vm with the same name'
 
     provisioner = provisioner_factory.create_provisioner(backend=backend, **provisioner_params)
-    v_m._provisioner = provisioner  # pylint: disable=protected-access
+    v_m._provisioner = provisioner
     assert v_m == provisioner.list_instances(
     )[0], 'provisioner with the same params should rediscover created resources'
 
@@ -165,7 +165,7 @@ def test_can_terminate_vm_instance(provisioner, definition, backend, provisioner
     assert not provisioner.list_instances()
 
 
-def test_can_trigger_cleanup(definition, provisioner, backend, provisioner_params):  # pylint: disable=no-self-use
+def test_can_trigger_cleanup(definition, provisioner, backend, provisioner_params):
     provisioner.get_or_create_instance(definition)
     assert len(provisioner.list_instances()) == 1
     provisioner.cleanup(wait=True)

--- a/unit_tests/rest/test_compaction_manager_client.py
+++ b/unit_tests/rest/test_compaction_manager_client.py
@@ -11,7 +11,7 @@
 #
 # Copyright (c) 2022 ScyllaDB
 
-# pylint: disable=W,C,R
+
 from functools import partial
 
 from sdcm.remote.libssh2_client import Result

--- a/unit_tests/test_adaptive_timeouts.py
+++ b/unit_tests/test_adaptive_timeouts.py
@@ -10,7 +10,6 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2023 ScyllaDB
-# pylint: disable-all
 import logging
 import time
 import uuid

--- a/unit_tests/test_alternator_streams_kcl.py
+++ b/unit_tests/test_alternator_streams_kcl.py
@@ -29,7 +29,7 @@ pytestmark = [
 @pytest.mark.skip("test isn't yet fully working")
 def test_01_kcl_with_ycsb(
     request, docker_scylla, events, params
-):  # pylint: disable=too-many-locals
+):
     params.update(dict(
         dynamodb_primarykey_type="HASH_AND_RANGE",
         alternator_use_dns_routing=True,

--- a/unit_tests/test_audit.py
+++ b/unit_tests/test_audit.py
@@ -5,7 +5,7 @@ from sdcm.audit import get_audit_log_rows
 from sdcm.cluster import BaseNode
 
 
-class DummyAuditNode(BaseNode):  # pylint: disable=abstract-method
+class DummyAuditNode(BaseNode):
 
     system_log = Path(__file__).parent.resolve() / 'test_data' / 'test_audit.log'
 

--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -16,7 +16,7 @@ import unittest
 
 from sdcm.utils.version_utils import ComparableScyllaVersion
 
-from utils.get_supported_scylla_base_versions import UpgradeBaseVersion  # pylint: disable=no-name-in-module, import-error
+from utils.get_supported_scylla_base_versions import UpgradeBaseVersion
 
 
 def general_test(scylla_repo='', linux_distro='', cloud_provider=None):

--- a/unit_tests/test_chaos_mesh.py
+++ b/unit_tests/test_chaos_mesh.py
@@ -12,7 +12,6 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2021 ScyllaDB
-# pylint: skip-file
 
 from dataclasses import dataclass, field
 from typing import Dict

--- a/unit_tests/test_clean_cloud_resources_func.py
+++ b/unit_tests/test_clean_cloud_resources_func.py
@@ -38,13 +38,13 @@ class CleanInstanceAwsTest(unittest.TestCase):
     def test_empty_tags_dict(self, _):
         self.assertRaisesRegex(AssertionError, "not provided", clean_instances_aws, {})
 
-    def test_empty_list(self, ec2_client):  # pylint: disable=no-self-use
+    def test_empty_list(self, ec2_client):
         with patch.object(resources_cleanup, "list_instances_aws", Mock(return_value={})) as list_instances_aws:
             resources_cleanup.clean_instances_aws({"TestId": 1111, })
         list_instances_aws.assert_called_with(tags_dict={"TestId": 1111, }, group_as_region=True)
         ec2_client().terminate_instances.assert_not_called()
 
-    def test_sct_runner(self, ec2_client):  # pylint: disable=no-self-use
+    def test_sct_runner(self, ec2_client):
         with patch.object(
                 resources_cleanup, "list_instances_aws",
                 Mock(return_value={"eu-north-1": [SCT_RUNNER_AWS]})) as list_instances_aws:
@@ -52,7 +52,7 @@ class CleanInstanceAwsTest(unittest.TestCase):
         list_instances_aws.assert_called_with(tags_dict={"TestId": 1111, }, group_as_region=True)
         ec2_client().terminate_instances.assert_not_called()
 
-    def test_terminate(self, ec2_client):  # pylint: disable=no-self-use
+    def test_terminate(self, ec2_client):
         with patch.object(
                 resources_cleanup, "list_instances_aws",
                 Mock(return_value={"eu-north-1": [{"InstanceId": "i-1111"}]})) as list_instances_aws:
@@ -66,7 +66,7 @@ class CleanElasticIpsAws(unittest.TestCase):
     def test_empty_tags_dict(self, _):
         self.assertRaisesRegex(AssertionError, "not provided", clean_elastic_ips_aws, {})
 
-    def test_empty_list(self, ec2_client):  # pylint: disable=no-self-use
+    def test_empty_list(self, ec2_client):
         with patch.object(
                 resources_cleanup, "list_elastic_ips_aws",
                 Mock(return_value={})) as list_elastic_ips_aws:
@@ -75,7 +75,7 @@ class CleanElasticIpsAws(unittest.TestCase):
         ec2_client().disassociate_address.assert_not_called()
         ec2_client().release_address.assert_not_called()
 
-    def test_release(self, ec2_client):  # pylint: disable=no-self-use
+    def test_release(self, ec2_client):
         return_value = {"eu-north-1": [{
             "AssociationId": 2222,
             "AllocationId": 3333,
@@ -94,7 +94,7 @@ class CleanClustersGkeTest(unittest.TestCase):
     def test_empty_tags_dict(self):
         self.assertRaisesRegex(AssertionError, "not provided", clean_clusters_gke, {})
 
-    def test_destroy(self):  # pylint: disable=no-self-use
+    def test_destroy(self):
         cluster = MagicMock()
         with patch.object(
                 resources_cleanup, "list_clusters_gke",
@@ -108,7 +108,7 @@ class CleanInstancesGceTest(unittest.TestCase):
     def test_empty_tags_dict(self):
         self.assertRaisesRegex(AssertionError, "not provided", clean_instances_gce, {})
 
-    def test_destroy(self):  # pylint: disable=no-self-use
+    def test_destroy(self):
         instance = MagicMock()
         with patch.object(
                 resources_cleanup, "list_instances_gce",

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -11,7 +11,6 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
-# pylint: disable=too-few-public-methods
 
 import re
 import json
@@ -50,8 +49,8 @@ from unit_tests.lib.events_utils import EventsUtilsMixin
 from unit_tests.test_utils_common import DummyNode
 
 
-class DummyDbCluster(BaseCluster, BaseScyllaCluster):  # pylint: disable=abstract-method
-    # pylint: disable=super-init-not-called
+class DummyDbCluster(BaseCluster, BaseScyllaCluster):
+
     def __init__(self, nodes, params=None):
         self.nodes = nodes
         self.params = params or sct_config.SCTConfiguration()
@@ -106,9 +105,9 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
                 for line in log_text.splitlines(keepends=True):
                     temp_log.write(line)
                     temp_log.flush()
-                    self._db_log_reader._read_and_publish_events()  # pylint: disable=protected-access
+                    self._db_log_reader._read_and_publish_events()
         else:
-            self._db_log_reader._read_and_publish_events()  # pylint: disable=protected-access
+            self._db_log_reader._read_and_publish_events()
 
     @classmethod
     def tearDownClass(cls):
@@ -444,9 +443,9 @@ class TestBaseMonitorSet(unittest.TestCase):
         self.assertEqual(self.monitor_cluster.monitoring_version, "master")
 
 
-class NodetoolDummyNode(BaseNode):  # pylint: disable=abstract-method
+class NodetoolDummyNode(BaseNode):
 
-    def __init__(self, resp, myregion=None, myname=None, myrack=None):  # pylint: disable=super-init-not-called
+    def __init__(self, resp, myregion=None, myname=None, myrack=None):
         self.resp = resp
         self.myregion = myregion
         self.myname = myname
@@ -461,14 +460,14 @@ class NodetoolDummyNode(BaseNode):  # pylint: disable=abstract-method
     def name(self):
         return self.myname
 
-    def run_nodetool(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def run_nodetool(self, *args, **kwargs):
         return Result(exited=0, stderr="", stdout=self.resp)
 
 
-class DummyScyllaCluster(BaseScyllaCluster, BaseCluster):  # pylint: disable=abstract-method
+class DummyScyllaCluster(BaseScyllaCluster, BaseCluster):
     nodes: List['NodetoolDummyNode']
 
-    def __init__(self, params):  # pylint: disable=super-init-not-called
+    def __init__(self, params):
         self.nodes = params
         self.name = 'dummy_cluster'
         self.added_password_suffix = False
@@ -481,7 +480,7 @@ class DummyScyllaCluster(BaseScyllaCluster, BaseCluster):  # pylint: disable=abs
 
 class TestNodetoolStatus(unittest.TestCase):
 
-    def test_can_get_nodetool_status_typical(self):  # pylint: disable=no-self-use
+    def test_can_get_nodetool_status_typical(self):
         resp = "\n".join(["Datacenter: eastus",
                           "==================",
                           "Status=Up/Down",
@@ -503,7 +502,7 @@ class TestNodetoolStatus(unittest.TestCase):
                            '10.0.198.153': {'state': 'UN', 'load': '?', 'tokens': '256', 'owns': '?',
                                             'host_id': 'fba174cd-917a-40f6-ab62-cc58efaaf301', 'rack': '1a'}}}
 
-    def test_can_get_nodetool_status_typical_with_one_space_after_host_id(self):  # pylint: disable=no-self-use
+    def test_can_get_nodetool_status_typical_with_one_space_after_host_id(self):
         """case for https://github.com/scylladb/scylla-cluster-tests/issues/7274"""
         resp = "\n".join(["Datacenter: datacenter1",
                           "=======================",
@@ -524,7 +523,7 @@ class TestNodetoolStatus(unittest.TestCase):
                             'host_id': '7b8f86bf-c70c-4246-a273-146057e12431', 'rack': 'rack1'},
                            }}
 
-    def test_datacenter_name_per_region(self):  # pylint: disable=no-self-use
+    def test_datacenter_name_per_region(self):
         resp = "\n".join(["Datacenter: eastus",
                           "==================",
                           "Status=Up/Down",
@@ -552,7 +551,7 @@ class TestNodetoolStatus(unittest.TestCase):
         datacenter_name_per_region = db_cluster.get_datacenter_name_per_region(db_nodes=[node1])
         assert datacenter_name_per_region == {'east-us': 'eastus'}
 
-    def test_get_rack_names_per_datacenter_and_rack_idx(self):  # pylint: disable=no-self-use
+    def test_get_rack_names_per_datacenter_and_rack_idx(self):
         resp = "\n".join(["Datacenter: eastus",
                           "==================",
                           "Status=Up/Down",
@@ -583,7 +582,7 @@ class TestNodetoolStatus(unittest.TestCase):
         nodes_per_region = db_cluster.get_nodes_per_datacenter_and_rack_idx()
         assert nodes_per_region == {('east-us', '1'): [node1, node2], ('west-us', '2'): [node3, ]}
 
-    def test_can_get_nodetool_status_ipv6(self):  # pylint: disable=no-self-use
+    def test_can_get_nodetool_status_ipv6(self):
         resp = "\n".join(["Datacenter: eu-north",
                           "====================",
                           "Status=Up/Down",
@@ -605,7 +604,7 @@ class TestNodetoolStatus(unittest.TestCase):
                            '2a05:d016:cf8:de00:339e:d0d:9446:1980': {'state': 'UN', 'load': '1.04MB', 'tokens': '256', 'owns': '?',
                                                                      'host_id': 'd67e8502', 'rack': '1a'}}}
 
-    def test_can_get_nodetool_status_azure(self):  # pylint: disable=no-self-use
+    def test_can_get_nodetool_status_azure(self):
         resp = "\n".join(["Datacenter: eastus",
                          "==================",
                           "Status=Up/Down",
@@ -718,7 +717,7 @@ def test_base_node_cpuset_not_configured(cat_results):
 
 
 @pytest.mark.integration
-def test_get_any_ks_cf_list(docker_scylla, params, events):  # pylint: disable=unused-argument
+def test_get_any_ks_cf_list(docker_scylla, params, events):
 
     cluster = DummyScyllaCluster([docker_scylla])
     cluster.params = params
@@ -800,7 +799,7 @@ def test_get_any_ks_cf_list(docker_scylla, params, events):  # pylint: disable=u
 
 
 @pytest.mark.integration
-def test_filter_out_ks_with_rf_one(docker_scylla, params, events):  # pylint: disable=unused-argument
+def test_filter_out_ks_with_rf_one(docker_scylla, params, events):
 
     cluster = DummyScyllaCluster([docker_scylla])
     cluster.params = params
@@ -822,7 +821,7 @@ def test_filter_out_ks_with_rf_one(docker_scylla, params, events):  # pylint: di
 
 
 @pytest.mark.integration
-def test_is_table_has_no_sstables(docker_scylla, params, events):  # pylint: disable=unused-argument
+def test_is_table_has_no_sstables(docker_scylla, params, events):
     """
     test is_table_has_no_sstables filter function, as it would be used in `disrupt_snapshot_operations` nemesis
     """
@@ -879,7 +878,7 @@ def test_is_table_has_no_sstables(docker_scylla, params, events):  # pylint: dis
 
 
 class TestNodetool(unittest.TestCase):
-    def test_describering_parsing(self):  # pylint: disable=no-self-use
+    def test_describering_parsing(self):
         """ Test "nodetool describering" output parsing """
         resp = "\n".join(["Schema Version:00703362-03ed-3b41-afcb-ed34c1d1586c TokenRange:",
                           "TokenRange(start_token:-9193109213506951143, end_token:9202125676696964746, "

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -26,10 +26,8 @@ RPM_URL = 'https://s3.amazonaws.com/downloads.scylladb.com/enterprise/rpm/unstab
           '9f724fedb93b4734fcfaec1156806921ff46e956-2bdfa9f7ef592edaf15e028faf3b7f695f39ebc1' \
           '-525a0255f73d454f8f97f32b8bdd71c8dec35d3d-a6b2b2355c666b1893f702a587287da978aeec22/71/scylla.repo'
 
-# pylint: disable=no-self-use
 
-
-class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-methods
+class ConfigurationTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         logging.basicConfig(level=logging.ERROR)
@@ -78,7 +76,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
     def test_03_dump_help_config_yaml(self):
         logging.debug(self.conf.dump_help_config_yaml())
 
-    def test_03_dump_help_config_markdown(self):  # pylint: disable=invalid-name
+    def test_03_dump_help_config_markdown(self):
         logging.debug(self.conf.dump_help_config_markdown())
 
     @pytest.mark.integration
@@ -196,7 +194,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         assert len(amis) == 2
         assert all(ami.startswith('ami-') for ami in amis)
 
-    def test_12_scylla_version_ami_case1(self):  # pylint: disable=invalid-name
+    def test_12_scylla_version_ami_case1(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_SCYLLA_VERSION'] = get_latest_scylla_release(product='scylla')
 
@@ -205,7 +203,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf.verify_configuration()
 
     @pytest.mark.integration
-    def test_12_scylla_version_ami_case2(self):  # pylint: disable=invalid-name
+    def test_12_scylla_version_ami_case2(self):
         os.environ.pop('SCT_AMI_ID_DB_SCYLLA', None)
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_SCYLLA_VERSION'] = '99.0.3'
@@ -222,7 +220,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf.verify_configuration()
 
     @pytest.mark.integration
-    def test_12_scylla_version_repo_case1(self):  # pylint: disable=invalid-name
+    def test_12_scylla_version_repo_case1(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_SCYLLA_VERSION'] = get_latest_scylla_release(product='scylla')
 
@@ -230,14 +228,14 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf.verify_configuration()
 
     @pytest.mark.integration
-    def test_12_scylla_version_repo_case2(self):  # pylint: disable=invalid-name
+    def test_12_scylla_version_repo_case2(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_SCYLLA_VERSION'] = '99.0.3'
 
         self.assertRaisesRegex(
             ValueError, r"AMIs for scylla_version='99.0.3' not found in eu-west-1 arch=x86_64", sct_config.SCTConfiguration)
 
-    def test_12_scylla_version_repo_ubuntu(self):  # pylint: disable=invalid-name
+    def test_12_scylla_version_repo_ubuntu(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'gce'
         os.environ['SCT_SCYLLA_LINUX_DISTRO'] = 'ubuntu-xenial'
         os.environ['SCT_SCYLLA_LINUX_DISTRO_LOADER'] = 'ubuntu-xenial'
@@ -257,7 +255,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertEqual(conf.get('scylla_repo_loader'),
                          "https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-5.2.list")
 
-    def test_12_scylla_version_repo_ubuntu_loader_centos(self):  # pylint: disable=invalid-name
+    def test_12_scylla_version_repo_ubuntu_loader_centos(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'gce'
         os.environ['SCT_SCYLLA_LINUX_DISTRO'] = 'ubuntu-xenial'
         os.environ['SCT_SCYLLA_LINUX_DISTRO_LOADER'] = 'centos'
@@ -278,7 +276,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertEqual(conf.get('scylla_repo_loader'),
                          "https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-5.2.repo")
 
-    def test_12_k8s_scylla_version_ubuntu_loader_centos(self):  # pylint: disable=invalid-name
+    def test_12_k8s_scylla_version_ubuntu_loader_centos(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'k8s-local-kind'
         os.environ['SCT_SCYLLA_LINUX_DISTRO'] = 'ubuntu-xenial'
         os.environ['SCT_SCYLLA_LINUX_DISTRO_LOADER'] = 'centos'
@@ -292,7 +290,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                          'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-5.2.repo')
 
     @pytest.mark.integration
-    def test_13_scylla_version_ami_branch_latest(self):  # pylint: disable=invalid-name
+    def test_13_scylla_version_ami_branch_latest(self):
         os.environ.pop('SCT_AMI_ID_DB_SCYLLA', None)
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_SCYLLA_VERSION'] = 'branch-5.2:latest'
@@ -304,7 +302,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         assert len(amis) == 2
         assert all(ami.startswith('ami-') for ami in amis)
 
-    def test_conf_check_required_files(self):  # pylint: disable=no-self-use
+    def test_conf_check_required_files(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         ami_id = get_ssm_ami(
             '/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id', region_name='eu-west-1')
@@ -316,7 +314,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf.verify_configuration()
         conf.check_required_files()
 
-    def test_conf_check_required_files_negative(self):  # pylint: disable=no-self-use
+    def test_conf_check_required_files_negative(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/stress_cmd_with_bad_profile.yaml'
         os.environ['SCT_STRESS_CMD'] = """cassandra-stress user profile=/tmp/1232123123123123123.yaml ops'(insert=100)'\
@@ -334,7 +332,6 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         def get_dupes(c):
             '''sort/tee/izip'''
 
-            # pylint: disable=invalid-name
             a, b = itertools.tee(sorted(c))
             next(b, None)
             r = None
@@ -398,7 +395,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         with unittest.mock.patch.object(sct_config, 'get_branch_version', return_value='2019.1.1', clear=True):
             conf = sct_config.SCTConfiguration()
             conf.verify_configuration()
-            conf._get_target_upgrade_version()  # pylint: disable=protected-access
+            conf._get_target_upgrade_version()
         self.assertEqual(conf.get('target_upgrade_version'), '2019.1.1')
 
     def test_15a_new_scylla_repo_by_scylla_version(self):
@@ -416,7 +413,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                 unittest.mock.patch.object(sct_config, 'find_scylla_repo', return_value=resolved_repo_link, clear=True):
             conf = sct_config.SCTConfiguration()
             conf.verify_configuration()
-            conf._get_target_upgrade_version()  # pylint: disable=protected-access
+            conf._get_target_upgrade_version()
 
         self.assertEqual(conf.get('scylla_repo'), resolved_repo_link)
         target_upgrade_version = conf.get('target_upgrade_version')
@@ -437,7 +434,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         with unittest.mock.patch.object(sct_config, 'get_branched_gce_images', return_value=[image], clear=True):
             conf = sct_config.SCTConfiguration()
             conf.verify_configuration()
-            conf._get_target_upgrade_version()  # pylint: disable=protected-access
+            conf._get_target_upgrade_version()
 
         self.assertEqual(conf.get('gce_image_db'), resolved_image_link)
 

--- a/unit_tests/test_coredump.py
+++ b/unit_tests/test_coredump.py
@@ -10,8 +10,8 @@ from unit_tests.lib.data_pickle import Pickler
 from unit_tests.lib.mock_remoter import MockRemoter
 
 
-class FakeNode(BaseNode):  # pylint: disable=abstract-method
-    # pylint: disable=super-init-not-called
+class FakeNode(BaseNode):
+
     def __init__(self, remoter, logdir):
         self.remoter = remoter
         os.makedirs(logdir, exist_ok=True)

--- a/unit_tests/test_decode_backtrace.py
+++ b/unit_tests/test_decode_backtrace.py
@@ -26,7 +26,7 @@ from unit_tests.test_utils_common import DummyNode
 from unit_tests.lib.events_utils import EventsUtilsMixin
 
 
-class DecodeDummyNode(DummyNode):  # pylint: disable=abstract-method
+class DecodeDummyNode(DummyNode):
 
     def copy_scylla_debug_info(self, node_name, debug_file):
         return "scylla_debug_info_file"
@@ -92,17 +92,17 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
         )
 
     def _read_and_publish_events(self):
-        self._db_log_reader._read_and_publish_events()  # pylint: disable=protected-access
+        self._db_log_reader._read_and_publish_events()
 
     def _read_and_publish_events_no_decoding(self):
-        self._db_log_reader_no_decoding._read_and_publish_events()  # pylint: disable=protected-access
+        self._db_log_reader_no_decoding._read_and_publish_events()
 
     def setUp(self):
         self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'system.log')
 
     def test_01_reactor_stall_is_not_decoded_if_disabled(self):
         self.monitor_node.start_decode_on_monitor_node_thread()
-        self._read_and_publish_events_no_decoding()  # pylint: disable=protected-access
+        self._read_and_publish_events_no_decoding()
         self.monitor_node.termination_event.set()
         self.monitor_node.stop_task_threads()
         self.monitor_node.wait_till_tasks_threads_are_stopped()
@@ -139,7 +139,7 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
                 self.assertEqual(event['backtrace'].strip(),
                                  "addr2line -Cpife scylla_debug_info_file {}".format(' '.join(event['raw_backtrace'].split("\n"))))
 
-    def test_03_decode_interlace_reactor_stall(self):  # pylint: disable=invalid-name
+    def test_03_decode_interlace_reactor_stall(self):
 
         self.test_config.DECODING_QUEUE = Queue()
         self.test_config.BACKTRACE_DECODING = True
@@ -147,7 +147,7 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
         self.monitor_node.start_decode_on_monitor_node_thread()
         self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'system_interlace_stall.log')
 
-        self._read_and_publish_events()  # pylint: disable=protected-access
+        self._read_and_publish_events()
 
         self.monitor_node.termination_event.set()
         self.monitor_node.stop_task_threads()

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -66,7 +66,7 @@ class BaseEventsTest(unittest.TestCase, EventsUtilsMixin):
         return get_logger_event_summary(_registry=self.events_processes_registry)
 
 
-class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
+class SctEventsTests(BaseEventsTest):
     # increase the max length to see the full strings in the AssertionError which precedes the diff
     maxDiff = None
 
@@ -516,7 +516,7 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
             with EventCounterContextManager(DatabaseLogEvent.REACTOR_STALLED,
                                             name=count_condition_name,
                                             _registry=self.events_processes_registry) as counter_manager:
-                assert counter_manager._event_type == (  # pylint: disable=protected-access
+                assert counter_manager._event_type == (
                     DatabaseLogEvent.REACTOR_STALLED, )
                 DatabaseLogEvent.REACTOR_STALLED().add_info("node4", "Reactor stalled for 13 ms", 111).publish()
                 DatabaseLogEvent.REACTOR_STALLED().add_info("node1", "Reactor stalled for 33 ms", 111).publish()
@@ -542,7 +542,7 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
                                              name=count_condition_name,
                                              _registry=self.events_processes_registry)
 
-        assert counter._event_type == (DatabaseLogEvent.REACTOR_STALLED, )  # pylint: disable=protected-access
+        assert counter._event_type == (DatabaseLogEvent.REACTOR_STALLED, )
         counter.start_event_counter()
         with self.wait_for_n_events(self.get_events_counter(), count=4, timeout=5):
             DatabaseLogEvent.REACTOR_STALLED().add_info("node4", "Reactor stalled for 13 ms", 111).publish()
@@ -571,7 +571,7 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
             with EventCounterContextManager(DatabaseLogEvent.REACTOR_STALLED,
                                             name=count_condition_name,
                                             _registry=self.events_processes_registry) as counter_manager:
-                assert counter_manager._event_type == (  # pylint: disable=protected-access
+                assert counter_manager._event_type == (
                     DatabaseLogEvent.REACTOR_STALLED, )
                 DatabaseLogEvent.REACTOR_STALLED().add_info("node4", "Reactor stalled for 13ms", 111).publish()
                 DatabaseLogEvent.REACTOR_STALLED().add_info("node1", "Reactor stalled for 33ms", 111).publish()
@@ -590,7 +590,7 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
             with EventCounterContextManager((DatabaseLogEvent.REACTOR_STALLED, DatabaseLogEvent.KERNEL_CALLSTACK),
                                             name=count_condition_name,
                                             _registry=self.events_processes_registry) as counter_manager:
-                assert counter_manager._event_type == (  # pylint: disable=protected-access
+                assert counter_manager._event_type == (
                     DatabaseLogEvent.REACTOR_STALLED, DatabaseLogEvent.KERNEL_CALLSTACK)
 
                 DatabaseLogEvent.REACTOR_STALLED().add_info("node1", "Reactor stalled for 33 ms", 111).publish()
@@ -621,7 +621,7 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
             with EventCounterContextManager((DatabaseLogEvent.REACTOR_STALLED, DatabaseLogEvent.KERNEL_CALLSTACK),
                                             name=count_condition_name,
                                             _registry=self.events_processes_registry) as counter_manager:
-                assert counter_manager._event_type == (  # pylint: disable=protected-access
+                assert counter_manager._event_type == (
                     DatabaseLogEvent.REACTOR_STALLED, DatabaseLogEvent.KERNEL_CALLSTACK)
 
                 DatabaseLogEvent.REACTOR_STALLED().add_info("node1", "Reactor stalled for 33 ms", 111).publish()
@@ -661,9 +661,9 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
                 EventCounterContextManager((DatabaseLogEvent.REACTOR_STALLED, DatabaseLogEvent.BACKTRACE),
                                            name=count_condition_name2,
                                            _registry=self.events_processes_registry) as counter_manager2:
-                assert counter_manager1._event_type == (  # pylint: disable=protected-access
+                assert counter_manager1._event_type == (
                     DatabaseLogEvent.REACTOR_STALLED, DatabaseLogEvent.KERNEL_CALLSTACK)
-                assert counter_manager2._event_type == (  # pylint: disable=protected-access
+                assert counter_manager2._event_type == (
                     DatabaseLogEvent.REACTOR_STALLED, DatabaseLogEvent.BACKTRACE)
 
                 DatabaseLogEvent.REACTOR_STALLED().add_info("node1", "Reactor stalled for 33 ms", 111).publish()
@@ -718,7 +718,7 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
             with EventCounterContextManager((DatabaseLogEvent.REACTOR_STALLED, DatabaseLogEvent.KERNEL_CALLSTACK),
                                             name=count_condition_name1,
                                             _registry=self.events_processes_registry) as counter_manager1:
-                assert counter_manager1._event_type == (  # pylint: disable=protected-access
+                assert counter_manager1._event_type == (
                     DatabaseLogEvent.REACTOR_STALLED, DatabaseLogEvent.KERNEL_CALLSTACK)
                 DatabaseLogEvent.REACTOR_STALLED().add_info("node1", "Reactor stalled for 33 ms", 111).publish()
                 DatabaseLogEvent.BACKTRACE().add_info(node="node1", line_number=22,
@@ -727,7 +727,7 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
                 with EventCounterContextManager((DatabaseLogEvent.REACTOR_STALLED, DatabaseLogEvent.BACKTRACE),
                                                 name=count_condition_name2,
                                                 _registry=self.events_processes_registry) as counter_manager2:
-                    assert counter_manager2._event_type == (  # pylint: disable=protected-access
+                    assert counter_manager2._event_type == (
                         DatabaseLogEvent.REACTOR_STALLED, DatabaseLogEvent.BACKTRACE)
 
                     DatabaseLogEvent.REACTOR_STALLED().add_info("node2", "Reactor stalled for 499 ms", 111).publish()
@@ -793,7 +793,7 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
                 nemesis_event.duration = 15
                 raise
 
-            except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 pytest.fail("we shouldn't reach this code path")
 
         assert nemesis_event.errors_formatted == ''

--- a/unit_tests/test_gce_log_monitor.py
+++ b/unit_tests/test_gce_log_monitor.py
@@ -5,12 +5,12 @@ from sdcm.utils.gce_utils import GceLoggingClient
 from unit_tests.test_events import BaseEventsTest
 
 
-class FakeGceLogClient(GceLoggingClient):  # pylint: disable=too-few-public-methods
+class FakeGceLogClient(GceLoggingClient):
 
-    def __init__(self):  # pylint: disable=super-init-not-called
+    def __init__(self):
         pass
 
-    def get_system_events(self, from_: float, until: float):  # pylint: disable=unused-argument
+    def get_system_events(self, from_: float, until: float):
         """This is example output from GCE logging system in dictionary form."""
         entry = {
             'protoPayload': {
@@ -59,7 +59,7 @@ class FakeGceLogClient(GceLoggingClient):  # pylint: disable=too-few-public-meth
 
 class FakeGceNode(GCENode):
 
-    def __init__(self, logging_client: GceLoggingClient):  # pylint: disable=super-init-not-called
+    def __init__(self, logging_client: GceLoggingClient):
         self._gce_logging_client = logging_client
         self._last_logs_fetch_time = 1656590843.0
 

--- a/unit_tests/test_gemini_thread.py
+++ b/unit_tests/test_gemini_thread.py
@@ -22,7 +22,7 @@ pytestmark = [
 ]
 
 
-class DBCluster:  # pylint: disable=too-few-public-methods
+class DBCluster:
     def __init__(self, nodes):
         self.nodes = nodes
 

--- a/unit_tests/test_hydra_sh.py
+++ b/unit_tests/test_hydra_sh.py
@@ -75,7 +75,6 @@ class HydraTestCaseParams:
         pass
 
 
-# pylint: disable=too-many-public-methods
 class LongevityPipelineTest:
     """
     This class takes pipeline parameters and produces hydra test cases parameters as a tuple in hydra_test_cases
@@ -135,11 +134,11 @@ class LongevityPipelineTest:
         return not_expected
 
     @cached_property
-    def pattern_remove_known_key(self):  # pylint: disable=no-self-use
+    def pattern_remove_known_key(self):
         return 'ssh-keygen -R "1.1.1.1" || true'
 
     @cached_property
-    def pattern_rsync_aws_token(self):  # pylint: disable=no-self-use
+    def pattern_rsync_aws_token(self):
         return "rsync -ar -e 'ssh -o StrictHostKeyChecking=no' --delete ~/.aws ubuntu@1.1.1.1:/home/ubuntu/"
 
     @cached_property
@@ -180,7 +179,7 @@ class LongevityPipelineTest:
         return self.collect_logs_cmd_docker
 
     @cached_property
-    def collect_logs_cmd_docker(self):  # pylint: disable=no-self-use
+    def collect_logs_cmd_docker(self):
         # Command line that should be run in the docker
         return 'collect-logs'
 
@@ -204,7 +203,7 @@ class LongevityPipelineTest:
         return self.send_email_cmd_docker
 
     @cached_property
-    def send_email_cmd_docker(self):  # pylint: disable=no-self-use
+    def send_email_cmd_docker(self):
         # Command line that should be run in the docker
         return 'send-email --test-status SUCCESS --start-time 1627268929 --email-recipients qa@scylladb.com'
 

--- a/unit_tests/test_kafka.py
+++ b/unit_tests/test_kafka.py
@@ -52,7 +52,6 @@ def test_01_kafka_cdc_source_connector(request, docker_scylla, kafka_cluster, pa
     - from GitHub release url
     """
 
-    # pylint: disable=unused-argument,unnecessary-lambda
     params['kafka_backend'] = 'localstack'
 
     disable_tablets = ""

--- a/unit_tests/test_lib_utils.py
+++ b/unit_tests/test_lib_utils.py
@@ -20,7 +20,7 @@ from test_lib.utils import get_data_by_path, MagicList
 logging.basicConfig(level=logging.DEBUG)
 
 
-class TestClass:  # pylint: disable=too-few-public-methods
+class TestClass:
     __test__ = False  # Mark this class to be not collected by pytest.
 
     def __init__(self, **kwargs):
@@ -35,7 +35,7 @@ class TestClass:  # pylint: disable=too-few-public-methods
 
 
 class TestLibUtilsTest(unittest.TestCase):
-    def test_magic_list(self):  # pylint: disable=no-self-use
+    def test_magic_list(self):
         tmp = MagicList([
             TestClass(val1=1, val2=2),
             TestClass(val1=3, val2=5),
@@ -51,7 +51,7 @@ class TestLibUtilsTest(unittest.TestCase):
             repr(sorted(tmp.group_by('val2').items(), key=lambda item: item[0])),
             "[(0, [<val1=10,val2=0>]), (2, [<val1=1,val2=2>]), (5, [<val1=3,val2=5>])]")
 
-    def test_get_data_by_path(self):  # pylint: disable=no-self-use
+    def test_get_data_by_path(self):
         data = {
             'l1_key': {
                 'l2_key': 10

--- a/unit_tests/test_log_collector.py
+++ b/unit_tests/test_log_collector.py
@@ -10,7 +10,7 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2022 ScyllaDB
-# pylint: disable=redefined-outer-name
+
 import uuid
 
 import pytest

--- a/unit_tests/test_manual.py
+++ b/unit_tests/test_manual.py
@@ -36,10 +36,8 @@ if TYPE_CHECKING:
 
 logging.basicConfig(format="%(asctime)s - %(levelname)-8s - %(name)-10s: %(message)s", level=logging.DEBUG)
 
-# pylint: disable=line-too-long
 
-
-class Node:  # pylint: disable=no-init,too-few-public-methods
+class Node:
     def __init__(self):
         self.ssh_login_info = {'hostname': '34.253.205.91',
                                'user': 'centos',
@@ -49,12 +47,12 @@ class Node:  # pylint: disable=no-init,too-few-public-methods
         self.ip_address = '34.253.205.91'
 
 
-class DbNode:  # pylint: disable=no-init,too-few-public-methods
+class DbNode:
     ip_address = "34.244.157.61"
     dc_idx = 1
 
 
-class LoaderSetDummy:  # pylint: disable=no-init,too-few-public-methods
+class LoaderSetDummy:
     def __init__(self):
         self.nodes = [Node()]
         self.params = {}
@@ -98,7 +96,7 @@ class TestCassandraStressExporter(unittest.TestCase):
         cls.metrics = nemesis_metrics_obj()
 
     def test_01(self):
-        tmp_file = tempfile.NamedTemporaryFile(mode='w+')  # pylint: disable=consider-using-with
+        tmp_file = tempfile.NamedTemporaryFile(mode='w+')
         cs_exporter = CassandraStressExporter("127.0.0.1", self.metrics, 'write',
                                               tmp_file.name, loader_idx=1, cpu_idx=0)
 
@@ -138,7 +136,7 @@ class TestCassandraStressHDRExporter(unittest.TestCase):
         cls.metrics = nemesis_metrics_obj()
 
     def test_01_mixed(self):
-        tmp_file = tempfile.NamedTemporaryFile(mode='w+')  # pylint: disable=consider-using-with
+        tmp_file = tempfile.NamedTemporaryFile(mode='w+')
         cs_exporter = CassandraStressHDRExporter("127.0.0.1", self.metrics, 'mixed',
                                                  tmp_file.name, loader_idx=1, cpu_idx=0)
 
@@ -165,7 +163,7 @@ class TestCassandraStressHDRExporter(unittest.TestCase):
         res.result(10)
 
     def test_02_write(self):
-        tmp_file = tempfile.NamedTemporaryFile(mode='w+')  # pylint: disable=consider-using-with
+        tmp_file = tempfile.NamedTemporaryFile(mode='w+')
         cs_exporter = CassandraStressHDRExporter("127.0.0.1", self.metrics, 'write',
                                                  tmp_file.name, loader_idx=1, cpu_idx=0)
 
@@ -185,7 +183,7 @@ class TestCassandraStressHDRExporter(unittest.TestCase):
         res.result(10)
 
     def test_03_read(self):
-        tmp_file = tempfile.NamedTemporaryFile(mode='w+')  # pylint: disable=consider-using-with
+        tmp_file = tempfile.NamedTemporaryFile(mode='w+')
         cs_exporter = CassandraStressHDRExporter("127.0.0.1", self.metrics, 'read',
                                                  tmp_file.name, loader_idx=1, cpu_idx=0)
 
@@ -205,7 +203,7 @@ class TestCassandraStressHDRExporter(unittest.TestCase):
         res.result(10)
 
     def test_04_mixed_only_write(self):
-        tmp_file = tempfile.NamedTemporaryFile(mode='w+')  # pylint: disable=consider-using-with
+        tmp_file = tempfile.NamedTemporaryFile(mode='w+')
         cs_exporter = CassandraStressHDRExporter("127.0.0.1", self.metrics, 'mixed',
                                                  tmp_file.name, loader_idx=1, cpu_idx=0)
 
@@ -247,7 +245,7 @@ class BaseSCTEventsTest(unittest.TestCase):
 
 @unittest.skip("manual tests")
 class TestStressThread(BaseSCTEventsTest):
-    def test_01(self):  # pylint: disable=no-self-use
+    def test_01(self):
         start_metrics_server()
         cstress = CassandraStressThread(LoaderSetDummy(), timeout=60, node_list=[DbNode()], stress_num=1,
                                         stress_cmd="cassandra-stress write cl=ONE duration=3m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)'"
@@ -271,7 +269,7 @@ class TestStressThread(BaseSCTEventsTest):
     @staticmethod
     def test_02():
 
-        tmp_file = tempfile.NamedTemporaryFile(mode='w+')  # pylint: disable=consider-using-with
+        tmp_file = tempfile.NamedTemporaryFile(mode='w+')
         tailer = CassandraStressEventsPublisher(node=Node(), cs_log_filename=tmp_file.name)
 
         res = tailer.start()
@@ -291,7 +289,7 @@ class TestStressThread(BaseSCTEventsTest):
 
 @unittest.skip("manual tests")
 class TestYcsbStressThread(BaseSCTEventsTest):
-    def test_01(self):  # pylint: disable=no-self-use
+    def test_01(self):
         params = dict(alternator_port=8080)  # , dynamodb_primarykey_type='HASH_AND_RANGE')
         loader_set = LoaderSetDummy()
         thread1 = YcsbStressThread(loader_set,

--- a/unit_tests/test_microbenchmarking.py
+++ b/unit_tests/test_microbenchmarking.py
@@ -14,8 +14,6 @@ from sdcm.microbenchmarking import MicroBenchmarkingResultsAnalyzer, LargeNumber
 
 LOGGER = logging.getLogger("microbenchmarking-tests")
 
-# pylint: disable=invalid-name
-
 
 class MicroBenchmarkingResultsAnalyzerMock(MicroBenchmarkingResultsAnalyzer):
     _mock_returns = None
@@ -63,7 +61,7 @@ class MicroBenchmarkingResultsAnalyzerMock(MicroBenchmarkingResultsAnalyzer):
         return params_hash
 
 
-class TestMBM(unittest.TestCase):  # pylint: disable=too-many-public-methods
+class TestMBM(unittest.TestCase):
     def setUp(self):
         self.mbra = MicroBenchmarkingResultsAnalyzerMock(email_recipients=(
             'alex.bykov@scylladb.com', ), es_index="microbenchmarking")
@@ -85,7 +83,7 @@ class TestMBM(unittest.TestCase):  # pylint: disable=too-many-public-methods
         return expected_obj
 
     def test_object_exists(self):
-        # pylint: disable=protected-access
+
         self.assertIsInstance(self.mbra, MicroBenchmarkingResultsAnalyzer)
         self.assertEqual(self.mbra.hostname, 'monster')
         self.assertEqual(self.mbra._email_recipients, ('alex.bykov@scylladb.com', ))

--- a/unit_tests/test_nemesis.py
+++ b/unit_tests/test_nemesis.py
@@ -77,12 +77,12 @@ class FakeTester:
     def get_test_details(self):
         pass
 
-    def id(self):  # pylint: disable=invalid-name,no-self-use
+    def id(self):
         return 0
 
 
 class FakeNemesis(Nemesis):
-    def __new__(cls, tester_obj, termination_event, *args):  # pylint: disable=unused-argument
+    def __new__(cls, tester_obj, termination_event, *args):
         return object.__new__(cls)
 
     def disrupt(self):
@@ -121,7 +121,7 @@ class FakeCategoricalMonkey(CategoricalMonkey):
 
 class AddRemoveDCMonkey(ChaosMonkey):
     @ChaosMonkey.add_disrupt_method
-    def disrupt_rnd_method(self):  # pylint: disable=no-self-use
+    def disrupt_rnd_method(self):
         print("It Works!")
 
     def disrupt(self):
@@ -138,8 +138,6 @@ def test_list_nemesis_of_added_disrupt_methods(capsys):
     nemesis.call_next_nemesis()
     captured = capsys.readouterr()
     assert "It Works!" in captured.out
-
-# pylint: disable=super-init-not-called,too-many-ancestors
 
 
 def test_is_it_on_kubernetes():
@@ -175,7 +173,6 @@ def test_is_it_on_kubernetes():
 
     params = {'nemesis_interval': 10, 'nemesis_filter_seeds': 1}
 
-    # pylint: disable=protected-access
     assert FakeNemesis(FakeTester(db_cluster=FakeLocalMinimalScyllaPodCluster(),
                        params=params), None)._is_it_on_kubernetes()
     assert FakeNemesis(FakeTester(db_cluster=FakeGkeScyllaPodCluster(), params=params), None)._is_it_on_kubernetes()
@@ -186,7 +183,6 @@ def test_is_it_on_kubernetes():
     assert not FakeNemesis(FakeTester(db_cluster=FakeScyllaDockerCluster(), params=params), None)._is_it_on_kubernetes()
 
 
-# pylint: disable=protected-access
 def test_categorical_monkey():
     tester = FakeTester()
 
@@ -238,7 +234,7 @@ def test_use_disabled_monkey():
 
 
 class TestSisyphusMonkeyNemesisFilter:
-    # pylint: disable=no-self-use
+
     @pytest.fixture(autouse=True)
     def expected_topology_changes_methods(self):
         return [
@@ -335,7 +331,7 @@ class TestSisyphusMonkeyNemesisFilter:
             assert disrupt_method in expected_config_and_schema_changes_methods, \
                 f"{disrupt_method=} from {collected_disrupt_methods_names=} was not found in {expected_config_and_schema_changes_methods=}"
 
-    def test_add_sisyphus_with_filter_in_parallel_nemesis_run(self, expected_schema_changes_methods, expected_topology_changes_methods):  # pylint: disable=too-many-locals
+    def test_add_sisyphus_with_filter_in_parallel_nemesis_run(self, expected_schema_changes_methods, expected_topology_changes_methods):
         tester = ClusterTesterForTests()
         tester._init_params()
         tester.db_cluster = Cluster(nodes=[Node(), Node()])

--- a/unit_tests/test_network_config.py
+++ b/unit_tests/test_network_config.py
@@ -22,7 +22,6 @@ class RegionAZSubnets(NamedTuple):
     subnets: list[str]
 
 
-# pylint: disable=too-few-public-methods
 class RegionsData:
     UsEast1Region = [RegionAZSubnets(region="us-east-1", availability_zone="a", subnets=['subnet-0a09ba4421ec6aaa8',
                                                                                          'subnet-03d8900174e00a73d']),
@@ -48,7 +47,7 @@ class RegionsData:
 
 
 class FakeEC2NetworkConfiguration(EC2NetworkConfiguration):
-    # pylint: disable=super-init-not-called
+
     def __init__(self, regions: list[str], availability_zones: list[str], network_interfaces_count: int,
                  params: dict = None):
         self.regions = regions

--- a/unit_tests/test_profiler.py
+++ b/unit_tests/test_profiler.py
@@ -30,7 +30,7 @@ from unit_tests.lib.test_profiler.lib2 import LibProfileableProcessCustomClass, 
     LibProfileableProcessCustomClassWithRun, LibProfileableThreadCustomClass, LibProfileableThreadCustomClassWithRun, \
     LibProfileableThread, LibProfileableProcess
 
-from sdcm.utils.profiler import ProfilerFactory, ProfileableProcess as pp, ProfileableThread as pt  # pylint: disable=ungrouped-imports
+from sdcm.utils.profiler import ProfilerFactory, ProfileableProcess as pp, ProfileableThread as pt
 
 
 def function_sleep():
@@ -125,7 +125,7 @@ class TestProfileFactory(unittest.TestCase):
             'main',
         ]
         for sub in self._subroutines:
-            dirs_to_expect.append(sub._name)  # pylint: disable=protected-access
+            dirs_to_expect.append(sub._name)
 
         not_found = []
         for directory in dirs_to_expect:
@@ -182,7 +182,7 @@ class TestProfileFactory(unittest.TestCase):
                     break
         tmp.stop()
 
-    def _add_tests(self):  # pylint: disable=too-many-statements
+    def _add_tests(self):
         self._subroutines.append(Thread(target=thread_body, name="Thread.daemon", daemon=True))
         self._subroutines.append(LibThread(target=thread_body, name="lib.Thread.daemon", daemon=True))
         self._subroutines.append(ThreadCustomClass(target=thread_body, name="Thread.CustomClass.daemon", daemon=True))

--- a/unit_tests/test_python_driver.py
+++ b/unit_tests/test_python_driver.py
@@ -8,7 +8,7 @@ from unit_tests.test_cluster import DummyDbCluster, DummyNode, DummyRemote
 log = logging.getLogger(__name__)
 
 
-class Node(DummyNode):  # pylint: disable=abstract-method
+class Node(DummyNode):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._host_id = ''
@@ -27,7 +27,7 @@ def test_01_test_python_driver_serverless_connectivity(params):
 
     # local bundle file
     params['k8s_connection_bundle_file'] = '/home/fruch/Downloads/k8s_config.yaml'
-    node._host_id = '0d56abe0-91f9-43ee-9b39-4536488b6089'  # pylint: disable=protected-access
+    node._host_id = '0d56abe0-91f9-43ee-9b39-4536488b6089'
     node.remoter = DummyRemote()
     db_cluster = DummyDbCluster(nodes=[node], params=params)
     node.parent_cluster = db_cluster

--- a/unit_tests/test_remoter.py
+++ b/unit_tests/test_remoter.py
@@ -31,7 +31,6 @@ from sdcm.cluster_k8s import KubernetesCluster
 class FakeKluster(KubernetesCluster):
     k8s_server_url = None
 
-    # pylint: disable=super-init-not-called
     def __init__(self, k8s_server_url):
         self.k8s_server_url = k8s_server_url
 
@@ -51,7 +50,6 @@ class FakeKluster(KubernetesCluster):
         pass
 
 
-# pylint: disable=too-many-nested-blocks
 def generate_all_commands_with_all_options():
     all_commands_with_all_options = []
     for ip in ['::1', '127.0.0.1']:
@@ -98,17 +96,16 @@ class TestRemoteCmdRunners(unittest.TestCase):
                 pod_name='sct-cluster-dc-1-kind-0', container="scylla", namespace="scylla")
         try:
             result = remoter.run(stmt, **kwargs)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             result = exc
         paramiko_thread_results.append(result)
         try:
             result = remoter.run(stmt, **kwargs)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             result = exc
         paramiko_thread_results.append(result)
         remoter.stop()
 
-    # pylint: disable=too-many-arguments
     @staticmethod
     def _create_and_run_in_same_thread(remoter_type, host, key_file, stmt, kwargs, paramiko_thread_results):
         if issubclass(remoter_type, (RemoteCmdRunner, RemoteLibSSH2CmdRunner)):
@@ -120,13 +117,13 @@ class TestRemoteCmdRunners(unittest.TestCase):
                 pod_name='sct-cluster-dc-1-kind-0', container="scylla", namespace="scylla")
         try:
             result = remoter.run(stmt, **kwargs)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             result = exc
         paramiko_thread_results.append(result)
-        remoter._reconnect()  # pylint: disable=protected-access
+        remoter._reconnect()
         try:
             result = remoter.run(stmt, **kwargs)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             result = exc
         paramiko_thread_results.append(result)
         remoter.stop()
@@ -135,13 +132,13 @@ class TestRemoteCmdRunners(unittest.TestCase):
     def _create_and_run_in_separate_thread(remoter, stmt, kwargs, paramiko_thread_results):
         try:
             result = remoter.run(stmt, **kwargs)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             result = exc
         paramiko_thread_results.append(result)
-        remoter._reconnect()  # pylint: disable=protected-access
+        remoter._reconnect()
         try:
             result = remoter.run(stmt, **kwargs)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             result = exc
         paramiko_thread_results.append(result)
         remoter.stop()
@@ -200,7 +197,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
 
     # @parameterized.expand(ALL_COMMANDS_WITH_ALL_OPTIONS)
     @unittest.skip('To be ran manually')
-    def test_run_in_mainthread(  # pylint: disable=too-many-arguments
+    def test_run_in_mainthread(
             self, remoter_type, host: str, stmt: str, verbose: bool, ignore_status: bool, new_session: bool, retry: int,
             timeout: Union[float, None]):
         kwargs = {
@@ -211,7 +208,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
             'timeout': timeout}
         try:
             expected = LocalCmdRunner().run(stmt, **kwargs)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             expected = exc
 
         if issubclass(remoter_type, (RemoteCmdRunner, RemoteLibSSH2CmdRunner)):
@@ -223,12 +220,12 @@ class TestRemoteCmdRunners(unittest.TestCase):
                 pod_name='sct-cluster-dc-1-kind-0', container="scylla", namespace="scylla")
         try:
             result = remoter.run(stmt, **kwargs)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             result = exc
-        remoter._reconnect()  # pylint: disable=protected-access
+        remoter._reconnect()
         try:
             result2 = remoter.run(stmt, **kwargs)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             result2 = exc
         remoter.stop()
 
@@ -237,7 +234,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
 
     # @parameterized.expand(ALL_COMMANDS_WITH_ALL_OPTIONS)
     @unittest.skip('To be ran manually')
-    def test_create_and_run_in_same_thread(  # pylint: disable=too-many-arguments,too-many-locals
+    def test_create_and_run_in_same_thread(
             self, remoter_type, host: str, stmt: str, verbose: bool, ignore_status: bool, new_session: bool,
             retry: int, timeout: Union[float, None]):
         kwargs = {
@@ -249,7 +246,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
         self.log.info(repr({stmt: stmt, **kwargs}))
         try:
             expected = LocalCmdRunner().run(stmt, **kwargs)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             expected = exc
 
         paramiko_thread_results = []
@@ -264,7 +261,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
 
     # @parameterized.expand(ALL_COMMANDS_WITH_ALL_OPTIONS)
     @unittest.skip('To be ran manually')
-    def test_create_and_run_in_separate_thread(  # pylint: disable=too-many-arguments
+    def test_create_and_run_in_separate_thread(
             self, remoter_type, host: str, stmt: str, verbose: bool, ignore_status: bool,
             new_session: bool, retry: int, timeout: Union[float, None]):
         kwargs = {
@@ -276,7 +273,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
         self.log.info(repr({stmt: stmt, **kwargs}))
         try:
             expected = LocalCmdRunner().run(stmt, **kwargs)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             expected = exc
 
         # Paramiko fails too often when it is invoked like that, that is why it is not in the test
@@ -332,7 +329,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
         self.log.info(repr({stmt: stmt, **kwargs}))
         try:
             expected = LocalCmdRunner().run(stmt, **kwargs)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             expected = exc
 
         libssh2_thread_results = []
@@ -385,7 +382,7 @@ class TestSudoAndRunShellScript(unittest.TestCase):
     def setUpClass(cls) -> None:
         class _Runner(CommandRunner):
             def run(self, cmd, *_, **__):
-                self.command_to_run = cmd  # pylint: disable=attribute-defined-outside-init
+                self.command_to_run = cmd
 
             def _create_connection(self):
                 pass

--- a/unit_tests/test_replication_strategy_utils.py
+++ b/unit_tests/test_replication_strategy_utils.py
@@ -7,23 +7,23 @@ from sdcm.utils.replication_strategy_utils import temporary_replication_strategy
 
 class TestReplicationStrategies:
 
-    def test_can_create_simple_replication_strategy(self):  # pylint: disable=no-self-use
+    def test_can_create_simple_replication_strategy(self):
         strategy = SimpleReplicationStrategy(replication_factor=3)
         assert str(strategy) == "{'class': 'SimpleStrategy', 'replication_factor': 3}"
 
-    def test_can_create_network_topology_replication_strategy(self):  # pylint: disable=no-self-use
+    def test_can_create_network_topology_replication_strategy(self):
         strategy = NetworkTopologyReplicationStrategy(dc1=3, dc2=8)
         assert str(strategy) == "{'class': 'NetworkTopologyStrategy', 'dc1': 3, 'dc2': 8}"
 
-    def test_can_create_network_topology_replication_strategy_with_default_rf(self):  # pylint: disable=no-self-use
+    def test_can_create_network_topology_replication_strategy_with_default_rf(self):
         strategy = NetworkTopologyReplicationStrategy(2, dc1=3, dc2=8)
         assert str(strategy) == "{'class': 'NetworkTopologyStrategy', 'replication_factor': 2, 'dc1': 3, 'dc2': 8}"
 
-    def test_can_create_network_topology_replication_strategy_only_with_default_rf(self):  # pylint: disable=no-self-use
+    def test_can_create_network_topology_replication_strategy_only_with_default_rf(self):
         strategy = NetworkTopologyReplicationStrategy(3)
         assert str(strategy) == "{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}"
 
-    def test_can_create_simple_replication_strategy_from_string(self):  # pylint: disable=no-self-use
+    def test_can_create_simple_replication_strategy_from_string(self):
         strategy = ReplicationStrategy.from_string(
             "REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 4}")
         assert isinstance(strategy, SimpleReplicationStrategy)
@@ -35,34 +35,34 @@ class TestReplicationStrategies:
         assert isinstance(strategy, SimpleReplicationStrategy)
         assert str(strategy) == "{'class': 'SimpleStrategy', 'replication_factor': 4}"
 
-    def test_can_create_network_topology_replication_strategy_from_string(self):  # pylint: disable=no-self-use
+    def test_can_create_network_topology_replication_strategy_from_string(self):
         strategy = ReplicationStrategy.from_string(
             "REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'DC1' : 2, 'DC2': 8}")
         assert isinstance(strategy, NetworkTopologyReplicationStrategy)
         assert str(strategy) == "{'class': 'NetworkTopologyStrategy', 'DC1': 2, 'DC2': 8}"
 
-    def test_can_create_network_topology_replication_strategy_from_string_with_replication_factor(self):  # pylint: disable=no-self-use
+    def test_can_create_network_topology_replication_strategy_from_string_with_replication_factor(self):
         strategy = ReplicationStrategy.from_string(
             "REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2}")
         assert isinstance(strategy, NetworkTopologyReplicationStrategy)
         assert str(strategy) == "{'class': 'NetworkTopologyStrategy', 'replication_factor': 2}"
 
-    def test_get_replication_startegy_from_string_with_few_curly_braces(self):  # pylint: disable=no-self-use
+    def test_get_replication_startegy_from_string_with_few_curly_braces(self):
         strategy = ReplicationStrategy.from_string(
             "replication = {'class': 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1'} "
             "AND durable_writes = true AND tablets = {'enabled': false}")
         assert str(strategy) == "{'class': 'SimpleStrategy', 'replication_factor': 1}"
 
-    def test_cannot_create_network_topology_replication_strategy_without_replication_factor(self):  # pylint: disable=no-self-use
+    def test_cannot_create_network_topology_replication_strategy_without_replication_factor(self):
         with pytest.raises(ValueError):
             NetworkTopologyReplicationStrategy()
 
-    def test_can_create_local_replication_strategy(self):  # pylint: disable=no-self-use
+    def test_can_create_local_replication_strategy(self):
         strategy = LocalReplicationStrategy()
         assert str(strategy) == "{'class': 'LocalStrategy'}"
 
 
-class Cluster:  # pylint: disable=unused-argument,too-few-public-methods
+class Cluster:
     class Session:
         @staticmethod
         def execute(cql, timeout=None):
@@ -81,12 +81,12 @@ class Cluster:  # pylint: disable=unused-argument,too-few-public-methods
         return Cluster.Session()
 
 
-class Node():  # pylint: disable=too-few-public-methods
+class Node():
 
     def __init__(self):
         self.parent_cluster = Cluster()
 
-    def run_cqlsh(self, cql):  # pylint: disable=no-self-use
+    def run_cqlsh(self, cql):
         if 'some error' in cql:
             raise AttributeError("found some error")
         print(cql)
@@ -97,7 +97,7 @@ class Node():  # pylint: disable=too-few-public-methods
 
 class TestReplicationStrategySetter:
 
-    def test_temporary_replication_strategy_setter_rolls_back_on_exit(self, capsys):  # pylint: disable=no-self-use
+    def test_temporary_replication_strategy_setter_rolls_back_on_exit(self, capsys):
         with temporary_replication_strategy_setter(node=Node()) as replication_setter:
             replication_setter(
                 ks=SimpleReplicationStrategy(3),
@@ -117,7 +117,7 @@ class TestReplicationStrategySetter:
             # shouldn't do anything else
             next(out)
 
-    def test_temporary_replication_strategy_setter_rolls_back_on_failure(self, capsys):  # pylint: disable=no-self-use
+    def test_temporary_replication_strategy_setter_rolls_back_on_failure(self, capsys):
         with pytest.raises(AttributeError), temporary_replication_strategy_setter(node=Node()) as replication_setter:
             replication_setter(
                 keyspace=SimpleReplicationStrategy(3), keyspace_x='some error',

--- a/unit_tests/test_sct_events_base.py
+++ b/unit_tests/test_sct_events_base.py
@@ -26,8 +26,6 @@ from sdcm.sct_events.base import \
 Y = None  # define a global name for pickle.
 
 
-# pylint: disable=protected-access,invalid-name,abstract-method,redefined-outer-name,global-statement
-
 class TestSctEventDefaultRegistry(unittest.TestCase):
     def test_sct_event_is_in_registry(self):
         self.assertIn("SctEvent", SctEvent._sct_event_types_registry)
@@ -93,7 +91,7 @@ class TestSctEvent(SctEventTestCase):
         self.assertIsInstance(y, SctEventProtocol)
 
     def test_subclass_twice_with_same_name(self):
-        # pylint: disable=unused-variable
+
         class Y(SctEvent):
             pass
 
@@ -137,7 +135,7 @@ class TestSctEvent(SctEventTestCase):
         self.assertNotEqual(z, y)
 
     def test_equal_pickle_unpickle(self):
-        global Y  # pylint: disable=global-variable-not-assigned; assigned by class definition  # noqa: PLW0603
+        global Y  # noqa: PLW0603
 
         class Y(SctEvent):
             pass
@@ -305,7 +303,6 @@ class TestSctEvent(SctEventTestCase):
         class Y(SctEvent):
             T: Type[YT]
 
-        # pylint: disable=too-few-public-methods
         class Mixin:
             severity = Severity.WARNING
 
@@ -360,7 +357,6 @@ class TestSctEvent(SctEventTestCase):
                 self.attr1 = attr1
                 super().__init__(severity=Severity.ERROR)
 
-        # pylint: disable=too-few-public-methods
         class Mixin:
             severity = Severity.WARNING
 
@@ -372,7 +368,7 @@ class TestSctEvent(SctEventTestCase):
         self.assertEqual(yt.attr1, "value1")
 
     def test_add_subevent_type_pickle(self):
-        global Y  # pylint: disable=global-variable-not-assigned; assigned by class definition  # noqa: PLW0603
+        global Y  # noqa: PLW0603
 
         class Y(SctEvent):
             T: Type[SctEvent]
@@ -493,7 +489,7 @@ class TestLogEvent(SctEventTestCase):
         self.assertTrue(y._ready_to_publish)
 
     def test_clone_fresh(self):
-        global Y  # pylint: disable=global-variable-not-assigned; assigned by class definition  # noqa: PLW0603
+        global Y  # noqa: PLW0603
 
         class Y(LogEvent):
             pass
@@ -516,7 +512,7 @@ class TestLogEvent(SctEventTestCase):
         self.assertIsInstance(y, SctEventProtocol)
 
     def test_clone_with_info(self):
-        global Y  # pylint: disable=global-variable-not-assigned; assigned by class definition  # noqa: PLW0603
+        global Y  # noqa: PLW0603
 
         class Y(LogEvent):
             pass

--- a/unit_tests/test_sct_events_continuous_events_registry.py
+++ b/unit_tests/test_sct_events_continuous_events_registry.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-self-use
+
 
 import uuid
 from pathlib import Path

--- a/unit_tests/test_sct_events_database.py
+++ b/unit_tests/test_sct_events_database.py
@@ -94,10 +94,10 @@ class TestDatabaseLogEvent(unittest.TestCase):
         self.assertSetEqual(set(dir(DatabaseLogEvent)) - set(dir(LogEvent)),
                             {ev.type for ev in SYSTEM_ERROR_EVENTS})
 
-    def test_disk_error_event(self):  # pylint: disable=line-too-long
+    def test_disk_error_event(self):
 
         disk_error_event = DatabaseLogEvent.DISK_ERROR()
-        # pylint: disable=line-too-long
+
         log_lines = """2022-02-07T06:13:14+00:00 longevity-tls-1tb-7d-4-6-db-node-5279f155-0-4 !    INFO |  [shard 8] compaction - [Compact keyspace1.standard1 089530c0-87dd-11ec-8382-519d84e34cb0] Compacting [/var/lib/scylla/data/keyspace1/standard1-b8e41570875811ec8382519d84e34cb0/md-287128-big-Data.db:level=2:origin=compaction,/var/lib/scylla/data/keyspace1/standard1-b8e41570875811ec8382519d84e34cb0/md-287112-big-Data.db:level=2:origin=compaction,/var/lib/scylla/data/keyspace1/standard1-b8e41570875811ec8382519d84e34cb0/md-290136-big-Data.db:level=2:origin=compaction,/var/lib/scylla/data/keyspace1/standard1-b8e41570875811ec8382519d84e34cb0/md-291192-big-Data.db:level=1:origin=compaction]
 2022-02-07T06:13:14+00:00 longevity-tls-1tb-7d-4-6-db-node-5279f155-0-4 !     ERR | blk_update_request: critical medium error, dev nvme0n11, sector 4141328 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 0
 2022-02-07T06:13:14+00:00 longevity-tls-1tb-7d-4-6-db-node-5279f155-0-4 !     ERR |  [shard 6] storage_service - Shutting down communications due to I/O errors until operator intervention: Disk error: std::system_error (error system:61, No data available)

--- a/unit_tests/test_sct_events_events_analyzer.py
+++ b/unit_tests/test_sct_events_events_analyzer.py
@@ -32,7 +32,6 @@ class TestEventsAnalyzer(unittest.TestCase, EventsUtilsMixin):
     def tearDownClass(cls) -> None:
         cls.teardown_events_processes()
 
-    # pylint: disable=protected-access
     def test_events_analyzer(self):
         initial_events_no = self.events_main_device.events_counter  # coming from other tests
         start_events_analyzer(_registry=self.events_processes_registry)

--- a/unit_tests/test_sct_events_events_handler.py
+++ b/unit_tests/test_sct_events_events_handler.py
@@ -23,9 +23,8 @@ from sdcm.test_config import TestConfig
 from unit_tests.lib.events_utils import EventsUtilsMixin
 
 
-# pylint: disable=too-few-public-methods
 class TestEventsHandler(unittest.TestCase, EventsUtilsMixin):
-    # pylint: disable=invalid-name
+
     @classmethod
     def setUpClass(cls) -> None:
         cls.setup_events_processes(events_device=False, events_main_device=True, registry_patcher=False)
@@ -34,7 +33,7 @@ class TestEventsHandler(unittest.TestCase, EventsUtilsMixin):
     def tearDownClass(cls) -> None:
         cls.teardown_events_processes()
 
-    def test_events_handler(self):  # pylint: disable=no-self-use
+    def test_events_handler(self):
         with unittest.mock.patch("sdcm.sct_events.handlers.schema_disagreement.SchemaDisagreementHandler.handle", spec=True) as mock:
             start_events_handler(_registry=self.events_processes_registry)
             events_handler = get_events_process(name=EVENTS_HANDLER_ID, _registry=self.events_processes_registry)
@@ -45,8 +44,8 @@ class TestEventsHandler(unittest.TestCase, EventsUtilsMixin):
 
             try:
                 assert events_handler.is_alive()
-                assert events_handler._registry == self.events_main_device._registry  # pylint: disable=protected-access
-                assert events_handler._registry == self.events_processes_registry  # pylint: disable=protected-access
+                assert events_handler._registry == self.events_main_device._registry
+                assert events_handler._registry == self.events_processes_registry
                 event1 = CassandraStressLogEvent.SchemaDisagreement()
                 with self.wait_for_n_events(events_handler, count=1, timeout=1):
                     self.events_main_device.publish_event(event1)

--- a/unit_tests/test_sct_events_events_processes.py
+++ b/unit_tests/test_sct_events_events_processes.py
@@ -19,7 +19,7 @@ from sdcm.sct_events.events_processes import \
     EventsProcessesRegistry, create_default_events_process_registry, get_default_events_process_registry
 
 
-class FakeProcess:  # pylint: disable=too-few-public-methods
+class FakeProcess:
     def __init__(self, _registry=None):
         self._registry = _registry
         self.started = False
@@ -33,10 +33,9 @@ class TestEventsProcessesRegistry(unittest.TestCase):
         self.registry = EventsProcessesRegistry("some_path")
 
     def test_fresh(self):
-        self.assertEqual(self.registry._registry_dict, {})  # pylint: disable=protected-access
+        self.assertEqual(self.registry._registry_dict, {})
         self.assertEqual(self.registry.log_dir, Path("some_path"))
 
-    # pylint: disable=protected-access
     def test_start_events_process(self):
         self.registry.start_events_process("test", FakeProcess)
         self.assertEqual(len(self.registry._registry_dict), 1)

--- a/unit_tests/test_sct_events_file_logger.py
+++ b/unit_tests/test_sct_events_file_logger.py
@@ -24,7 +24,7 @@ from unit_tests.lib.events_utils import EventsUtilsMixin
 
 
 class TestFileLogger(unittest.TestCase, EventsUtilsMixin):
-    # pylint: disable=protected-access
+
     def setUp(self) -> None:
         self.setup_events_processes(events_device=False, events_main_device=True, registry_patcher=False)
         start_events_logger(_registry=self.events_processes_registry)

--- a/unit_tests/test_sct_events_filters.py
+++ b/unit_tests/test_sct_events_filters.py
@@ -90,16 +90,16 @@ class TestEventsFilter(unittest.TestCase):
     def test_regex_pattern(self):
         pattern = re.compile("lalala")
         db_events_filter = EventsFilter(regex=pattern)
-        self.assertEqual(db_events_filter._regex, pattern)  # pylint: disable=protected-access
+        self.assertEqual(db_events_filter._regex, pattern)
         self.assertEqual(db_events_filter.regex, pattern.pattern)
         self.assertEqual(db_events_filter, pickle.loads(pickle.dumps(db_events_filter)))
         db_events_filter.to_json()
 
     def test_regex_string(self):
         db_events_filter = EventsFilter(regex="lalala")
-        self.assertEqual(db_events_filter._regex,  # pylint: disable=protected-access
+        self.assertEqual(db_events_filter._regex,
                          re.compile("lalala", re.MULTILINE | re.DOTALL))
-        self.assertEqual(db_events_filter._regex.pattern, "lalala")  # pylint: disable=protected-access
+        self.assertEqual(db_events_filter._regex.pattern, "lalala")
         self.assertEqual(db_events_filter.regex, "lalala")
         self.assertEqual(db_events_filter, pickle.loads(pickle.dumps(db_events_filter)))
         db_events_filter.to_json()

--- a/unit_tests/test_sct_events_grafana.py
+++ b/unit_tests/test_sct_events_grafana.py
@@ -33,8 +33,6 @@ from sdcm.wait import wait_for
 
 from unit_tests.lib.events_utils import EventsUtilsMixin
 
-# pylint: disable=protected-access
-
 
 class TestGrafana(unittest.TestCase, EventsUtilsMixin):
     @classmethod

--- a/unit_tests/test_sct_events_loaders.py
+++ b/unit_tests/test_sct_events_loaders.py
@@ -187,7 +187,7 @@ class TestScyllaBenchEvent(unittest.TestCase):
 
         try:
             raise ValueError('Stress command completed with bad status 1')
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             scylla_bench_event.severity = Severity.ERROR
             scylla_bench_event.add_error([str(exc)])
 
@@ -408,7 +408,7 @@ class TestCassandraStressLogEvent(unittest.TestCase):
         self.assertSetEqual(set(dir(CassandraStressLogEvent)) - set(dir(LogEvent)),
                             {ev.type for ev in chain(CS_NORMAL_EVENTS, CS_ERROR_EVENTS)})
 
-    def test_cs_hint_in_flight_error(self):  # pylint: disable=no-self-use
+    def test_cs_hint_in_flight_error(self):
         self.get_event(line='java.io.IOException: Operation x10 on key(s) [334f37384f4d32303430]: Error executing: '
                        '(OverloadedException): Queried host (10.0.3.167/10.0.3.167:9042) was overloaded: Too many '
                        'in flight hints: 10490670',
@@ -476,7 +476,7 @@ class TestGeminiLogEvent(unittest.TestCase):
         self.assertEqual(event.line_number, 1)
         self.assertIsNone(event.backtrace)
         self.assertIsNone(event.raw_backtrace)
-        self.assertTrue(event._ready_to_publish)  # pylint: disable=protected-access
+        self.assertTrue(event._ready_to_publish)
         event.event_id = "3eaf9cb2-b54b-43f5-8472-d0fbf5c25f72"
         self.assertEqual(
             str(event),
@@ -497,7 +497,7 @@ class TestGeminiLogEvent(unittest.TestCase):
         self.assertEqual(event.line_number, 0)
         self.assertIsNone(event.backtrace)
         self.assertIsNone(event.raw_backtrace)
-        self.assertFalse(event._ready_to_publish)  # pylint: disable=protected-access
+        self.assertFalse(event._ready_to_publish)
         event.event_id = "3ce0cdeb-0866-40ce-9a20-25ea3ae08be2"
         self.assertEqual(
             str(event),

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -455,7 +455,7 @@ class ScyllaYamlTest(unittest.TestCase):
         assert yaml1.enable_sstables_mc_format == append_scylla_args_dict["enable_sstables_mc_format"]
         assert yaml1.enable_sstables_md_format == append_scylla_args_dict["enable_sstables_md_format"]
 
-        assert yaml1.force_schema_commit_log == append_scylla_args_dict["force_schema_commit_log"]  # pylint: disable=no-member
+        assert yaml1.force_schema_commit_log == append_scylla_args_dict["force_schema_commit_log"]
 
     @staticmethod
     def test_copy():

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -38,24 +38,20 @@ def is_builtin(inst):
     return inst.__module__ == __builtin__
 
 
-# pylint: disable=too-few-public-methods
 class FakeCluster:
     seed_nodes_addresses = ['1.1.1.1']
 
 
-# pylint: disable=too-few-public-methods
 class TestConfigWithLdap:
     LDAP_ADDRESS = '1.1.1.1', '389'
     IP_SSH_CONNECTIONS = "private"
 
 
-# pylint: disable=too-few-public-methods
 class TestConfigWithoutLdap:
     LDAP_ADDRESS = None
     IP_SSH_CONNECTIONS = "private"
 
 
-# pylint: disable=too-few-public-methods
 class FakeNode:
     parent_cluster = FakeCluster()
     public_ip_address = '2.2.2.2'
@@ -378,7 +374,7 @@ class ScyllaYamlNodeAttrBuilderTest(ScyllaYamlClusterAttrBuilderBase):
 BASE_FOLDER = os.path.join(os.path.dirname(__file__), 'test_data/test_scylla_yaml_builders')
 
 
-class FakeRemoter:  # pylint: disable=too-few-public-methods
+class FakeRemoter:
     def send_file(self, *_, **__):
         pass
 
@@ -403,10 +399,10 @@ class ObjectDict(dict):
         raise AttributeError(f"There no {item} attribute")
 
 
-class DummyCluster(BaseScyllaCluster, BaseCluster):  # pylint: disable=too-few-public-methods
+class DummyCluster(BaseScyllaCluster, BaseCluster):
     nodes: List['DummyNode']
 
-    def __init__(self, params):  # pylint: disable=super-init-not-called
+    def __init__(self, params):
         self.nodes = []
         self.params = params
         self.name = 'dummy_cluster'
@@ -421,12 +417,11 @@ class DummyCluster(BaseScyllaCluster, BaseCluster):  # pylint: disable=too-few-p
         for node in self.nodes:
             node.config_setup(append_scylla_args=self.get_scylla_args())
 
-    # pylint: disable=too-many-arguments
     def add_nodes(self, count, ec2_user_data='', dc_idx=0, rack=0, enable_auto_bootstrap=False, instance_type=None):
         pass
 
 
-class DummyNode(BaseNode):  # pylint: disable=abstract-method,too-many-instance-attributes
+class DummyNode(BaseNode):
     _system_log = None
     is_enterprise = False
     distro = Distro.CENTOS7
@@ -518,7 +513,7 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method,too-many-instance-
         return self._system_log
 
     @property
-    def is_nonroot_install(self):  # pylint: disable=invalid-overridden-method
+    def is_nonroot_install(self):
         return False
 
     @system_log.setter

--- a/unit_tests/test_sdcm_mgmt_common.py
+++ b/unit_tests/test_sdcm_mgmt_common.py
@@ -4,12 +4,12 @@ from sdcm.utils.distro import Distro
 
 class TestManagerVersions:
 
-    def test_get_manager_scylla_backend_returns_repo_address(self):  # pylint: disable=no-self-use
+    def test_get_manager_scylla_backend_returns_repo_address(self):
         url = get_manager_scylla_backend("2025", Distro.UBUNTU22)
 
         assert url == 'https://downloads.scylladb.com/deb/debian/scylla-2025.1.list'
 
-    def test_get_manager_repo_from_defaults_returns_repo_address(self):  # pylint: disable=no-self-use
+    def test_get_manager_repo_from_defaults_returns_repo_address(self):
         url = get_manager_repo_from_defaults("3.5", Distro.UBUNTU22)
 
         assert url == 'https://downloads.scylladb.com/deb/debian/scylladb-manager-3.5.list'

--- a/unit_tests/test_seed_selector.py
+++ b/unit_tests/test_seed_selector.py
@@ -10,7 +10,7 @@ from sdcm.test_config import TestConfig
 from unit_tests.dummy_remote import DummyRemote
 
 
-class DummyNode(sdcm.cluster.BaseNode):  # pylint: disable=abstract-method
+class DummyNode(sdcm.cluster.BaseNode):
     def init(self):
         super().init()
         self.remoter.stop()
@@ -29,7 +29,7 @@ class DummyNode(sdcm.cluster.BaseNode):  # pylint: disable=abstract-method
         return '127.0.0.%s' % self.name.replace('node', '')
 
     @property
-    def is_nonroot_install(self):  # pylint: disable=invalid-overridden-method
+    def is_nonroot_install(self):
         return False
 
 

--- a/unit_tests/test_send_email.py
+++ b/unit_tests/test_send_email.py
@@ -8,7 +8,7 @@ from sdcm.send_email import LongevityEmailReporter, read_email_data_from_file
 
 
 class LongevityEmailReporterTest(LongevityEmailReporter):
-    def send_email(self, email):  # pylint disable:no-self-use
+    def send_email(self, email):
         return
 
 
@@ -16,11 +16,11 @@ class EmailReporterTest(unittest.TestCase):
     temp_dir = None
 
     @classmethod
-    def setUpClass(cls):  # pylint: disable=invalid-name
+    def setUpClass(cls):
         cls.temp_dir = tempfile.mkdtemp()
 
     @classmethod
-    def tearDownClass(cls):  # pylint: disable=invalid-name
+    def tearDownClass(cls):
         shutil.rmtree(cls.temp_dir)
 
     def _get_report_data(self, zipfile_path):
@@ -28,7 +28,7 @@ class EmailReporterTest(unittest.TestCase):
             file.extractall(self.temp_dir)
             return read_email_data_from_file(os.path.join(self.temp_dir, 'email_data.json'))
 
-    def test_longevity_report_big_file(self):  # pylint: disable=no-self-use
+    def test_longevity_report_big_file(self):
         test_results = self._get_report_data('test_data/test_send_email/LongevityEmailReporter/big_report.zip')
         self.assertTrue(test_results)
         reporter = LongevityEmailReporterTest(email_recipients='some@host.com', logdir=self.temp_dir)

--- a/unit_tests/test_sla_utils.py
+++ b/unit_tests/test_sla_utils.py
@@ -15,7 +15,7 @@ from unit_tests.test_cluster import DummyDbCluster
 logging.basicConfig(level=logging.DEBUG)
 
 
-class DummyNode(BaseNode):  # pylint: disable=abstract-method
+class DummyNode(BaseNode):
     _system_log = None
     is_enterprise = False
     distro = Distro.CENTOS7
@@ -76,19 +76,16 @@ class FakeServiceLevel(ServiceLevel):
 
 class FakePrometheus:
     @staticmethod
-    # pylint: disable=unused-argument
     def get_scylla_io_queue_total_operations(start_time, end_time, node_ip, irate_sample_sec='60s'):
         return {'127.0.0.1': {'sl:default': [410.5785714285715, 400.36428571428576],
                               'sl:sl200_abc': [177.11428571428573, 182.02857142857144],
                               'sl:sl50_abc': [477.11428571428573, 482.02857142857144]}
                 }
 
-    # pylint: disable=unused-argument,no-self-use
     def get_scylla_reactor_utilization(self, start_time, end_time, instance):
         return 100
 
 
-# pylint: disable=too-few-public-methods
 class FakeSession:
     default_timeout = 0
 

--- a/unit_tests/test_test_lib_cql_types.py
+++ b/unit_tests/test_test_lib_cql_types.py
@@ -4,8 +4,8 @@ from test_lib.cql_types import CQLTypeBuilder, NOT_EMBEDDABLE_COLUMN_TYPES, COLL
 
 class CQLColumnTypeTest(unittest.TestCase):
 
-    def test_get_random(self):  # pylint: disable=no-self-use
-        # pylint: disable=invalid-name,unused-variable,no-member,protected-access
+    def test_get_random(self):
+
         already_used = {}
         EMBEDDABLE_NON_COLLECTION_COLUMN_TYPES = \
             [e for e in ALL_COLUMN_TYPES if e not in NOT_EMBEDDABLE_COLUMN_TYPES and e not in COLLECTION_COLUMN_TYPES]
@@ -25,8 +25,8 @@ class CQLColumnTypeTest(unittest.TestCase):
         random_type = CQLTypeBuilder.get_random(already_used, allow_levels=1)
         assert random_type is None, "We should reach end of variants here, and therefore None should be returned"
 
-    def test_str_and_remember_forget_variants(self):  # pylint: disable=no-self-use
-        # pylint: disable=no-member,protected-access
+    def test_str_and_remember_forget_variants(self):
+
         type_int = CQLTypeBuilder('int')
         assert type_int._get_available_variants(
             already_created_info={},

--- a/unit_tests/test_tester.py
+++ b/unit_tests/test_tester.py
@@ -42,8 +42,6 @@ class FakeSCTConfiguration(SCTConfiguration):
 
 ClusterTester.__test__ = False
 
-# pylint: disable=too-many-instance-attributes
-
 
 class ClusterTesterForTests(ClusterTester):
     _sct_log = None
@@ -92,7 +90,7 @@ class ClusterTesterForTests(ClusterTester):
         pass
 
     @property
-    def elasticsearch(self):  # pylint: disable=invalid-overridden-method
+    def elasticsearch(self):
         return None
 
     @silence()
@@ -115,15 +113,15 @@ class ClusterTesterForTests(ClusterTester):
         self.events_processes_registry_patcher.stop()
 
     def _validate_results(self):
-        self.result._excinfo = []  # pylint: disable=protected-access
+        self.result._excinfo = []
         final_event = self.final_event
         unittest_final_event = self.unittest_final_event
         self._remove_errors_from_unittest_results(self._outcome)
         events_by_category = self.events
         sleep(0.3)
         # cache files info before deleting the folder
-        sct_log = self.sct_log  # pylint: disable=pointless-statement
-        event_summary = self.event_summary  # pylint: disable=pointless-statement
+        sct_log = self.sct_log
+        event_summary = self.event_summary
         shutil.rmtree(self.logdir)
         for event_category, total_events in event_summary.items():
             assert len(events_by_category[event_category]) == total_events, \
@@ -228,7 +226,7 @@ class CriticalErrorNotCaughtTest(ClusterTesterForTests):
             end_time = time.time() + 2
             while time.time() < end_time:
                 time.sleep(0.1)
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             pass
 
     def _validate_results(self):

--- a/unit_tests/test_utils__operator__multitenant_common.py
+++ b/unit_tests/test_utils__operator__multitenant_common.py
@@ -47,14 +47,14 @@ class FakePerformanceTest(FakeTestBase):
     pass
 
 
-class FakeDbCluster:  # pylint: disable=too-few-public-methods
+class FakeDbCluster:
     def __init__(self, fake_index):
         self.fake_index = fake_index
         self.k8s_clusters = [type("FakeK8SCluster", (), {"tenants_number": 2})]
         self.params = {}
 
 
-class FakeMultitenantTestBase:  # pylint: disable=too-few-public-methods
+class FakeMultitenantTestBase:
     def __init__(self):
         self.test_config = TestConfig()
         self.test_config.set_test_id_only("fake-test-id")
@@ -95,7 +95,6 @@ class UtilsOperatorMultitenantCommonTests(unittest.TestCase):
             if k.startswith('SCT_'):
                 del os.environ[k]
 
-    # pylint: disable=protected-access
     def _multitenant_class_with_shared_options(self, klass):
         os.environ['SCT_CONFIG_FILES'] = (
             'unit_tests/test_data/test_config/multitenant/shared_option_values.yaml')

--- a/unit_tests/test_utils_common.py
+++ b/unit_tests/test_utils_common.py
@@ -30,7 +30,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 class TestUtils(unittest.TestCase):
-    def test_scylla_bench_metrics_conversion(self):  # pylint: disable=no-self-use
+    def test_scylla_bench_metrics_conversion(self):
         metrics = {"4ms": 4.0, "950µs": 0.95, "30ms": 30.0, "8.592961906s": 8592.961905999999,
                    "18.120703ms": 18.120703, "5.963775µs": 0.005963775, "9h0m0.024080491s": 32400024.080491,
                    "1m0.024080491s": 60024.080491, "546431": 546431.0}
@@ -52,7 +52,7 @@ class TestDownloadDir(unittest.TestCase):
 
         self.clear_cloud_downloaded_path(sct_update_db_packages)
 
-        def touch_file(client, bucket, key, local_file_path):  # pylint: disable=unused-argument
+        def touch_file(client, bucket, key, local_file_path):
             Path(local_file_path).touch()
 
         with unittest.mock.patch("sdcm.utils.common._s3_download_file", new=touch_file):
@@ -63,7 +63,7 @@ class TestDownloadDir(unittest.TestCase):
     def test_update_db_packages_gce(self):
         sct_update_db_packages = 'gs://scratch.scylladb.com/sct_test/'
 
-        class FakeObject:  # pylint: disable=too-few-public-methods
+        class FakeObject:
             def __init__(self, name):
                 self.name = name
 
@@ -86,11 +86,11 @@ class TestDownloadDir(unittest.TestCase):
         assert update_db_packages is None
 
 
-class Remoter:  # pylint: disable=too-few-public-methods
+class Remoter:
     def __init__(self, system_log):
         self.system_log = system_log
 
-    def run(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def run(self, *args, **kwargs):
         lines = ["[shard 11] sstables_loader - load_and_stream: started ops_uuid=a2661989-6836-418f-aa67-2c5466499848, process [0-1] out",
                  "[shard  2] sstables_loader - Done loading new SSTables for keyspace=keyspace1, table=standard1, load_and_stream=true, "
                  "primary_replica_only=false, status=succeeded"
@@ -100,8 +100,8 @@ class Remoter:  # pylint: disable=too-few-public-methods
                 file.write(f"{line}\n")
 
 
-class DummyDbCluster(BaseCluster, BaseScyllaCluster):  # pylint: disable=abstract-method
-    # pylint: disable=super-init-not-called
+class DummyDbCluster(BaseCluster, BaseScyllaCluster):
+
     def __init__(self, nodes):
         self.nodes = nodes
         self.params = sct_config.SCTConfiguration()
@@ -115,7 +115,7 @@ class DummyDbCluster(BaseCluster, BaseScyllaCluster):  # pylint: disable=abstrac
         pass
 
 
-class DummyNode(BaseNode):  # pylint: disable=abstract-method
+class DummyNode(BaseNode):
     _system_log = None
     is_enterprise = False
     is_product_enterprise = False
@@ -164,7 +164,7 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method
         pass
 
     @property
-    def is_nonroot_install(self) -> bool:  # pylint: disable=invalid-overridden-method
+    def is_nonroot_install(self) -> bool:
         return False
 
     @property

--- a/unit_tests/test_utils_data_validator.py
+++ b/unit_tests/test_utils_data_validator.py
@@ -28,7 +28,7 @@ def test_view_names_for_updated_data(params):
     data_validator = LongevityDataValidator(longevity_self_object=MockLongevityTest(params=params),
                                             user_profile_name='c-s_lwt',
                                             base_table_partition_keys=['domain', 'published_date'])
-    data_validator._validate_updated_per_view = [True, True]  # pylint: disable=protected-access
+    data_validator._validate_updated_per_view = [True, True]
     views_list = data_validator.list_of_view_names_for_update_test()
     assert views_list == [('blogposts_update_one_column_lwt_indicator',
                            'blogposts_update_one_column_lwt_indicator_after_update',
@@ -44,6 +44,6 @@ def test_view_names_for_updated_data_not_found(params):
     data_validator = LongevityDataValidator(longevity_self_object=MockLongevityTest(params=params),
                                             user_profile_name='c-s_lwt',
                                             base_table_partition_keys=['domain', 'published_date'])
-    data_validator._validate_updated_per_view = [True, True]  # pylint: disable=protected-access
+    data_validator._validate_updated_per_view = [True, True]
     views_list = data_validator.list_of_view_names_for_update_test()
     assert views_list == []

--- a/unit_tests/test_utils_database_query_utils.py
+++ b/unit_tests/test_utils_database_query_utils.py
@@ -5,7 +5,7 @@ from unit_tests.test_cluster import DummyScyllaCluster
 
 
 @pytest.mark.integration
-def test_fetch_all_rows(docker_scylla, params, events):  # pylint: disable=unused-argument
+def test_fetch_all_rows(docker_scylla, params, events):
 
     cluster = DummyScyllaCluster([docker_scylla])
     cluster.params = params

--- a/unit_tests/test_utils_distro.py
+++ b/unit_tests/test_utils_distro.py
@@ -276,7 +276,7 @@ VERSION_ID 18.04
 }
 
 
-class TestDistro(unittest.TestCase):  # pylint: disable=too-many-public-methods
+class TestDistro(unittest.TestCase):
     def test_unknown(self):
         self.assertTrue(Distro.UNKNOWN.is_unknown)
         distro = Distro.from_os_release(DISTROS_OS_RELEASE["Unknown"])

--- a/unit_tests/test_utils_docker.py
+++ b/unit_tests/test_utils_docker.py
@@ -11,8 +11,6 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
-# pylint: disable=too-few-public-methods,too-many-statements,protected-access,attribute-defined-outside-init
-# pylint: disable=too-many-public-methods,too-many-instance-attributes
 
 from __future__ import absolute_import
 
@@ -28,13 +26,13 @@ build_args = {}
 
 
 class DummyDockerClient:
-    class api:  # pylint: disable=invalid-name
+    class api:
         @staticmethod
         def build(*args, **kwargs):
             build_args['123456'] = (args, kwargs)
             return '''{"stream": "Successfully built 123456"}'''
 
-    class containers:  # pylint: disable=invalid-name
+    class containers:
         @staticmethod
         def list(*args, **kwargs):
             return args, kwargs
@@ -53,7 +51,7 @@ class DummyDockerClient:
             container.run_args = args, kwargs
             return container
 
-    class images:  # pylint: disable=invalid-name
+    class images:
         @staticmethod
         def build(*args, **kwargs):
             return (args, kwargs,), [{"stream": "blah"}]
@@ -168,7 +166,7 @@ class TestContainerManager(unittest.TestCase):
                              ContainerManager.default_docker_client)
 
         with self.subTest("Docker client without name argument"):
-            self.node.None_docker_client = Mock()  # pylint: disable=invalid-name
+            self.node.None_docker_client = Mock()
             self.node.docker_client = sentinel.none_docker_client
             self.assertEqual(ContainerManager.get_docker_client(self.node), sentinel.none_docker_client)
             self.node.None_docker_client.assert_not_called()
@@ -412,7 +410,7 @@ class TestContainerManager(unittest.TestCase):
             rsa_key_mock.return_value.get_base64.assert_called_once_with()
             self.container.exec_run.assert_called_once()
 
-            # pylint: disable=unsubscriptable-object; disable this message for .call_args[]
+            # disable this message for .call_args[]
             self.assertIn(" 0123456789 ", " ".join(self.container.exec_run.call_args[0][0]))
             self.assertEqual(self.container.exec_run.call_args[1]["user"], sentinel.ssh_user)
 

--- a/unit_tests/test_utils_k8s.py
+++ b/unit_tests/test_utils_k8s.py
@@ -109,7 +109,7 @@ def test_helm_values_try_set_by_list_index():
     assert False, "expected 'ValueError' exception was not raised"
 
 
-class FakeK8SKluster:  # pylint: disable=too-few-public-methods
+class FakeK8SKluster:
     def __init__(self):
         self.get_api_client = mock.MagicMock()
         self.region_name = 'fake-region-1'
@@ -167,8 +167,7 @@ ns2_eachpod_callbacks_as_list = [
 ]
 
 
-# pylint: disable=protected-access
-def test_scylla_pods_ip_change_tracker_01_positive_scenario():  # pylint: disable=too-many-statements
+def test_scylla_pods_ip_change_tracker_01_positive_scenario():
     # Init objects
     core_v1_api_mock, k8s_kluster, ip_mapper = mock.Mock(), FakeK8SKluster(), {}
     namespace1, pod_names1 = 'scylla', ("pod-name-1", "pod-name-2", "pod-name-3")

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -185,7 +185,7 @@ def test_07_get_git_tag_from_helm_chart_version__wrong_input(chart_version):
     assert False, f"'ValueError' was expected, but absent. Returned value: {git_tag}"
 
 
-class ClassWithVersiondMethods:  # pylint: disable=too-few-public-methods
+class ClassWithVersiondMethods:
     def __init__(self, scylla_version, nemesis_like_class):
         params = {"scylla_version": scylla_version}
         if scylla_version.startswith('enterprise:'):
@@ -210,52 +210,52 @@ class ClassWithVersiondMethods:  # pylint: disable=too-few-public-methods
             self.nodes = nodes
 
     @scylla_versions((None, "4.3"))
-    def oss_method(self):  # pylint: disable=no-self-use
+    def oss_method(self):
         return "any 4.3.x and lower"
 
     @scylla_versions(("4.4.rc1", "4.4.rc1"), ("4.4.rc4", "4.5"))
-    def oss_method(self):  # pylint: disable=no-self-use,function-redefined
+    def oss_method(self):
         return "all 4.4 and 4.5 except 4.4.rc2 and 4.4.rc3"
 
     @scylla_versions(("4.6.rc1", None))
-    def oss_method(self):  # pylint: disable=no-self-use,function-redefined
+    def oss_method(self):
         return "4.6.rc1 and higher"
 
     @scylla_versions((None, "2019.1"))
-    def es_method(self):  # pylint: disable=no-self-use
+    def es_method(self):
         return "any 2019.1.x and lower"
 
     @scylla_versions(("2020.1.rc1", "2020.1.rc1"), ("2020.1.rc4", "2021.1"))
-    def es_method(self):  # pylint: disable=no-self-use,function-redefined
+    def es_method(self):
         return "all 2020.1 and 2021.1 except 2020.1.rc2 and 2020.1.rc3"
 
     @scylla_versions(("2022.1.rc1", None))
-    def es_method(self):  # pylint: disable=no-self-use,function-redefined
+    def es_method(self):
         return "2022.1.rc1 and higher"
 
     @scylla_versions((None, "4.3"), (None, "2019.1"))
-    def mixed_method(self):  # pylint: disable=no-self-use
+    def mixed_method(self):
         return "any 4.3.x and lower, any 2019.1.x and lower"
 
     @scylla_versions(("4.4.rc1", "4.4.rc1"), ("4.4.rc4", "4.5"),
                      ("2020.1.rc1", "2020.1.rc1"), ("2020.1.rc4", "2021.1"))
-    def mixed_method(self):  # pylint: disable=no-self-use,function-redefined
+    def mixed_method(self):
         return "all 4.4, 4.5, 2020.1 and 2021.1 except 4.4.rc2, 4.4.rc3, 2020.1.rc2 and 2020.1.rc3"
 
     @scylla_versions(("4.6.rc1", None), ("2022.1.rc1", None))
-    def mixed_method(self):  # pylint: disable=no-self-use,function-redefined
+    def mixed_method(self):
         return "4.6.rc1 and higher, 2022.1.rc1 and higher"
 
     @scylla_versions(("4.6.rc1", None))
-    def new_oss_method(self):  # pylint: disable=no-self-use,function-redefined
+    def new_oss_method(self):
         return "4.6.rc1 and higher"
 
     @scylla_versions(("2022.1.rc1", None))
-    def new_es_method(self):  # pylint: disable=no-self-use,function-redefined
+    def new_es_method(self):
         return "4.6.rc1 and higher"
 
     @scylla_versions(("4.6.rc1", None), ("2022.1.rc1", None))
-    def new_mixed_method(self):  # pylint: disable=no-self-use,function-redefined
+    def new_mixed_method(self):
         return "4.6.rc1 and higher"
 
 

--- a/unit_tests/test_wait.py
+++ b/unit_tests/test_wait.py
@@ -10,7 +10,7 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2023 ScyllaDB
-# pylint: disable=all
+
 
 from __future__ import absolute_import
 import logging

--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -15,7 +15,7 @@ import re
 
 import pytest
 import requests
-from cassandra.cluster import Cluster  # pylint: disable=no-name-in-module
+from cassandra.cluster import Cluster
 from cassandra.auth import PlainTextAuthProvider
 
 from sdcm.utils import alternator

--- a/upgrade_schema_test.py
+++ b/upgrade_schema_test.py
@@ -13,8 +13,7 @@
 #
 # Copyright (c) 2016 ScyllaDB
 
-# TODO: this test seem to be broken, hence disabling all pylint checks
-# pylint: disable=all
+# TODO: this test seem to be broken
 
 import random
 import struct

--- a/utils/build_system/create_test_release_jobs.py
+++ b/utils/build_system/create_test_release_jobs.py
@@ -30,7 +30,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class JenkinsPipelines:
-    def __init__(self, base_job_dir, sct_branch_name, sct_repo, username=None, password=None):  # pylint: disable=too-many-arguments
+    def __init__(self, base_job_dir, sct_branch_name, sct_repo, username=None, password=None):
         if not username and not password:
             creds = KeyStore().get_json("jenkins.json")
             username, password = creds.get('username'), creds.get('password')
@@ -195,7 +195,7 @@ class JenkinsPipelines:
 
         return description
 
-    def create_job_tree(self, local_path: str | Path,  # pylint: disable=too-many-arguments
+    def create_job_tree(self, local_path: str | Path,
                         create_freestyle_jobs: bool = True,
                         create_pipelines_jobs: bool = True,
                         template_context: dict | None = None,

--- a/utils/cloud_cleanup/aws/clean_aws.py
+++ b/utils/cloud_cleanup/aws/clean_aws.py
@@ -104,7 +104,7 @@ def stop_instance(instance):
             ])
             instance.stop()
             update_argus_resource_status(test_id, name, 'terminate')
-    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         eprint("stop instance %s error: %s" % (instance.id, str(exc)))
 
 
@@ -117,7 +117,7 @@ def remove_protection(instance):
                     'Value': False
                 })
             print_instance(instance, "Disabling API Termination protection")
-    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         eprint("DisableApiTermination protection %s error: %s" % (instance.id, str(exc)))
 
 
@@ -134,7 +134,7 @@ def terminate_instance(instance):
             ])
             instance.terminate()
             update_argus_resource_status(test_id, name, 'terminate')
-    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         eprint("terminate instance %s error: %s" % (instance.id, str(exc)))
 
 
@@ -237,7 +237,7 @@ def delete_volume(volume):
         print_volume(volume, "deleting")
         if not DRY_RUN:
             volume.delete()
-    except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception:  # noqa: BLE001
         pass
 
 
@@ -288,7 +288,7 @@ def release_address(eip_dict, client):
                 client.release_address(AllocationId=eip_dict['AllocationId'])
             elif "PublicIp" in eip_dict:
                 client.release_address(PublicIp=eip_dict['PublicIp'])
-    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         print(exc)
 
 

--- a/utils/cloud_cleanup/azure/clean_azure.py
+++ b/utils/cloud_cleanup/azure/clean_azure.py
@@ -54,7 +54,7 @@ def get_vm_creation_time(v_m, resource_group_name):
             compute_client.virtual_machines.begin_update(resource_group_name, v_m.name, parameters={
                 "tags": tags,
             })
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.info(
                 "Failed to update VM tags: %s in resource group: %s with exception: %s",
                 v_m.name, resource_group_name, exc)
@@ -73,7 +73,7 @@ def get_rg_creation_time(resource_group):
         resource_group.tags = tags
         try:
             resource_client.resource_groups.create_or_update(resource_group.name, resource_group)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.info("Failed to update RG tags: %s with exception: %s", resource_group.name, exc)
     return creation_time
 
@@ -103,7 +103,7 @@ def delete_virtual_machine(resource_group_name, vm_name, test_id, dry_run=False)
         LOGGER.info("Deleting VM: %s in resource group: %s", vm_name, resource_group_name)
         try:
             compute_client.virtual_machines.begin_delete(resource_group_name, vm_name)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.info(
                 "Failed to delete VM: %s in resource group: %s with exception: %s", vm_name, resource_group_name, exc)
             return
@@ -117,7 +117,7 @@ def stop_virtual_machine(resource_group_name, vm_name, test_id, dry_run=False):
         LOGGER.info("Stopping VM: %s in resource group: %s", vm_name, resource_group_name)
         try:
             compute_client.virtual_machines.begin_deallocate(resource_group_name, vm_name, test_id)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.info("Failed to stop VM: %s in resource group: %s with exception: %s",
                         vm_name, resource_group_name, exc)
             return
@@ -131,7 +131,7 @@ def delete_resource_group(resource_group_name, dry_run=False):
         LOGGER.info("Deleting resource group: %s", resource_group_name)
         try:
             resource_client.resource_groups.begin_delete(resource_group_name)
-        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.info("Failed to delete resource group: %s with exception: %s", resource_group_name, exc)
 
 

--- a/utils/cloud_cleanup/gce/clean_gce.py
+++ b/utils/cloud_cleanup/gce/clean_gce.py
@@ -59,7 +59,7 @@ def clean_gce_instances(instances_client, project_id, dry_run):
                         res.done()
                         LOGGER.info("%s terminated", instance.name)
                         update_argus_resource_status(instance_metadata.get('TestId', ''), instance.name, 'terminate')
-                    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+                    except Exception as exc:  # noqa: BLE001
                         LOGGER.error("error while terminating instance %s: %s", instance.name, exc)
                 else:
                     LOGGER.info("dry run: would terminate instance %s, creation time: %s",
@@ -75,7 +75,7 @@ def clean_gce_instances(instances_client, project_id, dry_run):
                         res.done()
                         LOGGER.info("%s stopped", instance.name)
                         update_argus_resource_status(instance_metadata.get('TestId', ''), instance.name, 'stop')
-                    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+                    except Exception as exc:  # noqa: BLE001
                         LOGGER.error("error while stopping instance %s: %s", instance.name, exc)
                 else:
                     LOGGER.info("dry run: would stop instance %s, creation time: %s", instance.name, vm_creation_time)

--- a/utils/decode_kallsyms.py
+++ b/utils/decode_kallsyms.py
@@ -23,7 +23,7 @@ def cut_addresses_from_log_line_kernel_callstack(line):
 
 def get_lines_from_log(file_path):
     file_content = {}
-    with open(file_path, 'r') as file:  # pylint: disable=unspecified-encoding
+    with open(file_path, 'r') as file:
         for line in file:
             if ('kernel callstack' in line and '0x' in line) or 'Reactor stalled for' in line:
                 file_content[line] = cut_addresses_from_log_line_kernel_callstack(line)
@@ -31,7 +31,7 @@ def get_lines_from_log(file_path):
 
 
 def get_kallsyms(path_to_kallsyms):
-    with open(path_to_kallsyms, 'r') as file:  # pylint: disable=unspecified-encoding
+    with open(path_to_kallsyms, 'r') as file:
         file_content = file.readlines()
     return file_content
 
@@ -44,10 +44,10 @@ def decode_kernel_callstacks(results_file='results.log', input_file='system.log'
                              clear_output_file=True):
     file_content = get_kallsyms(kallsyms_file)
     if clear_output_file:
-        with open(results_file, 'w'):  # pylint: disable=unspecified-encoding
+        with open(results_file, 'w'):
             print(f'clearing file {results_file}')
 
-    with open(results_file, 'a') as file:  # pylint: disable=unspecified-encoding
+    with open(results_file, 'a') as file:
         for full_line, stall in get_lines_from_log(input_file).items():
             append_content_to_file(file, '#' * 76)
             append_content_to_file(file, full_line)
@@ -66,4 +66,4 @@ def decode(input_file, kallsyms_file, results_file):
 
 
 if __name__ == "__main__":
-    decode()  # pylint: disable=no-value-for-parameter
+    decode()

--- a/utils/fix_es_mapping.py
+++ b/utils/fix_es_mapping.py
@@ -38,4 +38,4 @@ def fix_es_mapping(index_name):
 
 
 if __name__ == '__main__':
-    fix_es_mapping()  # pylint: disable=no-value-for-parameter
+    fix_es_mapping()

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -29,7 +29,7 @@ start_support_backend = {'azure': {'scylla': '5.2', 'enterprise': '2023.1'}}
 unsupported_versions = ['5.3', ]
 
 
-class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
+class UpgradeBaseVersion:
 
     oss_start_support_version = None
     ent_start_support_version = None
@@ -82,7 +82,7 @@ class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
         LOGGER.info("Support start versions set: oss=%s enterprise=%s", self.oss_start_support_version,
                     self.ent_start_support_version)
 
-    def get_supported_scylla_base_versions(self, supported_versions) -> list:  # pylint: disable=too-many-branches
+    def get_supported_scylla_base_versions(self, supported_versions) -> list:
         """
         We have special base versions list for each release, and we don't support to upgraded from enterprise
         to opensource. This function is used to get the base versions list which will be used in the upgrade test.

--- a/utils/migrate_latency_results_to_argus.py
+++ b/utils/migrate_latency_results_to_argus.py
@@ -18,7 +18,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 LOGGER = logging.getLogger(__name__)
 
 
-def migrate(creds, job_name, days=7, index_name="performancestatsv2", dry_run=True):  # pylint: disable=too-many-locals
+def migrate(creds, job_name, days=7, index_name="performancestatsv2", dry_run=True):
     ks = KeyStore()
     es_conf = ks.get_elasticsearch_token()
     elastic_search = Elasticsearch(**es_conf)

--- a/utils/migrate_nemesis_data.py
+++ b/utils/migrate_nemesis_data.py
@@ -21,7 +21,7 @@ LOGGER = logging.getLogger(__name__)
 @click.option('--new-index', default='nemesis_data', help='name of the target index')
 @click.option('--days', default=10, type=int, help="how many days backwards to migrate")
 @click.argument('old_index_name', type=str, default='longevitytest')
-def migrate(old_index_name, dry_run, new_index, days):  # pylint: disable=too-many-locals
+def migrate(old_index_name, dry_run, new_index, days):
 
     logging.basicConfig(level=logging.DEBUG)
     logging.config.dictConfig({
@@ -129,4 +129,4 @@ def migrate(old_index_name, dry_run, new_index, days):  # pylint: disable=too-ma
 
 
 if __name__ == '__main__':
-    migrate()  # pylint: disable=no-value-for-parameter
+    migrate()

--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -112,7 +112,7 @@ class ScyllaDoctor:
             sd_package = Package(name="scylla-doctor", date="", version=self.version, revision_id="", build_id="")
             LOGGER.info("Saving Scylla doctor package in Argus...")
             self.test_config.argus_client().submit_packages([sd_package])
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             LOGGER.error("Unable to collect Scylla Doctor package version for Argus - skipping...", exc_info=True)
 
     def find_local_python3_binary(self, user_home: str):

--- a/utils/split_sct_log.py
+++ b/utils/split_sct_log.py
@@ -33,10 +33,10 @@ def get_time(line_content):
 input_dir = Path.cwd()
 Path(input_dir / "parts").mkdir(exist_ok=True)
 with open(input_dir / "sct.log", "r", encoding="utf-8") as sct_log:
-    idx = 0  # pylint: disable=invalid-name
+    idx = 0
     line = sct_log.readline()
     time = get_time(line)
-    part_file = open(input_dir / "parts" / f"{idx:03d}_{time}_start.log", "w",  # pylint: disable=consider-using-with
+    part_file = open(input_dir / "parts" / f"{idx:03d}_{time}_start.log", "w",
                      encoding="utf-8")
     part_file.write(line)
     for line in sct_log.readlines():
@@ -46,7 +46,7 @@ with open(input_dir / "sct.log", "r", encoding="utf-8") as sct_log:
             print(f"processing nemesis: {name[:-1]}...")
             time = get_time(line)
             part_file.close()
-            part_file = open(  # pylint: disable=consider-using-with
+            part_file = open(
                 input_dir / "parts" / f"{idx:03d}_{time}_{name[:-1]}.log", "w", encoding="utf-8")
         part_file.write(line)
     part_file.close()

--- a/utils/update_field.py
+++ b/utils/update_field.py
@@ -90,11 +90,11 @@ def update_value(index_name, test_id, new_job_name):
             test_data["test_details"]["job_name"],
         )
         test_data["test_details"]["job_name"] = new_job_name
-        elastic_search.update(   # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
+        elastic_search.update(
             index=index_name, id=hit["_id"], doc=test_data
         )
         click.secho(f"updated {test_data['test_details']['test_id']}", fg="green")
 
 
 if __name__ == "__main__":
-    update_value()  # pylint: disable=no-value-for-parameter
+    update_value()


### PR DESCRIPTION
Pylint is no longer used, I think we can remove all the pylint disables. Ruff has less checks than pylint, if needed we can add more check Ruff to compensate (followup PR).

Warning: This might negatively affect backports, if we are backporting any line that was disabled, but I think that is small risk

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] None needed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
