### PR TITLE
chore: upgrade cassandra-stress to 3.18.0 release

### DIFF
--- a/defaults/docker_images/cassandra-stress/values_cassandra-stress.yaml
+++ b/defaults/docker_images/cassandra-stress/values_cassandra-stress.yaml
@@ -1,2 +1,2 @@
 cassandra-stress:
-  image: scylladb/cassandra-stress:3.17.3
+  image: scylladb/cassandra-stress:3.18.0


### PR DESCRIPTION
Cassandra-Stress switched to Java 21 as the base Java version

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
