### PR TITLE
fix(renovate): stop doing on big PR for all docker chanegs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,10 @@
   "extends": [
     "config:recommended"
   ],
+  "ignorePresets": [
+    "group:monorepos",
+    "group:recommended"
+  ],
   "schedule": [
     "every weekend"
   ],
@@ -52,7 +56,7 @@
       "enabled": true
     },
     {
-      "groupName": "All Helm values files",
+      "groupName": null,
       "matchManagers": [
         "helm-values"
       ],


### PR DESCRIPTION
we never want to have all of the stress tools get updates in the same PRs each one has it's own review process, and be be reverted/backported on it's own flow.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
