### PR TITLE
fix(is_scylla_installed): stop using package manager

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1069,7 +1069,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         elif not isinstance(self.parent_cluster.params, SCTConfiguration):
             TestFrameworkEvent(source=self.__class__.__name__,
                                message=f"The 'params' attribute expected to by 'SCTConfiguration`, "
-                                       f"but actually it is a `{type(self.parent_cluster.params)}`",
+                               f"but actually it is a `{type(self.parent_cluster.params)}`",
                                trace=sys._getframe().f_back,  # pylint: disable=protected-access
                                severity=Severity.ERROR).publish()
 
@@ -1702,7 +1702,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
                 )
             )
             ScyllaYamlUpdateEvent(node_name=self.name, message=f"ScyllaYaml has been changed on node: {self.name}. "
-                                                               f"Diff: {diff}").publish()
+                                  f"Diff: {diff}").publish()
 
     def remote_manager_yaml(self):
         return self._remote_yaml(path=SCYLLA_MANAGER_YAML_PATH)
@@ -2161,13 +2161,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
         self.install_package(package_name=package_name, ignore_status=True)
 
     def is_scylla_installed(self, raise_if_not_installed=False):
-        if self.distro.is_rhel_like or self.distro.is_sles:
-            result = self.remoter.run(f'rpm -q {self.scylla_pkg()}', verbose=False, ignore_status=True)
-        elif self.distro.is_ubuntu or self.distro.is_debian:
-            result = self.remoter.run(f'dpkg-query --status {self.scylla_pkg()}', verbose=False, ignore_status=True)
-        else:
-            raise ValueError(f"Unsupported Linux distribution: {self.distro}")
-        if result.exit_status == 0:
+        if self.get_scylla_binary_version():
             return True
         elif raise_if_not_installed:
             raise Exception(f"There is no pre-installed ScyllaDB on {self}")
@@ -4819,7 +4813,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             gce_pd_ssd_disk_size_db = self.params.get('gce_pd_ssd_disk_size_db')
             if not (gce_n_local_ssd_disk_db > 0 and gce_pd_ssd_disk_size_db > 0):
                 msg = f"Hybrid RAID cannot be configured without NVMe ({gce_n_local_ssd_disk_db}) " \
-                      f"and PD-SSD ({gce_pd_ssd_disk_size_db})"
+                    f"and PD-SSD ({gce_pd_ssd_disk_size_db})"
                 raise ValueError(msg)
 
             # The script to configure a hybrid RAID is named "hybrid_raid.py" and located on the private repository.


### PR DESCRIPTION
Today we are using package manager to search if Scylla is installed Since we have in the repo now both `scylla` and
`scylla-enterprise`(which is a virtual package) the current implemntaion will identify as enterprise and will fail with the following error
```
There is no pre-installed ScyllaDB on ...
```

Modifying the logic to check for scylla version instead

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/releng-testing/job/artifacts/job/artifacts-azure-image-test/33/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
