### PR TITLE
fix(docker): disable `print_kernel_callstack` for docker backend

### DIFF
--- a/defaults/docker_config.yaml
+++ b/defaults/docker_config.yaml
@@ -3,3 +3,4 @@ logs_transport: docker
 use_preinstalled_scylla: true
 docker_image: ''
 scylla_linux_distro: 'centos'
+print_kernel_callstack: false


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-cluster-tests/issues/10633

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
