### PR TITLE
improvement(perf): remove redundancy in `performance_regression_test`

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -41,11 +41,6 @@ class PerformanceTestWorkload(Enum):
     MIXED = "mixed"
 
 
-class PerformanceTestType(Enum):
-    THROUGHPUT = "throughput"
-    LATENCY = "latency"
-
-
 class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):  # pylint: disable=too-many-public-methods
 
     """
@@ -289,7 +284,7 @@ class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):  
         results = self.get_stress_results(queue=stress_queue)
 
         self.build_histogram(
-            PerformanceTestWorkload.READ, PerformanceTestType.LATENCY,
+            PerformanceTestWorkload.READ,
             hdr_tags=stress_queue.hdr_tags)
         self.update_test_details()
         self.display_results(results, test_name='test_latency' if not nemesis else 'test_latency_with_nemesis')
@@ -307,7 +302,7 @@ class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):  
             self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
         results = self.get_stress_results(queue=stress_queue)
         self.build_histogram(
-            PerformanceTestWorkload.WRITE, PerformanceTestType.LATENCY,
+            PerformanceTestWorkload.WRITE,
             hdr_tags=stress_queue.hdr_tags)
         self.update_test_details()
         self.display_results(results, test_name='test_latency')
@@ -325,7 +320,7 @@ class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):  
             self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
         results = self.get_stress_results(queue=stress_queue)
         self.build_histogram(
-            PerformanceTestWorkload.MIXED, PerformanceTestType.LATENCY,
+            PerformanceTestWorkload.MIXED,
             hdr_tags=stress_queue.hdr_tags)
         self.update_test_details(scylla_conf=True)
         self.display_results(results, test_name='test_latency')
@@ -535,7 +530,7 @@ class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):  
         results = self.get_stress_results(queue=stress_queue)
 
         self.build_histogram(
-            PerformanceTestWorkload.WRITE, PerformanceTestType.THROUGHPUT,
+            PerformanceTestWorkload.WRITE,
             hdr_tags=stress_queue.hdr_tags)
         self.update_test_details(scylla_conf=True)
         self.display_results(results, test_name='test_write')
@@ -569,7 +564,7 @@ class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):  
         results = self.get_stress_results(queue=stress_queue)
 
         self.build_histogram(
-            PerformanceTestWorkload.READ, PerformanceTestType.THROUGHPUT,
+            PerformanceTestWorkload.READ,
             hdr_tags=stress_queue.hdr_tags)
         self.update_test_details(scylla_conf=True)
         self.display_results(results, test_name='test_read')
@@ -602,7 +597,7 @@ class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):  
         results = self.get_stress_results(queue=stress_queue)
 
         self.build_histogram(
-            PerformanceTestWorkload.MIXED, PerformanceTestType.THROUGHPUT,
+            PerformanceTestWorkload.MIXED,
             hdr_tags=stress_queue.hdr_tags)
         self.update_test_details(scylla_conf=True)
         self.display_results(results, test_name='test_mixed')
@@ -794,8 +789,7 @@ class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):  
         self.check_regression()
         self.kill_stress_thread()
 
-    def build_histogram(self, workload: PerformanceTestWorkload, test_type: PerformanceTestType,
-                        hdr_tags: list):
+    def build_histogram(self, workload: PerformanceTestWorkload, hdr_tags: list):
         if not self.params["use_hdrhistogram"]:
             return
 


### PR DESCRIPTION
The `PerformanceTestType` class is not used anymore.
So, delete it and update all the function interfaces which have it in their interfaces.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
