### PR TITLE
fix(docker): don't use GossipingPropertyFileSnitch for docker

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2139,7 +2139,8 @@ class SCTConfiguration(dict):
                         f" Got error: {repr(exp)}, on item '{param}'") from exp
 
         # 15 Force endpoint_snitch to GossipingPropertyFileSnitch if using simulated_regions or simulated_racks
-        if (self.get("simulated_regions") or 0) > 1 or (self.get("simulated_racks") or 0) > 1:
+        num_of_db_nodes = sum([int(i) for i in str(self.get("n_db_nodes") or 0).split(" ")])
+        if (self.get("simulated_regions") or 0) > 1 or (self.get("simulated_racks") or 0) > 1 and num_of_db_nodes > 1 and cluster_backend != "docker":
             if snitch := self.get("endpoint_snitch"):
                 assert snitch.endswith("GossipingPropertyFileSnitch"), \
                     f"Simulating racks requires endpoint_snitch to be GossipingPropertyFileSnitch while it set to {self['endpoint_snitch']}"


### PR DESCRIPTION
this backend currectly doesn't support it, since we don't generate the files need for it, as in other backends

Ref: https://github.com/scylladb/scylla-cluster-tests/pull/10641

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-docker-test/36/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
