### PR TITLE
fix(nemesis): disable MV tests for tablets

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5032,6 +5032,11 @@ class Nemesis:
         if self.cluster.nemesis_count > 1 and SkipPerIssues(issues="https://github.com/scylladb/scylladb/issues/21695", params=self.tester.params):
             raise UnsupportedNemesis("Skip create index nemesis with parallel nemesis run")
 
+        # Disable MV tests with tablets.
+        if is_tablets_feature_enabled(self.target_node):
+            if SkipPerIssues(issues="https://github.com/scylladb/scylla-enterprise/issues/5461", params=self.tester.params):
+                raise UnsupportedNemesis("https://github.com/scylladb/scylla-enterprise/issues/5461")
+
         with self.cluster.cql_connection_patient(self.target_node, connect_timeout=300) as session:
 
             ks_cf_list = self.cluster.get_non_system_ks_cf_list(self.target_node, filter_out_mv=True)
@@ -5068,6 +5073,11 @@ class Nemesis:
         Verify the MV can be used in a query.
         Finally, drop the MV.
         """
+
+        # Disable MV tests with tablets.
+        if is_tablets_feature_enabled(self.target_node):
+            if SkipPerIssues(issues="https://github.com/scylladb/scylla-enterprise/issues/5461", params=self.tester.params):
+                raise UnsupportedNemesis("https://github.com/scylladb/scylla-enterprise/issues/5461")
 
         free_nodes = [node for node in self.cluster.data_nodes if not node.running_nemesis]
         if not free_nodes:


### PR DESCRIPTION
Conditionally disable MV tests (CreateIndex and AddRemoveMv) if tablets enabled and scylladb/scylla-enterprise#5461 is open.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
