### PR TITLE
improvement(decode_backtrace): improve logic

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1563,18 +1563,15 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         self._decoding_backtraces_thread.start()
 
     def decode_backtrace(self):
-        scylla_debug_file = None
         while True:
             event = None
-            obj = None
             try:
                 obj = self.test_config.DECODING_QUEUE.get(timeout=5)
                 if obj is None:
                     break
                 event = obj["event"]
                 self.log.debug("Event origin severity: %s", event.severity)
-                if not scylla_debug_file:
-                    scylla_debug_file = self.copy_scylla_debug_info(obj["node"], obj["debug_file"])
+                scylla_debug_file = self.copy_scylla_debug_info(obj["node"], obj["build_id"])
                 output = self.decode_raw_backtrace(scylla_debug_file, " ".join(event.raw_backtrace.split('\n')))
                 event.backtrace = output.stdout
                 the_map = FindIssuePerBacktrace()
@@ -1597,6 +1594,8 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
                 pass
             except Exception as details:  # pylint: disable=broad-except  # noqa: BLE001
                 self.log.error("failed to decode backtrace %s", details)
+                if "is closed" in details:
+                    break
             finally:
                 if event:
                     event.ready_to_publish()
@@ -1605,38 +1604,60 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             if self.termination_event.is_set() and self.test_config.DECODING_QUEUE.empty():
                 break
 
-    def copy_scylla_debug_info(self, node_name: str, debug_file: str):
-        """Copy scylla debug file from db-node to monitor-node
+    def copy_scylla_debug_info(self, node_name: str, build_id: str):
+        """Copy scylla debug file from db-node to monitor-node.
+
+        Skip if debug file already exists on monitor node.
 
         Copy via builder
         :param node_name: db node name
         :type node_name: str
-        :param scylla_debug_file: path to scylla_debug_file on db-node
-        :type scylla_debug_file: str
+        :param build_id: build id of scylla binary
+        :type build_id: str
         :returns: path on monitor node
         :rtype: {str}
         """
-
+        final_scylla_debug_file = os.path.join("/tmp", f"debug_{build_id}")
+        res = self.remoter.run(
+            "test -f {}".format(final_scylla_debug_file), ignore_status=True, verbose=False)
+        if res.exited == 0:
+            return final_scylla_debug_file
         db_nodes = self.parent_cluster.targets['db_cluster'].nodes
         db_node = next(iter([n for n in db_nodes if n.name == node_name]), None)
         assert db_node, f"Node named: {node_name} wasn't found"
 
+        debug_file = db_node.get_scylla_debuginfo_file(build_id)
+        LOGGER.debug("Debug info file %s", debug_file)
         base_scylla_debug_file = os.path.basename(debug_file)
-        transit_scylla_debug_file = os.path.join(db_node.parent_cluster.logdir,
-                                                 base_scylla_debug_file)
-        final_scylla_debug_file = os.path.join("/tmp", base_scylla_debug_file)
-
-        if not os.path.exists(transit_scylla_debug_file):
-            db_node.remoter.receive_files(debug_file, transit_scylla_debug_file)
-        res = self.remoter.run(
-            "test -f {}".format(final_scylla_debug_file), ignore_status=True, verbose=False)
-        if res.exited != 0:
-            self.remoter.send_files(transit_scylla_debug_file,  # pylint: disable=not-callable
-                                    final_scylla_debug_file)
+        transit_scylla_debug_file = os.path.join(db_node.parent_cluster.logdir, base_scylla_debug_file)
+        db_node.remoter.receive_files(debug_file, transit_scylla_debug_file)
+        self.remoter.send_files(transit_scylla_debug_file, final_scylla_debug_file)
         self.log.info("File on monitor node %s: %s", self, final_scylla_debug_file)
         self.log.info("Remove transit file: %s", transit_scylla_debug_file)
         os.remove(transit_scylla_debug_file)
         return final_scylla_debug_file
+
+    def get_scylla_debuginfo_file(self, build_id: str):
+        """Lookup the scylla debug information for a given build_id."""
+        # first try default location
+        scylla_debug_info = '/usr/lib/debug/bin/scylla.debug'
+        results = self.remoter.run(f'[[ -f {scylla_debug_info} ]]', ignore_status=True)
+        if results.ok:
+            return scylla_debug_info
+
+        # then try the relocatable location
+        results = self.remoter.run('ls /usr/lib/debug/opt/scylladb/libexec/scylla*.debug', ignore_status=True)
+        if results.stdout.strip():
+            return results.stdout.strip()
+
+        # then look it up based on the build id
+        if build_id:
+            scylla_debug_info = f"/usr/lib/debug/.build-id/{build_id[:2]}/{build_id[2:]}.debug"
+            results = self.remoter.run(f'[[ -f {scylla_debug_info} ]]', ignore_status=True)
+            if results.ok:
+                return scylla_debug_info
+
+        raise Exception("Couldn't find scylla debug information")
 
     def decode_raw_backtrace(self, scylla_debug_file, raw_backtrace):
         """run decode backtrace on monitor node

--- a/sdcm/db_log_reader.py
+++ b/sdcm/db_log_reader.py
@@ -199,11 +199,9 @@ class DbLogReader(Process):
                 backtrace["event"].publish()
                 continue
             try:
-                scylla_debug_info = self.get_scylla_debuginfo_file()
-                LOGGER.debug("Debug info file %s", scylla_debug_info)
                 self._decoding_queue.put({
                     "node": self._node_name,
-                    "debug_file": scylla_debug_info,
+                    "build_id": self._build_id,
                     "event": backtrace["event"],
                 })
             except Exception:  # pylint: disable=broad-except
@@ -245,33 +243,6 @@ class DbLogReader(Process):
 
     def get_scylla_build_id(self) -> str | None:
         return self._build_id
-
-    def get_scylla_debuginfo_file(self):
-        """
-        Lookup the scylla debug information, in various places it can be.
-
-        :return the path to the scylla debug information
-        :rtype str
-        """
-        # first try default location
-        scylla_debug_info = '/usr/lib/debug/bin/scylla.debug'
-        results = self._remoter.run('[[ -f {} ]]'.format(scylla_debug_info), ignore_status=True)
-        if results.ok:
-            return scylla_debug_info
-
-        # then try the relocatable location
-        results = self._remoter.run('ls /usr/lib/debug/opt/scylladb/libexec/scylla*.debug', ignore_status=True)
-        if results.stdout.strip():
-            return results.stdout.strip()
-
-        # then look it up base on the build id
-        if build_id := self.get_scylla_build_id():
-            scylla_debug_info = "/usr/lib/debug/.build-id/{0}/{1}.debug".format(build_id[:2], build_id[2:])
-            results = self._remoter.run('[[ -f {} ]]'.format(scylla_debug_info), ignore_status=True)
-            if results.ok:
-                return scylla_debug_info
-
-        raise Exception("Couldn't find scylla debug information")
 
     def stop(self):
         self._terminate_event.set()

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -69,11 +69,6 @@ class DummyDbCluster(BaseCluster, BaseScyllaCluster):  # pylint: disable=abstrac
         pass
 
 
-class DummyDbLogReader(DbLogReader):
-    def get_scylla_debuginfo_file(self):
-        return "scylla_debug_info_file"
-
-
 class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
     @classmethod
     def setUpClass(cls):
@@ -94,7 +89,7 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
 
     @cached_property
     def _db_log_reader(self):
-        return DummyDbLogReader(
+        return DbLogReader(
             system_log=self.node.system_log,
             remoter=self.node.remoter,
             node_name=str(self),

--- a/unit_tests/test_decode_backtrace.py
+++ b/unit_tests/test_decode_backtrace.py
@@ -32,11 +32,6 @@ class DecodeDummyNode(DummyNode):  # pylint: disable=abstract-method
         return "scylla_debug_info_file"
 
 
-class DummyDbLogReader(DbLogReader):
-    def get_scylla_debuginfo_file(self):
-        return "scylla_debug_info_file"
-
-
 class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
     @classmethod
     def setUpClass(cls):
@@ -76,7 +71,7 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
 
     @cached_property
     def _db_log_reader(self):
-        return DummyDbLogReader(
+        return DbLogReader(
             system_log=self.node.system_log,
             node_name=str(self),
             remoter=self.node.remoter,
@@ -87,7 +82,7 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
 
     @cached_property
     def _db_log_reader_no_decoding(self):
-        return DummyDbLogReader(
+        return DbLogReader(
             system_log=self.node.system_log,
             node_name=str(self),
             remoter=self.node.remoter,


### PR DESCRIPTION
Current logic for decoding backtrace was locking db log processing for duration of getting path to scylla debug file. Also it was downloading debug file once - possibly resulting in wrong backtrace decode in upgrade tests.

Moved logic for getting debug file info to decoding queue, so it's not locking db log processing loop. Also downloading debug file to monitor node (where decoding is done) to `/tmp/debug_<build_id>` and skipping download if it's already there.

closes: https://github.com/scylladb/qa-tasks/issues/57

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [jenkins](https://jenkins.scylladb.com/job/scylla-staging/job/lukasz/job/longevity-100gb-4h-test/2/) - to be verified

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
