### PR TITLE
fix(hydra): clean-resources/list-resources default to scan all regions

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -296,6 +296,10 @@ def clean_resources(ctx, post_behavior, user, test_id, logdir, dry_run, backend)
     add_file_logger()
 
     user_param = {"RunByUser": user} if user else {}
+    if user:
+        os.environ["SCT_REGION_NAME"] = os.environ.get("SCT_REGION_NAME", "")
+        os.environ["SCT_GCE_DATACENTER"] = os.environ.get("SCT_GCE_DATACENTER", "")
+        os.environ["SCT_AZURE_REGION_NAME"] = os.environ.get("SCT_AZURE_REGION_NAME", "")
 
     if not post_behavior and user and not test_id and not logdir:
         click.echo(f"Clean all resources belong to user `{user}'")
@@ -362,6 +366,11 @@ def list_resources(ctx, user, test_id, get_all, get_all_running, verbose, backen
     if all([not get_all, not get_all_running, not user, not test_id]):
         click.echo(list_resources.get_help(ctx))
         sys.exit(1)
+
+    if get_all_running or user:
+        os.environ['SCT_REGION_NAME'] = os.environ.get('SCT_REGION_NAME', '')
+        os.environ['SCT_GCE_DATACENTER'] = os.environ.get('SCT_GCE_DATACENTER', '')
+        os.environ['SCT_AZURE_REGION_NAME'] = os.environ.get('SCT_AZURE_REGION_NAME', '')
 
     if get_all_running:
         table_header = ["Name", "Region-AZ", "PublicIP", "TestId", "RunByUser", "LaunchTime"]


### PR DESCRIPTION
cause when people are using it locally, it doesn't scan all regions but just the default regions in each cloud

people were leaving lot of AWS resources behind in some resources with them knowning about them.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
