### PR TITLE
fix(sct_event): ignore `auth_service - Unexpected exception` events

### DIFF
--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -151,5 +151,12 @@ def enable_default_filters(sct_config: SCTConfiguration):  # pylint: disable=unu
                                 event_class=DatabaseLogEvent.ABORTING_ON_SHARD,
                                 regex=r'.*Parent connection [\d]+ is aborting on shard').publish()
 
+    # As per discussion in https://github.com/scylladb/scylladb/issues/9862, the fix in
+    # https://github.com/scylladb/scylladb/pull/17910 will not be backported in 2024.2
+    # so this error will be reduced to a warning
+    EventsSeverityChangerFilter(new_severity=Severity.WARNING,
+                                event_class=DatabaseLogEvent.DATABASE_ERROR,
+                                regex=r'.*auth_service - Unexpected exception while revoking all permissions on dropped table: service::group0_concurrent_modification.*').publish()
+
 
 __all__ = ("start_events_device", "stop_events_device", "enable_default_filters")


### PR DESCRIPTION
Refs: https://github.com/scylladb/scylladb/issues/9862
 The fix in https://github.com/scylladb/scylladb/pull/17910 will not be backported so the error should be ignored

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
