### PR TITLE
Check limited voters feature after upgrade

### DIFF
--- a/sdcm/exceptions.py
+++ b/sdcm/exceptions.py
@@ -95,3 +95,7 @@ class NemesisStressFailure(Exception):
 
 class BannedQueryExecUnexpectedSuccess(Exception):
     """Exception when query executed successfully on banned node"""
+
+
+class Group0LimitedVotersFeatureNotEnableOnNodes(Exception):
+    """Raise if feature group0_limited_voters is enabled on nodes"""

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -885,7 +885,8 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         for node in self.db_cluster.nodes:
             result = wait_for(func=self.db_cluster.is_features_enabled_on_node,
                               timeout=60,
-                              step=f"Check feature enabled on node {node.name}",
+                              step=1,
+                              text=f"Check feature enabled on node {node.name}",
                               throw_exc=False,
                               feature_list=[CONSISTENT_TOPOLOGY_CHANGES_FEATURE],
                               node=node)


### PR DESCRIPTION
New feature limited voters enabled after all nodes upgrade to >=2025.2. After it was enabled, cluster can have not more than 5 raft voters if cluster size > 5 nodes. Adding new method to validate that feature is enabled on all nodes after upgrade


Also raft topology upgrade procedure was fixed. Previously, `wait_for` function failed with error:
```
< t:2025-05-05 10:46:36,064 f:wait.py         l:83   c:sdcm.wait            p:ERROR > last error: ValueError("could not convert string to float: 'Check feature enabled on node rolling-upgrade-artifacts--ubuntu-n-db-node-621570fc-0-2'")
< t:2025-05-05 10:46:36,067 f:wait.py         l:79   c:sdcm.wait            p:ERROR > Wait for: is_features_enabled_on_node: timeout - 60 seconds - expired
< t:2025-05-05 10:46:36,067 f:wait.py         l:83   c:sdcm.wait            p:ERROR > last error: ValueError("could not convert string to float: 'Check feature enabled on node rolling-upgrade-artifacts--ubuntu-n-db-node-621570fc-0-3'")
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [Upgrade from 2025.1->2025.2(test_generic_cluster_upgrade)](https://argus.scylladb.com/tests/scylla-cluster-tests/2a062184-2e6d-4fb5-a8df-7018bd76b165) Upgrade passed. Only error messages related to seastar_memory - oversized allocation
- [Upgrade from 2025.1 -> 2025.2(test_rolling_upgrade)](https://argus.scylladb.com/tests/scylla-cluster-tests/27735d15-f999-4566-a955-674bcc779b24) also passed, only error messages related to   seastar_memory - oversized allocation

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
