### PR TITLE
Fix quoting when creating materialized views

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -356,8 +356,8 @@ class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):
             # Create materialized view
             view_name = base_table_name + '_mv'
             self.log.debug('Create materialized view: {0}.{1}'.format(ks_name, view_name))
-            self.create_materialized_view(ks_name, base_table_name, view_name, ['"C0"'], ['key'], session,
-                                          mv_columns=['"C0"', 'key'])
+            self.create_materialized_view(ks_name, base_table_name, view_name, ['C0'], ['key'], session,
+                                          mv_columns=['C0', 'key'])
 
             # Wait for the materialized view is built
             self._wait_for_view(self.db_cluster, session, ks_name, view_name)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5069,7 +5069,6 @@ class Nemesis:
                 if not column:
                     raise UnsupportedNemesis(
                         'A supported column for creating MV is not found. nemesis can\'t run')
-                column = f'"{column}"'
                 self.log.info("Stopping Scylla on node %s", self.target_node.name)
                 self.target_node.stop_scylla()
                 InfoEvent(message=f'Create a materialized-view for table {ks_name}.{base_table_name}').publish()

--- a/sdcm/utils/cql_utils.py
+++ b/sdcm/utils/cql_utils.py
@@ -23,10 +23,10 @@ def cql_quote_if_needed(identifier: str) -> str:
 
     https://cassandra.apache.org/doc/stable/cassandra/cql/definitions.html#identifiers
     """
-    identifier_regex = re.compile(r'^[^0-9][a-z0-9_]+$')
-    if not identifier_regex.match(identifier):
-        return f'"{identifier}"'
-    return identifier
+    identifier_regex = re.compile(r'^[a-z][a-z0-9_]*$')
+    if identifier_regex.match(identifier):
+        return identifier
+    return f'"{identifier}"'
 
 
 def cql_unquote_if_needed(identifier: str):

--- a/unit_tests/test_cql_utils.py
+++ b/unit_tests/test_cql_utils.py
@@ -1,0 +1,41 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+from sdcm.utils.cql_utils import cql_quote_if_needed, cql_unquote_if_needed
+
+
+def test_cql_quote_if_needed():
+    assert cql_quote_if_needed('v') == 'v'
+    assert cql_quote_if_needed('0') == '"0"'
+    assert cql_quote_if_needed('v0') == 'v0'
+    assert cql_quote_if_needed('0v') == '"0v"'
+    assert cql_quote_if_needed('C') == '"C"'
+    assert cql_quote_if_needed('C0') == '"C0"'
+    assert cql_quote_if_needed('0C') == '"0C"'
+    assert cql_quote_if_needed('column1') == 'column1'
+    assert cql_quote_if_needed('columnA') == '"columnA"'
+    assert cql_quote_if_needed('1column') == '"1column"'
+    assert cql_quote_if_needed('Column1') == '"Column1"'
+
+
+def test_cql_unquote_if_needed():
+    assert cql_unquote_if_needed('"quoted"') == 'quoted'
+    assert cql_unquote_if_needed('unquoted') == 'unquoted'
+    assert cql_unquote_if_needed('"quoted_left') == '"quoted_left'
+    assert cql_unquote_if_needed('quoted_right"') == 'quoted_right"'
+    assert cql_unquote_if_needed('quoted_"_middle') == 'quoted_"_middle'
+    assert cql_unquote_if_needed('quoted_"_multiple"') == 'quoted_"_multiple"'
+    assert cql_unquote_if_needed('quoted_"_multiple"') == 'quoted_"_multiple"'
+    assert cql_unquote_if_needed('"quote"_"multiple"') == 'quote"_"multiple'
+    assert cql_unquote_if_needed('""') == ''
+    assert cql_unquote_if_needed('"') == '"'


### PR DESCRIPTION
Fixed regex in `cql_quote_if_needed`.
| | Before| After|
|--------|--------|--------|
| `cql_quote_if_needed('v')` | `'"v"'`| `'v'`|
| `cql_quote_if_needed('C0')` | `'C0'`| `'"C0"'`|
| `cql_quote_if_needed('1x')` | `'"1x"'`| `'"1x"'`|
| `cql_quote_if_needed('x1')` | `'x1'`| `'x1'`|
| `cql_quote_if_needed('x1T')` | `'"x1T"'`| `'"x1T"'`|

Refactored and fixed `create_materialized_view` to no longer rely on manually quoting column names.
Also, in nemesis, the code only worked on the assumption that the column names required quoting but the primary keys did not.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/0e0d06c9-4d35-41f1-ab08-df5a9c414776

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
