### PR TITLE
improvement(jenkins_params): Update scylla_repo description

### DIFF
--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -52,7 +52,9 @@ def call() {
             string(defaultValue: '', description: '', name: 'scylla_ami_id')
             string(defaultValue: '', description: '', name: 'gce_image_db')
             string(defaultValue: '', description: '', name: 'scylla_version')
-            string(defaultValue: '', description: '', name: 'scylla_repo')
+            string(defaultValue: '',
+                   description: 'ScyllaDB repository e.g., http://downloads.scylladb.com/deb/debian/scylla-2025.2.list,
+                   name: 'scylla_repo')
 
             string(defaultValue: '',
                    description: "Which version to use for oracle cluster during gemini test",

--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -32,7 +32,7 @@ def call(Map pipelineParams) {
                    description: 'a Scylla version to run against',
                    name: 'scylla_version')
             string(defaultValue: '',
-                   description: 'a Scylla repo to run against',
+                   description: 'ScyllaDB repository e.g., http://downloads.scylladb.com/deb/debian/scylla-2025.2.list',
                    name: 'scylla_repo')
 
             string(defaultValue: '',

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -57,7 +57,9 @@ def call(Map pipelineParams) {
 	    string(defaultValue: '', description: 'Azure image for ScyllaDB ', name: 'azure_image_db')
 	    string(defaultValue: '', description: 'cloud path for RPMs, s3:// or gs:// ', name: 'update_db_packages')
             string(name: 'scylla_version', defaultValue: '', description: 'Version of ScyllaDB')
-            string(name: 'scylla_repo', defaultValue: '', description: 'Repository for ScyllaDB')
+            string(defaultValue: '',
+                   description: 'ScyllaDB repository e.g., http://downloads.scylladb.com/deb/debian/scylla-2025.2.list',
+                   name: 'scylla_repo')
 
             // Provisioning Configuration
             separator(name: 'PROVISIONING', sectionHeader: 'Provisioning Configuration')

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -78,7 +78,9 @@ def call(Map pipelineParams) {
             string(defaultValue: '', description: '', name: 'scylla_ami_id')
             string(defaultValue: "${pipelineParams.get('scylla_version', '2025.1')}", description: '', name: 'scylla_version')
             // When branching to manager version branch, set scylla_version to the latest release
-            string(defaultValue: '', description: '', name: 'scylla_repo')
+            string(defaultValue: '',
+                   description: 'ScyllaDB repository e.g., http://downloads.scylladb.com/deb/debian/scylla-2025.2.list',
+                   name: 'scylla_repo')
             string(defaultValue: "${pipelineParams.get('gce_image_db', '')}",
                    description: "gce image of scylla (since scylla_version doesn't work with gce)",
                    name: 'gce_image_db')  // TODO: remove setting once hydra is able to discover scylla images in gce from scylla_version

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -37,8 +37,12 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('base_versions', '')}",
                    description: 'Base version in which the upgrade will start from.\nFormat should be for example -> 4.5,4.6 (or single version, or \'\' to use the auto mode)',
                    name: 'base_versions')
-            string(defaultValue: '', description: '', name: 'new_scylla_repo')
-            string(defaultValue: '', description: '', name: 'scylla_repo')
+            string(defaultValue: '',
+                   description: 'ScyllaDB repository to upgrade to. Specify the repository URL and optionally a specific version after a colon. For example: `https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-2025.2.list:2025.2.5`',
+                   name: 'new_scylla_repo')
+            string(defaultValue: '',
+                   description: 'ScyllaDB repository e.g., http://downloads.scylladb.com/deb/debian/scylla-2025.2.list',
+                   name: 'scylla_repo')
             string(defaultValue: '',
                    description: 'cloud path for RPMs, s3:// or gs://',
                    name: 'update_db_packages')

--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -33,7 +33,9 @@ def call(Map pipelineParams) {
 
             string(defaultValue: '', description: '', name: 'scylla_ami_id')
             string(defaultValue: '', description: '', name: 'scylla_version')
-            string(defaultValue: '', description: '', name: 'scylla_repo')
+            string(defaultValue: '',
+                   description: 'Url to the repo of scylla version to install scylla. Can provide specific version after a colon e.g: `https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-2021.1.list:2021.1.18`',
+                   name: 'scylla_repo')
             string(defaultValue: "${pipelineParams.get('provision_type', 'spot')}",
                    description: 'spot_low_price|on_demand|spot_fleet|spot_low_price|spot',
                    name: 'provision_type')

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -36,7 +36,9 @@ def call(Map pipelineParams) {
                name: 'availability_zone')
 
             string(defaultValue: '', description: '', name: 'scylla_ami_id')
-            string(defaultValue: '', description: '', name: 'new_scylla_repo')
+            string(defaultValue: '',
+                   description: 'ScyllaDB repository to upgrade to. Specify the repository URL and optionally a specific version after a colon. For example: `https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-2025.2.list:2025.2.5`',
+                   name: 'new_scylla_repo')
 
             string(defaultValue: "${pipelineParams.get('provision_type', 'spot_low_price')}",
                    description: 'spot_low_price|on_demand|spot_fleet|spot_low_price',


### PR DESCRIPTION
The parameters `scylla_repo` and `byo_scylla_repo` may appear similar,r but expect different types of input:

-  scylla_repo expects a GitHub repository URL (e.g., a source repo or branch for Scylla).
- byo_scylla_repo expects a YUM repository URL, such as:
    https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-2023.1.repo

This PR updates the documentation to clarify the distinction and reduce confusion.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
