### PR TITLE
fix(triggers): fix the typo on the gemini job name

### DIFF
--- a/jenkins-pipelines/master-triggers/sct_triggers/tier1-custom-time-trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/tier1-custom-time-trigger.xml
@@ -30,7 +30,7 @@ stress_duration=1440</properties>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
           <projects>
-            ../tier1/gemini-1tb-10h,../tier1/longevity-1tb-5days-azure-test,../tier1/longevity-large-partition-200k-pks-4days-gce-test,../tier1/longevity-mv-si-4days-streaming-test,../tier1/longevity-schema-topology-changes-12h-test,../tier1/longevity-twcs-48h-test,../tier1/longevity-multidc-schema-topology-changes-12h-test,../tier1/longevity-50gb-3days-test,../tier1/longevity-150gb-asymmetric-cluster-12h-test</projects>
+            ../tier1/gemini-1tb-10h-test,../tier1/longevity-1tb-5days-azure-test,../tier1/longevity-large-partition-200k-pks-4days-gce-test,../tier1/longevity-mv-si-4days-streaming-test,../tier1/longevity-schema-topology-changes-12h-test,../tier1/longevity-twcs-48h-test,../tier1/longevity-multidc-schema-topology-changes-12h-test,../tier1/longevity-50gb-3days-test,../tier1/longevity-150gb-asymmetric-cluster-12h-test</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>


### PR DESCRIPTION
cause of this mistake this job isn't getting triggered

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
