### PR TITLE
fix(latte): avoid hdrh files reading and stress start race

### DIFF
--- a/sdcm/stress/latte_thread.py
+++ b/sdcm/stress/latte_thread.py
@@ -233,6 +233,12 @@ class LatteStressThread(DockerBasedStressThread):  # pylint: disable=too-many-in
                 remote_log_file=remote_hdr_file_name_full_path,
                 target_log_file=os.path.join(loader.logdir, remote_hdr_file_name),
             )
+            # NOTE: running dozens of commands in parallel on a single SCT runner
+            #       it is easy to get stress command to run earlier than the HDRH file
+            #       starts being read.
+            #       So, to avoid data loss by time mismatch we start reading earlier
+            #       to make sure we do not race with stress threads start time.
+            hdrh_logger_context.start()
         else:
             hdrh_logger_context = contextlib.nullcontext()
         stress_cmd += f" -- {hosts} "


### PR DESCRIPTION
If we run dozens of latte stress commands then we may hit the race
where we start reading HDR histogram files later then they get populated.
It will lead to the ignoring of line which happened to be written before the reding start time.

So, fix it by starting the HDR histograms file readers earlier
to avoid such a race even on slow SCT runner which have only 2 vCPUs.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-perf-latency-regression-latte#25](https://argus.scylladb.com/tests/scylla-cluster-tests/5fee738b-fb8f-452e-add4-693e10f335e9)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
