### PR TITLE
fix(github-actions): generated code validation to post to correct repo

### DIFF
--- a/.github/actions/run-validation/action.yml
+++ b/.github/actions/run-validation/action.yml
@@ -35,6 +35,6 @@ runs:
       uses: peter-evans/create-or-update-comment@v4
       with:
         token: ${{ inputs.github_token }}
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        repository: ${{ github.event.pull_request.base.repo.full_name }}
         issue-number: ${{ github.event.pull_request.number }}
         body-path: pr_comment.txt


### PR DESCRIPTION
by mistake the action is trying to post comments to the repo the PR is coming from, and not to the one it's targeting

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
