### PR TITLE
feature(vector): add support for vector.dev logging

### DIFF
--- a/data_dir/monitoring-dash-template.json
+++ b/data_dir/monitoring-dash-template.json
@@ -1364,6 +1364,28 @@
                             "legendFormat": "Dropped {{instance}}",
                             "range": true,
                             "refId": "B"
+                        },
+                                                {
+                            "datasource": "prometheus",
+                            "editorMode": "code",
+                            "exemplar": false,
+                            "expr": "increase(vector_component_received_events_total{component_id=\"sct-runner\", dc=~\"$dc\", instance=~\"[[node]]\"}[10m])",
+                            "format": "time_series",
+                            "instant": false,
+                            "intervalFactor": 1,
+                            "legendFormat": "Processed {{instance}}",
+                            "range": true,
+                            "refId": "C"
+                        },
+                        {
+                            "datasource": "prometheus",
+                            "editorMode": "code",
+                            "expr": "increase(vector_component_discarded_events_total{component_id=\"sct-runner\", dc=~\"$dc\", instance=~\"[[node]]\"}[10m])",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "legendFormat": "Dropped {{instance}}",
+                            "range": true,
+                            "refId": "D"
                         }
                     ],
                     "title": "Logs create/drop rates",

--- a/data_dir/scylla-dash-per-server-nemesis.master.json
+++ b/data_dir/scylla-dash-per-server-nemesis.master.json
@@ -8117,6 +8117,28 @@
             "legendFormat": "Dropped {{instance}}",
             "range": true,
             "refId": "B"
+          },
+          {
+            "datasource": "prometheus",
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "increase(vector_component_received_events_total{component_id=\"sct-runner\", dc=~\"$dc\", instance=~\"[[node]]\"}[10m])",
+            "format": "time_series",
+            "instant": false,
+            "intervalFactor": 1,
+            "legendFormat": "Processed {{instance}}",
+            "range": true,
+            "refId": "C"
+          },
+          {
+            "datasource": "prometheus",
+            "editorMode": "code",
+            "expr": "increase(vector_component_discarded_events_total{component_id=\"sct-runner\", dc=~\"$dc\", instance=~\"[[node]]\"}[10m])",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Dropped {{instance}}",
+            "range": true,
+            "refId": "D"
           }
         ],
         "title": "Logs create/drop rates",

--- a/sct.py
+++ b/sct.py
@@ -226,6 +226,9 @@ def provision_resources(backend, test_name: str, config: str):
     if params.get("logs_transport") == 'syslog-ng':
         click.echo("Provision syslog-ng logging service")
         test_config.configure_syslogng(localhost)
+    elif params.get("logs_transport") == 'vector':
+        click.echo("Provision vector logging service")
+        test_config.configure_vector(localhost)
     else:
         click.echo("No need provision logging service")
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2980,6 +2980,7 @@ class BaseNode(AutoSshContainerMixin):
             logs_transport=self.parent_cluster.params.get('logs_transport'),
             hostname=self.name,
             log_file=log_file,
+            test_config=self.test_config,
         ).to_string()
         self.remoter.sudo(shell_script_cmd(script, quote="'"))
 
@@ -3516,7 +3517,8 @@ class BaseCluster:
         user_data_builder = ScyllaUserDataBuilder(cluster_name=self.name,
                                                   bootstrap=enable_auto_bootstrap,
                                                   user_data_format_version=user_data_format_version, params=self.params,
-                                                  syslog_host_port=self.test_config.get_logging_service_host_port())
+                                                  syslog_host_port=self.test_config.get_logging_service_host_port(),
+                                                  test_config=self.test_config)
         return user_data_builder.to_string()
 
     def get_node_private_ips(self):
@@ -5473,6 +5475,7 @@ class BaseMonitorSet:
         self.local_metrics_addr = start_metrics_server()  # start prometheus metrics server locally and return local ip
         self.sct_ip_port = self.set_local_sct_ip()
         self.grafana_port = 3000
+        self.prometheus_port = 9090
         self.prometheus_retention = "365d"
         self.monitor_branch = self.params.get('monitor_branch')
         self.grafana_start_time = 0
@@ -6037,7 +6040,6 @@ class BaseMonitorSet:
             {scylla_manager_servers_arg} \
             -d `realpath "{self.monitoring_data_dir}"` -l -v master,{self.monitoring_version} \
             -b "--web.enable-admin-api --storage.tsdb.retention.time={self.prometheus_retention}" \
-            -b "--web.enable--remote-write-receiver" \
             -c 'GF_USERS_DEFAULT_THEME=dark'
         """)
         node.remoter.run("bash -ce '%s'" % run_script, verbose=True)

--- a/sdcm/localhost.py
+++ b/sdcm/localhost.py
@@ -20,12 +20,13 @@ from sdcm.utils.k8s import HelmContainerMixin
 from sdcm.utils.gce_utils import GcloudContainerMixin
 from sdcm.utils.ldap import LDAP_PORT, LDAP_SSL_PORT, LdapContainerMixin
 from sdcm.utils.syslogng import SyslogNGContainerMixin
+from sdcm.utils.vector_dev import VectorDevContainerMixin
 
 LOGGER = logging.getLogger(__name__)
 
 
 class LocalHost(SyslogNGContainerMixin, GcloudContainerMixin, HelmContainerMixin, LdapContainerMixin,
-                JavaContainerMixin):
+                JavaContainerMixin, VectorDevContainerMixin):
     def __init__(self, user_prefix: Optional[str] = None, test_id: Optional[str] = None) -> None:
         self._containers = {}
         self.tags = {}

--- a/sdcm/provision/common/configuration_script.py
+++ b/sdcm/provision/common/configuration_script.py
@@ -26,7 +26,9 @@ from sdcm.provision.common.utils import (
     install_syslogng_exporter,
     disable_daily_apt_triggers,
     configure_syslogng_destination_conf,
-    configure_syslogng_file_source
+    configure_syslogng_file_source,
+    install_vector_service,
+    configure_vector_target_script,
 )
 from sdcm.provision.user_data import CLOUD_INIT_SCRIPTS_PATH
 
@@ -52,7 +54,7 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
         return ''
 
     @staticmethod
-    def _skip_if_already_run() -> str:
+    def _skip_if_already_run_syslogng() -> str:
         """
         If a node was configured before sct-runner, skip syslog-ng installation. Just ensure
         that logging destination is updated in the configuration and the service is
@@ -62,6 +64,20 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
         if [ -f {CLOUD_INIT_SCRIPTS_PATH}/done ] && command -v syslog-ng >/dev/null 2>&1; then
             write_syslog_ng_destination
             sudo systemctl restart syslog-ng
+            exit 0
+        fi
+        """)
+
+    @staticmethod
+    def _skip_if_already_run_vector() -> str:
+        """
+        If a node was configured before sct-runner, skip vector installation. Just ensure
+        that logging destination is updated in the configuration and the service is
+        restarted, to retrigger sending logs.
+        """
+        return dedent(f"""
+        if [ -f {CLOUD_INIT_SCRIPTS_PATH}/done ] && command -v vector >/dev/null 2>&1; then
+            sudo systemctl restart vector
             exit 0
         fi
         """)
@@ -96,7 +112,9 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
                 host=self.syslog_host_port[0],
                 port=self.syslog_host_port[1],
                 throttle_per_second=SYSLOGNG_LOG_THROTTLE_PER_SECOND)
-        script += self._skip_if_already_run()
+            script += self._skip_if_already_run_syslogng()
+        if self.logs_transport == "vector":
+            script += self._skip_if_already_run_vector()
         script += disable_daily_apt_triggers()
         if self.logs_transport == 'syslog-ng':
             script += update_repo_cache()
@@ -106,6 +124,12 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
                 script += configure_syslogng_file_source(log_file=self.log_file)
             script += restart_syslogng_service()
             script += install_syslogng_exporter()
+
+        if self.logs_transport == 'vector':
+            script += update_repo_cache()
+            script += install_vector_service()
+            host, port = self.syslog_host_port
+            script += configure_vector_target_script(host=host, port=port)
 
         if self.configure_sshd:
             script += configure_sshd_script()

--- a/sdcm/provision/common/configuration_script.py
+++ b/sdcm/provision/common/configuration_script.py
@@ -13,6 +13,7 @@
 
 import abc
 from textwrap import dedent
+from typing import Any
 
 from sdcm.provision.common.builders import AttrBuilder
 from sdcm.provision.common.utils import (
@@ -42,6 +43,7 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
     configure_sshd: bool = True
     hostname: str = ''
     log_file: str = ''
+    test_config: Any | None = None
 
     def to_string(self) -> str:
         script = self._start_script()

--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -54,6 +54,8 @@ def configure_vector_target_script(host: str, port: int) -> str:
         sources:
             journald:
                 type: journald
+            vector_metrics:
+                type: internal_metrics
 
         transforms:
             filter_audit:
@@ -68,6 +70,14 @@ def configure_vector_target_script(host: str, port: int) -> str:
                 inputs:
                     - filter_audit
                 address: {host}:{port}
+                healthcheck: false
+            prometheus:
+                type: prometheus_exporter
+                address: 0.0.0.0:9577
+                inputs:
+                  - vector_metrics
+                healthcheck: false
+
         " > /etc/vector/vector.yaml
 
         systemctl kill -s HUP --kill-who=main vector.service

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1445,7 +1445,7 @@ class SCTConfiguration(dict):
                   "we enable kms by default since if we use scylla 2023.1.3 and up"),
 
         dict(name="logs_transport", env="SCT_LOGS_TRANSPORT", type=str,
-             help="How to transport logs: syslog-ng, ssh or docker", choices=("ssh", "docker", "syslog-ng")),
+             help="How to transport logs: syslog-ng, ssh or docker", choices=("ssh", "docker", "syslog-ng", "vector")),
 
         dict(name="collect_logs", env="SCT_COLLECT_LOGS", type=boolean,
              help="Collect logs from instances and sct runner"),

--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -477,7 +477,7 @@ class LogEvent(Generic[T_log_event], InformationalEvent, abstract=True):
                 # 2021-04-06 13:03:28  ...
                 event_time = " ".join(splitted_line[:2])
 
-            self.source_timestamp = dateutil.parser.parse(event_time).timestamp()
+            self.source_timestamp = dateutil.parser.parse(event_time).replace(tzinfo=timezone.utc) .timestamp()
         except ValueError:
             pass
         self.event_timestamp = time.time()

--- a/sdcm/sct_provision/aws/cluster.py
+++ b/sdcm/sct_provision/aws/cluster.py
@@ -269,6 +269,7 @@ class DBCluster(ClusterBase):
             cluster_name=self.cluster_name,
             user_data_format_version=self.params.get('user_data_format_version'),
             syslog_host_port=self._test_config.get_logging_service_host_port(),
+            test_config=self._test_config,
         ).to_string()
 
     def _zero_token_instance_parameters(self, region_id: int, availability_zone: int = 0) -> AWSInstanceParams:
@@ -385,6 +386,7 @@ class OracleDBCluster(ClusterBase):
             cluster_name=self.cluster_name,
             user_data_format_version=self.params.get('oracle_user_data_format_version'),
             syslog_host_port=self._test_config.get_logging_service_host_port(),
+            test_config=self._test_config,
         ).to_string()
 
 
@@ -402,6 +404,7 @@ class LoaderCluster(ClusterBase):
             params=self.params,
             syslog_host_port=self._test_config.get_logging_service_host_port(),
             aws_additional_interface=network_interfaces_count(self.params) > 1,
+            test_config=self._test_config,
         ).to_string()
 
 
@@ -420,6 +423,7 @@ class MonitoringCluster(ClusterBase):
         return AWSInstanceUserDataBuilder(
             params=self.params,
             syslog_host_port=self._test_config.get_logging_service_host_port(),
+            test_config=self._test_config,
         ).to_string()
 
 

--- a/sdcm/sct_provision/region_definition_builder.py
+++ b/sdcm/sct_provision/region_definition_builder.py
@@ -27,6 +27,7 @@ from sdcm.sct_provision.user_data_objects.apt_daily_triggers import DisableAptTr
 from sdcm.sct_provision.user_data_objects.scylla import ScyllaUserDataObject
 from sdcm.sct_provision.user_data_objects.sshd import SshdUserDataObject
 from sdcm.sct_provision.user_data_objects.syslog_ng import SyslogNgUserDataObject, SyslogNgExporterUserDataObject
+from sdcm.sct_provision.user_data_objects.vector_dev import VectorDevUserDataObject
 from sdcm.sct_provision.user_data_objects.walinuxagent import EnableWaLinuxAgent
 from sdcm.test_config import TestConfig
 
@@ -147,6 +148,7 @@ class DefinitionBuilder(abc.ABC):
             DisableAptTriggersUserDataObject,
             SyslogNgUserDataObject,
             SyslogNgExporterUserDataObject,
+            VectorDevUserDataObject,
             SshdUserDataObject,
             EnableWaLinuxAgent,
             ScyllaUserDataObject,

--- a/sdcm/sct_provision/user_data_objects/vector_dev.py
+++ b/sdcm/sct_provision/user_data_objects/vector_dev.py
@@ -1,0 +1,32 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+from dataclasses import dataclass
+
+from sdcm.provision.common.utils import configure_vector_target_script, install_vector_service
+from sdcm.sct_provision.user_data_objects import SctUserDataObject
+
+
+@dataclass
+class VectorDevUserDataObject(SctUserDataObject):
+
+    @property
+    def is_applicable(self) -> bool:
+        return self.params.get('logs_transport') == 'vector'
+
+    @property
+    def script_to_run(self) -> str:
+        script = install_vector_service()
+        host, port = self.test_config.get_logging_service_host_port()
+        script += configure_vector_target_script(
+            host=host, port=port)
+        return script

--- a/sdcm/sct_provision/user_data_objects/vector_dev.py
+++ b/sdcm/sct_provision/user_data_objects/vector_dev.py
@@ -27,6 +27,5 @@ class VectorDevUserDataObject(SctUserDataObject):
     def script_to_run(self) -> str:
         script = install_vector_service()
         host, port = self.test_config.get_logging_service_host_port()
-        script += configure_vector_target_script(
-            host=host, port=port)
+        script += configure_vector_target_script(host=host, port=port)
         return script

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -241,6 +241,7 @@ class TestConfig(metaclass=Singleton):
         return ConfigurationScriptBuilder(
             syslog_host_port=host_port,
             logs_transport=cls._tester_obj.params.get('logs_transport') if cls._tester_obj else "syslog-ng",
+            test_config=cls(),
         ).to_string()
 
     @classmethod

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -939,7 +939,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
 
         if self.params.get("logs_transport") == 'syslog-ng':
             self.test_config.configure_syslogng(self.localhost)
-
+        if self.params.get("logs_transport") == 'vector':
+            self.test_config.configure_vector(self.localhost)
         self.alternator: alternator.api.Alternator = alternator.api.Alternator(sct_params=self.params)
         self.alternator = alternator.api.Alternator(sct_params=self.params)
 

--- a/sdcm/utils/vector_dev.py
+++ b/sdcm/utils/vector_dev.py
@@ -1,0 +1,117 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB
+
+import os
+import logging
+import getpass
+from functools import cached_property
+from pwd import getpwnam
+from tempfile import mkstemp
+from typing import Optional
+
+from sdcm.utils.docker_utils import ContainerManager
+
+VECTOR_DEV_IMAGE = "timberio/vector:0.46.1-alpine"
+VECTOR_DEV_PORT = 49153  # Non-root
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class VectorDevContainerMixin:
+    @cached_property
+    def vector_confpath(self) -> str:
+        return generate_vector_conf_file()
+
+    @property
+    def vector_port(self) -> Optional[int]:
+        return ContainerManager.get_container_port(self, "vector", VECTOR_DEV_PORT)
+
+    @property
+    def vector_log_dir(self) -> Optional[str]:
+        # This should work after process that had run container was terminated and another one starts
+        # that is why it is not using variable to store log directory instead
+        return ContainerManager.get_host_volume_path(
+            instance=self,
+            container_name="vector",
+            path_in_container="/var/log",
+        )
+
+    def vector_container_run_args(self, logdir: str) -> dict:
+        basedir, logdir = os.path.split(logdir)
+        logdir = os.path.abspath(os.path.join(os.environ.get("_SCT_LOGDIR", basedir), logdir))
+        os.makedirs(logdir, exist_ok=True)
+        LOGGER.debug("vector will store logs at %s", logdir)
+        volumes = {
+            self.vector_confpath: {"bind": "/etc/vector/vector.yaml", "mode": "ro,z"},
+            logdir: {"bind": "/var/log", "mode": "z"},
+        }
+        username = getpass.getuser()
+        return {
+            'image': VECTOR_DEV_IMAGE,
+            'name': f"{self.name}-vector",
+            'command': " -c /etc/vector/vector.yaml",
+            'auto_remove': True,
+            'ports': {f"{VECTOR_DEV_PORT}/tcp": None},
+            'volumes': volumes,
+            'environment': {
+                'PUID': getpwnam(username).pw_uid,
+                'PGID': getpwnam(username).pw_gid,
+            }
+        }
+
+
+def generate_vector_conf_file():
+    conf_fd, conf_path = mkstemp(prefix="vector", suffix=".yaml")
+    with os.fdopen(conf_fd, 'w') as file_obj:
+        file_obj.write(VECTOR_CONF.format(port=VECTOR_DEV_PORT))
+    LOGGER.debug("vector conf file created in '%s'", conf_path)
+    return conf_path
+
+
+VECTOR_CONF = """
+# Vector configuration file
+# This file is used to configure the Vector agent.
+
+sources:
+  sct_nodes:
+    type: vector
+    address: 0.0.0.0:{port}
+
+transforms:
+  format_logs:
+    type: remap
+    inputs:
+      - sct_nodes
+    source: |
+       .timestamp = format_timestamp!(.timestamp, "%Y-%m-%dT%H:%M:%S%.3f")
+
+       .level = upcase(to_syslog_level!(to_int!(.PRIORITY)))
+       pad_count = if 7 - length(to_string(.level)) > 0 {{ 7 - length(to_string(.level)) }} else {{ 0 }}
+
+       # Generate padding using a static array of spaces
+       padding = join!(slice!([" "], 0, pad_count), "")
+
+       .level_padded = padding + "!" + .level
+        .comp = join!([.SYSLOG_IDENTIFIER, "[", ._PID, "]"], "")
+       .message = join!([.timestamp, .host, .level_padded, "|" , .comp,  .message], " ")
+
+sinks:
+  file_by_host:
+    type: file
+    inputs:
+      - format_logs
+    path: /var/log/hosts/{{{{ .host }}}}/messages.log
+    encoding:
+      codec: text
+"""

--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -23,3 +23,7 @@ gemini_log_cql_statements: false
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i4i.16xlarge'
+
+# enable vector.dev logging for all tier1
+# TODO: remove this when vector.dev logging is enabled by default
+logs_transport: 'vector'

--- a/test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml
+++ b/test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml
@@ -29,3 +29,7 @@ authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
 
 use_preinstalled_scylla: true
+
+# enable vector.dev logging for all tier1
+# TODO: remove this when vector.dev logging is enabled by default
+logs_transport: 'vector'

--- a/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
@@ -44,3 +44,5 @@ authorizer: 'CassandraAuthorizer'
 
 nemesis_during_prepare: false
 use_preinstalled_scylla: true
+
+logs_transport: 'vector'

--- a/test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml
@@ -32,3 +32,7 @@ authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
 
 use_dns_names: true
+
+# enable vector.dev logging for all tier1
+# TODO: remove this when vector.dev logging is enabled by default
+logs_transport: 'vector'

--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -82,3 +82,7 @@ use_preinstalled_scylla: true
 # Run a verification every 10 minutes:
 # Disabled due to https://github.com/scylladb/scylladb/issues/23743
 # run_tombstone_gc_verification: '{"ks_cf": "scylla_bench.test", "interval": 600, "propagation_delay_in_seconds": 300}'
+
+# enable vector.dev logging for all tier1
+# TODO: remove this when vector.dev logging is enabled by default
+logs_transport: 'vector'

--- a/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
@@ -33,3 +33,7 @@ server_encrypt: true
 internode_encryption: 'dc'
 
 user_prefix: 'parallel-topology-schema-changes-multidc-12h'
+
+# enable vector.dev logging for all tier1
+# TODO: remove this when vector.dev logging is enabled by default
+logs_transport: 'vector'

--- a/test-cases/longevity/longevity-mv-si-4days.yaml
+++ b/test-cases/longevity/longevity-mv-si-4days.yaml
@@ -31,3 +31,7 @@ user_prefix: 'longevity-mv-si-4d'
 space_node_threshold: 644245
 
 use_preinstalled_scylla: true
+
+# enable vector.dev logging for all tier1
+# TODO: remove this when vector.dev logging is enabled by default
+logs_transport: 'vector'

--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -28,3 +28,7 @@ post_prepare_cql_cmds: "ALTER TABLE scylla_bench.test with gc_grace_seconds = 12
 
 
 round_robin: true
+
+# enable vector.dev logging for all tier1
+# TODO: remove this when vector.dev logging is enabled by default
+logs_transport: 'vector'

--- a/test_user_data_builders.py
+++ b/test_user_data_builders.py
@@ -1,0 +1,67 @@
+import json
+
+import pytest
+
+from sdcm.sct_provision.aws.user_data import ScyllaUserDataBuilder
+from sdcm.utils.sct_cmd_helpers import get_test_config
+
+pytestmark = pytest.mark.parametrize(
+    'logs_transport',
+    [
+        'libssh2',
+        'syslog-ng',
+        'vector',
+    ],
+)
+
+
+@pytest.fixture
+def test_config():
+    config = get_test_config()
+    config.set_test_id("12345678-87654321")
+    config.SYSLOGNG_ADDRESS = ("localhost", 12345)
+    return config
+
+
+def test_user_data_format_version_v2_building(logs_transport, test_config):
+    builder = ScyllaUserDataBuilder(
+        cluster_name="test",
+        syslog_host_port=('0.0.0.0', 1234),
+        user_data_format_version='2',
+        test_config=test_config,
+        params={"data_volume_disk_num": 0, "logs_transport": logs_transport},
+    )
+    output = builder.to_string()
+    json_output = json.loads(output)
+    assert 'post_configuration_script' in json_output
+    assert json_output["start_scylla_on_first_boot"] is False
+    assert json_output['raid_level'] == 0
+
+
+def test_user_data_format_version_v1_building(logs_transport, test_config):
+    builder = ScyllaUserDataBuilder(
+        cluster_name="test",
+        syslog_host_port=("0.0.0.0", 1234),
+        test_config=test_config,
+        user_data_format_version="1",
+        params={"data_volume_disk_num": 0, "logs_transport": logs_transport},
+    )
+    output = builder.to_string()
+    assert '--stop-services --base64postscript=' in output
+
+
+def test_user_data_format_version_v3_building(logs_transport, test_config):
+    builder = ScyllaUserDataBuilder(
+        cluster_name="test",
+        user_data_format_version="3",
+        syslog_host_port=("0.0.0.0", 1234),
+        test_config=test_config,
+        params={"data_volume_disk_num": 0, "logs_transport": logs_transport},
+    )
+    output = builder.return_in_format_v3()
+
+    assert 'Content-Type: multipart/mixed' in output
+    assert 'Content-Type: x-scylla/json' in output
+    assert 'Content-Type: text/cloud-config' in output
+    assert 'Content-Type: text/x-shellscript' in output
+    print(output)


### PR DESCRIPTION
Since we want to align with scylla-cloud, and modernize
our logging setup, we are adding the support of vector

this commmit handles the installtion phase on nodes
and the setup of the aggragator on the sct-runner (test side)
that would collect all logs and put them into files

later we'll work on optimizing it, compression, formatting of logs
of putting into centerilize logs service that can be searched

Closes: https://github.com/scylladb/scylla-cluster-tests/issues/7010

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/121/ (short longevity)
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-large-partition-200k-pks-4days-gce-test/11/ (teir1 longevity 12h)
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2404-arm-test/11/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-amazon2023-arm-test/12/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-amazon2023-test/21/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-amazon2023-test/21/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2404-test/46/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2204-test/66/
- [x] 🟢  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-rocky9-test/53/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-amazon2023-test/23/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2404-test/47/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-azure-image-test/56/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-gce-image-test/7/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-rocky9-selinux-test/19/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### TODO

- [x] create dashboard for logs stats (once they work)
- [ ]  ~~enable compression all over~~ - skipping this for now, we'll see if need after it we'll have some more stats of longer runs

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
