### PR TITLE
Revert "chore(deps): bump s-b version to 0.2.3"

### DIFF
--- a/defaults/docker_images/scylla-bench/values_scylla-bench.yaml
+++ b/defaults/docker_images/scylla-bench/values_scylla-bench.yaml
@@ -1,2 +1,2 @@
 scylla-bench:
-  image: scylladb/scylla-bench:0.2.3
+  image: scylladb/scylla-bench:0.1.25


### PR DESCRIPTION
Reverts scylladb/scylla-cluster-tests#10698

since seems like https://github.com/scylladb/scylla-bench/issues/183 is breaking validation of s-b, we revert it back