### PR TITLE
fix(enable_default_filters): move DB event filter for raft error to default filters

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -100,12 +100,6 @@ def ignore_topology_change_coordinator_errors():
             ))
             stack.enter_context(DbEventsFilter(
                 db_event=DatabaseLogEvent.RUNTIME_ERROR,
-                line=r".*raft_topology - topology change coordinator fiber got error std::runtime_error"
-                     r" \(raft topology: exec_global_command\(barrier\) failed with seastar::rpc::closed_erro"
-                     r"r \(connection is closed\)\)"
-            ))
-            stack.enter_context(DbEventsFilter(
-                db_event=DatabaseLogEvent.RUNTIME_ERROR,
                 line=r".*raft_topology - drain rpc failed, proceed to fence old writes:.*connection is closed",
             ))
         yield

--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -33,7 +33,6 @@ from sdcm.sct_events.events_processes import \
     EVENTS_GRAFANA_ANNOTATOR_ID, EVENTS_GRAFANA_AGGREGATOR_ID, EVENTS_GRAFANA_POSTMAN_ID, \
     EventsProcessesRegistry, create_default_events_process_registry, get_events_process, EVENTS_HANDLER_ID, EVENTS_COUNTER_ID
 from sdcm.utils.issues import SkipPerIssues
-from sdcm.sct_events.group_common_events import ignore_topology_change_coordinator_errors
 
 
 EVENTS_DEVICE_START_DELAY = 1  # seconds
@@ -154,7 +153,10 @@ def enable_default_filters(sct_config: SCTConfiguration):  # pylint: disable=unu
     # upgrades and any place where the race between raft global barrier and gossipier could
     # take place. So ignore such messages globally for any sct test.
     # TODO: this should be removed after gossiper will be removed.
-    ignore_topology_change_coordinator_errors().__enter__()
+    DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR,
+                   line=r".*raft_topology - topology change coordinator fiber got error std::runtime_error"
+                        r" \(raft topology: exec_global_command\(barrier\) failed with seastar::rpc::closed_error"
+                        r" \(connection is closed\)\)").publish()
 
 
 __all__ = ("start_events_device", "stop_events_device", "enable_default_filters")


### PR DESCRIPTION
PR scylladb/scylla-cluster-tests/#10386 filter some expected
raft error messages globally. But this change broke integration
unit test. Issue scylladb/scylla-cluster-tests#10676.

Move DB event Filter from `ignore_topology_change_coordinator_errors`
context manager to `enable_default_filters`. If the event will be
filtered globally, then no need to filter it with cm.

Fixes #10676

### Testing
- [Executed JOB](https://argus.scylladb.com/tests/scylla-cluster-tests/3fcbd6a7-ab00-4273-a641-eef96526469e) - Job mostly passed, only coredump during decommission. will be investigated

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
