### PR TITLE
fix(aws utils): retry on botocore.exceptions.ClientError

### DIFF
--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -18,6 +18,7 @@ from functools import cached_property
 from typing import List, Dict, get_args
 
 import boto3
+import botocore
 from botocore.exceptions import ClientError
 from mypy_boto3_ec2 import EC2ServiceResource, EC2Client
 from mypy_boto3_ec2.literals import ArchitectureTypeType
@@ -417,7 +418,7 @@ class PublicIpNotReady(Exception):
     pass
 
 
-@retrying(n=90, sleep_time=10, allowed_exceptions=(PublicIpNotReady,),
+@retrying(n=90, sleep_time=10, allowed_exceptions=(PublicIpNotReady, botocore.exceptions.ClientError),
           message="Waiting for instance to get public ip")
 def ec2_instance_wait_public_ip(instance):
     instance.reload()


### PR DESCRIPTION
Adding a node failed with 'The instance ID does not exist', but actually it exists. Instance reload failes with 'botocore.exceptions.ClientErrorInvalidInstanceID.NotFound'. To wait for the instance is ready, we need to retry on this client error.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11124

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
