### PR TITLE
fix(perf-regression-test): parse stress results before pushing to ES

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2368,7 +2368,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         return results and not errors
 
     def get_stress_results(self, queue, store_results=True) -> list[dict | None]:
-        results = queue.get_results()
+        results = queue.parse_results()[0]
         if store_results and self.create_stats:
             self.update_stress_results(results)
         return results


### PR DESCRIPTION
Recent refactor of the stress threads API renamed public methods to better align with their function.
This change fixes the API usage to ensure stress results are correctly parsed before being pushed to ElasticSearch.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
Tested by local run, but also the following job is running
- [x] :green_circle: [mini-elasticity-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/mini-elasticity-test/6/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
