### PR TITLE
fix(decode_backtrace): handle non-exist debug info better

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1597,7 +1597,7 @@ class BaseNode(AutoSshContainerMixin):
                 pass
             except Exception as details:  # noqa: BLE001
                 self.log.error("failed to decode backtrace %s", details)
-                if "is closed" in details:
+                if "is closed" in str(details):
                     break
             finally:
                 if event:


### PR DESCRIPTION
scylladb/scylla-cluster-tests#10646 introduced some unsafe code

the when debug info doesn't it fail like the following:
```
20:58:29      raise Exception("Couldn't find scylla debug information")
20:58:29  Exception: Couldn't find scylla debug information
20:58:29
20:58:29  During handling of the above exception, another exception occurred:
20:58:29
20:58:29  Traceback (most recent call last):
20:58:29    File "/usr/local/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
20:58:29      self.run()
20:58:29    File "/usr/local/lib/python3.10/threading.py", line 953, in run
20:58:29      self._target(*self._args, **self._kwargs)
20:58:29    File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 1600, in decode_backtrace
20:58:29      if "is closed" in details:
20:58:29  TypeError: argument of type 'Exception' is not iterable
```

the mistake was to treat Exception as string, with turn it into a string

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
