### PR TITLE
fix(wait_for_machine_image_configured): shouldn't ignore exceptions

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3037,7 +3037,7 @@ class BaseNode(AutoSshContainerMixin):
 
     def wait_for_machine_image_configured(self):
         self.log.info("Waiting for Scylla Machine Image setup to finish...")
-        wait.wait_for(self.is_machine_image_configured, step=10, timeout=300, throw_exc=False)
+        wait.wait_for(self.is_machine_image_configured, step=10, timeout=600, throw_exc=True)
 
     def get_sysctl_properties(self) -> Dict[str, str]:
         sysctl_properties = {}


### PR DESCRIPTION
seems like this function is retrying for 5min, and then silently giving up the change is doubling the timeout, and making it raise exception when it's timing out

this was causing clusters to start in split-brain, since configuration of seed wasn't updated by the test, and was using the out-of-the-box configuration from SMI that points to itself.

Fixes: #11122

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
