### PR TITLE
fix(logcollector): omit copying a non-exisintg remote log file

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -219,6 +219,10 @@ class CommandLog(BaseLogEntity):  # pylint: disable=too-few-public-methods
         remote_logfile = LogCollector.collect_log_remotely(node=node,
                                                            cmd=self.cmd,
                                                            log_filename=os.path.join(remote_dst, self.name))
+        if not remote_logfile:
+            LOGGER.warning(
+                "Nothing to collect. Command '%s' did not prepare log file on remote host '%s'", self.cmd, node.name)
+            return None
         LogCollector.receive_log(node=node,
                                  remote_log_path=remote_logfile,
                                  local_dir=local_dst,


### PR DESCRIPTION
The CommandLog.collect method in sdcm/logcollector.py always attempts to copy a log file from a remote node, even when no log was prepared by the command. The change adds a check to ensure that the file is prepared on a remote host, before attempting to copy it.

Refs: https://github.com/scylladb/scylla-cluster-tests/issues/10716

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :yellow_circle: [pr-provision-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/52/consoleFull)
The test itself failed, but due to some other issue. The indication that this fix helps is that there is no such entries in the SCT log (also visible in jenkins build console output):
```
11:19:15  Error occured during collecting of db.crt on host: PR-provision-test-master-db-node-c19e5b97-1
11:19:15  'NoneType' object is not iterable
```
For instance the previous build [#51](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/51/consoleFull) of the same job (executed from SCT master), has these lines.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
