### PR TITLE
feature(aws): tag ec2 instances at creation

### DIFF
--- a/sdcm/provision/aws/provisioner.py
+++ b/sdcm/provision/aws/provisioner.py
@@ -20,6 +20,7 @@ from typing import List, Optional, Union
 from mypy_boto3_ec2 import EC2Client
 from mypy_boto3_ec2.service_resource import Instance
 
+from sdcm.utils.aws_utils import tags_as_ec2_tags
 from sdcm.provision.aws.capacity_reservation import SCTCapacityReservation
 from sdcm.provision.aws.dedicated_host import SCTDedicatedHosts
 from sdcm.provision.aws.instance_parameters import AWSInstanceParams
@@ -101,6 +102,12 @@ class AWSInstanceProvisioner(InstanceProvisionerBase):
             tags: List[TagsType]) -> List[Instance]:
         instance_parameters_dict = instance_parameters.model_dump(
             exclude_none=True, exclude_defaults=True, exclude_unset=True, encode_user_data=False)
+
+        # picks the tags of the first instance to apply to all instances upfront
+        # later those would be updated with individual tags (Name, etc.)
+        instance_parameters_dict['TagSpecifications'] = [
+            {"ResourceType": "instance", "Tags": tags_as_ec2_tags(tags[0])}]
+
         if cr_id := SCTCapacityReservation.reservations.get(provision_parameters.availability_zone, {}).get(
                 instance_parameters.InstanceType):
             instance_parameters_dict['CapacityReservationSpecification'] = {
@@ -167,16 +174,24 @@ class AWSInstanceProvisioner(InstanceProvisionerBase):
             instance_parameters: AWSInstanceParams,
             count: int,
             tags: List[TagsType]) -> List[Instance]:
+
+        instance_parameters_dict = instance_parameters.model_dump(
+            exclude_none=True,
+            exclude_unset=True,
+            exclude_defaults=True,
+            encode_user_data=True,
+        )
+
+        # picks the tags of the first instance to apply to all instances upfront
+        # later those would be updated with individual tags (Name, etc.)
+        instance_parameters_dict['TagSpecifications'] = [
+            {"ResourceType": "spot-fleet-request", "Tags": tags_as_ec2_tags(tags[0])}]
+
         request_id = create_spot_fleet_instance_request(
             region_name=provision_parameters.region_name,
             count=count,
             fleet_role=self._iam_fleet_role,
-            instance_parameters=instance_parameters.model_dump(
-                exclude_none=True,
-                exclude_unset=True,
-                exclude_defaults=True,
-                encode_user_data=True,
-            ),
+            instance_parameters=instance_parameters_dict
         )
         instance_ids = wait_for_provision_request_done(
             region_name=provision_parameters.region_name,
@@ -259,6 +274,11 @@ class AWSInstanceProvisioner(InstanceProvisionerBase):
             instance_parameters: AWSInstanceParams,
             count: int,
             tags: List[TagsType]) -> List[Instance]:
+
+        # picks the tags of the first instance to apply to all instances upfront
+        # later those would be updated with individual tags (Name, etc.)
+        tag_specifications = [{"ResourceType": "spot-instances-request", "Tags": tags_as_ec2_tags(tags[0])},]
+
         request_ids = create_spot_instance_request(
             region_name=provision_parameters.region_name,
             count=count,
@@ -270,6 +290,7 @@ class AWSInstanceProvisioner(InstanceProvisionerBase):
             ),
             full_availability_zone=self._full_availability_zone_name(provision_parameters),
             valid_until=self._spot_valid_until,
+            tag_specifications=tag_specifications,
         )
         instance_ids = wait_for_provision_request_done(
             region_name=provision_parameters.region_name,

--- a/sdcm/provision/aws/utils.py
+++ b/sdcm/provision/aws/utils.py
@@ -16,14 +16,26 @@ import contextlib
 import datetime
 import time
 from textwrap import dedent
-from typing import Any, Callable, List, Dict, Optional
+from typing import (
+    Any,
+    Callable,
+    List,
+    Dict,
+    Optional,
+    Sequence,
+)
 
 import boto3
 from botocore.exceptions import ClientError
 from mypy_boto3_ec2 import EC2ServiceResource, EC2Client
 from mypy_boto3_ec2.service_resource import Instance
-from mypy_boto3_ec2.type_defs import InstanceTypeDef, SpotFleetLaunchSpecificationTypeDef, \
-    RequestSpotLaunchSpecificationTypeDef, SpotFleetRequestConfigDataTypeDef
+from mypy_boto3_ec2.type_defs import (
+    InstanceTypeDef,
+    SpotFleetLaunchSpecificationTypeDef,
+    RequestSpotLaunchSpecificationTypeDef,
+    SpotFleetRequestConfigDataTypeDef,
+    TagSpecificationTypeDef,
+)
 
 from sdcm.provision.aws.constants import SPOT_REQUEST_TIMEOUT, SPOT_REQUEST_WAITING_TIME, STATUS_FULFILLED, \
     SPOT_STATUS_UNEXPECTED_ERROR, SPOT_PRICE_TOO_LOW, FLEET_LIMIT_EXCEEDED_ERROR, SPOT_CAPACITY_NOT_AVAILABLE_ERROR
@@ -221,6 +233,7 @@ def create_spot_instance_request(
         instance_parameters: RequestSpotLaunchSpecificationTypeDef,
         full_availability_zone: str,
         valid_until: datetime.datetime = None,
+        tag_specifications: Sequence[TagSpecificationTypeDef] = None
 ) -> List[str]:
     params = {
         'DryRun': False,
@@ -228,6 +241,7 @@ def create_spot_instance_request(
         'Type': 'one-time',
         'LaunchSpecification': instance_parameters,
         'AvailabilityZoneGroup': full_availability_zone,
+        'TagSpecifications': tag_specifications,
     }
     if valid_until:
         params['ValidUntil'] = valid_until


### PR DESCRIPTION
this change is introducing tags using `TagSpecifications` as part of calls to create instances

since callas are creating multiple instances,
the tag would be update to more accurate ones after creation of instances (for example `Name` or `NodeIndex`)

Closes: #11188

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] test provision of different type
- [x] test non provision code - spot in aws CI provision, locally on_demend  

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
