### PR TITLE
fix(azure): improved handling of spot instances provision

### DIFF
--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -20,11 +20,11 @@ from dataclasses import dataclass, field
 from typing import Dict, Optional, Any, List
 
 import binascii
-from azure.core.exceptions import ResourceNotFoundError, AzureError
+from azure.core.exceptions import ResourceNotFoundError, AzureError, ODataV4Error
 from azure.mgmt.compute.models import VirtualMachine, RunCommandInput
 from invoke import Result
 
-from sdcm.provision.provisioner import InstanceDefinition, PricingModel, ProvisionError
+from sdcm.provision.provisioner import InstanceDefinition, PricingModel, ProvisionError, OperationPreemptedError
 from sdcm.provision.user_data import UserDataBuilder
 from sdcm.utils.azure_utils import AzureService
 
@@ -121,8 +121,11 @@ class VirtualMachineProvider:
                     LOGGER.warning("Instance view is not available for VM %s", v_m.name)
                 self._cache[v_m.name] = v_m
                 v_ms.append(v_m)
-            except AzureError as err:
+            except ODataV4Error as err:
                 LOGGER.error("Error when waiting for VM %s: %s", definition.name, str(err))
+                if err.code == 'OperationPreempted':
+                    raise OperationPreemptedError(err)  # spot instance preemption, abort provision immediately
+            except AzureError as err:
                 error_to_raise = err
         if error_to_raise:
             raise ProvisionError(error_to_raise)

--- a/sdcm/provision/provisioner.py
+++ b/sdcm/provision/provisioner.py
@@ -55,6 +55,10 @@ class ProvisionError(Exception):
     pass
 
 
+class OperationPreemptedError(Exception):
+    pass
+
+
 class ProvisionerError(Exception):
     pass
 

--- a/unit_tests/provisioner/fake_azure_service.py
+++ b/unit_tests/provisioner/fake_azure_service.py
@@ -19,7 +19,7 @@ import subprocess
 from pathlib import Path
 from typing import List, Any, Dict
 
-from azure.core.exceptions import ResourceNotFoundError, AzureError
+from azure.core.exceptions import ResourceNotFoundError, AzureError, ODataV4Error, _HttpResponseCommonAPI
 from azure.mgmt.network.models import (NetworkSecurityGroup, Subnet, PublicIPAddress, NetworkInterface, VirtualNetwork)
 from azure.mgmt.resource.resources.models import ResourceGroup
 from azure.mgmt.compute.models import VirtualMachine, Image, InstanceViewStatus, RunCommandResult
@@ -39,8 +39,12 @@ def dict_keys_to_camel_case(dct):
 
 class WaitableObject:
 
+    def __init__(self, error: AzureError = None):
+        self.error = error
+
     def wait(self):
-        pass
+        if self.error:
+            raise self.error
 
 
 class ResultableObject:
@@ -462,7 +466,14 @@ class FakeVirtualMachines:
         priority = parameters.get("priority") or ""
         if tags.get("JenkinsJobTag") == "FailSpotDB" and priority.lower() == "spot" and tags.get("NodeType") == "scylla-db":
             # for testing fallback on demand
-            raise AzureError("Failing creating db spot instance because JenkinsJobTag is FailSpotDB")
+            class Resp(_HttpResponseCommonAPI):
+                @property
+                def status_code(self):
+                    return 409
+
+                def text(self):
+                    return '{"message": "preemption error msg", "error": {"message": "preemption error", "code": "OperationPreempted"}}'
+            return WaitableObject(error=ODataV4Error(response=Resp()))
 
         base = {
             "id": f"/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/{resource_group_name}"


### PR DESCRIPTION
When provisioning spot instances it may happen that instance is preempted during creation.
In that case it destroys all related resources like ip's, nic's etc. causing cached values to be invalid. 
Probably it also breaks fallback to `on_demand` due the same.

fix is by detecting preemption errors and recreate cache. 
Used retrying from SCT's utils to allow retry on provision error and skip when there's problem with preemption straight to fallback.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/5198

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - labelled with azure provision test 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
