### PR TITLE
improvement(longevityPipeline.groovy): move BYO to config section

### DIFF
--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -51,13 +51,21 @@ def call(Map pipelineParams) {
                name: 'prepare_stress_duration')
 
             // ScyllaDB Configuration
-	    separator(name: 'SCYLLA_DB', sectionHeader: 'ScyllaDB Configuration Selection (Choose only one from below 6 options)')
-	    string(defaultValue: '', description: 'AMI ID for ScyllaDB ', name: 'scylla_ami_id')
-	    string(defaultValue: '', description: 'GCE image for ScyllaDB ', name: 'gce_image_db')
-	    string(defaultValue: '', description: 'Azure image for ScyllaDB ', name: 'azure_image_db')
-	    string(defaultValue: '', description: 'cloud path for RPMs, s3:// or gs:// ', name: 'update_db_packages')
+            separator(name: 'SCYLLA_DB', sectionHeader: 'ScyllaDB Configuration Selection. Choose only one from AMI, GCE, Azure, ScyllaDB Repo, or BYO ScyllaDB')
+            string(defaultValue: '', description: 'AMI ID for ScyllaDB ', name: 'scylla_ami_id')
+            string(defaultValue: '', description: 'GCE image for ScyllaDB ', name: 'gce_image_db')
+            string(defaultValue: '', description: 'Azure image for ScyllaDB ', name: 'azure_image_db')
+            string(defaultValue: '', description: 'cloud path for RPMs, s3:// or gs:// ', name: 'update_db_packages')
             string(name: 'scylla_version', defaultValue: '', description: 'Version of ScyllaDB')
             string(name: 'scylla_repo', defaultValue: '', description: 'Repository for ScyllaDB')
+            string(defaultValue: '',
+                   description: (
+                       'Custom "scylladb" repo to use. Leave empty if byo is not needed. \n' +
+                       'If set then it must be proper GH repo. Example: git@github.com:personal-username/scylla.git'),
+                   name: 'byo_scylla_repo')
+            string(defaultValue: '',
+                   description: 'Branch of the custom "scylladb" repo. Leave empty if byo is not needed.',
+                   name: 'byo_scylla_branch')
 
             // Provisioning Configuration
             separator(name: 'PROVISIONING', sectionHeader: 'Provisioning Configuration')
@@ -182,14 +190,6 @@ def call(Map pipelineParams) {
                     name: 'extra_environment_variables')
             // BYO ScyllaDB Configuration
             separator(name: 'BYO_SCYLLA', sectionHeader: 'BYO ScyllaDB Configuration')
-            string(defaultValue: '',
-                   description: (
-                       'Custom "scylladb" repo to use. Leave empty if byo is not needed. \n' +
-                       'If set then it must be proper GH repo. Example: git@github.com:personal-username/scylla.git'),
-                   name: 'byo_scylla_repo')
-            string(defaultValue: '',
-                   description: 'Branch of the custom "scylladb" repo. Leave empty if byo is not needed.',
-                   name: 'byo_scylla_branch')
             string(defaultValue: '/scylla-master/byo/byo_build_tests_dtest',
                    description: 'Used when byo scylladb repo+branch is provided. Default "/scylla-master/byo/byo_build_tests_dtest"',
                    name: 'byo_job_path')


### PR DESCRIPTION
Following Argus change https://github.com/scylladb/argus/pull/674 that moves Scylla BYO to ScyllaDB Configuration section.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/jsmolar/job/BYO-to-Config-Section/2/parameters/
![image](https://github.com/user-attachments/assets/785596fe-a104-4195-bb87-d21ed7b231c8)


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
