### PR TITLE
fix(rack_mapping): remove self from staticmethod

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3436,7 +3436,7 @@ class BaseCluster:
         return rack_names_mapping
 
     @staticmethod
-    def get_rack_names_per_datacenter_from_rack_mapping(self, rack_mapping) -> dict[str, list[str]]:
+    def get_rack_names_per_datacenter_from_rack_mapping(rack_mapping) -> dict[str, list[str]]:
         by_region_rack_names = defaultdict(list)
         for (region, _), v in rack_mapping.items():
             by_region_rack_names.setdefault(region, []).append(v)


### PR DESCRIPTION
We didn't notice error in staticmethod `self` arg.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11098

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
