### PR TITLE
fix(performance): change error threshold for steps test

### DIFF
--- a/configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml
+++ b/configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml
@@ -24,6 +24,16 @@ latency_decorator_error_thresholds:
         fixed_limit: 1
       P99 read:
         fixed_limit: 3
+    "600000":
+      P90 read:
+        fixed_limit: 1
+      P99 read:
+        fixed_limit: 40
+    "700000":
+      P90 read:
+        fixed_limit: 1
+      P99 read:
+        fixed_limit: 50
     unthrottled:
       P90 read:
         fixed_limit: null

--- a/configurations/performance/latency-decorator-error-thresholds-steps-ent-vnodes.yaml
+++ b/configurations/performance/latency-decorator-error-thresholds-steps-ent-vnodes.yaml
@@ -24,6 +24,16 @@ latency_decorator_error_thresholds:
         fixed_limit: 1
       P99 read:
         fixed_limit: 5
+    "600000":
+      P90 read:
+        fixed_limit: 1
+      P99 read:
+        fixed_limit: 40
+    "700000":
+      P90 read:
+        fixed_limit: 1
+      P99 read:
+        fixed_limit: 50
     unthrottled:
       P90 read:
         fixed_limit: null


### PR DESCRIPTION
Following discussions with Roy, the P99 read error threshold will be increased for steps 600K and 700K in both vnode and tablet tests.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
