### PR TITLE
fix(sct_runner.py): rename update_at_scope to begin_update_at_scope

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -1183,7 +1183,7 @@ class AzureSctRunner(SctRunner):
             }
         )
         LOGGER.info("Setting SCT runner labels to: %s", tags_to_create)
-        resource_mgmt_client.tags.update_at_scope(scope=instance.id, parameters=params)
+        resource_mgmt_client.tags.begin_update_at_scope(scope=instance.id, parameters=params)
         LOGGER.info("SCT runner tags set to: %s", tags_to_create)
 
 


### PR DESCRIPTION
In https://pypi.org/project/azure-mgmt-resource/ a breaking change of: Renamed operation TagsOperations.update_at_scope to TagsOperations.begin_update_at_scope is introduced.
Fixes: #10659

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [longevity 3h azure](https://jenkins.scylladb.com/job/scylla-master/job/reproducers/job/longevity-10gb-3h-azure-test99/2/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
