### PR TITLE
fix(coredump): handle cases where dump doesn't have exceutable name

### DIFF
--- a/sdcm/coredump.py
+++ b/sdcm/coredump.py
@@ -333,7 +333,8 @@ class CoredumpThreadBase(Thread):  # pylint: disable=too-many-instance-attribute
 
     def update_new_coredump_with_exec_information(self, core_info: CoreDumpInfo) -> None:
         core = self._get_core_by_pid(core_info.pid)
-        core_info.update(executable=core['exe'], executable_version=self._get_executable_version(core['exe']))
+        core_info.update(executable=core.get('exe', 'N\A'),
+                         executable_version=self._get_executable_version(core.get('exe', 'N\A')))
 
     @staticmethod
     def _extract_version(release_version: str) -> Optional[str]:
@@ -386,7 +387,7 @@ class CoredumpExportSystemdThread(CoredumpThreadBase):
 
         pid_list = []
         for dump in coredump_infos:
-            if "bash" not in dump['exe'] and "fwupd" not in dump['exe']:
+            if "bash" not in dump.get('exe', "") and "fwupd" not in dump.get('exe', ''):
                 pid_list.append(CoreDumpInfo(pid=str(dump['pid']), node=self.node))
         return pid_list
 


### PR DESCRIPTION
seems like in some situation coredump might not have executable, we should collec that coredmp regardless

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
