### PR TITLE
feature(nemesis): introduce nemesis node allocator

### DIFF
--- a/sdcm/cluster_azure.py
+++ b/sdcm/cluster_azure.py
@@ -22,6 +22,7 @@ from sdcm.sct_events.system import SpotTerminationEvent
 from sdcm.sct_provision import region_definition_builder
 from sdcm.sct_provision.instances_provider import provision_instances_with_fallback
 from sdcm.utils.decorators import retrying
+from sdcm.utils.nemesis_utils.node_allocator import mark_new_nodes_as_running_nemesis
 from sdcm.utils.net import resolve_ip_to_dns
 
 LOGGER = logging.getLogger(__name__)
@@ -212,6 +213,7 @@ class AzureCluster(cluster.BaseCluster):
                          node_type=node_type)
         self.log.debug("AzureCluster constructor")
 
+    @mark_new_nodes_as_running_nemesis
     def add_nodes(self, count, ec2_user_data='', dc_idx=0, rack=0, enable_auto_bootstrap=False, instance_type=None):
         self.log.info("Adding nodes to cluster")
         nodes = []

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -23,6 +23,7 @@ from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.filters import DbEventsFilter
 from sdcm.utils.docker_utils import get_docker_bridge_gateway, Container, ContainerManager, DockerException
 from sdcm.utils.health_checker import check_nodes_status
+from sdcm.utils.nemesis_utils.node_allocator import mark_new_nodes_as_running_nemesis
 from sdcm.utils.net import get_my_public_ip
 
 DEFAULT_SCYLLA_DB_IMAGE = "scylladb/scylla-nightly"
@@ -290,6 +291,7 @@ class DockerCluster(cluster.BaseCluster):
             self.nodes.append(node)
         return self.nodes
 
+    @mark_new_nodes_as_running_nemesis
     def add_nodes(self, count, ec2_user_data="", dc_idx=0, rack=0, enable_auto_bootstrap=False, instance_type=None):
         assert instance_type is None, "docker can't provision different instance types"
         return self._get_nodes() if self.test_config.REUSE_CLUSTER else self._create_nodes(count, enable_auto_bootstrap)

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -45,6 +45,7 @@ from sdcm.keystore import pub_key_from_private_key_file
 from sdcm.sct_events.system import SpotTerminationEvent
 from sdcm.utils.common import list_instances_gce, gce_meta_to_dict
 from sdcm.utils.decorators import retrying
+from sdcm.utils.nemesis_utils.node_allocator import mark_new_nodes_as_running_nemesis
 from sdcm.utils.net import resolve_ip_to_dns
 
 
@@ -523,6 +524,7 @@ class GCECluster(cluster.BaseCluster):
         except Exception as ex:  # noqa: BLE001
             raise CreateGCENodeError('Failed to create node: %s' % ex) from ex
 
+    @mark_new_nodes_as_running_nemesis
     def add_nodes(self, count, ec2_user_data='', dc_idx=0, rack=0, enable_auto_bootstrap=False, instance_type=None):
         if count <= 0:
             return []

--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -48,6 +48,7 @@ from sdcm.utils.aws_utils import (
     tags_as_ec2_tags,
     EksClusterCleanupMixin,
 )
+from sdcm.utils.nemesis_utils.node_allocator import mark_new_nodes_as_running_nemesis
 
 
 P = ParamSpec("P")
@@ -787,6 +788,7 @@ class EksScyllaPodCluster(ScyllaPodCluster):
     PodContainerClass = EksScyllaPodContainer
     nodes: List[EksScyllaPodContainer]
 
+    @mark_new_nodes_as_running_nemesis
     def add_nodes(self,
                   count: int,
                   ec2_user_data: str = "",

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -35,6 +35,7 @@ from sdcm.utils.gce_utils import (
     gce_private_addresses,
 )
 from sdcm.utils.ci_tools import get_test_name
+from sdcm.utils.nemesis_utils.node_allocator import mark_new_nodes_as_running_nemesis
 from sdcm.cluster_k8s import KubernetesCluster, ScyllaPodCluster, BaseScyllaPodContainer, CloudK8sNodePool
 from sdcm.cluster_gce import MonitorSetGCE
 from sdcm.keystore import KeyStore
@@ -588,6 +589,7 @@ class GkeScyllaPodCluster(ScyllaPodCluster):
     node_pool: 'GkeNodePool'
     PodContainerClass = GkeScyllaPodContainer
 
+    @mark_new_nodes_as_running_nemesis
     def add_nodes(self,
                   count: int,
                   ec2_user_data: str = "",

--- a/sdcm/utils/nemesis_utils/__init__.py
+++ b/sdcm/utils/nemesis_utils/__init__.py
@@ -1,0 +1,13 @@
+import enum
+
+
+class NEMESIS_TARGET_POOLS(enum.Enum):
+    data_nodes = "data_nodes"
+    zero_nodes = "zero_nodes"
+    all_nodes = "nodes"
+
+
+class DefaultValue:
+    """
+    This is class is intended to be used as default value for the cases when None is not applicable
+    """

--- a/sdcm/utils/nemesis_utils/node_allocator.py
+++ b/sdcm/utils/nemesis_utils/node_allocator.py
@@ -1,0 +1,266 @@
+import logging
+import random
+import threading
+from enum import Enum
+from contextlib import contextmanager
+from collections.abc import Iterable
+from functools import wraps
+from typing import TYPE_CHECKING, Union
+
+from sdcm.sct_events import Severity
+from sdcm.sct_events.system import TestFrameworkEvent
+from sdcm.utils.metaclasses import Singleton
+from sdcm.utils.nemesis_utils import NEMESIS_TARGET_POOLS, DefaultValue
+
+if TYPE_CHECKING:
+    from sdcm.cluster import BaseNode
+
+LOGGER = logging.getLogger(__name__)
+
+
+class NemesisNodeAllocationError(Exception):
+    """Base exception for allocation failures."""
+
+
+class AllNodesRunNemesisError(NemesisNodeAllocationError):
+    """Raised when all candidate nodes are already running nemeses."""
+
+
+class NoNodeMatchesCriteriaError(NemesisNodeAllocationError):
+    """Raised when no available nodes match the specified filters."""
+
+
+class NemesisNodeAllocator(metaclass=Singleton):
+    def __init__(self, tester_obj):
+        self.lock = threading.Lock()
+        self._tester = tester_obj
+        self.active_nemesis_on_nodes: dict['BaseNode', str] = {}
+
+    def _get_pool_type_nodes(self, pool_type: Enum) -> list['BaseNode']:
+        all_nodes = self._tester.all_db_nodes
+        match pool_type:
+            case NEMESIS_TARGET_POOLS.all_nodes:
+                return all_nodes
+            case NEMESIS_TARGET_POOLS.zero_nodes:
+                return [node for node in all_nodes if node._is_zero_token_node]
+            case NEMESIS_TARGET_POOLS.data_nodes:
+                return [node for node in all_nodes if not node._is_zero_token_node]
+            case _:
+                raise NemesisNodeAllocationError(f"Unsupported pool type: {pool_type}")
+
+    @staticmethod
+    def _filter_nodes(nodes_to_filter: list['BaseNode'],
+                      is_seed: bool | DefaultValue | None = DefaultValue,
+                      dc_idx: int | None = None,
+                      rack: int | None = None,
+                      filter_seed: bool = False) -> list['BaseNode']:
+        """
+        Filters nodes based on is_seed, dc_idx, rack criteria.
+
+        :param nodes_to_filter: list of nodes to filter.
+        :param is_seed: specifies whether to filter nodes based on their seed status.
+            - DefaultValue: no filtering based on seed status
+            - True: include only seed nodes
+            - False: exclude seed nodes
+        :param dc_idx: data center index to filter nodes by.
+        :param rack: rack index to filter nodes by.
+        :param filter_seed: if True, excludes seed nodes by default unless `is_seed` is explicitly set.
+        """
+        if is_seed is DefaultValue:
+            is_seed = False if filter_seed else None
+
+        filtered = list(nodes_to_filter)
+        if is_seed is not None:
+            filtered = [node for node in filtered if node.is_seed == is_seed]
+        if dc_idx is not None:
+            filtered = [node for node in filtered if node.dc_idx == dc_idx]
+        if rack is not None:
+            filtered = [node for node in filtered if node.rack == rack]
+        return filtered
+
+    def select_target_node(self,
+                           nemesis_name: str,
+                           pool_type: Enum,
+                           filter_seed: bool,
+                           is_seed: bool | DefaultValue | None = DefaultValue,
+                           dc_idx: int | None = None,
+                           rack: int | None = None,
+                           allow_only_last_node_in_rack: bool = False,
+                           node_list: list['BaseNode'] | None = None
+                           ) -> 'BaseNode':
+        """
+        Selects a not allocated node as a target for the nemesis.
+
+        Raises instance of NemesisNodeAllocationError if no nodes are available or match the criteria.
+        """
+        with self.lock:
+            nodes = self._get_pool_type_nodes(pool_type)
+            available_for_selection = [node for node in nodes if node not in self.active_nemesis_on_nodes]
+            if node_list:
+                available_for_selection = list(set(available_for_selection) & set(node_list))
+
+            if not available_for_selection:
+                reserved_nodes_map = {n.name: nem for n, nem in self.active_nemesis_on_nodes.items()}
+                reason = f"All nodes from pool '{pool_type.value}' are running nemeses:\n{reserved_nodes_map}"
+                raise AllNodesRunNemesisError(f"{nemesis_name}: node allocation failed.\n{reason}")
+
+            candidate_nodes = self._filter_nodes(
+                available_for_selection, is_seed=is_seed, dc_idx=dc_idx, rack=rack, filter_seed=filter_seed)
+
+            if not candidate_nodes:
+                dc_str = f'dc_idx={dc_idx}' if dc_idx is not None else ''
+                rack_str = f'rack={rack}' if rack is not None else ''
+                seed_str = f'is_seed={is_seed}' if is_seed is not DefaultValue else ''
+                filter_str = ", ".join([dc_str, rack_str, seed_str])
+                reason = (
+                    f"The following '{pool_type.value}' nodes are available for selection, but none of "
+                    f"them match the specified criteria ({filter_str}).\n"
+                    f"{[n.name for n in available_for_selection]}.")
+                raise NoNodeMatchesCriteriaError(f"{nemesis_name}: node allocation failed.\n{reason}")
+
+            selected_node: 'BaseNode'
+            if allow_only_last_node_in_rack and rack is not None:
+                selected_node = candidate_nodes[-1]
+            else:
+                selected_node = random.choice(candidate_nodes)
+
+            self.active_nemesis_on_nodes[selected_node] = nemesis_name
+            selected_node.running_nemesis = nemesis_name
+            LOGGER.info("%s: selected target node %s. Marked it as running nemesis.",
+                        nemesis_name, selected_node.name)
+            return selected_node
+
+    def set_running_nemesis(self, node: 'BaseNode', nemesis_name: str) -> bool:
+        """
+        Sets running nemesis for the node.
+
+        This is for the cases when e.g. a new node is added by a nemesis, which is running on another target node.
+        """
+        with self.lock:
+            if node in self.active_nemesis_on_nodes:
+                TestFrameworkEvent(
+                    source=self.__class__.__name__,
+                    message=f"{nemesis_name}: setting running nemesis failed.\nTried to set running nemesis for "
+                            f"node {node.name}, but it was already reserved by '{self.active_nemesis_on_nodes[node]}' nemesis.",
+                    severity=Severity.ERROR
+                ).publish()
+                return False
+
+            self.active_nemesis_on_nodes[node] = nemesis_name
+            node.running_nemesis = nemesis_name
+            LOGGER.info("%s: set running nemesis for node %s.", nemesis_name, node.name)
+            return True
+
+    def unset_running_nemesis(self, node: 'BaseNode', nemesis_name: str):
+        """Unsets running nemesis, making the node available for other nemeses."""
+        with self.lock:
+            if node in self.active_nemesis_on_nodes:
+                if self.active_nemesis_on_nodes[node] == nemesis_name:
+                    del self.active_nemesis_on_nodes[node]
+                    node.running_nemesis = None
+                    LOGGER.info("%s: unset running nemesis for node %s.", nemesis_name, node.name)
+                else:
+                    TestFrameworkEvent(
+                        source=self.__class__.__name__,
+                        message=f"{nemesis_name}: unsetting running nemesis failed.\nTried to unset '{nemesis_name}' "
+                                f"nemesis from node {node.name}, but it was running another "
+                                f"'{self.active_nemesis_on_nodes[node]}' nemesis.",
+                        severity=Severity.ERROR
+                    ).publish()
+            else:
+                TestFrameworkEvent(
+                    source=self.__class__.__name__,
+                    message=f"{nemesis_name}: unsetting running nemesis failed.\nTried to unset '{nemesis_name}' "
+                            f"nemesis from node {node.name}, but it was not running any nemesis.",
+                    severity=Severity.ERROR
+                ).publish()
+
+    def unset_running_nemesis_from_all_nodes(self, nemesis_name: str):
+        """
+        Unsets the specified nemesis from all nodes that run it.
+
+        The primary use case is when a nemesis creates new node(s), which are supposed to stay in the cluster
+        after the nemesis is finished. To avoid stale records in the allocator, and for the subsequent nemeses to
+        be able to use the new node(s), we need to release them after disruption is finished.
+        """
+        with self.lock:
+            nodes_to_release = [node for node, owner in self.active_nemesis_on_nodes.items() if owner == nemesis_name]
+            if nodes_to_release:
+                LOGGER.info("%s: unset running nemesis from nodes: %s",
+                            nemesis_name, [n.name for n in nodes_to_release])
+                for node in nodes_to_release:
+                    del self.active_nemesis_on_nodes[node]
+                    node.running_nemesis = None
+
+    def switch_target_node(self, old_node: 'BaseNode', new_node: 'BaseNode', nemesis_name: str) -> bool:
+        """
+        Switches the nemesis target from an old node to a new one.
+
+        Raises NemesisNodeAllocationError if the new node is already running another nemesis.
+        """
+        if old_node == new_node:
+            return True
+
+        with self.lock:
+            if new_node in self.active_nemesis_on_nodes:
+                reason = f"Requested node is already running nemesis '{self.active_nemesis_on_nodes[new_node]}'"
+                raise NemesisNodeAllocationError(f"{nemesis_name}: node switching failed.\n{reason}")
+            if old_node and old_node in self.active_nemesis_on_nodes:
+                if self.active_nemesis_on_nodes[old_node] == nemesis_name:
+                    del self.active_nemesis_on_nodes[old_node]
+                    old_node.running_nemesis = None
+                    LOGGER.info("%s: released old target node %s during switch.", nemesis_name, old_node.name)
+                else:
+                    TestFrameworkEvent(
+                        source=self.__class__.__name__,
+                        message=f"{nemesis_name}: switching target node failed.\nDuring switch, old node "
+                                f"{old_node.name} was running another '{self.active_nemesis_on_nodes[old_node]}' nemesis.",
+                        severity=Severity.ERROR
+                    ).publish()
+
+            self.active_nemesis_on_nodes[new_node] = nemesis_name
+            new_node.running_nemesis = nemesis_name
+            LOGGER.info("%s: switched target node to %s.", nemesis_name, new_node.name)
+            return True
+
+    @contextmanager
+    def nodes_running_nemesis(self, nodes: Union[Iterable['BaseNode'], 'BaseNode'], nemesis_name: str):
+        """Temporarily marks nodes as running the specified nemesis."""
+        if not isinstance(nodes, Iterable):
+            nodes = [nodes]
+        marked_nodes = []
+        try:
+            for node in nodes:
+                if not self.set_running_nemesis(node, nemesis_name):
+                    for marked_node in marked_nodes:
+                        self.unset_running_nemesis(marked_node, nemesis_name)
+                    marked_nodes.clear()
+                    raise NemesisNodeAllocationError(
+                        f"{nemesis_name}: failed to set running nemesis for all requested nodes; "
+                        f"{node.name} was already reserved.")
+                marked_nodes.append(node)
+            yield
+        finally:
+            for node in marked_nodes:
+                self.unset_running_nemesis(node, nemesis_name)
+
+
+def mark_new_nodes_as_running_nemesis(func):
+    """
+    Decorator for `add_nodes` API of a cluster object.
+
+    If `disruption_name` parameter is passed to the `add_nodes` method of a cluster, the newly added nodes are
+    immediately marked as running the disruption in question.
+    """
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        allocator = getattr(self.test_config.tester_obj(), 'nemesis_allocator', None)
+        disruption_name = kwargs.pop('disruption_name', None)
+
+        new_nodes = func(self, *args, **kwargs)
+        if new_nodes and allocator and disruption_name:
+            for node in new_nodes:
+                allocator.set_running_nemesis(node, disruption_name)
+        return new_nodes
+    return wrapper

--- a/unit_tests/nemesis/fake_cluster.py
+++ b/unit_tests/nemesis/fake_cluster.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass, field
 
 from sdcm.cluster import BaseScyllaCluster
+from sdcm.utils.nemesis_utils.node_allocator import NemesisNodeAllocator
 from unit_tests.dummy_remote import LocalLoaderSetDummy
 
 
@@ -49,9 +50,15 @@ class FakeTester:
     loaders: LocalLoaderSetDummy = field(default_factory=LocalLoaderSetDummy)
     db_cluster: Cluster | BaseScyllaCluster = field(default_factory=lambda: Cluster(nodes=[Node(), Node()]))
     monitors: list = field(default_factory=list)
+    nemesis_allocator: NemesisNodeAllocator = None
+
+    @property
+    def all_db_nodes(self):
+        return self.db_cluster.nodes if self.db_cluster else []
 
     def __post_init__(self):
         self.db_cluster.params = self.params
+        self.nemesis_allocator = NemesisNodeAllocator(self)
 
     def create_stats(self):
         pass

--- a/unit_tests/nemesis/test_node_allocator.py
+++ b/unit_tests/nemesis/test_node_allocator.py
@@ -1,0 +1,202 @@
+"""
+This module tests core responsibilities of NemesisNodeAllocator entity -
+nodes selection, release; state management and thread safety.
+"""
+
+import threading
+import time
+import pytest
+import random
+
+from sdcm.cluster import BaseNode
+from sdcm.utils.nemesis_utils import NEMESIS_TARGET_POOLS
+from sdcm.utils.nemesis_utils.node_allocator import NemesisNodeAllocator, NemesisNodeAllocationError, AllNodesRunNemesisError
+
+
+@pytest.fixture(autouse=True)
+def reset_node_allocator_singleton():
+    """Reset NemesisNodeAllocator singleton state before each test"""
+    if hasattr(NemesisNodeAllocator.__class__, '_instances'):
+        NemesisNodeAllocator.__class__._instances.clear()
+    yield
+
+
+class MockNode(BaseNode):
+    def __init__(self, name, node_type="data_nodes", is_seed=False, dc_idx=0, rack=0):
+        self.name = name
+        self.node_type = node_type
+        self.is_seed = is_seed
+        self.dc_idx = dc_idx
+        self.rack = rack
+        self._is_zero_token_node = (node_type == "zero_nodes")
+
+    def __repr__(self):
+        return f"MockNode({self.name})"
+
+
+class MockTester:
+    def __init__(self, nodes):
+        self._nodes = list(nodes)
+
+    @property
+    def all_db_nodes(self):
+        return self._nodes
+
+    def add_node(self, node):
+        self._nodes.append(node)
+
+    def remove_node(self, node):
+        if node in self._nodes:
+            self._nodes.remove(node)
+
+
+@pytest.fixture
+def allocator_with_nodes():
+    """Provides an allocator instance with a set of mock nodes."""
+    nodes = [
+        MockNode("node-1", dc_idx=0, rack=0, is_seed=True),
+        MockNode("node-2", dc_idx=0, rack=0),
+        MockNode("node-3", dc_idx=0, rack=1),
+        MockNode("z-node-1", node_type="zero_nodes", dc_idx=0, rack=0),
+    ]
+    tester = MockTester(nodes)
+    allocator = NemesisNodeAllocator(tester)
+    return allocator, tester, nodes
+
+
+def test_nodes_list(allocator_with_nodes):
+    allocator, tester, nodes = allocator_with_nodes
+    assert len(allocator._get_pool_type_nodes(NEMESIS_TARGET_POOLS.all_nodes)) == 4
+
+    tester.remove_node(nodes[0])
+    assert len(allocator._get_pool_type_nodes(NEMESIS_TARGET_POOLS.all_nodes)) == 3
+
+    tester.add_node(nodes[0])
+    assert len(allocator._get_pool_type_nodes(NEMESIS_TARGET_POOLS.all_nodes)) == 4
+
+
+def test_select_and_release_target_node(allocator_with_nodes):
+    allocator, _, _ = allocator_with_nodes
+
+    # select a node
+    selected_node = allocator.select_target_node(
+        nemesis_name="TestNemesis", pool_type=NEMESIS_TARGET_POOLS.data_nodes, filter_seed=False)
+    assert selected_node is not None
+    assert selected_node in allocator.active_nemesis_on_nodes
+    assert allocator.active_nemesis_on_nodes[selected_node] == "TestNemesis"
+
+    # select another node
+    second_node = allocator.select_target_node(
+        nemesis_name="SecondNemesis", pool_type=NEMESIS_TARGET_POOLS.data_nodes, filter_seed=False)
+    assert second_node is not None
+    assert second_node != selected_node
+
+    # release the first node
+    allocator.unset_running_nemesis(selected_node, "TestNemesis")
+    assert selected_node not in allocator.active_nemesis_on_nodes
+
+
+def test_no_available_nodes(allocator_with_nodes):
+    allocator, _, nodes = allocator_with_nodes
+
+    data_nodes = [n for n in nodes if n.node_type == "data_nodes"]
+    for i, node in enumerate(data_nodes):
+        allocator.set_running_nemesis(node, f"Nemesis-{i}")
+
+    with pytest.raises(AllNodesRunNemesisError):
+        allocator.select_target_node(
+            nemesis_name="ExtraNemesis", pool_type=NEMESIS_TARGET_POOLS.data_nodes, filter_seed=False)
+
+
+def test_nodes_filtering(allocator_with_nodes):
+    allocator, _, _ = allocator_with_nodes
+
+    # filter seed node
+    seed_node = allocator.select_target_node(
+        "SeedNemesis", NEMESIS_TARGET_POOLS.data_nodes, filter_seed=False, is_seed=True)
+    assert seed_node.is_seed
+
+    # filter a rack
+    rack1_node = allocator.select_target_node(
+        "RackNemesis", NEMESIS_TARGET_POOLS.data_nodes, filter_seed=False, rack=1)
+    assert rack1_node.rack == 1
+
+    # filter a pool type
+    znode = allocator.select_target_node("ZNodeNemesis", NEMESIS_TARGET_POOLS.zero_nodes, filter_seed=False)
+    assert znode.node_type == "zero_nodes"
+
+
+def test_switch_target_node(allocator_with_nodes):
+    allocator, _, nodes = allocator_with_nodes
+
+    allocator.set_running_nemesis(nodes[1], "SwitchNemesis")
+    assert nodes[1] in allocator.active_nemesis_on_nodes
+
+    switch_ok = allocator.switch_target_node(old_node=nodes[1], new_node=nodes[2], nemesis_name="SwitchNemesis")
+    assert switch_ok
+    assert nodes[1] not in allocator.active_nemesis_on_nodes
+    assert nodes[2] in allocator.active_nemesis_on_nodes
+    assert allocator.active_nemesis_on_nodes[nodes[2]] == "SwitchNemesis"
+
+
+def test_switch_to_reserved_node_fails(allocator_with_nodes):
+    allocator, _, nodes = allocator_with_nodes
+
+    allocator.set_running_nemesis(nodes[1], "NemesisA")
+    allocator.set_running_nemesis(nodes[2], "NemesisB")
+
+    with pytest.raises(NemesisNodeAllocationError, match="Requested node is already running nemesis"):
+        allocator.switch_target_node(old_node=nodes[1], new_node=nodes[2], nemesis_name="NemesisA")
+    assert allocator.active_nemesis_on_nodes[nodes[1]] == "NemesisA"
+    assert allocator.active_nemesis_on_nodes[nodes[2]] == "NemesisB"
+
+
+def test_thread_safety():
+    """Check for race conditions under pressure."""
+    nodes = [MockNode(f"node-{i}") for i in range(5)]
+    tester = MockTester(nodes)
+    allocator = NemesisNodeAllocator(tester)
+
+    results, errors = [], []
+
+    def worker_thread(worker_id):
+        try:
+            for _ in range(10):
+                nemesis_name = f"Nemesis-{worker_id}"
+                node = allocator.select_target_node(nemesis_name, NEMESIS_TARGET_POOLS.data_nodes, False)
+                if node:
+                    time.sleep(random.uniform(0.05, 0.1))
+                    results.append(node)
+                    allocator.unset_running_nemesis(node, nemesis_name)
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker_thread, args=(i,)) for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"Threads failed with errors: {errors}"
+    # number of successful node selections should be 4 workers * 10 iterations
+    assert len(results) == 40
+
+
+def test_context_manager_sets_and_releases_single_node(allocator_with_nodes):
+    allocator, _, nodes = allocator_with_nodes
+    node_to_mark = nodes[0]
+
+    with allocator.nodes_running_nemesis(node_to_mark, "CtxNemesis"):
+        assert allocator.active_nemesis_on_nodes.get(node_to_mark) == "CtxNemesis"
+
+    assert node_to_mark not in allocator.active_nemesis_on_nodes
+
+
+def test_context_manager_sets_and_releases_multiple_nodes(allocator_with_nodes):
+    allocator, _, nodes = allocator_with_nodes
+    nodes_to_mark = [nodes[0], nodes[1]]
+
+    with allocator.nodes_running_nemesis(nodes_to_mark, "MultiCtxNemesis"):
+        assert all(node in allocator.active_nemesis_on_nodes for node in nodes_to_mark)
+
+    assert all(node not in allocator.active_nemesis_on_nodes for node in nodes_to_mark)

--- a/unit_tests/nemesis/test_sisyphus.py
+++ b/unit_tests/nemesis/test_sisyphus.py
@@ -7,6 +7,7 @@ import pytest
 
 from sdcm.nemesis import Nemesis, SisyphusMonkey
 from sdcm.nemesis_registry import NemesisRegistry
+from sdcm.utils.nemesis_utils.node_allocator import NemesisNodeAllocator
 from unit_tests.nemesis.fake_cluster import FakeTester, PARAMS, Cluster, Node
 from unit_tests.nemesis.test_registry import FlagClass
 from unit_tests.test_tester import ClusterTesterForTests
@@ -122,6 +123,9 @@ def test_add_sisyphus_with_filter_in_parallel_nemesis_run():
                                          "flag_c"]
     tester.params["nemesis_exclude_disabled"] = True
     tester.params["nemesis_multiply_factor"] = 1
+
+    tester.nemesis_allocator = NemesisNodeAllocator(tester)
+
     nemesises = tester.get_nemesis_class()
 
     expected_selectors = ["flag_common", "flag_common and not flag_a",  "flag_c"]


### PR DESCRIPTION
Previously we were adding locked sections in different parts of nemesis.py, to prevent parallel nemeses from selecting the same target node. However, managing these locks across multiple locations became increasingly difficult, but race condition issue appears periodically in new places.

This change introduces a NemesisNodeAllocator entity, which centralizes the logic of selecting and tracking nodes used in nemeses execution. It helpts to ensure synchronization between parallel nemeses.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-schema-topology-changes-12h-test tier1 longevity, that has parallel nemeses](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/longevity-schema-topology-changes-12h-test/8/) (the step of logs collection failed in this run as builder instance went offline at the end, but the test itself was executed and node allocator logs are also present in Jenkins console output)
- [x] check for parallel nemesis synchronization of target node selection: [longevity-100gb-4h with 2 parallel nemeses](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-100gb-4h-test/20/)
Some SCT log entries from the new node_allocator module:
```
❯ egrep -i 'node_allocator' sct-f3405cf3.log
< t:2025-06-21 20:16:23,417 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > StartStopMajorCompaction-c86c920b: selected target node longevity-100gb-4h-sync-par-db-node-f3405cf3-5. Marked it as running nemesis.
< t:2025-06-21 20:16:23,445 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > StartStopMajorCompaction-f3c05dc5: selected target node longevity-100gb-4h-sync-par-db-node-f3405cf3-4. Marked it as running nemesis.
< t:2025-06-21 20:16:35,462 f:node_allocator.py l:174  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > StartStopMajorCompaction-f3c05dc5: unset running nemesis from nodes: ['longevity-100gb-4h-sync-par-db-node-f3405cf3-4']
< t:2025-06-21 20:16:36,573 f:node_allocator.py l:174  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > StartStopMajorCompaction-c86c920b: unset running nemesis from nodes: ['longevity-100gb-4h-sync-par-db-node-f3405cf3-5']
< t:2025-06-21 20:21:35,463 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SlaIncreaseSharesDuringLoad-83d38987: selected target node longevity-100gb-4h-sync-par-db-node-f3405cf3-5. Marked it as running nemesis.
< t:2025-06-21 20:21:36,574 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SlaIncreaseSharesDuringLoad-211f76a4: selected target node longevity-100gb-4h-sync-par-db-node-f3405cf3-4. Marked it as running nemesis.
< t:2025-06-21 20:21:37,265 f:node_allocator.py l:174  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SlaIncreaseSharesDuringLoad-83d38987: unset running nemesis from nodes: ['longevity-100gb-4h-sync-par-db-node-f3405cf3-5']
< t:2025-06-21 20:21:37,267 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > CreateIndex-91b81680: selected target node longevity-100gb-4h-sync-par-db-node-f3405cf3-2. Marked it as running nemesis.
< t:2025-06-21 20:21:38,381 f:node_allocator.py l:174  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SlaIncreaseSharesDuringLoad-211f76a4: unset running nemesis from nodes: ['longevity-100gb-4h-sync-par-db-node-f3405cf3-4']
< t:2025-06-21 20:21:38,386 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > CreateIndex-02a0f65a: selected target node longevity-100gb-4h-sync-par-db-node-f3405cf3-1. Marked it as running nemesis.
< t:2025-06-21 20:21:38,838 f:node_allocator.py l:174  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > CreateIndex-91b81680: unset running nemesis from nodes: ['longevity-100gb-4h-sync-par-db-node-f3405cf3-2']
< t:2025-06-21 20:21:38,839 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > StartStopCleanupCompaction-4e7e9c22: selected target node longevity-100gb-4h-sync-par-db-node-f3405cf3-4. Marked it as running nemesis.
< t:2025-06-21 20:21:39,949 f:node_allocator.py l:174  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > CreateIndex-02a0f65a: unset running nemesis from nodes: ['longevity-100gb-4h-sync-par-db-node-f3405cf3-1']
...
```
- [x] check for `switch target node` capability: [longevity-5gb-1h-nemesis + SerialRestartOfElectedTopologyCoordinatorNemesis test configs](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/longevity-100gb-4h-test/21/)
Some SCT log entries from the new node_allocator module, which indicate that switching was performed:
```
❯ egrep -i 'node_allocator' sct-2da3077f.log
< t:2025-06-22 11:33:52,596 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SerialRestartElectedTopologyCoordinator-c2d13129: selected target node longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-1. Marked it as running nemesis.
< t:2025-06-22 11:33:54,357 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SearchCoordinator-8de7f587: selected target node longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-3. Marked it as running nemesis.
< t:2025-06-22 11:33:55,718 f:node_allocator.py l:155  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SearchCoordinator-8de7f587: unset running nemesis for node longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-3.
< t:2025-06-22 11:34:11,918 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SearchCoordinator-5cbd5eb8: selected target node longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-2. Marked it as running nemesis.
< t:2025-06-22 11:34:13,286 f:node_allocator.py l:155  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SearchCoordinator-5cbd5eb8: unset running nemesis for node longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-2.
< t:2025-06-22 11:34:39,711 f:node_allocator.py l:174  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SerialRestartElectedTopologyCoordinator-c2d13129: unset running nemesis from nodes: ['longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-1']
< t:2025-06-22 11:37:55,230 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SerialRestartElectedTopologyCoordinator-7f84e26a: selected target node longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-1. Marked it as running nemesis.
< t:2025-06-22 11:37:56,800 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SearchCoordinator-f45484dd: selected target node longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-3. Marked it as running nemesis.
< t:2025-06-22 11:37:58,653 f:node_allocator.py l:155  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SearchCoordinator-f45484dd: unset running nemesis for node longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-3.
< t:2025-06-22 11:37:58,653 f:node_allocator.py l:197  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SerialRestartElectedTopologyCoordinator-7f84e26a: released old target node longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-1 during switch.
< t:2025-06-22 11:37:58,653 f:node_allocator.py l:205  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SerialRestartElectedTopologyCoordinator-7f84e26a: switched target node to longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-2.
< t:2025-06-22 11:38:19,850 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SearchCoordinator-1e1aa89d: selected target node longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-1. Marked it as running nemesis.
< t:2025-06-22 11:38:21,717 f:node_allocator.py l:155  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SearchCoordinator-1e1aa89d: unset running nemesis for node longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-1.
< t:2025-06-22 11:38:54,050 f:node_allocator.py l:174  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SerialRestartElectedTopologyCoordinator-7f84e26a: unset running nemesis from nodes: ['longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-2']
< t:2025-06-22 11:42:09,661 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SerialRestartElectedTopologyCoordinator-31705a0c: selected target node longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-1. Marked it as running nemesis.
< t:2025-06-22 11:42:11,222 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SearchCoordinator-cf063712: selected target node longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-3. Marked it as running nemesis.
< t:2025-06-22 11:42:13,583 f:node_allocator.py l:155  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SearchCoordinator-cf063712: unset running nemesis for node longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-3.
< t:2025-06-22 11:42:13,583 f:node_allocator.py l:197  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SerialRestartElectedTopologyCoordinator-31705a0c: released old target node longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-1 during switch.
< t:2025-06-22 11:42:13,583 f:node_allocator.py l:205  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > SerialRestartElectedTopologyCoordinator-31705a0c: switched target node to longevity-5gb-1h-SerialRestartOfEle-db-node-2da3077f-3.
...
```
- [x] check for new nodes being immediately marked as running a nemesis when added during the nemesis execution: [longevity-100gb-4h + GrowShrinkClusterNemesis'](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-100gb-4h-test-copy1/10/)
```
❯ egrep -i 'node_allocator' sct-7c57fa12.log
< t:2025-06-21 18:12:24,609 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > GrowShrinkCluster-9bc1447c: selected target node longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-5. Marked it as running nemesis.
< t:2025-06-21 18:13:26,828 f:node_allocator.py l:145  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > GrowShrinkCluster-9bc1447c: set running nemesis for node longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-7.
< t:2025-06-21 18:13:26,828 f:node_allocator.py l:145  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > GrowShrinkCluster-9bc1447c: set running nemesis for node longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-8.
< t:2025-06-21 18:13:26,828 f:node_allocator.py l:145  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > GrowShrinkCluster-9bc1447c: set running nemesis for node longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-9.
< t:2025-06-21 18:22:07,242 f:node_allocator.py l:155  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > GrowShrinkCluster-9bc1447c: unset running nemesis for node longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-5.
< t:2025-06-21 18:22:07,242 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > GrowShrinkCluster-9bc1447c: selected target node longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-4. Marked it as running nemesis.
< t:2025-06-21 18:22:07,257 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > GrowShrinkCluster-9bc1447c: selected target node longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-2. Marked it as running nemesis.
< t:2025-06-21 18:22:07,271 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > GrowShrinkCluster-9bc1447c: selected target node longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-3. Marked it as running nemesis.
< t:2025-06-21 18:29:16,283 f:node_allocator.py l:174  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > GrowShrinkCluster-9bc1447c: unset running nemesis from nodes: ['longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-7', 'longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-8', 'longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-9', 'longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-4', 'longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-2', 'longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-3']
< t:2025-06-21 18:34:50,979 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > GrowShrinkCluster-24ba2f63: selected target node longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-7. Marked it as running nemesis.
< t:2025-06-21 18:35:51,637 f:node_allocator.py l:145  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > GrowShrinkCluster-24ba2f63: set running nemesis for node longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-10.
< t:2025-06-21 18:35:51,637 f:node_allocator.py l:145  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > GrowShrinkCluster-24ba2f63: set running nemesis for node longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-11.
< t:2025-06-21 18:35:51,637 f:node_allocator.py l:145  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > GrowShrinkCluster-24ba2f63: set running nemesis for node longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-12.
< t:2025-06-21 18:44:32,654 f:node_allocator.py l:155  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > GrowShrinkCluster-24ba2f63: unset running nemesis for node longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-7.
< t:2025-06-21 18:44:32,654 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > GrowShrinkCluster-24ba2f63: selected target node longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-7. Marked it as running nemesis.
< t:2025-06-21 18:44:32,670 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > GrowShrinkCluster-24ba2f63: selected target node longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-5. Marked it as running nemesis.
< t:2025-06-21 18:44:32,684 f:node_allocator.py l:126  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > GrowShrinkCluster-24ba2f63: selected target node longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-9. Marked it as running nemesis.
< t:2025-06-21 18:52:25,488 f:node_allocator.py l:174  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > GrowShrinkCluster-24ba2f63: unset running nemesis from nodes: ['longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-10', 'longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-11', 'longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-12', 'longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-7', 'longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-5', 'longevity-5gb-1h-GrowShrinkClusterN-db-node-7c57fa12-9']
...
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
