### PR TITLE
improvement(nemesis): ignore raft transferring snapshot failure

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -452,6 +452,12 @@ def ignore_raft_transport_failing():
             regex=r".*raft - .* Transferring snapshot.*not found",
             extra_time_to_expiration=30
         ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r"raft - \[[0-9a-f-]+\] Transferring snapshot to [0-9a-f-]+ failed with: seastar::rpc::remote_verb_error",
+            extra_time_to_expiration=30
+        ))
         yield
 
 


### PR DESCRIPTION
If a bootstraping node is stopped at just the right time during streaming it is possible to get a Transferring snapshot failure. This can happen in `disrupt_bootstrap_streaming_error.`

Example: 
https://argus.scylladb.com/tests/scylla-cluster-tests/7d3c6475-fa1b-444a-92d9-93f1bdececf6

```
2025-05-30T20:52:21.309+00:00 parallel-topology-schema-changes-mu-db-node-7d3c6475-1     !INFO | scylla[6080]:  [shard 0:main] raft_group_registry - marking Raft server 1b35e114-e421-46ad-a324-9567075e45a1 as alive for raft groups
2025-05-30T20:52:21.309+00:00 parallel-topology-schema-changes-mu-db-node-7d3c6475-1  !WARNING | scylla[6080]:  [shard 0:sl:d] querier - Read 491 live rows and 2238 tombstones for system_schema.columns <partition-range-scan> (-inf, +inf) (see tombstone_warn_threshold)
2025-05-30T20:52:21.309+00:00 parallel-topology-schema-changes-mu-db-node-7d3c6475-1  !WARNING | scylla[6080]:  [shard 0: gms] raft_topology - attempt to send acceptance response to 1b35e114-e421-46ad-a324-9567075e45a1 failed. The node may hang. It's safe to shut it down manually now. Error: Aborted while waiting for next tick on server: 1b35e114-e421-46ad-a324-9567075e45a1, latest applied entry: 0
2025-05-30T20:52:21.309+00:00 parallel-topology-schema-changes-mu-db-node-7d3c6475-1  !WARNING | scylla[6080]:  [shard 0:sl:d] mutation_partition - Memory usage of unpaged query exceeds soft limit of 1048576 (configured via max_memory_for_unlimited_query_soft_limit)
2025-05-30T20:52:21.309+00:00 parallel-topology-schema-changes-mu-db-node-7d3c6475-1      !ERR | scylla[6080]:  [shard 0: gms] raft - [052588d2-fbd0-43ca-afe3-43e87b8d699a] Transferring snapshot to 1b35e114-e421-46ad-a324-9567075e45a1 failed with: seastar::rpc::remote_verb_error (Abort requested while transferring snapshot from ID/IP: 052588d2-fbd0-43ca-afe3-43e87b8d699a/2a05:d018:12e3:f000:721c:4102:6c33:9ddc, snapshot descriptor id: 9bff7ae3-e517-4266-97d8-82c97dd44b3d, snapshot index: 2049)
2025-05-30T20:52:21.738+00:00 parallel-topology-schema-changes-mu-db-node-7d3c6475-1     !INFO | scylla[6080]:  [shard 0: gms] raft_topology - updating topology state: bootstrap: failed to accept 1b35e114-e421-46ad-a324-9567075e45a1
2025-05-30T20:52:21.738+00:00 parallel-topology-schema-changes-mu-db-node-7d3c6475-1     !INFO | scylla[6080]:  [shard 0: gms] gossip - Removed endpoint 2a05:d01c:964:7d01:7744:6ac3:7017:164
2025-05-30T20:52:21.738+00:00 parallel-topology-schema-changes-mu-db-node-7d3c6475-1     !INFO | scylla[6080]:  [shard 0: gms] gossip - InetAddress 1b35e114-e421-46ad-a324-9567075e45a1/2a05:d01c:964:7d01:7744:6ac3:7017:164 is now DOWN, status = UNKNOWN
2025-05-30T20:52:21.738+00:00 parallel-topology-schema-changes-mu-db-node-7d3c6475-1     !INFO | scylla[6080]:  [shard 0: gms] gossip - Finished to force remove node 2a05:d01c:964:7d01:7744:6ac3:7017:164
2025-05-30T20:52:21.738+00:00 parallel-topology-schema-changes-mu-db-node-7d3c6475-1     !INFO | scylla[6080]:  [shard 0: gms] raft_topology - node 1b35e114-e421-46ad-a324-9567075e45a1 moved to left state
2025-05-30T20:52:21.738+00:00 parallel-topology-schema-changes-mu-db-node-7d3c6475-1     !INFO | scylla[6080]:  [shard 0:main] raft_group_registry - marking Raft server 1b35e114-e421-46ad-a324-9567075e45a1 as dead for raft groups
```

the target node was restarted just then
```
May 30 20:52:21.255853 parallel-topology-schema-changes-mu-db-node-7d3c6475-23 systemd[1]: Stopping Scylla Server...
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
