### PR TITLE
test(elastic-cloud): add performance scale-out/scale-in tests

### DIFF
--- a/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-scale-out-larger.jenkinsfile
+++ b/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-scale-out-larger.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: 'eu-west-1',
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: """["test-cases/features/elasticity/elasticity-90-percent-perf-i4i-large-grow-i4i-4xlarge.yaml", "configurations/disable_kms.yaml"]""",
+    sub_tests: ["test_latency_mixed_with_nemesis"],
+)

--- a/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-scale-out-smaller.jenkinsfile
+++ b/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-scale-out-smaller.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    region: 'eu-west-1',
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: """["test-cases/features/elasticity/elasticity-90-percent-perf-i4i-4xlarge-grow-i4i-large.yaml", "configurations/disable_kms.yaml"]""",
+    sub_tests: ["test_latency_mixed_with_nemesis"],
+)

--- a/test-cases/features/elasticity/elasticity-90-percent-perf-i4i-4xlarge-grow-i4i-large.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-perf-i4i-4xlarge-grow-i4i-large.yaml
@@ -1,0 +1,48 @@
+# Test case for ScyllaDB elasticity at 90% utilization
+# The test writes approximately 3 TB of data to fill the cluster at around 90% utilization.
+# After the cluster is filled, a mixed workload is run at approximately 50% load.
+# The cluster is the scaled out then in with smaller nodes.
+test_duration: 800
+prepare_write_cmd: [
+  "cassandra-stress write no-warmup cl=QUORUM n=960000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..960000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=960000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=960000001..1920000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=960000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1920000001..2880000000",
+]
+
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=300 fixed=30000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..1440000000,720000000,14400000)'"
+
+
+n_db_nodes: 3
+simulated_racks: 3
+instance_type_db: 'i4i.4xlarge'
+
+nemesis_add_node_cnt: 3
+nemesis_grow_shrink_instance_type: 'i4i.large'
+
+n_loaders: 3
+instance_type_loader: 'c6i.2xlarge'
+
+n_monitor_nodes: 1
+instance_type_monitor: 't3.large'
+
+nemesis_class_name: 'GrowShrinkClusterNemesis'
+nemesis_interval: 30
+nemesis_sequence_sleep_between_ops: 10
+
+user_prefix: 'elasticity-test'
+ami_id_db_scylla_desc: 'VERSION_DESC'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
+backtrace_decoding: false
+print_kernel_callstack: true
+
+store_perf_results: false
+use_hdrhistogram: true
+email_recipients: ["scylla-perf-results@scylladb.com"]
+email_subject_postfix: 'elasticity test'
+parallel_node_operations: true
+
+append_scylla_yaml:
+  enable_tablets: true
+  tablets_mode_for_new_keyspaces: 'enabled'

--- a/test-cases/features/elasticity/elasticity-90-percent-perf-i4i-large-grow-i4i-4xlarge.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-perf-i4i-large-grow-i4i-4xlarge.yaml
@@ -1,0 +1,48 @@
+# Test case for ScyllaDB elasticity at 90% utilization
+# The test writes approximately 0.4 TB of data to fill the cluster at around 90% utilization.
+# After the cluster is filled, a mixed workload is run at approximately 50% load.
+# The cluster is the scaled out then in with larger nodes.
+test_duration: 800
+prepare_write_cmd: [
+  "cassandra-stress write no-warmup cl=QUORUM n=120000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..120000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=120000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=120000001..240000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=120000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=240000001..360000000",
+  ]
+
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=150 fixed=3300/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..180000000,90000000,1800000)'"
+
+
+n_db_nodes: 3
+simulated_racks: 3
+instance_type_db: 'i4i.large'
+
+nemesis_add_node_cnt: 3
+nemesis_grow_shrink_instance_type: 'i4i.4xlarge'
+
+n_loaders: 3
+instance_type_loader: 'c6i.2xlarge'
+
+n_monitor_nodes: 1
+instance_type_monitor: 't3.large'
+
+nemesis_class_name: 'GrowShrinkClusterNemesis'
+nemesis_interval: 30
+nemesis_sequence_sleep_between_ops: 10
+
+user_prefix: 'elasticity-test'
+ami_id_db_scylla_desc: 'VERSION_DESC'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1'
+backtrace_decoding: false
+print_kernel_callstack: true
+
+store_perf_results: false
+use_hdrhistogram: true
+email_recipients: ["scylla-perf-results@scylladb.com"]
+email_subject_postfix: 'elasticity test'
+parallel_node_operations: true
+
+append_scylla_yaml:
+  enable_tablets: true
+  tablets_mode_for_new_keyspaces: 'enabled'


### PR DESCRIPTION
Add tests that check the performance under load (~50%) while doing scale out and scale in with a different type of instance than the original cluster.
The tests will be run manually, on demand.
The test pass if there is no performance regression.

- add test that scales out and in with a smaller instance
 closes: #9256
 Argus: https://argus.scylladb.com/tests/scylla-cluster-tests/d9bb4661-49b3-4a93-8749-f78ae3ec1861
- add test that scales out and it with a larger instance 
  closes: #9257
  Argus: https://argus.scylladb.com/tests/scylla-cluster-tests/245d82d5-78a3-4a9a-adc7-5920fba379bb

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
