### PR TITLE
[Manager] 1-1 restore for Cloud clusters

### DIFF
--- a/defaults/manager_restore_benchmark_snapshots.yaml
+++ b/defaults/manager_restore_benchmark_snapshots.yaml
@@ -19,6 +19,7 @@ sizes:  # size of backed up dataset in GB
       col_n: 1
       replication: "NetworkTopologyStrategy"
       rf: 3
+    one_one_restore_params: None
   500gb_1t_ics:
     tag: "sm_20240813112034UTC"
     locations:
@@ -38,6 +39,7 @@ sizes:  # size of backed up dataset in GB
       col_n: 1
       replication: "NetworkTopologyStrategy"
       rf: 3
+    one_one_restore_params: None
   500gb_1t_ics_tablets:
     tag: "sm_20240813114617UTC"
     locations:
@@ -57,6 +59,7 @@ sizes:  # size of backed up dataset in GB
       col_n: 1
       replication: "NetworkTopologyStrategy"
       rf: 3
+    one_one_restore_params: None
   500gb_2t_ics:
     tag: "sm_20240819203428UTC"
     locations:
@@ -78,6 +81,7 @@ sizes:  # size of backed up dataset in GB
       col_n: 1
       replication: "NetworkTopologyStrategy"
       rf: 3
+    one_one_restore_params: None
   1tb_1t_ics:
     tag: "sm_20240814180009UTC"
     locations:
@@ -97,6 +101,7 @@ sizes:  # size of backed up dataset in GB
       col_n: 1
       replication: "NetworkTopologyStrategy"
       rf: 3
+    one_one_restore_params: None
   1tb_4t_twcs:
     tag: "sm_20240821145503UTC"
     locations:
@@ -119,6 +124,7 @@ sizes:  # size of backed up dataset in GB
       col_n:
       replication: "NetworkTopologyStrategy"
       rf: 3
+    one_one_restore_params: None
   1tb_2t_twcs:
     tag: "sm_20240827191125UTC"
     locations:
@@ -139,6 +145,7 @@ sizes:  # size of backed up dataset in GB
       col_n:
       replication: "NetworkTopologyStrategy"
       rf: 3
+    one_one_restore_params: None
   1.5tb_2t_ics:
     tag: "sm_20240820180152UTC"
     locations:
@@ -160,6 +167,7 @@ sizes:  # size of backed up dataset in GB
       col_n: 1
       replication: "NetworkTopologyStrategy"
       rf: 3
+    one_one_restore_params: None
   2tb_1t_ics:
     tag: "sm_20240816185129UTC"
     locations:
@@ -179,6 +187,7 @@ sizes:  # size of backed up dataset in GB
       col_n: 1
       replication: "NetworkTopologyStrategy"
       rf: 3
+    one_one_restore_params: None
 
   ### Cloud(Siren) cluster backups
 
@@ -201,3 +210,6 @@ sizes:  # size of backed up dataset in GB
       col_n: 1
       replication: "NetworkTopologyStrategy"
       rf: 3
+    one_one_restore_params:
+      account_credential_id: 1001
+      sm_cluster_id: "37299ddb-66af-4d5f-8b52-4d3b44872520"

--- a/defaults/manager_restore_benchmark_snapshots.yaml
+++ b/defaults/manager_restore_benchmark_snapshots.yaml
@@ -1,8 +1,9 @@
-bucket: "manager-backup-tests-permanent-snapshots-us-east-1"
 cs_read_cmd_template: "cassandra-stress read cl={cl} n={num_of_rows} -schema 'keyspace={keyspace_name} replication(strategy={replication},replication_factor={rf}) compaction(strategy={compaction})' -mode cql3 native -rate threads=500 -col 'size=FIXED({col_size}) n=FIXED({col_n})' -pop seq={sequence_start}..{sequence_end}"
 sizes:  # size of backed up dataset in GB
   1gb_1t_ics:
     tag: "sm_20240812100424UTC"
+    locations:
+      - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
     exp_timeout: 1200  # 20 minutes (timeout for restore data operation)
     scylla_version: "2024.2.0-rc1"
     number_of_nodes: 3
@@ -20,6 +21,8 @@ sizes:  # size of backed up dataset in GB
       rf: 3
   500gb_1t_ics:
     tag: "sm_20240813112034UTC"
+    locations:
+      - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
     exp_timeout: 14400  # 4 hours
     scylla_version: "2024.2.0-rc1"
     number_of_nodes: 3
@@ -37,6 +40,8 @@ sizes:  # size of backed up dataset in GB
       rf: 3
   500gb_1t_ics_tablets:
     tag: "sm_20240813114617UTC"
+    locations:
+      - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
     exp_timeout: 14400  # 4 hours
     scylla_version: "2024.2.0-rc1"
     number_of_nodes: 3
@@ -54,6 +59,8 @@ sizes:  # size of backed up dataset in GB
       rf: 3
   500gb_2t_ics:
     tag: "sm_20240819203428UTC"
+    locations:
+      - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
     exp_timeout: 14400  # 4 hours
     scylla_version: "2024.2.0-rc1"
     number_of_nodes: 3
@@ -73,6 +80,8 @@ sizes:  # size of backed up dataset in GB
       rf: 3
   1tb_1t_ics:
     tag: "sm_20240814180009UTC"
+    locations:
+      - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
     exp_timeout: 28800  # 8 hours
     scylla_version: "2024.2.0-rc1"
     number_of_nodes: 3
@@ -90,6 +99,8 @@ sizes:  # size of backed up dataset in GB
       rf: 3
   1tb_4t_twcs:
     tag: "sm_20240821145503UTC"
+    locations:
+      - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
     exp_timeout: 28800  # 8 hours
     scylla_version: "2024.2.0-rc1"
     number_of_nodes: 3
@@ -110,6 +121,8 @@ sizes:  # size of backed up dataset in GB
       rf: 3
   1tb_2t_twcs:
     tag: "sm_20240827191125UTC"
+    locations:
+      - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
     exp_timeout: 28800  # 8 hours
     scylla_version: "2024.2.0-rc1"
     number_of_nodes: 9
@@ -128,6 +141,8 @@ sizes:  # size of backed up dataset in GB
       rf: 3
   1.5tb_2t_ics:
     tag: "sm_20240820180152UTC"
+    locations:
+      - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
     exp_timeout: 43200  # 12 hours
     scylla_version: "2024.2.0-rc1"
     number_of_nodes: 3
@@ -147,6 +162,8 @@ sizes:  # size of backed up dataset in GB
       rf: 3
   2tb_1t_ics:
     tag: "sm_20240816185129UTC"
+    locations:
+      - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
     exp_timeout: 57600  # 16 hours
     scylla_version: "2024.2.0-rc1"
     number_of_nodes: 3
@@ -158,6 +175,28 @@ sizes:  # size of backed up dataset in GB
       num_of_rows: 2147483648
       compaction: "IncrementalCompactionStrategy"
       cl: "ONE"
+      col_size: 1024
+      col_n: 1
+      replication: "NetworkTopologyStrategy"
+      rf: 3
+
+  ### Cloud(Siren) cluster backups
+
+  50gb_1t_ics_cloud_single:
+    tag: "sm_20250404103340UTC"
+    locations:
+      - "AWS_US_EAST_1:s3:scylla-cloud-backup-74-89-1ph7p0-manager-tests"
+    exp_timeout: 3600  # 1 hour
+    scylla_version: "2024.2.5"
+    number_of_nodes: 3
+    prohibit_verification_read: false
+    dataset:
+      schema:
+        "50gb_ics_quorum_1024_1_2024_2_5":
+          - standard1: 50
+      num_of_rows: 52428800
+      compaction: "IncrementalCompactionStrategy"
+      cl: "QUORUM"
       col_size: 1024
       col_n: 1
       replication: "NetworkTopologyStrategy"

--- a/defaults/manager_restore_benchmark_snapshots.yaml
+++ b/defaults/manager_restore_benchmark_snapshots.yaml
@@ -213,3 +213,120 @@ sizes:  # size of backed up dataset in GB
     one_one_restore_params:
       account_credential_id: 1001
       sm_cluster_id: "37299ddb-66af-4d5f-8b52-4d3b44872520"
+
+  50gb_1t_ics_cloud_single_non_encrypted:
+    tag: "sm_20250428100042UTC"
+    locations:
+      - "AWS_US_EAST_1:s3:scylla-cloud-backup-164-193-s510gk-manager-tests"
+    exp_timeout: 3600  # 1 hour
+    scylla_version: "2024.2.5"
+    number_of_nodes: 3
+    prohibit_verification_read: false
+    dataset:
+      schema:
+        "50gb_ics_quorum_1024_1_2024_2_5":
+          - standard1: 50
+      num_of_rows: 52428800
+      compaction: "IncrementalCompactionStrategy"
+      cl: "QUORUM"
+      col_size: 1024
+      col_n: 1
+      replication: "NetworkTopologyStrategy"
+      rf: 3
+    one_one_restore_params:
+      account_credential_id: 1001
+      sm_cluster_id: "fb0ef6d1-5a70-45e4-82e1-73da00646400"
+
+  50gb_1t_ics_cloud_multi:
+    tag: "sm_20250407152554UTC"
+    locations:
+      - "AWS_EU_WEST_1:s3:scylla-cloud-backup-85-100-72z8hn-manager-tests"
+      - "AWS_EU_WEST_2:s3:scylla-cloud-backup-85-101-5sq81w-manager-tests"
+    exp_timeout: 28800  # 8 hours
+    scylla_version: "2024.2.5"
+    number_of_nodes: 6
+    prohibit_verification_read: false
+    dataset:
+      schema:
+        "50gb_ics_quorum_1024_1_2024_2_5":
+          - standard1: 50
+      num_of_rows: 52428800
+      compaction: "IncrementalCompactionStrategy"
+      cl: "QUORUM"
+      col_size: 1024
+      col_n: 1
+      replication: "NetworkTopologyStrategy"
+      rf: 3
+    one_one_restore_params:
+      account_credential_id: 1001
+      sm_cluster_id: "b113c1a7-66bc-46c0-813a-bad4b49bb5a6"
+
+  1tb_1t_ics_cloud_single:
+    tag: "sm_20250410142519UTC"
+    locations:
+      - "AWS_US_EAST_1:s3:scylla-cloud-backup-100-120-8gr7m6-manager-tests"
+    exp_timeout: 28800  # 8 hours
+    scylla_version: "2024.2.5"
+    number_of_nodes: 3
+    prohibit_verification_read: false
+    dataset:
+      schema:
+        "1024gb_ics_quorum_1024_1_2024_2_5":
+          - standard1: 1024
+      num_of_rows: 1073741824
+      compaction: "IncrementalCompactionStrategy"
+      cl: "QUORUM"
+      col_size: 1024
+      col_n: 1
+      replication: "NetworkTopologyStrategy"
+      rf: 3
+    one_one_restore_params:
+      account_credential_id: 1001
+      sm_cluster_id: "54be9444-7438-4130-9636-25307df16dae"
+
+  1tb_1t_ics_cloud_single_4xlarge:
+    tag: "sm_20250424214635UTC"
+    locations:
+      - "AWS_US_EAST_1:s3:scylla-cloud-backup-158-187-76l6lg-manager-tests"
+    exp_timeout: 28800  # 8 hours
+    scylla_version: "2024.2.5"
+    number_of_nodes: 3
+    prohibit_verification_read: false
+    dataset:
+      schema:
+        "1024gb_ics_quorum_1024_1_2024_2_5":
+          - standard1: 1024
+      num_of_rows: 1073741824
+      compaction: "IncrementalCompactionStrategy"
+      cl: "QUORUM"
+      col_size: 1024
+      col_n: 1
+      replication: "NetworkTopologyStrategy"
+      rf: 3
+    one_one_restore_params:
+      account_credential_id: 1001
+      sm_cluster_id: "1ae9c048-523d-48e8-9174-fde4abee800d"
+
+  1tb_1t_ics_cloud_multi:
+    tag: "sm_20250415113357UTC"
+    locations:
+      - "AWS_EU_WEST_1:s3:scylla-cloud-backup-113-139-ab9m67-manager-tests"
+      - "AWS_EU_WEST_2:s3:scylla-cloud-backup-113-141-xo80f3-manager-tests"
+    exp_timeout: 28800  # 8 hours
+    scylla_version: "2024.2.5"
+    number_of_nodes: 6
+    prohibit_verification_read: false
+    dataset:
+      schema:
+        "1024gb_ics_quorum_1024_1_2024_2_5":
+          - standard1: 1024
+      num_of_rows: 1073741824
+      compaction: "IncrementalCompactionStrategy"
+      cl: "QUORUM"
+      col_size: 1024
+      col_n: 1
+      replication: "NetworkTopologyStrategy"
+      rf: 3
+    one_one_restore_params:
+      account_credential_id: 1001
+      sm_cluster_id: "929c53c2-725f-48ec-912f-f0b1a7629243"

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -388,7 +388,21 @@ class BucketOperations(ClusterTester):
     def sync_gs_buckets(source: str, destination: str) -> None:
         LOCALRUNNER.run(f"gsutil -m rsync -r gs://{source} gs://{destination}")
 
-    def copy_backup_snapshot_bucket(self, source: str, destination: str) -> None:
+    def get_region_from_bucket_location(self, location: str) -> str:
+        cluster_backend = self.params.get("cluster_backend")
+
+        if cluster_backend == "aws":
+            # extract region name from AWS_US_EAST_1:s3:scylla-cloud-backup-8072-7216-v5dn53 to us-east-1
+            return location.split(":")[0].split("_", 1)[1].replace("_", "-").lower()
+        elif cluster_backend == "gce":
+            # extract region name from GCE_US_EAST_1:gcs:scylla-cloud-backup-23-29-6q0i5q to us-east1
+            parts = location.split(":")[0].split("_")[1:]
+            assert len(parts) == 3, f"Can't extract region from location {location}"
+            return f"{parts[0].lower()}-{parts[1].lower()}{parts[2]}"
+        else:
+            raise ValueError(f"Unsupported cluster backend - {cluster_backend}, should be either aws or gce")
+
+    def copy_backup_snapshot_bucket(self, source: str, destination: str, region: str) -> None:
         """Copy bucket with Manager backup snapshots.
         The process consists of two stages - new bucket creation and data sync (original bucket -> newly created).
         The main use case is to make a copy of a bucket created in a test with Cloud (siren) cluster since siren
@@ -398,7 +412,6 @@ class BucketOperations(ClusterTester):
         Only AWS and GCE backends are supported.
         """
         cluster_backend = self.params.get("cluster_backend")
-        region = next(iter(self.params.region_names), '')
 
         if cluster_backend == "aws":
             self.create_s3_bucket(name=destination, region=region)
@@ -1412,7 +1425,21 @@ class ManagerSuspendTests(ManagerTestFunctionsMixIn):
 
 class ManagerHelperTests(ManagerTestFunctionsMixIn):
 
-    def test_prepare_backup_snapshot(self):
+    def _unlock_cloud_key(self) -> str | None:
+        """The operation is required to make the particular Cloud cluster key reusable.
+        For that, the key should be unlocked from the original cluster.
+        """
+        self.log.info("Unlock the EaR key used by cluster to reuse it while restoring to a new cluster (1-1 restore)")
+        ear_key = self.db_cluster.get_ear_key()
+
+        if not ear_key:
+            self.log.warning("No EaR key found, skipping unlock")
+            return None
+
+        self.db_cluster.unlock_ear_key()
+        return ear_key.get("keyid")
+
+    def test_prepare_backup_snapshot(self):  # pylint: disable=too-many-locals  # noqa: PLR0914
         """Test prepares backup snapshot for its future use in nemesis or restore benchmarks
 
         Steps:
@@ -1424,23 +1451,26 @@ class ManagerHelperTests(ManagerTestFunctionsMixIn):
         """
         is_cloud_manager = self.params.get("use_cloud_manager")
 
+        self.log.info("Initialize Scylla Manager")
+        mgr_cluster = self.db_cluster.get_cluster_manager()
+
+        self.log.info("Define backup location")
+        if is_cloud_manager:
+            # Extract location from an automatically scheduled backup task
+            auto_backup_task = mgr_cluster.backup_task_list[0]
+            location_list = [auto_backup_task.get_task_info_dict()["location"]]
+
+            self.log.info("Delete scheduled backup task to not interfere")
+            mgr_cluster.delete_task(auto_backup_task)
+        else:
+            location_list = self.locations
+
         self.log.info("Populate the cluster with data")
         backup_size = self.params.get("mgmt_prepare_snapshot_size")  # in Gb
         assert backup_size and backup_size >= 1, "Backup size must be at least 1Gb"
 
         ks_name, cs_write_cmds = self.build_snapshot_preparer_cs_write_cmd(backup_size)
         self.run_and_verify_stress_in_threads(cs_cmds=cs_write_cmds, stop_on_failure=True)
-
-        self.log.info("Initialize Scylla Manager")
-        mgr_cluster = self.db_cluster.get_cluster_manager()
-
-        self.log.info("Define backup location")
-        if is_cloud_manager:
-            # Extract location from automatically scheduled backup task
-            auto_backup_task = mgr_cluster.backup_task_list[0]
-            location_list = [auto_backup_task.get_task_info_dict()["location"]]
-        else:
-            location_list = self.locations
 
         self.log.info("Run backup and wait for it to finish")
         backup_task = mgr_cluster.create_backup_task(location_list=location_list, rate_limit_list=["0"])
@@ -1450,21 +1480,35 @@ class ManagerHelperTests(ManagerTestFunctionsMixIn):
 
         if is_cloud_manager:
             self.log.info("Copy bucket with snapshot since the original bucket is deleted together with cluster")
-            # from ["'AWS_US_EAST_1:s3:scylla-cloud-backup-8072-7216-v5dn53'"] to scylla-cloud-backup-8072-7216-v5dn53
-            original_bucket_name = location_list[0].split(":")[-1].rstrip("'")
-            bucket_name = original_bucket_name + "-manager-tests"
-            self.copy_backup_snapshot_bucket(source=original_bucket_name, destination=bucket_name)
+            # can be several locations for multiDC cluster, for example,
+            # 'AWS_EU_SOUTH_1:s3:scylla-cloud-backup-170-176-15c7bm,AWS_EU_WEST_1:s3:scylla-cloud-backup-170-175-9dy2w4'
+            location_list = location_list[0].split(",")
+            for location in location_list:
+                # from AWS_US_EAST_1:s3:scylla-cloud-backup-8072-7216-v5dn53' to scylla-cloud-backup-8072-7216-v5dn53
+                original_bucket_name = location.split(":")[-1].strip("'")
+                bucket_name = original_bucket_name + "-manager-tests"
+                region = self.get_region_from_bucket_location(location)
+                self.copy_backup_snapshot_bucket(source=original_bucket_name, destination=bucket_name, region=region)
+
+        if is_cloud_manager:
+            cluster_id = self.db_cluster.cloud_cluster_id
+            key_id = self._unlock_cloud_key()
+            manager_cluster_id = self.db_cluster.get_manager_cluster_id()
         else:
-            bucket_name = location_list[0]
+            cluster_id = mgr_cluster.id
+            key_id = "N/A"
+            manager_cluster_id = "N/A"
 
         self.log.info("Send snapshot details to Argus")
         snapshot_details = {
             "tag": backup_task.get_snapshot_tag(),
             "size": backup_size,
-            "bucket": bucket_name,
+            "locations": ",".join(location_list),
             "ks_name": ks_name,
             "scylla_version": self.params.get_version_based_on_conf()[0],
-            "cluster_id": mgr_cluster.id,
+            "cluster_id": cluster_id,
+            "ear_key_id": key_id,
+            "manager_cluster_id": manager_cluster_id,
         }
         send_manager_snapshot_details_to_argus(
             argus_client=self.test_config.argus_client(),

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -43,6 +43,7 @@ from sdcm.tester import ClusterTester
 from sdcm.cluster import TestConfig
 from sdcm.nemesis import MgmtRepair
 from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations
+from sdcm.utils.aws_utils import AwsIAM
 from sdcm.utils.common import reach_enospc_on_node, clean_enospc_on_node
 from sdcm.utils.features import is_tablets_feature_enabled
 from sdcm.utils.loader_utils import LoaderUtilsMixin
@@ -66,8 +67,8 @@ class ManagerTestMetrics:
 class SnapshotData:
     """Describes the backup snapshot:
 
-    - bucket: S3 bucket name
-    - tag: snapshot tag, for example 'sm_20240816185129UTC'
+    - locations: backup locations
+    - tag: snapshot tag, for example, 'sm_20240816185129UTC'
     - exp_timeout: expected timeout for the restore operation
     - dataset: dict with snapshot dataset details such as cl, replication, schema, etc.
     - keyspaces: list of keyspaces presented in backup
@@ -76,7 +77,7 @@ class SnapshotData:
       created via c-s user profile.
     - node_ids: list of node ids where backup was created
     """
-    bucket: str
+    locations: list[str]
     tag: str
     exp_timeout: int
     dataset: dict[str, str | int | dict]
@@ -434,7 +435,7 @@ class SnapshotOperations(ClusterTester):
         try:
             snapshot_dict = all_snapshots_dict["sizes"][snapshot_name]
         except KeyError:
-            raise ValueError(f"Snapshot data for size '{snapshot_name}'GB was not found in the {snapshots_config} file")
+            raise ValueError(f"Snapshot data for '{snapshot_name}' was not found in the {snapshots_config} file")
 
         ks_tables_map = {}
         for ks, ts in snapshot_dict["dataset"]["schema"].items():
@@ -442,7 +443,7 @@ class SnapshotOperations(ClusterTester):
             ks_tables_map[ks] = t_names
 
         snapshot_data = SnapshotData(
-            bucket=all_snapshots_dict["bucket"],
+            locations=snapshot_dict["locations"],
             tag=snapshot_dict["tag"],
             exp_timeout=snapshot_dict["exp_timeout"],
             dataset=snapshot_dict["dataset"],
@@ -1674,6 +1675,14 @@ class ManagerInstallationTests(ManagerTestFunctionsMixIn):
 
 class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
 
+    def tearDown(self):
+        """Unlock EaR key used by Cloud cluster to reuse it in the future
+        Otherwise, if not unlocked, the key will be deleted together with the cluster
+        """
+        if self.params.get("use_cloud_manager"):
+            self.db_cluster.unlock_ear_key()
+        super().tearDown()
+
     def get_restore_extra_parameters(self) -> str:
         extra_params = self.params.get('mgmt_restore_extra_params')
         return extra_params if extra_params else None
@@ -1698,6 +1707,18 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
             sut_timestamp=manager_version_timestamp,
             row_name=dataset_label,
         )
+
+    def _adjust_aws_restore_policy(self, snapshot: SnapshotData, cluster_id: str) -> None:
+        assert self.params.get("use_cloud_manager"), "Should be applied to Cloud-managed clusters only"
+
+        iam_client = AwsIAM()
+        policies = iam_client.get_policy_by_name_prefix(f"s3-scylla-cloud-backup-{cluster_id}")
+        for policy_arn in policies:
+            for location in snapshot.locations:
+                iam_client.add_resource_to_iam_policy(
+                    policy_arn=policy_arn,
+                    resource_to_add=f"arn:aws:s3:::{location.split(':')[-1]}",
+                )
 
     def test_backup_and_restore_only_data(self):
         """The test is extensively used for restore benchmarking purposes and consists of the following steps:
@@ -1747,17 +1768,28 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
                            All snapshots are defined in the 'defaults/manager_restore_benchmark_snapshots.yaml'
             restore_outside_manager: set True to restore outside of Manager via nodetool refresh
         """
-        manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
+        self.log.info("Initialize Scylla Manager")
         mgr_cluster = self.db_cluster.get_cluster_manager()
 
+        self.log.info("Define snapshot details and location")
         snapshot_data = self.get_snapshot_data(snapshot_name)
+        locations = snapshot_data.locations
+
+        if self.params.get("use_cloud_manager"):
+            self.log.info("Delete scheduled backup task to not interfere")
+            auto_backup_task = mgr_cluster.backup_task_list[0]
+            mgr_cluster.delete_task(auto_backup_task)
+
+            self.log.info("Adjust restore cluster backup policy")
+            if self.params.get("cluster_backend") == "aws":
+                self._adjust_aws_restore_policy(snapshot_data, cluster_id=self.db_cluster.cloud_cluster_id)
+
+            self.log.info("Grant admin permissions to scylla_manager user")
+            self.db_cluster.nodes[0].run_cqlsh(cmd="grant scylla_admin to scylla_manager")
 
         self.log.info("Restoring the schema")
-        location = [f"s3:{snapshot_data.bucket}"]
         self.restore_backup_with_task(mgr_cluster=mgr_cluster, snapshot_tag=snapshot_data.tag, timeout=600,
-                                      restore_schema=True, location_list=location)
-        for ks_name in snapshot_data.keyspaces:
-            self.set_ks_strategy_to_network_and_rf_according_to_cluster(keyspace=ks_name, repair_after_alter=False)
+                                      restore_schema=True, location_list=locations)
 
         if restore_outside_manager:
             self.log.info("Restoring the data outside the Manager")
@@ -1766,18 +1798,18 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
                     mgr_cluster=mgr_cluster,
                     snapshot_tag=snapshot_data.tag,
                     ks_tables_list=snapshot_data.ks_tables_map,
-                    location=location[0],
+                    location=locations[0],
                     precreated_backup=True,
                 )
             restore_time = timer.duration
         else:
-            self.log.info("Restoring the data with Manager task")
+            self.log.info("Restoring the data with standard L&S approach")
             extra_params = self.get_restore_extra_parameters()
             task = self.restore_backup_with_task(mgr_cluster=mgr_cluster, snapshot_tag=snapshot_data.tag,
                                                  timeout=snapshot_data.exp_timeout, restore_data=True,
-                                                 location_list=location, extra_params=extra_params)
+                                                 location_list=locations, extra_params=extra_params)
             restore_time = task.duration
-            manager_version_timestamp = manager_tool.sctool.client_version_timestamp
+            manager_version_timestamp = mgr_cluster.sctool.client_version_timestamp
             self._send_restore_results_to_argus(task, manager_version_timestamp, dataset_label=snapshot_name)
 
         self.manager_test_metrics.restore_time = restore_time

--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -147,10 +147,12 @@ class ManagerSnapshotDetails(StaticGenericResultTable):
         Columns = [
             ColumnMetadata(name="tag", unit="", type=ResultType.TEXT),
             ColumnMetadata(name="size", unit="GB", type=ResultType.INTEGER),
-            ColumnMetadata(name="bucket", unit="", type=ResultType.TEXT),
+            ColumnMetadata(name="locations", unit="", type=ResultType.TEXT),
             ColumnMetadata(name="ks_name", unit="", type=ResultType.TEXT),
             ColumnMetadata(name="cluster_id", unit="", type=ResultType.TEXT),
             ColumnMetadata(name="scylla_version", unit="", type=ResultType.TEXT),
+            ColumnMetadata(name="ear_key_id", unit="", type=ResultType.TEXT),
+            ColumnMetadata(name="manager_cluster_id", unit="", type=ResultType.TEXT),
         ]
 
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5342,6 +5342,18 @@ class BaseScyllaCluster:
         for node in self.nodes:
             node.log_message(message, level)
 
+    def unlock_ear_key(self, ignore_status: bool = False) -> None:
+        """Unlock EaR key from Cloud cluster.
+
+        Key unlock after test execution makes it reusable with the same backup snapshot, for example,
+        while testing Scylla Manager 1-1-restore. If not unlocked, the key is deleted together with cluster.
+        """
+        raise NotImplementedError("The method should come from siren-tests sct_plugin module")
+
+    def get_ear_key(self):
+        """Get EaR key of Cloud cluster"""
+        raise NotImplementedError("The method should come from siren-tests sct_plugin module")
+
 
 class BaseLoaderSet():
 

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -11,6 +11,7 @@
 #
 # Copyright (c) 2021 ScyllaDB
 import functools
+import json
 import socket
 import time
 import logging
@@ -565,3 +566,54 @@ def aws_check_instance_type_supported(instance_type: str, region_name: str) -> b
             return False
         raise
     return True
+
+
+class AwsIAM:
+    def __init__(self):
+        self.account_id = boto3.client("sts").get_caller_identity()["Account"]
+        self._policy_format = f"arn:aws:iam::{self.account_id}:policy/" + "{}"
+        self._role_format = f"arn:aws:iam::{self.account_id}:role/" + "{}"
+
+    @cached_property
+    def iam_client(self):
+        return boto3.client('iam')
+
+    def get_full_arn(self, policy_name, policy_type):
+        if policy_type == "policy":
+            arn_format = self._policy_format
+        elif policy_type == "role":
+            arn_format = self._role_format
+        else:
+            raise TypeError(f"Unsupported policy type: {policy_type}")
+        return arn_format.format(policy_name)
+
+    def get_policy_by_name_prefix(self, prefix: str) -> list[str]:
+        policies = []
+        paginator = self.iam_client.get_paginator('list_policies')
+        for page in paginator.paginate():
+            for policy in page['Policies']:
+                policy_name = policy['PolicyName']
+                if policy_name.startswith(prefix):
+                    policies.append(self.get_full_arn(policy_name=policy_name, policy_type="policy"))
+        return policies
+
+    def add_resource_to_iam_policy(self, policy_arn: str, resource_to_add: str) -> None:
+        policy = self.iam_client.get_policy(PolicyArn=policy_arn)
+        policy_version = self.iam_client.get_policy_version(
+            PolicyArn=policy_arn,
+            VersionId=policy['Policy']['DefaultVersionId']
+        )
+        policy_document = policy_version['PolicyVersion']['Document']
+
+        for statement in policy_document['Statement']:
+            if statement['Effect'] == 'Allow':
+                if "/*" in statement['Resource'][0]:
+                    statement['Resource'].append(resource_to_add + "/*")
+                else:
+                    statement['Resource'].append(resource_to_add)
+
+        self.iam_client.create_policy_version(
+            PolicyArn=policy_arn,
+            PolicyDocument=json.dumps(policy_document),
+            SetAsDefault=True
+        )


### PR DESCRIPTION
The PR introduces Manager 1-1 restore test for Cloud clusters.

Together with that, it enhances the existing snapshots preparation and regular L&S restore tests to support Cloud clusters.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [generate  backup, regular SCT cluster](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master-clone/job/helper-prepare-backup-snapshot/10/)
- [x] [generate backup, Cloud cluster](https://jenkins.scylladb.com/view/scylla-manager/job/manager-master/job/1-1-restore/job/prepare-snapshot-aws-single-dc/112/) (final status is failed because of the [issue](https://github.com/scylladb/siren/issues/13281))
- [x] [L&S restore for regular SCT cluster, pre-created backup](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master-clone/job/backup-restore-custom-dataset-test/5) (expected failure since invalid snapshot usage, the setup works as expected)
- [x] [L&S restore for regular SCT cluster, backup first](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master-clone/job/backup-restore-custom-dataset-test/4)
- [x] [L&S restore for Cloud cluster](https://jenkins.scylladb.com/view/scylla-manager/job/manager-master/job/1-1-restore/job/benchmark-regular-restore-aws-single-dc/31/)
- [x] [1-1 restore](https://jenkins.scylladb.com/view/scylla-manager/job/manager-master/job/1-1-restore/job/benchmark-1-1-restore-aws-single-dc/37/) (expected failure because of env issue - the test works as expected)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
