### PR TITLE
fix(preload): use proper timeout for preload stress commands

### DIFF
--- a/add_new_dc_test.py
+++ b/add_new_dc_test.py
@@ -77,7 +77,12 @@ class TestAddNewDc(LongevityTest):
     def prewrite_db_with_data(self) -> None:
         self.log.info("Prewriting database...")
         stress_cmd = self.params.get('prepare_write_cmd')
-        pre_thread = self.run_stress_thread(stress_cmd=stress_cmd, stats_aggregate_cmds=False, round_robin=False)
+        pre_thread = self.run_stress_thread(
+            stress_cmd=stress_cmd,
+            duration=self.params.get('prepare_stress_duration'),
+            stats_aggregate_cmds=False,
+            round_robin=False,
+        )
         self.verify_stress_thread(pre_thread)
         self.log.info("Database pre write completed")
 

--- a/admission_control_overload_test.py
+++ b/admission_control_overload_test.py
@@ -27,8 +27,13 @@ class AdmissionControlOverloadTest(ClusterTester):
     def run_load(self, job_num, job_cmd, is_prepare=False):
         is_ever_triggered = False
         if is_prepare and not skip_optional_stage('prepare_write'):
-            prepare_stress_queue = self.run_stress_thread(stress_cmd=job_cmd, stress_num=job_num, prefix='preload-',
-                                                          stats_aggregate_cmds=False)
+            prepare_stress_queue = self.run_stress_thread(
+                stress_cmd=job_cmd,
+                duration=self.params.get('prepare_stress_duration'),
+                stress_num=job_num,
+                prefix='preload-',
+                stats_aggregate_cmds=False,
+            )
             self.get_stress_results(prepare_stress_queue)
         elif not is_prepare and not skip_optional_stage('main_load'):
             stress_queue = []

--- a/performance_regression_alternator_test.py
+++ b/performance_regression_alternator_test.py
@@ -88,7 +88,10 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
                         params.update({'stress_num': 1, 'round_robin': True})
 
                     for stress_cmd in prepare_write_cmd:
-                        params.update({'stress_cmd': stress_cmd.replace('dynamodb', stress_type)})
+                        params.update({
+                            'stress_cmd': stress_cmd.replace('dynamodb', stress_type),
+                            'duration': self.params.get('prepare_stress_duration'),
+                        })
 
                         # Run all stress commands
                         params.update(dict(stats_aggregate_cmds=False))
@@ -97,8 +100,13 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
 
                 # One stress cmd command
                 else:
-                    stress_queue.append(self.run_stress_thread(stress_cmd=prepare_write_cmd.replace('dynamodb', stress_type), stress_num=1,
-                                                               prefix='preload-', stats_aggregate_cmds=False))
+                    stress_queue.append(self.run_stress_thread(
+                        stress_cmd=prepare_write_cmd.replace('dynamodb', stress_type),
+                        duration=self.params.get('prepare_stress_duration'),
+                        stress_num=1,
+                        prefix='preload-',
+                        stats_aggregate_cmds=False,
+                    ))
 
             for stress in stress_queue:
                 self.get_stress_results(queue=stress, store_results=False)

--- a/performance_regression_gradual_grow_throughput.py
+++ b/performance_regression_gradual_grow_throughput.py
@@ -158,7 +158,10 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):  # py
             params['compaction_strategy'] = compaction_strategy
 
         for stress_cmd in population_commands:
-            params.update({'stress_cmd': stress_cmd})
+            params.update({
+                'stress_cmd': stress_cmd,
+                'duration': self.params.get('prepare_stress_duration'),
+            })
             # Run all stress commands
             params.update(dict(stats_aggregate_cmds=False))
             self.log.debug('RUNNING stress cmd: {}'.format(stress_cmd))

--- a/performance_regression_operator_multi_tenant_test.py
+++ b/performance_regression_operator_multi_tenant_test.py
@@ -62,7 +62,10 @@ class PerformanceRegressionOperatorMultiTenantTest(MultiTenantTestMixin, Perform
                     "'%s' DB cluster: Populating data using round_robin", db_cluster_name)
                 params.update({'stress_num': 1, 'round_robin': True})
             for stress_cmd in prepare_write_cmd:
-                params.update({'stress_cmd': stress_cmd})
+                params.update({
+                    'stress_cmd': stress_cmd,
+                    'duration': self.params.get('prepare_stress_duration'),
+                })
                 # Run all stress commands
                 params.update(dict(stats_aggregate_cmds=False))
                 self.log.debug("'%s' DB cluster: RUNNING stress cmd: %s",

--- a/performance_regression_row_level_repair_test.py
+++ b/performance_regression_row_level_repair_test.py
@@ -83,7 +83,10 @@ class PerformanceRegressionRowLevelRepairTest(ClusterTester):
                     if consistency_level:
                         stress_cmd = self._update_cl_in_stress_cmd(  # noqa: PLW2901
                             str_stress_cmd=stress_cmd, consistency_level=consistency_level)
-                    params.update({'stress_cmd': stress_cmd})
+                    params.update({
+                        'stress_cmd': stress_cmd,
+                        'duration': self.params.get('prepare_stress_duration'),
+                    })
 
                     # Run all stress commands
                     params.update(dict(stats_aggregate_cmds=False))

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -244,13 +244,21 @@ class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):  
                 for stress_cmd in prepare_write_cmd:
                     params.update({'stress_cmd': stress_cmd})
                     # Run all stress commands
-                    params.update(dict(stats_aggregate_cmds=False))
+                    params.update(dict(
+                        stats_aggregate_cmds=False,
+                        duration=self.params.get('prepare_stress_duration'),
+                    ))
                     self.log.debug('RUNNING stress cmd: {}'.format(stress_cmd))
                     stress_queue.append(self.run_stress_thread(**params))
             # One stress cmd command
             else:
-                stress_queue.append(self.run_stress_thread(stress_cmd=prepare_write_cmd, stress_num=1,
-                                                           prefix='preload-', stats_aggregate_cmds=False))
+                stress_queue.append(self.run_stress_thread(
+                    stress_cmd=prepare_write_cmd,
+                    duration=self.params.get('prepare_stress_duration'),
+                    stress_num=1,
+                    prefix='preload-',
+                    stats_aggregate_cmds=False,
+                ))
 
             for stress in stress_queue:
                 self.get_stress_results(queue=stress, store_results=False)

--- a/sdcm/utils/loader_utils.py
+++ b/sdcm/utils/loader_utils.py
@@ -260,14 +260,26 @@ class LoaderUtilsMixin:
                     self.log.debug("Using round_robin for multiple Keyspaces...")
                     for i in range(1, keyspace_num + 1):
                         keyspace_name = self._get_keyspace_name(i)
-                        self._run_all_stress_cmds(write_queue, params={'stress_cmd': prepare_write_cmd,
-                                                                       'keyspace_name': keyspace_name,
-                                                                       'round_robin': True})
+                        self._run_all_stress_cmds(
+                            write_queue,
+                            params={
+                                'stress_cmd': prepare_write_cmd,
+                                'duration': self.params.get('prepare_stress_duration'),
+                                'keyspace_name': keyspace_name,
+                                'round_robin': True,
+                            },
+                        )
                 # Not using round_robin and all keyspaces will run on all loaders
                 else:
-                    self._run_all_stress_cmds(write_queue, params={'stress_cmd': prepare_write_cmd,
-                                                                   'keyspace_num': keyspace_num,
-                                                                   'round_robin': self.params.get('round_robin')})
+                    self._run_all_stress_cmds(
+                        write_queue,
+                        params={
+                            'stress_cmd': prepare_write_cmd,
+                            'duration': self.params.get('prepare_stress_duration'),
+                            'keyspace_num': keyspace_num,
+                            'round_robin': self.params.get('round_robin'),
+                        },
+                    )
 
             if prepare_cs_user_profiles:
                 self.run_cs_user_profiles(cs_profiles=prepare_cs_user_profiles, stress_queue=write_queue)


### PR DESCRIPTION
For the moment, if we define custom duration for the main stress load
then we get a timeout based on it for every stress command, even preload one.

When it is bigger than duration of the preload command it is ok,
but when it is smaller than we get false negative result.

So, fix it by specifying preload duration in functions designed
to call exactly this type of stress commands.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/7327

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
