### PR TITLE
fix(unit-test): skip the T`estBaseVersion.test_2025_1_release_centos` test

### DIFF
--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -14,8 +14,9 @@
 
 import unittest
 
-from sdcm.utils.version_utils import ComparableScyllaVersion
+import pytest
 
+from sdcm.utils.version_utils import ComparableScyllaVersion
 from utils.get_supported_scylla_base_versions import UpgradeBaseVersion
 
 
@@ -115,6 +116,7 @@ class TestBaseVersion(unittest.TestCase):
         version_list = general_test(scylla_repo, linux_distro)
         assert {'2024.1', '2024.2', '6.2'}.issubset(set(version_list))
 
+    @pytest.mark.skip("'zstd' support is absent in this branch")
     def test_2025_1_release_centos(self):
         scylla_repo = self.url_base + '/branch-2025.1/rpm/centos/2025-02-23T16:19:08Z/scylla.repo'
         linux_distro = 'centos-9'


### PR DESCRIPTION
The `TestBaseVersion.test_2025_1_release_centos` requires zstd support.
But it is absent in this branch and we get following error:

```
  FileNotFoundError: [Errno 2] No such file or directory: 'zstd'
```

So, skip this test to unblock CI.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
