### PR TITLE
improvement(sct): Do not require AWS for conf-docs and update-conf-docs

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -194,7 +194,7 @@ class SctLoader(unittest.TestLoader):
 def cli(ctx):
     disable_loggers_during_startup()
     # Ugly way of filtering the few command that do not require OKTA verification
-    if ctx.invoked_subcommand not in ("update-conf-docs", "nemesis-list", "create-nemesis-pipelines"):
+    if ctx.invoked_subcommand not in ("update-conf-docs", "conf-docs", "nemesis-list", "create-nemesis-pipelines"):
         try_auth_with_okta()
 
         key_store = KeyStore()
@@ -925,28 +925,16 @@ def conf(config_file, backend):
 @cli.command('conf-docs', help="Show all available configuration in yaml/markdown format")
 @click.option('-o', '--output-format', type=click.Choice(["yaml", "markdown"]), default="yaml", help="type of the output")
 def conf_docs(output_format):
-    add_file_logger()
-
-    os.environ['SCT_CLUSTER_BACKEND'] = "aws"  # just to pass SCTConfiguration() verification.
-
-    config_logger = logging.getLogger('sdcm.sct_config')
-    config_logger.setLevel(logging.ERROR)
     if output_format == 'markdown':
-        click.secho(SCTConfiguration().dump_help_config_markdown())
+        click.secho(SCTConfiguration.dump_help_config_markdown())
     elif output_format == 'yaml':
-        click.secho(SCTConfiguration().dump_help_config_yaml())
+        click.secho(SCTConfiguration.dump_help_config_yaml())
 
 
 @cli.command('update-conf-docs', help="Update the docs configuration markdown")
 def update_conf_docs():
-    add_file_logger()
-
-    os.environ['SCT_CLUSTER_BACKEND'] = "aws"  # just to pass SCTConfiguration() verification.
-
-    config_logger = logging.getLogger('sdcm.sct_config')
-    config_logger.setLevel(logging.ERROR)
     markdown_file = Path(__name__).parent / 'docs' / 'configuration_options.md'
-    markdown_file.write_text(SCTConfiguration().dump_help_config_markdown())
+    markdown_file.write_text(SCTConfiguration.dump_help_config_markdown())
     click.secho(f"docs written into {markdown_file}")
 
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2817,7 +2817,8 @@ class SCTConfiguration(dict):
         """
         return anyconfig.dumps(self.dict(), ac_parser="yaml")
 
-    def dump_help_config_markdown(self):
+    @classmethod
+    def dump_help_config_markdown(cls):
         """
         Dump all configuration options with their defaults and help to string in markdown format
 
@@ -2832,6 +2833,7 @@ class SCTConfiguration(dict):
             * **list:** can be appended by adding `++` as the first item of the list
                    `export SCT_SCYLLA_D_OVERRIDES_FILES='["++", "extra_file/scylla.d/io.conf"]'`
         """
+        defaults = anyconfig.load(sct_abs_path('defaults/test_default.yaml'))
 
         def strip_help_text(text):
             """
@@ -2842,32 +2844,34 @@ class SCTConfiguration(dict):
 
         ret = strip_help_text(header)
 
-        for opt in self.config_options:
+        for opt in cls.config_options:
             ret += '\n\n'
             if opt['help']:
                 help_text = '<br>'.join(strip_help_text(opt['help']).splitlines())
             else:
                 help_text = ''
             appendable = ' (appendable)' if is_config_option_appendable(opt.get('name')) else ''
-            default = self.get_default_value(opt['name'])
+            default = defaults.get(opt['name'], None)
             default_text = default if default else 'N/A'
             ret += f"""## **{opt['name']}** / {opt['env']}\n\n{help_text}\n\n**default:** {default_text}\n\n**type:** {opt.get('type').__name__}{appendable}\n"""
 
         return ret
 
-    def dump_help_config_yaml(self):
+    @classmethod
+    def dump_help_config_yaml(cls):
         """
         Dump all configuration options with their defaults and help to string in yaml format
 
         :return: str
         """
+        defaults = anyconfig.load(sct_abs_path('defaults/test_default.yaml'))
         ret = ""
-        for opt in self.config_options:
+        for opt in cls.config_options:
             if opt['help']:
-                help_text = '\n'.join(["# {}".format(l.strip()) for l in opt['help'].splitlines() if l.strip()]) + '\n'
+                help_text = '\n'.join("# {}".format(l.strip()) for l in opt['help'].splitlines() if l.strip()) + '\n'
             else:
                 help_text = ''
-            default = self.get_default_value(opt['name'])
+            default = defaults.get(opt['name'], None)
             default = default if default else 'N/A'
             ret += "{help_text}{name}: {default}\n\n".format(help_text=help_text, default=default, **opt)
 


### PR DESCRIPTION
Currently, both conf-docs and update-conf-docs require AWS due to instantiation of SCTConfiguration class. Make required methods class methods to prevent unnecessary validation. This also speeds up the entire process.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
