### PR TITLE
feature(config): switch allocation memmory event severity

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -308,3 +308,5 @@ mgmt_snapshots_preparer_params:
   num_of_rows: ''
   sequence_start: ''
   sequence_end: ''
+
+allocation_as_errors: true

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1761,6 +1761,10 @@ class SCTConfiguration(dict):
              help="Workload name, can be: write|read|mixed|unset."
                   "Used for e.g. latency_calculator_decorator (use with 'use_hdrhistogram' set to true)."
                   "If unset, workload is taken from test name."),
+
+        dict(name="allocation_as_errors", env="SCT_ALLOCATION_AS_ERRORS", type=boolean,
+             help="If set to True, allocation errors will be treated as test errors. "
+                  "If set to False, allocation errors will be treated as warnings."),
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',

--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -158,5 +158,10 @@ def enable_default_filters(sct_config: SCTConfiguration):
                         r" \(raft topology: exec_global_command\(barrier\) failed with seastar::rpc::closed_error"
                         r" \(connection is closed\)\)").publish()
 
+    if not sct_config.get('allocation_as_errors'):
+        EventsSeverityChangerFilter(new_severity=Severity.WARNING,
+                                    event_class=DatabaseLogEvent.OVERSIZED_ALLOCATION,
+                                    regex=r'.*seastar_memory - oversized allocation:').publish()
+
 
 __all__ = ("start_events_device", "stop_events_device", "enable_default_filters")


### PR DESCRIPTION
Allocation memory warning mark jobs as failed because processes as errors. Adding new config parameter which could be passed as ENV variable to change severity for such error events to warning

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
