### PR TITLE
fix(nemesis): fail test is capacity issue would break topology

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -111,7 +111,7 @@ from sdcm.utils.quota import configure_quota_on_node_for_scylla_user_context, is
     write_data_to_reach_end_of_quota
 from sdcm.utils.compaction_ops import CompactionOps, StartStopCompactionArgs
 from sdcm.utils.context_managers import nodetool_context, DbNodeLogger
-from sdcm.utils.decorators import retrying, latency_calculator_decorator
+from sdcm.utils.decorators import critical_on_capacity_issues, retrying, latency_calculator_decorator
 from sdcm.utils.decorators import timeout as timeout_decor
 from sdcm.utils.decorators import skip_on_capacity_issues
 from sdcm.utils.docker_utils import ContainerManager
@@ -1174,10 +1174,10 @@ class Nemesis:
         self.log.info("Adding new node to cluster...")
         InfoEvent(message='StartEvent - Adding new node to cluster').publish()
         if is_zero_node:
-            new_node = skip_on_capacity_issues(self.cluster.add_nodes)(
+            new_node = critical_on_capacity_issues(self.cluster.add_nodes)(
                 count=1, dc_idx=self.target_node.dc_idx, enable_auto_bootstrap=True, rack=rack, is_zero_node=is_zero_node)[0]
         else:
-            new_node = skip_on_capacity_issues(self.cluster.add_nodes)(
+            new_node = critical_on_capacity_issues(self.cluster.add_nodes)(
                 count=1, dc_idx=self.target_node.dc_idx, enable_auto_bootstrap=True, rack=rack)[0]
         self.monitoring_set.reconfigure_scylla_monitoring()
         self.set_current_running_nemesis(node=new_node)  # prevent to run nemesis on new node when running in parallel

--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -23,9 +23,11 @@ from typing import Optional, Callable
 from botocore.exceptions import ClientError
 
 from sdcm.argus_results import send_result_to_argus
+from sdcm.sct_events import Severity
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.event_counter import EventCounterContextManager
 from sdcm.exceptions import UnsupportedNemesis
+from sdcm.sct_events.system import TestFrameworkEvent
 
 LOGGER = logging.getLogger(__name__)
 
@@ -369,6 +371,25 @@ def skip_on_capacity_issues(func: callable) -> callable:
         except ClientError as ex:
             if "InsufficientInstanceCapacity" in str(ex):
                 raise UnsupportedNemesis("Capacity Issue") from ex
+            raise
+    return wrapper
+
+
+def critical_on_capacity_issues(func: callable) -> callable:
+    """
+    Decorator to end the test with a critical event due to capacity issues
+    This should be used when a failure would leave the cluster in an inconsistent topology state
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except ClientError as ex:
+            if "InsufficientInstanceCapacity" in str(ex):
+                TestFrameworkEvent(source=callable.__name__,
+                                   message=f"Test failed due to capacity issues: {ex} "
+                                   "cluster is probably unbalanced, continuing with test would yield unknown results",
+                                   severity=Severity.CRITICAL).publish()
             raise
     return wrapper
 


### PR DESCRIPTION
If a skip occurs here, it will leave the cluster in an unbalanced topology, which will cause errors later in other disruptions.

Example failure: https://argus.scylladb.com/tests/scylla-cluster-tests/9e935144-b1de-415b-8d63-b05446ed9c52/nemesis 
```
disrupt_terminate_and_replace_node	longevity-cdc-100gb-4h-2024-2-db-node-9e935144-5	Skipped	2025-06-09 13:05:42	2025-06-09 13:13:38
Nemesis Information
  Class: Sisyphus
  Name: disrupt_terminate_and_replace_node
  Status: Skipped
  Skip reason: Capacity Issue
Target Information
  Name: longevity-cdc-100gb-4h-2024-2-db-node-9e935144-5
  Public IP: 54.160.183.183
  Private IP: 10.12.11.25
  State: terminated
  Shards: 14
```

Then later repairs fail.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/62740f79-9f14-4266-be14-51c0126c76bb/events

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
