### PR TITLE
fix(siren): introduce cloud_cluster_name config parameter

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -141,6 +141,15 @@ scylla cloud cluster id
 **type:** int
 
 
+## **cloud_cluster_name** / SCT_CLOUD_CLUSTER_NAME
+
+scylla cloud cluster name
+
+**default:** N/A
+
+**type:** str
+
+
 ## **cloud_prom_bearer_token** / SCT_CLOUD_PROM_BEARER_TOKEN
 
 scylla cloud promproxy bearer_token to federate monitoring data into our monitoring instance

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -296,6 +296,9 @@ class SCTConfiguration(dict):
         dict(name="cloud_cluster_id", env="SCT_CLOUD_CLUSTER_ID", type=int,
              help="""scylla cloud cluster id"""),
 
+        dict(name="cloud_cluster_name", env="SCT_CLOUD_CLUSTER_NAME", type=str,
+             help="""scylla cloud cluster name"""),
+
         dict(name="cloud_prom_bearer_token", env="SCT_CLOUD_PROM_BEARER_TOKEN", type=str,
              help="""scylla cloud promproxy bearer_token to federate monitoring data into our monitoring instance"""),
 


### PR DESCRIPTION
scylla-cloud.yaml (which is used as a configuration for SCT longevities) is going to be extended https://github.com/scylladb/siren-tests/pull/1884/commits/5b2315b257fa9ada2c239942fe325bbbb7c3bd13 with new parameter `cloud_cluster_name`.

To keep up with the changes in siren-tests, the same param should be added to SCT to not fail on config validation step.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [scylla-cloud-longevity-small-set-1h-aws](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/longevity-tests/job/Appqa/job/scylla-cloud-longevity-small-set-1h-aws/46/) (test failure is not related to the change)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code