### PR TITLE
improvement(performance): set error threshold for instruction-per-ops

### DIFF
--- a/configurations/performance/perf_simple/latency-decorator-error-thresholds-perf-simple-query-microbenchmark_arm64.yaml
+++ b/configurations/performance/perf_simple/latency-decorator-error-thresholds-perf-simple-query-microbenchmark_arm64.yaml
@@ -1,0 +1,6 @@
+latency_decorator_error_thresholds:
+  read:
+    instructions_per_op:
+      fixed_limit: 40000
+    allocs_per_op:
+      best_pct: 5

--- a/configurations/performance/perf_simple/latency-decorator-error-thresholds-perf-simple-query-microbenchmark_x86_64.yaml
+++ b/configurations/performance/perf_simple/latency-decorator-error-thresholds-perf-simple-query-microbenchmark_x86_64.yaml
@@ -1,0 +1,6 @@
+latency_decorator_error_thresholds:
+  read:
+    instructions_per_op:
+      fixed_limit: 40000
+    allocs_per_op:
+      best_pct: 5

--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64.jenkinsfile
@@ -7,7 +7,7 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'microbenchmarking_test.PerfSimpleQueryTest.test_perf_simple_query',
-    test_config: 'test-cases/microbenchmarking/amazon_perf_simple_query_ARM.yaml',
+    test_config: """["test-cases/microbenchmarking/amazon_perf_simple_query_ARM.yaml","configurations/performance/perf_simple/latency-decorator-error-thresholds-perf-simple-query-microbenchmark_arm64.yaml"]""",
     email_recipients: "scylla-perf-results@scylladb.com",
     perf_extra_jobs_to_compare: """["simple_query_weekly_microbenchmark_enterprise","scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64"]""",
 )

--- a/jenkins-pipelines/performance/branch-perf-v15/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v15/scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64.jenkinsfile
@@ -7,7 +7,7 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'microbenchmarking_test.PerfSimpleQueryTest.test_perf_simple_query',
-    test_config: """[ 'test-cases/microbenchmarking/amazon_perf_simple_query_ARM.yaml', 'test-cases/microbenchmarking/amazon_perf_simple_query_x86.yaml' ]""",
+    test_config: """[ 'test-cases/microbenchmarking/amazon_perf_simple_query_ARM.yaml', 'test-cases/microbenchmarking/amazon_perf_simple_query_x86.yaml', 'configurations/performance/perf_simple/latency-decorator-error-thresholds-perf-simple-query-microbenchmark_x86_64.yaml' ]""",
     email_recipients: "scylla-perf-results@scylladb.com",
     perf_extra_jobs_to_compare: """["simple_query_weekly_microbenchmark_enterprise_x86_64","scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64"]""",
 )

--- a/microbenchmarking_test.py
+++ b/microbenchmarking_test.py
@@ -41,7 +41,9 @@ class PerfSimpleQueryTest(ClusterTester):
                 PerfSimpleQueryAnalyzer(self._test_index).check_regression(
                     self._test_id, is_gce=is_gce,
                     extra_jobs_to_compare=self.params.get('perf_extra_jobs_to_compare'))
-            send_perf_simple_query_result_to_argus(self.test_config.argus_client(), results)
+
+            error_thresholds = self.params.get("latency_decorator_error_thresholds")
+            send_perf_simple_query_result_to_argus(self.test_config.argus_client(), results, error_thresholds)
 
     def update_test_with_errors(self):
         self.log.info("update_test_with_errors: Suppress writing errors to ES")

--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -171,10 +171,7 @@ class PerfSimpleQueryResult(StaticGenericResultTable):
                    ColumnMetadata(name="tasks_per_op", unit="", type=ResultType.FLOAT, higher_is_better=False),
                    ]
 
-        ValidationRules = {
-            "allocs_per_op": ValidationRule(best_pct=5),
-            "instructions_per_op": ValidationRule(best_pct=5),
-        }
+        ValidationRules = dict()
 
 
 class IOPropertiesResultsTable(StaticGenericResultTable):
@@ -344,10 +341,23 @@ def send_result_to_argus(argus_client: ArgusClient, workload: str, name: str, de
         submit_results_to_argus(argus_client, result_table)
 
 
-def send_perf_simple_query_result_to_argus(argus_client: ArgusClient, result: dict):
-    stats = result["stats"]
+def send_perf_simple_query_result_to_argus(argus_client: ArgusClient, result: dict, error_thresholds: dict):
+    def set_validation_rules(column_metadata):
+        if column_threshold := error_thresholds.get(workload, {}).get(column_metadata, {}):
+            LOGGER.debug("%s_threshold result: %s", column_metadata, column_threshold)
+            return ValidationRule(**column_threshold)
+        else:
+            return ValidationRule(best_pct=5)
 
-    result_table = PerfSimpleQueryResult(workload=result["test_properties"]["type"], parameters=result["parameters"])
+    stats = result["stats"]
+    workload = result["test_properties"]["type"]
+    validation_rules = dict()
+    validation_rules["instructions_per_op"] = set_validation_rules("instructions_per_op")
+    validation_rules["allocs_per_op"] = set_validation_rules("allocs_per_op")
+
+    result_table = PerfSimpleQueryResult(workload=workload, parameters=result["parameters"])
+    result_table.validation_rules = validation_rules
+    LOGGER.debug("result_table.validation_rules result: %s", result_table.validation_rules)
     for key, value in stats.items():
         result_table.add_result(column=key, row="#1", value=value, status=Status.UNSET)
     submit_results_to_argus(argus_client, result_table)


### PR DESCRIPTION
Set error threshold for `instruction-ops` in Perf Simple Query tests. 
The current automatic threshold is too sensitive and overly dependent on previous results. 
We should implement a fixed threshold instead. 
This will ensure we only identify instances with extremely low instruction counts.

Task: https://github.com/scylladb/scylla-cluster-tests/issues/11121

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [perf-simple-query-weekly-microbenchmark_arm64_test](https://argus.scylladb.com/tests/scylla-cluster-tests/f537292c-a34b-4656-a2c3-d9610df4c2fb)
![Screenshot from 2025-06-17 16-36-16](https://github.com/user-attachments/assets/5b4bfc29-29a8-4a99-b484-d6680e5483bb)

- [ ]  [perf-simple-query-weekly-microbenchmark_x86_64](https://argus.scylladb.com/tests/scylla-cluster-tests/88277e2c-1e6f-4530-862b-595d5a06ff67)
![Screenshot from 2025-06-18 15-50-47](https://github.com/user-attachments/assets/0e4b015e-74da-4065-92cd-eb57ca06ba97)



### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
