### PR TITLE
fix(azure): fetch offical source-available release correctly

### DIFF
--- a/sdcm/provision/azure/utils.py
+++ b/sdcm/provision/azure/utils.py
@@ -20,8 +20,11 @@ from azure.mgmt.compute.models import GalleryImageVersion, CommunityGalleryImage
 
 from sdcm.provision.provisioner import VmArch
 from sdcm.utils.azure_utils import AzureService
-from sdcm.utils.version_utils import SCYLLA_VERSION_GROUPED_RE, is_enterprise
-
+from sdcm.utils.version_utils import (
+    SCYLLA_VERSION_GROUPED_RE,
+    is_enterprise,
+    ComparableScyllaVersion,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -96,7 +99,7 @@ def get_released_scylla_images(  # pylint: disable=unused-argument
 
 ) -> list[CommunityGalleryImageVersion]:
     branch_version = '.'.join(scylla_version.split('.')[:2])
-    if is_enterprise(branch_version):
+    if is_enterprise(branch_version) and ComparableScyllaVersion(branch_version) < '2025.1.0':
         gallery_image_name = f'scylla-enterprise-{branch_version}'
     else:
         gallery_image_name = f'scylla-{branch_version}'


### PR DESCRIPTION
cause of the date version of 2025.1, the code was trying to fetch the release from the wrong repository, and fail like:

```
ValueError: Azure Image for scylla_version='2025.1' not found in eastus
```

this commit add the logic to move to the none enterprise repo as needed

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested locally with hydra list-resources

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
