### PR TITLE
test(perf): add latency steady state test

### DIFF
--- a/docs/bisecting-with-sct.md
+++ b/docs/bisecting-with-sct.md
@@ -43,7 +43,7 @@ def test_write(self):
     self.bisect_ref_value = self.bisect_result_value * 0.95 if self.bisect_ref_value is None else self.bisect_ref_value
     # update bisect_result_value with the result value for further comparison
     self.bisect_result_value = sum([int(result['op rate']) for result in results])
-    self.build_histogram(PerformanceTestWorkload.WRITE, PerformanceTestType.THROUGHPUT)
+    self.build_histogram(stress_queue.stress_operation, hdr_tags=stress_queue.hdr_tags)
     self.update_test_details(scylla_conf=True)
     self.display_results(results, test_name='test_write')
     self.check_regression()

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -27,6 +27,7 @@ from sdcm.sct_events import Severity
 from sdcm.sct_events.filters import EventsSeverityChangerFilter
 from sdcm.sct_events.loaders import CassandraStressEvent
 from sdcm.sct_events.system import HWPerforanceEvent, InfoEvent
+from sdcm.utils.common import ParallelObject
 from sdcm.utils.decorators import log_run_info, latency_calculator_decorator, optional_stage
 from sdcm.utils.nemesis_utils.indexes import wait_for_view_to_be_built
 
@@ -610,6 +611,56 @@ class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):  
         self.wait_no_compactions_running()
         self.run_fstrim_on_all_db_nodes()
         self.run_mixed_workload()
+
+    def test_latency_steady_state(self):
+        """Test designed to run multiple stress commands, possibly, using different stress operation types.
+
+        For example, 'latte' uses rune function names in HDR histogram tags,
+        so we should gather all the unique tags into separate lists - one per stress operation type
+        """
+        self.run_fstrim_on_all_db_nodes()
+        self.preload_data()
+        self.wait_no_compactions_running()
+        self.run_fstrim_on_all_db_nodes()
+
+        stress_operation_mapping = {}
+        for stress_cmd in self.params.get("stress_cmd"):
+            stress_thread = self.run_stress_thread(stress_cmd=stress_cmd, stress_num=1, round_robin=True)
+            stress_op = stress_thread.stress_operation  # test depends on the 'stress_operation' attr
+            assert stress_op, "stress operation type should not be empty: %s" % stress_op
+            if stress_op not in stress_operation_mapping:
+                stress_operation_mapping[stress_op] = []
+            stress_operation_mapping[stress_op].append(stress_thread)
+
+        def _test_latency_steady_state_template(workload: str, *args):
+            tester, stress_queue = args  # blindly assume 2 args
+
+            # NOTE: "steady" word from the func name will be used by the latency calculator decorator
+            @latency_calculator_decorator(workload_type=workload)
+            def _test_latency_steady_state(tester, stress_queue: list):
+                for stress_thread in stress_queue:
+                    self.verify_stress_thread(stress_thread)
+
+                # NOTE: 'hdr_tags' will be used by the latency calculator decorator
+                hdr_tags = []
+                for stress_thread in stress_queue:
+                    hdr_tags.extend(stress_thread.hdr_tags)
+                return {"hdr_tags": hdr_tags}  # must be dict with 'hdr_tags' key
+
+            # NOTE: 'tester' arg must be first and positional due to latency calculator decorator expectations
+            return _test_latency_steady_state(tester, stress_queue=stress_queue)
+
+        object_set = ParallelObject(
+            timeout=None,
+            objects=[
+                [_stress_op, self, _stress_queue]
+                for _stress_op, _stress_queue in stress_operation_mapping.items()
+            ],
+            num_workers=len(stress_operation_mapping))
+        object_set.run(
+            func=_test_latency_steady_state_template,
+            unpack_objects=True,
+            ignore_exceptions=False)
 
     def test_latency_read_with_nemesis(self):
         self.run_fstrim_on_all_db_nodes()

--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -171,51 +171,101 @@ def submit_results_to_argus(argus_client: ArgusClient, result_table: GenericResu
             raise
 
 
-def send_result_to_argus(argus_client: ArgusClient, workload: str, name: str, description: str, cycle: int, result: dict,
-                         start_time: float = 0, error_thresholds: dict = None):
-    result_table = workload_to_table[workload]()
+def send_result_to_argus(argus_client: ArgusClient, workload: str, name: str, description: str,  # noqa: PLR0914
+                         cycle: int, result: dict, start_time: float = 0, error_thresholds: dict = None):
+    """Sends results to Argus service.
+
+    This function creates following data tables in Argus:
+    - Stress commands latency results table is registered always
+      and it stores parsed values taken from the HDR histograms.
+    - Summary table for above results is registered
+      when "result['hdr_summary']" has more than 2 rows with unique HDR tags.
+      It is useful for cases when we run multiple stress commands of different types in parallel
+      like customer-scenarios covered by latte stress commands.
+      It stores the worst P90 and P99 latencies among all of the rows/results
+      and summary throughput for all of them even if workload types are different.
+    - Reactor stalls table is registered
+      when relevant SCT events occured (result['reactor_stalls_stats'])
+      during the measured time range.
+    """
+    result_table, result_table_summary = workload_to_table[workload](), workload_to_table[workload]()
     result_table.name = f"{workload} - {name} - latencies"
     result_table.description = f"{workload} workload - {description}"
+    result_table_summary.name = f"{workload} - {name} - Summary latencies"
+    result_table_summary.description = f"{workload} workload summary - {description}"
     if error_thresholds:
         error_thresholds = error_thresholds[workload]["default"] | error_thresholds[workload].get(name, {})
         result_table.validation_rules = {metric: ValidationRule(**rules) for metric, rules in error_thresholds.items()}
+        result_table_summary.validation_rules = result_table.validation_rules
     try:
         start_time = datetime.fromtimestamp(start_time or time.time(), tz=timezone.utc).strftime('%H:%M:%S')
     except ValueError:
         start_time = "N/A"
-    for operation in ["write", "read"]:
-        summary = result["hdr_summary"]
-        if operation.upper() not in summary:
-            continue
-        for percentile in ["90", "99"]:
-            value = summary[operation.upper()][f"percentile_{percentile}"]
-            result_table.add_result(column=f"P{percentile} {operation}",
-                                    row=f"Cycle #{cycle}",
-                                    value=value,
-                                    status=Status.UNSET)
-        if value := summary[operation.upper()].get("throughput", None):
-            result_table.add_result(column=f"Throughput {operation.lower()}",
-                                    row=f"Cycle #{cycle}",
-                                    value=value,
-                                    status=Status.UNSET)
 
-    result_table.add_result(column="duration", row=f"Cycle #{cycle}",
-                            value=result["duration_in_sec"], status=Status.UNSET)
-    try:
-        overview_screenshot = [screenshot for screenshot in result["screenshots"] if "overview" in screenshot][0]
-        result_table.add_result(column="Overview", row=f"Cycle #{cycle}",
-                                value=overview_screenshot, status=Status.UNSET)
-    except IndexError:
-        pass
-    try:
-        qa_screenshot = [screenshot for screenshot in result["screenshots"]
-                         if "scylla-per-server-metrics-nemesis" in screenshot][0]
-        result_table.add_result(column="QA dashboard", row=f"Cycle #{cycle}",
-                                value=qa_screenshot, status=Status.UNSET)
-    except IndexError:
-        pass
-    result_table.add_result(column="start time", row=f"Cycle #{cycle}",
-                            value=start_time, status=Status.UNSET)
+    summary_throughput, summary_worst_lat = 0, {}
+    summary_row_name = f"Cycle #{cycle} (Summary of all HDR tags)"
+    overview_screenshot = [s for s in result["screenshots"] if "overview" in s]
+    qa_screenshot = [s for s in result["screenshots"] if "scylla-per-server-metrics-nemesis" in s]
+    hdr_summary = result.get("hdr_summary", {})
+    hdr_summary_len = len(hdr_summary)
+    skip_hdr_tag = hdr_summary_len == 1 or (workload == "mixed" and hdr_summary_len == 2)
+    for i, (workload_type_and_hdr_tag, hdr_data) in enumerate(hdr_summary.items()):
+        (workload_type, hdr_tag) = workload_type_and_hdr_tag.split("--", maxsplit=1)
+        row_name = f"Cycle #{cycle}" + "" if skip_hdr_tag else f" (HDR tag: {hdr_tag})"
+        for percentile in ("90", "99"):
+            if (workload_type, percentile) not in summary_worst_lat:
+                summary_worst_lat[(workload_type, percentile)] = 0.0
+            column_name = f"P{percentile} {workload_type.lower()}"
+            value = hdr_data[f"percentile_{percentile}"]
+            result_table.add_result(
+                column=column_name,
+                row=row_name,
+                value=value,
+                status=Status.UNSET,
+            )
+            if summary_worst_lat[(workload_type, percentile)] < value:
+                summary_worst_lat[(workload_type, percentile)] = value
+                result_table_summary.add_result(
+                    column=column_name,
+                    row=summary_row_name,
+                    value=value,
+                    status=Status.UNSET,
+                )
+        if value := hdr_data.get("throughput", None):
+            summary_throughput += value
+            result_table.add_result(
+                column=f"Throughput {workload_type.lower()}",
+                row=row_name,
+                value=value,
+                status=Status.UNSET,
+            )
+        if (i > 0 and skip_hdr_tag) or not skip_hdr_tag:
+            continue
+        result_table.add_result(column="duration", row=row_name, value=result["duration_in_sec"], status=Status.UNSET)
+        result_table.add_result(column="start time", row=row_name, value=start_time, status=Status.UNSET)
+        if overview_screenshot:
+            result_table.add_result(column="Overview", row=row_name, value=overview_screenshot[0], status=Status.UNSET)
+        if qa_screenshot:
+            result_table.add_result(column="QA dashboard", row=row_name, value=qa_screenshot[0], status=Status.UNSET)
+
+    if hdr_summary_len > 2:
+        result_table_summary.add_result(
+            column=f"Throughput {workload_type.lower()}",
+            row=summary_row_name,
+            value=summary_throughput,
+            status=Status.UNSET,
+        )
+        result_table_summary.add_result(
+            column="duration", row=summary_row_name, value=result["duration_in_sec"], status=Status.UNSET)
+        result_table_summary.add_result(
+            column="start time", row=summary_row_name, value=start_time, status=Status.UNSET)
+        if overview_screenshot:
+            result_table_summary.add_result(
+                column="Overview", row=summary_row_name, value=overview_screenshot[0], status=Status.UNSET)
+        if qa_screenshot:
+            result_table_summary.add_result(
+                column="QA dashboard", row=summary_row_name, value=qa_screenshot[0], status=Status.UNSET)
+        submit_results_to_argus(argus_client, result_table_summary)
     submit_results_to_argus(argus_client, result_table)
     for event in result["reactor_stalls_stats"]:  # each stall event has own table
         event_name = event.split(".")[-1]

--- a/sdcm/stress/base.py
+++ b/sdcm/stress/base.py
@@ -53,10 +53,14 @@ class DockerBasedStressThread:  # pylint: disable=too-many-instance-attributes
         self.shutdown_timeout = 180  # extra 3 minutes
         self.stop_test_on_failure = stop_test_on_failure
         self.hdr_tags = []
+        self.stress_operation = self.set_stress_operation(stress_cmd)
 
         if "k8s" not in self.params.get("cluster_backend") and self.docker_image_name:
             for loader in self.loader_set.nodes:
                 RemoteDocker.pull_image(loader, self.docker_image_name)
+
+    def set_stress_operation(self, stress_cmd):
+        return ""
 
     @cached_property
     def docker_image_name(self):

--- a/sdcm/stress/latte_thread.py
+++ b/sdcm/stress/latte_thread.py
@@ -95,6 +95,9 @@ class LatteStressThread(DockerBasedStressThread):  # pylint: disable=too-many-in
 
     DOCKER_IMAGE_PARAM_NAME = "stress_image.latte"
 
+    def set_stress_operation(self, stress_cmd):
+        return get_latte_operation_type(self.stress_cmd)
+
     def build_stress_cmd(self, cmd_runner, loader, hosts):  # pylint: disable=too-many-locals
         # extract the script so we know which files to mount into the docker image
         script_name_regx = re.compile(r'([/\w-]*\.rn)')
@@ -198,15 +201,14 @@ class LatteStressThread(DockerBasedStressThread):  # pylint: disable=too-many-in
         if not os.path.exists(loader.logdir):
             os.makedirs(loader.logdir, exist_ok=True)
 
-        stress_operation = get_latte_operation_type(self.stress_cmd)
-        first_tag_or_op = "-" + (find_latte_tags(self.stress_cmd) or [stress_operation])[0]
+        first_tag_or_op = "-" + (find_latte_tags(self.stress_cmd) or [self.stress_operation])[0]
         log_file_name = os.path.join(
             loader.logdir, 'latte%s-l%s-c%s-%s.log' % (first_tag_or_op, loader_idx, cpu_idx, uuid.uuid4()))
         LOGGER.debug('latte benchmarking tool local log: %s', log_file_name)
 
         # TODO: fix usage of the "$HOME". Code works when home is "/". It will fail for non-root.
         log_id = self._build_log_file_id(loader_idx, cpu_idx, "")
-        remote_hdr_file_name = f"hdrh-latte-{stress_operation}-{log_id}.hdr"
+        remote_hdr_file_name = f"hdrh-latte-{self.stress_operation}-{log_id}.hdr"
         LOGGER.debug("latte remote HDR histogram log file: %s", remote_hdr_file_name)
         local_hdr_file_name = os.path.join(loader.logdir, remote_hdr_file_name)
         LOGGER.debug("latte HDR local file %s", local_hdr_file_name)
@@ -260,7 +262,7 @@ class LatteStressThread(DockerBasedStressThread):  # pylint: disable=too-many-in
                     keyspace=keyspace_holder,
                     instance_name=loader.ip_address,
                     metrics=nemesis_metrics_obj(),
-                    stress_operation=stress_operation,
+                    stress_operation=self.stress_operation,
                     stress_log_filename=log_file_name,
                     loader_idx=loader_idx, cpu_idx=cpu_idx), \
                 LatteHDRExporter(
@@ -268,7 +270,7 @@ class LatteStressThread(DockerBasedStressThread):  # pylint: disable=too-many-in
                     instance_name=loader.ip_address,
                     hdr_tags=self.hdr_tags,
                     metrics=nemesis_metrics_obj(),
-                    stress_operation=stress_operation,
+                    stress_operation=self.stress_operation,
                     stress_log_filename=local_hdr_file_name,
                     loader_idx=loader_idx, cpu_idx=cpu_idx), \
                 LatteStressEvent(

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -86,8 +86,26 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
         self.compaction_strategy = compaction_strategy
         self.set_hdr_tags(stress_cmd)
 
+    def set_stress_operation(self, stress_cmd):
+        if " mixed " in stress_cmd:
+            self.stress_operation = "mixed"
+        elif " read " in stress_cmd:
+            self.stress_operation = "read"
+        elif " write " in stress_cmd:
+            self.stress_operation = "write"
+        elif " counter_read " in stress_cmd:
+            self.stress_operation = "counter_read"
+        elif " counter_write " in stress_cmd:
+            self.stress_operation = "counter_write"
+        elif " user " in stress_cmd:
+            self.stress_operation = "user"
+        else:
+            raise ValueError(
+                "Cannot detect supported stress operation type from the stress command: %s" % stress_cmd)
+        return self.stress_operation
+
     def set_hdr_tags(self, stress_cmd):
-        # TODO: add support for the "counter_write" and "user" modes?
+        # TODO: add support for the "counter_write", "counter_read" and "user" modes?
         params = get_stress_cmd_params(stress_cmd)
         if "fixed threads" in params:
             if " mixed " in stress_cmd:

--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -179,7 +179,7 @@ def _find_hdr_tags(*args):
 
 
 def latency_calculator_decorator(original_function: Optional[Callable] = None, *, legend: Optional[str] = None,
-                                 cycle_name: Optional[str] = None):
+                                 cycle_name: Optional[str] = None, workload_type: Optional[str] = None):
     """
     Gets the start time, end time and then calculates the latency based on function 'calculate_latency'.
 
@@ -231,7 +231,9 @@ def latency_calculator_decorator(original_function: Optional[Callable] = None, *
                 return res
             monitor = monitoring_set.nodes[0]
             screenshots = monitoring_set.get_grafana_screenshots(node=monitor, test_start_time=start)
-            if 'read' in test_name:
+            if workload_type:
+                workload = workload_type
+            elif 'read' in test_name:
                 workload = 'read'
             elif 'write' in test_name:
                 workload = 'write'

--- a/sdcm/utils/hdrhistogram.py
+++ b/sdcm/utils/hdrhistogram.py
@@ -315,9 +315,9 @@ class _HdrRangeHistogramBuilder:
         # 4) NOT_SUPPORTED: 'ycsb', it supports HDR histograms, but doesn't use tags in it.
         #    So, the 'ycsb' case should be handled separately.
         hdr_tag = hdr_tag.lower().strip()
-        if any(w_word in hdr_tag for w_word in ("write", "insert", "update")):
+        if any(w_word in hdr_tag for w_word in ("write", "insert", "update", "delete")):
             return "WRITE"
-        elif any(r_word in hdr_tag for r_word in ("read", "select", "get")):
+        elif any(r_word in hdr_tag for r_word in ("read", "select", "get", "count")):
             return "READ"
         elif self.stress_operation in ("WRITE", "READ"):
             # branch for the scylla-bench case with its 'co-fixed' and 'raw' tags

--- a/sdcm/utils/hdrhistogram.py
+++ b/sdcm/utils/hdrhistogram.py
@@ -328,7 +328,8 @@ class _HdrRangeHistogramBuilder:
     def _get_summary_for_operation_by_hdr_tag(self, histogram: _HdrRangeHistogram) -> dict[str, dict[str, int]] | None:
         if histogram.histogram and (parsed_summary := self._convert_raw_histogram(
                 histogram.histogram, histogram.start_time, histogram.end_time)):
-            return {self._get_workload_type_by_hdr_tag(histogram.hdr_tag): asdict(parsed_summary)}
+            actual_workload_type = self._get_workload_type_by_hdr_tag(histogram.hdr_tag)
+            return {f"{actual_workload_type}--{histogram.hdr_tag}": asdict(parsed_summary)}
         return None
 
     @staticmethod

--- a/unit_tests/test_argus_results.py
+++ b/unit_tests/test_argus_results.py
@@ -24,41 +24,43 @@ def test_send_latency_decorator_result_to_argus():
     argus_mock = MagicMock()
     argus_mock.submit_results = MagicMock()
     result = json.loads(Path(__file__).parent.joinpath("test_data/latency_decorator_result.json").read_text())
+    cycle_num = 1
     send_result_to_argus(
         argus_client=argus_mock,
         workload="mixed",
         name="test",
         description="test",
-        cycle=1,
+        cycle=cycle_num,
         result=result,
         start_time=1721564063.4528425
     )
+    row_name = f"Cycle #{cycle_num}"
     expected_calls = [
         call(LatencyCalculatorMixedResult(
             sut_timestamp=0,
             results=[
-                Cell(column='P90 write', row='Cycle #1', value=2.15, status=Status.UNSET),
-                Cell(column='P99 write', row='Cycle #1', value=3.62, status=Status.UNSET),
-                Cell(column='P90 read', row='Cycle #1', value=2.86, status=Status.UNSET),
-                Cell(column='P99 read', row='Cycle #1', value=5.36, status=Status.UNSET),
-                Cell(column='duration', row='Cycle #1', value=2654, status=Status.UNSET),
-                Cell(column='Overview', row='Cycle #1',
+                Cell(column='P90 write', row=row_name, value=2.15, status=Status.UNSET),
+                Cell(column='P99 write', row=row_name, value=3.62, status=Status.UNSET),
+                Cell(column='duration', row=row_name, value=2654, status=Status.UNSET),
+                Cell(column='start time', row=row_name, value='12:14:23', status=Status.UNSET),
+                Cell(column='Overview', row=row_name,
                      value='https://cloudius-jenkins-test.s3.amazonaws.com/a9b9a308-6ff8-4cc8-b33d-c439f75c9949/20240721_125838/'
                            'grafana-screenshot-overview-20240721_125838-perf-latency-grow-shrink-ubuntu-monitor-node-a9b9a308-1.png',
                      status=Status.UNSET),
-                Cell(column='QA dashboard', row='Cycle #1',
+                Cell(column='QA dashboard', row=row_name,
                      value='https://cloudius-jenkins-test.s3.amazonaws.com/a9b9a308-6ff8-4cc8-b33d-c439f75c9949/20240721_125838/'
                            'grafana-screenshot-scylla-master-perf-regression-latency-650gb-grow-shrink-scylla-per-server-metrics-nemesis'
                            '-20240721_125845-perf-latency-grow-shrink-ubuntu-monitor-node-a9b9a308-1.png',
                      status=Status.UNSET),
-                Cell(column='start time', row='Cycle #1', value='12:14:23', status=Status.UNSET)
+                Cell(column='P90 read', row=row_name, value=2.86, status=Status.UNSET),
+                Cell(column='P99 read', row=row_name, value=5.36, status=Status.UNSET),
             ]
         )),
         call(ReactorStallStatsResult(
             sut_timestamp=0,
             results=[
-                Cell(column='total', row='Cycle #1', value=18, status=Status.UNSET),
-                Cell(column='10ms', row='Cycle #1', value=18, status=Status.UNSET)
+                Cell(column='total', row=row_name, value=18, status=Status.UNSET),
+                Cell(column='10ms', row=row_name, value=18, status=Status.UNSET)
             ]
         ))
     ]

--- a/unit_tests/test_data/latency_decorator_result.json
+++ b/unit_tests/test_data/latency_decorator_result.json
@@ -198,7 +198,7 @@
     }
   ],
   "hdr_summary": {
-    "WRITE": {
+    "WRITE--WRITE-rt": {
       "start_time": 1721564063.4528425,
       "end_time": 1721566723000.0,
       "stddev": 954797.9976915072,
@@ -214,7 +214,7 @@
         "percentile_99": ""
       }
     },
-    "READ": {
+    "READ--READ-rt": {
       "start_time": 1721564063.4528425,
       "end_time": 1721566723000.0,
       "stddev": 1205563.31676526,


### PR DESCRIPTION
We plan to start running complex stress commands as part of performance
tests for such scenarios as `custom-d1/w1` and `custom-d1/w2`.
Those use dozens of latte/rune functions which use different HDR tags.
    
So, to be able to test performance, add latency steady state test.
Also, make this test support multiple workload types with multiple HDR tags.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-perf-latency-regression-latte#36](https://argus.scylladb.com/tests/scylla-cluster-tests/b4fd90bf-5825-4b4e-b59e-db5d2b1f6aff)
- [scylla-staging/valerii/vp-scylla-master-perf-regression-latency-650gb-with-nemesis#17](https://argus.scylladb.com/tests/scylla-cluster-tests/baa1e3f7-0704-41a1-b81a-25949cf0690f)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
