### PR TITLE
fix(nemesis): enhance disrupt_mgmt_restore to restore schema out of Manager

### DIFF
--- a/sdcm/mgmt/helpers.py
+++ b/sdcm/mgmt/helpers.py
@@ -1,0 +1,84 @@
+import gzip
+import json
+import os
+import re
+from pathlib import Path
+
+from sdcm.utils.common import download_dir_from_cloud
+
+
+CREATE_KS_REPLICATION_BLOCK_PATTERN = re.compile(r"replication\s*=\s*({.*?})")
+REPLICATION_DICT_KEYS_PATTERN = re.compile(r"'([^']+)':")
+
+
+def get_schema_create_statements_from_snapshot(
+        bucket: str,
+        mgr_cluster_id: str,
+        snapshot_tag: str,
+        exclude_system_ks: bool = True,
+        exclude_roles: bool = True,
+) -> tuple[list[str], list[str]]:
+    """Parses schema information from a snapshot file and extracts CQL statements for keyspaces, tables, views and other
+    entities. Excludes entries related to system keyspaces and roles if the corresponding flags are set to True.
+
+    Important note: only AWS is supported for now.
+
+    Returns:
+        tuple[list[str], list[str]]: A tuple containing two lists:
+            - List of CQL statements for creating keyspaces.
+            - List of CQL statements for other entities (tables, views and others except excluded ones).
+    """
+    s3_dir_with_schema_json = f"s3://{bucket}/backup/schema/cluster/{mgr_cluster_id}"
+    temp_dir_with_schema_files = download_dir_from_cloud(url=s3_dir_with_schema_json)
+
+    # If several backups have been created for the same cluster, the downloaded dir will contain several files.
+    # Thus, the matching schema file should be found by the snapshot tag.
+    for filename in os.listdir(temp_dir_with_schema_files):
+        if snapshot_tag in filename:
+            schema_filename = Path(temp_dir_with_schema_files, filename)
+            break
+    else:
+        raise FileNotFoundError(f"Schema file for snapshot {snapshot_tag} not found in {s3_dir_with_schema_json}")
+
+    with gzip.open(schema_filename, 'rt', encoding='utf-8') as gz_file:
+        schema = json.load(gz_file)
+
+    keyspace_statements = []
+    other_entities_statements = []
+
+    for entry in schema:
+        if exclude_system_ks:
+            if entry["keyspace"].startswith("system"):
+                continue
+
+        if exclude_roles:
+            if entry["type"] == "role":
+                continue
+
+        if entry["type"] == "keyspace":
+            keyspace_statements.append(entry["cql_stmt"])
+        else:
+            other_entities_statements.append(entry["cql_stmt"])
+
+    return keyspace_statements, other_entities_statements
+
+
+def get_dc_name_from_ks_statement(ks_statement: str) -> list[str]:
+    """Extracts the name of a datacenter from a CREATE KEYSPACE statement.
+
+    For example, for the statement:
+
+        "CREATE KEYSPACE \"5gb_stcs_quorum_64_16_2024_2_4\"
+            WITH replication = {'class': 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'us-east': '3'}
+            AND durable_writes = true
+            AND tablets = {'enabled': false};"
+
+    the function will return ["us-east"].
+    """
+    # Firstly, the code extracts the whole replication block from the statement.
+    # Then, it finds all keys in the replication dictionary and filters out the 'class' key.
+    # It doesn't search for dc_name in the replication block directly because the order of keys might be different.
+    replication_block = CREATE_KS_REPLICATION_BLOCK_PATTERN.search(ks_statement).group(1)
+    _keys = REPLICATION_DICT_KEYS_PATTERN.findall(replication_block)
+
+    return [key for key in _keys if key != 'class']

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -69,6 +69,7 @@ from sdcm.db_stats import PrometheusDBStats
 from sdcm.log import SDCMAdapter
 from sdcm.logcollector import save_kallsyms_map
 from sdcm.mgmt.common import TaskStatus, ScyllaManagerError, get_persistent_snapshots
+from sdcm.mgmt.helpers import get_dc_name_from_ks_statement, get_schema_create_statements_from_snapshot
 from sdcm.nemesis_publisher import NemesisElasticSearchPublisher
 from sdcm.prometheus import nemesis_metrics_obj
 from sdcm.provision.scylla_yaml import SeedProvider
@@ -2920,6 +2921,42 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 stress_queue.append(read_thread)
             return stress_queue
 
+        def _restore_schema(locations: list, cluster_id: str, tag: str) -> None:
+            """Introduced to cover two flows:
+
+            - When a backup snapshot has different DC name than the current cluster's DC name -
+            restore schema out of the Manager applying CQL statements saved in schema.json file
+
+            - When backup snapshot has the same DC name as the current cluster's DC name -
+            restore schema using the Manager (sctool restore --restore-schema ...)
+            """
+            ks_statements, other_statements = get_schema_create_statements_from_snapshot(
+                bucket=locations[0].split(':')[-1],
+                mgr_cluster_id=cluster_id,
+                snapshot_tag=tag,
+            )
+
+            dc_under_test_name = next(iter(self.cluster.get_nodetool_status()))
+            # Test is supposed to work with single DC setups only, so we can take the first DC name
+            dc_from_backup_name = get_dc_name_from_ks_statement(ks_statements[0])[0]
+            self.log.debug("DC name from backup: %s, DC name under test: %s", dc_from_backup_name, dc_under_test_name)
+
+            if dc_under_test_name != dc_from_backup_name:
+                self.log.info("DC names mismatch - restoring the schema manually altering cql statements and "
+                              "applying them one by one")
+                # Alter the dc_name in keyspace cql statements to match the current cluster's dc_name
+                old_dc_block = f"'{dc_from_backup_name}':"  # Include quotes and colon to avoid unintended replacements
+                new_dc_block = f"'{dc_under_test_name}':"
+                ks_statements = [stmt.replace(old_dc_block, new_dc_block) for stmt in ks_statements]
+                # Apply cql statements one by one to restore schema
+                for cql_stmt in ks_statements + other_statements:
+                    self.target_node.run_cqlsh(cql_stmt)
+            else:
+                self.log.info("Restoring the schema using the Scylla Manager")
+                task = mgr_cluster.create_restore_task(restore_schema=True, location_list=locations, snapshot_tag=tag)
+                task.wait_and_get_final_status(step=10, timeout=6 * 60)  # 6 giving minutes to restore the schema
+                assert task.status == TaskStatus.DONE, f'Schema restoration failed: snapshot tag - {tag}'
+
         skip_issues = [
             "https://github.com/scylladb/scylla-manager/issues/3829",
             "https://github.com/scylladb/scylla-manager/issues/4049"
@@ -2951,16 +2988,12 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         test_keyspaces = [cql_unquote_if_needed(keyspace) for keyspace in self.cluster.get_test_keyspaces()]
         # Keyspace names that start with a digit are surrounded by quotation marks in the output of a describe query
         if chosen_snapshot_info["keyspace_name"] not in test_keyspaces:
-            self.log.info("Restoring the schema of the keyspace '%s'",
-                          chosen_snapshot_info["keyspace_name"])
-            restore_task = mgr_cluster.create_restore_task(restore_schema=True, location_list=location_list,
-                                                           snapshot_tag=chosen_snapshot_tag)
-
-            restore_task.wait_and_get_final_status(step=10,
-                                                   timeout=6*60)  # giving 6 minutes to restore the schema
-            assert restore_task.status == TaskStatus.DONE, \
-                f'Schema restoration of {chosen_snapshot_tag} has failed!'
-
+            self.log.info("Restoring the schema of the keyspace '%s'", chosen_snapshot_info["keyspace_name"])
+            _restore_schema(
+                locations=location_list,
+                cluster_id=chosen_snapshot_info["cluster_id"],
+                tag=chosen_snapshot_tag,
+            )
             with ignore_ycsb_connection_refused():
                 self.cluster.restart_scylla()  # After schema restoration, you should restart the nodes
 


### PR DESCRIPTION
Sometimes the DC name of a cluster under test and DC name of a backup cluster might be different. In such a case, the regular schema restore using the Manager fails since DC names mismatch.

To work around this issue, the schema might be restored "manually" (or out of Manager) applying cql statements taken from the schema.json file stored in a backup snapshot.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Manager OPS Nemesis with simulated racks](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/longevity-100gb-manager-ops-4h/11/)
- [x] [Nemesis Manager restore](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/longevity-5gb-1h-MgmtRestore-aws-test/4/)
- [x] [Operator](https://argus.scylladb.com/tests/scylla-cluster-tests/64574458-c35f-4458-b8bb-8607df2d9540) - required `disrupt_mgmt_restore` has PASSED

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
