### PR TITLE
fix(nemesis): increase rebuild timeout

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4064,7 +4064,7 @@ class Nemesis:
         """
         self._destroy_data_and_restart_scylla()
 
-        timeout = 1800 if self._is_it_on_kubernetes() else 400
+        timeout = 1800
         if self.cluster.params.get('cluster_backend') == 'azure':
             timeout += 1200  # Azure reboot can take up to 20min to initiate
 


### PR DESCRIPTION
The time rebuild needs to finish is proportionate to the amount of data streamed.
For example, for 40GB @ 50MB/s it needs 800s.

Fixes errors like https://argus.scylladb.com/tests/scylla-cluster-tests/74aa35ba-9e36-4727-86ba-757897ea5ced
Where rebuild took 12 minutes, but had a timeout of 200 seconds


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
