### PR TITLE
improvement(config): use 1 monitor node by default

### DIFF
--- a/configurations/nemesis/additional_configs/docker_backend.yaml
+++ b/configurations/nemesis/additional_configs/docker_backend.yaml
@@ -13,7 +13,6 @@ user_prefix: 'longevity-1gb-1h-nemesis'
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 seeds_num: 3
 
 nemesis_interval: 3

--- a/configurations/nemesis/longevity-5gb-1h-nemesis.yaml
+++ b/configurations/nemesis/longevity-5gb-1h-nemesis.yaml
@@ -14,7 +14,6 @@ stress_cmd:
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 seeds_num: 3
 
 instance_type_db: 'i4i.large'

--- a/configurations/performance/cql-stress-6gb-8-col-i4i-mini-test-throughput.yaml
+++ b/configurations/performance/cql-stress-6gb-8-col-i4i-mini-test-throughput.yaml
@@ -9,7 +9,6 @@ stress_cmd_m: "cql-stress-cassandra-stress mixed no-warmup cl=QUORUM duration=80
 use_prepared_loaders: false  # no need for that - using docker anyway
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_loader: 'c6i.large'
 instance_type_db: 'i4i.large'

--- a/configurations/performance/latte-perf-regression-latency-steady-state-custom-d1-workload1.yaml
+++ b/configurations/performance/latte-perf-regression-latency-steady-state-custom-d1-workload1.yaml
@@ -1,5 +1,4 @@
 test_duration: 300
-n_monitor_nodes: 1
 n_db_nodes: 8
 n_loaders: 2
 stress_duration: 60

--- a/configurations/scale-up/scale-up-base.yaml
+++ b/configurations/scale-up/scale-up-base.yaml
@@ -3,7 +3,6 @@ test_duration: 480
 
 n_db_nodes: 3
 
-n_monitor_nodes: 1
 
 #GCE
 use_preinstalled_scylla: false  # required when using non standard instance type

--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -41,7 +41,6 @@ k8s_use_chaos_mesh: true
 k8s_minio_storage_size: '60Gi'
 
 k8s_n_monitor_nodes: 0
-n_monitor_nodes: 1
 # NOTE: if we do not specify 'k8s_n_loader_pods_per_cluster' then value of the 'n_loaders' is used
 n_loaders: 1
 n_db_nodes: 4

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -54,7 +54,6 @@ gce_root_disk_type_monitor: 'pd-standard'
 root_disk_size_monitor: 50
 gce_n_local_ssd_disk_monitor: 0
 
-n_monitor_nodes: 1
 
 user_credentials_path: '~/.ssh/scylla_test_id_ed25519'
 use_preinstalled_scylla: true

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -103,6 +103,7 @@ use_legacy_cluster_init: false
 internode_encryption: 'all'
 
 use_mgmt: true
+n_monitor_nodes: 1
 manager_prometheus_port: 5090
 scylla_mgmt_pkg: ''
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -91,7 +91,7 @@ Number list of loader nodes in multiple data centers
 
 Number list of monitor nodes in multiple data centers
 
-**default:** N/A
+**default:** 1
 
 **type:** int_or_space_separated_ints
 

--- a/internal_test_data/complex_test_case_with_version.yaml
+++ b/internal_test_data/complex_test_case_with_version.yaml
@@ -13,7 +13,6 @@ stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=5760m -mode cql3 nat
                   "cassandra-stress read cl=QUORUM duration=5760m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compression=DeflateCompressor compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native compression=none -rate threads=20 -pop seq=1..100000000 -log interval=5"]
 n_db_nodes: 6
 n_loaders: 3
-n_monitor_nodes: 1
 nemesis_class_name: 'ChaosMonkey'
 user_prefix: 'longevity-50gb-4d-not-jenkins'
 space_node_threshold: 644245094

--- a/internal_test_data/cs_user_profile.yaml
+++ b/internal_test_data/cs_user_profile.yaml
@@ -2,7 +2,6 @@ test_duration: 5
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 user_prefix: 'fruch-testing'
 
 cs_user_profiles:

--- a/internal_test_data/minimal_test_case.yaml
+++ b/internal_test_data/minimal_test_case.yaml
@@ -2,7 +2,6 @@ test_duration: 5
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 user_prefix: 'fruch-testing'
 
 stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=10m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=2 -pop seq=1..3000 -log interval=5" ]

--- a/internal_test_data/multi_region_dc_test_case.yaml
+++ b/internal_test_data/multi_region_dc_test_case.yaml
@@ -3,7 +3,6 @@ region_name: 'eu-west-1 us-east-1'
 n_db_nodes: '2 1'
 rack_aware_loader: true
 n_loaders: 1
-n_monitor_nodes: 1
 monitor_branch: 'branch-2.1'
 user_prefix: manager-regression-DISTRO-VERSION
 space_node_threshold: 6442

--- a/internal_test_data/network_config_interface_not_defined.yaml
+++ b/internal_test_data/network_config_interface_not_defined.yaml
@@ -2,7 +2,6 @@ test_duration: 5
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 user_prefix: 'fruch-testing'
 
 stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=10m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=2 -pop seq=1..3000 -log interval=5" ]

--- a/internal_test_data/network_config_interface_param_not_defined.yaml
+++ b/internal_test_data/network_config_interface_param_not_defined.yaml
@@ -2,7 +2,6 @@ test_duration: 5
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 user_prefix: 'fruch-testing'
 
 stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=10m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=2 -pop seq=1..3000 -log interval=5" ]

--- a/internal_test_data/network_config_interface_param_public_not_primary.yaml
+++ b/internal_test_data/network_config_interface_param_public_not_primary.yaml
@@ -2,7 +2,6 @@ test_duration: 5
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 user_prefix: 'fruch-testing'
 
 stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=10m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=2 -pop seq=1..3000 -log interval=5" ]

--- a/internal_test_data/simple_test_case.yaml
+++ b/internal_test_data/simple_test_case.yaml
@@ -6,7 +6,6 @@ stress_cmd:
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 nemesis_class_name: 'NoOpMonkey'
 

--- a/internal_test_data/stress_cmd_with_bad_profile.yaml
+++ b/internal_test_data/stress_cmd_with_bad_profile.yaml
@@ -2,7 +2,6 @@ test_duration: 5
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 user_prefix: 'fruch-testing'
 db_type: scylla
 instance_type_db: 'i4i.large'

--- a/templates/test_config/template-longevity-5gb-1h-base.yaml.j2
+++ b/templates/test_config/template-longevity-5gb-1h-base.yaml.j2
@@ -14,7 +14,6 @@ stress_cmd:
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 seeds_num: 3
 
 instance_type_db: 'i4i.large'

--- a/test-cases/PR-provision-test-docker.yaml
+++ b/test-cases/PR-provision-test-docker.yaml
@@ -4,7 +4,6 @@ stress_cmd: ["cassandra-stress write cl=ONE duration=1m -schema 'replication(str
              ]
 
 n_loaders: 1
-n_monitor_nodes: 1
 n_db_nodes: 1
 
 instance_type_runner: c6i.2xlarge

--- a/test-cases/PR-provision-test.yaml
+++ b/test-cases/PR-provision-test.yaml
@@ -18,7 +18,6 @@ n_loaders: 1
 instance_type_db: 'i4i.large'
 # testing the force iotune feature
 force_run_iotune: true
-n_monitor_nodes: 1
 n_db_nodes: 3
 
 nemesis_class_name: SisyphusMonkey

--- a/test-cases/cdc/cdc-replication-longevity.yaml
+++ b/test-cases/cdc/cdc-replication-longevity.yaml
@@ -12,7 +12,6 @@ instance_type_db_oracle: 'i3.large'
 n_loaders: 1
 instance_type_loader: 'c6i.large'
 
-n_monitor_nodes: 1
 
 nemesis_class_name: 'CategoricalMonkey'
 

--- a/test-cases/enterprise-features/workload-prioritization/longevity/longevity-sla-system-24h.yaml
+++ b/test-cases/enterprise-features/workload-prioritization/longevity/longevity-sla-system-24h.yaml
@@ -9,7 +9,6 @@ stress_cmd: ["cassandra-stress read cl=QUORUM duration=1380m -schema 'replicatio
 
 n_db_nodes: 6
 n_loaders: 2
-n_monitor_nodes: 1
 round_robin: true
 
 sla: true

--- a/test-cases/features/2mv-backpressure-4d.yaml
+++ b/test-cases/features/2mv-backpressure-4d.yaml
@@ -5,7 +5,6 @@ stress_cmd: ["cassandra-stress user profile=/tmp/c-s_profile_2mv_2queries.yaml o
             "cassandra-stress user profile=/tmp/c-s_profile_2mv_2queries.yaml ops'(mv_p_read1=1,mv_p_read2=1)' cl=QUORUM duration=5760m -mode cql3 native -pop seq=1..250000000 -rate threads=10"]
 n_db_nodes: 6
 n_loaders: 4
-n_monitor_nodes: 1
 
 user_prefix: 'longevity-2mv-backpressure-4d'
 

--- a/test-cases/features/add-new-dc.yaml
+++ b/test-cases/features/add-new-dc.yaml
@@ -8,7 +8,6 @@ verify_data_after_entire_test: "cassandra-stress read cl=LOCAL_ONE n=20900 -mode
 n_db_nodes: 3 0  # make n_db_nodes configured as multi-dc with last dc set to 0 (so later easily new node can be added)
 region_name: 'eu-west-1 eu-west-2'
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.xlarge'
 seeds_num: 3

--- a/test-cases/features/alternator-ttl/longevity-alternator-1h-scan-12h-ttl-no-lwt-2h-grace-4loaders-sisyphus.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-1h-scan-12h-ttl-no-lwt-2h-grace-4loaders-sisyphus.yaml
@@ -39,7 +39,6 @@ dynamodb_primarykey_type: HASH_AND_RANGE
 
 n_loaders: 4
 instance_type_db: 'i4i.2xlarge'
-n_monitor_nodes: 1
 n_db_nodes: 6
 
 nemesis_class_name: 'SisyphusMonkey'

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired-data.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-8m-grace-sisyphus-rewrite-expired-data.yaml
@@ -30,7 +30,6 @@ dynamodb_primarykey_type: HASH_AND_RANGE
 
 n_loaders: 2
 instance_type_db: 'i4i.large'
-n_monitor_nodes: 1
 n_db_nodes: 6
 
 nemesis_class_name: 'SisyphusMonkey'

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-no-lwt-8m-grace-sisyphus.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-36m-ttl-no-lwt-8m-grace-sisyphus.yaml
@@ -23,7 +23,6 @@ dynamodb_primarykey_type: HASH_AND_RANGE
 
 n_loaders: 2
 instance_type_db: 'i4i.large'
-n_monitor_nodes: 1
 n_db_nodes: 6
 
 nemesis_class_name: 'SisyphusMonkey'

--- a/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-multiple-ttl-8m-grace.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-4m-scan-multiple-ttl-8m-grace.yaml
@@ -78,7 +78,6 @@ dynamodb_primarykey_type: HASH_AND_RANGE
 
 n_loaders: 4
 instance_type_db: 'i4i.2xlarge'
-n_monitor_nodes: 1
 n_db_nodes: 6
 
 nemesis_class_name: 'NoOpMonkey'

--- a/test-cases/features/alternator-ttl/longevity-alternator-disable-enable-ttl.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-disable-enable-ttl.yaml
@@ -29,7 +29,6 @@ dynamodb_primarykey_type: HASH_AND_RANGE
 
 n_loaders: 2
 instance_type_db: 'i4i.large'
-n_monitor_nodes: 1
 n_db_nodes: 6
 
 nemesis_class_name: 'NoOpMonkey'

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-big-dataset.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-big-dataset.yaml
@@ -35,7 +35,6 @@ dynamodb_primarykey_type: HASH_AND_RANGE
 
 n_loaders: 4
 instance_type_db: 'i4i.2xlarge'
-n_monitor_nodes: 1
 n_db_nodes: 6
 
 nemesis_class_name: 'NoOpMonkey'

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-large-writes.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-large-writes.yaml
@@ -34,7 +34,6 @@ dynamodb_primarykey_type: HASH_AND_RANGE
 
 n_loaders: 4
 instance_type_db: 'i4i.2xlarge'
-n_monitor_nodes: 1
 n_db_nodes: 6
 
 nemesis_class_name: 'NoOpMonkey'

--- a/test-cases/features/alternator-ttl/longevity-alternator-ttl-lwt.yaml
+++ b/test-cases/features/alternator-ttl/longevity-alternator-ttl-lwt.yaml
@@ -17,7 +17,6 @@ dynamodb_primarykey_type: HASH_AND_RANGE
 
 n_loaders: 2
 instance_type_db: 'i4i.2xlarge'
-n_monitor_nodes: 1
 n_db_nodes: 6
 
 nemesis_class_name: 'NoOpMonkey'

--- a/test-cases/features/compaction-throughput-limit.yaml
+++ b/test-cases/features/compaction-throughput-limit.yaml
@@ -4,7 +4,6 @@ stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM n=20000000 -schema 're
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.xlarge'
 instance_type_loader: 'c7i.large'

--- a/test-cases/features/corrupt-then-rebuild.yaml
+++ b/test-cases/features/corrupt-then-rebuild.yaml
@@ -7,7 +7,6 @@ stress_read_cmd:  "cassandra-stress read cl=ONE n=10000 -mode cql3 native -rate 
 
 n_db_nodes: 6
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
 

--- a/test-cases/features/destroy-data-then-repair.yaml
+++ b/test-cases/features/destroy-data-then-repair.yaml
@@ -5,7 +5,6 @@ stress_read_cmd:  "cassandra-stress read cl=ONE n=10000 -mode cql3 native -rate 
 
 n_db_nodes: 6
 n_loaders: 2
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.large'
 

--- a/test-cases/features/dns-cluster-5min.yaml
+++ b/test-cases/features/dns-cluster-5min.yaml
@@ -6,7 +6,6 @@ stress_cmd: "cassandra-stress write no-warmup cl=QUORUM duration=15m -schema 're
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
 instance_type_loader: 'c6i.4xlarge'

--- a/test-cases/features/elasticity/elasticity-90-percent-with-nemesis.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-with-nemesis.yaml
@@ -14,7 +14,6 @@ pre_create_keyspace: "CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication =
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 nemesis_grow_shrink_instance_type: 'i4i.large'
 
 instance_type_loader: 'c6i.2xlarge'

--- a/test-cases/features/elasticity/longevity-elasticity-many-small-tables.yaml
+++ b/test-cases/features/elasticity/longevity-elasticity-many-small-tables.yaml
@@ -18,7 +18,6 @@ batch_size: 125
 cs_duration: ''
 
 n_loaders: 4
-n_monitor_nodes: 1
 n_db_nodes: 3
 add_node_cnt: 0
 

--- a/test-cases/features/enospc-30mins.yaml
+++ b/test-cases/features/enospc-30mins.yaml
@@ -5,7 +5,6 @@ stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=20m -schema 'rep
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_db: 'c3.large' # for cassandra we'll use 'm3.large'
 instance_type_loader: 'c6i.4xlarge'

--- a/test-cases/features/full-cluster-stop-start.yaml
+++ b/test-cases/features/full-cluster-stop-start.yaml
@@ -7,7 +7,6 @@ stress_read_cmd: "cassandra-stress read cl=QUORUM n=1500000 -mode cql3 native  -
 
 n_db_nodes: 6
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.large'
 user_prefix: 'cases-full-stop-start'

--- a/test-cases/features/gce-multiple-dc-shutdown-30mins.yaml
+++ b/test-cases/features/gce-multiple-dc-shutdown-30mins.yaml
@@ -5,6 +5,5 @@ stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=30m -schema 'rep
 
 n_db_nodes: 2
 n_loaders: 1
-n_monitor_nodes: 1
 
 user_prefix: 'gce-multi-dc-shutdown-1-7'

--- a/test-cases/features/google-cloud-snitch-multi-dc.yaml
+++ b/test-cases/features/google-cloud-snitch-multi-dc.yaml
@@ -5,7 +5,6 @@ stress_cmd: cassandra-stress write cl=QUORUM duration=20m -schema 'replication(s
 gce_datacenter: 'us-east1 us-west1'
 n_db_nodes: "3 3"
 n_loaders: 2
-n_monitor_nodes: 1
 simulated_racks: 0
 
 user_prefix: 'google-snitch'

--- a/test-cases/features/hinted-handoff.yaml
+++ b/test-cases/features/hinted-handoff.yaml
@@ -4,7 +4,6 @@ test_duration: 300
 # cluster definition
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
 

--- a/test-cases/features/ics_space_amplification_goal_test.yaml
+++ b/test-cases/features/ics_space_amplification_goal_test.yaml
@@ -15,7 +15,6 @@ round_robin: true
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
 

--- a/test-cases/features/limit-streaming-io.yaml
+++ b/test-cases/features/limit-streaming-io.yaml
@@ -16,7 +16,6 @@ stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_loader: 'c6i.2xlarge'
 instance_type_monitor: 't3.large'

--- a/test-cases/features/per-partition-limit.yaml
+++ b/test-cases/features/per-partition-limit.yaml
@@ -14,7 +14,6 @@ stress_cmd: [
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.large'
 instance_type_loader: 'c7i.large'

--- a/test-cases/features/refresh-30mins-100mb.yaml
+++ b/test-cases/features/refresh-30mins-100mb.yaml
@@ -6,7 +6,6 @@ stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=20m -schema 'rep
 
 n_db_nodes: 2
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.large'
 

--- a/test-cases/features/refresh-30mins-120gb.yaml
+++ b/test-cases/features/refresh-30mins-120gb.yaml
@@ -6,7 +6,6 @@ stress_cmd: cassandra-stress mixed no-warmup cl=QUORUM duration=80m -schema 'rep
 
 n_db_nodes: 3
 n_loaders: 2
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.large'
 

--- a/test-cases/features/repair-240mins-100G.yaml
+++ b/test-cases/features/repair-240mins-100G.yaml
@@ -5,7 +5,6 @@ stress_cmd: cassandra-stress write cl=QUORUM duration=240m -schema 'replication(
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
 

--- a/test-cases/features/sl-workloads-test.yaml
+++ b/test-cases/features/sl-workloads-test.yaml
@@ -2,7 +2,6 @@ test_duration: 300
 
 n_db_nodes: 3
 n_loaders: 2
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.xlarge'
 instance_type_loader: 'c5.2xlarge'

--- a/test-cases/features/stop-compaction-ics.yaml
+++ b/test-cases/features/stop-compaction-ics.yaml
@@ -2,7 +2,6 @@ test_duration: 60
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.large'
 

--- a/test-cases/features/stop-compaction.yaml
+++ b/test-cases/features/stop-compaction.yaml
@@ -2,7 +2,6 @@ test_duration: 80
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.large'
 

--- a/test-cases/features/system-sla-test.yaml
+++ b/test-cases/features/system-sla-test.yaml
@@ -2,7 +2,6 @@ test_duration: 180
 
 n_db_nodes: 3
 n_loaders: 3
-n_monitor_nodes: 1
 
 instance_type_db: 'i3.2xlarge'
 instance_type_loader: 'c6i.2xlarge'

--- a/test-cases/features/test_add_remove_ldap_role_permission.yaml
+++ b/test-cases/features/test_add_remove_ldap_role_permission.yaml
@@ -10,7 +10,6 @@ authorizer: 'CassandraAuthorizer'
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 instance_type_db: 'i4i.large'
 user_prefix: 'test-add-remove-ldap-permissions'
 stress_cmd: "cassandra-stress write no-warmup cl=QUORUM duration=10m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=2 -pop seq=1..1002003 -log interval=5"

--- a/test-cases/features/tombstone_gc/longevity-tombstone-gc-modes.yaml
+++ b/test-cases/features/tombstone_gc/longevity-tombstone-gc-modes.yaml
@@ -4,7 +4,6 @@ stress_cmd: ["scylla-bench -workload=timeseries -mode=write -replication-factor=
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.large'
 

--- a/test-cases/features/uda_udf.yaml
+++ b/test-cases/features/uda_udf.yaml
@@ -5,7 +5,6 @@ stress_cmd: ["cassandra-stress user profile=/tmp/c-s_uda_udf.yaml ops'(my_avg=1,
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
 experimental_features:

--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -2,7 +2,6 @@ test_duration: 780
 n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-n_monitor_nodes: 1
 instance_type_db: 'i4i.2xlarge'
 instance_type_loader: 'm6i.xlarge'
 

--- a/test-cases/gemini/gemini-3h-cdc-postimage-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-postimage-write.yaml
@@ -1,7 +1,6 @@
 test_duration: 300
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 instance_type_db: 'i4i.4xlarge'
 
 user_prefix: 'gemini-cdc-postimage-write'

--- a/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
@@ -1,7 +1,6 @@
 test_duration: 300
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 instance_type_db: 'i4i.4xlarge'
 
 user_prefix: 'gemini-cdc-preimage-write'

--- a/test-cases/gemini/gemini-3h-cdc-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-write.yaml
@@ -1,7 +1,6 @@
 test_duration: 300
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 instance_type_db: 'i4i.4xlarge'
 
 user_prefix: 'gemini-cdc-write'

--- a/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
@@ -2,7 +2,6 @@ test_duration: 500
 n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-n_monitor_nodes: 1
 instance_type_db: 'i4i.large'
 
 user_prefix: 'ics-cdc-gemini-basic-3h'

--- a/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
@@ -2,7 +2,6 @@ test_duration: 500
 n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-n_monitor_nodes: 1
 instance_type_db: 'i4i.large'
 
 user_prefix: 'ics-gemini-nemesis-3h'

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -2,7 +2,6 @@ test_duration: 300
 n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-n_monitor_nodes: 1
 instance_type_db: 'i4i.large'
 
 user_prefix: 'gemini-with-nemesis-3h-normal'

--- a/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
@@ -2,7 +2,6 @@ test_duration: 500
 n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-n_monitor_nodes: 1
 instance_type_db: 'i4i.xlarge'
 
 user_prefix: 'gemini-basic-3h'

--- a/test-cases/gemini/gemini-8h-large-num-columns.yaml
+++ b/test-cases/gemini/gemini-8h-large-num-columns.yaml
@@ -2,7 +2,6 @@ test_duration: 500
 n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-n_monitor_nodes: 1
 instance_type_db: 'i3en.3xlarge'
 instance_type_loader: 'c6i.4xlarge'
 

--- a/test-cases/gemini/gemini-basic-3h-ics.yaml
+++ b/test-cases/gemini/gemini-basic-3h-ics.yaml
@@ -2,7 +2,6 @@ test_duration: 500
 n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-n_monitor_nodes: 1
 instance_type_db: 'i4i.large'
 
 user_prefix: 'ics-gemini-basic-3h'

--- a/test-cases/gemini/gemini-basic-3h.yaml
+++ b/test-cases/gemini/gemini-basic-3h.yaml
@@ -2,7 +2,6 @@ test_duration: 500
 n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1
-n_monitor_nodes: 1
 instance_type_db: 'i4i.large'
 
 user_prefix: 'gemini-basic-3h'

--- a/test-cases/jepsen/jepsen.yaml
+++ b/test-cases/jepsen/jepsen.yaml
@@ -10,7 +10,6 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 n_db_nodes: 5
 n_loaders: 1
-n_monitor_nodes: 1
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'debian-buster'
 use_preinstalled_scylla: false

--- a/test-cases/jepsen/jepsen_with_raft.yaml
+++ b/test-cases/jepsen/jepsen_with_raft.yaml
@@ -10,7 +10,6 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 n_db_nodes: 5
 n_loaders: 1
-n_monitor_nodes: 1
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'debian-buster'
 use_preinstalled_scylla: false

--- a/test-cases/kafka/longevity-kafka-cdc.yaml
+++ b/test-cases/kafka/longevity-kafka-cdc.yaml
@@ -10,7 +10,6 @@ stress_cmd: ["cassandra-stress write cl=ONE n=1000 -schema 'replication(strategy
              "python_thread -thread=KafkaCDCReaderThread -read_number_of_key=1000"]
 
 n_loaders: 1
-n_monitor_nodes: 1
 n_db_nodes: 1
 
 instance_type_runner: c7i.2xlarge

--- a/test-cases/kafka/longevity-kafka-sink.yaml
+++ b/test-cases/kafka/longevity-kafka-sink.yaml
@@ -1,7 +1,6 @@
 test_duration: 60
 
 n_loaders: 1
-n_monitor_nodes: 1
 n_db_nodes: 1
 
 instance_type_runner: c7i.2xlarge

--- a/test-cases/load/admission_control_overload_test.yaml
+++ b/test-cases/load/admission_control_overload_test.yaml
@@ -6,7 +6,6 @@ stress_cmd_w: "cassandra-stress user profile=/tmp/cs_profile_background_reads_ov
 
 n_db_nodes: 1
 n_loaders: 12
-n_monitor_nodes: 1
 instance_type_db: 'i4i.large'
 instance_type_loader: 'c5.4xlarge'
 instance_type_monitor: 't3.small'

--- a/test-cases/longevity/longevity-1-rf-test-12h.yaml
+++ b/test-cases/longevity/longevity-1-rf-test-12h.yaml
@@ -20,7 +20,6 @@ stress_cmd: ["scylla-bench -workload=sequential -mode=write  -replication-factor
 
 n_db_nodes: 3
 n_loaders: 2
-n_monitor_nodes: 1
 round_robin: true
 
 instance_type_db: 'i4i.xlarge'

--- a/test-cases/longevity/longevity-100GB-48h-cloud-CloudLimitedChaosMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-100GB-48h-cloud-CloudLimitedChaosMonkey-tls.yaml
@@ -7,7 +7,6 @@ run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", 
 
 n_db_nodes: 6
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.large' # instance type is defined in the jenkins job (with default value in the jenkinsfile for the cloud longevity
 

--- a/test-cases/longevity/longevity-100gb-4h-cql-stress.yaml
+++ b/test-cases/longevity/longevity-100gb-4h-cql-stress.yaml
@@ -8,7 +8,6 @@ stress_cmd: ["cql-stress-cassandra-stress write cl=QUORUM duration=240m -schema 
 
 n_db_nodes: 6
 n_loaders: 1
-n_monitor_nodes: 1
 seeds_num: 3
 simulated_racks: 3
 

--- a/test-cases/longevity/longevity-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-100gb-4h.yaml
@@ -8,7 +8,6 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=240m -schema 'replicatio
 
 n_db_nodes: 6
 n_loaders: 2
-n_monitor_nodes: 1
 seeds_num: 3
 
 instance_type_db: 'i4i.4xlarge'

--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -4,7 +4,6 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replicatio
 
 n_db_nodes: 6
 n_loaders: 2
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
 gce_instance_type_db: 'n2-highmem-16'

--- a/test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey-cql-stress.yaml
+++ b/test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey-cql-stress.yaml
@@ -6,7 +6,6 @@ stress_read_cmd: ["cql-stress-cassandra-stress read cl=QUORUM duration=11h -sche
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 5}']
 n_db_nodes: 6
 n_loaders: 1
-n_monitor_nodes: 1
 simulated_racks: 3
 
 instance_type_db: 'i4i.2xlarge'

--- a/test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml
+++ b/test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml
@@ -6,7 +6,6 @@ stress_read_cmd: ["cassandra-stress read cl=ONE duration=11h -schema 'replicatio
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 5}']
 n_db_nodes: 6
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
 gce_instance_type_db: 'n2-highmem-16'

--- a/test-cases/longevity/longevity-1TB-3days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-3days-authorization-and-tls-ssl.yaml
@@ -14,7 +14,6 @@ round_robin: true
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 seeds_num: 3
 
 instance_type_db: 'i4i.2xlarge'

--- a/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
@@ -14,7 +14,6 @@ round_robin: true
 
 n_db_nodes: 6
 n_loaders: 4
-n_monitor_nodes: 1
 seeds_num: 2
 
 instance_type_db: 'i4i.2xlarge'

--- a/test-cases/longevity/longevity-200GB-48h-network-monkey.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-network-monkey.yaml
@@ -6,7 +6,6 @@ stress_read_cmd: ["cassandra-stress read cl=ONE duration=2780m -schema 'replicat
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 5}']
 n_db_nodes: 6
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
 

--- a/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -12,7 +12,6 @@ run_fullscan:
   - '{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 5}'
 n_db_nodes: 6
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
 azure_instance_type_db: 'Standard_L16s_v3'

--- a/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -22,7 +22,6 @@ round_robin: true
 
 n_db_nodes: 6
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_db: 'i3en.3xlarge'
 instance_type_loader: 'c6i.2xlarge'

--- a/test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml
@@ -10,7 +10,6 @@ run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", 
 availability_zone: 'a,b,c'
 n_db_nodes: 6
 n_loaders: 3
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
 # Seems the c5.xlarge type is small for this load - I receive OOM on 2 loaders

--- a/test-cases/longevity/longevity-5TB-1day.yaml
+++ b/test-cases/longevity/longevity-5TB-1day.yaml
@@ -17,7 +17,6 @@ round_robin: true
 
 n_db_nodes: 6
 n_loaders: 4
-n_monitor_nodes: 1
 seeds_num: 2
 
 instance_type_db: 'i4i.2xlarge'

--- a/test-cases/longevity/longevity-alternator-200GB-48h.yaml
+++ b/test-cases/longevity/longevity-alternator-200GB-48h.yaml
@@ -32,7 +32,6 @@ round_robin: true
 dynamodb_primarykey_type: HASH_AND_RANGE
 
 n_loaders: 4
-n_monitor_nodes: 1
 n_db_nodes: 6
 
 # Instance types

--- a/test-cases/longevity/longevity-alternator-3h-multidc.yaml
+++ b/test-cases/longevity/longevity-alternator-3h-multidc.yaml
@@ -31,7 +31,6 @@ round_robin: true
 n_db_nodes: '3 3'
 instance_type_db: 'i4i.4xlarge'
 n_loaders: '2 2'
-n_monitor_nodes: 1
 
 rack_aware_loader: true
 region_aware_loader: true

--- a/test-cases/longevity/longevity-alternator-3h.yaml
+++ b/test-cases/longevity/longevity-alternator-3h.yaml
@@ -35,7 +35,6 @@ round_robin: true
 
 n_loaders: 4
 instance_type_db: 'i4i.4xlarge'
-n_monitor_nodes: 1
 n_db_nodes: 6
 
 nemesis_class_name: 'SisyphusMonkey'

--- a/test-cases/longevity/longevity-alternator-streams-100gb-12h.yaml
+++ b/test-cases/longevity/longevity-alternator-streams-100gb-12h.yaml
@@ -36,7 +36,6 @@ round_robin: true
 
 n_loaders: 3
 n_db_nodes: 6
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
 instance_type_loader: 'c6i.4xlarge'

--- a/test-cases/longevity/longevity-aws-custom-d2-workload1-3dcs.yaml
+++ b/test-cases/longevity/longevity-aws-custom-d2-workload1-3dcs.yaml
@@ -1,5 +1,4 @@
 test_duration: 255
-n_monitor_nodes: 1
 n_db_nodes: '3 3 3'
 n_loaders: '3 1 1'
 instance_type_db: 'i4i.2xlarge'

--- a/test-cases/longevity/longevity-aws-custom-d2-workload1-5dcs.yaml
+++ b/test-cases/longevity/longevity-aws-custom-d2-workload1-5dcs.yaml
@@ -1,5 +1,4 @@
 test_duration: 1440
-n_monitor_nodes: 1
 n_db_nodes: '12 12 12 12 12'
 n_loaders: '5 1 1 1 1'
 instance_type_db: 'i3en.large'

--- a/test-cases/longevity/longevity-cdc-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-4h.yaml
@@ -10,7 +10,6 @@ stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile.yaml ops
 availability_zone: 'a,b,c'
 n_db_nodes: 6
 n_loaders: 2
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
 

--- a/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-large-cluster.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-large-cluster.yaml
@@ -9,7 +9,6 @@ stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc.
 n_db_nodes: '15 15 15'
 instance_type_db: 'i4i.large'
 n_loaders: '2 2 2'
-n_monitor_nodes: 1
 
 rack_aware_loader: true
 region_aware_loader: true

--- a/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml
@@ -9,7 +9,6 @@ stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc.
 n_db_nodes: '4 4'
 instance_type_db: 'i4i.4xlarge'
 n_loaders: '2 2'
-n_monitor_nodes: 1
 
 rack_aware_loader: true
 region_aware_loader: true

--- a/test-cases/longevity/longevity-cdc-3d-400gb.yaml
+++ b/test-cases/longevity/longevity-cdc-3d-400gb.yaml
@@ -14,7 +14,6 @@ stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile_400gb.ya
 
 n_db_nodes: 6
 n_loaders: 4
-n_monitor_nodes: 1
 
 round_robin: true
 

--- a/test-cases/longevity/longevity-change-cluster-size-by-2-times.yaml
+++ b/test-cases/longevity/longevity-change-cluster-size-by-2-times.yaml
@@ -12,7 +12,6 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=720m no-warmup -schema '
 
 n_db_nodes: 3
 n_loaders: 2
-n_monitor_nodes: 1
 
 instance_type_db: 'i3en.xlarge'
 

--- a/test-cases/longevity/longevity-counters-3h.yaml
+++ b/test-cases/longevity/longevity-counters-3h.yaml
@@ -5,7 +5,6 @@ stress_read_cmd: "scylla-bench -workload=uniform -mode=counter_read   -replicati
 
 n_db_nodes: 6
 n_loaders:  1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.large'
 

--- a/test-cases/longevity/longevity-counters-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-multidc.yaml
@@ -7,7 +7,6 @@ stress_read_cmd: "scylla-bench -workload=uniform -mode=counter_read   -replicati
 availability_zone: 'a,b,c'
 n_db_nodes: '3 3 3'
 n_loaders:  '1 1 1'
-n_monitor_nodes: 1
 
 rack_aware_loader: true
 region_aware_loader: true

--- a/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
@@ -6,7 +6,6 @@ stress_read_cmd: ["cassandra-stress read cl=ONE duration=360m -schema 'replicati
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 5}']
 n_db_nodes: 6
 n_loaders: 2
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
 

--- a/test-cases/longevity/longevity-encryption-at-rest-20GB-6h-multidc.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-20GB-6h-multidc.yaml
@@ -11,7 +11,6 @@ stress_cmd: [
 round_robin: true
 n_db_nodes: '3 3'
 n_loaders: '1 1'
-n_monitor_nodes: 1
 
 rack_aware_loader: true
 region_aware_loader: true

--- a/test-cases/longevity/longevity-encryption-at-rest-50GB-1day-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-50GB-1day-authorization-and-tls-ssl.yaml
@@ -9,7 +9,6 @@ stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=1440m -mode cql3 nat
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 60}']
 n_db_nodes: 6
 n_loaders: 3
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
 instance_type_loader: 'c6i.2xlarge'

--- a/test-cases/longevity/longevity-gce-custom-d1-workload1-hybrid-raid.yaml
+++ b/test-cases/longevity/longevity-gce-custom-d1-workload1-hybrid-raid.yaml
@@ -1,5 +1,4 @@
 test_duration: 900
-n_monitor_nodes: 1
 n_db_nodes: 8
 n_loaders: 2
 

--- a/test-cases/longevity/longevity-gce-custom-d1-workload2-hybrid-raid.yaml
+++ b/test-cases/longevity/longevity-gce-custom-d1-workload2-hybrid-raid.yaml
@@ -1,5 +1,4 @@
 test_duration: 900
-n_monitor_nodes: 1
 n_db_nodes: '5 5'
 n_loaders: '1 1'
 simulated_regions: 2

--- a/test-cases/longevity/longevity-harry-2h.yaml
+++ b/test-cases/longevity/longevity-harry-2h.yaml
@@ -3,7 +3,6 @@ stress_cmd: ["cassandra-harry -run-time 2 -run-time-unit HOURS"]
 
 n_db_nodes: 6
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.large'
 

--- a/test-cases/longevity/longevity-large-collections-12h.yaml
+++ b/test-cases/longevity/longevity-large-collections-12h.yaml
@@ -5,7 +5,6 @@ stress_cmd: [
 
 n_db_nodes: 6
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i3en.3xlarge'
 

--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -41,7 +41,6 @@ post_prepare_cql_cmds: ["CREATE MATERIALIZED VIEW scylla_bench.view_test AS SELE
 
 n_db_nodes: 6
 n_loaders: 5 # Each loader will have 1 scylla-bench process at every step of the test (prepare, verify, stress & stress_read)
-n_monitor_nodes: 1
 
 round_robin: true
 

--- a/test-cases/longevity/longevity-large-partition-3h.yaml
+++ b/test-cases/longevity/longevity-large-partition-3h.yaml
@@ -32,7 +32,6 @@ post_prepare_cql_cmds: "CREATE MATERIALIZED VIEW scylla_bench.view_test AS SELEC
 
 n_db_nodes: 6
 n_loaders: 4
-n_monitor_nodes: 1
 
 round_robin: true
 

--- a/test-cases/longevity/longevity-large-partition-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-4days.yaml
@@ -19,7 +19,6 @@ post_prepare_cql_cmds: "CREATE MATERIALIZED VIEW scylla_bench.view_test AS SELEC
 
 n_db_nodes: 6
 n_loaders: 3
-n_monitor_nodes: 1
 
 instance_type_db: 'i3en.3xlarge'
 azure_instance_type_db: 'Standard_L32s_v3'

--- a/test-cases/longevity/longevity-large-partition-8h.yaml
+++ b/test-cases/longevity/longevity-large-partition-8h.yaml
@@ -35,7 +35,6 @@ post_prepare_cql_cmds: [
 
 n_db_nodes: 6
 n_loaders: 4
-n_monitor_nodes: 1
 
 round_robin: true
 

--- a/test-cases/longevity/longevity-large-partitions-deletions-and-reversed-queries.yaml
+++ b/test-cases/longevity/longevity-large-partitions-deletions-and-reversed-queries.yaml
@@ -18,7 +18,6 @@ post_prepare_cql_cmds: "CREATE MATERIALIZED VIEW scylla_bench.view_test AS SELEC
 
 n_db_nodes: 3
 n_loaders: 2
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
 

--- a/test-cases/longevity/longevity-large-partitions-with-network-nemesis-1h.yaml
+++ b/test-cases/longevity/longevity-large-partitions-with-network-nemesis-1h.yaml
@@ -22,7 +22,6 @@ post_prepare_cql_cmds: "CREATE MATERIALIZED VIEW scylla_bench.view_test AS SELEC
 n_db_nodes: 3
 
 n_loaders: 2
-n_monitor_nodes: 1
 
 round_robin: true
 

--- a/test-cases/longevity/longevity-lwt-1loader-3h.yaml
+++ b/test-cases/longevity/longevity-lwt-1loader-3h.yaml
@@ -5,7 +5,6 @@ stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(se
 
 n_db_nodes: 6
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.large'
 

--- a/test-cases/longevity/longevity-lwt-24h-multidc.yaml
+++ b/test-cases/longevity/longevity-lwt-24h-multidc.yaml
@@ -5,7 +5,6 @@ stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.y
 
 n_db_nodes: '4 3 2'
 n_loaders: '1 1 1'
-n_monitor_nodes: 1
 
 rack_aware_loader: true
 region_aware_loader: true

--- a/test-cases/longevity/longevity-lwt-500G-3d.yaml
+++ b/test-cases/longevity/longevity-lwt-500G-3d.yaml
@@ -16,7 +16,6 @@ stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'
 
 n_db_nodes: 6
 n_loaders: 3
-n_monitor_nodes: 1
 round_robin: true
 
 instance_type_db: 'i4i.2xlarge'

--- a/test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml
@@ -5,7 +5,6 @@ stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(se
 
 n_db_nodes: 6
 n_loaders: 3
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.large'
 

--- a/test-cases/longevity/longevity-lwt-basic-24h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-24h.yaml
@@ -7,7 +7,6 @@ stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(se
 
 n_db_nodes: 6
 n_loaders: 3
-n_monitor_nodes: 1
 round_robin: true
 
 instance_type_db: 'i4i.large'

--- a/test-cases/longevity/longevity-lwt-basic-3h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-3h.yaml
@@ -9,7 +9,6 @@ stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(se
 
 n_db_nodes: 6
 n_loaders: 3
-n_monitor_nodes: 1
 round_robin: true
 
 instance_type_db: 'i4i.large'

--- a/test-cases/longevity/longevity-lwt-parallel-24h.yaml
+++ b/test-cases/longevity/longevity-lwt-parallel-24h.yaml
@@ -7,7 +7,6 @@ stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(se
 
 n_db_nodes: 6
 n_loaders: 3
-n_monitor_nodes: 1
 round_robin: true
 
 instance_type_db: 'i4i.large'

--- a/test-cases/longevity/longevity-mini-test-1h.yaml
+++ b/test-cases/longevity/longevity-mini-test-1h.yaml
@@ -3,7 +3,6 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=90m -schema 'replication
 
 n_db_nodes: 6
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.large'
 

--- a/test-cases/longevity/longevity-multi-dc-rack-aware-with-znode-in-diff_dc.yaml
+++ b/test-cases/longevity/longevity-multi-dc-rack-aware-with-znode-in-diff_dc.yaml
@@ -8,7 +8,6 @@ stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'repl
              ]
 n_db_nodes: '4 4 0'
 n_loaders: '1 1'
-n_monitor_nodes: 1
 n_db_zero_token_nodes: '0 1 1'
 
 rack_aware_loader: true

--- a/test-cases/longevity/longevity-multi-dc-rack-aware.yaml
+++ b/test-cases/longevity/longevity-multi-dc-rack-aware.yaml
@@ -8,7 +8,6 @@ stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'repl
              ]
 n_db_nodes: '3 3'
 n_loaders: '1 1'
-n_monitor_nodes: 1
 
 rack_aware_loader: true
 region_aware_loader: true

--- a/test-cases/longevity/longevity-multi-dc-rackaware-validation.yaml
+++ b/test-cases/longevity/longevity-multi-dc-rackaware-validation.yaml
@@ -9,7 +9,6 @@ stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=120m -schema 'repl
 rack_aware_loader: true
 n_db_nodes: '6 6'
 n_loaders: '1 1'
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
 

--- a/test-cases/longevity/longevity-multi-keyspaces.yaml
+++ b/test-cases/longevity/longevity-multi-keyspaces.yaml
@@ -18,7 +18,6 @@ nemesis_interval: 30
 # Env
 n_db_nodes: 6
 n_loaders: 10
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.8xlarge'
 gce_instance_type_db: 'n2-highmem-64'

--- a/test-cases/longevity/longevity-multidc-parallel-network-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-network-schema-changes-12h.yaml
@@ -10,7 +10,6 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=720m -schema 'replicatio
              ]
 n_db_nodes: '4 4'
 n_loaders: '2 1'
-n_monitor_nodes: 1
 
 rack_aware_loader: true
 region_aware_loader: true

--- a/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
@@ -12,7 +12,6 @@ stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'repl
 availability_zone: 'a,b,c'
 n_db_nodes: '6 6'
 n_loaders: '2 1'
-n_monitor_nodes: 1
 
 rack_aware_loader: true
 region_aware_loader: true

--- a/test-cases/longevity/longevity-mv-si-4days.yaml
+++ b/test-cases/longevity/longevity-mv-si-4days.yaml
@@ -12,7 +12,6 @@ run_fullscan: ['{"mode": "table", "ks_cf": "random", "interval": 15}']
 
 n_db_nodes: 6
 n_loaders: 2
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.8xlarge'
 gce_instance_type_db: 'n2-highmem-64'

--- a/test-cases/longevity/longevity-mv-synchronous-updates-12h.yaml
+++ b/test-cases/longevity/longevity-mv-synchronous-updates-12h.yaml
@@ -15,7 +15,6 @@ stress_read_cmd: ["cassandra-stress mixed cl=QUORUM duration=690m  -schema 'repl
 
 n_db_nodes: 6
 n_loaders: 2
-n_monitor_nodes: 1
 round_robin: true
 
 instance_type_db: 'i4i.4xlarge'

--- a/test-cases/longevity/longevity-ndbench-12-nodes-multidc-4h.yaml
+++ b/test-cases/longevity/longevity-ndbench-12-nodes-multidc-4h.yaml
@@ -13,7 +13,6 @@ stress_cmd: >-
 region_name: 'us-east-1 eu-west-1'
 n_db_nodes: '6 6'
 n_loaders: '2 2'
-n_monitor_nodes: 1
 
 rack_aware_loader: true
 region_aware_loader: true

--- a/test-cases/longevity/longevity-ndbench-192-nodes-multidc-4h.yaml
+++ b/test-cases/longevity/longevity-ndbench-192-nodes-multidc-4h.yaml
@@ -13,7 +13,6 @@ stress_cmd: >-
 region_name: 'us-east-1 eu-west-1'
 n_db_nodes: '96 96'
 n_loaders: '32 32'
-n_monitor_nodes: 1
 
 rack_aware_loader: true
 region_aware_loader: true

--- a/test-cases/longevity/longevity-nosqlbench-3h.yaml
+++ b/test-cases/longevity/longevity-nosqlbench-3h.yaml
@@ -6,7 +6,6 @@ stress_cmd: [
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
 gce_instance_type_db: 'n2-highmem-16'

--- a/test-cases/longevity/longevity-parallel-schema-changes-12h-cql-stress.yaml
+++ b/test-cases/longevity/longevity-parallel-schema-changes-12h-cql-stress.yaml
@@ -14,7 +14,6 @@ stress_cmd: [
 
 n_db_nodes: 6
 n_loaders: 2
-n_monitor_nodes: 1
 simulated_racks: 3
 
 instance_type_db: 'i4i.2xlarge'

--- a/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
@@ -15,7 +15,6 @@ stress_cmd: [
 
 n_db_nodes: 6
 n_loaders: 2
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.xlarge'
 

--- a/test-cases/longevity/longevity-schema-changes-3h.yaml
+++ b/test-cases/longevity/longevity-schema-changes-3h.yaml
@@ -8,7 +8,6 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replicatio
 
 n_db_nodes: 3
 n_loaders: 2
-n_monitor_nodes: 1
 round_robin: true
 
 instance_type_db: 'i3en.large'

--- a/test-cases/longevity/longevity-sla-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-sla-100gb-4h.yaml
@@ -13,7 +13,6 @@ stress_cmd: [
 
 n_db_nodes: 6
 n_loaders: 2
-n_monitor_nodes: 1
 seeds_num: 3
 round_robin: true
 

--- a/test-cases/longevity/longevity-topology-changes-3h.yaml
+++ b/test-cases/longevity/longevity-topology-changes-3h.yaml
@@ -15,7 +15,6 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replicatio
 availability_zone: 'a'
 n_db_nodes: 3
 n_loaders: 2
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.8xlarge'
 gce_instance_type_db: 'n2-highmem-32'

--- a/test-cases/longevity/longevity-twcs-3h.yaml
+++ b/test-cases/longevity/longevity-twcs-3h.yaml
@@ -11,7 +11,6 @@ stress_read_cmd: [
 
 n_db_nodes: 6
 n_loaders: 3
-n_monitor_nodes: 1
 
 round_robin: true
 instance_type_db: 'i4i.2xlarge'

--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -12,7 +12,6 @@ stress_read_cmd: [
 
 n_db_nodes: 6
 n_loaders: 3
-n_monitor_nodes: 1
 
 instance_type_db: 'i3en.xlarge'
 

--- a/test-cases/longevity/longevity-user-profile-d.yaml
+++ b/test-cases/longevity/longevity-user-profile-d.yaml
@@ -10,7 +10,6 @@ stress_cmd: ["cassandra-stress user profile=scylla-qa-internal/profile-d/profile
 
 n_db_nodes: 3
 n_loaders: 3
-n_monitor_nodes: 1
 availability_zone: 'a,b,c'
 
 

--- a/test-cases/longevity/longevity-ycsb-a-100M.yaml
+++ b/test-cases/longevity/longevity-ycsb-a-100M.yaml
@@ -68,7 +68,6 @@ round_robin: true
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
 instance_type_loader: 'c5.9xlarge' # 32 vCPU, 72 GB RAM, 10GiB

--- a/test-cases/longevity/longevity-ycsb-a-10M.yaml
+++ b/test-cases/longevity/longevity-ycsb-a-10M.yaml
@@ -68,7 +68,6 @@ round_robin: true
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
 instance_type_loader: 'c5.9xlarge' # 32 vCPU, 72 GB RAM, 10GiB

--- a/test-cases/longevity/longevity-ycsb-a-1B.yaml
+++ b/test-cases/longevity/longevity-ycsb-a-1B.yaml
@@ -67,7 +67,6 @@ round_robin: true
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
 instance_type_loader: 'c5.9xlarge' # 32 vCPU, 72 GB RAM, 10GiB

--- a/test-cases/longevity/longevity-ycsb-a-1M.yaml
+++ b/test-cases/longevity/longevity-ycsb-a-1M.yaml
@@ -78,7 +78,6 @@ round_robin: true
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
 instance_type_loader: 'c5.9xlarge' # 32 vCPU, 72 GB RAM, 10GiB

--- a/test-cases/manager/manager-backup-1TB-gce.yaml
+++ b/test-cases/manager/manager-backup-1TB-gce.yaml
@@ -17,7 +17,6 @@ prepare_wait_no_compactions_timeout: 120
 
 n_db_nodes: 6
 n_loaders: 2
-n_monitor_nodes: 1
 
 gce_instance_type_db: 'n2-highmem-8'
 gce_n_local_ssd_disk_db: 8

--- a/test-cases/manager/manager-backup-and-restore-4TB-single-node.yaml
+++ b/test-cases/manager/manager-backup-and-restore-4TB-single-node.yaml
@@ -24,7 +24,6 @@ instance_type_loader: 'c5.xlarge'
 region_name: us-east-1
 n_db_nodes: 1
 n_loaders: 4
-n_monitor_nodes: 1
 
 user_prefix: manager-regression
 space_node_threshold: 6442

--- a/test-cases/manager/manager-backup-restore-set-dataset.yaml
+++ b/test-cases/manager/manager-backup-restore-set-dataset.yaml
@@ -12,7 +12,6 @@ instance_type_loader: 'c6i.xlarge'
 region_name: us-east-1
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 client_encrypt: true
 

--- a/test-cases/manager/manager-installation-set-distro.yaml
+++ b/test-cases/manager/manager-installation-set-distro.yaml
@@ -4,7 +4,6 @@ instance_type_db: 'i4i.large'
 
 n_db_nodes: 1
 n_loaders: 0
-n_monitor_nodes: 1
 
 client_encrypt: true
 

--- a/test-cases/manager/manager-multiple-restores-schema-and-data.yaml
+++ b/test-cases/manager/manager-multiple-restores-schema-and-data.yaml
@@ -6,6 +6,5 @@ instance_type_db: 'i3en.3xlarge'
 region_name: us-east-1
 n_db_nodes: 6
 n_loaders: 1
-n_monitor_nodes: 1
 
 user_prefix: manager-regression

--- a/test-cases/manager/manager-no-delta-backup-set-dataset.yaml
+++ b/test-cases/manager/manager-no-delta-backup-set-dataset.yaml
@@ -8,7 +8,6 @@ instance_type_loader: 'c6i.xlarge'
 
 region_name: 'us-east-1'
 n_db_nodes: 3
-n_monitor_nodes: 1
 n_loaders: 1
 
 client_encrypt: true

--- a/test-cases/manager/manager-regression-azure.yaml
+++ b/test-cases/manager/manager-regression-azure.yaml
@@ -5,7 +5,6 @@ stress_read_cmd: "cassandra-stress read cl=QUORUM n=4000000 -schema 'replication
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 azure_image_monitor: 'RedHat:RHEL:9_5:latest'
 # Default 50 GB value is changed here as the size of the corresponding disk in the VM image: 64 GB

--- a/test-cases/manager/manager-regression-ipv6.yaml
+++ b/test-cases/manager/manager-regression-ipv6.yaml
@@ -9,7 +9,6 @@ instance_type_loader: 'c6i.large'
 region_name: 'eu-west-1'
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 client_encrypt: true
 

--- a/test-cases/manager/manager-regression-multiDC-gce.yaml
+++ b/test-cases/manager/manager-regression-multiDC-gce.yaml
@@ -5,7 +5,6 @@ stress_read_cmd: "cassandra-stress read cl=QUORUM n=4000000 -schema 'replication
 
 n_db_nodes: "2 1"
 n_loaders: 1
-n_monitor_nodes: 1
 simulated_racks: 0
 
 client_encrypt: true

--- a/test-cases/manager/manager-regression-multiDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-multiDC-set-distro.yaml
@@ -10,7 +10,6 @@ rack_aware_loader: true
 region_name: 'us-east-1 us-west-2'
 n_db_nodes: '2 1'
 n_loaders: 1
-n_monitor_nodes: 1
 simulated_racks: 0
 
 client_encrypt: true

--- a/test-cases/manager/manager-regression-singleDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-singleDC-set-distro.yaml
@@ -9,7 +9,6 @@ instance_type_loader: 'c6i.large'
 region_name: 'us-east-1'
 n_db_nodes: '3'
 n_loaders: 1
-n_monitor_nodes: 1
 
 client_encrypt: true
 

--- a/test-cases/manager/manager-repair-control.yaml
+++ b/test-cases/manager/manager-repair-control.yaml
@@ -16,7 +16,6 @@ instance_type_loader: 'c6i.2xlarge'
 
 n_db_nodes: 9
 n_loaders: 4
-n_monitor_nodes: 1
 
 user_prefix: manager-repair-control
 space_node_threshold: 6442

--- a/test-cases/manager/manager-repair-intensity-multiple-repaired-nodes.yaml
+++ b/test-cases/manager/manager-repair-intensity-multiple-repaired-nodes.yaml
@@ -16,7 +16,6 @@ instance_type_loader: 'c6i.2xlarge'
 
 n_db_nodes: 9
 n_loaders: 4
-n_monitor_nodes: 1
 
 user_prefix: manager-repair
 space_node_threshold: 6442

--- a/test-cases/manager/manager-repair-intensity-single-repaired-nodes.yaml
+++ b/test-cases/manager/manager-repair-intensity-single-repaired-nodes.yaml
@@ -16,7 +16,6 @@ instance_type_loader: 'c6i.2xlarge'
 
 n_db_nodes: 6
 n_loaders: 4
-n_monitor_nodes: 1
 
 user_prefix: manager-repair
 space_node_threshold: 6442

--- a/test-cases/manager/manager-restore-outside.yaml
+++ b/test-cases/manager/manager-restore-outside.yaml
@@ -4,7 +4,6 @@ instance_type_db: 'i4i.2xlarge'
 
 region_name: us-east-1
 n_db_nodes: 3
-n_monitor_nodes: 1
 n_loaders: 0
 
 client_encrypt: true

--- a/test-cases/manager/prepare_snapshot/100GB_dataset.yaml
+++ b/test-cases/manager/prepare_snapshot/100GB_dataset.yaml
@@ -5,7 +5,6 @@ instance_type_loader: 'c6i.large'
 
 n_db_nodes: 3
 n_loaders: 2
-n_monitor_nodes: 1
 
 mgmt_prepare_snapshot_size: 100  # GB
 

--- a/test-cases/manager/prepare_snapshot/10GB_dataset.yaml
+++ b/test-cases/manager/prepare_snapshot/10GB_dataset.yaml
@@ -5,7 +5,6 @@ instance_type_loader: 'c6i.large'
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 mgmt_prepare_snapshot_size: 10  # GB
 

--- a/test-cases/manager/prepare_snapshot/2TB_dataset.yaml
+++ b/test-cases/manager/prepare_snapshot/2TB_dataset.yaml
@@ -5,7 +5,6 @@ instance_type_loader: 'c6i.2xlarge'
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 mgmt_prepare_snapshot_size: 2048  # GB
 

--- a/test-cases/manager/prepare_snapshot/5GB_dataset.yaml
+++ b/test-cases/manager/prepare_snapshot/5GB_dataset.yaml
@@ -5,7 +5,6 @@ instance_type_loader: 'c6i.large'
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 mgmt_prepare_snapshot_size: 5  # GB
 

--- a/test-cases/nemesis/longevity-5gb-1h-EndOfQuotaNemesis.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-EndOfQuotaNemesis.yaml
@@ -8,7 +8,6 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 seeds_num: 3
 
 instance_type_db: 'i4i.large'

--- a/test-cases/performance/perf-regression-2mv.yaml
+++ b/test-cases/performance/perf-regression-2mv.yaml
@@ -12,7 +12,6 @@ stress_cmd_no_mv_profile: 'data_dir/cs_no_mv_basic_profile.yaml'
 
 n_db_nodes: 6
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_db: 'i3.2xlarge'
 instance_type_loader: 'c5.2xlarge'

--- a/test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml
@@ -32,7 +32,6 @@ stress_cmd_m: >-2
 
 n_db_nodes: 3
 n_loaders: 3
-n_monitor_nodes: 1
 
 instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.small'

--- a/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
@@ -40,7 +40,6 @@ alternator_write_isolation: 'forbid'
 
 n_db_nodes: 3
 n_loaders: 3
-n_monitor_nodes: 1
 
 instance_type_db: 'i3.2xlarge'
 instance_type_loader: 'c5.2xlarge'

--- a/test-cases/performance/perf-regression-latency-125gb.yaml
+++ b/test-cases/performance/perf-regression-latency-125gb.yaml
@@ -10,7 +10,6 @@ stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=60m -schema '
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.large'

--- a/test-cases/performance/perf-regression-latency-1TB.yaml
+++ b/test-cases/performance/perf-regression-latency-1TB.yaml
@@ -11,7 +11,6 @@ stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=60m -schema '
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_db: 'i3.4xlarge'
 instance_type_loader: 'c6i.2xlarge'

--- a/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
@@ -10,7 +10,6 @@ stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=600m -schema 
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.large'

--- a/test-cases/performance/perf-regression-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-latency-500gb-30min.yaml
@@ -13,7 +13,6 @@ k8s_loader_run_type: 'static'
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_loader: 'c4.2xlarge'
 instance_type_monitor: 't3.small'

--- a/test-cases/performance/perf-regression-latency-650gb-elasticity.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-elasticity.yaml
@@ -10,7 +10,6 @@ stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_loader: 'c6i.2xlarge'
 instance_type_monitor: 't3.large'

--- a/test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml
@@ -10,7 +10,6 @@ stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.large'

--- a/test-cases/performance/perf-regression-latency-650gb-upgrade.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-upgrade.yaml
@@ -11,7 +11,6 @@ stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 
 n_db_nodes: 6
 nemesis_add_node_cnt: 0
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_loader: 'c6i.2xlarge'
 instance_type_monitor: 't3.large'

--- a/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
@@ -10,7 +10,6 @@ stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.large'

--- a/test-cases/performance/perf-regression-latency-cdc-mixed-poll-batching.yaml
+++ b/test-cases/performance/perf-regression-latency-cdc-mixed-poll-batching.yaml
@@ -11,7 +11,6 @@ stress_cdc_log_reader_batching_enable: true
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_loader: 'c4.2xlarge'
 instance_type_monitor: 't3.small'

--- a/test-cases/performance/perf-regression-latency-k8s-multitenant.yaml
+++ b/test-cases/performance/perf-regression-latency-k8s-multitenant.yaml
@@ -16,7 +16,6 @@ k8s_loader_run_type: 'static'
 k8s_deploy_monitoring: false
 
 n_db_nodes: 3
-n_monitor_nodes: 1
 
 instance_type_loader: 'c4.2xlarge'
 instance_type_monitor: 't3.small'

--- a/test-cases/performance/perf-regression-latency-lwt-big.yaml
+++ b/test-cases/performance/perf-regression-latency-lwt-big.yaml
@@ -40,7 +40,6 @@ stress_cmd_lwt_mixed_baseline: "cassandra-stress user profile=/tmp/cs_lwt_perf_b
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_loader: 'c4.2xlarge'
 instance_type_monitor: 't3.small'

--- a/test-cases/performance/perf-regression-latency-lwt-small.yaml
+++ b/test-cases/performance/perf-regression-latency-lwt-small.yaml
@@ -41,7 +41,6 @@ stress_cmd_lwt_mixed_baseline: "cassandra-stress user profile=/tmp/cs_lwt_perf_s
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_loader: 'c4.2xlarge'
 instance_type_monitor: 't3.small'

--- a/test-cases/performance/perf-regression-latency-mv-read-concurrency.yaml
+++ b/test-cases/performance/perf-regression-latency-mv-read-concurrency.yaml
@@ -10,7 +10,6 @@ stress_cmd_mv: "scylla-bench -workload=uniform -mode=write -replication-factor=2
 
 n_db_nodes: 3
 n_loaders: 2
-n_monitor_nodes: 1
 
 instance_type_loader: 'c6i.2xlarge'
 instance_type_monitor: 't3.large'

--- a/test-cases/performance/perf-regression-predefined-throughput-steps.yaml
+++ b/test-cases/performance/perf-regression-predefined-throughput-steps.yaml
@@ -38,7 +38,6 @@ round_robin: true
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
 instance_type_loader: 'c7i.8xlarge'

--- a/test-cases/performance/perf-regression-throughput-125gb.yaml
+++ b/test-cases/performance/perf-regression-throughput-125gb.yaml
@@ -13,7 +13,6 @@ stress_multiplier: 2
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.large'

--- a/test-cases/performance/perf-regression-throughput-baremetal-5gb.yaml
+++ b/test-cases/performance/perf-regression-throughput-baremetal-5gb.yaml
@@ -25,7 +25,6 @@ s3_baremetal_config: baremetal_config_example
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 db_nodes_public_ip: []
 db_nodes_private_ip: []

--- a/test-cases/performance/perf-regression-throughput-cdc-mixed-poll-batching.yaml
+++ b/test-cases/performance/perf-regression-throughput-cdc-mixed-poll-batching.yaml
@@ -10,7 +10,6 @@ stress_cdc_log_reader_batching_enable: true
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_loader: 'c4.2xlarge'
 instance_type_monitor: 't3.small'

--- a/test-cases/performance/perf-regression-throughput-lwt-big.yaml
+++ b/test-cases/performance/perf-regression-throughput-lwt-big.yaml
@@ -43,7 +43,6 @@ stress_cmd_lwt_mixed_baseline: "cassandra-stress user profile=/tmp/cs_lwt_perf_b
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_loader: 'c4.2xlarge'
 instance_type_monitor: 't3.small'

--- a/test-cases/performance/perf-regression-throughput-lwt-small.yaml
+++ b/test-cases/performance/perf-regression-throughput-lwt-small.yaml
@@ -42,7 +42,6 @@ stress_cmd_lwt_mixed_baseline: "cassandra-stress user profile=/tmp/cs_lwt_perf_s
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_loader: 'c4.2xlarge'
 instance_type_monitor: 't3.small'

--- a/test-cases/performance/perf-regression-user-profiles.yaml
+++ b/test-cases/performance/perf-regression-user-profiles.yaml
@@ -4,7 +4,6 @@ test_duration: 800
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_db: 'c3.large' # for cassandra we'll want 'm3.large'
 instance_type_loader: 'c5.2xlarge'

--- a/test-cases/performance/perf-regression-write-latency-cdc.yaml
+++ b/test-cases/performance/perf-regression-write-latency-cdc.yaml
@@ -3,7 +3,6 @@ test_duration: 500
 stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=10 throttle=2500/s' -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..500000000,250000000,25000000)' "
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.small'

--- a/test-cases/performance/perf-regression-write-throughput-cdc.yaml
+++ b/test-cases/performance/perf-regression-write-throughput-cdc.yaml
@@ -3,7 +3,6 @@ test_duration: 500
 stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=100 -pop seq=1..30000000"
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_loader: 'c4.2xlarge'
 instance_type_monitor: 't3.small'

--- a/test-cases/performance/perf-regression.100threads.100M-keys-z3-enterprise.yaml
+++ b/test-cases/performance/perf-regression.100threads.100M-keys-z3-enterprise.yaml
@@ -15,7 +15,6 @@ scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/
 k8s_loader_run_type: 'static'
 use_prepared_loaders: true
 n_db_nodes: 3
-n_monitor_nodes: 1
 
 # Loaders
 gce_instance_type_loader: 'c2-standard-30'

--- a/test-cases/performance/perf-regression.100threads.30M-keys-i4i-enterprise.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys-i4i-enterprise.yaml
@@ -13,7 +13,6 @@ k8s_loader_run_type: 'static'
 
 n_db_nodes: 3
 n_loaders: 6
-n_monitor_nodes: 1
 
 # AWS
 instance_type_db: 'i4i.2xlarge'

--- a/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys-i4i.yaml
@@ -13,7 +13,6 @@ k8s_loader_run_type: 'static'
 
 n_db_nodes: 3
 n_loaders: 6
-n_monitor_nodes: 1
 
 
 # AWS

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -14,7 +14,6 @@ k8s_scylla_disk_gi: 1760
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 #AWS
 instance_type_db: 'i3.2xlarge'

--- a/test-cases/performance/perf-row-level-repair-1TB.yaml
+++ b/test-cases/performance/perf-row-level-repair-1TB.yaml
@@ -13,7 +13,6 @@ stress_cmd: "scylla-bench -workload=sequential -mode=write -max-rate=300 -replic
 
 n_db_nodes: 3
 n_loaders: 8
-n_monitor_nodes: 1
 
 instance_type_db: 'i3.4xlarge'
 instance_type_loader: 'c4.2xlarge'

--- a/test-cases/performance/perf-search-best-throughput-config.yaml
+++ b/test-cases/performance/perf-search-best-throughput-config.yaml
@@ -7,7 +7,6 @@ stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=30m -schema '
 
 n_db_nodes: 3
 n_loaders: 2
-n_monitor_nodes: 1
 
 num_loaders_step: 0
 stress_threads_start_num: 50

--- a/test-cases/performance/ycsb/perf-base.yaml
+++ b/test-cases/performance/ycsb/perf-base.yaml
@@ -46,7 +46,6 @@ stress_cmd: >-2
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
 instance_type_loader: 'c5.9xlarge'

--- a/test-cases/scale/longevity-5000-tables.yaml
+++ b/test-cases/scale/longevity-5000-tables.yaml
@@ -11,7 +11,6 @@ add_cs_user_profiles_extra_tables: true
 batch_size: 100
 
 n_loaders: 3
-n_monitor_nodes: 1
 n_db_nodes: 1
 add_node_cnt: 5
 

--- a/test-cases/scale/longevity-many-clients-4h.yaml
+++ b/test-cases/scale/longevity-many-clients-4h.yaml
@@ -8,7 +8,6 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=240m -schema 'replicatio
 
 n_db_nodes: 6
 n_loaders: 50
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.metal'
 instance_type_loader: 'c7i.large'

--- a/test-cases/scale/longevity-scale-5dcs-cluster-xl.yaml
+++ b/test-cases/scale/longevity-scale-5dcs-cluster-xl.yaml
@@ -12,7 +12,6 @@ cluster_target_size: '25 25 25 25 25'
 add_node_cnt: 10
 n_loaders: '1 1 1 1 1'
 region_aware_loader: true
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.xlarge'
 

--- a/test-cases/scale/scale-cluster.yaml
+++ b/test-cases/scale/scale-cluster.yaml
@@ -18,7 +18,6 @@ n_db_nodes: 15
 add_node_cnt: 1
 cluster_target_size: 25
 n_loaders: 4
-n_monitor_nodes: 1
 
 # AWS
 instance_type_db: 'i4i.large'

--- a/test-cases/scylla-operator/kubernetes-operator-upgrade.yaml
+++ b/test-cases/scylla-operator/kubernetes-operator-upgrade.yaml
@@ -8,7 +8,6 @@ n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
 
 n_loaders: 1
-n_monitor_nodes: 1
 
 k8s_scylla_operator_helm_repo: 'https://storage.googleapis.com/scylla-operator-charts/stable'
 k8s_scylla_operator_chart_version: 'latest'  # will pick up the latest stable version, i.e. 'v1.3.0'

--- a/test-cases/scylla-operator/kubernetes-platform-upgrade.yaml
+++ b/test-cases/scylla-operator/kubernetes-platform-upgrade.yaml
@@ -25,7 +25,6 @@ n_loaders: 4
 k8s_n_loader_pods_per_cluster: 4
 k8s_loader_run_type: 'dynamic'
 
-n_monitor_nodes: 1
 
 k8s_enable_performance_tuning: true
 k8s_scylla_operator_helm_repo: 'https://storage.googleapis.com/scylla-operator-charts/latest'

--- a/test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml
+++ b/test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml
@@ -8,7 +8,6 @@ n_db_nodes: 3
 k8s_n_scylla_pods_per_cluster: 3
 
 n_loaders: 1
-n_monitor_nodes: 1
 
 use_mgmt: false
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-12h-multitenant-14-clients.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-12h-multitenant-14-clients.yaml
@@ -24,7 +24,6 @@ k8s_n_scylla_pods_per_cluster: 3
 instance_type_db: 'i4i.4xlarge'
 
 # NOTE: 1 (one) monitoring node per tenant
-n_monitor_nodes: 1
 
 n_loaders: 14
 k8s_n_loader_pods_per_cluster: 1

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-add-remove-rack.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-add-remove-rack.yaml
@@ -5,7 +5,6 @@ n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
 
 n_loaders: 2
-n_monitor_nodes: 1
 
 nemesis_class_name: 'AddRemoveRackNemesis'
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-backup.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-backup.yaml
@@ -5,7 +5,6 @@ n_db_nodes: 3
 k8s_n_scylla_pods_per_cluster: 3
 
 n_loaders: 2
-n_monitor_nodes: 1
 
 k8s_minio_storage_size: 300Gi
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-cluster-rolling.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-cluster-rolling.yaml
@@ -5,7 +5,6 @@ n_db_nodes: 3
 k8s_n_scylla_pods_per_cluster: 3
 
 n_loaders: 2
-n_monitor_nodes: 1
 
 nemesis_class_name: 'ClusterRollingRestart'
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-grow-shrink.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-grow-shrink.yaml
@@ -5,7 +5,6 @@ n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
 
 n_loaders: 2
-n_monitor_nodes: 1
 
 nemesis_class_name: 'GrowShrinkClusterNemesis'
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-mgmt-restore.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-mgmt-restore.yaml
@@ -6,7 +6,6 @@ n_db_nodes: 3
 k8s_n_scylla_pods_per_cluster: 3
 
 n_loaders: 2
-n_monitor_nodes: 1
 
 nemesis_class_name: 'MgmtRestore'
 nemesis_during_prepare: false

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-multitenant.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-multitenant.yaml
@@ -20,7 +20,6 @@ k8s_n_scylla_pods_per_cluster: 3
 # NOTE: K8S Scylla nodes have 3.5Tb disk size
 k8s_scylla_disk_gi: 1745
 
-n_monitor_nodes: 1
 
 # NOTE: we deploy here 4 K8S nodes of the 'loader' type and going to create 2 pairs of loader pods.
 n_loaders: 4

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-nodetool-flush-and-reshard.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-nodetool-flush-and-reshard.yaml
@@ -13,7 +13,6 @@ n_db_nodes: 3
 k8s_n_scylla_pods_per_cluster: 3
 
 n_loaders: 2
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
 gce_instance_type_db: 'n2-highmem-16'

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-repair.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-repair.yaml
@@ -5,7 +5,6 @@ n_db_nodes: 3
 k8s_n_scylla_pods_per_cluster: 3
 
 n_loaders: 2
-n_monitor_nodes: 1
 
 nemesis_class_name: 'MgmtRepair'
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-replace.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-replace.yaml
@@ -5,7 +5,6 @@ n_db_nodes: 3
 k8s_n_scylla_pods_per_cluster: 3
 
 n_loaders: 2
-n_monitor_nodes: 1
 
 nemesis_class_name: 'OperatorNodeReplace'
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-stop-start.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-stop-start.yaml
@@ -5,7 +5,6 @@ n_db_nodes: 3
 k8s_n_scylla_pods_per_cluster: 3
 
 n_loaders: 2
-n_monitor_nodes: 1
 
 nemesis_class_name: 'StopStartMonkey'
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-terminate-decommission-add.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-terminate-decommission-add.yaml
@@ -5,7 +5,6 @@ n_db_nodes: 3
 k8s_n_scylla_pods_per_cluster: 3
 
 n_loaders: 2
-n_monitor_nodes: 1
 
 nemesis_class_name: 'DisruptKubernetesNodeThenDecommissionAndAddScyllaNode'
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-terminate-replace.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-terminate-replace.yaml
@@ -5,7 +5,6 @@ n_db_nodes: 3
 k8s_n_scylla_pods_per_cluster: 3
 
 n_loaders: 2
-n_monitor_nodes: 1
 
 nemesis_class_name: 'DisruptKubernetesNodeThenReplaceScyllaNode'
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h.yaml
@@ -5,7 +5,6 @@ n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
 
 n_loaders: 2
-n_monitor_nodes: 1
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_selector: 'kubernetes'

--- a/test-cases/scylla-operator/longevity-scylla-operator-alternator-http-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-alternator-http-3h.yaml
@@ -40,7 +40,6 @@ round_robin: true
 instance_type_db: 'i4i.4xlarge'
 n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
-n_monitor_nodes: 1
 n_loaders: 2
 # NOTE: only 'dynamic' loader run type works for YCSB while
 # https://github.com/scylladb/scylla-cluster-tests/issues/7279 is not fixed

--- a/test-cases/scylla-operator/longevity-scylla-operator-alternator-https-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-alternator-https-3h.yaml
@@ -40,7 +40,6 @@ round_robin: true
 instance_type_db: 'i4i.4xlarge'
 n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
-n_monitor_nodes: 1
 n_loaders: 2
 # NOTE: only 'dynamic' loader run type works for YCSB while
 # https://github.com/scylladb/scylla-cluster-tests/issues/7279 is not fixed

--- a/test-cases/scylla-operator/longevity-scylla-operator-basic-12h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-basic-12h.yaml
@@ -14,7 +14,6 @@ n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
 
 n_loaders: 2
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
 gce_instance_type_db: 'n2-highmem-16'

--- a/test-cases/scylla-operator/longevity-scylla-operator-many-clients-4h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-many-clients-4h.yaml
@@ -9,7 +9,6 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=240m -schema 'replicatio
 n_db_nodes: 5
 k8s_n_scylla_pods_per_cluster: 4
 n_loaders: 50
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.metal'
 instance_type_loader: 'c6i.large'

--- a/test-cases/scylla-operator/longevity-scylla-operator-multidc-12h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-multidc-12h.yaml
@@ -12,7 +12,6 @@ round_robin: true
 
 n_db_nodes: 4
 n_loaders: 1
-n_monitor_nodes: 1
 k8s_n_scylla_pods_per_cluster: 3
 
 nemesis_class_name: 'SisyphusMonkey'

--- a/test-cases/scylla-operator/longevity-scylla-operator-multidc-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-multidc-3h.yaml
@@ -12,7 +12,6 @@ round_robin: true
 
 n_db_nodes: 4
 n_loaders: 1
-n_monitor_nodes: 1
 k8s_n_scylla_pods_per_cluster: 3
 
 nemesis_class_name: 'SisyphusMonkey'

--- a/test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml
+++ b/test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml
@@ -11,7 +11,6 @@ prepare_cs_user_profiles:
 
 n_db_nodes: 6
 n_loaders: 2
-n_monitor_nodes: 1
 
 gce_instance_type_db: 'n2-highmem-4'
 gce_instance_type_loader: 'n2-highmem-4'

--- a/test-cases/upgrades/generic-rolling-upgrade.yaml
+++ b/test-cases/upgrades/generic-rolling-upgrade.yaml
@@ -6,7 +6,6 @@ test_duration: 360
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 num_nodes_to_rollback: 2   # max is n_db_nodes -1, after upgrading 4 nodes last node can't be rollback
 

--- a/test-cases/upgrades/manager-upgrade.yaml
+++ b/test-cases/upgrades/manager-upgrade.yaml
@@ -9,7 +9,6 @@ instance_type_loader: 'c6i.large'
 region_name: 'us-east-1'
 n_db_nodes: '3'
 n_loaders: 1
-n_monitor_nodes: 1
 
 client_encrypt: true
 

--- a/test-cases/upgrades/multi-dc-rolling-upgrade.yaml
+++ b/test-cases/upgrades/multi-dc-rolling-upgrade.yaml
@@ -8,7 +8,6 @@ instance_type_db: 'i4i.2xlarge'
 rack_aware_loader: true
 n_db_nodes: '3 3'
 n_loaders: '1 1'
-n_monitor_nodes: 1
 region_aware_loader: true
 num_nodes_to_rollback: 2   # max is n_db_nodes -1, after upgrading 4 nodes last node can't be rollback
 

--- a/test-cases/upgrades/rolling-upgrade-latency-regression.yaml
+++ b/test-cases/upgrades/rolling-upgrade-latency-regression.yaml
@@ -2,7 +2,6 @@ test_duration: 360
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 prepare_write_cmd:
   # NOTE: --duration in these commands is number of rows that will be written.

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -16,7 +16,6 @@ stress_after_cluster_upgrade: scylla-bench -workload=sequential -mode=read -repl
 
 n_db_nodes: 6
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
 instance_type_loader: 'c7i.2xlarge'

--- a/unit_tests/test_data/scylla_yaml_update.yaml
+++ b/unit_tests/test_data/scylla_yaml_update.yaml
@@ -2,7 +2,6 @@ test_duration: 60
 
 n_db_nodes: 3
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.large'
 

--- a/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.yaml
@@ -18,7 +18,6 @@ n_loaders: 1
 instance_type_db: 'i4i.large'
 # testing the force iotune feature
 force_run_iotune: true
-n_monitor_nodes: 1
 n_db_nodes: 3
 
 nemesis_class_name: SisyphusMonkey

--- a/unit_tests/test_data/test_scylla_yaml_builders/jepsen.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/jepsen.yaml
@@ -10,7 +10,6 @@ root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 n_db_nodes: 5
 n_loaders: 1
-n_monitor_nodes: 1
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'debian-buster'
 user_prefix: 'jepsen'

--- a/unit_tests/test_data/test_scylla_yaml_builders/longevity-10gb-3h.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/longevity-10gb-3h.yaml
@@ -4,7 +4,6 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replicatio
 
 n_db_nodes: 6
 n_loaders: 2
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
 gce_instance_type_db: 'n2-highmem-16'

--- a/unit_tests/test_data/test_scylla_yaml_builders/manager-backup-1TB-gce.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/manager-backup-1TB-gce.yaml
@@ -17,7 +17,6 @@ prepare_wait_no_compactions_timeout: 120
 
 n_db_nodes: 4
 n_loaders: 2
-n_monitor_nodes: 1
 
 gce_instance_type_db: 'n2-highmem-16'
 gce_n_local_ssd_disk_db: 8

--- a/unit_tests/test_data/test_scylla_yaml_builders/multi_network_interfaces/cdc-replication-longevity.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/multi_network_interfaces/cdc-replication-longevity.yaml
@@ -12,7 +12,6 @@ instance_type_db_oracle: 'i3.large'
 n_loaders: 1
 instance_type_loader: 'c6i.large'
 
-n_monitor_nodes: 1
 
 nemesis_class_name: 'CategoricalMonkey'
 

--- a/unit_tests/test_data/test_scylla_yaml_builders/multi_network_interfaces/longevity-10gb-3h.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/multi_network_interfaces/longevity-10gb-3h.yaml
@@ -4,7 +4,6 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replicatio
 
 n_db_nodes: 6
 n_loaders: 2
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.4xlarge'
 gce_instance_type_db: 'n2-highmem-16'

--- a/unit_tests/test_data/test_scylla_yaml_builders/perf-regression.100threads.30M-keys.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/perf-regression.100threads.30M-keys.yaml
@@ -7,7 +7,6 @@ stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=50m -schema '
 
 n_db_nodes: 3
 n_loaders: 4
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
 instance_type_loader: 'c4.2xlarge'

--- a/unit_tests/test_data/test_scylla_yaml_builders/rolling-upgrade.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/rolling-upgrade.yaml
@@ -18,7 +18,6 @@ stress_after_cluster_upgrade: scylla-bench -workload=sequential -mode=read -repl
 
 n_db_nodes: 4
 n_loaders: 1
-n_monitor_nodes: 1
 
 instance_type_db: 'i4i.2xlarge'
 


### PR DESCRIPTION
Usually we want monitor node to be present in all tests (except artifact ones).

Made `n_monitor_nodes: 1` as default and removed from configs where it was set to this.

follow up from: https://github.com/scylladb/scylla-cluster-tests/pull/11078
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - I verified if artifact tests have it set to 0 and checked all files that set `n_db_nodes: and not n_monitor_nodes:` to find if we didn't expect it in some test.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
