### PR TITLE
fix(integration): make scylla container have shared volume mounts

### DIFF
--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -80,8 +80,8 @@ def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # pylint: di
         localhost = LocalHost(user_prefix='unit_test_fake_user', test_id='unit_test_fake_test_id')
         create_ca(localhost)
 
-    extra_docker_opts = (f'-p {ALTERNATOR_PORT} -p {BaseNode.CQL_PORT} --cpus="1" -v {entryfile_path}:/entry.sh'
-                         f' -v {ssl_dir}:{SCYLLA_SSL_CONF_DIR}'
+    extra_docker_opts = (f'-p {ALTERNATOR_PORT} -p {BaseNode.CQL_PORT} --cpus="1" -v {entryfile_path}:/entry.sh:z'
+                         f' -v {ssl_dir}:{SCYLLA_SSL_CONF_DIR}:z'
                          ' --entrypoint /entry.sh')
 
     scylla = RemoteDocker(LocalNode("scylla", cluster), image_name=docker_version,


### PR DESCRIPTION
Container's -v paths are missing ':z' option, which might prevent container from starting, when SELinux is enabled.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)

Fixes #10826