### PR TITLE
fix(upgrade_test): increase timeout for truncates

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -3052,7 +3052,7 @@ class FillDatabaseData(ClusterTester):
 
     @staticmethod
     def cql_truncate_simple_tables(session, rows):
-        truncate_query = 'TRUNCATE TABLE truncate_table%d'
+        truncate_query = 'TRUNCATE TABLE truncate_table%d USING TIMEOUT 300s'
         for i in range(rows):
             session.execute(truncate_query % i)
 
@@ -3198,6 +3198,8 @@ class FillDatabaseData(ClusterTester):
 
     @retrying(n=3, sleep_time=20, allowed_exceptions=ProtocolException)
     def truncate_table(self, session, truncate):
+        if "using timeout" not in truncate.lower():
+            truncate = f"{truncate} USING TIMEOUT 300s"
         LOGGER.debug(truncate)
         session.execute(truncate)
 


### PR DESCRIPTION
The truncate operation may take several minutes.
Increase the timeout of the truncate itself to prevent the session from retrying the truncate (this is mostly a cosmetic change, but will result in less errors in log).
Increase the timeout of the execute to match that of the truncat to ensure the operation has enough time to finish.

closes: #10677
closes: #4866

See https://github.com/scylladb/scylla-cluster-tests/issues/10677#issuecomment-2949279576 for an example failure.
The same timeout is also set in nemesis, ref: https://github.com/scylladb/scylla-cluster-tests/pull/5879

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
