### PR TITLE
improvement(PerformanceRegressionPredefinedStepsTest): Run alter table earlier

### DIFF
--- a/performance_regression_gradual_grow_throughput.py
+++ b/performance_regression_gradual_grow_throughput.py
@@ -131,12 +131,12 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
         # run a write workload as a preparation
         if workload.preload_data and not skip_optional_stage('perf_preload_data'):
             self.preload_data()
-            self.wait_no_compactions_running(n=400, sleep_time=120)
-            self.run_fstrim_on_all_db_nodes()
-
             if post_prepare_cql_cmds := self.params.get('post_prepare_cql_cmds'):
                 self.log.debug("Execute post prepare queries: %s", post_prepare_cql_cmds)
                 self._run_cql_commands(post_prepare_cql_cmds)
+
+            self.wait_no_compactions_running(n=400, sleep_time=120)
+            self.run_fstrim_on_all_db_nodes()
 
         self.run_gradual_increase_load(workload=workload,
                                        stress_num=stress_num,


### PR DESCRIPTION
Before this change, the alter table to disable speculative retry (or any other change we want to do) would run right before we start the main stress which cause some noise in the begining of the stress as schema tries to reach agreement across nodes and all prepared statements are being invalidated. With this change the alter table happens right after the preload as we wait anyway for compactions to settle.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
