### PR TITLE
fix(builders): limit executors to one

### DIFF
--- a/sdcm/utils/aws_builder.py
+++ b/sdcm/utils/aws_builder.py
@@ -96,7 +96,7 @@ jenkins.save()
 
 class AwsBuilder:
     NUM_CPUS = 2
-    NUM_EXECUTORS = 4
+    NUM_EXECUTORS = 1
     VERSION = 'v3'
 
     def __init__(self, region: AwsRegion, params=None, number=1):

--- a/sdcm/utils/gce_builder.py
+++ b/sdcm/utils/gce_builder.py
@@ -53,7 +53,7 @@ ComputeEngineCloud gcpCloud = new ComputeEngineCloud(config.name, config.project
 gcpCloud.setNoDelayProvisioning(true)
 
 InstanceConfiguration instanceConfiguration = new InstanceConfiguration()
-instanceConfiguration.setNumExecutorsStr("4")
+instanceConfiguration.setNumExecutorsStr("1")
 instanceConfiguration.setOneShot(false)
 instanceConfiguration.setNamePrefix("builders")
 instanceConfiguration.setDescription("SCT Jenkins builders")


### PR DESCRIPTION
since we are running into multiple issue with builders running out of memory during artifact tests, we are taking this number down from 4 to 1, until we can figure out a better solution for artifact tests (it's own builders ?)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
