### PR TITLE
improvement(add_drop_column): fetch tables data more efficiently

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2076,8 +2076,7 @@ class Nemesis:
                     to_be_skipped = []
                 else:
                     to_be_skipped = to_be_skipped.split(',') + to_be_skipped_default
-                tables = get_db_tables(session=session,
-                                       keyspace_name=ks,
+                tables = get_db_tables(keyspace_name=ks,
                                        node=self.target_node,
                                        with_compact_storage=False)
                 if to_be_skipped:

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -99,6 +99,8 @@ DEFAULT_AWS_REGION = "eu-west-1"
 DOCKER_CGROUP_RE = re.compile("/docker/([0-9a-f]+)")
 SCYLLA_AMI_OWNER_ID_LIST = ["797456418907", "158855661827"]
 SCYLLA_GCE_IMAGES_PROJECT = "scylla-images"
+CREATE_TABLE_REGEX = re.compile(
+    r'CREATE\s+TABLE\s+(?P<keyspace>[^\s.]+)\.(?P<table>[^\s(]+)\s*\([^)]+\)(?P<options>[^;]*)')
 
 
 class KeyBasedLock():
@@ -1599,28 +1601,29 @@ def get_ami_tags(ami_id, region_name):
             return {}
 
 
-def get_db_tables(session, keyspace_name, node, with_compact_storage=True):
+def get_db_tables(keyspace_name, node, with_compact_storage=None):
     """
-    Return tables from keystore based on their compact storage feature
+    Return tables from keyspace based on their compact storage feature.
     Arguments:
-        session -- DB session
-        ks -- Keypsace name
-        with_compact_storage -- If True, return non compact tables, if False, return compact tables
-
+        keyspace_name -- Keyspace name
+        node -- Node to run CQLSH commands
+        with_compact_storage -- If True, return tables with compact storage; if False, return tables without compact storage; if None, return all tables
     """
     output = []
-    for row in list(session.execute(f"select table_name from system_schema.tables where keyspace_name='{keyspace_name}'")):
-        try:
-            create_table_statement = node.run_cqlsh(f"describe {keyspace_name}.{row.table_name}").stdout.upper()
-        except (UnexpectedExit, Libssh2_UnexpectedExit) as err:
-            # SCT issue https://github.com/scylladb/scylla-cluster-tests/issues/7240
-            # May happen when disrupt_add_remove_dc nemesis run in parallel to the disrupt_add_drop_column
-            LOGGER.error("Failed to describe '%s.%s' table. Maybe the table has been deleted. Error: %s",
-                         keyspace_name, row.table_name, err.result.stderr)
+    try:
+        schema_output = node.run_cqlsh("DESC SCHEMA WITH INTERNALS").stdout
+    except (UnexpectedExit, Libssh2_UnexpectedExit) as err:
+        LOGGER.error("Failed to describe schema: %s", err.result.stderr)
+        return output
+
+    for match in CREATE_TABLE_REGEX.findall(schema_output):
+        element_keyspace, table_name, options = match
+        if element_keyspace != keyspace_name:
             continue
 
-        if with_compact_storage is None or (("WITH COMPACT STORAGE" in create_table_statement) == with_compact_storage):
-            output.append(row.table_name)
+        has_compact_storage = "COMPACT STORAGE" in options
+        if with_compact_storage is None or has_compact_storage == with_compact_storage:
+            output.append(table_name)
 
     return output
 

--- a/unit_tests/test_common_get_db_tables.py
+++ b/unit_tests/test_common_get_db_tables.py
@@ -1,0 +1,119 @@
+"""
+Tests for get_db_tables function in sdcm.utils.common
+"""
+import os
+import pytest
+from unittest.mock import MagicMock
+
+from sdcm.utils.common import get_db_tables
+
+
+@pytest.fixture
+def schema_content():
+    """Fixture to load test schema content from file."""
+    test_schema_path = os.path.join(
+        os.path.dirname(__file__),
+        'test_data',
+        'schema_with_internals.log'
+    )
+    with open(test_schema_path, 'r', encoding='utf-8') as file:
+        return file.read()
+
+
+@pytest.fixture
+def mock_node(schema_content):
+    """Fixture for a mock node with run_cqlsh method."""
+    mock_node = MagicMock()
+    mock_node.run_cqlsh.return_value.stdout = schema_content
+    return mock_node
+
+
+def test_get_db_tables_keyspace1_compact_storage(mock_node):
+    """Test get_db_tables returns no tables for keyspace1 with compact storage."""
+    tables = get_db_tables(
+        keyspace_name="keyspace1",
+        node=mock_node,
+        with_compact_storage=True
+    )
+
+    assert tables == [], f"Expected no tables with compact storage, got {tables}"
+    assert all("_view" not in table for table in tables), f"Found materialized views in {tables}"
+
+
+def test_get_db_tables_with_compact_storage_filter_returns_empty_list(mock_node):
+    """Test get_db_tables returns no tables when filtering for compact storage in a keyspace without them."""
+    tables = get_db_tables(
+        keyspace_name="keyspace1",
+        node=mock_node,
+        with_compact_storage=True
+    )
+
+    assert tables == [], f"Expected no tables with compact storage, got {tables}"
+    assert all("_view" not in table for table in tables), f"Found materialized views in {tables}"
+
+
+def test_get_db_tables_with_non_compact_storage_filter(mock_node):
+    """Test get_db_tables returns only non-compact storage tables."""
+    tables = get_db_tables(
+        keyspace_name="keyspace1",
+        node=mock_node,
+        with_compact_storage=False
+    )
+
+    expected_tables = {"standard1"}
+    assert set(tables) == expected_tables, f"Expected tables {expected_tables}, got {tables}"
+    assert all("_view" not in table for table in tables), f"Found materialized views in {tables}"
+
+
+def test_get_db_tables_without_storage_filter(mock_node):
+    """Test get_db_tables returns all tables when no storage filter is applied."""
+    tables = get_db_tables(
+        keyspace_name="keyspace1",
+        node=mock_node,
+        with_compact_storage=None
+    )
+
+    expected_tables = {"standard1"}
+    assert set(tables) == expected_tables, f"Expected tables {expected_tables}, got {tables}"
+    assert all("_view" not in table for table in tables), f"Found materialized views in {tables}"
+
+
+def test_get_db_tables_returns_correct_tables_for_keyspace(mock_node):
+    """Test get_db_tables returns only tables from the specified keyspace."""
+    tables = get_db_tables(
+        keyspace_name="feeds",
+        node=mock_node,
+        with_compact_storage=None
+    )
+
+    expected_tables = {"table0", "table1"}
+    assert set(tables) == expected_tables, f"Expected tables {expected_tables}, got {tables}"
+    assert all("_view" not in table for table in tables), f"Found materialized views in {tables}"
+    assert "standard1" not in tables, "Found table from wrong keyspace"
+    assert "standard1_view" not in tables, "Found materialized view"
+
+
+def test_get_db_tables_filters_for_compact_storage_tables(mock_node):
+    """Test get_db_tables correctly filters for compact storage tables."""
+    tables = get_db_tables(
+        keyspace_name="feeds",
+        node=mock_node,
+        with_compact_storage=True
+    )
+
+    expected_tables = {"table0"}
+    assert set(tables) == expected_tables, f"Expected tables {expected_tables}, got {tables}"
+    assert all("_view" not in table for table in tables), f"Found materialized views in {tables}"
+
+
+def test_get_db_tables_filters_for_non_compact_storage_tables(mock_node):
+    """Test get_db_tables correctly filters for non-compact storage tables."""
+    tables = get_db_tables(
+        keyspace_name="feeds",
+        node=mock_node,
+        with_compact_storage=False
+    )
+
+    expected_tables = {"table1"}
+    assert set(tables) == expected_tables, f"Expected tables {expected_tables}, got {tables}"
+    assert all("_view" not in table for table in tables), f"Found materialized views in {tables}"

--- a/unit_tests/test_data/schema_with_internals.log
+++ b/unit_tests/test_data/schema_with_internals.log
@@ -1,0 +1,113 @@
+CREATE KEYSPACE keyspace1 WITH replication = {'class': 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'us-east-1': '3'} AND durable_writes = true AND tablets = {'enabled': true};
+
+CREATE TABLE keyspace1.standard1 (
+    key blob,
+    "C0" blob,
+    "C1" blob,
+    "C2" blob,
+    "C3" blob,
+    "C4" blob,
+    "C5" blob,
+    "C6" blob,
+    "C7" blob,
+    "C8" blob,
+    "C9" blob,
+    crshbcrwpo map<frozen<map<frozen<list<int>>, tinyint>>, frozen<map<frozen<set<frozen<list<varint>>>>, blob>>>,
+    h20v4vxfhe set<frozen<set<text>>>,
+    jmxgjsft7g map<frozen<map<frozen<set<blob>>, frozen<list<uuid>>>>, frozen<list<frozen<set<bigint>>>>>,
+    zh96jan37t set<boolean>,
+    PRIMARY KEY (key)
+) WITH ID = 723c22e0-419d-11f0-ba8a-6204816e4cf0
+AND bloom_filter_fp_chance = 0.01
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
+    AND comment = 'test cf'
+    AND compaction = {'class': 'SizeTieredCompactionStrategy'}
+    AND compression = {}
+    AND crc_check_chance = 1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND speculative_retry = '99.0PERCENTILE'
+    AND scylla_encryption_options = {'cipher_algorithm': 'AES/ECB/PKCS5Padding', 'key_provider': 'KmsKeyProviderFactory', 'kms_host': 'auto', 'secret_key_strength': '128'}
+    AND tombstone_gc = {'mode': 'repair', 'propagation_delay_in_seconds': '3600'};
+
+ALTER TABLE keyspace1.standard1 DROP mq6dryh9j0 USING TIMESTAMP 1749081338155440;
+ALTER TABLE keyspace1.standard1 DROP mu414787s2 USING TIMESTAMP 1749081245060757;
+
+CREATE MATERIALIZED VIEW keyspace1.standard1_view AS
+    SELECT "C2", key
+    FROM keyspace1.standard1
+    WHERE "C2" IS NOT null AND key IS NOT null
+    PRIMARY KEY ("C2", key)
+
+AND ID = 64ab7bc0-41a3-11f0-b456-7dcf9010e066
+    AND CLUSTERING ORDER BY (key ASC)
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
+    AND comment = 'test MV'
+    AND compaction = {'class': 'IncrementalCompactionStrategy'}
+    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND crc_check_chance = 1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND speculative_retry = '99.0PERCENTILE'
+    AND tombstone_gc = {'mode': 'repair', 'propagation_delay_in_seconds': '3600'};
+
+
+CREATE ROLE IF NOT EXISTS cassandra WITH LOGIN = true AND SUPERUSER = true;
+
+
+CREATE TABLE feeds.table0 (
+    field1 text,
+    field2 text,
+    field3 date,
+    field4 text,
+    PRIMARY KEY (field1)
+) WITH COMPACT STORAGE
+AND ID = 7c9d02f0-414c-11f0-8642-d7326fe5998c
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
+    AND comment = ''
+    AND compaction = {'class': 'SizeTieredCompactionStrategy'}
+    AND compression = {}
+    AND crc_check_chance = 1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND speculative_retry = '99.0PERCENTILE'
+    AND tombstone_gc = {'mode': 'repair', 'propagation_delay_in_seconds': '3600'};
+
+
+CREATE INDEX table0_field4_table0 ON feeds.table0(field4);
+
+
+CREATE TABLE feeds.table1 (
+    field1 text,
+    field2 text,
+    field3 date,
+    field4 text,
+    PRIMARY KEY (field1)
+) WITH ID = 7e7ff3c0-414c-11f0-bf3a-2543c411037a
+AND bloom_filter_fp_chance = 0.01
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
+    AND comment = ''
+    AND compaction = {'class': 'SizeTieredCompactionStrategy'}
+    AND compression = {}
+    AND crc_check_chance = 1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND speculative_retry = '99.0PERCENTILE'
+    AND tombstone_gc = {'mode': 'repair', 'propagation_delay_in_seconds': '3600'};
+
+
+CREATE INDEX table1_field4_table1 ON feeds.table1(field4);


### PR DESCRIPTION
When there's a test with many tables (e.g. 5k tables test), add drop column nemesis stuck because fetching table info is done one by one.

Improvement by querying tables info with `DESC SCHEMA WITH INTERNALS` statement, which responds with all keyspaces and tables.

closes: https://github.com/scylladb/scylla-cluster-tests/issues/11062

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] - https://argus.scylladb.com/tests/scylla-cluster-tests/17fa3d33-c611-4a30-a1c6-86607c335659 - AddDropColumn nemesis passed step of getting tables in ~6 seconds

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
