### PR TITLE
fix(nemesis): exclude 'Duration' type column as primary key for MV

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5044,7 +5044,8 @@ class Nemesis(NemesisFlags):
             if not ks_cf_list:
                 raise UnsupportedNemesis("No table found to create index on")
             ks, cf = random.choice(ks_cf_list).split('.')
-            column = get_random_column_name(session, ks, cf, filter_out_static_columns=True)
+            column = get_random_column_name(session, ks, cf, filter_out_static_columns=True,
+                                            filter_out_column_types=['counter'])
             if not column:
                 raise UnsupportedNemesis("No column found to create index on")
             try:
@@ -5080,6 +5081,7 @@ class Nemesis(NemesisFlags):
             if SkipPerIssues(issues="https://github.com/scylladb/scylla-enterprise/issues/5461", params=self.tester.params):
                 raise UnsupportedNemesis("https://github.com/scylladb/scylla-enterprise/issues/5461")
 
+        unsupported_primary_key_columns = ['duration', 'counter']
         free_nodes = [node for node in self.cluster.data_nodes if not node.running_nemesis]
         if not free_nodes:
             raise UnsupportedNemesis("Not enough free nodes for nemesis. Skipping.")
@@ -5096,10 +5098,13 @@ class Nemesis(NemesisFlags):
             view_name = f'{base_table_name}_view'
             with self.cluster.cql_connection_patient(node=cql_query_executor_node, connect_timeout=600) as session:
                 primary_key_columns = get_column_names(
-                    session=session, ks=ks_name, cf=base_table_name, is_primary_key=True)
+                    session=session, ks=ks_name, cf=base_table_name, is_primary_key=True,
+                    filter_out_column_types=unsupported_primary_key_columns)
                 # selecting a supported column for creating a materialized-view (not a collection type).
                 column = get_random_column_name(session=session, ks=ks_name,
-                                                cf=base_table_name, filter_out_collections=True, filter_out_static_columns=True)
+                                                cf=base_table_name, filter_out_collections=True,
+                                                filter_out_static_columns=True,
+                                                filter_out_column_types=unsupported_primary_key_columns)
                 if not column:
                     raise UnsupportedNemesis(
                         'A supported column for creating MV is not found. nemesis can\'t run')

--- a/unit_tests/test_get_columns_for_primary_cluster_keys.py
+++ b/unit_tests/test_get_columns_for_primary_cluster_keys.py
@@ -1,0 +1,53 @@
+import pytest
+from unittest.mock import MagicMock
+from sdcm.utils.nemesis_utils.indexes import get_column_names
+
+
+@pytest.fixture
+def mocked_session():
+    session = MagicMock()
+    session.execute.return_value = [
+        MagicMock(column_name='id', type='int'),
+        MagicMock(column_name='username', type='text'),
+        MagicMock(column_name='tags', type='list<text>'),
+        MagicMock(column_name='scores', type='set<int>'),
+        MagicMock(column_name='metadata', type='map<text, text>'),
+        MagicMock(column_name='counter_col', type='counter'),
+        MagicMock(column_name='duration_col', type='duration'),
+    ]
+    return session
+
+
+def test_get_column_names_no_filters(mocked_session):
+    result = set(get_column_names(mocked_session, 'ks', 'cf'))
+    expected = {'id', 'username', 'tags', 'scores', 'metadata', 'counter_col', 'duration_col'}
+    assert result == expected
+
+
+def test_get_column_names_filter_collections(mocked_session):
+    result = set(get_column_names(mocked_session, 'ks', 'cf', filter_out_collections=True))
+    excluded = {'tags', 'scores', 'metadata'}
+    included = {'id', 'username', 'counter_col', 'duration_col'}
+    assert excluded.isdisjoint(result)
+    assert included.issubset(result)
+
+
+def test_get_column_names_filter_unsupported(mocked_session):
+    result = set(get_column_names(
+        mocked_session, 'ks', 'cf',
+        filter_out_column_types=['counter', 'duration']
+    ))
+    excluded = {'counter_col', 'duration_col'}
+    included = {'id', 'username', 'tags', 'scores', 'metadata'}
+    assert excluded.isdisjoint(result)
+    assert included.issubset(result)
+
+
+def test_get_column_names_combined_filters(mocked_session):
+    result = set(get_column_names(
+        mocked_session, 'ks', 'cf',
+        filter_out_collections=True,
+        filter_out_column_types=['counter', 'duration']
+    ))
+    expected = {'id', 'username'}
+    assert result == expected


### PR DESCRIPTION
this commit excludes 'Duration' and 'counter' column types from
 primary keys for MV and secondary index  creation
fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11022

Testing:
https://jenkins.scylladb.com/job/scylla-staging/job/eugene_test_folder/job/duration_columns_test/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
