### PR TITLE
fix(_refuse_connection_from_banned_node): remove banned node from list before cql session

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5357,6 +5357,7 @@ class Nemesis:
         simulate_node_unavailability = node_operations.block_scylla_ports if use_iptables else node_operations.pause_scylla_with_sigstop
         with self.run_nemesis(node_list=self.cluster.nodes,
                               nemesis_label=f"Running {simulate_node_unavailability.__name__}") as working_node, ExitStack() as stack:
+            stack.callback(drop_keyspace, node=working_node)
             target_host_id = self.target_node.host_id
             stack.callback(self._remove_node_add_node, verification_node=working_node, node_to_remove=self.target_node,
                            remove_node_host_id=target_host_id)
@@ -5392,6 +5393,9 @@ class Nemesis:
                             "Query from banned node was executed succesful with Consistency.QUORUM")
                     except (NoHostAvailable, OperationTimedOut, Unavailable) as exc:
                         self.log.debug("Query failed with error: %s as expected", exc)
+            self.log.debug("Remove banned node %s from cluster node lsit", self.target_node.name)
+            # need to remove it before create cluster connection, so banned node was not in ip list
+            self.cluster.nodes.remove(self.target_node)
 
             with self.cluster.cql_connection_patient(working_node) as session:
                 LOGGER.debug("Check keyspace %s.%s is empty", keyspace_name, table_name)


### PR DESCRIPTION
Banned node should be remove from node list before cql session to cluster will be initialized. in this case the ip address of the banned will be added to ip list for `get_node_cql_ips`.
More details in [scylladb/scylla-cluster-tests#10503](https://github.com/scylladb/scylla-cluster-tests/issues/10503#issuecomment-2894125344)

Fixes issue: scylladb/scylla-cluster-tests#10503

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
