### PR TITLE
fix(cluster_aws): stop allocating public addresses if not needed

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -921,7 +921,7 @@ class BaseNode(AutoSshContainerMixin):
         private_ipv4_addresses = [to_inet_ntop_format(address) for address in private_ipv4_addresses]
         return list(set(public_ipv4_addresses + private_ipv4_addresses + [to_inet_ntop_format(self._get_ipv6_ip_address())]))
 
-    def _wait_public_ip(self):
+    def _wait_ip_address_ready(self):
         public_ips, _ = self._refresh_instance_state()
         while not public_ips:
             time.sleep(1)
@@ -3529,11 +3529,11 @@ class BaseCluster:
                                                   test_config=self.test_config)
         return user_data_builder.to_string()
 
-    def get_node_private_ips(self):
-        return [node.private_ip_address for node in self.nodes]
+    def get_node_private_ips(self) -> list[str]:
+        return list(filter(None, [node.private_ip_address for node in self.nodes]))
 
-    def get_node_public_ips(self):
-        return [node.public_ip_address for node in self.nodes]
+    def get_node_public_ips(self) -> list[str]:
+        return list(filter(None, [node.public_ip_address for node in self.nodes]))
 
     def get_node_cql_ips(self, nodes: list[BaseNode] | None = None):
         nodes = nodes if nodes else self.nodes

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -107,7 +107,7 @@ class GCENode(cluster.BaseNode):
         return True
 
     def init(self):
-        self._wait_public_ip()
+        self._wait_ip_address_ready()
 
         # sleep 10 seconds for waiting users are added to system
         # related issue: https://github.com/scylladb/scylla-cluster-tests/issues/1121

--- a/sdcm/sct_provision/aws/instance_parameters_builder.py
+++ b/sdcm/sct_provision/aws/instance_parameters_builder.py
@@ -144,6 +144,7 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
         return {
             'SubnetId': self._ec2_subnet_ids[self.region_id][self.availability_zone][interface_index],
             'Groups': self._ec2_security_group_ids[self.region_id],
+            # 'AssociatePublicIpAddress': interface_index == 0,
         }
 
     @property

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -418,6 +418,10 @@ class PublicIpNotReady(Exception):
     pass
 
 
+class PrivateIpNotReady(Exception):
+    pass
+
+
 @retrying(n=90, sleep_time=10, allowed_exceptions=(PublicIpNotReady, botocore.exceptions.ClientError),
           message="Waiting for instance to get public ip")
 def ec2_instance_wait_public_ip(instance):
@@ -425,6 +429,15 @@ def ec2_instance_wait_public_ip(instance):
     if instance.public_ip_address is None:
         raise PublicIpNotReady(instance)
     LOGGER.debug("[%s] Got public ip: %s", instance, instance.public_ip_address)
+
+
+@retrying(n=90, sleep_time=10, allowed_exceptions=(PrivateIpNotReady, botocore.exceptions.ClientError),
+          message="Waiting for instance to get public ip")
+def ec2_instance_wait_private_ip(instance):
+    instance.reload()
+    if instance.private_ip_address is None:
+        raise PrivateIpNotReady(instance)
+    LOGGER.debug("[%s] Got private ip: %s", instance, instance.private_ip_address)
 
 
 def ec2_ami_get_root_device_name(image_id, region_name):


### PR DESCRIPTION
historically when working with 2 network interfaces we enable public address for the 2nd interface (since it's not automatic)

but since we rework the 2 network interface configuration for AWS we are not running the test with public addresses anymore.

so this change is limiting the creating of public addresses only to cases the configuration suggests using public addresses

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested manually locally - provision + artifact test 
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-200gb-48h-network-monkey-test/4/ (run for 14 hours, just with networking nemesis)
- [ ] 🕙  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-200gb-48h-network-monkey-test/5/ (run only with topology changes for couple of hours)
 
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
