### PR TITLE
fix(unittest): fix pytest collection warning

### DIFF
--- a/unit_tests/nemesis/test_sisyphus.py
+++ b/unit_tests/nemesis/test_sisyphus.py
@@ -18,6 +18,7 @@ class TestNemesisClass(Nemesis):
     flag_b = False
     flag_c = False
     flag_common = False
+    __test__ = False  # Prevent pytest from treating this as a test class
 
     def __init__(self, tester_obj, termination_event, *args, nemesis_selector=None, nemesis_seed=None, **kwargs):
         super().__init__(tester_obj, termination_event, *args, nemesis_selector=nemesis_selector,


### PR DESCRIPTION
mark TestNemesisClass as not a test, so pytest can ignore it

otherwis it fail like:
```
collecting ...
.../unit_tests/nemesis/test_sisyphus.py:14: PytestCollectionWarning: cannot collect test class 'TestNemesisClass'
because it has a __init__ constructor (from: nemesis/test_sisyphus.py)
    class TestNemesisClass(Nemesis):
.../unit_tests/nemesis/test_sisyphus.py:14: PytestCollectionWarning: cannot collect test class 'TestNemesisClass'
because it has a __init__ constructor (from: nemesis/test_specific_nemesis.py)
    class TestNemesisClass(Nemesis):
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
