### PR TITLE
Default region change to us-east-1

### DIFF
--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -26,7 +26,7 @@ def call(Map pipelineParams) {
                description: 'aws|gce|azure|docker',
                name: 'backend')
 
-            string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
+            string(defaultValue: "${pipelineParams.get('region', 'us-east-1')}",
                description: 'Supported: us-east-1 | eu-west-1 | eu-west-2 | eu-north-1 | eu-central-1 | us-west-2 | random (randomly select region)',
                name: 'region')
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -61,7 +61,7 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('backend', 'aws')}",
                description: 'aws|gce',
                name: 'backend')
-            string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
+            string(defaultValue: "${pipelineParams.get('region', 'us-east-1')}",
                description: 'Supported: us-east-1 | eu-west-1 | eu-west-2 | eu-north-1 | eu-central-1 | us-west-2 | random (randomly select region)',
                name: 'region')
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -20,7 +20,7 @@ def call(Map pipelineParams) {
                description: 'aws|gce',
                name: 'backend')
 
-            string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
+            string(defaultValue: "${pipelineParams.get('region', 'us-east-1')}",
                description: 'us-east-1|eu-west-1',
                name: 'region')
 

--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -19,7 +19,7 @@ def call(Map pipelineParams) {
                description: 'aws|gce',
                name: 'backend')
 
-            string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
+            string(defaultValue: "${pipelineParams.get('region', 'us-east-1')}",
                description: 'us-east-1|eu-west-1',
                name: 'region')
 

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -25,7 +25,7 @@ def call(Map pipelineParams) {
                description: 'aws|gce|azure',
                name: 'backend')
 
-            string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
+            string(defaultValue: "${pipelineParams.get('region', 'us-east-1')}",
                description: 'Supported: us-east-1 | eu-west-1 | eu-west-2 | eu-north-1 | eu-central-1 | us-west-2 | random (randomly select region)',
                name: 'region')
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",


### PR DESCRIPTION
AMIs are created by default in `us-east-1`. The default region we use in Jenkins jobs is `eu-west-1`.
This PR changes the default region to match AMIs default location.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
