### PR TITLE
fix(nemesis): fix shuffle list of disruptions

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1877,10 +1877,12 @@ class Nemesis:
         Usually retrieved from the test yaml by using the "nemesis_selector", more about nemesis_selector behaviour in sct_config.py
         """
         self.log.debug(f'nemesis_seed to be used is {self.nemesis_seed}')
-        self.log.debug(f"nemesis stack BEFORE SHUFFLE is {self._disruption_list_names}")
+        self.log.debug(f"nemesis stack BEFORE SHUFFLE is {[nemesis.__name__ for nemesis in disruption_list]}")
         nemesis_multiply_factor = nemesis_multiply_factor or self.cluster.params.get('nemesis_multiply_factor') or 1
-        random.Random(self.nemesis_seed).shuffle(disruption_list * nemesis_multiply_factor)
-        self.log.info(f"List of Nemesis to execute: {self._disruption_list_names}")
+        multipled_disruption_list = disruption_list * nemesis_multiply_factor
+        random.Random(self.nemesis_seed).shuffle(multipled_disruption_list)
+        self.log.info(f"List of Nemesis to execute: {[nemesis.__name__ for nemesis in multipled_disruption_list]}")
+        return multipled_disruption_list
 
     @cached_property
     def infinite_cycle(self):
@@ -5648,7 +5650,7 @@ class SisyphusMonkey(Nemesis):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.disruptions_list = self.build_disruptions_by_selector(self.nemesis_selector)
-        self.shuffle_list_of_disruptions(self.disruptions_list)
+        self.disruptions_list = self.shuffle_list_of_disruptions(self.disruptions_list)
 
     def disrupt(self):
         self.call_next_nemesis()
@@ -5763,7 +5765,7 @@ class EnableDisableTableEncryptionAwsKmsProviderMonkey(Nemesis):
             'disrupt_enable_disable_table_encryption_aws_kms_provider_without_rotation',
             'disrupt_enable_disable_table_encryption_aws_kms_provider_with_rotation',
         ])
-        self.shuffle_list_of_disruptions(self.disruptions_list)
+        self.disruptions_list = self.shuffle_list_of_disruptions(self.disruptions_list)
 
     def disrupt(self):
         self.call_next_nemesis()
@@ -6091,7 +6093,7 @@ class ScyllaCloudLimitedChaosMonkey(Nemesis):
             'disrupt_soft_reboot_node',
             'disrupt_truncate'
         ])
-        self.shuffle_list_of_disruptions(self.disruptions_list)
+        self.disruptions_list = self.shuffle_list_of_disruptions(self.disruptions_list)
 
     def disrupt(self):
         # Limit the nemesis scope to only one relevant to scylla cloud, where we defined we don't have AWS api access:
@@ -6107,7 +6109,7 @@ class MdcChaosMonkey(Nemesis):
             'disrupt_no_corrupt_repair',
             'disrupt_nodetool_decommission'
         ])
-        self.shuffle_list_of_disruptions(self.disruptions_list)
+        self.disruptions_list = self.shuffle_list_of_disruptions(self.disruptions_list)
 
     def disrupt(self):
         self.call_next_nemesis()
@@ -6262,7 +6264,7 @@ class DisruptKubernetesNodeThenReplaceScyllaNode(Nemesis):
             'disrupt_drain_kubernetes_node_then_replace_scylla_node',
             'disrupt_terminate_kubernetes_host_then_replace_scylla_node',
         ])
-        self.shuffle_list_of_disruptions(self.disruptions_list)
+        self.disruptions_list = self.shuffle_list_of_disruptions(self.disruptions_list)
 
     def disrupt(self):
         self.call_next_nemesis()
@@ -6294,7 +6296,7 @@ class DisruptKubernetesNodeThenDecommissionAndAddScyllaNode(Nemesis):
             'disrupt_drain_kubernetes_node_then_decommission_and_add_scylla_node',
             'disrupt_terminate_kubernetes_host_then_decommission_and_add_scylla_node',
         ])
-        self.shuffle_list_of_disruptions(self.disruptions_list)
+        self.disruptions_list = self.shuffle_list_of_disruptions(self.disruptions_list)
 
     def disrupt(self):
         self.call_next_nemesis()
@@ -6312,7 +6314,7 @@ class K8sSetMonkey(Nemesis):
             'disrupt_drain_kubernetes_node_then_decommission_and_add_scylla_node',
             'disrupt_terminate_kubernetes_host_then_decommission_and_add_scylla_node',
         ])
-        self.shuffle_list_of_disruptions(self.disruptions_list)
+        self.disruptions_list = self.shuffle_list_of_disruptions(self.disruptions_list)
 
     def disrupt(self):
         self.call_next_nemesis()
@@ -6503,7 +6505,7 @@ class ScyllaOperatorBasicOperationsMonkey(Nemesis):
             'disrupt_mgmt_backup_specific_keyspaces',
             'disrupt_mgmt_backup',
         ])
-        self.shuffle_list_of_disruptions(self.disruptions_list)
+        self.disruptions_list = self.shuffle_list_of_disruptions(self.disruptions_list)
 
     def disrupt(self):
         self.call_next_nemesis()


### PR DESCRIPTION
`shuffle_list_of_disruptions` were based on `shuffle` side effect, but was getting wrong list (after multiplication). Effectively making this method not working.

Fix by not relying on side effect, rather returning reshuffled list.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] - tested locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
