### PR TITLE
fix(treewide): Disable Tombstone GC for now

### DIFF
--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -81,4 +81,5 @@ use_preinstalled_scylla: true
 
 
 # Run a verification every 10 minutes:
-run_tombstone_gc_verification: '{"ks_cf": "scylla_bench.test", "interval": 600, "propagation_delay_in_seconds": 300}'
+# Disabled due to https://github.com/scylladb/scylladb/issues/23743
+# run_tombstone_gc_verification: '{"ks_cf": "scylla_bench.test", "interval": 600, "propagation_delay_in_seconds": 300}'

--- a/test-cases/longevity/longevity-large-partition-8h.yaml
+++ b/test-cases/longevity/longevity-large-partition-8h.yaml
@@ -66,4 +66,5 @@ data_validation: |
   partition_range_with_data_validation: 0-100
   limit_rows_number: 5555
 # Run a verification every 10 minutes:
-run_tombstone_gc_verification: '{"ks_cf": "scylla_bench.test", "interval": 600, "propagation_delay_in_seconds": 300}'
+# Disabled due to https://github.com/scylladb/scylladb/issues/23743
+# run_tombstone_gc_verification: '{"ks_cf": "scylla_bench.test", "interval": 600, "propagation_delay_in_seconds": 300}'

--- a/test-cases/longevity/longevity-lwt-500G-3d.yaml
+++ b/test-cases/longevity/longevity-lwt-500G-3d.yaml
@@ -29,5 +29,6 @@ space_node_threshold: 64424
 
 user_prefix: 'longevity-lwt-500G-3d'
 # Set tombstone_gc to 'repair' + a propagation_delay_in_seconds of 5 minutes for the tombstone-gc-verification table:
-post_prepare_cql_cmds: "ALTER TABLE cqlstress_lwt_example.blogposts with tombstone_gc = {'mode': 'repair', 'propagation_delay_in_seconds':'300'};"
-run_tombstone_gc_verification: '{"ks_cf": "cqlstress_lwt_example.blogposts", "interval": 300, "propagation_delay_in_seconds": 300}' # 'ks.cf, interval(sec), propagation_delay_in_seconds(sec)'
+# Disabled due to https://github.com/scylladb/scylladb/issues/23743
+# post_prepare_cql_cmds: "ALTER TABLE cqlstress_lwt_example.blogposts with tombstone_gc = {'mode': 'repair', 'propagation_delay_in_seconds':'300'};"
+# run_tombstone_gc_verification: '{"ks_cf": "cqlstress_lwt_example.blogposts", "interval": 300, "propagation_delay_in_seconds": 300}' # 'ks.cf, interval(sec), propagation_delay_in_seconds(sec)'


### PR DESCRIPTION
Disabled due to https://github.com/scylladb/scylladb/issues/23743, which might take a while to fix.
Prevents unnecessary fails due to a known bug, the feature itself it flawed regardless and the tombstone_gc is not a critical check, nor a check that worked particularly well.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] None

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
