### PR TITLE
improvement(performance): support different threads amount for every throttle step

### DIFF
--- a/configurations/performance/cassandra_stress_gradual_load_reduced_steps_number.yaml
+++ b/configurations/performance/cassandra_stress_gradual_load_reduced_steps_number.yaml
@@ -1,4 +1,8 @@
 # Define load ops for steps
+# # For debugging, you can set a specific thread count for each step (per load).
+## The value of perf_gradual_threads[load] must be either:
+##   - a single-element list or integer (applied to all throttle steps)
+##   - a list with the same length as perf_gradual_throttle_steps[load] (one thread count per step).
 perf_gradual_threads: {"read": 620, "write": 400, "mixed": 1900}
 perf_gradual_throttle_steps: {"read": ['450000', '700000', 'unthrottled'], "mixed": ['300000', '450000', 'unthrottled'], "write": ['200000', 'unthrottled']}  # where every value is in ops
 perf_gradual_step_duration: {"read": '20m', "write": None, "mixed": '20m'}

--- a/configurations/performance/cassandra_stress_gradual_load_steps.yaml
+++ b/configurations/performance/cassandra_stress_gradual_load_steps.yaml
@@ -1,4 +1,8 @@
 # Define load ops for steps
+# # For debugging, you can set a specific thread count for each step (per load).
+## The value of perf_gradual_threads[load] must be either:
+##   - a single-element list or integer (applied to all throttle steps)
+##   - a list with the same length as perf_gradual_throttle_steps[load] (one thread count per step).
 perf_gradual_threads: {"read": 620, "write": 400, "mixed": 1900}
 perf_gradual_throttle_steps: {"read": ['150000', '300000', '450000', '600000', '700000', 'unthrottled'], "mixed": ['50000', '150000', '300000', '450000', 'unthrottled'], "write": ['200000', '300000', 'unthrottled']}  # where every value is in ops
 perf_gradual_step_duration: {"read": '30m', "write": None, "mixed": '30m'}

--- a/configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml
+++ b/configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml
@@ -1,4 +1,8 @@
 # Define load ops for steps
+# # For debugging, you can set a specific thread count for each step (per load).
+## The value of perf_gradual_threads[load] must be either:
+##   - a single-element list or integer (applied to all throttle steps)
+##   - a list with the same length as perf_gradual_throttle_steps[load] (one thread count per step).
 perf_gradual_threads: {"read": 620, "write": 400, "mixed": 1900}
 perf_gradual_throttle_steps: {"read": ['150000', '300000', '450000', '600000', '700000', 'unthrottled'], "mixed": ['50000', '150000', '300000', '450000', 'unthrottled'], "write": ['200000', '300000', 'unthrottled']}  # where every value is in ops
 perf_gradual_step_duration: {"read": '30m', "write": None, "mixed": '30m'}

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -2573,7 +2573,7 @@ cassandra-stress commands.<br>You can specify everything but the -node parameter
 
 ## **perf_gradual_threads** / SCT_PERF_GRADUAL_THREADS
 
-Threads amount of c-s load for gradual performance test per sub-test. Example: {'read': 100, 'write': 200, 'mixed': 300}
+Threads amount of stress load for gradual performance test per sub-test. Example: {'read': 100, 'write': [200, 300], 'mixed': 300}
 
 **default:** N/A
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -142,3 +142,32 @@ first download the file to the SCT folder, and execute the following command:
 ```bash
 ./docker/env/hydra.sh 'bash -c "sudo pip install pystack; pystack core core.python3.1000.bd43fbcd0c4b44488ce7e97e25fe1a28.1804.1745768005000000"'
 ```
+
+
+## How to define parameters for performance throughput test ?
+There are 3 parameters that can be defined in the yaml file to control the performance throughput test (example here: `configurations/performance/cassandra_stress_gradual_load_steps.yaml`):
+
+```
+perf_gradual_throttle_steps - Define throttle for load steps in ops per sub-test (read / write / mixed).
+                                Example: {'read': ['100000', '150000'], 'write': [200, unthrottled], 'mixed': ['300']}
+```
+```
+perf_gradual_threads - Threads amount of stress load per sub-test (read / write / mixed).
+                       For debugging, you can set a specific thread count for each step (per load).
+                       The value of perf_gradual_threads[load] must be either:
+                           - a single-element list or integer(applied to all throttle steps)
+                                Example: {'read': 100, 'write': 200, 'mixed': [200, 300]}
+
+                           - a list with the same length as perf_gradual_throttle_steps[load] (one thread count per step).
+                                Example: {'read': [100, 200], 'write': [200, 300], 'mixed': [300]}
+```
+```
+perf_gradual_throttle_duration - Define duration for each step in seconds per sub-test (read / write / mixed).
+                                    Example: {'read': '30m', 'write': None, 'mixed': '30m'}
+```
+
+Those parameters can be overridden during job triggering by setting the environment variables in `extra_environment_variables`:
+```bash
+SCT_PERF_GRADUAL_THREADS={"read": [450, 400, 450], "write": 400, "mixed": 1900}
+SCT_PERF_GRADUAL_THROTTLE_STEPS={"read": ['700000', 'unthrottled', 'unthrottled'], "mixed": ['50000', '150000', '300000', '450000', 'unthrottled'], "write": ['200000', '300000', 'unthrottled']}
+```

--- a/performance_regression_gradual_grow_throughput.py
+++ b/performance_regression_gradual_grow_throughput.py
@@ -1,10 +1,11 @@
 import pathlib
 import time
 from enum import Enum
-from collections import defaultdict
+from collections import defaultdict, Counter
 
 import json
-from typing import NamedTuple
+from dataclasses import dataclass, replace
+from typing import List, Union
 
 from performance_regression_test import PerformanceRegressionTest
 from sdcm.utils.common import skip_optional_stage
@@ -20,16 +21,22 @@ class CSPopulateDistribution(Enum):
     UNIFORM = "uniform"
 
 
-class Workload(NamedTuple):
+@dataclass
+class Workload:
     workload_type: str
     cs_cmd_tmpl: list
     cs_cmd_warm_up: list | None
-    num_threads: int
+    num_threads: Union[List[int], int]
     throttle_steps: list
     preload_data: bool
     drop_keyspace: bool
     wait_no_compactions: bool
     step_duration: str
+
+    def __post_init__(self):
+        if isinstance(self.num_threads, int):
+            # If only one thread count is provided, convert it to a list
+            self.num_threads = [self.num_threads]
 
 
 class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
@@ -192,6 +199,7 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
             self.log.debug('collected latency values are: %s', latency_results)
             self.update({"latency_during_ops": latency_results})
             return latency_results
+        return {step: {"step": step, "legend": "", "cycles": []}}
 
     def run_step(self, stress_cmds, current_throttle, num_threads, step_duration):
         results = []
@@ -218,9 +226,70 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
         with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
             session.execute(f'DROP KEYSPACE IF EXISTS {"keyspace1"};')
 
+    @staticmethod
+    def _step_names(step_names, total_counts):
+        """
+        Helper function to generate names based on throttle_steps and num_threads.
+        Example:
+            step_names = ["100", "unthrottled", "unthrottled"]
+            total_counts = {"unthrottled": 2, "100": 1}
+            Result: ["100", "unthrottled_1", "unthrottled_2"]
+        """
+        step_seen = {}
+        result = []
+        for name in step_names:
+            step_seen[name] = step_seen.get(name, 0) + 1
+            if total_counts[name] > 1:
+                result.append(f"{name}_{step_seen[name]}")
+            else:
+                result.append(name)
+        return result
+
+    def get_sequential_throttle_steps(self, workload: Workload):
+        """
+        Returns a list of throttle step names based on throttle_steps and num_threads.
+        - If all num_threads are the same, use throttle_step (with count if repeated).
+        - If num_threads are unique per step, use '<throttle_step>_<num_threads>_threads'.
+          If this combination repeats, append a count.
+        """
+        throttle_steps = workload.throttle_steps
+        num_threads = workload.num_threads
+
+        if len(set(num_threads)) == 1:
+            # All thread counts are the same, only add count for repeated steps
+            step_names = throttle_steps
+        else:
+            # Each step has a unique thread count, use <throttle_step>_<num_threads>_threads
+            step_names = [f"{step}_{threads}_threads" for step, threads in zip(throttle_steps, num_threads)]
+
+        total_counts = Counter(step_names)
+
+        return self._step_names(step_names, total_counts)
+
+    @staticmethod
+    def update_num_threads_for_steps(workload: Workload):
+        """
+        Ensures that the `num_threads` list in the workload matches the length of `throttle_steps`.
+        If only one thread count is provided but multiple throttle steps exist, the single value is repeated
+        to match the number of steps.
+
+        Args:
+            workload (Workload): The workload namedtuple containing `num_threads` and `throttle_steps`.
+
+        Returns:
+            Workload: A new Workload instance with an updated `num_threads` list if needed.
+        """
+        if len(workload.num_threads) == 1 and len(workload.throttle_steps) > 1:
+            workload = replace(workload, num_threads=[workload.num_threads[0]] * len(workload.throttle_steps))
+        return workload
+
+    # pylint: disable=too-many-arguments,too-many-locals
     def run_gradual_increase_load(self, workload: Workload, stress_num, num_loaders, test_name):  # noqa: PLR0914
+        workload = self.update_num_threads_for_steps(workload=workload)
+
         if workload.cs_cmd_warm_up is not None:
-            self.warmup_cache(workload.cs_cmd_warm_up, workload.num_threads)
+            # Use the maximum thread count for warmup to ensure the cache is warmed up with the highest level of concurrency
+            self.warmup_cache(workload.cs_cmd_warm_up, max(workload.num_threads))
             # Wait for 4 minutes after warmup to let for all background processes to finish
             time.sleep(240)
 
@@ -229,18 +298,20 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
             self.create_test_stats(sub_type=workload.workload_type, doc_id_with_timestamp=True)
         total_summary = {}
 
-        for throttle_step in workload.throttle_steps:
-            self.log.info("Run cs command with rate: %s Kops", throttle_step)
+        sequential_steps = self.get_sequential_throttle_steps(workload)
+        for throttle_step, num_threads, current_throttle_step in zip(workload.throttle_steps, workload.num_threads, sequential_steps):
+            self.log.info("Run cs command with rate: %s Kops; threads: %s; step name: %s", throttle_step, num_threads,
+                          current_throttle_step)
             current_throttle = f"fixed={int(int(throttle_step) // (num_loaders * stress_num))}/s" if throttle_step != "unthrottled" else ""
-            run_step = ((latency_calculator_decorator(legend=f"Gradual test step {throttle_step} op/s",
-                                                      cycle_name=throttle_step))(self.run_step))
+            run_step = ((latency_calculator_decorator(legend=f"Gradual test step {current_throttle_step} op/s",
+                                                      cycle_name=current_throttle_step))(self.run_step))
             results, _ = run_step(stress_cmds=workload.cs_cmd_tmpl, current_throttle=current_throttle,
-                                  num_threads=workload.num_threads, step_duration=workload.step_duration)
+                                  num_threads=num_threads, step_duration=workload.step_duration)
 
             calculate_result = self._calculate_average_max_latency(results)
             self.update_test_details(scylla_conf=True)
-            summary_result = self.check_latency_during_steps(step=throttle_step)
-            summary_result[throttle_step].update({"ops_rate": calculate_result["op rate"] * num_loaders})
+            summary_result = self.check_latency_during_steps(step=current_throttle_step)
+            summary_result[current_throttle_step].update({"ops_rate": calculate_result["op rate"] * num_loaders})
             total_summary.update(summary_result)
             if workload.drop_keyspace:
                 self.drop_keyspace()


### PR DESCRIPTION
This commit present support per-step thread count configuration.

Allow specifying a different thread count for each throttle step in gradual load tests.
This change is intended for debugging purposes and helps to find the best test configuration
by enabling fine-grained control over thread allocation per step.


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [perf-regression-predefined-throughput-steps-sanity-vnodes
](https://argus.scylladb.com/tests/scylla-cluster-tests/8247c911-bc09-4aba-aaa4-f9fcb125b7cb)
- [x] [perf-regression-predefined-throughput-steps-sanity-vnodes - few steps with same name and different threads count](https://argus.scylladb.com/tests/scylla-cluster-tests/0228f5e3-1440-4c36-bf16-904b1802bcc1)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
