### PR TITLE
fix(change_severity_filter): Add new pattern to expected error message

### DIFF
--- a/sdcm/utils/raft/__init__.py
+++ b/sdcm/utils/raft/__init__.py
@@ -320,6 +320,10 @@ class RaftFeature(RaftFeatureOperations):
                                         event_class=DatabaseLogEvent.DATABASE_ERROR,
                                         regex=r".*raft.*applier fiber stopped because of the error.*abort requested",
                                         extra_time_to_expiration=timeout),
+            EventsSeverityChangerFilter(new_severity=Severity.WARNING,
+                                        event_class=DatabaseLogEvent.RUNTIME_ERROR,
+                                        regex=r".*raft_topology - tablets draining failed.*connection is closed\)\). Aborting the topology operation",
+                                        extra_time_to_expiration=timeout),
         )
 
     def is_cluster_topology_consistent(self) -> bool:


### PR DESCRIPTION
Nemesis decommission_streaming_err aborts decommission topology operation Depend on time when it happened and with tablets, New error message which is expected , could appear. Change severity for this message during decommission_streaming_err from error to warning


Job where error 
```
2025-05-30T16:28:33.681+00:00 longevity-10gb-3h-2025-2-db-node-3b34a1b4-0-1      !ERR | scylla[4451]:  [shard  0: gms] raft_topology - tablets draining failed with std::runtime_error (raft topology: exec_global_command(barrier) failed with seastar::rpc::closed_error (connection is closed)). Aborting the topology operation
````
was seen last time: https://argus.scylladb.com/tests/scylla-cluster-tests/3b34a1b4-0a9b-42c8-b803-3def8862fcef

After fix, the message should have warning severity

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
