### PR TITLE
fix(sdcm/iotune): Do not submit results if test doesn't exist

### DIFF
--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -286,6 +286,11 @@ def send_iotune_results_to_argus(argus_client: ArgusClient, results: dict, node,
         LOGGER.warning("Will not submit to argus - no client initialized")
         return
 
+    run = argus_client.get_run()
+    if not run["test_id"]:
+        LOGGER.warning("No test exists for this run, skipping submitting results")
+        return
+
     class IOPropertiesResultsTable(GenericResultTable):
         class Meta:
             name = f"{params.get('cluster_backend')} - {node.db_node_instance_type} - Disk Performance"

--- a/sdcm/utils/validators/iotune.py
+++ b/sdcm/utils/validators/iotune.py
@@ -98,4 +98,5 @@ class IOTuneValidator:
     def _format_results_to_console(self):
         LOGGER.info("Disk performance values validation - testing %s", self.results["mountpoint"])
         for key, val in self.results["active"].items():
-            LOGGER.info("[%s] %s: %s (%.0f%)", self.results["mountpoint"], key, val, self.results["deviation_pct"][key])
+            LOGGER.info("[%s] %s: %s (%.0f%%)", self.results["mountpoint"],
+                        key, val, self.results["deviation_pct"][key])


### PR DESCRIPTION
This fix addresses an issue for jobs that have no argus test created for
them, causing a failure to occur. It also fixes the logger line for
console output of the results.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Jenkins](https://jenkins.scylladb.com/job/releng-testing/job/artifacts/job/artifacts-ami-test/30/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
