### PR TITLE
fix(SLs): remove scylla_scheduler_runtime_ms metric check

### DIFF
--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -315,24 +315,6 @@ class PrometheusDBStats:
         else:
             return res
 
-    def get_scylla_scheduler_runtime_ms(self, start_time, end_time, node_ip, irate_sample_sec='30s'):
-        """
-        Get Scylla CPU scheduler runtime from PrometheusDB
-
-        :return: list of tuples (unix time, op/s)
-        """
-        if not self._check_start_end_time(start_time, end_time):
-            return {}
-        # the query is taken from the Grafana Dashborad definition
-        query = 'avg(irate(scylla_scheduler_runtime_ms{group=~"sl:.*", instance="%s"}  [%s] )) ' \
-            'by (group, instance)' % (node_ip, irate_sample_sec)
-        results = self.query(query=query, start=start_time, end=end_time)
-        res = defaultdict(dict)
-        for item in results:
-            res[item['metric']['instance']].update({item['metric']['group']:
-                                                    [float(runtime[1]) for runtime in item['values']]})
-        return res
-
     def get_scylla_io_queue_total_operations(self, start_time, end_time, node_ip, irate_sample_sec='30s'):
         """
         Get Scylla CPU scheduler runtime from PrometheusDB
@@ -350,26 +332,6 @@ class PrometheusDBStats:
         for item in results:
             res[item['metric']['instance']].update({item['metric']['class']:
                                                     [float(runtime[1]) for runtime in item['values']]})
-        return res
-
-    def get_scylla_scheduler_shares_per_sla(self, start_time, end_time, node_ip):
-        """
-        Get scylla_scheduler_shares from PrometheusDB
-
-        :return: list of tuples (unix time, op/s)
-        """
-        if not self._check_start_end_time(start_time, end_time):
-            return {}
-        # the query is taken from the Grafana Dashborad definition
-        query = 'avg(scylla_scheduler_shares{group=~"sl:.*", instance="%s"} ) by (group, instance)' % node_ip
-        results = self.query(query=query, start=start_time, end=end_time)
-        res = {}
-        for item in results:
-            try:
-                res[item['metric']['group']] = {int(i[1]) for i in item['values']}
-            except Exception as error:  # noqa: BLE001
-                # average value may be returned not integer. Ignore it
-                LOGGER.error("Failed to analyze results of query: %s\nResults: %s\nError: %s", query, results, error)
         return res
 
     def get_scylla_storage_proxy_replica_cross_shard_ops(self, start_time, end_time):

--- a/test-cases/features/system-sla-test.yaml
+++ b/test-cases/features/system-sla-test.yaml
@@ -3,7 +3,7 @@ test_duration: 180
 n_db_nodes: 3
 n_loaders: 3
 
-instance_type_db: 'i3.2xlarge'
+instance_type_db: 'i3.xlarge'
 instance_type_loader: 'c6i.2xlarge'
 
 pre_create_keyspace: "CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1024};"


### PR DESCRIPTION
Remove the scylla_scheduler_runtime_ms metric verification from test_read_throughput_1to5_ratio due to looking into resources/CPU \ is wrong because 1 operation from low shares user can consume more resources than several operations from high shares the user

There is only 1 check in the test left: check CS read ratio

also test now has lower instances->latency about 1s on read and As a result, better stability in terms of expected CS read ratio

Now test also shows stable results with lower cpu utilization

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/6c68cfa0-94a5-4599-ae7f-ee28a3c44751/events runs 90-77

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
