### PR TITLE
fix(scylla_yaml): Allow usage of any option in append_scylla_yaml

### DIFF
--- a/unit_tests/test_data/test_scylla_yaml_builders/functional.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/functional.result.json
@@ -21,5 +21,6 @@
   "auto_bootstrap": true,
   "enable_ipv6_dns_lookup": false,
   "listen_interface": "eth0",
-  "hinted_handoff_enabled": false
+  "hinted_handoff_enabled": false,
+  "test_parameter": "test_value"
 }

--- a/unit_tests/test_data/test_scylla_yaml_builders/functional.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/functional.yaml
@@ -35,3 +35,6 @@ scylla_network_config:
   public: false
   use_dns: false
   nic: 0  #  If ipv4 and public is True it has to be primary network interface (device index is 0)
+
+append_scylla_yaml:
+  test_parameter: test_value


### PR DESCRIPTION
Previously, the class did not allow it and it would fail on non existing field. Update testcase to verify this
* Use pydantic v2 validation
   * This could be extracted to another PR or commit if necessary

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] unit testing

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

