### PR TITLE
fix(manager): apply dc-mapping only if restoring tables, not schema

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -757,7 +757,7 @@ class ManagerTestFunctionsMixIn(
     def restore_backup_with_task(self, mgr_cluster, snapshot_tag, timeout, restore_schema=False, restore_data=False,
                                  location_list=None, extra_params=None):
         location_list = location_list if location_list else self.locations
-        dc_mapping = self.get_dc_mapping()
+        dc_mapping = self.get_dc_mapping() if restore_data else None
         restore_task = mgr_cluster.create_restore_task(restore_schema=restore_schema, restore_data=restore_data,
                                                        location_list=location_list, snapshot_tag=snapshot_tag,
                                                        dc_mapping=dc_mapping, extra_params=extra_params)

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -615,7 +615,9 @@ class ManagerCluster(ScyllaManagerBase):
             cmd += " --location {} ".format(locations_names)
         if snapshot_tag:
             cmd += f" --snapshot-tag {snapshot_tag}"
-        if dc_mapping:
+        if dc_mapping and restore_data:
+            # --dc-mapping flag is applicable only for --restore-tables mode
+            # https://manager.docs.scylladb.com/stable/sctool/restore.html#dc-mapping
             cmd += f" --dc-mapping {dc_mapping}"
         if extra_params:
             cmd += f" {extra_params}"


### PR DESCRIPTION
Manager restore operation flag `--dc-mapping` is applicable for tables restore mode only ([docs](https://manager.docs.scylladb.com/stable/sctool/restore.html#dc-mapping)). 
Thus, should not be applied while restoring the schema.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [ubuntu22-sanity-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master-clone/job/ubuntu22-sanity-test/9/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code