### PR TITLE
fix(coredump): wait for active coredumps completion

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1242,7 +1242,7 @@ class BaseNode(AutoSshContainerMixin):  # pylint: disable=too-many-instance-attr
             time.sleep(1)
 
         if self._coredump_thread:
-            self._coredump_thread.join(20*60)
+            self._coredump_thread.join(60*60)
         if self._journal_thread:
             self._journal_thread.stop(timeout // 10)
         if self._scylla_manager_journal_thread:

--- a/unit_tests/test_data/test_coredump/systemd/exceptions_limit_not_reached_test_remoter.json
+++ b/unit_tests/test_data/test_coredump/systemd/exceptions_limit_not_reached_test_remoter.json
@@ -202,5 +202,14 @@
       "exited": 0,
       "exit_status": 0
     }
+  ],
+  "systemctl list-units --type=service --state=running | grep -q \"systemd-coredump@\"": [
+        {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "",
+      "stderr": "",
+      "exited": 1,
+      "exit_status": 1
+    }
   ]
 }

--- a/unit_tests/test_data/test_coredump/systemd/exceptions_limit_reached_test_remoter.json
+++ b/unit_tests/test_data/test_coredump/systemd/exceptions_limit_reached_test_remoter.json
@@ -86,5 +86,14 @@
       "exited": 0,
       "exit_status": 0
     }
+  ],
+  "systemctl list-units --type=service --state=running | grep -q \"systemd-coredump@\"": [
+        {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "",
+      "stderr": "",
+      "exited": 1,
+      "exit_status": 1
+    }
   ]
 }

--- a/unit_tests/test_data/test_coredump/systemd/fail_get_list_test_remoter.json
+++ b/unit_tests/test_data/test_coredump/systemd/fail_get_list_test_remoter.json
@@ -19,5 +19,14 @@
       },
       "reason": null
     }
+  ],
+  "systemctl list-units --type=service --state=running | grep -q \"systemd-coredump@\"": [
+        {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "",
+      "stderr": "",
+      "exited": 1,
+      "exit_status": 1
+    }
   ]
 }

--- a/unit_tests/test_data/test_coredump/systemd/fail_upload_test_remoter.json
+++ b/unit_tests/test_data/test_coredump/systemd/fail_upload_test_remoter.json
@@ -259,5 +259,14 @@
       "exited": 0,
       "exit_status": 0
     }
+  ],
+  "systemctl list-units --type=service --state=running | grep -q \"systemd-coredump@\"": [
+        {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "",
+      "stderr": "",
+      "exited": 1,
+      "exit_status": 1
+    }
   ]
 }

--- a/unit_tests/test_data/test_coredump/systemd/success_test_remoter.json
+++ b/unit_tests/test_data/test_coredump/systemd/success_test_remoter.json
@@ -304,5 +304,14 @@
       "exited": 0,
       "exit_status": 0
     }
+  ],
+  "systemctl list-units --type=service --state=running | grep -q \"systemd-coredump@\"": [
+        {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "",
+      "stderr": "",
+      "exited": 1,
+      "exit_status": 1
+    }
   ]
 }

--- a/unit_tests/test_data/test_coredump/systemd/success_test_systemd_248_remoter.json
+++ b/unit_tests/test_data/test_coredump/systemd/success_test_systemd_248_remoter.json
@@ -203,5 +203,14 @@
       "exited": 0,
       "exit_status": 0
     }
+  ],
+  "systemctl list-units --type=service --state=running | grep -q \"systemd-coredump@\"": [
+        {
+      "__instance__": "fabric.runners.Result",
+      "stdout": "",
+      "stderr": "",
+      "exited": 1,
+      "exit_status": 1
+    }
   ]
 }


### PR DESCRIPTION
Creating coredump may take long (even 13 minutes). During that time test may fail and exit - this prevents from collecting such cores.

Fix by waiting for all services that create cores to complete before getting list of cores. It freezes main loop - so it won't end until it continues (and at next step, adding cores to process, which also prevent from ending coredump thread).

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/10748

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] - [example run with core](https://argus.scylladb.com/tests/scylla-cluster-tests/bfcf066e-1ba9-4e4b-ae63-29586789b62e) - (see in sct.log that it logged `CoredumpExportSystemdThread: Coredump completed` several lines after `systemd[1]: systemd-coredump@0-6259-0.service: Deactivated successfully.`

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
