### PR TITLE
fix(node_rack): stop assuming node existing

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -353,7 +353,7 @@ class BaseNode(AutoSshContainerMixin):
             if self.parent_cluster.node_type == "scylla-db":
                 if self._is_node_ready_run_scylla_commands():
                     rack_names = self.parent_cluster.get_rack_names_per_datacenter_and_rack_idx(db_nodes=[self])
-                    self._node_rack = list(rack_names.values())[0]
+                    self._node_rack = next(iter(rack_names.values()), None)
             else:
                 if not (rack_names := self.test_config.tester_obj().rack_names_per_datacenter_and_rack_idx_map):
                     return self._node_rack


### PR DESCRIPTION
there logic in this function to check first if nodes are operational but it doesn't cover the case of node not yet exists

this commit is using `next(iter(...), None)` to be able to gracefully handle situation we get back empty dict of rack information

Fixes: #11116

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
