### PR TITLE
fix(nemesis): fix minimum `bloom_filter_fp_chance`

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2483,7 +2483,9 @@ class Nemesis:
                 1.0: Disables the Bloom filter.
             default: bloom_filter_fp_chance = 0.01
         """
-        self._modify_table_property(name="bloom_filter_fp_chance", val=random.random() / 2)
+        # minimum value cannot be 0, as that would require "infinite" memory
+        # the actual minimum value is 6.71e-05, as declared in `min_supported_bloom_filter_fp_chance()`
+        self._modify_table_property(name="bloom_filter_fp_chance", val=random.uniform(6.71e-05, 0.5))
 
     def toggle_table_gc_mode(self):
         """


### PR DESCRIPTION
Scylla defines a non-zero lower limit and the randmom function can generate a value lower than that.

See table `probs` in https://github.com/scylladb/scylladb/blob/master/utils/bloom_calculations.hh 

Fixes error like 
```
2025-05-30 21:37:05.714: (DisruptionEvent Severity.ERROR) period_type=end event_id=94cc409b-8164-4ab1-b355-10873813c809 duration=3s: nemesis_name=ModifyTable target_node=Node longevity-parallel-topology-schema--db-node-8f4cc451-17 [54.144.178.69 | 10.12.9.26] errors=<Error from server: code=2300 [Query invalid because of configuration issue] message="bloom_filter_fp_chance must be larger than 6.71e-05 and less than or equal to 1.0 (got 4.6043881451351965e-05)">
Traceback (most recent call last):
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 5337, in wrapper
result = method(*args[1:], **kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 2908, in disrupt_modify_table
disrupt_func()
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 2566, in modify_table_bloom_filter_fp_chance
self._modify_table_property(name="bloom_filter_fp_chance", val=random.random() / 2)
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 2105, in _modify_table_property
session.execute(cmd)
File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/common.py", line 1315, in execute_verbose
return execute_orig(*args, **kwargs)
File "cassandra/cluster.py", line 2762, in cassandra.cluster.Session.execute
File "cassandra/cluster.py", line 5166, in cassandra.cluster.ResponseFuture.result
cassandra.protocol.ConfigurationException: <Error from server: code=2300 [Query invalid because of configuration issue] message="bloom_filter_fp_chance must be larger than 6.71e-05 and less than or equal to 1.0 (got 4.6043881451351965e-05)">
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
