### PR TITLE
fix(nemesis): increase timeout waiting node down

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5532,8 +5532,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             stack.callback(drop_keyspace, node=working_node)
 
             with simulate_node_unavailability(self.target_node):
-                # target node stopped by Contextmanger. Wait while its status will be updated
-                wait_for(node_operations.is_node_seen_as_down, timeout=600, throw_exc=True,
+                # target node stopped by Contextmanger. Wait while its status will be updated.
+                # with tablets and multidc it could take more time.
+                wait_for(node_operations.is_node_seen_as_down, timeout=1800, throw_exc=True,
                          down_node=self.target_node, verification_node=working_node, text=f"Wait other nodes see {self.target_node.name} as DOWN...")
                 self.log.debug("Remove node %s : hostid: %s with blocked scylla from cluster",
                                self.target_node.name, target_host_id)


### PR DESCRIPTION
After logs investigation, wait of node to be down
by nemesises: disrupt_refuse_connection_with_* could take more than 10 minutes for test configuration with
tablets, large data sets and multidc clusters, especially when verification node and target nodes are in different DCes

Fixes: #10434

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
