### PR TITLE
improvement(performance): wait for no tablets splits

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3483,6 +3483,21 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
             assert not self.is_compaction_running, "Waiting until all compactions settle down"
         _is_no_compaction_running()
 
+    @measure_time
+    def wait_for_no_tablets_splits(self, n=3, sleep_time=180):
+        # Wait until there are no tablets splits happened
+        @retrying(n=n, sleep_time=sleep_time, allowed_exceptions=(AssertionError,))
+        def _is_no_tablets_splits():
+            query = "select resize_type from system.tablets"
+            with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0], connect_timeout=600) as session:
+                query_result = session.execute(query)
+
+            results_set = set([result_row.resize_type for result_row in query_result])
+            self.log.debug("resize_type all results: %s", results_set)
+            assert results_set == {'none'} or not results_set, (
+                "Tablet splits or merges still in progress: %s" % results_set)
+        _is_no_tablets_splits()
+
     def metric_has_data(self, metric_query, n=80, sleep_time=60, ):
         """
         wait for any prometheus metric to have data in it


### PR DESCRIPTION
In the test_read performance test, we observed that even without any write operations, compactions were occurring. These compactions are a result of tablet splits and can happen several minutes after the wait_no_compactions function has finished.
To address this, we will now verify that no tablet splits or merges are active by checking the system.tablets table. The new condition for system idleness requires the resize_type column to be 'none' for all relevant tablets for a continuous period of three minutes.

Task: https://github.com/scylladb/scylla-cluster-tests/issues/10945

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [mixed (with tablets)](https://argus.scylladb.com/tests/scylla-cluster-tests/251efad6-5125-444c-86d8-e3305f8f2419)
```
< t:2025-05-31 09:55:55,601 f:db_log_reader.py l:123  c:sdcm.db_log_reader   p:DEBUG > 2025-05-31T09:55:55.484+00:00 perf-regression-predefined-steps-ub-db-node-251efad6-1     !INFO | scylla[5166]:  [shard  0:strm] storage_service - Starting the tablet split monitor...
< t:2025-05-31 09:55:59,182 f:db_log_reader.py l:123  c:sdcm.db_log_reader   p:DEBUG > 2025-05-31T09:55:58.530+00:00 perf-regression-predefined-steps-ub-db-node-251efad6-3     !INFO | scylla[5031]:  [shard  0:strm] storage_service - Starting the tablet split monitor...
< t:2025-05-31 09:56:00,566 f:db_log_reader.py l:123  c:sdcm.db_log_reader   p:DEBUG > 2025-05-31T09:56:00.259+00:00 perf-regression-predefined-steps-ub-db-node-251efad6-2     !INFO | scylla[5021]:  [shard  0:strm] storage_service - Starting the tablet split monitor...
< t:2025-05-31 10:59:00,267 f:tester.py       l:3496 c:PerformanceRegressionPredefinedStepsTest p:DEBUG > resize_type all results: {'none'}
< t:2025-05-31 11:42:07,330 f:tester.py       l:3496 c:PerformanceRegressionPredefinedStepsTest p:DEBUG > resize_type all results: {'none'}
< t:2025-05-31 12:18:02,945 f:tester.py       l:3496 c:PerformanceRegressionPredefinedStepsTest p:DEBUG > resize_type all results: {'none'}
< t:2025-05-31 12:54:02,607 f:tester.py       l:3496 c:PerformanceRegressionPredefinedStepsTest p:DEBUG > resize_type all results: {'none'}
< t:2025-05-31 13:30:04,220 f:tester.py       l:3496 c:PerformanceRegressionPredefinedStepsTest p:DEBUG > resize_type all results: {'none'}
< t:2025-05-31 14:06:16,235 f:tester.py       l:3496 c:PerformanceRegressionPredefinedStepsTest p:DEBUG > resize_type all results: {'none'}
```
- [x] [read (with tablets)](https://argus.scylladb.com/tests/scylla-cluster-tests/cc243080-4514-4f31-aaea-f4b95be8e9cd)
- [x] [read (vnodes)](https://argus.scylladb.com/tests/scylla-cluster-tests/3d42858f-2c4a-4695-a5cc-a6278e64873a)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
