### PR TITLE
Revert "fix(teardown): clean all exit hooks"

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -84,7 +84,7 @@ from sdcm.utils.aws_utils import init_monitoring_info_from_params, get_ec2_servi
 from sdcm.utils.ci_tools import get_job_name, get_job_url
 from sdcm.utils.common import format_timestamp, wait_ami_available, \
     download_dir_from_cloud, get_post_behavior_actions, get_testrun_status, download_encrypt_keys, rows_to_list, \
-    make_threads_be_daemonic_by_default, ParallelObject, clear_out_all_exit_hooks, change_default_password, \
+    make_threads_be_daemonic_by_default, ParallelObject, change_default_password, \
     parse_python_thread_command, get_data_dir_path
 from sdcm.utils.cql_utils import cql_quote_if_needed, cql_unquote_if_needed
 from sdcm.utils.database_query_utils import PartitionsValidationAttributes, fetch_all_rows
@@ -3084,11 +3084,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         self.log.info('Test ID: {}'.format(self.test_config.test_id()))
         self._check_alive_routines_and_report_them()
         self._check_if_db_log_time_consistency_looks_good()
-        self.remove_python_exit_hooks()
-
-    @silence()
-    def remove_python_exit_hooks(self):
-        clear_out_all_exit_hooks()
 
     @silence()
     def _check_if_db_log_time_consistency_looks_good(self):

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2485,16 +2485,6 @@ def make_threads_be_daemonic_by_default():
     threading.current_thread()._daemonic = True
 
 
-def clear_out_all_exit_hooks():
-    """
-    Some thread-related code is using threading._register_atexit to hook to python program exit
-    in order teardown gracefully as result test can halt at the end for any period of time, even for days.
-    To avoid that we clear it out to be sure that nothing is hooked and test is terminated right after
-      teardown.
-    """
-    threading._threading_atexits.clear()
-
-
 def validate_if_scylla_load_high_enough(start_time, wait_cpu_utilization, prometheus_stats,
                                         event_severity=Severity.ERROR, instance=None):
     end_time = int(time.time())


### PR DESCRIPTION
This reverts commit 4cd351747c8e1bda18be8345e5cb4e6c6f5defe8.

Seems like removing some of the atexit hooks, can cause python to segfault during shutdown, when there a callback coming in from c code of libev (within python-driver).

so we are taking this code part out, assuming we don't have any more libraries that leave any running threads behind (we have code that check that at the very end of test run)

Fixes: #9784

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ami-test/30/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2404-arm-test/10/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-amazon2023-arm-test/11/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-amazon2023-test/18/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-amazon2023-test/18/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2404-test/44/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2204-test/65/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-rocky9-test/50/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-amazon2023-test/20/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2404-test/45/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
