### PR TITLE
fix(perf-pipeline): add Argus step to pipeline

### DIFF
--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -272,6 +272,19 @@ def call(Map pipelineParams) {
                                                 }
                                             }
                                         }
+                                        stage('Create Argus Test Run') {
+                                            catchError(stageResult: 'FAILURE') {
+                                                script {
+                                                    wrap([$class: 'BuildUser']) {
+                                                        dir('scylla-cluster-tests') {
+                                                            timeout(time: 5, unit: 'MINUTES') {
+                                                                createArgusTestRun(params)
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
                                         stage("Create SCT Runner for ${sub_test}") {
                                             wrap([$class: 'BuildUser']) {
                                                 dir('scylla-cluster-tests') {


### PR DESCRIPTION
Perf pipeline does not create argus run. Added this step to support linking Argus to job builds and have them even if fails at early stage.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - https://jenkins.scylladb.com/job/scylla-staging/job/lukasz/job/scylla-enterprise-perf-regression-predefined-throughput-steps-vnodes-cql-stress/11/ - I aborted it after pushed runs to argus

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
