### PR TITLE
feature(gemini): adjust default Gemini flags

### DIFF
--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -96,8 +96,8 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
             "min-clustering-keys": 2,
             "partition-key-distribution": "normal",  # Distribution for hitting the partition
             # These two are used to control the memory usage of Gemini
-            "token-range-slices": 512,  # Number of partitions
-            "partition-key-buffer-reuse-size": 100,  # Internal Channel Size per parittion value generation
+            "token-range-slices": 10000,  # Number of partitions
+            "partition-key-buffer-reuse-size": 125,  # Internal Channel Size per parittion value generation
             "statement-log-file-compression": "zstd",
         }
 
@@ -108,7 +108,7 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
     def _generate_gemini_command(self):
         seed = self.params.get("gemini_seed") or random.randint(1, 100)
         table_options = self.params.get("gemini_table_options")
-        log_statements = self.params.get("gemini_log_cql_statements") or False
+        log_statements = self.params.get("gemini_log_cql_statements") or True
         test_nodes = ",".join(self.test_cluster.get_node_cql_ips())
 
         cmd = f"gemini \

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -443,6 +443,9 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
 
     def check_regression(self, test_id, data, is_gce=False, node_benchmarks=None, email_subject_postfix=None):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements, too-many-arguments  # noqa: PLR0914
         doc = self.get_test_by_id(test_id)
+        if not doc:
+            raise ValueError(f'Cannot find test by id: {test_id}!')
+
         full_test_name = doc["_source"]["test_details"]["test_name"]
         test_name = full_test_name.split('.')[-1]  # Example: longevity_test.LongevityTest.test_custom_time
         test_start_time = datetime.utcfromtimestamp(float(doc["_source"]["test_details"]["start_time"]))

--- a/unit_tests/test_gemini_thread.py
+++ b/unit_tests/test_gemini_thread.py
@@ -88,8 +88,8 @@ def test_01_gemini_thread(request, docker_scylla, params):
         "--max-clustering-keys=4",
         "--min-clustering-keys=2",
         "--partition-key-distribution=normal",
-        "--token-range-slices=512",
-        "--partition-key-buffer-reuse-size=100",
+        "--token-range-slices=10000",
+        "--partition-key-buffer-reuse-size=125",
         "--statement-log-file-compression=zstd",
     ]
 


### PR DESCRIPTION
1. Set number of partitions to 10_000 by default
2. Set internal values buffer size `token-range-slices` to 125
3. Enable logging for CQL statements executed on Test and Oracle cluster

Increasing the numbner of parititions and `token-range-slices` produces
greater throughput for gemini, current stats are really bad, 2k writes/s
and 200 reads/s, with this increase it, writes will go to 15k/s and
reads to 4k/s.
This is fine for now, until further gemini optimizations are done.

Enabling CQL statement logging, allows us to trace what gemini is doing
and will help us investigate issues found when working with the tool.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] https://argus.scylladb.com/tests/scylla-cluster-tests/c14b6056-798d-4bb3-befd-0e041d7b6b61

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
