### PR TITLE
fix(null-inserts): Upgrade default config

### DIFF
--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-with-null-inserts.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-with-null-inserts.jenkinsfile
@@ -6,9 +6,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingUpgradePipeline(
     backend: 'gce',
     base_versions: '',  // auto mode
-    linux_distro: 'centos-8',
-    gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-8',
-
+    linux_distro: 'ubuntu-focal',
+    use_preinstalled_scylla: true,
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
     test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-with-null-inserts.yaml"]'''
 )


### PR DESCRIPTION
This updates config for this job to be in line with our modern pipelines
for gce. Previous one didn't work since centos8 stream has been removed
long time ago.

Fixes: #10974

Testing:
 - [x] [Jenkins](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/rolling-upgrade-with-null-inserts-test/2/)
 - [x] [Argus](https://argus.scylladb.com/tests/scylla-cluster-tests/5e2800a8-ee14-41b6-ab59-faaab34e541b)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
