### PR TITLE
fix(cluster): increase waiting time for UN node status

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5018,7 +5018,7 @@ class BaseScyllaCluster:
             node.start_scylla(verify_up=True)
             self.log.debug("'%s' restarted.", node.name)
 
-    @retrying(n=15, sleep_time=5, allowed_exceptions=ClusterNodesNotReady)
+    @retrying(n=30, sleep_time=10, allowed_exceptions=ClusterNodesNotReady)
     def wait_all_nodes_un(self):
         for node in self.nodes:
             self.check_nodes_up_and_normal(verification_node=node)


### PR DESCRIPTION
Increase the total time before failure to avoid having errors when just waiting longer would suffice.

Fixes issues like https://argus.scylladb.com/tests/scylla-cluster-tests/c1770542-5ea3-4df1-a193-8277f0c2fa64, where waiting 1-2 minutes extra would have been ok.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
