### PR TITLE
fix(docker): fix set kernel perf event paranoid set

### DIFF
--- a/docker/scylla-sct/centos/Dockerfile
+++ b/docker/scylla-sct/centos/Dockerfile
@@ -24,6 +24,7 @@ RUN microdnf update && \
         sudo \
     	openssh-server \
  		docker-ce-cli \
+        procps-ng \
         rsync && \
     microdnf clean all && \
     echo "autostart=false" >> /etc/supervisord.conf.d/scylla-server.conf && \

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -56,6 +56,7 @@ class NodeContainerMixin:
         smp = 1
         if self.node_type == 'db':
             scylla_args = self.parent_cluster.params.get('append_scylla_args')
+            privileged = bool(self.parent_cluster.params.get('print_kernel_callstack'))
             smp_match = re.search(r'--smp\s(\d+)', scylla_args)
             smp = int(smp_match.group(1)) if smp_match else 1
 
@@ -63,6 +64,7 @@ class NodeContainerMixin:
                     image=self.node_container_image_tag,
                     command=f'--seeds="{seed_ip}"' if seed_ip else None,
                     volumes=volumes,
+                    privileged=privileged,
                     network=self.parent_cluster.params.get('docker_network'),
                     nano_cpus=smp*10**9)  # Same as `docker run --cpus=N ...' CLI command.
 


### PR DESCRIPTION
When using docker and setting `print_kernel_callstack` param we need to set `kernel.perf_event_paranoid=0` - which didn't work due missing params and proper privileges for docker.

refs: https://github.com/scylladb/scylla-cluster-tests/issues/10633

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - tested locally with docker backend

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
