### PR TITLE
fix(oracle): disable experimental features

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -548,7 +548,8 @@ class BaseNode(AutoSshContainerMixin):
                 if kms_host_data["aws_region"] == "auto":
                     append_scylla_yaml["kms_hosts"][kms_host_name]["aws_region"] = self.vm_region
             scylla_yml.update(append_scylla_yaml)
-
+        if self.parent_cluster.node_type == "oracle-db":
+            scylla_yml.experimental_features = []  # Oracle Scylla does not use experimental features
         return scylla_yml
 
     def refresh_ip_address(self):


### PR DESCRIPTION
Oracle cluster should not use experimental features.

Remove them upon node setup.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11061

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] - https://argus.scylladb.com/tests/scylla-cluster-tests/4b3145cc-3940-4254-84e6-6aa32ffc5402

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
