### PR TITLE
fix(test_sdcm_mgmt_cli): remove assignment to `mock.PropertyMock`

### DIFF
--- a/unit_tests/test_sdcm_mgmt_cli.py
+++ b/unit_tests/test_sdcm_mgmt_cli.py
@@ -19,8 +19,8 @@ def test_01_get_task_info_dict():
         ├──────────────────────────────────────┼────────────────────────┼──────────┼────────┤
         │ 13814000-1dd2-11b2-a009-02c33d089f9b │ 07 Jan 23 23:08:59 UTC │ 0s       │ DONE   │
         ╰──────────────────────────────────────┴────────────────────────┴──────────┴────────╯"""))
-    stderr = mock.PropertyMock = None
-    exited = mock.PropertyMock = 0
+    stderr = mock.PropertyMock(return_value=None)
+    exited = mock.PropertyMock(return_value=0)
     type(remoter_result).stdout = stdout
     type(remoter_result).stderr = stderr
     type(remoter_result).exited = exited


### PR DESCRIPTION
test was wrongly assinging None or 0, into `mock.PropertyMock`

which in turns yield the following errors, in multiple tests:

```
>       if isinstance(value, PropertyMock):
E       TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
