### PR TITLE
fix(reuse_cluster): disable capacity reservation when reusing

### DIFF
--- a/sdcm/provision/aws/capacity_reservation.py
+++ b/sdcm/provision/aws/capacity_reservation.py
@@ -64,7 +64,7 @@ class SCTCapacityReservation:
         if not cls.is_capacity_reservation_enabled(params) and not force_fetch:
             LOGGER.info("Capacity reservation is not enabled. Skipping reservation.")
             return
-        test_id = params.get("reuse_cluster") or params.get("test_id")
+        test_id = params.get("test_id")
         ec2 = boto3.client('ec2', region_name=params.region_names[0])
         reservations = ec2.describe_capacity_reservations(
             Filters=[
@@ -123,7 +123,8 @@ class SCTCapacityReservation:
         """Returns True if capacity reservation is enabled."""
         is_single_dc = str(params.get("n_db_nodes")).isdigit() or params.get('simulated_regions') > 0
         return (params.get("cluster_backend") == "aws"
-                and (params.get("test_id") or params.get("reuse_cluster"))
+                and params.get("test_id")
+                and not params.get("reuse_cluster")
                 and params.get('use_capacity_reservation') is True
                 and params.get('instance_provision') == 'on_demand'
                 and is_single_dc)
@@ -140,7 +141,7 @@ class SCTCapacityReservation:
             LOGGER.info("Capacity reservation already created. Skipping reservation.")
             return
         region = params.region_names[0]
-        test_id = params.get("reuse_cluster") or params.get("test_id")
+        test_id = params.get("test_id")
         ec2 = boto3.client('ec2', region_name=region)
         placement_group_arn = None
 


### PR DESCRIPTION
When reusing cluster there's no point in use of cr's: anyway it's cancelled and we don't want to reserve it again.

Disable capacity reservation feature for reuse_cluster cases.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11180

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
