### PR TITLE
fix(gcp_cleanup): Fix gcp filter to collect correct disks for clean up

### DIFF
--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -292,7 +292,8 @@ class GkeCleaner(GcloudContainerMixin):
         disks_per_zone = {}
         try:
             disks = json.loads(self.gcloud.run(
-                'compute disks list --format="json(name,zone)" --filter="name~^gke-.*-pvc-.* AND -users:*"'))
+                'compute disks list --format="json(name,zone)" --filter="(name~^gke-.*-pvc-.* OR name~^pvc-.*) '
+                'AND -users:*"'))
         except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
             LOGGER.error("`gcloud compute disks list' failed to run: %s", exc)
         else:


### PR DESCRIPTION
Fix GCP filter in compute disks list command to collect correct disks for clean up

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/10697

### Testing

- [x] https://jenkins.scylladb.com/job/scylla-operator/job/operator-master/job/gke/job/longevity-scylla-operator-3h-gke-test/127/execution/node/270/log/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
