### PR TITLE
fix(remote): add exception info to `_run_on_retryable_exception`

### DIFF
--- a/sdcm/remote/kubernetes_cmd_runner.py
+++ b/sdcm/remote/kubernetes_cmd_runner.py
@@ -229,7 +229,7 @@ class KubernetesCmdRunner(RemoteCmdRunnerBase):
         return True
 
     def _run_on_retryable_exception(self, exc: Exception, new_session: bool) -> bool:
-        self.log.error(exc)
+        self.log.error(exc, exc_info=exc)
         if isinstance(exc, self.exception_retryable):
             raise RetryableNetworkException(str(exc), original=exc)
         return True

--- a/sdcm/remote/remote_cmd_runner.py
+++ b/sdcm/remote/remote_cmd_runner.py
@@ -107,7 +107,7 @@ class RemoteCmdRunner(RemoteCmdRunnerBase, ssh_transport='fabric', default=True)
             )
 
     def _run_on_retryable_exception(self, exc: Exception, new_session: bool) -> bool:
-        self.log.error(exc)
+        self.log.error(exc, exc_info=exc)
         self.ssh_is_up.clear()
         if self._is_error_retryable(str(exc)):
             raise RetryableNetworkException(str(exc), original=exc)

--- a/sdcm/remote/remote_libssh_cmd_runner.py
+++ b/sdcm/remote/remote_libssh_cmd_runner.py
@@ -63,7 +63,7 @@ class RemoteLibSSH2CmdRunner(RemoteCmdRunnerBase, ssh_transport='libssh2'):  # p
         return False
 
     def _run_on_retryable_exception(self, exc: Exception, new_session: bool) -> bool:
-        self.log.error(exc)
+        self.log.error(exc, exc_info=exc)
         if isinstance(exc, FailedToRunCommand) and not new_session:
             self.log.debug('Reestablish the session...')
             try:


### PR DESCRIPTION
It may happen that `str(exc)` is an empty string, so this logging line will give no info

Example
https://argus.scylladb.com/tests/scylla-cluster-tests/d17288c2-89af-4ee9-8bd4-a04bc30fe6dc

> 2025-04-08 19:15:41.503: (InfoEvent Severity.ERROR) period_type=not-set event_id=12df3c74-5505-4c03-a8d1-ebf2cec5e41c: message=Failed to wait for having no ongoing tablets topology operations. Exception: RetryableNetworkException('')

and in sct log there is only

> < t:2025-04-08 19:15:41,497 f:remote_libssh_cmd_runner.py l:66   c:RemoteLibSSH2CmdRunner p:ERROR > 


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] N/A

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
