### PR TITLE
fix(large-partition-200k-test): adjust s-b retry number/interval values

### DIFF
--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -18,20 +18,20 @@ prepare_verify_cmd: ["scylla-bench -workload=sequential -mode=read -replication-
 
 stress_cmd: [
               # Write additional 750 partitions with 200k rows each (on top of what was written in prepare_write_cmd) - test total partitions is 2000
-             "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=750 -partition-offset=1251 -clustering-row-count=200000 -clustering-row-size=uniform:100..8192 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations=0 -duration=6420m",
+             "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=750 -partition-offset=1251 -clustering-row-count=200000 -clustering-row-size=uniform:100..8192 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations=0 -duration=6420m -retry-number=30 -retry-interval=500ms,5s",
              # due to increasing of amount deleted rows/partitions (delete nemeses) we need to insert back the part (from 251 to 750 partitions) of the rows. Otherwise, the table may become empty after few deletions.
              # Partition range from 751 to 1250 won't be re-written, remains as tombstones
              # Also, the first 250 partitions (as defined in partition_range_with_data_validation) won't be deleted. So it is not needed to be re-written
-             "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=500 -partition-offset=251 -clustering-row-count=200000 -clustering-row-size=uniform:512..5120 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations=0 -duration=6420m"
+             "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=500 -partition-offset=251 -clustering-row-count=200000 -clustering-row-size=uniform:512..5120 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations=0 -duration=6420m -retry-number=30 -retry-interval=500ms,5s"
             ]
 
 stress_read_cmd: [
                    # Read the first 250 paritions with validate-data flag (Partitions we don't delete during the test)
-                  "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=250 -partition-offset=1 -clustering-row-count=200000 -clustering-row-size=uniform:512..5120 -concurrency=50 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations=0 -duration=6420m -validate-data",
+                  "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=250 -partition-offset=1 -clustering-row-count=200000 -clustering-row-size=uniform:512..5120 -concurrency=50 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations=0 -duration=6420m -validate-data -retry-number=30 -retry-interval=500ms,5s",
                   # Read partitions 251-1250 (1000 partitions)
-                  "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=1000 -partition-offset=251 -clustering-row-count=200000 -clustering-row-size=uniform:512..5120 -rows-per-request=10 -consistency-level=quorum -timeout=90s -concurrency=200 -connection-count=100 -iterations=0 -duration=6420m",
+                  "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=1000 -partition-offset=251 -clustering-row-count=200000 -clustering-row-size=uniform:512..5120 -rows-per-request=10 -consistency-level=quorum -timeout=90s -concurrency=200 -connection-count=100 -iterations=0 -duration=6420m -retry-number=30 -retry-interval=500ms,5s",
                   # Read partitions 1251-2000 (750 partitions) that are being written during the test (different row size)
-                  "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=750 -partition-offset=1251 -clustering-row-count=200000 -clustering-row-size=uniform:100..8192 -rows-per-request=10 -consistency-level=quorum -timeout=90s -concurrency=150 -connection-count=100 -iterations=0 -duration=6420m"
+                  "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=750 -partition-offset=1251 -clustering-row-count=200000 -clustering-row-size=uniform:100..8192 -rows-per-request=10 -consistency-level=quorum -timeout=90s -concurrency=150 -connection-count=100 -iterations=0 -duration=6420m -retry-number=30 -retry-interval=500ms,5s"
                  ]
 
 # Create MV and set tombstone_gc to 'repair' + a propagation_delay_in_seconds of 5 minutes for the tombstone-gc-verification table:


### PR DESCRIPTION
`longevity-large-partition-200k-pks-4days` test is not stable throughout 2024.1 LTS series of releases (and show similar behavior in newer LTS releases), regularly failing with scylla-bench queries timing out.

After reviewing the other existing test configs with scylla-bench workloads, particularly the ones with large partitions, it was noticed that those have retry number/interval values of the s-b command adjusted (compared to default `retry-number=10 retry-interval=80ms,1s` values).
This change also adjusts s-b command retry-number and retry-interval values for main load of this test (`stress_cmd` and `stress_read_cmd` parameters of the test config), which makes the test much more stable.

Refs: https://github.com/scylladb/scylla-cluster-tests/issues/9640

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] the test was executed 4 times against 2024.1.17, with the adjusted values in s-b read commands - retry-number=30 and retry-interval=500ms,5s:
:green_circle: [run1](https://argus.scylladb.com/tests/scylla-cluster-tests/21cf52b3-c508-4819-9d24-406057452345) :green_circle: [run2](https://argus.scylladb.com/tests/scylla-cluster-tests/0f8edad7-53a5-4b58-9973-21a878769494) :green_circle: [run3](https://argus.scylladb.com/tests/scylla-cluster-tests/69d51d8a-5c10-4d50-95ae-d52192717dd6) :green_circle: [run4](https://argus.scylladb.com/tests/scylla-cluster-tests/e5ba6cc5-cc1a-4f7a-be54-c09b905decf5)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
