### PR TITLE
fix(rack_aware): activate only if more then one rack in a region

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3429,6 +3429,13 @@ class BaseCluster:
 
         return rack_names_mapping
 
+    @staticmethod
+    def get_rack_names_per_datacenter_from_rack_mapping(self, rack_mapping) -> dict[str, list[str]]:
+        by_region_rack_names = defaultdict(list)
+        for (region, _), v in rack_mapping.items():
+            by_region_rack_names.setdefault(region, []).append(v)
+        return by_region_rack_names
+
     def get_nodes_per_datacenter_and_rack_idx(self, db_nodes: list[BaseNode] | None = None):
         db_nodes = db_nodes if db_nodes else self.nodes
         nodes_mapping = {}

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -157,7 +157,8 @@ class CassandraStressThread(DockerBasedStressThread):
             if self.params.get("rack_aware_loader"):
                 # if there are multiple rack/AZs configured, we'll try to configue c-s to pin to them
                 rack_names = self.loader_set.get_rack_names_per_datacenter_and_rack_idx(db_nodes=self.node_list)
-                if len(set(rack_names.values())) > 1 and 'rack' in self._get_available_suboptions(cmd_runner, '-node'):
+                by_region_rack_names = self.loader_set.get_rack_names_per_datacenter_from_rack_mapping(rack_names)
+                if any(len(racks) > 1 for racks in by_region_rack_names.values()) and 'rack' in self._get_available_suboptions(cmd_runner, '-node'):
                     if loader_rack := rack_names.get((str(loader.region), str(loader.rack))):
                         stress_cmd += f"rack={loader_rack} "
                         node_list = self.loader_set.get_nodes_per_datacenter_and_rack_idx(


### PR DESCRIPTION
by mistake the logic would assume that every multi-dc case has multiple racks, it was counting racks across all regions/datacenters.

this fix introduce a new helper function reshuffle the data into mapping per datacenter, and check if we have more then one rack in any of the datacenters

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
