### PR TITLE
fix(cloud_monitor): assume QA==qa

### DIFF
--- a/sdcm/utils/cloud_monitor/report.py
+++ b/sdcm/utils/cloud_monitor/report.py
@@ -204,9 +204,9 @@ class InstancesTimeDistributionReport(BaseReport, metaclass=abc.ABCMeta):
 
 class QAonlyInstancesTimeDistributionReport(InstancesTimeDistributionReport):
     def _is_user_be_skipped(self, instance):
-        return instance.owner == "qa" or instance.owner not in self.qa_users
+        return instance.owner in ["qa", "QA"] or instance.owner not in self.qa_users
 
 
 class NonQaInstancesTimeDistributionReport(InstancesTimeDistributionReport):
     def _is_user_be_skipped(self, instance):
-        return instance.owner == "qa" or instance.owner in self.qa_users
+        return instance.owner in ["qa", "QA"] or instance.owner in self.qa_users


### PR DESCRIPTION
the code was checking `owner=='qa'` and missing the GCE builder which has metadata like `RunByUser: QA`

which in turns cause reports about them got into the wrong email, and people to miss unattended resources

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
