### PR TITLE
chore(deps): bump s-b version to 0.2.3

### DIFF
--- a/defaults/docker_images/scylla-bench/values_scylla-bench.yaml
+++ b/defaults/docker_images/scylla-bench/values_scylla-bench.yaml
@@ -1,2 +1,2 @@
 scylla-bench:
-  image: scylladb/scylla-bench:0.1.25
+  image: scylladb/scylla-bench:0.2.3


### PR DESCRIPTION
Main changes are following:
- added possibility of getting s-b and scylladb-gocql driver versions
- scylladb-gocql driver is reverted from v1.14.5 to v1.14.4

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :orange_circle: [longevity-schema-topology-changes-12h-test with stress duration reduced to 120mins](https://argus.scylladb.com/tests/scylla-cluster-tests/036faaaf-ea81-4757-8e6a-7bd46d904faa)
This particular test was an indication of problem with scylla-gocql driver v.1.14.5 recently - all test runs with that driver version were failing with
```
Stress command execution failed with: Command did not complete within 43800 seconds!
...
2025/03/24 13:55:34 gocql: unable to dial control conn 10.12.11.39:9042: dial tcp 10.12.11.39:9042: connect: connection refused
```
kind of error.
So this test indicates that the s-b v0.2.3 (that uses driver v1.14.4) is not having that issue.
The test run itself is marked as failed as it has an error event, which is due to known issue https://github.com/scylladb/scylla-cluster-tests/issues/9490

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
