### PR TITLE
Revert "fix(manager): update persistent snapshot used in Nemesis"

### DIFF
--- a/defaults/manager_persistent_snapshots.yaml
+++ b/defaults/manager_persistent_snapshots.yaml
@@ -6,120 +6,64 @@ aws:
       number_of_rows: 5242880
       expected_timeout: 1800  # 30 minutes
       snapshots:
-        us-east-1:
-          sm_20250206093521UTC:
-            keyspace_name: "5gb_stcs_quorum_64_16_2024_2_4"
-            scylla_version: "2024.2.4"
-            scylla_product: "enterprise"
-            number_of_nodes: 3
-            # Recording cluster_id which is required for snapshots cleanup from the bucket in the future
-            cluster_id: "baac78e2-4b60-4a5b-8d16-6bbf9d70321a"
-          sm_20240812150350UTC:
-            keyspace_name: "5gb_sizetiered_6_0"
-            scylla_version: "6.0.2"
-            scylla_product: "oss"
-            number_of_nodes: 3
-            cluster_id: "9b8c43c0-ebbc-4c59-a23f-dbdbeda9d9e0"
-        eu-west-1:
-          sm_20241202161158UTC:
-            keyspace_name: "5gb_sizetiered_2024_2"
-            scylla_version: "2024.2.0"
-            scylla_product: "enterprise"
-            number_of_nodes: 3
-            cluster_id: "e61259b5-77eb-4cad-8db1-1fc4a6f3991d"
-          sm_20241203091117UTC:
-            keyspace_name: "5gb_sizetiered_6_1"
-            scylla_version: "6.1.4"
-            scylla_product: "oss"
-            number_of_nodes: 3
-            cluster_id: "f3e64aed-62db-4bd3-82cc-55c83fed82c8"
+        'sm_20240812150136UTC':
+          keyspace_name: "5gb_sizetiered_2024_2_0_rc1"
+          scylla_version: "2024.2.0~rc1"
+          scylla_product: "enterprise"
+          number_of_nodes: 3
+          # Recording cluster_id which is required for snapshots cleanup from the bucket in the future
+          cluster_id: "36d35f0b-2f9c-4df4-8d24-3a5093cf07d3"
+        'sm_20240812150350UTC':
+          keyspace_name: "5gb_sizetiered_6_0"
+          scylla_version: "6.0.2"
+          scylla_product: "oss"
+          number_of_nodes: 3
+          cluster_id: "9b8c43c0-ebbc-4c59-a23f-dbdbeda9d9e0"
     10:
       number_of_rows: 10485760
       expected_timeout: 3600  # 60 minutes
       snapshots:
-        us-east-1:
-          sm_20250206093952UTC:
-            keyspace_name: "10gb_stcs_quorum_64_16_2024_2_4"
-            scylla_version: "2024.2.4"
-            scylla_product: "enterprise"
-            number_of_nodes: 3
-            cluster_id: "064c2b1c-99ad-4e7d-b3ad-0fd9591edd39"
-          sm_20240812150801UTC:
-            keyspace_name: "10gb_sizetiered_6_0"
-            scylla_version: "6.0.2"
-            scylla_product: "oss"
-            number_of_nodes: 3
-            cluster_id: "947e78ed-e988-41d6-92b5-faaf8ad7bbc0"
-        eu-west-1:
-          sm_20241203091417UTC:
-            keyspace_name: "10gb_sizetiered_2024_2"
-            scylla_version: "2024.2.0"
-            scylla_product: "enterprise"
-            number_of_nodes: 3
-            cluster_id: "5c17bec0-ee5c-4fc3-93cd-1e5916a8da57"
-          sm_20241203091651UTC:
-            keyspace_name: "10gb_sizetiered_6_1"
-            scylla_version: "6.1.4"
-            scylla_product: "oss"
-            number_of_nodes: 3
-            cluster_id: "71878cc5-1268-4e87-b849-c433e4d8a4ed"
+        'sm_20241010102035UTC':
+          keyspace_name: "10gb_sizetiered_2024_2_0_rc3"
+          scylla_version: "2024.2.0~rc3"
+          scylla_product: "enterprise"
+          number_of_nodes: 3
+          cluster_id: "c5ae2ea7-72f3-4350-85d4-7956c1837b8a"
+        'sm_20240812150801UTC':
+          keyspace_name: "10gb_sizetiered_6_0"
+          scylla_version: "6.0.2"
+          scylla_product: "oss"
+          number_of_nodes: 3
+          cluster_id: "947e78ed-e988-41d6-92b5-faaf8ad7bbc0"
     100:
       number_of_rows: 104857600
       expected_timeout: 18000  # 300 minutes
       snapshots:
-        us-east-1:
-          sm_20250206102841UTC:
-            keyspace_name: "100gb_stcs_quorum_64_16_2024_2_4"
-            scylla_version: "2024.2.4"
-            scylla_product: "enterprise"
-            number_of_nodes: 3
-            cluster_id: "4d9e8d6c-ffb5-4a13-83f0-adb4f5298e44"
-          sm_20240812164539UTC:
-            keyspace_name: "100gb_sizetiered_6_0"
-            scylla_version: "6.0.2"
-            scylla_product: "oss"
-            number_of_nodes: 3
-            cluster_id: "931ff656-51c0-432c-9495-9b4850061b65"
-        eu-west-1:
-          sm_20241203103619UTC:
-            keyspace_name: "100gb_sizetiered_2024_2"
-            scylla_version: "2024.2.0"
-            scylla_product: "enterprise"
-            number_of_nodes: 3
-            cluster_id: "a152b771-fe7a-4826-8958-999bd4cb2ea2"
-          sm_20241203104551UTC:
-            keyspace_name: "100gb_sizetiered_6_1"
-            scylla_version: "6.1.4"
-            scylla_product: "oss"
-            number_of_nodes: 3
-            cluster_id: "5becc815-1961-4c81-9557-131d308cd67c"
+        'sm_20240812162646UTC':
+          keyspace_name: "100gb_sizetiered_2024_2_0_rc1"
+          scylla_version: "2024.2.0~rc1"
+          scylla_product: "enterprise"
+          number_of_nodes: 3
+          cluster_id: "ebeab8af-cde8-492c-a7ee-d71b88872e4c"
+        'sm_20240812164539UTC':
+          keyspace_name: "100gb_sizetiered_6_0"
+          scylla_version: "6.0.2"
+          scylla_product: "oss"
+          number_of_nodes: 3
+          cluster_id: "931ff656-51c0-432c-9495-9b4850061b65"
     2048:
-      number_of_rows: 2147483648
-      expected_timeout: 132000  # 2200 minutes
-      snapshots:
-        us-east-1:
-          sm_20250206145422UTC:
-            keyspace_name: "2048gb_stcs_quorum_64_16_2024_2_4"
-            scylla_version: "2024.2.4"
+        number_of_rows: 2147483648
+        expected_timeout: 132000  # 2200 minutes
+        snapshots:
+          'sm_20240904154553UTC':
+            keyspace_name: "2tb_sizetiered_2024_2_0_rc1"
+            scylla_version: "2024.2.0~rc1"
             scylla_product: "enterprise"
             number_of_nodes: 3
-            cluster_id: "f6c0b53d-100b-4410-aec9-07be11b3a224"
-          sm_20240905214537UTC:
+            cluster_id: "adb4afb6-27fe-4b26-914e-4f5cc3551955"
+          'sm_20240905214537UTC':
             keyspace_name: "2tb_sizetiered_6_0"
             scylla_version: "6.0.2"
             scylla_product: "oss"
             number_of_nodes: 3
             cluster_id: "7fc7ce78-2e7e-4348-a8f7-29ae6494f6c9"
-        eu-west-1:
-          sm_20241205173847UTC:
-            keyspace_name: "2048gb_sizetiered_2024_2"
-            scylla_version: "2024.2.0"
-            scylla_product: "enterprise"
-            number_of_nodes: 3
-            cluster_id: "cd688eb4-409c-49b7-8165-0f586febde40"
-          sm_20241205214509UTC:
-            keyspace_name: "2048gb_sizetiered_6_1"
-            scylla_version: "6.1.4"
-            scylla_product: "oss"
-            number_of_nodes: 3
-            cluster_id: "f65efbab-415e-40bc-aa3c-1720256a1025"


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-cluster-tests/issues/10602

This reverts commit d28156fd5657488ee45405b83095261d9387d087.

This change has been merged into branch-2024.1 mistakenly.

New backups contain tablets = `{'enabled': false}` property in cql statements used by Manager to restore the schema.

This property is unknown to Scylla 2024.1. That's why the restore in this branch fails with `Unknown property 'tablets'"` error.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-10gb-3h-test](https://argus.scylladb.com/tests/scylla-cluster-tests/74b3c132-cde3-4c31-8f36-68e6b79c4933) (the test was interrupted after required `disrupt_mgmt_restore` had passed)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code