### PR TITLE
fix(hydra): fix podman support

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -225,12 +225,14 @@ function run_in_docker () {
          -v /var/run/docker.sock:/var/run/docker.sock
          -v /dev:/dev:rw
          --tmpfs "${HOME_DIR}/.docker:exec,uid=$(id -u ${USER}),gid=$(id -g ${USER})"
+         --tmpfs "${HOME_DIR}/.local:exec,uid=$(id -u ${USER}),gid=$(id -g ${USER}),size=256m"
          -e HOME="${HOME_DIR}"
        )
     elif [ -z "$is_podman" ]; then
         docker_common_args+=(
            -v /var/run:/run
            -v /dev:/dev:rw
+           --tmpfs "${HOME_DIR}/.local:exec,mode=1777"
            -u ${USER_ID}
            )
     else
@@ -254,7 +256,6 @@ function run_in_docker () {
         -v /tmp:/tmp \
         -v /var/tmp:/var/tmp \
         -v "${HOME_DIR}:${HOME_DIR}" \
-        --tmpfs "${HOME_DIR}/.local:exec,uid=$(id -u ${USER}),gid=$(id -g ${USER}),size=256m" \
         -w "${SCT_DIR}" \
         -e JOB_NAME="${JOB_NAME}" \
         -e BUILD_URL="${BUILD_URL}" \


### PR DESCRIPTION
mounting of tmpfs couldn't be done base on `uid` in podman same it is done in docker, and we need to split it into two distict argument for each.

with out is, podman just fails stright away, with unsupported feature

Fix: #10706

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
