### PR TITLE
fix(sct.py): Call finalize_sct_run if setting custom status

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1764,6 +1764,7 @@ def finish_argus_test_run(jenkins_status):
         if jenkins_status == "ABORTED":
             new_status = TestStatus.ABORTED
         test_config.argus_client().set_sct_run_status(new_status)
+        test_config.argus_client().finalize_sct_run()
     except ArgusClientError:
         LOGGER.error("Failed to submit data to Argus", exc_info=True)
 


### PR DESCRIPTION
In cases where SCT run fails to reach tearDown stage and send the
completion timestamp of the run (and status itself) sct tries to set one
of the possible fail states based on the pipeline health, however it
does not set the timestamp which can lead to issues with displaying
those runs on the argus frontend side.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
