### PR TITLE
fix(test-hydra-macos): run also when hydra script change

### DIFF
--- a/.github/workflows/test-hydra-macos.yaml
+++ b/.github/workflows/test-hydra-macos.yaml
@@ -1,9 +1,12 @@
+name: Test Hydra on MacOS
+
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
     paths:
       - 'docker/env/Dockerfile'
       - 'docker/env/build_n_push.sh'
+      - 'docker/env/hydra.sh'
       - 'requirements.in'
       - 'requirements.txt'
 


### PR DESCRIPTION
change in `hydra.sh` also affect the possibility to run on MacOS and we should trigger this check when it's changes

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
