### PR TITLE
fix(nemesis): exclude 'Duration' type column as primary key for MV

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5094,10 +5094,12 @@ class Nemesis:
             view_name = f'{base_table_name}_view'
             with self.cluster.cql_connection_patient(node=cql_query_executor_node, connect_timeout=600) as session:
                 primary_key_columns = get_column_names(
-                    session=session, ks=ks_name, cf=base_table_name, is_primary_key=True)
+                    session=session, ks=ks_name, cf=base_table_name, is_primary_key=True, filter_out_mv_unsupported=True)
                 # selecting a supported column for creating a materialized-view (not a collection type).
                 column = get_random_column_name(session=session, ks=ks_name,
-                                                cf=base_table_name, filter_out_collections=True, filter_out_static_columns=True)
+                                                cf=base_table_name, filter_out_collections=True,
+                                                filter_out_static_columns=True,
+                                                filter_out_mv_unsupported=True)
                 if not column:
                     raise UnsupportedNemesis(
                         'A supported column for creating MV is not found. nemesis can\'t run')

--- a/sdcm/utils/nemesis_utils/indexes.py
+++ b/sdcm/utils/nemesis_utils/indexes.py
@@ -26,6 +26,21 @@ from sdcm.sct_events.system import InfoEvent
 LOGGER = logging.getLogger(__name__)
 
 
+UNSUPPORTED_PK_NATIVE_TYPES: set[str] = {
+    "counter",
+    "duration",
+}
+
+UNSUPPORTED_PK_COLLECTION_TYPES: tuple[str, ...] = (
+    "list",
+    "set",
+    "map",
+)
+
+# If a type string starts with this, it is frozen and therefore allowed
+FROZEN_PREFIX: str = "frozen<"
+
+
 def is_cf_a_view(node: BaseNode, ks, cf) -> bool:
     """
     Check if a CF is a materialized-view or not (a normal table)
@@ -41,24 +56,43 @@ def is_cf_a_view(node: BaseNode, ks, cf) -> bool:
             return False
 
 
-def get_column_names(session, ks, cf, is_primary_key: bool = False, filter_out_collections: bool = False, filter_out_static_columns: bool = False) -> list:
+def get_column_names(session, ks, cf, is_primary_key: bool = False,
+                     filter_out_collections: bool = False,
+                     filter_out_static_columns: bool = False,
+                     filter_out_mv_unsupported: bool = False) -> list:
     column_types = "'regular'" if filter_out_static_columns else "'static', 'regular'"
     filter_kind = f" kind in ({column_types})" if not is_primary_key else "kind in ('partition_key', 'clustering')"
+
     res = session.execute(f"SELECT column_name, type FROM system_schema.columns"
                           f" WHERE keyspace_name = '{ks}'"
                           f" AND table_name = '{cf}'"
                           f" AND {filter_kind}"
                           f" ALLOW FILTERING")
     res_list = list(res)
-    column_names = [row.column_name for row in res_list]
-    if filter_out_collections:
-        collection_types = ('list', 'set', 'map')
-        column_names = [row.column_name for row in res_list if not str(row.type).startswith(collection_types)]
+
+    def is_supported(row) -> bool:
+        col_type = str(row.type).lower()
+
+        if filter_out_collections or filter_out_mv_unsupported:
+            if col_type.startswith(UNSUPPORTED_PK_COLLECTION_TYPES) and not col_type.startswith(FROZEN_PREFIX):
+                return False
+        if filter_out_mv_unsupported and col_type in UNSUPPORTED_PK_NATIVE_TYPES:
+            return False
+        if filter_out_mv_unsupported:
+            if '<' not in col_type and not col_type.startswith(FROZEN_PREFIX):
+                return False
+        return True
+
+    column_names = [row.column_name for row in res_list if is_supported(row)]
     return column_names
 
 
-def get_random_column_name(session, ks, cf, filter_out_collections: bool = False, filter_out_static_columns: bool = False) -> str | None:
-    if column_names := get_column_names(session=session, ks=ks, cf=cf, filter_out_collections=filter_out_collections, filter_out_static_columns=filter_out_static_columns):
+def get_random_column_name(session, ks, cf, filter_out_collections: bool = False,
+                           filter_out_static_columns: bool = False,
+                           filter_out_mv_unsupported: bool = False) -> str | None:
+    if column_names := get_column_names(session=session, ks=ks, cf=cf, filter_out_collections=filter_out_collections,
+                                        filter_out_static_columns=filter_out_static_columns,
+                                        filter_out_mv_unsupported=filter_out_mv_unsupported):
         return random.choice(column_names)
     return None
 


### PR DESCRIPTION
this commit excludes 'Duration' column types from primary keys for MV creation
fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11022


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
