### PR TITLE
fix(test): fix missing monitor nodes

### DIFF
--- a/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-large-cluster.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-large-cluster.yaml
@@ -9,6 +9,7 @@ stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc.
 n_db_nodes: '15 15 15'
 instance_type_db: 'i4i.large'
 n_loaders: '2 2 2'
+n_monitor_nodes: 1
 
 rack_aware_loader: true
 region_aware_loader: true

--- a/test-cases/longevity/longevity-multidc-parallel-network-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-network-schema-changes-12h.yaml
@@ -10,6 +10,7 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=720m -schema 'replicatio
              ]
 n_db_nodes: '4 4'
 n_loaders: '2 1'
+n_monitor_nodes: 1
 
 rack_aware_loader: true
 region_aware_loader: true

--- a/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
@@ -12,6 +12,7 @@ stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'repl
 availability_zone: 'a,b,c'
 n_db_nodes: '6 6'
 n_loaders: '2 1'
+n_monitor_nodes: 1
 
 rack_aware_loader: true
 region_aware_loader: true


### PR DESCRIPTION
When updating configs recently we dropped `n_monitor_nodes` config from some multidc scenarios.

fix by adding it back.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11073

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
