### PR TITLE
fix(search_inconsistent_host_ids): use correct logic

### DIFF
--- a/sdcm/utils/raft/__init__.py
+++ b/sdcm/utils/raft/__init__.py
@@ -394,7 +394,7 @@ class RaftFeature(RaftFeatureOperations):
         LOGGER.debug("Difference between group0 and token ring: %s", host_ids)
         # Starting from 2025.2 not all alive nodes are voters. get
         # non voters node only for older versions < 2025.2
-        if not host_ids and limited_voters_feature_enabled:
+        if not host_ids and not limited_voters_feature_enabled:
             LOGGER.debug("Get non-voter member hostids")
             host_ids = self.get_group0_non_voters()
         return host_ids


### PR DESCRIPTION
In PR: https://github.com/scylladb/scylla-cluster-tests/pull/10636 after switch to use feature name instead of version was used wrong logic in if statement.
Check non voters should be done only if feature GROUP0_LIMITED_VOTERS is not enabled

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [for feature disabled(mising) in 6.2 - Passed](https://argus.scylladb.com/tests/scylla-cluster-tests/255c1fcd-065f-4f9e-910a-a193064bb92a)
- [for feature enabled in 2025.2.dev - Passed](https://argus.scylladb.com/tests/scylla-cluster-tests/e9741367-3fd6-4d05-9a39-a3efce535f4c)
- [for multidc with 2025.2 - passed](https://argus.scylladb.com/tests/scylla-cluster-tests/65f99735-c0ce-41f8-8ba5-1ff132b517d2)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
