### PR TITLE
fix(microbanchmark): skip update_test_with_errors

### DIFF
--- a/microbenchmarking_test.py
+++ b/microbenchmarking_test.py
@@ -42,3 +42,6 @@ class PerfSimpleQueryTest(ClusterTester):
                     self._test_id, is_gce=is_gce,
                     extra_jobs_to_compare=self.params.get('perf_extra_jobs_to_compare'))
             send_perf_simple_query_result_to_argus(self.test_config.argus_client(), results)
+
+    def update_test_with_errors(self):
+        self.log.info("update_test_with_errors: Suppress writing errors to ES")


### PR DESCRIPTION
'test_perf_simple_query' fails with 'Limit of total fields [1000] has been exceeded'. Attempts to fix it failed.
It was decided to skip update_test_with_errors function in this test

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
