### PR TITLE
improvement(adaptive_timeout): lower timeout values when using tablets

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -106,6 +106,7 @@ StartupTestEvent: NORMAL
 TestTimeoutEvent: CRITICAL
 TestFrameworkEvent: CRITICAL
 SoftTimeoutEvent: ERROR
+HardTimeoutEvent: CRITICAL
 ElasticsearchEvent: ERROR
 SpotTerminationEvent: CRITICAL
 AwsKmsEvent: ERROR

--- a/sdcm/sct_events/system.py
+++ b/sdcm/sct_events/system.py
@@ -104,6 +104,12 @@ class SoftTimeoutEvent(TestFrameworkEvent):
         super().__init__(source='SoftTimeout', severity=Severity.ERROR, trace=sys._getframe().f_back, message=message)
 
 
+class HardTimeoutEvent(TestFrameworkEvent):
+    def __init__(self, operation: str, duration: int | float, hard_timeout: int | float):
+        message = f"operation '{operation}' exceeded hard-timeout of {hard_timeout}s"
+        super().__init__(source='HardTimeout', severity=Severity.CRITICAL, trace=sys._getframe().f_back, message=message)
+
+
 class ElasticsearchEvent(InformationalEvent):
     def __init__(self, doc_id: str, error: str):
         super().__init__(severity=Severity.ERROR)

--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -1,26 +1,53 @@
 import logging
 import time
-from contextlib import contextmanager
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager, nullcontext
 from enum import Enum
 from typing import Any
 
-from sdcm.sct_events.system import SoftTimeoutEvent
+from sdcm.sct_events.system import SoftTimeoutEvent, HardTimeoutEvent
 from sdcm.utils.adaptive_timeouts.load_info_store import NodeLoadInfoService, AdaptiveTimeoutStore, ESAdaptiveTimeoutStore, \
     NodeLoadInfoServices
+from sdcm.utils.features import is_tablets_feature_enabled
 
 LOGGER = logging.getLogger(__name__)
 
+TABLETS_SOFT_TIMEOUT = 1 * 60 * 60
+TABLETS_HARD_TIMEOUT = 3 * 60 * 60
 
-def _get_decommission_timeout(node_info_service: NodeLoadInfoService) -> tuple[int, dict[str, Any]]:
+
+def _get_decommission_timeout(node_info_service: NodeLoadInfoService,
+                              tablets_enabled: bool = False) -> tuple[tuple[int, int | None], dict[str, Any]]:
     """Calculate timeout for decommission operation based on node load info. Still experimental, used to gather historical data."""
     try:
+        node_info = node_info_service.as_dict()
+        if tablets_enabled:
+            node_info["tablets_enabled"] = True
+            return (TABLETS_SOFT_TIMEOUT, TABLETS_HARD_TIMEOUT), node_info
+
+        # For non-tablet cases, calculate based on data size
         # rough estimation from previous runs almost 9h for 1TB
-        timeout = int(node_info_service.node_data_size_mb * 0.03)
-        timeout = max(timeout, 7200)  # 2 hours minimum
-        return timeout, node_info_service.as_dict()
+        timeout = max(int(node_info_service.node_data_size_mb * 0.03), 7200)  # 2 hours minimum
+        return (timeout, None), node_info
     except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
         LOGGER.warning("Failed to calculate decommission timeout: \n%s \nDefaulting to 6 hours", exc)
-        return 6*60*60, {}
+        return (6*60*60, None), {}
+
+
+def _get_new_node_timeout(node_info_service: NodeLoadInfoService,
+                          timeout: int | float = None,
+                          tablets_enabled: bool = False,) -> tuple[tuple[int, int | None], dict[str, Any]]:
+    """Calculate timeout for adding a new node operation"""
+    try:
+        node_info = node_info_service.as_dict()
+        if tablets_enabled:
+            node_info["tablets_enabled"] = True
+            return (TABLETS_SOFT_TIMEOUT, TABLETS_HARD_TIMEOUT), node_info
+        # For non-tablet cases, use the passed timeout
+        return (timeout, None), node_info
+    except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+        LOGGER.warning("Failed to get node info for timeout: \n%s", exc)
+        return (timeout, None), {}
 
 
 def _get_soft_timeout(node_info_service: NodeLoadInfoService, timeout: int | float = None) -> tuple[int | float, dict[str, Any]]:
@@ -53,7 +80,7 @@ class Operations(Enum):
 
     maps to (function, (required arguments))"""
     DECOMMISSION = ("decommission", _get_decommission_timeout, ())
-    NEW_NODE = ("new_node", _get_soft_timeout, ("timeout",))
+    NEW_NODE = ("new_node", _get_new_node_timeout, ("timeout",))
     CREATE_INDEX = ("create_index", _get_soft_timeout, ("timeout",))
     START_SCYLLA = ("start_scylla", _get_soft_timeout, ("timeout",))
     RESTART_SCYLLA = ("restart_scylla", _get_soft_timeout, ("timeout",))
@@ -83,8 +110,52 @@ class TestInfoServices:  # pylint: disable=too-few-public-methods
         )
 
 
+class TimeoutMonitor:
+    """
+    Monitors an operation and publishes error or critical event, when soft or hard timeouts is reached, correspondingly
+    """
+
+    def __init__(self, operation: str, soft_timeout: int | float, hard_timeout: int | float = None, start_time: float | None = None):
+        self.operation = operation
+        self.soft_timeout = soft_timeout
+        self.hard_timeout = hard_timeout
+        self.start_time = start_time or time.monotonic()
+        self.soft_timeout_triggered = False
+        self.executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="timeout_monitor")
+        self.running = False
+
+    def __enter__(self):
+        if self.soft_timeout or self.hard_timeout:
+            self.running = True
+            self.executor.submit(self._monitor_timeouts)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.running = False
+        try:
+            self.executor.shutdown(wait=False, cancel_futures=True)
+        except Exception as exc:
+            LOGGER.exception("Error shutting down timeout monitor executor for %s: %s", self.operation, exc)
+
+    def _monitor_timeouts(self):
+        while self.running:
+            duration = time.monotonic() - self.start_time
+
+            if self.hard_timeout and duration > self.hard_timeout:
+                HardTimeoutEvent(
+                    operation=self.operation, duration=duration, hard_timeout=self.hard_timeout).publish_or_dump()
+                self.running = False
+                return
+            if not self.soft_timeout_triggered and self.soft_timeout and duration > self.soft_timeout:
+                SoftTimeoutEvent(
+                    operation=self.operation, duration=duration, soft_timeout=self.soft_timeout).publish_or_dump()
+                self.soft_timeout_triggered = True
+
+            time.sleep(5.0)
+
+
 @contextmanager
-def adaptive_timeout(operation: Operations, node: "BaseNode",  # noqa: F821
+def adaptive_timeout(operation: Operations, node: "BaseNode",  # noqa: PLR0914, F821
                      stats_storage: AdaptiveTimeoutStore = ESAdaptiveTimeoutStore(), **kwargs):
     """
     Calculate timeout in seconds for given operation based on node load info and return its value.
@@ -92,29 +163,47 @@ def adaptive_timeout(operation: Operations, node: "BaseNode",  # noqa: F821
     Also store node load info and timeout value in AdaptiveTimeoutStore (ES by default) for future reference.
     Use Operation.SOFT_TIMEOUT to set timeout explicitly without calculations.
     """
-    args = {}
-    for arg in operation.value[2]:
-        assert arg in kwargs, f"Argument '{arg}' is required for operation {operation.name}"
-        args[arg] = kwargs[arg]
-    timeout, load_metrics = operation.value[1](node_info_service=NodeLoadInfoServices().get(node), **args)
-    load_metrics = load_metrics | TestInfoServices.get(node)
-    start_time = time.time()
+    tablet_sensitive_op = operation in {Operations.DECOMMISSION, Operations.NEW_NODE}
+    tablets_enabled = is_tablets_feature_enabled(node)
+
+    _, timeout_func, required_arg_names = operation.value
+    args = {arg: kwargs[arg] for arg in required_arg_names}
+
+    if tablet_sensitive_op:
+        args['tablets_enabled'] = tablets_enabled
+    result = timeout_func(node_info_service=NodeLoadInfoServices().get(node), **args)
+    if tablet_sensitive_op:
+        (soft_timeout, hard_timeout), load_metrics = result
+    else:
+        soft_timeout, load_metrics = result
+        hard_timeout = None
+    load_metrics.update(TestInfoServices.get(node))
+
+    start_time = time.monotonic()
     timeout_occurred = False
+    monitor_ctx = (TimeoutMonitor(operation.name, soft_timeout, hard_timeout, start_time=start_time)
+                   if tablet_sensitive_op and tablets_enabled and hard_timeout
+                   else nullcontext())
+
     try:
-        yield timeout
+        with monitor_ctx:
+            yield hard_timeout or soft_timeout
     except Exception as exc:  # pylint: disable=broad-except
         exc_name = exc.__class__.__name__
         if "timeout" in exc_name.lower() or "timed out" in str(exc):
             timeout_occurred = True
         raise
     finally:
-        duration = time.time() - start_time
-        if duration > timeout:
+        duration = time.monotonic() - start_time
+        soft_timeout_exceeded = soft_timeout and duration > soft_timeout
+        if soft_timeout_exceeded:
             timeout_occurred = True
-            SoftTimeoutEvent(operation=operation.name, soft_timeout=timeout, duration=duration).publish_or_dump()
+        if timeout_occurred and not (tablet_sensitive_op and tablets_enabled):
+            SoftTimeoutEvent(operation=operation.name, soft_timeout=soft_timeout, duration=duration).publish_or_dump()
+
         try:
             if load_metrics:
                 stats_storage.store(metrics=load_metrics, operation=operation.name, duration=duration,
-                                    timeout=timeout, timeout_occurred=timeout_occurred)
+                                    timeout=soft_timeout, timeout_occurred=timeout_occurred)
         except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
             LOGGER.warning("Failed to store adaptive timeout stats: \n%s", exc)

--- a/sdcm/utils/features.py
+++ b/sdcm/utils/features.py
@@ -80,11 +80,12 @@ def is_tablets_feature_enabled(node) -> bool:
     """
     with node.remote_scylla_yaml() as scylla_yaml:
         # for backward compatibility of 2024.1 and earlier
-        if "tablets" in scylla_yaml.experimental_features:
+        scylla_conf = scylla_yaml.dict()
+        if "tablets" in (scylla_conf.get("experimental_features") or []):
             return True
-        if scylla_yaml.dict().get("enable_tablets"):
+        if scylla_conf.get("enable_tablets"):
             return True
-        if scylla_yaml.dict().get("tablets_mode_for_new_keyspaces") in ["enabled", "enforced"]:
+        if scylla_conf.get("tablets_mode_for_new_keyspaces") in ["enabled", "enforced"]:
             return True
 
     return False

--- a/unit_tests/test_adaptive_timeouts.py
+++ b/unit_tests/test_adaptive_timeouts.py
@@ -22,7 +22,7 @@ from invoke import Result
 
 from sdcm.remote import RemoteCmdRunnerBase
 from sdcm.utils.adaptive_timeouts.load_info_store import AdaptiveTimeoutStore
-from sdcm.utils.adaptive_timeouts import Operations, adaptive_timeout
+from sdcm.utils.adaptive_timeouts import Operations, adaptive_timeout, TABLETS_HARD_TIMEOUT
 from unit_tests.test_cluster import DummyDbCluster
 
 LOGGER = logging.getLogger(__name__)
@@ -120,6 +120,13 @@ def adaptive_timeout_store():
     return store
 
 
+@pytest.fixture(autouse=True)
+def mock_tablets_feature():
+    with mock.patch('sdcm.utils.adaptive_timeouts.is_tablets_feature_enabled') as mock_feature:
+        mock_feature.return_value = False
+        yield mock_feature
+
+
 @mock.patch('sdcm.sct_events.base.SctEvent.publish_or_dump')
 def test_soft_timeout_is_raised_when_timeout_reached(publish_or_dump, fake_node, adaptive_timeout_store):
     with adaptive_timeout(operation=Operations.SOFT_TIMEOUT, node=fake_node, timeout=0.1, stats_storage=adaptive_timeout_store) as timeout:
@@ -151,3 +158,33 @@ def test_decommission_timeout_is_calculated_and_stored(publish_or_dump, fake_nod
         assert timeout == 7200  # based on data size
     publish_or_dump.assert_not_called()
     assert MemoryAdaptiveTimeoutStore().get(operation=Operations.DECOMMISSION.name, timeout_occurred=False)
+
+
+@mock.patch('sdcm.sct_events.system.SoftTimeoutEvent.publish_or_dump')
+@mock.patch('sdcm.sct_events.system.HardTimeoutEvent.publish_or_dump')
+def test_tablets_decommission_uses_predefined_timeouts(hard_timeout_mock, soft_timeout_mock,
+                                                       fake_node, adaptive_timeout_store, mock_tablets_feature):
+    mock_tablets_feature.return_value = True
+    with adaptive_timeout(operation=Operations.DECOMMISSION, node=fake_node,
+                          stats_storage=adaptive_timeout_store) as timeout:
+        assert timeout == TABLETS_HARD_TIMEOUT
+
+    soft_timeout_mock.assert_not_called()
+    hard_timeout_mock.assert_not_called()
+    metrics = adaptive_timeout_store.get(operation=Operations.DECOMMISSION.name)
+    assert metrics[0].get("tablets_enabled") is True
+
+
+@mock.patch('sdcm.sct_events.system.SoftTimeoutEvent.publish_or_dump')
+@mock.patch('sdcm.sct_events.system.HardTimeoutEvent.publish_or_dump')
+def test_tablets_new_node_uses_predefined_timeouts(hard_timeout_mock, soft_timeout_mock,
+                                                   fake_node, adaptive_timeout_store, mock_tablets_feature):
+    mock_tablets_feature.return_value = True
+    with adaptive_timeout(operation=Operations.NEW_NODE, node=fake_node, stats_storage=adaptive_timeout_store,
+                          timeout=9999) as timeout:
+        assert timeout == TABLETS_HARD_TIMEOUT
+
+    soft_timeout_mock.assert_not_called()
+    hard_timeout_mock.assert_not_called()
+    metrics = adaptive_timeout_store.get(operation=Operations.NEW_NODE.name)
+    assert metrics[0].get("tablets_enabled") is True


### PR DESCRIPTION
The change adds ability to set low adaptive timeout values for selected operations (like decommission and add node), when using tablets, with added behaviour:
- publish error event when operation takes more than 1 hour
- publish critical event (which stops the test) when operation takes more than 3 hours

The change also updates `sdcm/utils/features.py::is_tablets_feature_enabled` helper, to have a fallback value for `experimental_features` attribute in scylla_yaml object in SCT, in case the attribute holds None value for some reason. This helps to avoid problems like:
```
if "tablets" in scylla_yaml.experimental_features:
TypeError: argument of type 'NoneType' is not iterable
```
that had us to revert the previous attempt to introduce the feature of hard adaptive timeouts.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [artifacts-ubuntu2004-nonroot](https://jenkins.scylladb.com/job/scylla-master/job/reproducers/job/artifacts-ubuntu2004-nonroot-test/3/)
This test verifies that offline install artifacts tests are OK with the changes in adaptive_timeout.

And the regression check for changes in adaptive_timeout itself:
for small soft/hard timeouts like
```
-TABLETS_SOFT_TIMEOUT = 1 * 60 * 60
-TABLETS_HARD_TIMEOUT = 3 * 60 * 60
+# TABLETS_SOFT_TIMEOUT = 1 * 60 * 60
+# TABLETS_HARD_TIMEOUT = 3 * 60 * 60
+TABLETS_SOFT_TIMEOUT = 180
+TABLETS_HARD_TIMEOUT = 240
```
the test executed locally fails as expected:
```
----------------------------------------------------------------------
sdcm.sct_events.system.TestResultEvent: ================================= TEST RESULTS =================================

----- LAST CRITICAL EVENT ----------------------------------------------------
2025-05-07 14:51:18.521: (HardTimeoutEvent Severity.CRITICAL) period_type=one-time event_id=562d3490-81b1-4800-aea9-e392c884a674 during_nemesis=NodetoolDecommission, source=HardTimeout message=operation 'DECOMMISSION' exceeded hard-timeout of 240s
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
