### PR TITLE
[Backport perf-v16] fix(auto backport): trigger with labeled event

### DIFF
--- a/.github/workflows/add-label-when-promoted.yaml
+++ b/.github/workflows/add-label-when-promoted.yaml
@@ -7,9 +7,9 @@ on:
       - branch-*.*
       - branch-perf-v*
       - manager-*.*
-    pull_request_target:
-      types: [labeled]
-      branches: [master]
+  pull_request_target:
+    types: [labeled]
+    branches: [master]
 
 env:
   DEFAULT_BRANCH: 'master'


### PR DESCRIPTION
auto backport doesn't trigger when a PR is already closed and the labels are been added after. this is because `pull_request_target` was under push event instead of it's own

Fixing it

(cherry picked from commit 072a599b695d6290534dc7db627ca14270c279bd)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
