### PR TITLE
feature(gemini): report version to argus

### DIFF
--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -25,6 +25,7 @@ from sdcm.utils.common import FileFollowerThread
 from sdcm.sct_events.loaders import GeminiStressEvent, GeminiStressLogEvent
 from sdcm.stress_thread import DockerBasedStressThread
 from sdcm.utils.docker_remote import RemoteDocker
+from sdcm.reporting.tooling_reporter import GeminiVersionReporter
 
 LOGGER = logging.getLogger(__name__)
 
@@ -173,6 +174,13 @@ class GeminiStressThread(DockerBasedStressThread):
         LOGGER.debug("gemini local log: %s", log_file_name)
 
         gemini_cmd = self._generate_gemini_command()
+        try:
+            prefix, *_ = gemini_cmd.split("gemini", maxsplit=1)
+            reporter = GeminiVersionReporter(docker, prefix, loader.parent_cluster.test_config.argus_client())
+            reporter.report()
+        except Exception:  # noqa: BLE001
+            LOGGER.info("Failed to collect scylla-bench version information", exc_info=True)
+
         with cleanup_context, GeminiEventsPublisher(node=loader, gemini_log_filename=log_file_name) as publisher, GeminiStressEvent(node=loader, cmd=gemini_cmd, log_file_name=log_file_name) as gemini_stress_event:
             try:
                 publisher.event_id = gemini_stress_event.event_id

--- a/sdcm/reporting/tooling_reporter.py
+++ b/sdcm/reporting/tooling_reporter.py
@@ -225,3 +225,42 @@ class ScyllaBenchGoCqlDriverVersionReporter(ToolReporterBase):
 
     def _collect_version_info(self) -> None:
         pass
+
+
+class GeminiVersionReporter(ToolReporterBase):
+    """
+    Reports Gemini and scylla gocql driver versions used in SCT.
+    """
+    TOOL_NAME = "gemini"
+
+    def _collect_version_info(self) -> None:
+        output = self.runner.run(f"{self.command_prefix} {self.TOOL_NAME} --version-json")
+        LOGGER.debug("%s: Collected gemini version output:\n%s", self, output.stdout)
+        version_info = json.loads(output.stdout)
+        LOGGER.debug("Result:\n%s", version_info)
+
+        s_b_info = version_info.get("gemini", {})
+        self.version = f"{s_b_info.get('version', '#FAILED_CHECK_LOGS')}"
+        self.date = s_b_info.get('commit_date')
+        self.revision_id = s_b_info.get('commit_sha')
+
+        if driver_details := version_info.get("scylla-driver", {}):
+            GeminiGoCqlDriverVersionReporter(
+                driver_version=driver_details.get('version'),
+                date=driver_details.get("commit_date"),
+                revision_id=driver_details.get("commit_sha"),
+                argus_client=self.argus_client
+            ).report()
+
+
+class GeminiGoCqlDriverVersionReporter(ToolReporterBase):
+    TOOL_NAME = "gemini-gocql-driver"
+
+    def __init__(self, driver_version: str, date: str, revision_id: str, argus_client: ArgusSCTClient = None) -> None:
+        super().__init__(None, "", argus_client)
+        self.version = driver_version
+        self.date = date
+        self.revision_id = revision_id
+
+    def _collect_version_info(self) -> None:
+        pass


### PR DESCRIPTION
with those change now gemini would report the version and the gocql version to Argus

Closes: scylladb/qa-tasks#1879

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
