### PR TITLE
test(elastic-cloud): add test that fills to 90% after scale out

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1050,6 +1050,15 @@ Used for scale test: max size of the cluster
 **type:** int_or_space_separated_ints
 
 
+## **cluster_target_instance_type** / SCT_CLUSTER_TARGET_INSTANCE_TYPE
+
+The type of instances added to reach `cluster_target_size`
+
+**default:** N/A
+
+**type:** str (appendable)
+
+
 ## **space_node_threshold** / SCT_SPACE_NODE_THRESHOLD
 
 Space node threshold before starting nemesis (bytes)<br>The default value is 6GB (6x1024^3 bytes)<br>This value is supposed to reproduce<br>https://github.com/scylladb/scylla/issues/1140

--- a/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-double-cluster-smaller-8xl.jenkinsfile
+++ b/jenkins-pipelines/oss/features/elasticity/elasticity-90-percent-double-cluster-smaller-8xl.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "aws",
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/features/elasticity/elasticity-90-percent-perf-i4i-2xlarge-grow-fill-i4i-large.yaml',
+)

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -163,6 +163,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
             add_node_cnt = self.params.get('add_node_cnt')
             nodes_by_dcx = group_nodes_by_dc_idx(self.db_cluster.data_nodes)
             current_cluster_size = [len(nodes_by_dcx[dcx]) for dcx in sorted(nodes_by_dcx)]
+            instance_type = self.params.get('cluster_target_instance_type') or self.params.get('instance_type_db')
 
             InfoEvent(
                 message=f"Starting to grow cluster from {self.params.get('n_db_nodes')} to {cluster_target_size}").publish()
@@ -175,7 +176,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
                             target - current_cluster_size[dcx]) >= add_node_cnt else target - current_cluster_size[dcx]
                         InfoEvent(message=f"Adding next number of nodes {add_nodes_num} to dc_idx {dcx}").publish()
                         added_nodes.extend(self.db_cluster.add_nodes(
-                            count=add_nodes_num, enable_auto_bootstrap=True, dc_idx=dcx, rack=None))
+                            count=add_nodes_num, enable_auto_bootstrap=True, dc_idx=dcx, rack=None, instance_type=instance_type))
 
                 self.monitors.reconfigure_scylla_monitoring()
                 up_timeout = MAX_TIME_WAIT_FOR_NEW_NODE_UP

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -698,6 +698,9 @@ class SCTConfiguration(dict):
         dict(name="cluster_target_size", env="SCT_CLUSTER_TARGET_SIZE", type=int_or_space_separated_ints,
              help="""Used for scale test: max size of the cluster"""),
 
+        dict(name="cluster_target_instance_type", env="SCT_CLUSTER_TARGET_INSTANCE_TYPE", type=str,
+             help="""The type of instances added to reach `cluster_target_size`"""),
+
         dict(name="space_node_threshold", env="SCT_SPACE_NODE_THRESHOLD",
              type=int, k8s_multitenancy_supported=True,
              help="""

--- a/test-cases/features/elasticity/elasticity-90-percent-perf-i4i-8xlarge-grow-fill-i4i-large.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-perf-i4i-8xlarge-grow-fill-i4i-large.yaml
@@ -1,0 +1,35 @@
+# Test case for ScyllaDB elasticity at 90% utilization
+# The test writes approximately 6 TB of data to fill the cluster at around 90% utilization.
+# After the cluster is filled, smaller nodes are added to the cluster.
+# The cluster is then filled to 90% again
+test_duration: 1200
+# the prepare write is long, increase the default duration to avoid soft timeout
+prepare_stress_duration: 600
+prepare_write_cmd: [
+  "cassandra-stress write no-warmup cl=QUORUM n=1920000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..1920000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=1920000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1920000001..3840000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=1920000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=3840000001..5760000000",
+]
+
+stress_cmd: [
+  "cassandra-stress write no-warmup cl=QUORUM n=120000000 -schema keyspace=keyspace2 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=20000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..120000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=120000000 -schema keyspace=keyspace2 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=20000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop seq=120000001..240000000",
+  "cassandra-stress write no-warmup cl=QUORUM n=120000000 -schema keyspace=keyspace2 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=100 fixed=20000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop seq=240000001..360000000",
+]
+
+n_db_nodes: 3
+simulated_racks: 3
+instance_type_db: 'i4i.8xlarge'
+
+cluster_target_size: 6
+add_node_cnt: 3
+cluster_target_instance_type: 'i4i.large'
+
+n_loaders: 3
+instance_type_loader: 'c6i.2xlarge'
+instance_type_monitor: 't3.large'
+
+nemesis_class_name: 'NoOpMonkey'
+
+user_prefix: 'elasticity-test'
+round_robin: true


### PR DESCRIPTION
Add tests that checks that a heterogenous cluster does not run out of space at 90% utilization.
The combination of instances are selected based on their difference in disk space per shard.
These tests will be run on demand, periodically.
The tests pass by not running out of space.
  
  - add test that scales out a cluster at 90% and fills it back to 90% 
   closes: #9597
    - [x] https://argus.scylladb.com/tests/scylla-cluster-tests/288b59c2-6036-43fb-9de8-fd9b32b6c495
   
refs:  https://github.com/scylladb/scylla-cluster-tests/issues/9129

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
