### PR TITLE
fix(add-label-when-promoted): match regex for perf

### DIFF
--- a/.github/workflows/add-label-when-promoted.yaml
+++ b/.github/workflows/add-label-when-promoted.yaml
@@ -53,7 +53,7 @@ jobs:
         id: check_label
         run: |
           label_name="${{ github.event.label.name }}"
-          if [[ "$label_name" =~ ^backport/[0-9]+\.[0-9]+$ ]]; then
+          if [[ "$label_name" =~ ^backport/([0-9]+\.[0-9]+|[a-zA-Z]+-[a-zA-Z0-9]+)$ ]]; then
             echo "Label matches backport/X.X pattern."
             echo "backport_label=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
The current implementation doesn't work when there is a need to backport to the perf-v16 branch

Fixing it

