### PR TITLE
fix(syslogng): use backoff timeout in retries in installation sequence

### DIFF
--- a/sdcm/provision/common/configuration_script.py
+++ b/sdcm/provision/common/configuration_script.py
@@ -18,6 +18,7 @@ from sdcm.provision.common.builders import AttrBuilder
 from sdcm.provision.common.utils import (
     configure_sshd_script,
     restart_sshd_service,
+    configure_backoff_timeout,
     update_repo_cache,
     install_syslogng_service,
     configure_syslogng_target_script,
@@ -89,6 +90,7 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
         # 5. Make sure that whenever you use "cat <<EOF >>/file", make sure that EOF has no spaces in front of it
         script = ''
 
+        script += configure_backoff_timeout()
         if self.logs_transport == 'syslog-ng':
             script += configure_syslogng_destination_conf(
                 host=self.syslog_host_port[0],

--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -80,6 +80,23 @@ def restart_syslogng_service():
     return "systemctl restart syslog-ng  || true\n"
 
 
+def configure_backoff_timeout():
+    return dedent("""\
+        backoff() {
+            local attempt=$1
+            local max_timeout=${2:-60}
+            local base=${3:-5}
+            local timeout
+
+            timeout=$((attempt * base))
+            if [ $timeout -gt $max_timeout ]; then
+                timeout=$max_timeout
+            fi
+            echo $timeout
+        }
+    """)
+
+
 def update_repo_cache():
     return dedent("""\
         if yum --help 2>/dev/null 1>&2 ; then
@@ -95,7 +112,7 @@ def update_repo_cache():
                 if apt-get -y update; then
                     break
                 fi
-                sleep 0.5
+                sleep $(backoff $n)
             done
         else
             echo "Unsupported distro"
@@ -112,17 +129,18 @@ def install_syslogng_service():
                 yum reinstall -y syslog-ng
                 SYSLOG_NG_INSTALLED=1
             else
-                for n in 1 2 3; do # cloud-init is running it with set +o braceexpand
+                for n in 1 2 3 4 5 6 7 8 9; do # cloud-init is running it with set +o braceexpand
                     if yum install -y epel-release; then
                         break
                     fi
-                    sleep 1
+                    sleep $(backoff $n)
                 done
 
                 for n in 1 2 3 4 5 6 7 8 9; do # cloud-init is running it with set +o braceexpand
                     if yum install -y --downloadonly syslog-ng; then
                         break
                     fi
+                    sleep $(backoff $n)
                 done
 
                 for n in 1 2 3; do # cloud-init is running it with set +o braceexpand
@@ -130,7 +148,7 @@ def install_syslogng_service():
                         SYSLOG_NG_INSTALLED=1
                         break
                     fi
-                    sleep 10
+                    sleep $(backoff $n)
                 done
             fi
         elif apt-get --help 2>/dev/null 1>&2 ; then
@@ -147,6 +165,7 @@ def install_syslogng_service():
                         SYSLOG_NG_INSTALLED=1
                         break
                     fi
+                    sleep $(backoff $n)
                 done
             fi
         else


### PR DESCRIPTION
Update the syslogng installation sequence, replacing hardcoded sleep command arguments with values selected as per simple backoff pattern. This should improve resilience against temporary network or mirror issues.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] to check retry (and the backoff timeout itself) the test was executed locally with this small modification to trigger couple retries:
```
-                    if yum install -y epel-release; then
+                    if [ $n -eq 3 ] && yum install -y epel-release; then
```
the timeout was executed successfully for those 2 iterations, with the expected backoff values:
```
< t:2025-05-13 19:26:28,309 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: + rpm -q syslog-ng
< t:2025-05-13 19:26:28,309 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: + for n in 1 2 3 4 5 6 7 8 9
< t:2025-05-13 19:26:28,309 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: + '[' 1 -eq 3 ']'
< t:2025-05-13 19:26:28,309 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: ++ backoff 1
< t:2025-05-13 19:26:28,309 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: ++ local attempt=1
< t:2025-05-13 19:26:28,309 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: ++ local max_timeout=60
< t:2025-05-13 19:26:28,309 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: ++ local base=5
< t:2025-05-13 19:26:28,309 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: ++ local timeout
< t:2025-05-13 19:26:28,309 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: ++ timeout=5
< t:2025-05-13 19:26:28,309 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: ++ '[' 5 -gt 60 ']'
< t:2025-05-13 19:26:28,309 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: ++ echo 5
< t:2025-05-13 19:26:28,309 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: + sleep 5
< t:2025-05-13 19:26:33,315 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: + for n in 1 2 3 4 5 6 7 8 9
< t:2025-05-13 19:26:33,315 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: + '[' 2 -eq 3 ']'
< t:2025-05-13 19:26:33,315 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: ++ backoff 2
< t:2025-05-13 19:26:33,315 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: ++ local attempt=2
< t:2025-05-13 19:26:33,315 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: ++ local max_timeout=60
< t:2025-05-13 19:26:33,315 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: ++ local base=5
< t:2025-05-13 19:26:33,315 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: ++ local timeout
< t:2025-05-13 19:26:33,315 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: ++ timeout=10
< t:2025-05-13 19:26:33,315 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: ++ '[' 10 -gt 60 ']'
< t:2025-05-13 19:26:33,315 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: ++ echo 10
< t:2025-05-13 19:26:33,316 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: + sleep 10
< t:2025-05-13 19:26:43,327 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: + for n in 1 2 3 4 5 6 7 8 9
< t:2025-05-13 19:26:43,327 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: + '[' 3 -eq 3 ']'
< t:2025-05-13 19:26:43,327 f:base.py         l:231  c:RemoteLibSSH2CmdRunner p:DEBUG > <34.23.101.75>: + yum install -y epel-release
```

A regression check to ensure that the change didn't affect normal flow of syslogng installation sequence:
:green_circle: [artifacts-centos9-arm-test](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/artifacts-centos9-arm-test/9/)
:green_circle: [artifacts-ubuntu2204-test](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/artifacts-ubuntu2204-test/8/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
