### PR TITLE
fix(add_node): fix add node in simulated racks

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -367,7 +367,10 @@ class AWSCluster(cluster.BaseCluster):
         return ec2_user_data
 
     def _create_or_find_instances(self, count, ec2_user_data, dc_idx, az_idx=0, instance_type=None, is_zero_node=False):
-        nodes = [node for node in self.nodes if node.dc_idx == dc_idx and node.rack == az_idx]
+        is_rack_simulated = self.params.get("simulated_racks")
+        # find if nodes in given az already exist
+        # skip node.rack comparison if racks are simulated to prevent issue when rack was removed
+        nodes = [node for node in self.nodes if node.dc_idx == dc_idx and (node.rack == az_idx or is_rack_simulated)]
         if nodes:
             return self._create_instances(count, ec2_user_data, dc_idx, az_idx, instance_type=instance_type, is_zero_node=is_zero_node)
         if self.test_config.REUSE_CLUSTER:


### PR DESCRIPTION
When rack is removed, then `_create_or_find_instances` does not find existing nodes and tries to get instances. When using simulated racks feature, it may find ones and return them instead creating new.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11140

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [X] - [nodetool seed decommission nemesis](https://argus.scylladb.com/tests/scylla-cluster-tests/59409eec-920a-4645-a4f2-d4466a387c31) - failed but different error. Nodes were added

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
