### PR TITLE
fix(cloud-init): retry on waiting for it to be done

### DIFF
--- a/sdcm/provision/helpers/cloud_init.py
+++ b/sdcm/provision/helpers/cloud_init.py
@@ -18,6 +18,7 @@ from packaging.version import Version
 from sdcm.provision.provisioner import VmInstance
 from sdcm.provision.user_data import CLOUD_INIT_SCRIPTS_PATH
 from sdcm.remote import RemoteCmdRunnerBase
+from sdcm.utils.decorators import retrying
 
 LOGGER = logging.getLogger(__name__)
 
@@ -26,6 +27,8 @@ class CloudInitError(Exception):
     pass
 
 
+@retrying(n=20, sleep_time=10, allowed_exceptions=(CloudInitError, ),
+          message="waiting for cloud-init to complete")
 def wait_cloud_init_completes(remoter: RemoteCmdRunnerBase, instance: VmInstance):
     """Connects to VM with SSH and waits for cloud-init to complete. Verify if everything went ok.
     """


### PR DESCRIPTION
since version `Cloud-init v. 25.1.2` cloud-init might fail with some transient errors from `cloud-init status --wait`

```
Failed due to systemd unit failure. Ensure all cloud-init services are enabled, and
check 'systemctl' or 'journalctl' for more information.
```

seems like trying more times, after the whole cloud-init process is done, it dissappers. so the funtion doing this call was decoreated with `@retrying`

Fixes: #11049

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :clock1: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2204-test/68/


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
