### PR TITLE
fix(nemesis): cluster repair added to nemeis to make it more safe

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1074,6 +1074,8 @@ class Nemesis:
         self.current_disruption = label
 
     def disrupt_destroy_data_then_repair(self):
+        """repair at the beginning added to avoid c-s failure 'data wasn't validated'"""
+        self.run_repair_on_nodes(self.cluster.data_nodes)
         self._destroy_data_and_restart_scylla()
         # try to save the node
         self.repair_nodetool_repair()


### PR DESCRIPTION
repair added to avoid c-s data validation failure while starting scylla

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
