### PR TITLE
fix(docker artifact): stop checking for docker latest

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -247,22 +247,6 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
                                 f"matches: {snitch_matches_scylla_yaml}"
                             )
 
-    def verify_docker_latest_match_release(self) -> None:
-        for product in typing.get_args(ScyllaProduct):
-            latest_version = get_latest_scylla_release(product=product)
-
-            url = 'https://hub.docker.com/v2/repositories/scylladb/{}/tags/{}'
-            docker_latest = requests.get(url.format(product, 'latest')).json()
-            docker_release = requests.get(url.format(product, latest_version)).json()
-            self.log.debug('latest info: %s', pprint.pformat(docker_latest))
-            self.log.debug('%s info: %s ', latest_version, pprint.pformat(docker_release))
-
-            latest_digests = set(image['digest'] for image in docker_latest['images'])
-            release_digests = set(image['digest'] for image in docker_release['images'])
-
-            assert latest_digests == release_digests, \
-                f"latest != {latest_version}, images digest differs [{latest_digests}] != [{release_digests}]"
-
     def verify_nvme_write_cache(self) -> None:
         if self.write_back_cache is None or self.node.parent_cluster.is_additional_data_volume_used():
             return
@@ -480,9 +464,6 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
                 perftune_checker = PerftuneOutputChecker(self.node)
                 perftune_checker.compare_perftune_results()
 
-        if backend == 'docker':
-            with self.subTest("Check docker latest tags"):
-                self.verify_docker_latest_match_release()
 
     def run_scylla_doctor(self):
         if self.params.get('client_encrypt') and SkipPerIssues("https://github.com/scylladb/field-engineering/issues/2280", self.params):

--- a/docker/scylla-sct/centos/Dockerfile
+++ b/docker/scylla-sct/centos/Dockerfile
@@ -18,7 +18,7 @@ USER root
 
 RUN curl -L https://download.docker.com/linux/centos/docker-ce.repo -o /etc/yum.repos.d/docker-ce.repo
 
-RUN microdnf update && \
+RUN microdnf -y update && \
 	microdnf -y install \
         iproute \
         sudo \


### PR DESCRIPTION
For some reason (historical), we keep checking during this test that the docker `latest` tag matches the current Docker version for both `scylladb` and `scylla-enterprise`. Since we now have only the source available, we no longer need this check.
Let's remove it completely, as it's failing our tests

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/scylla-master/job/artifacts/job/artifacts-docker-test/1314/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
