### PR TITLE
fix(integration-test): stop using sudo under podman

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -168,11 +168,11 @@ else
   die "Please make sure you install either podman or docker on this machine to run hydra"
 fi
 
-if [[ ${USER} == "jenkins" || ${USER} == "runner" || -z "`$tool images ${DOCKER_REPO}:${VERSION} -q`" ]]; then
+if [[ ${USER} == "jenkins" || ${USER} == "runner" || -z "`$tool images ${DOCKER_REGISTRY}/${DOCKER_REPO}:${VERSION} -q`" ]]; then
     echo "Pull version $VERSION from Docker Hub..."
     $tool pull ${DOCKER_REGISTRY}/${DOCKER_REPO}:${VERSION}
 else
-    echo "There is ${DOCKER_REPO}:${VERSION} in local cache, using it."
+    echo "There is ${DOCKER_REGISTRY}/${DOCKER_REPO}:${VERSION} in local cache, using it."
 fi
 
 if [ -z "$HYDRA_DRY_RUN" ]; then
@@ -237,7 +237,7 @@ function run_in_docker () {
            )
     else
         PODMAN_PORT=$(EPHEMERAL_PORT)
-        podman system service -t 0 tcp:localhost:${PODMAN_PORT} &
+        podman system --log-level=error service -t 0 tcp:localhost:${PODMAN_PORT} &
         trap "exit" INT TERM
         trap "kill 0" EXIT
         docker_common_args+=(
@@ -285,7 +285,7 @@ function run_in_docker () {
         --ulimit core=-1 \
         -v /var/lib/systemd/coredump:/var/lib/systemd/coredump \
         --name="${SCT_TEST_ID}_$(date +%s)" \
-        ${DOCKER_REPO}:${VERSION} \
+        ${DOCKER_REGISTRY}/${DOCKER_REPO}:${VERSION} \
         /bin/bash -c "${PREPARE_CMD}; ${TERM_SET_SIZE} eval '${CMD_TO_RUN}'"
 }
 

--- a/sct.py
+++ b/sct.py
@@ -94,7 +94,7 @@ from sdcm.utils.resources_cleanup import (
 from sdcm.utils.nemesis import NemesisJobGenerator
 from sdcm.utils.net import get_sct_runner_ip
 from sdcm.utils.jepsen import JepsenResults
-from sdcm.utils.docker_utils import docker_hub_login
+from sdcm.utils.docker_utils import docker_hub_login, running_in_podman
 from sdcm.monitorstack import (restore_monitoring_stack, get_monitoring_stack_services,
                                kill_running_monitoring_stack_services)
 from sdcm.utils.log import setup_stdout_logger, disable_loggers_during_startup
@@ -1116,16 +1116,17 @@ def integration_tests(test):
     get_test_config().logdir()
     add_file_logger()
 
-    # setup prerequisites for the integration test is identical
-    # to the kind local functional tests
-    # TODO: to refactor setup_prerequisites out of LocalKindCluster
-    sct_config = SCTConfiguration()
-    local_cluster = mini_k8s.LocalKindCluster(
-        software_version="",
-        user_prefix="",
-        params=sct_config,
-    )
-    local_cluster.setup_prerequisites()
+    if not running_in_podman():  # we can't do sudo commands within rootless podman
+        # setup prerequisites for the integration test is identical
+        # to the kind local functional tests
+        # TODO: to refactor setup_prerequisites out of LocalKindCluster
+        sct_config = SCTConfiguration()
+        local_cluster = mini_k8s.LocalKindCluster(
+            software_version="",
+            user_prefix="",
+            params=sct_config,
+        )
+        local_cluster.setup_prerequisites()
 
     sys.exit(pytest.main(['-v', '-p', 'no:warnings', '-m', 'integration', 'unit_tests/{}'.format(test)]))
 

--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -74,15 +74,21 @@ class RemoteDocker(BaseNode):
         except (ValueError, socket.herror):
             return self.external_address
 
-    @cached_property
-    def running_in_docker(self):
-        ok = self.node.remoter.run("test /.dockerenv", ignore_status=True).ok
-        ok |= 'docker' in self.node.remoter.run('ls /proc/self/cgroup', ignore_status=True).stdout
+    @staticmethod
+    @cache
+    def running_in_docker(node):
+        ok = node.remoter.run("test /.dockerenv", ignore_status=True).ok
+        ok |= 'docker' in node.remoter.run('ls /proc/self/cgroup', ignore_status=True).stdout
         return ok
+
+    @staticmethod
+    @cache
+    def running_in_podman(node) -> bool:
+        return 'podman' in node.remoter.run('echo $container', ignore_status=True).stdout
 
     @cached_property
     def sudo_needed(self):
-        return 'sudo ' if self.running_in_docker else ''
+        return 'sudo ' if self.running_in_docker(self.node) and not self.running_in_podman(self.node) else ''
 
     def create_network(self, docker_network):
         try:
@@ -158,7 +164,8 @@ class RemoteDocker(BaseNode):
     def pull_image(node, image):
         # Login docker-hub before pull, in case node authentication is expired or not logged-in.
         docker_hub_login(remoter=node.remoter, use_sudo=node.is_docker)
-        remote_cmd = node.remoter.sudo if node.is_docker else node.remoter.run
+        remote_cmd = node.remoter.sudo if RemoteDocker.running_in_docker(
+            node) and not RemoteDocker.running_in_podman(node) else node.remoter.run
         remote_cmd(f"docker pull {image}", verbose=True, retry=3)
 
     def __enter__(self):

--- a/sdcm/utils/docker_utils.py
+++ b/sdcm/utils/docker_utils.py
@@ -498,6 +498,10 @@ def running_in_docker():
         )
 
 
+def running_in_podman():
+    return os.environ.get('container') == 'podman'
+
+
 def get_docker_bridge_gateway(remoter):
     result = remoter.run(
         "docker inspect -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}' bridge",

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -71,7 +71,7 @@ def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # pylint: di
 
     alternator_flags = f"--alternator-port {ALTERNATOR_PORT} --alternator-write-isolation=always"
     docker_version = docker_scylla_args.get(
-        'image', "scylladb/scylla-nightly:2025.2.0-dev-0.20250302.0343235aa269")
+        'image', "docker.io/scylladb/scylla-nightly:2025.2.0-dev-0.20250302.0343235aa269")
     cluster = LocalScyllaClusterDummy(params=params)
 
     ssl_dir = (Path(__file__).parent.parent / 'data_dir' / 'ssl_conf').absolute()

--- a/unit_tests/test_gemini_thread.py
+++ b/unit_tests/test_gemini_thread.py
@@ -55,7 +55,7 @@ def test_01_gemini_thread(request, docker_scylla, params):
         stress_cmd=cmd,
         test_cluster=test_cluster,
         oracle_cluster=test_cluster,
-        timeout=120,
+        timeout=360,
         params=params,
     )
 
@@ -96,7 +96,7 @@ def test_gemini_thread_without_cluster(request, docker_scylla, params):
         stress_cmd=cmd,
         test_cluster=test_cluster,
         oracle_cluster=None,
-        timeout=120,
+        timeout=360,
         params=params,
     )
 


### PR DESCRIPTION
docker base loader were using sudo for some operations, and we can
run sudo currently under podman, so we need to identify it's podman
we are using, and stop calling sudo

Tested with:
```
HYDRA_TOOL=podman bash -x ./docker/env/hydra.sh python -m pytest unit_tests/test_ycsb_thread.py::test_01_dynamodb_api
HYDRA_TOOL=podman bash -x ./docker/env/hydra.sh integration-tests --test test_ycsb_thread.py::test_01_dynamodb_api
```

Fix: https://github.com/scylladb/scylla-cluster-tests/issues/10766

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
