### PR TITLE
fix(hydra.sh): correctly parse SCT_* env var values containing `=`

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -185,19 +185,19 @@ fi
 DOCKER_ADD_HOST_ARGS=()
 
 # export all SCT_* env vars into the docker run
-SCT_OPTIONS=$(env | sed -n 's/^\(SCT_.*\)=.*/--env \1/p')
+SCT_OPTIONS=$(env | sed -n 's/^\(SCT_[^=]*\)=.*/--env \1/p')
 
 # export all PYTEST_* env vars into the docker run
-PYTEST_OPTIONS=$(env | sed -n 's/^\(PYTEST_.*\)=.*/--env \1/p')
+PYTEST_OPTIONS=$(env | sed -n 's/^\(PYTEST_[^=]*\)=.*/--env \1/p')
 
 # export all BUILD_* env vars into the docker run
-BUILD_OPTIONS=$(env | sed -n 's/^\(BUILD_.*\)=.*/--env \1/p')
+BUILD_OPTIONS=$(env | sed -n 's/^\(BUILD_[^=]*\)=.*/--env \1/p')
 
 # export all AWS_* env vars into the docker run
-AWS_OPTIONS=$(env | sed -n 's/^\(AWS_.*\)=.*/--env \1/p')
+AWS_OPTIONS=$(env | sed -n 's/^\(AWS_[^=]*\)=.*/--env \1/p')
 
 # export all JENKINS_* env vars into the docker run
-JENKINS_OPTIONS=$(env | sed -n 's/^\(JENKINS_.*\)=.*/--env \1/p')
+JENKINS_OPTIONS=$(env | sed -n 's/^\(JENKINS_[^=]*\)=.*/--env \1/p')
 
 is_podman="$($tool --help | { grep -o podman || :; })"
 docker_common_args=()


### PR DESCRIPTION
SCT_* env variables were not parsed correctly for the `docker run --env` option, when value of the variable contained `=` characters. The issue was caused by the "greedy" regex that consumed all `=` characters up to the last one, misinterpreting the actual key-value separator.

This change adjusts the regex to correctly parse the values that include `=` characters.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
  - [x] :yellow_circle: [pr-provision-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/55/)
The test failed due to some another existing issue, but parsing and setting custom value for the SCT_PREPARE_WRITE_CMD env var is working as expected now.

Previously setting custom s-b stress commands (or any env. vars with `=` characters in the value) would result in the error:
```
12:00:17  [Pipeline] { (Create Argus Test Run)
...
12:00:19  Going to run './sct.py  create-argus-test-run'...
12:00:19  invalid argument "ode=write" for "-m, --memory" flag: invalid size: 'ode=write'
```
like here: [failed pr-provision-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/49/console)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
