### PR TITLE
Revert "improvement(adaptive_timeout): lower timeout values when using tablets"

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -106,7 +106,6 @@ StartupTestEvent: NORMAL
 TestTimeoutEvent: CRITICAL
 TestFrameworkEvent: CRITICAL
 SoftTimeoutEvent: ERROR
-HardTimeoutEvent: CRITICAL
 ElasticsearchEvent: ERROR
 SpotTerminationEvent: CRITICAL
 AwsKmsEvent: ERROR

--- a/sdcm/sct_events/system.py
+++ b/sdcm/sct_events/system.py
@@ -104,12 +104,6 @@ class SoftTimeoutEvent(TestFrameworkEvent):
         super().__init__(source='SoftTimeout', severity=Severity.ERROR, trace=sys._getframe().f_back, message=message)
 
 
-class HardTimeoutEvent(TestFrameworkEvent):
-    def __init__(self, operation: str, duration: int | float, hard_timeout: int | float):
-        message = f"operation '{operation}' exceeded hard-timeout of {hard_timeout}s"
-        super().__init__(source='HardTimeout', severity=Severity.CRITICAL, trace=sys._getframe().f_back, message=message)
-
-
 class ElasticsearchEvent(InformationalEvent):
     def __init__(self, doc_id: str, error: str):
         super().__init__(severity=Severity.ERROR)

--- a/unit_tests/test_adaptive_timeouts.py
+++ b/unit_tests/test_adaptive_timeouts.py
@@ -22,7 +22,7 @@ from invoke import Result
 
 from sdcm.remote import RemoteCmdRunnerBase
 from sdcm.utils.adaptive_timeouts.load_info_store import AdaptiveTimeoutStore
-from sdcm.utils.adaptive_timeouts import Operations, adaptive_timeout, TABLETS_HARD_TIMEOUT
+from sdcm.utils.adaptive_timeouts import Operations, adaptive_timeout
 from unit_tests.test_cluster import DummyDbCluster
 
 LOGGER = logging.getLogger(__name__)
@@ -120,13 +120,6 @@ def adaptive_timeout_store():
     return store
 
 
-@pytest.fixture(autouse=True)
-def mock_tablets_feature():
-    with mock.patch('sdcm.utils.adaptive_timeouts.is_tablets_feature_enabled') as mock_feature:
-        mock_feature.return_value = False
-        yield mock_feature
-
-
 @mock.patch('sdcm.sct_events.base.SctEvent.publish_or_dump')
 def test_soft_timeout_is_raised_when_timeout_reached(publish_or_dump, fake_node, adaptive_timeout_store):
     with adaptive_timeout(operation=Operations.SOFT_TIMEOUT, node=fake_node, timeout=0.1, stats_storage=adaptive_timeout_store) as timeout:
@@ -158,33 +151,3 @@ def test_decommission_timeout_is_calculated_and_stored(publish_or_dump, fake_nod
         assert timeout == 7200  # based on data size
     publish_or_dump.assert_not_called()
     assert MemoryAdaptiveTimeoutStore().get(operation=Operations.DECOMMISSION.name, timeout_occurred=False)
-
-
-@mock.patch('sdcm.sct_events.system.SoftTimeoutEvent.publish_or_dump')
-@mock.patch('sdcm.sct_events.system.HardTimeoutEvent.publish_or_dump')
-def test_tablets_decommission_uses_predefined_timeouts(hard_timeout_mock, soft_timeout_mock,
-                                                       fake_node, adaptive_timeout_store, mock_tablets_feature):
-    mock_tablets_feature.return_value = True
-    with adaptive_timeout(operation=Operations.DECOMMISSION, node=fake_node,
-                          stats_storage=adaptive_timeout_store) as timeout:
-        assert timeout == TABLETS_HARD_TIMEOUT
-
-    soft_timeout_mock.assert_not_called()
-    hard_timeout_mock.assert_not_called()
-    metrics = adaptive_timeout_store.get(operation=Operations.DECOMMISSION.name)
-    assert metrics[0].get("tablets_enabled") is True
-
-
-@mock.patch('sdcm.sct_events.system.SoftTimeoutEvent.publish_or_dump')
-@mock.patch('sdcm.sct_events.system.HardTimeoutEvent.publish_or_dump')
-def test_tablets_new_node_uses_predefined_timeouts(hard_timeout_mock, soft_timeout_mock,
-                                                   fake_node, adaptive_timeout_store, mock_tablets_feature):
-    mock_tablets_feature.return_value = True
-    with adaptive_timeout(operation=Operations.NEW_NODE, node=fake_node, stats_storage=adaptive_timeout_store,
-                          timeout=9999) as timeout:
-        assert timeout == TABLETS_HARD_TIMEOUT
-
-    soft_timeout_mock.assert_not_called()
-    hard_timeout_mock.assert_not_called()
-    metrics = adaptive_timeout_store.get(operation=Operations.NEW_NODE.name)
-    assert metrics[0].get("tablets_enabled") is True


### PR DESCRIPTION
Reverts scylladb/scylla-cluster-tests#10786

all offline install test start failing like the following:
```
2025-05-07 05:18:47.757: (TestFrameworkEvent Severity.ERROR) period_type=one-time event_id=b0de1e16-f971-46d9-8668-786409e8c29b, source=ArtifactsTest.SetUp()
exception=[Node artifacts-al2023-jenkins-db-node-5a7249f7-1 [108.129.146.246 | 10.4.1.5]] NodeSetupFailed: argument of type 'NoneType' is not iterable
Traceback (most recent call last):
File "/tmp/jenkins/workspace/scylla-master/artifacts-offline-install/artifacts-amazon2023-nonroot-test/scylla-cluster-tests/sdcm/cluster.py", line 3961, in node_startup
cl_inst.node_startup(_node, **setup_kwargs)
File "/tmp/jenkins/workspace/scylla-master/artifacts-offline-install/artifacts-amazon2023-nonroot-test/scylla-cluster-tests/sdcm/cluster.py", line 4864, in node_startup
node.start_scylla_server(verify_up=False)
File "/tmp/jenkins/workspace/scylla-master/artifacts-offline-install/artifacts-amazon2023-nonroot-test/scylla-cluster-tests/sdcm/cluster.py", line 2496, in start_scylla_server
with adaptive_timeout(operation=Operations.START_SCYLLA, node=self, timeout=timeout):
File "/usr/local/lib/python3.10/contextlib.py", line 135, in __enter__
return next(self.gen)
File "/tmp/jenkins/workspace/scylla-master/artifacts-offline-install/artifacts-amazon2023-nonroot-test/scylla-cluster-tests/sdcm/utils/adaptive_timeouts/__init__.py", line 167, in adaptive_timeout
tablets_enabled = is_tablets_feature_enabled(node)
File "/tmp/jenkins/workspace/scylla-master/artifacts-offline-install/artifacts-amazon2023-nonroot-test/scylla-cluster-tests/sdcm/utils/features.py", line 83, in is_tablets_feature_enabled
if "tablets" in scylla_yaml.experimental_features:
TypeError: argument of type 'NoneType' is not iterable
```

not sure how `experimental_features` becomes None, but we need to handle it better, until then it's blocking master, and we need to revert