### PR TITLE
ci(latte): data validation example using latte

### DIFF
--- a/data_dir/latte/validation.rn
+++ b/data_dir/latte/validation.rn
@@ -1,0 +1,196 @@
+// This rune script shows how we can do followig:
+// - Validate the number of returned rows in 'SELECT' queries
+// - Validate that the 'SELECT COUNT(...)' queries return integer equal to the expected rows number
+// - Do above for partitions of any size using 'partitions preset' latte feature
+// - Do above using prepared and non-prepared statements
+//
+// USAGE:
+// 1) Create schema:
+// $ latte schema workloads/validation.rn 172.17.0.2
+//
+// 2) Populate DB:
+// $ latte run workloads/validation.rn -q \
+//     -d 1000 -r 1000 -P row_count=1000 \
+//     -P rows_per_partition=1 -P partition_sizes="\"50:4,50:6\"" \
+//     -f insert -- 172.17.0.2
+//
+// 3) Do select queries with validation
+//
+// 3a) Get one row
+// $ latte run workloads/validation.rn -q \
+//     -d 1000 -r 1000 -P row_count=1000 \
+//     -P rows_per_partition=1 -P partition_sizes="\"50:4,50:6\"" \
+//     -f get -- 172.17.0.2
+//
+// 3b) Get many rows
+// $ latte run workloads/validation.rn -q \
+//     -d 1000 -r 1000 -P row_count=1000 \
+//     -P rows_per_partition=1 -P partition_sizes="\"50:4,50:6\"" \
+//     -f get_many -- 172.17.0.2
+//
+// 3c) Count
+// $ latte run workloads/validation.rn -q \
+//     -d 1000 -r 1000 -P row_count=1000 \
+//     -P rows_per_partition=1 -P partition_sizes="\"50:4,50:6\"" \
+//     -f count -- 172.17.0.2
+
+use latte::*;
+
+const ROW_COUNT = latte::param!("row_count", 1000000);
+const OFFSET = latte::param!("offset", 0);
+const REPLICATION_FACTOR = latte::param!("replication_factor", 3);
+const ROWS_PER_PARTITION = latte::param!("rows_per_partition", 1);
+// NOTE: 'partition_sizes' defines set of 'percent:multiplier' pairs to create multi-row partitions
+// of different sizes. Example: '95:1,4:2,1:4'
+const PARTITION_SIZES = latte::param!("partition_sizes", "100:1");
+
+const USE_PREPARED_STATEMENTS = latte::param!("use_prepared_statements", true);
+
+const DELETE_START_INDEX = latte::param!("delete_start_index", 0);
+const DELETE_END_INDEX = latte::param!("delete_end_index", 0);
+
+const KEYSPACE = "latte";
+const TABLE = "validation";
+
+const P_STMT = #{
+    "INSERT": #{
+        "NAME": "p_stmt_validation__insert",
+        "CQL": `INSERT INTO ${KEYSPACE}.${TABLE}(pk, ck) VALUES (:pk, :ck)`,
+    },
+    "GET": #{
+        "NAME": "p_stmt_validation__get",
+        "CQL": `SELECT pk, ck FROM ${KEYSPACE}.${TABLE} WHERE pk = :pk LIMIT 1`,
+    },
+    "GET_MANY": #{
+        "NAME": "p_stmt_validation__get_many",
+        "CQL": `SELECT pk, ck FROM ${KEYSPACE}.${TABLE} WHERE pk = :pk LIMIT :max_limit`,
+    },
+    "COUNT": #{
+        "NAME": "p_stmt_validation__count",
+        "CQL": `SELECT COUNT(*) FROM ${KEYSPACE}.${TABLE} WHERE pk = :pk`,
+    },
+    "DELETE": #{
+        "NAME": "p_stmt_validation__delete",
+        "CQL": `DELETE FROM ${KEYSPACE}.${TABLE} WHERE pk = :pk`,
+    },
+};
+
+pub async fn schema(db) {
+    db.execute(`CREATE KEYSPACE IF NOT EXISTS ${KEYSPACE} WITH REPLICATION = {
+        'class': 'NetworkTopologyStrategy', 'replication_factor': ${REPLICATION_FACTOR} }`).await?;
+
+    db.execute(`CREATE TABLE IF NOT EXISTS ${KEYSPACE}.${TABLE}(
+        pk bigint,
+        ck bigint,
+        PRIMARY KEY (pk, ck)
+    ) WITH CLUSTERING ORDER BY (ck ASC)`).await?;
+}
+
+pub async fn erase(db) {
+    db.execute(`TRUNCATE TABLE ${KEYSPACE}.${TABLE}`).await?
+}
+
+pub async fn prepare(db) {
+    db.init_partition_row_distribution_preset(
+        "main", ROW_COUNT, ROWS_PER_PARTITION, PARTITION_SIZES,
+    ).await?;
+    db.prepare(P_STMT.INSERT.NAME, P_STMT.INSERT.CQL).await?;
+    db.prepare(P_STMT.GET.NAME, P_STMT.GET.CQL).await?;
+    db.prepare(P_STMT.GET_MANY.NAME, P_STMT.GET_MANY.CQL).await?;
+    db.prepare(P_STMT.COUNT.NAME, P_STMT.COUNT.CQL).await?;
+    db.prepare(P_STMT.DELETE.NAME, P_STMT.DELETE.CQL).await?;
+}
+
+// User functions
+
+pub async fn insert(db, i) { // validation is not applicable
+    let idx = i % ROW_COUNT + OFFSET;
+    let partition = db.get_partition("main", idx).await;
+    partition.idx += OFFSET;
+    let pk = hash(partition.idx);
+    let ck = hash(idx);
+    if USE_PREPARED_STATEMENTS {
+        db.execute_prepared(P_STMT.INSERT.NAME, [pk, ck]).await?
+    } else {
+        db.execute(P_STMT.INSERT.CQL.replace(":pk", `${pk}`).replace(":ck", `${ck}`)).await?
+    }
+}
+
+pub async fn insert_or_delete(db, i) { // validation is not applicable
+    let idx = i % ROW_COUNT + OFFSET;
+    let do_delete = if idx > 0 && idx >= DELETE_START_INDEX && idx <= DELETE_END_INDEX { true } else { false };
+    let partition = db.get_partition("main", idx).await;
+    partition.idx += OFFSET;
+    let pk = hash(partition.idx);
+    let ck = hash(idx);
+    if do_delete {
+        println!(
+            "DEBUG: [{time}] DELETE a row for index: {idx}",
+            time=now_timestamp(), idx=idx,
+        );
+        if USE_PREPARED_STATEMENTS {
+            db.execute_prepared(P_STMT.DELETE.NAME, [pk]).await?
+        } else {
+            db.execute(P_STMT.DELETE.CQL.replace(":pk", `${pk}`)).await?
+        }
+    } else {
+        if USE_PREPARED_STATEMENTS {
+            db.execute_prepared(P_STMT.INSERT.NAME, [pk, ck]).await?
+        } else {
+            db.execute(P_STMT.INSERT.CQL.replace(":pk", `${pk}`).replace(":ck", `${ck}`)).await?
+        }
+    }
+}
+
+pub async fn get(db, i) { // make sure that we have only 1 row no matter how big partitions
+    let idx = i % ROW_COUNT + OFFSET;
+    let expect_deleted = if idx > 0 && idx >= DELETE_START_INDEX && idx <= DELETE_END_INDEX { true } else { false };
+    let partition = db.get_partition("main", idx).await;
+    partition.idx += OFFSET;
+    let pk = hash(partition.idx);
+    let custom_err = "custom very useful err msg for the 'get' function"; // optional
+    let validation_tuple = (1, 1, custom_err);
+    if expect_deleted {
+        custom_err = `Queries for indexes (${DELETE_START_INDEX}-${DELETE_END_INDEX}) were expected to return no rows`;
+        validation_tuple = (0, 0, custom_err);
+        println!(
+            "DEBUG: [{time}] GET a row for index: {idx} expecting 0 rows",
+            time=now_timestamp(), idx=idx,
+        );
+    }
+    if USE_PREPARED_STATEMENTS {
+        db.execute_prepared_with_validation(P_STMT.GET.NAME, [pk], validation_tuple).await?
+    } else {
+        db.execute_with_validation(P_STMT.GET.CQL.replace(":pk", `${pk}`), validation_tuple).await?
+    }
+}
+
+pub async fn get_many(db, i) { // make sure that we have rows num as expected
+    let idx = i % ROW_COUNT + OFFSET;
+    let partition = db.get_partition("main", idx).await;
+    partition.idx += OFFSET;
+    let pk = hash(partition.idx);
+    let max_limit = partition.size + 10; // make it be bigger than the expected value
+    let custom_err = "custom very useful err msg for the 'get_many' function"; // optional
+    let validation_tuple = (partition.size, partition.size, custom_err);
+    if USE_PREPARED_STATEMENTS {
+        db.execute_prepared_with_validation(P_STMT.GET_MANY.NAME, [pk, max_limit], validation_tuple).await?
+    } else {
+        let cql = P_STMT.GET_MANY.CQL.replace(":pk", `${pk}`).replace(":max_limit", `${max_limit}`);
+        db.execute_with_validation(cql, validation_tuple).await?
+    }
+}
+
+pub async fn count(db, i) { // checks that 'select count' integer result equals to the expected value
+    let idx = i % ROW_COUNT + OFFSET;
+    let partition = db.get_partition("main", idx).await;
+    partition.idx += OFFSET;
+    let pk = hash(partition.idx);
+    let custom_err = "custom very useful err msg for 'count' function"; // optional
+    let validation_tuple = (partition.size, partition.size, custom_err);
+    if USE_PREPARED_STATEMENTS {
+        db.execute_prepared_with_validation(P_STMT.COUNT.NAME, [pk], validation_tuple).await?
+    } else {
+        db.execute_with_validation(P_STMT.COUNT.CQL.replace(":pk", `${pk}`), validation_tuple).await?
+    }
+}

--- a/defaults/docker_images/latte/values_latte.yaml
+++ b/defaults/docker_images/latte/values_latte.yaml
@@ -1,2 +1,2 @@
 latte:
-  image: scylladb/latte:0.28.4-scylladb
+  image: vponomarovatscylladb/hydra-loaders:latte-0.28.5-scylladb-data-validation

--- a/test-cases/PR-provision-test.yaml
+++ b/test-cases/PR-provision-test.yaml
@@ -1,18 +1,39 @@
 test_duration: 60
-data_validation: |
-  validate_partitions: false
-  table_name: "scylla_bench.test"
-  primary_key_column: "pk"
-  max_partitions_in_test_table: 10
-  partition_range_with_data_validation: 0-10
+# NOTE: schema in latte gets created by a separate 'latte schema' command.
+#       So, it's schema params must be defined in the 'latte_schema_parameters' SCT config option
+#       and be supported by a rune script that is used.
+latte_schema_parameters:
+  keyspace: keyspace1_latte
+  compaction_strategy: IncrementalCompactionStrategy
+  column_count: 5
+  replication_factor: 3
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=1m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5",
-             "cassandra-stress counter_write cl=QUORUM duration=1m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=TimeWindowCompactionStrategy)' -mode cql3 native -rate threads=5 -pop seq=1..10000000"
-             ]
+prepare_write_cmd:
+  - >-
+    latte run --function=insert --consistency=ALL --duration=100000
+    -P keyspace=\"keyspace1_latte\"
+    --threads=3 --concurrency=128
+    --start-cycle=1 --end-cycle=100000 -P row_count=100000
+    -P key_size=10 -P column_count=5 -P column_size=34
+    data_dir/latte/validation.rn
 
-prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -max-rate=300 -replication-factor=3 -partition-count=10 -clustering-row-count=100 -clustering-row-size=5120 -concurrency=7 -rows-per-request=10",
-                     "scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=10 -clustering-row-count=100 -clustering-row-size=5120 -rows-per-request=10 -concurrency=7 -max-rate=32000 -duration=1m"
-                    ]
+stress_cmd:
+  - >-
+    latte run --function=insert_or_delete --consistency=QUORUM --duration=2100
+    -P keyspace=\"keyspace1_latte\"
+    --threads=1 --concurrency=128 --rate=50
+    --start-cycle=97000 --end-cycle=99100 -P row_count=100000
+    -P delete_start_index=98001 -P delete_end_index=98100
+    -P key_size=10 -P column_count=5 -P column_size=34
+    data_dir/latte/validation.rn
+  - >-
+    latte run --function=get --consistency=QUORUM --duration=200000
+    -P keyspace=\"keyspace1_latte\" --validation-strategy=retry
+    --threads=3 --concurrency=128 --rate=1000
+    --start-cycle=1 --end-cycle=100000 -P row_count=100000
+    -P delete_start_index=98001 -P delete_end_index=98100
+    -P key_size=10 -P column_count=5 -P column_size=34
+    data_dir/latte/validation.rn
 
 n_loaders: 1
 instance_type_db: 'i4i.large'


### PR DESCRIPTION
Provision CI job configuration example using unmerged latte feature
for checking number of returned rows in select queires (https://github.com/scylladb/latte/pull/60).

In this scenario do following:
- Populate data
- Run 2 commands in parallel
  - One deletes 100 rows in 40 seconds after start
  - Second reads rows and checks that deleted rows don't return in select queries.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
