### PR TITLE
fix(gemini_thread.py): fix appending of gemini default flags

### DIFF
--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -143,11 +143,9 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
 
         stress_cmd = self.stress_cmd.replace("\n", " ").strip()
 
-        for key, value in self.gemini_default_flags.items():
-            if not key in stress_cmd:
-                cmd += f"--{key}={value} "
+        cmd += " " + " ".join(f"--{key}={value}" for key, value in self.gemini_default_flags.items() if
+                              key not in stress_cmd) + " " + stress_cmd
 
-        cmd += stress_cmd
         self.gemini_commands.append(cmd)
         return cmd
 

--- a/unit_tests/test_gemini_thread.py
+++ b/unit_tests/test_gemini_thread.py
@@ -31,6 +31,7 @@ class DBCluster:  # pylint: disable=too-few-public-methods
 
 
 def test_01_gemini_thread(request, docker_scylla, params):
+    params.update({'gemini_table_options': ['gc_grace_seconds=60']})
     loader_set = LocalLoaderSetDummy(params=params)
     test_cluster = DBCluster([docker_scylla])
 
@@ -63,6 +64,9 @@ def test_01_gemini_thread(request, docker_scylla, params):
 
     request.addfinalizer(cleanup_thread)
 
+    expected_gemini_arguments = " --table-options=\"gc_grace_seconds=60\" --level=info --request-timeout=60s --connect-timeout=60s --consistency=QUORUM --async-objects-stabilization-backoff=1s --async-objects-stabilization-attempts=10 --dataset-size=large --oracle-host-selection-policy=token-aware --test-host-selection-policy=token-aware --drop-schema=true --fail-fast=true --materialized-views=false --use-lwt=false --use-counters=false --max-tables=1 --max-columns=16 --min-columns=8 --max-partition-keys=6 --min-partition-keys=2 --max-clustering-keys=4 --min-clustering-keys=2 --partition-key-distribution=normal --token-range-slices=512 --partition-key-buffer-reuse-size=100 --statement-log-file-compression=zstd --duration=1m --warmup=0 --concurrency=5 --mode=write --cql-features=basic --max-mutation-retries=100 --max-mutation-retries-backoff=100ms --replication-strategy=\"{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}\" --table-options=\"cdc = {'enabled': true, 'ttl': 0}\" --use-server-timestamps=true"
+    gemini_cmd = gemini_thread._generate_gemini_command()
+    assert expected_gemini_arguments in gemini_cmd
     gemini_thread.run()
 
     results = gemini_thread.get_gemini_results()


### PR DESCRIPTION
The default flags were wrongly concatenated without a leading space to the gemini command string
Fixes: #10581

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [test table options](https://argus.scylladb.com/tests/scylla-cluster-tests/0029ed86-9610-465a-807c-f860830b25c0)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
