### PR TITLE
feature(adaptive_timeouts): report results to Argus

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -312,3 +312,5 @@ mgmt_snapshots_preparer_params:
   num_of_rows: ''
   sequence_start: ''
   sequence_end: ''
+
+adaptive_timeout_store_metrics: true

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -3604,3 +3604,12 @@ Workload name, can be: write|read|mixed|unset.Used for e.g. latency_calculator_d
 **default:** N/A
 
 **type:** str (appendable)
+
+
+## **adaptive_timeout_store_metrics** / SCT_ADAPTIVE_TIMEOUT_STORE_METRICS
+
+Store adaptive timeout metrics in Argus. Disabled for performance tests only.
+
+**default:** True
+
+**type:** boolean

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2510,8 +2510,7 @@ class BaseNode(AutoSshContainerMixin):
         verify_up_timeout = verify_up_timeout or self.verify_up_timeout
         if verify_down:
             self.wait_db_down(timeout=timeout)
-        with adaptive_timeout(operation=Operations.START_SCYLLA, node=self, timeout=timeout):
-            self.start_service(service_name='scylla-server', timeout=timeout * 4)
+        self.start_service(service_name='scylla-server', timeout=timeout * 4)
         if verify_up:
             self.wait_db_up(timeout=verify_up_timeout)
 
@@ -2573,7 +2572,7 @@ class BaseNode(AutoSshContainerMixin):
         verify_up_timeout = verify_up_timeout or self.verify_up_timeout
         if verify_up_before:
             self.wait_db_up(timeout=verify_up_timeout)
-        with adaptive_timeout(operation=Operations.START_SCYLLA, node=self, timeout=timeout):
+        with adaptive_timeout(operation=Operations.RESTART_SCYLLA, node=self, timeout=timeout):
             self.restart_service(service_name='scylla-server', timeout=timeout * 2)
         if verify_up_after:
             self.wait_db_up(timeout=verify_up_timeout)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1778,6 +1778,9 @@ class SCTConfiguration(dict):
              help="Workload name, can be: write|read|mixed|unset."
                   "Used for e.g. latency_calculator_decorator (use with 'use_hdrhistogram' set to true)."
                   "If unset, workload is taken from test name."),
+
+        dict(name="adaptive_timeout_store_metrics", env="SCT_ADAPTIVE_TIMEOUT_STORE_METRICS", type=boolean,
+             help="Store adaptive timeout metrics in Argus. Disabled for performance tests only."),
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',

--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -170,9 +170,9 @@ def adaptive_timeout(operation: Operations, node: "BaseNode",  # noqa: PLR0914, 
     args = {arg: kwargs[arg] for arg in required_arg_names}
     store_metrics = node.parent_cluster.params.get("adaptive_timeout_store_metrics")
     if store_metrics:
-        metrics = {}
-    else:
         metrics = NodeLoadInfoServices().get(node)
+    else:
+        metrics = {}
     if tablet_sensitive_op:
         args['tablets_enabled'] = tablets_enabled
     result = timeout_func(node_info_service=metrics, **args)

--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Any
 
 from sdcm.sct_events.system import SoftTimeoutEvent, HardTimeoutEvent
-from sdcm.utils.adaptive_timeouts.load_info_store import NodeLoadInfoService, AdaptiveTimeoutStore, ESAdaptiveTimeoutStore, \
+from sdcm.utils.adaptive_timeouts.load_info_store import NodeLoadInfoService, AdaptiveTimeoutStore, ArgusAdaptiveTimeoutStore, \
     NodeLoadInfoServices
 from sdcm.utils.features import is_tablets_feature_enabled
 
@@ -156,7 +156,7 @@ class TimeoutMonitor:
 
 @contextmanager
 def adaptive_timeout(operation: Operations, node: "BaseNode",  # noqa: PLR0914, F821
-                     stats_storage: AdaptiveTimeoutStore = ESAdaptiveTimeoutStore(), **kwargs):
+                     stats_storage: AdaptiveTimeoutStore = ArgusAdaptiveTimeoutStore(), **kwargs):
     """
     Calculate timeout in seconds for given operation based on node load info and return its value.
     Upon exit, verify if timeout occurred and publish SoftTimeoutEvent if happened.
@@ -206,4 +206,4 @@ def adaptive_timeout(operation: Operations, node: "BaseNode",  # noqa: PLR0914, 
                 stats_storage.store(metrics=load_metrics, operation=operation.name, duration=duration,
                                     timeout=soft_timeout, timeout_occurred=timeout_occurred)
         except Exception as exc:  # noqa: BLE001
-            LOGGER.warning("Failed to store adaptive timeout stats: \n%s", exc)
+            LOGGER.warning("Failed to store adaptive timeout stats: \n%s", exc, exc_info=True)

--- a/test-cases/performance/perf-regression-2mv.yaml
+++ b/test-cases/performance/perf-regression-2mv.yaml
@@ -22,3 +22,5 @@ user_prefix: 'perf-regression-mv'
 store_perf_results: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 backtrace_decoding: false
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml
@@ -51,3 +51,5 @@ backtrace_decoding: false
 
 store_perf_results: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'alternator@scylladb.com']
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
@@ -53,3 +53,5 @@ space_node_threshold: 644245094
 
 store_perf_results: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'alternator@scylladb.com']
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-latency-125gb.yaml
+++ b/test-cases/performance/perf-regression-latency-125gb.yaml
@@ -27,3 +27,5 @@ store_perf_results: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 custom_es_index: 'performancestatsv2'
 use_hdrhistogram: true
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-latency-1TB.yaml
+++ b/test-cases/performance/perf-regression-latency-1TB.yaml
@@ -31,3 +31,5 @@ use_hdrhistogram: true
 use_placement_group: true
 use_capacity_reservation: true
 nemesis_add_node_cnt: 0
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
@@ -31,3 +31,5 @@ store_perf_results: true
 email_recipients: ["scylla-perf-results@scylladb.com"]
 use_prepared_loaders: true
 use_hdrhistogram: true
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-latency-500gb-30min.yaml
@@ -29,3 +29,5 @@ append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --
 store_perf_results: true
 use_mgmt: false
 email_recipients: ['scylla-perf-results@scylladb.com']
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-latency-650gb-elasticity.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-elasticity.yaml
@@ -37,3 +37,5 @@ parallel_node_operations: true
 cluster_health_check: false
 stress_image:
   cassandra-stress: 'scylladb/cassandra-stress:3.17.3'
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml
@@ -33,3 +33,5 @@ use_prepared_loaders: true
 use_hdrhistogram: true
 email_subject_postfix: 'latency during grow-shrink'
 hinted_handoff: 'enabled'
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-latency-650gb-upgrade.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-upgrade.yaml
@@ -35,3 +35,5 @@ email_subject_postfix: 'latency during upgrades'
 cluster_health_check: false
 stress_image:
   cassandra-stress: 'scylladb/cassandra-stress:3.17.5'
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
@@ -38,3 +38,5 @@ cluster_health_check: false
 stress_image:
   cassandra-stress: 'scylladb/cassandra-stress:3.17.5'
 hinted_handoff: 'enabled'
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-latency-cdc-mixed-poll-batching.yaml
+++ b/test-cases/performance/perf-regression-latency-cdc-mixed-poll-batching.yaml
@@ -25,3 +25,5 @@ append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --
 
 email_recipients: ['scylla-perf-results@scylladb.com', 'cdc@scylladb.com']
 backtrace_decoding: false
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-latency-k8s-multitenant.yaml
+++ b/test-cases/performance/perf-regression-latency-k8s-multitenant.yaml
@@ -29,3 +29,5 @@ round_robin: true
 store_perf_results: true
 use_mgmt: false
 email_recipients: ['scylla-perf-results@scylladb.com']
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-latency-lwt-big.yaml
+++ b/test-cases/performance/perf-regression-latency-lwt-big.yaml
@@ -56,3 +56,5 @@ backtrace_decoding: false
 store_perf_results: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'lwt@scylladb.com']
 email_subject_postfix: 'disk-wise(big dataset)'
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-latency-lwt-small.yaml
+++ b/test-cases/performance/perf-regression-latency-lwt-small.yaml
@@ -56,3 +56,5 @@ backtrace_decoding: false
 store_perf_results: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'lwt@scylladb.com']
 email_subject_postfix: 'memory-wise(small dataset)'
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-latency-mv-read-concurrency.yaml
+++ b/test-cases/performance/perf-regression-latency-mv-read-concurrency.yaml
@@ -27,3 +27,5 @@ store_perf_results: true
 use_prepared_loaders: true
 use_hdrhistogram: true
 custom_es_index: 'mv-overloading-latency-read'
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-predefined-throughput-steps.yaml
+++ b/test-cases/performance/perf-regression-predefined-throughput-steps.yaml
@@ -66,3 +66,5 @@ use_placement_group: true
 use_prepared_loaders: false
 stress_image:
   cassandra-stress: 'scylladb/cassandra-stress:3.17.5'
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-throughput-125gb.yaml
+++ b/test-cases/performance/perf-regression-throughput-125gb.yaml
@@ -33,3 +33,5 @@ email_subject_postfix: 'disk and cache'
 custom_es_index: 'performancestatsv2'
 
 use_hdrhistogram: true
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-throughput-baremetal-5gb.yaml
+++ b/test-cases/performance/perf-regression-throughput-baremetal-5gb.yaml
@@ -50,3 +50,5 @@ email_subject_postfix: 'disk and cache'
 custom_es_index: 'performancestatsv2'
 
 use_hdrhistogram: true
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-throughput-cdc-mixed-poll-batching.yaml
+++ b/test-cases/performance/perf-regression-throughput-cdc-mixed-poll-batching.yaml
@@ -28,3 +28,5 @@ experimental_features:
 
 email_recipients: ['scylla-perf-results@scylladb.com', 'cdc@scylladb.com']
 backtrace_decoding: false
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-throughput-lwt-big.yaml
+++ b/test-cases/performance/perf-regression-throughput-lwt-big.yaml
@@ -58,3 +58,5 @@ backtrace_decoding: false
 store_perf_results: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'lwt@scylladb.com']
 email_subject_postfix: 'disk-wise(big dataset)'
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-throughput-lwt-small.yaml
+++ b/test-cases/performance/perf-regression-throughput-lwt-small.yaml
@@ -57,3 +57,5 @@ backtrace_decoding: false
 store_perf_results: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'lwt@scylladb.com']
 email_subject_postfix: 'memory-wise(small dataset)'
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-user-profiles.yaml
+++ b/test-cases/performance/perf-regression-user-profiles.yaml
@@ -37,3 +37,5 @@ append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --
 backtrace_decoding: false
 
 email_recipients: ['scylla-perf-results@scylladb.com']
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-write-latency-cdc.yaml
+++ b/test-cases/performance/perf-regression-write-latency-cdc.yaml
@@ -18,3 +18,5 @@ append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --
 
 email_recipients: ['scylla-perf-results@scylladb.com', 'cdc@scylladb.com ']
 backtrace_decoding: false
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-write-throughput-cdc.yaml
+++ b/test-cases/performance/perf-regression-write-throughput-cdc.yaml
@@ -21,3 +21,5 @@ experimental_features:
 
 email_recipients: ['scylla-perf-results@scylladb.com', 'cdc@scylladb.com ']
 backtrace_decoding: false
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression.100threads.100M-keys-z3-enterprise.yaml
+++ b/test-cases/performance/perf-regression.100threads.100M-keys-z3-enterprise.yaml
@@ -60,3 +60,5 @@ use_hdrhistogram: true
 
 append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
 gce_project: 'gcp-local-ssd-latency'
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression.100threads.30M-keys-i4i-enterprise.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys-i4i-enterprise.yaml
@@ -44,3 +44,5 @@ custom_es_index: 'performancestatsv2'
 use_hdrhistogram: true
 
 append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
@@ -49,3 +49,5 @@ append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --
 use_placement_group: true
 use_capacity_reservation: true
 nemesis_add_node_cnt: 0
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -43,3 +43,5 @@ custom_es_index: 'performancestatsv2'
 use_hdrhistogram: true
 
 append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-row-level-repair-1TB.yaml
+++ b/test-cases/performance/perf-row-level-repair-1TB.yaml
@@ -28,3 +28,5 @@ store_perf_results: true
 backtrace_decoding: false
 
 email_recipients: ['scylla-perf-results@scylladb.com']
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-search-best-throughput-config.yaml
+++ b/test-cases/performance/perf-search-best-throughput-config.yaml
@@ -44,3 +44,5 @@ email_recipients: ['scylla-perf-results@scylladb.com']
 store_perf_results: false
 
 enable_argus: false
+
+adaptive_timeout_store_metrics: false

--- a/test-cases/performance/ycsb/perf-base.yaml
+++ b/test-cases/performance/ycsb/perf-base.yaml
@@ -58,3 +58,5 @@ authorizer: 'CassandraAuthorizer'
 user_prefix: 'perf-ycsb-latency-nemesis'
 email_subject_postfix: 'YCSB workloads'
 store_perf_results: true
+
+adaptive_timeout_store_metrics: false

--- a/unit_tests/test_adaptive_timeouts.py
+++ b/unit_tests/test_adaptive_timeouts.py
@@ -20,6 +20,7 @@ import pytest
 from invoke import Result
 
 from sdcm.remote import RemoteCmdRunnerBase
+from sdcm.sct_config import SCTConfiguration
 from sdcm.utils.adaptive_timeouts.load_info_store import AdaptiveTimeoutStore
 from sdcm.utils.adaptive_timeouts import Operations, adaptive_timeout, TABLETS_HARD_TIMEOUT
 from unit_tests.test_cluster import DummyDbCluster
@@ -33,7 +34,9 @@ class FakeNode():
         self.name = name
         self.remoter = remoter
         self.scylla_version_detailed = "2042.1.12-0.20220620.e23889f17"
-        self.parent_cluster = DummyDbCluster(nodes=[self], params={'n_db_nodes': 1})
+        params = SCTConfiguration()
+        params['n_db_nodes'] = 1
+        self.parent_cluster = DummyDbCluster(nodes=[self], params=params)
 
 
 class MemoryAdaptiveTimeoutStore(AdaptiveTimeoutStore):


### PR DESCRIPTION
since we are ditching EleasticSearch, this commit introduces a way to report the duration and timeouts used in operations

this only implements the option to send out the data, we don't yet have a client API to retrive it from Argus.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟡 https://argus.scylladb.com/tests/scylla-cluster-tests/68f900fd-a653-4faa-90b0-bf32b15b1fbd/results
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/122/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/123/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/124/
- [x] 🟢 https://argus.scylladb.com/tests/scylla-cluster-tests/05c86a0e-1789-46c8-85aa-7dd9f36b2afc/results
 - [x] 🟢  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/131/
 
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### TODOs
- [x] - drop the ESStore
- [x] - decide about metrics that we want to save
- [x] - hide the extra metrics when https://github.com/scylladb/argus/issues/690 is ready
### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
