### PR TITLE
fix(logcollector): ignore changes in log files when creating archive

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -647,7 +647,7 @@ class LogCollector:
         archive_dir, log_filename = os.path.split(log_filename)
         archive_name = os.path.join(archive_dir, archive_name or log_filename) + ".tar.zst"
         node.install_package('zstd', ignore_status=True)
-        if not node.remoter.run(f"tar --zstd -cf '{archive_name}' -C '{archive_dir}' '{log_filename}'", ignore_status=True).ok:
+        if not node.remoter.run(f"tar --zstd --warning=no-file-changed -cf '{archive_name}' -C '{archive_dir}' '{log_filename}'", ignore_status=True).ok:
             LOGGER.error("Unable to archive log `%s' to `%s'", log_filename, archive_name)
             return None
         if not check_archive(node.remoter, archive_name):
@@ -729,7 +729,7 @@ class LogCollector:
         archive_dir, log_filename = os.path.split(src_path)
 
         LocalCmdRunner().run(
-            cmd=f"tar --zstd -cf '{archive_name}' -C '{archive_dir}' --transform 's/{log_filename}/{src_name}/' '{log_filename}'")
+            cmd=f"tar --zstd --warning=no-file-changed -cf '{archive_name}' -C '{archive_dir}' --transform 's/{log_filename}/{src_name}/' '{log_filename}'")
 
         return archive_name
 


### PR DESCRIPTION
The change adds an option to `tar -cf` command execution during log collection, to suppress `file changed` warnings.
This should help to avoid `tar: <NODE_NAME>: file changed as we read it` errors when creating archives during log collection (and we don't care about changes in logs/log directories after test is finished and log collection step is initiated).

Closes: https://github.com/scylladb/scylla-cluster-tests/issues/10716

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
Couple of runs to ensure that logs are collected (and that it is OK on different distros):
- [x] :green_circle: [artifacts-ubuntu2204-test](https://argus.scylladb.com/tests/scylla-cluster-tests/47b219f9-a430-45cf-b245-23b367721dfb/logs)
- [x] :green_circle: [artifacts-centos9-arm-test](https://argus.scylladb.com/tests/scylla-cluster-tests/9411da97-36e5-4196-b6ac-02179dde78df/logs)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
