### PR TITLE
improvement(performance): change c-s version to 3.17.5

### DIFF
--- a/jenkins-pipelines/performance/branch-perf-v16/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-tablets.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v16/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-tablets.jenkinsfile
@@ -7,6 +7,6 @@ perfRegressionParallelPipeline(
     backend: "aws",
     aws_region: "us-east-1",
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
-    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml","configurations/perf-loaders-shard-aware-config.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml"]''',
     sub_tests: ["test_write_gradual_increase_load"],
 )

--- a/jenkins-pipelines/performance/branch-perf-v16/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-vnodes.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v16/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-vnodes.jenkinsfile
@@ -7,6 +7,6 @@ perfRegressionParallelPipeline(
     backend: "aws",
     aws_region: "us-east-1",
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
-    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml", "configurations/disable_kms.yaml", "configurations/tablets_disabled.yaml", "configurations/disable_speculative_retry.yaml","configurations/perf-loaders-shard-aware-config.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-vnodes.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml", "configurations/disable_kms.yaml", "configurations/tablets_disabled.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-vnodes.yaml"]''',
     sub_tests: ["test_write_gradual_increase_load"],
 )

--- a/test-cases/performance/perf-regression-predefined-throughput-steps.yaml
+++ b/test-cases/performance/perf-regression-predefined-throughput-steps.yaml
@@ -66,4 +66,4 @@ append_scylla_yaml:
 use_placement_group: true
 use_prepared_loaders: false
 stress_image:
-  cassandra-stress: 'scylladb/cassandra-stress:3.13.0'
+  cassandra-stress: 'scylladb/cassandra-stress:3.17.5'


### PR DESCRIPTION
Run throughput steps test with new 3.17.5 cassandra-stress version

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [**vnodes read** load test with `2025.2.0~dev-20250405`](https://github.com/scylladb/scylla-cluster-tests/pull/10620#issuecomment-2792071166) - Slight latency reduction for 450K step and 6% - 10% max read throughput improvement
- [x] [**vnodes write** load test with `2025.2.0~dev-20250405`](https://github.com/scylladb/scylla-cluster-tests/pull/10620#issuecomment-2792282109) - latency reduction for 200K & 300K steps (but the latency is too high, so I do not think it is meaningful) and 18% max write throughput improvement
- [x] [**vnodes write** load test with **`2024.1.0-20240206`**](https://github.com/scylladb/scylla-cluster-tests/pull/10620#issuecomment-2804006072) - latency reduction for 200K & 300K steps and 
2.7% max write throughput degradation. This degradation may be meaningless. We need to run more tests.
- [ ] [**vnodes mixed** load test with `2025.2.0~dev-20250405`](https://github.com/scylladb/scylla-cluster-tests/pull/10620#issuecomment-2792361855) - latency reduction for 200K & 300K steps (but the latency is too high, so I do not think it is meaningful) and 9% max write/read throughput degradation
- [ ] [**vnodes read** load test with **`2025.1.0~rc1-20250202`**](https://github.com/scylladb/scylla-cluster-tests/pull/10620#issuecomment-2794228549) - I ran the test with this Scylla version because we received high latency for 450K step in official runs. Latency for 450K step with cassandra-stress 3.17.5 is as expected with new cassandra-stress version. But there is degradation about 8% in max read throughput
- [x] [**tablets read** load test with `2025.2.0~dev-20250405`](https://github.com/scylladb/scylla-cluster-tests/pull/10620#issuecomment-2792094159) - Slight latency reduction for 450K step and 4.5% max read throughput improvement
- [x] [**tablets write** load test with `2024.1.0`](https://github.com/scylladb/scylla-cluster-tests/pull/10620#issuecomment-2804861110) - passed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
