### PR TITLE
feature(treewide): Use simulated racks globally

### DIFF
--- a/configurations/rolling-upgrade-with-tablets.yaml
+++ b/configurations/rolling-upgrade-with-tablets.yaml
@@ -3,6 +3,6 @@ stress_during_entire_upgrade: cassandra-stress write no-warmup cl=QUORUM n=20100
 stress_after_cluster_upgrade: cassandra-stress read no-warmup cl=QUORUM n=30200400 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=1000 -pop seq=1..30200400 -log interval=5
 
 
-n_db_nodes: 4
+n_db_nodes: 6
 
 enable_tablets_on_upgrade: true

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -222,7 +222,7 @@ run_fullscan: []
 
 stress_step_duration: '15m'
 simulated_regions: 0
-simulated_racks: 0
+simulated_racks: 3
 rack_aware_loader: false
 use_dns_names: false
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -3421,7 +3421,7 @@ Defines how many regions must be simulated on the Scylla config side. If set the
 
 Forces GossipingPropertyFileSnitch (regardless `endpoint_snitch`) to simulate racks.<br>Provide number of racks to simulate.
 
-**default:** N/A
+**default:** 3
 
 **type:** int
 

--- a/test-cases/enterprise-features/workload-prioritization/longevity/longevity-sla-system-24h.yaml
+++ b/test-cases/enterprise-features/workload-prioritization/longevity/longevity-sla-system-24h.yaml
@@ -7,7 +7,7 @@ stress_cmd: ["cassandra-stress read cl=QUORUM duration=1380m -schema 'replicatio
              "cassandra-stress read cl=QUORUM duration=1380m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 -pop seq=250000001..500000000 -log interval=5 -errors retries=50"
              ]
 
-n_db_nodes: 5
+n_db_nodes: 6
 n_loaders: 2
 n_monitor_nodes: 1
 round_robin: true

--- a/test-cases/features/2mv-backpressure-4d.yaml
+++ b/test-cases/features/2mv-backpressure-4d.yaml
@@ -3,7 +3,7 @@ test_duration: 6480
 prepare_write_cmd: "cassandra-stress user profile=/tmp/c-s_profile_2mv_2queries.yaml ops'(insert=1)' cl=QUORUM n=250000000 -mode cql3 native -rate threads=200"
 stress_cmd: ["cassandra-stress user profile=/tmp/c-s_profile_2mv_2queries.yaml ops'(insert=1)' cl=QUORUM duration=5760m -mode cql3 native -pop seq=250000000..500000000 -rate threads=200",
             "cassandra-stress user profile=/tmp/c-s_profile_2mv_2queries.yaml ops'(mv_p_read1=1,mv_p_read2=1)' cl=QUORUM duration=5760m -mode cql3 native -pop seq=1..250000000 -rate threads=10"]
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 4
 n_monitor_nodes: 1
 

--- a/test-cases/features/alternator-ttl/longevity-alternator-1h-scan-12h-ttl-no-lwt-2h-grace-4loaders-sisyphus.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-1h-scan-12h-ttl-no-lwt-2h-grace-4loaders-sisyphus.yaml
@@ -38,9 +38,9 @@ round_robin: true
 dynamodb_primarykey_type: HASH_AND_RANGE
 
 n_loaders: 4
-instance_type_db: 'i4i.4xlarge'
+instance_type_db: 'i4i.2xlarge'
 n_monitor_nodes: 1
-n_db_nodes: 4
+n_db_nodes: 6
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '033'

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired-data.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired-data.yaml
@@ -31,7 +31,7 @@ dynamodb_primarykey_type: HASH_AND_RANGE
 n_loaders: 2
 instance_type_db: 'i4i.large'
 n_monitor_nodes: 1
-n_db_nodes: 4
+n_db_nodes: 6
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '033'

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-no-lwt-8m-grace-sisyphus.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-no-lwt-8m-grace-sisyphus.yaml
@@ -24,7 +24,7 @@ dynamodb_primarykey_type: HASH_AND_RANGE
 n_loaders: 2
 instance_type_db: 'i4i.large'
 n_monitor_nodes: 1
-n_db_nodes: 4
+n_db_nodes: 6
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '033'

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-multiple-ttl-8m-grace.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-multiple-ttl-8m-grace.yaml
@@ -77,9 +77,9 @@ round_robin: true
 dynamodb_primarykey_type: HASH_AND_RANGE
 
 n_loaders: 4
-instance_type_db: 'i4i.4xlarge'
+instance_type_db: 'i4i.2xlarge'
 n_monitor_nodes: 1
-n_db_nodes: 4
+n_db_nodes: 6
 
 nemesis_class_name: 'NoOpMonkey'
 nemesis_seed: '033'

--- a/test-cases/features/alternator-ttl/longevity-alternator-disable-enable-ttl.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-disable-enable-ttl.yaml
@@ -30,7 +30,7 @@ dynamodb_primarykey_type: HASH_AND_RANGE
 n_loaders: 2
 instance_type_db: 'i4i.large'
 n_monitor_nodes: 1
-n_db_nodes: 4
+n_db_nodes: 6
 
 nemesis_class_name: 'NoOpMonkey'
 nemesis_seed: '033'

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-big-dataset.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-big-dataset.yaml
@@ -34,9 +34,9 @@ round_robin: true
 dynamodb_primarykey_type: HASH_AND_RANGE
 
 n_loaders: 4
-instance_type_db: 'i4i.4xlarge'
+instance_type_db: 'i4i.2xlarge'
 n_monitor_nodes: 1
-n_db_nodes: 4
+n_db_nodes: 6
 
 nemesis_class_name: 'NoOpMonkey'
 nemesis_seed: '007'

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-large-writes.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-large-writes.yaml
@@ -33,9 +33,9 @@ round_robin: true
 dynamodb_primarykey_type: HASH_AND_RANGE
 
 n_loaders: 4
-instance_type_db: 'i4i.4xlarge'
+instance_type_db: 'i4i.2xlarge'
 n_monitor_nodes: 1
-n_db_nodes: 4
+n_db_nodes: 6
 
 nemesis_class_name: 'NoOpMonkey'
 nemesis_seed: '007'

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-lwt.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-lwt.yaml
@@ -16,9 +16,9 @@ round_robin: true
 dynamodb_primarykey_type: HASH_AND_RANGE
 
 n_loaders: 2
-instance_type_db: 'i4i.4xlarge'
+instance_type_db: 'i4i.2xlarge'
 n_monitor_nodes: 1
-n_db_nodes: 4
+n_db_nodes: 6
 
 nemesis_class_name: 'NoOpMonkey'
 nemesis_seed: '007'

--- a/test-cases/features/corrupt-then-rebuild.yaml
+++ b/test-cases/features/corrupt-then-rebuild.yaml
@@ -5,7 +5,7 @@ test_duration: 10080
 # stress_write_cmd: "cassandra-stress write cl=QUORUM n=10000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..300300300"
 stress_read_cmd:  "cassandra-stress read cl=ONE n=10000 -mode cql3 native -rate threads=10 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1100200300 -log interval=5"
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 4
 n_monitor_nodes: 1
 

--- a/test-cases/features/destroy-data-then-repair.yaml
+++ b/test-cases/features/destroy-data-then-repair.yaml
@@ -3,7 +3,7 @@ test_duration: 10080
 # stress_write_cmd: "cassandra-stress write cl=QUORUM n=10000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=500 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..300300300"
 stress_read_cmd:  "cassandra-stress read cl=ONE n=10000 -mode cql3 native -rate threads=10 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1100200300 -log interval=5"
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 2
 n_monitor_nodes: 1
 

--- a/test-cases/features/elasticity/elasticity-90-percent-with-nemesis.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-with-nemesis.yaml
@@ -13,7 +13,6 @@ stress_cmd:
 pre_create_keyspace: "CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 64};"
 
 n_db_nodes: 3
-simulated_racks: 3
 n_loaders: 4
 n_monitor_nodes: 1
 nemesis_grow_shrink_instance_type: 'i4i.large'

--- a/test-cases/features/elasticity/longevity-elasticity-many-small-tables.yaml
+++ b/test-cases/features/elasticity/longevity-elasticity-many-small-tables.yaml
@@ -20,7 +20,6 @@ cs_duration: ''
 n_loaders: 4
 n_monitor_nodes: 1
 n_db_nodes: 3
-simulated_racks: 3
 add_node_cnt: 0
 
 instance_type_db: 'i4i.xlarge'

--- a/test-cases/features/full-cluster-stop-start.yaml
+++ b/test-cases/features/full-cluster-stop-start.yaml
@@ -5,7 +5,7 @@ stress_cmd: "cassandra-stress write no-warmup cl=QUORUM n=1500000 -schema 'repli
 stress_read_cmd: "cassandra-stress read cl=QUORUM n=1500000 -mode cql3 native  -rate threads=50 -pop seq=1..100000000 -log interval=5"
 
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 1
 n_monitor_nodes: 1
 

--- a/test-cases/features/google-cloud-snitch-multi-dc.yaml
+++ b/test-cases/features/google-cloud-snitch-multi-dc.yaml
@@ -6,6 +6,7 @@ gce_datacenter: 'us-east1 us-west1'
 n_db_nodes: "3 3"
 n_loaders: 2
 n_monitor_nodes: 1
+simulated_racks: 0
 
 user_prefix: 'google-snitch'
 

--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -1,9 +1,9 @@
 test_duration: 780
-n_db_nodes: 4
+n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 n_monitor_nodes: 1
-instance_type_db: 'i4i.4xlarge'
+instance_type_db: 'i4i.2xlarge'
 instance_type_loader: 'm6i.xlarge'
 
 user_prefix: 'gemini-1tb-10h'

--- a/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
@@ -1,5 +1,5 @@
 test_duration: 500
-n_db_nodes: 4
+n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 n_monitor_nodes: 1

--- a/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
@@ -1,5 +1,5 @@
 test_duration: 500
-n_db_nodes: 4
+n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 n_monitor_nodes: 1

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -1,9 +1,9 @@
 test_duration: 300
-n_db_nodes: 4
+n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 n_monitor_nodes: 1
-instance_type_db: 'i4i.2xlarge'
+instance_type_db: 'i4i.large'
 
 user_prefix: 'gemini-with-nemesis-3h-normal'
 

--- a/test-cases/gemini/gemini-8h-large-num-columns.yaml
+++ b/test-cases/gemini/gemini-8h-large-num-columns.yaml
@@ -1,5 +1,5 @@
 test_duration: 500
-n_db_nodes: 4
+n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 n_monitor_nodes: 1

--- a/test-cases/longevity/longevity-100GB-48h-cloud-CloudLimitedChaosMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-100GB-48h-cloud-CloudLimitedChaosMonkey-tls.yaml
@@ -5,7 +5,7 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=2860m  -schema 'replicat
 stress_read_cmd: ["cassandra-stress read cl=ONE duration=2860m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..100100150 -log interval=5"]
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 5}']
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 1
 n_monitor_nodes: 1
 

--- a/test-cases/longevity/longevity-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-100gb-4h.yaml
@@ -10,7 +10,6 @@ n_db_nodes: 6
 n_loaders: 2
 n_monitor_nodes: 1
 seeds_num: 3
-simulated_racks: 3
 
 instance_type_db: 'i4i.4xlarge'
 

--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -5,7 +5,6 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replicatio
 n_db_nodes: 6
 n_loaders: 2
 n_monitor_nodes: 1
-simulated_racks: 3
 
 instance_type_db: 'i4i.2xlarge'
 gce_instance_type_db: 'n2-highmem-16'

--- a/test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml
+++ b/test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml
@@ -7,7 +7,6 @@ run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", 
 n_db_nodes: 6
 n_loaders: 1
 n_monitor_nodes: 1
-simulated_racks: 3
 
 instance_type_db: 'i4i.2xlarge'
 gce_instance_type_db: 'n2-highmem-16'

--- a/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
@@ -16,7 +16,6 @@ n_db_nodes: 3
 n_loaders: 4
 n_monitor_nodes: 1
 seeds_num: 2
-simulated_racks: 3
 
 instance_type_db: 'i4i.4xlarge'
 gce_instance_type_db: 'n2-highmem-16'

--- a/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -10,11 +10,11 @@ stress_cmd:
   - "cassandra-stress read cl=ONE duration=2860m -schema 'keyspace=lowload1 replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=1  -col 'size=FIXED(50) n=FIXED(1)' -pop seq=1..500 -log interval=5"
 run_fullscan:
   - '{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 5}'
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 1
 n_monitor_nodes: 1
 
-instance_type_db: 'i4i.4xlarge'
+instance_type_db: 'i4i.2xlarge'
 azure_instance_type_db: 'Standard_L16s_v3'
 gce_instance_type_db: 'n2-highmem-16'
 

--- a/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -20,7 +20,7 @@ pre_create_keyspace: [
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "random", "interval": 240}']
 round_robin: true
 
-n_db_nodes: 5
+n_db_nodes: 6
 n_loaders: 4
 n_monitor_nodes: 1
 

--- a/test-cases/longevity/longevity-5TB-1day.yaml
+++ b/test-cases/longevity/longevity-5TB-1day.yaml
@@ -15,12 +15,12 @@ stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=1200m -mode cql3 nat
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "random", "interval": 120}']
 round_robin: true
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 4
 n_monitor_nodes: 1
 seeds_num: 2
 
-instance_type_db: 'i4i.4xlarge'
+instance_type_db: 'i4i.2xlarge'
 gce_instance_type_db: 'n2-highmem-32'
 gce_n_local_ssd_disk_db: 24
 azure_instance_type_db: 'Standard_L16s_v3'

--- a/test-cases/longevity/longevity-alternator-200GB-48h.yaml
+++ b/test-cases/longevity/longevity-alternator-200GB-48h.yaml
@@ -33,10 +33,10 @@ dynamodb_primarykey_type: HASH_AND_RANGE
 
 n_loaders: 4
 n_monitor_nodes: 1
-n_db_nodes: 4
+n_db_nodes: 6
 
 # Instance types
-instance_type_db: 'i4i.4xlarge'
+instance_type_db: 'i4i.2xlarge'
 azure_instance_type_db: 'Standard_L16s_v3'
 gce_instance_type_db: 'n2-highmem-32'
 gce_n_local_ssd_disk_db: 16

--- a/test-cases/longevity/longevity-alternator-3h-multidc.yaml
+++ b/test-cases/longevity/longevity-alternator-3h-multidc.yaml
@@ -31,8 +31,11 @@ round_robin: true
 n_db_nodes: '3 3'
 instance_type_db: 'i4i.4xlarge'
 n_loaders: '2 2'
-region_aware_loader: true
 n_monitor_nodes: 1
+
+rack_aware_loader: true
+region_aware_loader: true
+simulated_racks: 0
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '006'

--- a/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-large-cluster.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-large-cluster.yaml
@@ -6,12 +6,13 @@ stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc.
               "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc_preimage_postimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=180m -mode cql3 native -rate threads=50"
             ]
 
-rack_aware_loader: true
 n_db_nodes: '15 15 15'
 instance_type_db: 'i4i.large'
 n_loaders: '2 2 2'
+
+rack_aware_loader: true
 region_aware_loader: true
-n_monitor_nodes: 1
+simulated_racks: 0
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_selector: 'topology_changes'

--- a/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml
@@ -6,12 +6,14 @@ stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc.
               "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc_preimage_postimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=480m -mode cql3 native -rate threads=75"
              ]
 
-rack_aware_loader: true
 n_db_nodes: '4 4'
 instance_type_db: 'i4i.4xlarge'
 n_loaders: '2 2'
-region_aware_loader: true
 n_monitor_nodes: 1
+
+rack_aware_loader: true
+region_aware_loader: true
+simulated_racks: 0
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_selector: 'topology_changes'

--- a/test-cases/longevity/longevity-counters-3h.yaml
+++ b/test-cases/longevity/longevity-counters-3h.yaml
@@ -3,11 +3,11 @@ test_duration: 255
 stress_cmd:      "scylla-bench -workload=uniform -mode=counter_update -replication-factor=3 -partition-count=1000 -clustering-row-count=10 -concurrency 64 -duration 180m -validate-data"
 stress_read_cmd: "scylla-bench -workload=uniform -mode=counter_read   -replication-factor=3 -partition-count=1000 -clustering-row-count=10 -concurrency 16 -duration 180m -validate-data"
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders:  1
 n_monitor_nodes: 1
 
-instance_type_db: 'i4i.2xlarge'
+instance_type_db: 'i4i.large'
 
 user_prefix: longevity-counters-3h
 

--- a/test-cases/longevity/longevity-counters-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-multidc.yaml
@@ -9,6 +9,10 @@ n_db_nodes: '3 3 3'
 n_loaders:  '1 1 1'
 n_monitor_nodes: 1
 
+rack_aware_loader: true
+region_aware_loader: true
+simulated_racks: 0
+
 instance_type_db: 'i4i.2xlarge'
 
 user_prefix: longevity-counters-multidc

--- a/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
@@ -4,11 +4,11 @@ prepare_write_cmd: "cassandra-stress write cl=ALL n=200200300  -schema 'replicat
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=360m  -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=50  -col 'size=FIXED(200) n=FIXED(5)' -pop seq=400200300..600200300 -log interval=15"]
 stress_read_cmd: ["cassandra-stress read cl=ONE duration=360m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=50  -col 'size=FIXED(200) n=FIXED(5)' -pop seq=1..200200300 -log interval=5"]
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 5}']
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 2
 n_monitor_nodes: 1
 
-instance_type_db: 'i4i.4xlarge'
+instance_type_db: 'i4i.2xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_selector: 'limited'

--- a/test-cases/longevity/longevity-encryption-at-rest-20GB-6h-multidc.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-20GB-6h-multidc.yaml
@@ -9,10 +9,13 @@ stress_cmd: [
   "cassandra-stress read  cl=QUORUM duration=360m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=30 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
 ]
 round_robin: true
-rack_aware_loader: true
 n_db_nodes: '3 3'
 n_loaders: '1 1'
 n_monitor_nodes: 1
+
+rack_aware_loader: true
+region_aware_loader: true
+simulated_racks: 0
 
 instance_type_db: 'i4i.xlarge'
 

--- a/test-cases/longevity/longevity-large-collections-12h.yaml
+++ b/test-cases/longevity/longevity-large-collections-12h.yaml
@@ -3,7 +3,7 @@ stress_cmd: [
 "JVM_OPTION='-Xms8033M -Xmx8033M -Xmn400M' cassandra-stress user profile=/tmp/large_collections.yaml ops'(insert=3,read1=1,update1=1)' cl=QUORUM duration=720m -mode cql3 native -rate threads=20"
              ]
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 1
 n_monitor_nodes: 1
 

--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -42,7 +42,6 @@ post_prepare_cql_cmds: ["CREATE MATERIALIZED VIEW scylla_bench.view_test AS SELE
 n_db_nodes: 6
 n_loaders: 5 # Each loader will have 1 scylla-bench process at every step of the test (prepare, verify, stress & stress_read)
 n_monitor_nodes: 1
-simulated_racks: 3
 
 round_robin: true
 

--- a/test-cases/longevity/longevity-large-partition-3h.yaml
+++ b/test-cases/longevity/longevity-large-partition-3h.yaml
@@ -30,7 +30,7 @@ stress_cmd: ["scylla-bench -workload=sequential -mode=write -replication-factor=
 
 post_prepare_cql_cmds: "CREATE MATERIALIZED VIEW scylla_bench.view_test AS SELECT * FROM scylla_bench.test where ck IS NOT NULL AND pk is not null PRIMARY KEY (pk, ck) with comment = 'TEST VIEW'"
 
-n_db_nodes: 5
+n_db_nodes: 6
 n_loaders: 4
 n_monitor_nodes: 1
 

--- a/test-cases/longevity/longevity-large-partition-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-4days.yaml
@@ -17,7 +17,7 @@ stress_cmd: ["scylla-bench -workload=uniform -mode=read -replication-factor=3 -p
 
 post_prepare_cql_cmds: "CREATE MATERIALIZED VIEW scylla_bench.view_test AS SELECT * FROM scylla_bench.test where ck is not NULL and token(pk) > -4570794944214759424 and token(pk) < 4621334552741592064 AND v is not null PRIMARY KEY (v, ck, pk) with comment = 'TEST VIEW'"
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 3
 n_monitor_nodes: 1
 

--- a/test-cases/longevity/longevity-large-partition-8h.yaml
+++ b/test-cases/longevity/longevity-large-partition-8h.yaml
@@ -33,7 +33,7 @@ post_prepare_cql_cmds: [
                         "ALTER TABLE scylla_bench.test with tombstone_gc = {'mode': 'repair', 'propagation_delay_in_seconds':'300'};"
                         ]
 
-n_db_nodes: 5
+n_db_nodes: 6
 n_loaders: 4
 n_monitor_nodes: 1
 

--- a/test-cases/longevity/longevity-lwt-1loader-3h.yaml
+++ b/test-cases/longevity/longevity-lwt-1loader-3h.yaml
@@ -3,11 +3,11 @@ prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=100
 stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=20" ]
 stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=160m -mode native cql3 -rate threads=20" ]
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 1
 n_monitor_nodes: 1
 
-instance_type_db: 'i4i.2xlarge'
+instance_type_db: 'i4i.large'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '017'

--- a/test-cases/longevity/longevity-lwt-24h-multidc.yaml
+++ b/test-cases/longevity/longevity-lwt-24h-multidc.yaml
@@ -3,10 +3,13 @@ prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc
 stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=LOCAL_QUORUM serial-cl=LOCAL_SERIAL duration=1350m -mode native cql3 -rate threads=800" ]
 stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml ops'(select=1)' cl=LOCAL_QUORUM serial-cl=LOCAL_SERIAL duration=1350m -mode native cql3 -rate threads=800" ]
 
-rack_aware_loader: true
 n_db_nodes: '4 3 2'
 n_loaders: '1 1 1'
 n_monitor_nodes: 1
+
+rack_aware_loader: true
+region_aware_loader: true
+simulated_racks: 0
 
 instance_type_db: 'i4i.4xlarge'
 

--- a/test-cases/longevity/longevity-lwt-500G-3d.yaml
+++ b/test-cases/longevity/longevity-lwt-500G-3d.yaml
@@ -14,12 +14,12 @@ stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(lwt_
             ]
 stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(select=1)' cl=SERIAL duration=3420m -mode native cql3 -rate threads=10" ]
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 3
 n_monitor_nodes: 1
 round_robin: true
 
-instance_type_db: 'i4i.4xlarge'
+instance_type_db: 'i4i.2xlarge'
 instance_type_loader: 'c6i.2xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'

--- a/test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml
@@ -3,11 +3,11 @@ prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=100
 stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=1440m -mode native cql3 -rate threads=30" ]
 stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=1440m -mode native cql3 -rate threads=30" ]
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 3
 n_monitor_nodes: 1
 
-instance_type_db: 'i4i.2xlarge'
+instance_type_db: 'i4i.large'
 
 nemesis_class_name: 'SisyphusMonkey:3'
 nemesis_selector: ["disruptive", "not disruptive", "not disruptive and not manager_operation"]

--- a/test-cases/longevity/longevity-lwt-basic-24h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-24h.yaml
@@ -5,12 +5,12 @@ stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_upd
             ]
 stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=1440m -mode native cql3 -rate threads=20" ]
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 3
 n_monitor_nodes: 1
 round_robin: true
 
-instance_type_db: 'i4i.2xlarge'
+instance_type_db: 'i4i.large'
 gce_instance_type_db: 'n2-highmem-8'
 gce_n_local_ssd_disk_db: 8
 

--- a/test-cases/longevity/longevity-lwt-basic-3h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-3h.yaml
@@ -7,12 +7,12 @@ stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_upd
             ]
 stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=160m -mode native cql3 -rate threads=20" ]
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 3
 n_monitor_nodes: 1
 round_robin: true
 
-instance_type_db: 'i4i.2xlarge'
+instance_type_db: 'i4i.large'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '020'

--- a/test-cases/longevity/longevity-lwt-parallel-24h.yaml
+++ b/test-cases/longevity/longevity-lwt-parallel-24h.yaml
@@ -5,12 +5,12 @@ stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_upd
             ]
 stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=1440m -mode native cql3 -rate threads=20" ]
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 3
 n_monitor_nodes: 1
 round_robin: true
 
-instance_type_db: 'i4i.2xlarge'
+instance_type_db: 'i4i.large'
 
 nemesis_class_name: 'SisyphusMonkey:1 ModifyTableMonkey:1'
 nemesis_selector: ["disruptive", ""]

--- a/test-cases/longevity/longevity-mini-test-1h.yaml
+++ b/test-cases/longevity/longevity-mini-test-1h.yaml
@@ -1,7 +1,7 @@
 test_duration: 180
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=90m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=50 -pop seq=1..10000000 -log interval=5"]
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 1
 n_monitor_nodes: 1
 

--- a/test-cases/longevity/longevity-multi-dc-rack-aware-with-znode-in-diff_dc.yaml
+++ b/test-cases/longevity/longevity-multi-dc-rack-aware-with-znode-in-diff_dc.yaml
@@ -6,11 +6,14 @@ prepare_write_cmd:  ["cassandra-stress write cl=LOCAL_QUORUM n=20971520 -schema 
 stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3,eu-northscylla_node_north=0) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5 -errors retries=50",
              "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3,eu-northscylla_node_north=0) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5 -errors retries=50",
              ]
-rack_aware_loader: true
 n_db_nodes: '4 4 0'
 n_loaders: '1 1'
 n_monitor_nodes: 1
 n_db_zero_token_nodes: '0 1 1'
+
+rack_aware_loader: true
+region_aware_loader: true
+simulated_racks: 0
 
 instance_type_db: 'i4i.4xlarge'
 zero_token_instance_type_db: 'i4i.large'

--- a/test-cases/longevity/longevity-multi-dc-rack-aware.yaml
+++ b/test-cases/longevity/longevity-multi-dc-rack-aware.yaml
@@ -6,10 +6,13 @@ prepare_write_cmd:  ["cassandra-stress write cl=LOCAL_QUORUM n=20971520 -schema 
 stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5 -errors retries=50",
              "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5 -errors retries=50",
              ]
-rack_aware_loader: true
 n_db_nodes: '3 3'
 n_loaders: '1 1'
 n_monitor_nodes: 1
+
+rack_aware_loader: true
+region_aware_loader: true
+simulated_racks: 0
 
 instance_type_db: 'i4i.2xlarge'
 

--- a/test-cases/longevity/longevity-multidc-parallel-network-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-network-schema-changes-12h.yaml
@@ -8,11 +8,12 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=720m -schema 'replicatio
              "cassandra-stress read  cl=QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
              "cassandra-stress user profile=/tmp/cs_multidc_mv_lcs.yaml ops'(write=1,read=1,mv_read1=1,mv_read2=1)' -port jmx=6868 -mode cql3 native -rate threads=40 duration=700m -log interval=5",
              ]
-rack_aware_loader: true
 n_db_nodes: '4 4'
 n_loaders: '2 1'
+
+rack_aware_loader: true
 region_aware_loader: true
-n_monitor_nodes: 1
+simulated_racks: 0
 
 instance_type_db: 'i3en.xlarge'
 

--- a/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
@@ -9,12 +9,13 @@ stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'repl
              "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(insert=1,read=1,si_read1=1,si_read2=1)' cl=LOCAL_QUORUM duration=700m -mode cql3 native -rate threads=40 -log interval=5",
              ]
 
-rack_aware_loader: true
 availability_zone: 'a,b,c'
 n_db_nodes: '6 6'
 n_loaders: '2 1'
+
+rack_aware_loader: true
 region_aware_loader: true
-n_monitor_nodes: 1
+simulated_racks: 0
 
 instance_type_db: 'i3en.2xlarge'
 

--- a/test-cases/longevity/longevity-mv-si-4days.yaml
+++ b/test-cases/longevity/longevity-mv-si-4days.yaml
@@ -13,7 +13,6 @@ run_fullscan: ['{"mode": "table", "ks_cf": "random", "interval": 15}']
 n_db_nodes: 6
 n_loaders: 2
 n_monitor_nodes: 1
-simulated_racks: 3
 
 instance_type_db: 'i4i.8xlarge'
 gce_instance_type_db: 'n2-highmem-64'

--- a/test-cases/longevity/longevity-ndbench-12-nodes-multidc-4h.yaml
+++ b/test-cases/longevity/longevity-ndbench-12-nodes-multidc-4h.yaml
@@ -15,6 +15,10 @@ n_db_nodes: '6 6'
 n_loaders: '2 2'
 n_monitor_nodes: 1
 
+rack_aware_loader: true
+region_aware_loader: true
+simulated_racks: 0
+
 instance_type_db: 'i4i.xlarge'
 instance_type_loader: 'c6i.4xlarge'
 

--- a/test-cases/longevity/longevity-ndbench-192-nodes-multidc-4h.yaml
+++ b/test-cases/longevity/longevity-ndbench-192-nodes-multidc-4h.yaml
@@ -15,6 +15,10 @@ n_db_nodes: '96 96'
 n_loaders: '32 32'
 n_monitor_nodes: 1
 
+rack_aware_loader: true
+region_aware_loader: true
+simulated_racks: 0
+
 instance_type_db: 'i4i.xlarge'
 instance_type_loader: 'c6i.4xlarge'
 

--- a/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
@@ -16,7 +16,6 @@ stress_cmd: [
 n_db_nodes: 6
 n_loaders: 2
 n_monitor_nodes: 1
-simulated_racks: 3
 
 instance_type_db: 'i4i.2xlarge'
 

--- a/test-cases/longevity/longevity-topology-changes-3h.yaml
+++ b/test-cases/longevity/longevity-topology-changes-3h.yaml
@@ -13,7 +13,6 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replicatio
              ]
 
 availability_zone: 'a'
-simulated_racks: 3
 n_db_nodes: 3
 n_loaders: 2
 n_monitor_nodes: 1

--- a/test-cases/longevity/longevity-twcs-3h.yaml
+++ b/test-cases/longevity/longevity-twcs-3h.yaml
@@ -9,7 +9,7 @@ stress_read_cmd: [
     "scylla-bench -workload=timeseries -mode=read -partition-count=4000 -concurrency=100 -replication-factor=3 -clustering-row-count=10000 -clustering-row-size=200  -rows-per-request=1 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 300 -distribution uniform --connection-count 100 -retry-number=30 -retry-interval=80ms,1s -duration=170m"
     ]
 
-n_db_nodes: 5
+n_db_nodes: 6
 n_loaders: 3
 n_monitor_nodes: 1
 

--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -13,7 +13,6 @@ stress_read_cmd: [
 n_db_nodes: 3
 n_loaders: 3
 n_monitor_nodes: 1
-simulated_racks: 3
 
 instance_type_db: 'i3en.2xlarge'
 

--- a/test-cases/manager/manager-backup-1TB-gce.yaml
+++ b/test-cases/manager/manager-backup-1TB-gce.yaml
@@ -15,11 +15,11 @@ compaction_strategy: 'NullCompactionStrategy'
 post_prepare_cql_cmds: "ALTER TABLE keyspace1.standard1 WITH compaction = {'class': 'SizeTieredCompactionStrategy'}"
 prepare_wait_no_compactions_timeout: 120
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 2
 n_monitor_nodes: 1
 
-gce_instance_type_db: 'n2-highmem-16'
+gce_instance_type_db: 'n2-highmem-8'
 gce_n_local_ssd_disk_db: 8
 gce_instance_type_loader: 'e2-standard-16'
 

--- a/test-cases/manager/manager-multiple-restores-schema-and-data.yaml
+++ b/test-cases/manager/manager-multiple-restores-schema-and-data.yaml
@@ -4,7 +4,7 @@ instance_type_db: 'i3en.3xlarge'
 
 # Using this region specifically because the bucket that contain the persistent snapshots that this test use are in us-east-1
 region_name: us-east-1
-n_db_nodes: 5
+n_db_nodes: 6
 n_loaders: 1
 n_monitor_nodes: 1
 

--- a/test-cases/manager/manager-regression-multiDC-gce.yaml
+++ b/test-cases/manager/manager-regression-multiDC-gce.yaml
@@ -6,6 +6,7 @@ stress_read_cmd: "cassandra-stress read cl=QUORUM n=4000000 -schema 'replication
 n_db_nodes: "2 1"
 n_loaders: 1
 n_monitor_nodes: 1
+simulated_racks: 0
 
 client_encrypt: true
 

--- a/test-cases/manager/manager-regression-multiDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-multiDC-set-distro.yaml
@@ -11,6 +11,7 @@ region_name: 'us-east-1 us-west-2'
 n_db_nodes: '2 1'
 n_loaders: 1
 n_monitor_nodes: 1
+simulated_racks: 0
 
 client_encrypt: true
 

--- a/test-cases/performance/perf-regression-2mv.yaml
+++ b/test-cases/performance/perf-regression-2mv.yaml
@@ -10,11 +10,11 @@ stress_cmd_no_mv_profile: 'data_dir/cs_no_mv_basic_profile.yaml'
 #  - cmd: "cassandra-stress user profile=/tmp/cs_mv_basic_profile_by_firstname_id.yaml ops'(insert=1)' cl=QUORUM duration=5m -pop seq=20000000..30000000 -mode cql3 native -rate threads=100"
 #    profile: 'data_dir/cs_mv_basic_profile_by_firstname_id.yaml'
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 4
 n_monitor_nodes: 1
 
-instance_type_db: 'i3.4xlarge'
+instance_type_db: 'i3.2xlarge'
 instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.small'
 

--- a/test-cases/scale/longevity-many-clients-4h.yaml
+++ b/test-cases/scale/longevity-many-clients-4h.yaml
@@ -6,7 +6,7 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=240m -schema 'replicatio
              "cassandra-stress read  cl=QUORUM duration=240m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native connectionsPerHost=500 -rate threads=4 -pop seq=1..20971520 -col 'n=FIXED(2) size=FIXED(256)' -log interval=5"
              ]
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 50
 n_monitor_nodes: 1
 

--- a/test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml
+++ b/test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml
@@ -9,12 +9,12 @@ cs_user_profiles:
 prepare_cs_user_profiles:
     - scylla-qa-internal/custom_d1/rolling_upgrade_dataset.yaml,30m
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 2
 n_monitor_nodes: 1
 
-gce_instance_type_db: 'n2-highmem-8'
-gce_instance_type_loader: 'n2-highmem-8'
+gce_instance_type_db: 'n2-highmem-4'
+gce_instance_type_loader: 'n2-highmem-4'
 gce_n_local_ssd_disk_db: 2
 gce_pd_ssd_disk_size_db: 750
 gce_setup_hybrid_raid: true

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -14,7 +14,7 @@ stress_cmd_complex_verify_delete: cassandra-stress user no-warmup profile=/tmp/c
 stress_before_upgrade: scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=800 -clustering-row-count=5555 -clustering-row-size=uniform:100..1024 -concurrency=5 -connection-count=5 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data
 stress_after_cluster_upgrade: scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=800 -clustering-row-count=5555 -clustering-row-size=uniform:100..1024 -concurrency=20 -connection-count=20 -consistency-level=one -rows-per-request=100 -timeout=30s -validate-data
 
-n_db_nodes: 4
+n_db_nodes: 6
 n_loaders: 1
 n_monitor_nodes: 1
 

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -344,6 +344,7 @@ class ConfigurationTests(unittest.TestCase):
         os.environ['SCT_RACK_AWARE_LOADER'] = 'true'
         os.environ['SCT_REGION_NAME'] = "eu-west-1 eu-west-2"
         os.environ['SCT_AVAILABILITY_ZONE'] = 'a,b'
+        os.environ['SCT_SIMULATED_RACKS'] = "0"
         os.environ['SCT_N_DB_NODES'] = '2 2'
         os.environ['SCT_N_LOADERS'] = '2 2'
         os.environ['SCT_INSTANCE_TYPE_DB'] = 'i4i.large'

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -305,6 +305,7 @@ class ConfigurationTests(unittest.TestCase):
     def test_14_check_rackaware_config_false_loader(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_RACK_AWARE_LOADER'] = 'false'
+        os.environ['SCT_SIMULATED_RACKS'] = "0"
         os.environ['SCT_REGION_NAME'] = "eu-west-1"
         os.environ['SCT_AVAILABILITY_ZONE'] = 'a,b'
         os.environ['SCT_N_DB_NODES'] = '2'
@@ -324,6 +325,7 @@ class ConfigurationTests(unittest.TestCase):
         os.environ['SCT_RACK_AWARE_LOADER'] = 'true'
         os.environ['SCT_REGION_NAME'] = "eu-west-1"
         os.environ['SCT_AVAILABILITY_ZONE'] = 'a'
+        os.environ['SCT_SIMULATED_RACKS'] = "0"
         os.environ['SCT_N_DB_NODES'] = '2'
         os.environ['SCT_INSTANCE_TYPE_DB'] = 'i4i.large'
         os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-dummy'

--- a/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.result.json
@@ -2,7 +2,7 @@
   "broadcast_address": "__NODE_PRIVATE_ADDRESS__",
   "broadcast_rpc_address": "__NODE_PRIVATE_ADDRESS__",
   "listen_address": "__NODE_PRIVATE_ADDRESS__",
-  "endpoint_snitch": "org.apache.cassandra.locator.Ec2Snitch",
+  "endpoint_snitch": "org.apache.cassandra.locator.GossipingPropertyFileSnitch",
   "rpc_address": "__NODE_PRIVATE_ADDRESS__",
   "cluster_name": "dummy_cluster",
   "seed_provider": [

--- a/unit_tests/test_data/test_scylla_yaml_builders/functional.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/functional.result.json
@@ -2,7 +2,7 @@
   "broadcast_address": "__NODE_PRIVATE_ADDRESS__",
   "broadcast_rpc_address": "__NODE_PRIVATE_ADDRESS__",
   "listen_address": "__NODE_PRIVATE_ADDRESS__",
-  "endpoint_snitch": "org.apache.cassandra.locator.Ec2Snitch",
+  "endpoint_snitch": "org.apache.cassandra.locator.GossipingPropertyFileSnitch",
   "rpc_address": "__NODE_PRIVATE_ADDRESS__",
   "cluster_name": "dummy_cluster",
   "seed_provider": [

--- a/unit_tests/test_data/test_scylla_yaml_builders/jepsen.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/jepsen.result.json
@@ -2,7 +2,7 @@
   "broadcast_address": "__NODE_PRIVATE_ADDRESS__",
   "broadcast_rpc_address": "__NODE_PRIVATE_ADDRESS__",
   "listen_address": "__NODE_PRIVATE_ADDRESS__",
-  "endpoint_snitch": "org.apache.cassandra.locator.Ec2Snitch",
+  "endpoint_snitch": "org.apache.cassandra.locator.GossipingPropertyFileSnitch",
   "rpc_address": "__NODE_PRIVATE_ADDRESS__",
   "cluster_name": "dummy_cluster",
   "seed_provider": [

--- a/unit_tests/test_data/test_scylla_yaml_builders/longevity-10gb-3h.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/longevity-10gb-3h.result.json
@@ -1,7 +1,7 @@
 {
   "broadcast_address": "__NODE_IPV6_ADDRESS__",
   "listen_address": "__NODE_IPV6_ADDRESS__",
-  "endpoint_snitch": "org.apache.cassandra.locator.Ec2Snitch",
+  "endpoint_snitch": "org.apache.cassandra.locator.GossipingPropertyFileSnitch",
   "rpc_address": "__NODE_IPV6_ADDRESS__",
   "cluster_name": "dummy_cluster",
   "seed_provider": [

--- a/unit_tests/test_data/test_scylla_yaml_builders/manager-backup-1TB-gce.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/manager-backup-1TB-gce.result.json
@@ -2,7 +2,7 @@
   "broadcast_address": "__NODE_PRIVATE_ADDRESS__",
   "broadcast_rpc_address": "__NODE_PRIVATE_ADDRESS__",
   "listen_address": "__NODE_PRIVATE_ADDRESS__",
-  "endpoint_snitch": "org.apache.cassandra.locator.Ec2Snitch",
+  "endpoint_snitch": "org.apache.cassandra.locator.GossipingPropertyFileSnitch",
   "rpc_address": "__NODE_PRIVATE_ADDRESS__",
   "cluster_name": "dummy_cluster",
   "seed_provider": [

--- a/unit_tests/test_data/test_scylla_yaml_builders/multi_network_interfaces/cdc-replication-longevity.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/multi_network_interfaces/cdc-replication-longevity.result.json
@@ -3,6 +3,7 @@
   "listen_address": "0.0.0.0",
   "rpc_address": "0.0.0.0",
   "cluster_name": "dummy_cluster",
+  "endpoint_snitch": "org.apache.cassandra.locator.GossipingPropertyFileSnitch",
   "seed_provider": [
     {
       "class_name": "org.apache.cassandra.locator.SimpleSeedProvider",

--- a/unit_tests/test_data/test_scylla_yaml_builders/multi_network_interfaces/longevity-10gb-3h.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/multi_network_interfaces/longevity-10gb-3h.result.json
@@ -3,6 +3,7 @@
   "listen_address": "0.0.0.0",
   "rpc_address": "0.0.0.0",
   "cluster_name": "dummy_cluster",
+  "endpoint_snitch": "org.apache.cassandra.locator.GossipingPropertyFileSnitch",
   "seed_provider": [
     {
       "class_name": "org.apache.cassandra.locator.SimpleSeedProvider",

--- a/unit_tests/test_data/test_scylla_yaml_builders/perf-regression.100threads.30M-keys.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/perf-regression.100threads.30M-keys.result.json
@@ -2,7 +2,7 @@
   "broadcast_address": "__NODE_PRIVATE_ADDRESS__",
   "broadcast_rpc_address": "__NODE_PRIVATE_ADDRESS__",
   "listen_address": "__NODE_PRIVATE_ADDRESS__",
-  "endpoint_snitch": "org.apache.cassandra.locator.Ec2Snitch",
+  "endpoint_snitch": "org.apache.cassandra.locator.GossipingPropertyFileSnitch",
   "rpc_address": "__NODE_PRIVATE_ADDRESS__",
   "cluster_name": "dummy_cluster",
   "seed_provider": [

--- a/unit_tests/test_data/test_scylla_yaml_builders/rolling-upgrade.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/rolling-upgrade.result.json
@@ -2,7 +2,7 @@
   "broadcast_address": "__NODE_PRIVATE_ADDRESS__",
   "broadcast_rpc_address": "__NODE_PRIVATE_ADDRESS__",
   "listen_address": "__NODE_PRIVATE_ADDRESS__",
-  "endpoint_snitch": "org.apache.cassandra.locator.Ec2Snitch",
+  "endpoint_snitch": "org.apache.cassandra.locator.GossipingPropertyFileSnitch",
   "rpc_address": "__NODE_PRIVATE_ADDRESS__",
   "cluster_name": "dummy_cluster",
   "seed_provider": [


### PR DESCRIPTION
4 node tests were switched to 6 nodes test and sometimes I decreased the instance type

Fixes https://github.com/scylladb/scylla-cluster-tests/issues/10241

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] None, please let me know what tests you would like me to run.
   - Given that we are already running Tier 1 and Sanities with these changes, we have at least some confidence

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
   - Backports will be done for 2025.1 and perf branches, but I will do them only after we tested it sufficiently in master  
- [x] I didn't leave commented-out/debugging code

