### PR TITLE
fix(upload_sct_coredump): use tar command with sudo

### DIFF
--- a/utils/upload_sct_coredump.sh
+++ b/utils/upload_sct_coredump.sh
@@ -19,7 +19,7 @@ fi
 if ./docker/env/hydra.sh $EXTRA_HYDRA_ARGS "bash -c \"[[ -n \\\"\$( ls $COREDUMP_DIR )\\\" ]]\"" ; then
 
     # Compress the coredumps into a tar.gz file
-    ./docker/env/hydra.sh $EXTRA_HYDRA_ARGS "bash -c \"tar --zstd -cf $COREDUMP_TARBALL -C $COREDUMP_DIR .\""
+    ./docker/env/hydra.sh $EXTRA_HYDRA_ARGS "bash -c \"sudo tar --zstd -cf $COREDUMP_TARBALL -C $COREDUMP_DIR .\""
 
     # Upload the tar.gz file
     ./docker/env/hydra.sh $EXTRA_HYDRA_ARGS upload --test-id $SCT_TEST_ID $COREDUMP_TARBALL


### PR DESCRIPTION
if we don't use sudo, some of the coredumps can't be accessed and uploaded:
```
Going to run 'bash -c "tar --zstd -cf /tmp/sct-coredumps-1227c7f1.tar.zst -C /var/lib/systemd/coredump ."'...
tar: ./core.systemd-journal.0.3893bba5f375491bb375d3b1882eaf8c.127.1745995091000000.zst: Cannot open: Permission denied
tar: Exiting with failure status due to previous errors
```

so this commit add the sudo before the tar command

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
