### PR TITLE
Add custom config option for pipelines

### DIFF
--- a/jenkins-pipelines/hackathon/hackathon-custom-config.jenkinsfile
+++ b/jenkins-pipelines/hackathon/hackathon-custom-config.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "aws",
+    region: 'eu-west-1',
+    availability_zone: 'a',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/hackathon/hackathon-custom-config.yaml',
+    provision_type: 'on_demand',
+)

--- a/test-cases/hackathon/hackathon-custom-config.yaml
+++ b/test-cases/hackathon/hackathon-custom-config.yaml
@@ -1,0 +1,26 @@
+test_duration: 30
+stress_cmd: [
+  "cassandra-stress write cl=QUORUM duration=15m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 -pop seq=1..10000000 -log interval=5"
+]
+
+n_db_nodes: 3
+simulated_racks: 3
+instance_type_db: 'i4i.large'
+
+n_loaders: 3
+instance_type_loader: 'c6i.2xlarge'
+
+n_monitor_nodes: 1
+instance_type_monitor: 't3.large'
+
+user_prefix: 'hackathon-custom-config'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
+backtrace_decoding: false
+print_kernel_callstack: true
+parallel_node_operations: true
+
+append_scylla_yaml:
+  enable_tablets: true
+  tablets_mode_for_new_keyspaces: 'enabled'

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -63,6 +63,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('test_config', 'test-cases/artifacts/centos7.yaml')}",
                    description: 'a config file for the artifacts test',
                    name: 'test_config')
+            text(defaultValue: '',
+                    description: 'custom config file to be used on top of the test_config',
+                   name: "custom_config")
             string(defaultValue: "${pipelineParams.get('post_behavior_db_nodes', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_db_nodes')
@@ -126,7 +129,7 @@ def call(Map pipelineParams) {
                                              "AWS_SECRET_ACCESS_KEY=${env.AWS_SECRET_ACCESS_KEY}",
                                              "SCT_TEST_ID=${UUID.randomUUID().toString()}",]) {
 
-                                        def test_config = groovy.json.JsonOutput.toJson(params.test_config)
+                                        def test_config = env.TEST_CONFIG ?: groovy.json.JsonOutput.toJson(params.test_config)
                                         stage("Checkout (${instance_type})") {
                                             script {
                                                 loadEnvFromString(params.extra_environment_variables)
@@ -137,6 +140,21 @@ def call(Map pipelineParams) {
                                                 }
                                             }
                                             dockerLogin(params)
+                                        }
+                                        stage('Create Custom Config') {
+                                            steps {
+                                                catchError(stageResult: 'FAILURE') {
+                                                    script {
+                                                        wrap([$class: 'BuildUser']) {
+                                                            dir('scylla-cluster-tests') {
+                                                                timeout(time: 5, unit: 'MINUTES') {
+                                                                    createCustomConfig(params)
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
                                         }
                                         stage('Create Argus Test Run') {
                                             catchError(stageResult: 'FAILURE') {

--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -35,6 +35,9 @@ def call() {
             string(defaultValue: "test-cases/longevity/longevity-100gb-4h.yaml",
                    description: '',
                    name: 'test_config')
+            text(defaultValue: '',
+                   description: 'custom config file to be used on top of the test_config',
+                   name: "custom_config")
             string(defaultValue: "aws",
                description: 'aws|gce',
                name: 'backend')
@@ -136,6 +139,21 @@ def call() {
                   }
                   dockerLogin(params)
                }
+            }
+            stage('Create Custom Config') {
+                steps {
+                    catchError(stageResult: 'FAILURE') {
+                        script {
+                            wrap([$class: 'BuildUser']) {
+                                dir('scylla-cluster-tests') {
+                                    timeout(time: 5, unit: 'MINUTES') {
+                                        createCustomConfig(params)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
             stage('Create SCT Runner') {
                 steps {

--- a/vars/createArgusTestRun.groovy
+++ b/vars/createArgusTestRun.groovy
@@ -1,7 +1,7 @@
 #!groovy
 
 def call(Map params) {
-    def test_config = groovy.json.JsonOutput.toJson(params.test_config)
+    def test_config = env.TEST_CONFIG ?: groovy.json.JsonOutput.toJson(params.test_config)
     retry(3) {
 		sh """#!/bin/bash
 			set -xe

--- a/vars/createCustomConfig.groovy
+++ b/vars/createCustomConfig.groovy
@@ -1,0 +1,32 @@
+#!groovy
+import groovy.json.JsonSlurper
+import groovy.json.JsonOutput
+
+def call(Map params) {
+    // check if custom_config exists in the pipeline params
+    if (params.containsKey('custom_config') && params.custom_config) {
+        // Write custom config to file
+        def customConfigPath = 'custom_config.yaml'
+        writeFile file: customConfigPath, text: params.custom_config.toString()
+
+        // Parse test_config into a list
+        def testConfigRaw = params.test_config.toString()
+        def testConfigList
+        if (testConfigRaw.startsWith('[')) {
+                // JSON list
+                testConfigList = new JsonSlurper().parseText(testConfigRaw)
+            } else {
+                // Single string => convert to list
+                testConfigList = [testConfigRaw]
+            }
+
+        // Add custom config path to list
+        testConfigList << customConfigPath
+
+        // Convert back to JSON string
+        env.TEST_CONFIG = "'${JsonOutput.toJson(testConfigList)}'"
+    } else {
+        // If custom_config is not provided, use the original test_config
+        env.TEST_CONFIG = "'${params.test_config}'"
+    }
+}

--- a/vars/createSctRunner.groovy
+++ b/vars/createSctRunner.groovy
@@ -2,7 +2,7 @@
 
 def call(Map params, Integer test_duration, String region) {
     def cloud_provider = getCloudProviderFromBackend(params.backend)
-    def test_config = groovy.json.JsonOutput.toJson(params.test_config)
+    def test_config = env.TEST_CONFIG ?: groovy.json.JsonOutput.toJson(params.test_config)
     def test_name = groovy.json.JsonOutput.toJson(params.test_name)
 
     // NOTE: EKS jobs have 'availability_zone' be defined as 'a,b'

--- a/vars/finishArgusTestRun.groovy
+++ b/vars/finishArgusTestRun.groovy
@@ -3,7 +3,7 @@
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 
 def call(Map params, RunWrapper currentBuild) {
-    def test_config = groovy.json.JsonOutput.toJson(params.test_config)
+    def test_config = env.TEST_CONFIG ?: groovy.json.JsonOutput.toJson(params.test_config)
     def test_status = currentBuild.currentResult
 
     sh """#!/bin/bash

--- a/vars/getJobTimeouts.groovy
+++ b/vars/getJobTimeouts.groovy
@@ -3,7 +3,7 @@
 List<Integer> call(Map params, String region){
     // handle params which can be a json list
     def current_region = initAwsRegionParam(params.region, region)
-    def test_config = groovy.json.JsonOutput.toJson(params.test_config)
+    def test_config = env.TEST_CONFIG ?: groovy.json.JsonOutput.toJson(params.test_config)
     def cmd = """#!/bin/bash
     export SCT_CLUSTER_BACKEND="${params.backend}"
     export SCT_CONFIG_FILES=${test_config}

--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -65,6 +65,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('test_config', '')}",
                    description: 'a config file for the test',
                    name: 'test_config')
+            text(defaultValue: '',
+                    description: 'custom config file to be used on top of the test_config',
+                   name: "custom_config")
             string(defaultValue: "${pipelineParams.get('test_name', '')}",
                    description: 'Name of the test to run',
                    name: 'test_name')
@@ -115,6 +118,21 @@ def call(Map pipelineParams) {
                         }
                     }
                     dockerLogin(params)
+                }
+            }
+            stage('Create Custom Config') {
+                steps {
+                    catchError(stageResult: 'FAILURE') {
+                        script {
+                            wrap([$class: 'BuildUser']) {
+                                dir('scylla-cluster-tests') {
+                                    timeout(time: 5, unit: 'MINUTES') {
+                                        createCustomConfig(params)
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
             stage('Create Argus Test Run') {

--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -61,6 +61,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('test_config', '')}",
                    description: 'Test configuration file',
                    name: 'test_config')
+            text(defaultValue: '',
+                    description: 'custom config file to be used on top of the test_config',
+                   name: "custom_config")
             string(defaultValue: "${pipelineParams.get('test_name', '')}",
                    description: 'Name of the test to run',
                    name: 'test_name')
@@ -196,6 +199,21 @@ def call(Map pipelineParams) {
                                                         wrap([$class: 'BuildUser']) {
                                                             dir('scylla-cluster-tests') {
                                                                 checkout scm
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        stage('Create Custom Config') {
+                                            steps {
+                                                catchError(stageResult: 'FAILURE') {
+                                                    script {
+                                                        wrap([$class: 'BuildUser']) {
+                                                            dir('scylla-cluster-tests') {
+                                                                timeout(time: 5, unit: 'MINUTES') {
+                                                                    createCustomConfig(params)
+                                                                }
                                                             }
                                                         }
                                                     }

--- a/vars/provisionResources.groovy
+++ b/vars/provisionResources.groovy
@@ -2,7 +2,7 @@
 
 def call(Map params, String region){
     def current_region = initAwsRegionParam(params.region, region)
-    def test_config = groovy.json.JsonOutput.toJson(params.test_config)
+    def test_config = env.TEST_CONFIG ?: groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
 
     sh """#!/bin/bash

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -73,6 +73,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('test_config', '')}",
                    description: 'Test configuration file',
                    name: 'test_config')
+            text(defaultValue: '',
+                    description: 'custom config file to be used on top of the test_config',
+                   name: "custom_config")
             string(defaultValue: "${pipelineParams.get('test_name', '')}",
                    description: 'Name of the test to run',
                    name: 'test_name')
@@ -121,6 +124,21 @@ def call(Map pipelineParams) {
                                         checkout scm
                                         dockerLogin(params)
                                         (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout) = getJobTimeouts(params, builder.region)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            stage('Create Custom Config') {
+                steps {
+                    catchError(stageResult: 'FAILURE') {
+                        script {
+                            wrap([$class: 'BuildUser']) {
+                                dir('scylla-cluster-tests') {
+                                    timeout(time: 5, unit: 'MINUTES') {
+                                        createCustomConfig(params)
                                     }
                                 }
                             }

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -61,6 +61,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('test_config', '')}",
                    description: 'Test configuration file',
                    name: 'test_config')
+            text(defaultValue: '',
+                    description: 'custom config file to be used on top of the test_config',
+                   name: "custom_config")
             string(defaultValue: "${pipelineParams.get('test_name', '')}",
                    description: 'Name of the test to run',
                    name: 'test_name')
@@ -209,6 +212,21 @@ def call(Map pipelineParams) {
                                                             }
                                                         }
                                                         dockerLogin(params)
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        stage('Create Custom Config') {
+                                            steps {
+                                                catchError(stageResult: 'FAILURE') {
+                                                    script {
+                                                        wrap([$class: 'BuildUser']) {
+                                                            dir('scylla-cluster-tests') {
+                                                                timeout(time: 5, unit: 'MINUTES') {
+                                                                    createCustomConfig(params)
+                                                                }
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }

--- a/vars/runCleanupResource.groovy
+++ b/vars/runCleanupResource.groovy
@@ -6,7 +6,7 @@ def call(Map params, String region){
     if (params.gce_datacenter) {
         current_gce_datacenter = groovy.json.JsonOutput.toJson(params.gce_datacenter)
     }
-    def test_config = groovy.json.JsonOutput.toJson(params.test_config)
+    def test_config = env.TEST_CONFIG ?: groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
 
     sh """#!/bin/bash

--- a/vars/runCollectLogs.groovy
+++ b/vars/runCollectLogs.groovy
@@ -7,7 +7,7 @@ def call(Map params, String region){
     if (params.gce_datacenter) {
         current_gce_datacenter = groovy.json.JsonOutput.toJson(params.gce_datacenter)
     }
-    def test_config = groovy.json.JsonOutput.toJson(params.test_config)
+    def test_config = env.TEST_CONFIG ?: groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
     sh """#!/bin/bash
 

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -7,7 +7,8 @@ def call(Map params, String region, functional_test = false, Map pipelineParams 
     if (params.gce_datacenter) {
         current_gce_datacenter = groovy.json.JsonOutput.toJson(params.gce_datacenter)
     }
-    def test_config = groovy.json.JsonOutput.toJson(params.test_config)
+
+    def test_config = env.TEST_CONFIG ?: groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
     def perf_extra_jobs_to_compare = params.perf_extra_jobs_to_compare ? groovy.json.JsonOutput.toJson(params.perf_extra_jobs_to_compare) : ""
 


### PR DESCRIPTION
Add a new field to pipelines named `custom_config`.
A file named `custom_config.yaml` will be created with the field's contents and appended to the list of test configs.
This allows fast prototyping of new tests without having to go through the step of commiting a change to an existing config. 

Example usage:
![Screenshot From 2025-05-22 09-26-30](https://github.com/user-attachments/assets/ee9e5e95-2b75-486a-bb3d-9c6afb4bcdc9)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/ee0d1e57-0f1b-40ea-adb3-0fc19953a102/details

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
