### PR TITLE
fix(configuration): cluster nodes amount changed in configuration files

### DIFF
--- a/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
@@ -12,7 +12,7 @@ stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=6800m -schema 'replicati
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "random", "interval": 120}']
 round_robin: true
 
-n_db_nodes: 3
+n_db_nodes: 6
 n_loaders: 4
 n_monitor_nodes: 1
 seeds_num: 2

--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -10,7 +10,7 @@ stress_read_cmd: [
     ]
 
 
-n_db_nodes: 3
+n_db_nodes: 6
 n_loaders: 3
 n_monitor_nodes: 1
 simulated_racks: 3


### PR DESCRIPTION
this commit changes cluster nodes amount from 3 to 6 to have more instances per rack becasue previous configuration caused topology operations decommission/removenode failures, because not enough nodes in rack
 to migrate tablets.
fixes: https://github.com/scylladb/scylla-cluster-tests/issues/10610

### Testing
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/eugene_test_folder/job/nodes_per_rack_configuration/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
