### PR TITLE
improvement(send_email): don't fail having no recipients

### DIFF
--- a/vars/runSendEmail.groovy
+++ b/vars/runSendEmail.groovy
@@ -20,12 +20,17 @@ def call(Map params, RunWrapper currentBuild){
     env
     echo "Start send email ..."
     RUNNER_IP=\$(cat sct_runner_ip||echo "")
-    if [[ -n "\${RUNNER_IP}" ]] ; then
-        ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} send-email ${test_status} ${start_time} \
-        --runner-ip \${RUNNER_IP} --email-recipients "${email_recipients}"
+
+    if [[ -z "${email_recipients}" ]]; then
+        echo "Email was not sent because no recipient addresses were provided"
     else
-        ./docker/env/hydra.sh send-email ${test_status} ${start_time} --logdir "`pwd`" --email-recipients "${email_recipients}"
+        if [[ -n "\${RUNNER_IP}" ]] ; then
+            ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} send-email ${test_status} ${start_time} \
+            --runner-ip \${RUNNER_IP} --email-recipients "${email_recipients}"
+        else
+            ./docker/env/hydra.sh send-email ${test_status} ${start_time} --logdir "`pwd`" --email-recipients "${email_recipients}"
+        fi
+        echo "Email sent."
     fi
-    echo "Email sent."
     """
 }


### PR DESCRIPTION
For the moment we always send emails after test runs.
Not all of them are needed and they just generate additional noise.

So, allow to avoid 'sending email' action by providing empty value for the recipient email parameter.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-perf-latency-regression-latte#31](https://argus.scylladb.com/tests/scylla-cluster-tests/2d87a0a7-bd91-4f11-8b46-206f98325d5c)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
