### PR TITLE
fix(backtrace_decodeing): install correct debug symbols package

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2170,10 +2170,16 @@ class BaseNode(AutoSshContainerMixin):
             f"curl -sSf get.scylladb.com/server | sudo bash -s -- --scylla-version {version}")
 
     def install_scylla_debuginfo(self) -> None:
-        if self.distro.is_rhel_like or self.distro.is_sles:
-            package_name = fr"{self.scylla_pkg()}-debuginfo-{self.scylla_version}\*"
+        if ComparableScyllaVersion(self.scylla_version) > '2025.1.0~dev':
+            # since source available versions, theres only on option for package names
+            package_prefix = "scylla"
         else:
-            package_name = fr"{self.scylla_pkg()}-server-dbg={self.scylla_version}\*"
+            package_prefix = self.scylla_pkg()
+
+        if self.distro.is_rhel_like or self.distro.is_sles:
+            package_name = fr"{package_prefix}-debuginfo-{self.scylla_version}\*"
+        else:
+            package_name = fr"{package_prefix}-server-dbg={self.scylla_version}\*"
 
         self.log.debug("Installing Scylla debug info...")
         # using ignore_status=True cause of docker image doesn't have the repo/list available


### PR DESCRIPTION
cause of recent fix to packaging, we now have dummy package prefixed as `scylla-enterprise` and the code of `node.scylla_pkg()` return scylla-enterprise, using this name for the debug symbol package doesn't work.

this change is hardcoding the name for source available versions

Fixes: #11038

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
