### PR TITLE
fix(RemoteCmdRunner): fix scp destination string

### DIFF
--- a/sdcm/remote/remote_base.py
+++ b/sdcm/remote/remote_base.py
@@ -413,7 +413,7 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
             key_option = '-i %s' % os.path.expanduser(self.key_file)
         command = ("scp -r -o StrictHostKeyChecking=no -o BatchMode=yes "
                    "-o ConnectTimeout=%d -o ServerAliveInterval=%d "
-                   "-o UserKnownHostsFile=%s -P %d %s %s %s '%s'")
+                   "-o UserKnownHostsFile=%s -P %d %s %s %s %s")
         proxy_cmd = ''
         if self.proxy_host:
             proxy_cmd = self._make_proxy_cmd()


### PR DESCRIPTION
Scp command behaviour has changed on systems that have newer openssh version (v9.0+,
like in Ubuntu24) compared to older version (e.g. v8.*, Like in Ubuntu22). Newer openssh
versions use SFTP protocol by default. This affected the behavior of RemoteCmdRunner
send_files and receive_files API, where we quote path portion of desctination to be sure
that we can run the command with multiple remote paths.

This change removes single quotes around the destination parameter in scp command.
This helps to avoid improper shell expansion of remote path portion of destination.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/10584

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [pr-provision-test ](https://jenkins.scylladb.com/job/sct-github-PRs-scan/job/scylla-cluster-tests/job/PR-10585/5/)
- [x] executed a test locally (i.e environment uses local machine as sct-runner and runs test on remote scylla cluster) - the issue was observed on such setup

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
