### PR TITLE
fix(syslogng): update installation sequence for syslogng

### DIFF
--- a/sdcm/provision/common/configuration_script.py
+++ b/sdcm/provision/common/configuration_script.py
@@ -18,6 +18,7 @@ from sdcm.provision.common.builders import AttrBuilder
 from sdcm.provision.common.utils import (
     configure_sshd_script,
     restart_sshd_service,
+    update_repo_cache,
     install_syslogng_service,
     configure_syslogng_target_script,
     restart_syslogng_service,
@@ -96,6 +97,7 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
         script += self._skip_if_already_run()
         script += disable_daily_apt_triggers()
         if self.logs_transport == 'syslog-ng':
+            script += update_repo_cache()
             script += install_syslogng_service()
             script += configure_syslogng_target_script(hostname=self.hostname)
             if self.log_file:

--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -80,6 +80,29 @@ def restart_syslogng_service():
     return "systemctl restart syslog-ng  || true\n"
 
 
+def update_repo_cache():
+    return dedent("""\
+        if yum --help 2>/dev/null 1>&2 ; then
+            echo "Cleaning yum cache..."
+            yum clean all
+            rm -rf /var/cache/yum/
+        elif apt-get --help 2>/dev/null 1>&2 ; then
+            echo "Cleaning apt cache..."
+            apt-get clean all
+            rm -rf /var/cache/apt/
+
+            for n in 1 2 3 4 5 6 7 8 9; do
+                if apt-get -y update; then
+                    break
+                fi
+                sleep 0.5
+            done
+        else
+            echo "Unsupported distro"
+        fi
+    """)
+
+
 def install_syslogng_service():
     return dedent("""\
         SYSLOG_NG_INSTALLED=""
@@ -89,7 +112,13 @@ def install_syslogng_service():
                 yum reinstall -y syslog-ng
                 SYSLOG_NG_INSTALLED=1
             else
-                yum install -y epel-release
+                for n in 1 2 3; do # cloud-init is running it with set +o braceexpand
+                    if yum install -y epel-release; then
+                        break
+                    fi
+                    sleep 1
+                done
+
                 for n in 1 2 3 4 5 6 7 8 9; do # cloud-init is running it with set +o braceexpand
                     if yum install -y --downloadonly syslog-ng; then
                         break
@@ -112,13 +141,6 @@ def install_syslogng_service():
                 SYSLOG_NG_INSTALLED=1
             else
                 cat /etc/apt/sources.list
-                for n in 1 2 3 4 5 6 7 8 9; do # cloud-init is running it with set +o braceexpand
-                    if apt-get -y update ; then
-                        break
-                    fi
-                    sleep 0.5
-                done
-
                 for n in 1 2 3; do # cloud-init is running it with set +o braceexpand
                     DEBIAN_FRONTEND=noninteractive apt-get install -o DPkg::Lock::Timeout=300 -y syslog-ng || true
                     if dpkg-query --show syslog-ng ; then


### PR DESCRIPTION
The change adds a step of updating repo cache before installing syslogng package (similarly to how repo cache is cleaned at the beginning of cluster.py::BaseNode.node_setup sequence).
Additionally, the step of installing epel-release repository in rhel-like distros is wrapped with retries, to make it more error-resilient in case of temporary network or mirror issues.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/10815

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [artifacts-centos9-arm-test](https://argus.scylladb.com/tests/scylla-cluster-tests/a701e218-00d4-4236-bbc3-0aafd0a0ceaf)
- [x] :green_circle: [artifacts-debian12-test](https://argus.scylladb.com/tests/scylla-cluster-tests/5817f3b1-2e34-4f5f-b22a-bb1fcf208aea)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
