### PR TITLE
improvement(Jenkinsfile): Improve PR job

### DIFF
--- a/vars/pullRequestSetResult.groovy
+++ b/vars/pullRequestSetResult.groovy
@@ -7,7 +7,4 @@ def call(String status, String context, String description){
 			description: description,
 			targetUrl: "${env.JOB_URL}/workflow-stage")
 	}
-	if (status == 'failure') {
-		currentBuild.result = 'FAILURE'
-	}
 }

--- a/vars/pullRequestSetResult.groovy
+++ b/vars/pullRequestSetResult.groovy
@@ -5,6 +5,9 @@ def call(String status, String context, String description){
 		pullRequest.createStatus(status: status,
 			context: context,
 			description: description,
-			targetUrl: "${env.JOB_URL}/workflow-stage")
+			targetUrl: "${env.BUILD_URL}pipeline-overview")
+	}
+	if (status == 'failure') {
+		currentBuild.result = 'FAILURE'
 	}
 }


### PR DESCRIPTION
* Mark stage failure as well when failing the PR
* Redirect to `pipeline-overview` instead of `workflow-stage`
   * workflow stage has a problem of not being able to click through to individual runs
   * I find it easier to look at the run that failed directly.
   

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Hopefully via this PR

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
