### PR TITLE
feature(LogCollector): Use argus proxy URLs instead of S3 links

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -54,7 +54,7 @@ from sdcm.sct_runner import AwsSctRunner, GceSctRunner, AzureSctRunner, get_sct_
     update_sct_runner_tags, list_sct_runners
 from sdcm.utils.ci_tools import get_job_name, get_job_url
 from sdcm.utils.git import get_git_commit_id, get_git_status_info
-from sdcm.utils.argus import argus_offline_collect_events, get_argus_client
+from sdcm.utils.argus import argus_offline_collect_events, create_proxy_argus_s3_url, get_argus_client
 from sdcm.utils.aws_kms import AwsKms
 from sdcm.utils.azure_region import AzureRegion
 from sdcm.utils.cloud_monitor import cloud_report, cloud_qa_report
@@ -1267,7 +1267,8 @@ def collect_logs(test_id=None, logdir=None, backend=None, config_file=None):
             #  current_cluster_type will be "warning"
             if cluster_type == 'sct-runner' and cluster_type not in link:
                 current_cluster_type = link.split("/")[-1].split("-")[0]
-            table.add_row([current_cluster_type, link])
+            table.add_row([current_cluster_type, create_proxy_argus_s3_url(
+                link).format(collector.test_id, link.split("/")[-1])])
 
     click.echo(table.get_string(title="Collected logs by test-id: {}".format(collector.test_id)))
     update_sct_runner_tags(backend=backend, test_id=collector.test_id, tags={"logs_collected": True})

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -77,6 +77,7 @@ from sdcm.teardown_validators import teardown_validators_list
 from sdcm.tombstone_gc_verification_thread import TombstoneGcVerificationThread
 from sdcm.utils.action_logger import get_action_logger
 from sdcm.utils.alternator.consts import NO_LWT_TABLE_NAME
+from sdcm.utils.argus import create_proxy_argus_s3_url
 from sdcm.utils.aws_kms import AwsKms
 from sdcm.utils.aws_region import AwsRegion
 from sdcm.utils.aws_utils import init_monitoring_info_from_params, get_ec2_services, \
@@ -3732,7 +3733,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         json_file_path = os.path.join(self.logdir, "email_data.json")
 
         if email_data:
-            email_data['grafana_screenshots'] = grafana_screenshots
+            email_data['grafana_screenshots'] = [create_proxy_argus_s3_url(scr, True) for scr in grafana_screenshots]
             email_data["reporter"] = self.email_reporter.__class__.__name__
             self.log.debug('Save email data to file %s', json_file_path)
             self.log.debug('Email data: %s', email_data)

--- a/sdcm/utils/argus.py
+++ b/sdcm/utils/argus.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import os
 from pathlib import Path
 from uuid import UUID
@@ -70,3 +71,17 @@ def argus_offline_collect_events(client: ArgusSCTClient) -> None:
         event_category = EventsInfo(severity=severity, total_events=events_summary.get(severity, 0), messages=messages)
         events_sorted.append(event_category)
     client.submit_events(events_sorted)
+
+
+def create_proxy_argus_s3_url(url: str, general: bool = False) -> str:
+    if general:
+        if match := re.match(r"(https:\/\/)?(?P<bucket>[\w\-]*)\.s3(?P<region>\.[\w\-\d]*)?\.amazonaws.com\/(?P<key>.+)", url):
+            return f"https://argus.scylladb.com/api/v1/s3/{match.group('bucket')}/{match.group('key')}"
+        return url
+
+    if url.endswith(".png"):
+        url_format = "https://argus.scylladb.com/api/v1/tests/scylla-cluster-tests/{}/screenshot/{}"
+    else:
+        url_format = "https://argus.scylladb.com/api/v1/tests/scylla-cluster-tests/{}/log/{}/download"
+
+    return url_format

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -67,6 +67,7 @@ from prettytable import PrettyTable
 from sdcm.remote.libssh2_client import UnexpectedExit as Libssh2_UnexpectedExit
 from sdcm.sct_events import Severity
 from sdcm.sct_events.system import CpuNotHighEnoughEvent, SoftTimeoutEvent
+from sdcm.utils.argus import create_proxy_argus_s3_url
 from sdcm.utils.aws_utils import (
     AwsArchType,
     EksClusterForCleaner,
@@ -355,7 +356,7 @@ def list_logs_by_test_id(test_id):
             if log_type in log_file:
                 results.append({"file_path": log_file,
                                 "type": log_type,
-                                "link": "https://{}.s3.amazonaws.com/{}".format(S3Storage.bucket_name, log_file),
+                                "link": create_proxy_argus_s3_url(log_file).format(test_id, log_file.split("/")[-1]),
                                 "date": convert_to_date(log_file.split('/')[1])
                                 })
                 break


### PR DESCRIPTION
This change changes how links to the logs and screenshots are displayed
to the user in SCT reporting - instead of using raw S3 urls with public
bucket, the provided link now proxies the result through argus, allowing
bucket to be private.

Closes scyllab/qa-tasks#1874

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] [Jenkins](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/alexey-argus-testing/128/)
- 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
