### PR TITLE
fix(ScyllaYaml): replace enable_tablets with tablets_mode_for_new_keyspaces

### DIFF
--- a/configurations/force-gossip-topology-changes.yaml
+++ b/configurations/force-gossip-topology-changes.yaml
@@ -1,3 +1,4 @@
 append_scylla_yaml:
   force_gossip_topology_changes: true
   enable_tablets: false
+  tablets_mode_for_new_keyspaces: 'disabled'

--- a/configurations/tablets-initial-32.yaml
+++ b/configurations/tablets-initial-32.yaml
@@ -1,3 +1,4 @@
 append_scylla_yaml:
   enable_tablets: true
+  tablets_mode_for_new_keyspaces: 'enabled'
   tablets_initial_scale_factor: 4

--- a/configurations/tablets_disabled.yaml
+++ b/configurations/tablets_disabled.yaml
@@ -1,2 +1,3 @@
 append_scylla_yaml:
   enable_tablets: false
+  tablets_mode_for_new_keyspaces: 'disabled'

--- a/docker/scylla-sct/entry.sh
+++ b/docker/scylla-sct/entry.sh
@@ -12,5 +12,6 @@ authorizer: 'CassandraAuthorizer'
 EOM
 
 sed -e '/enable_tablets:.*/s/true/false/g' -i /etc/scylla/scylla.yaml
+sed -e '/tablets_mode_for_new_keyspaces:.*/s/enabled/disabled/g' -i /etc/scylla/scylla.yaml
 
 /docker-entrypoint.py $*

--- a/docker/scylla-sct/entry_ssl.sh
+++ b/docker/scylla-sct/entry_ssl.sh
@@ -19,5 +19,6 @@ client_encryption_options:
 EOM
 
 sed -e '/enable_tablets:.*/s/true/false/g' -i /etc/scylla/scylla.yaml
+sed -e '/tablets_mode_for_new_keyspaces:.*/s/enabled/disabled/g' -i /etc/scylla/scylla.yaml
 
 /docker-entrypoint.py $*

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -354,6 +354,7 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods,too-many-
     compaction_collection_items_count_warning_threshold: int = None  # None
 
     enable_tablets: bool = None  # False, but default scylla.yaml for some versions (e.g. 6.0) override it to True
+    tablets_mode_for_new_keyspaces: Literal['disabled', 'enabled', 'enforced'] = None  # enabled
     force_gossip_topology_changes: bool = None  # False
 
     reader_concurrency_semaphore_cpu_concurrency: int = None

--- a/sdcm/utils/features.py
+++ b/sdcm/utils/features.py
@@ -83,5 +83,7 @@ def is_tablets_feature_enabled(node) -> bool:
             return True
         if scylla_yaml.dict().get("enable_tablets"):
             return True
+        if scylla_yaml.dict().get("tablets_mode_for_new_keyspaces") in ["enabled", "enforced"]:
+            return True
 
     return False

--- a/test-cases/PR-provision-test-docker.yaml
+++ b/test-cases/PR-provision-test-docker.yaml
@@ -18,3 +18,4 @@ use_mgmt: false
 
 append_scylla_yaml:
   enable_tablets: false  # counters are not supported with tablets
+  tablets_mode_for_new_keyspaces: 'disabled'  # counters are not supported with tablets

--- a/test-cases/PR-provision-test.yaml
+++ b/test-cases/PR-provision-test.yaml
@@ -31,3 +31,4 @@ use_preinstalled_scylla: true
 
 append_scylla_yaml:
   enable_tablets: false  # counters are not supported with tablets
+  tablets_mode_for_new_keyspaces: 'disabled'  # counters are not supported with tablets

--- a/test-cases/longevity/longevity-aws-custom-d2-workload1-3dcs.yaml
+++ b/test-cases/longevity/longevity-aws-custom-d2-workload1-3dcs.yaml
@@ -26,6 +26,7 @@ append_scylla_yaml:
   # See: https://github.com/scylladb/scylladb/pull/21207
   enable_small_table_optimization_for_rbno: true
   enable_tablets: false
+  tablets_mode_for_new_keyspaces: 'disabled'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '029'

--- a/test-cases/longevity/longevity-aws-custom-d2-workload1-5dcs.yaml
+++ b/test-cases/longevity/longevity-aws-custom-d2-workload1-5dcs.yaml
@@ -26,6 +26,7 @@ append_scylla_yaml:
   # See: https://github.com/scylladb/scylladb/pull/21207
   enable_small_table_optimization_for_rbno: true
   enable_tablets: false
+  tablets_mode_for_new_keyspaces: 'disabled'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '007'

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -409,6 +409,7 @@ class ScyllaYamlTest(unittest.TestCase):
                 'workdir': None,
                 'write_request_timeout_in_ms': None,
                 'enable_tablets': None,
+                'tablets_mode_for_new_keyspaces': None,
                 'force_gossip_topology_changes': None,
                 'reader_concurrency_semaphore_cpu_concurrency': None,
             }

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -236,6 +236,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
 
         if self.params.get("enable_tablets_on_upgrade"):
             scylla_yaml_updates.update({"enable_tablets": True})
+            scylla_yaml_updates.update({"tablets_mode_for_new_keyspaces": "enabled"})
         if self.params.get("enable_views_with_tablets_on_upgrade"):
             scylla_yaml_updates.update({"experimental_features": ["views-with-tablets"]})
 


### PR DESCRIPTION
The configuration option was changed in https://github.com/scylladb/scylladb/pull/22273
Causing all SCT runs after it to run without tablets.
e.g. https://argus.scylladb.com/tests/scylla-cluster-tests/a50f6974-da50-4963-b7ea-bbfeac27bdca
2025.1 not affected **yet**, backport was yesterday.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/f04c9b13-6038-40b1-bd47-835a4c75a84f
  `2025.2.0~dev-20250403.fe8187e5940e`, before the change, keyspace1 has tablets enabled
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/b5f009d5-41b3-4130-8d1b-0436a62584a7
  `2025.2.0~dev-20250407.8d2a41db8231`, after the change, keyspace1 does not have tablets enabled
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/a89cfa9e-bce3-49fd-8929-210006d8b31f
  `2025.2.0~dev-20250407.8d2a41db8231`, after the change, with this fix, keyspace1 has tablets enabled

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
