### PR TITLE
fix(pydantic): fix serializer warning

### DIFF
--- a/sdcm/provision/common/user_data.py
+++ b/sdcm/provision/common/user_data.py
@@ -13,13 +13,12 @@
 
 import abc
 from enum import Enum
+from typing import Literal
 
 from sdcm.provision.common.builders import AttrBuilder
 
 
-class DataDeviceType(str, Enum):
-    ATTACHED = 'attached'
-    INSTANCE_STORE = 'instance_store'
+DataDeviceType = Literal['attached', 'instance_store']
 
 
 class RaidLevelType(int, Enum):

--- a/sdcm/sct_provision/aws/user_data.py
+++ b/sdcm/sct_provision/aws/user_data.py
@@ -47,8 +47,8 @@ class ScyllaUserDataBuilder(ScyllaUserDataBuilderBase):
          and use nvme disks otherwise
         """
         if self.params.get("data_volume_disk_num") > 0:
-            return DataDeviceType.ATTACHED.value
-        return DataDeviceType.INSTANCE_STORE.value
+            return "attached"
+        return "instance_store"
 
     @computed_field
     @property
@@ -56,7 +56,7 @@ class ScyllaUserDataBuilder(ScyllaUserDataBuilderBase):
         """
         Tell scylla setup to create RAID0 or RAID5 on disks
         """
-        return self.params.get("raid_level") or RaidLevelType.RAID0
+        return RaidLevelType(self.params.get("raid_level") or 0)
 
     @computed_field
     @property


### PR DESCRIPTION
pydantic excpect enum to be return:
```
Pydantic serializer warnings:
  Expected `enum` but got `str` with value `'instance_store'` - serialized value may not be as expected
  return self.__pydantic_serializer__.to_python(
```

change the enum to be retrun it's value with converted to string, that works as expected, and keep pydantic happy

while there aligned `raid_level` to return the enum expected regardless of configureation set or not.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
