### PR TITLE
feature(get_supported_scylla_base_versions): stop picking OSS version

### DIFF
--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -12,14 +12,20 @@
 # Copyright (c) 2021 ScyllaDB
 
 
-import unittest
-
 from sdcm.utils.version_utils import ComparableScyllaVersion
 
 from utils.get_supported_scylla_base_versions import UpgradeBaseVersion
 
+"""
+This module contains tests for the UpgradeBaseVersion class, which is used to determine
+the supported Scylla versions for upgrades based on the provided repository, backend, and Linux distribution.
+"""
+
 
 def general_test(scylla_repo='', linux_distro='', cloud_provider=None):
+    """
+    General test function to retrieve the list of supported Scylla versions for upgrade.
+    """
     scylla_version = None
 
     version_detector = UpgradeBaseVersion(scylla_repo, linux_distro, scylla_version)
@@ -28,99 +34,86 @@ def general_test(scylla_repo='', linux_distro='', cloud_provider=None):
     return version_list
 
 
-class TestBaseVersion(unittest.TestCase):
-    download_url_base = 'http://downloads.scylladb.com'
-    url_base = f'{download_url_base}/unstable/scylla'
-
-    def test_master(self):
-        scylla_repo = self.url_base + '/master/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
-        linux_distro = 'centos'
-        version_list = general_test(scylla_repo, linux_distro)
-        assert len(version_list) == 1
-        assert ComparableScyllaVersion(version_list[0]) > '5.4'
-
-    def test_ubuntu_22_azure_5_3(self):
-        scylla_repo = self.url_base + '/branch-5.3/deb/unified/2023-05-23T22:36:08Z/scylladb-5.3/scylla.list'
-        linux_distro = 'ubuntu-jammy'
-        cloud_provider = 'azure'
-        version_list = general_test(scylla_repo, linux_distro, cloud_provider)
-        self.assertEqual(version_list, ['5.2'])
-
-    def test_ubuntu_22_azure_2023_1(self):
-        scylla_repo = self.url_base +\
-            '-enterprise/enterprise-2023.1/deb/unified/2023-05-17T23:03:35Z/scylladb-2023.1/scylla.list'
-        linux_distro = 'ubuntu-jammy'
-        cloud_provider = 'azure'
-        version_list = general_test(scylla_repo, linux_distro, cloud_provider)
-        assert set(version_list) == {'5.2', '2023.1'}
-
-    def test_2021_1(self):
-        scylla_repo = self.url_base + '-enterprise/branch-2021.1/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
-        linux_distro = 'centos'
-        version_list = general_test(scylla_repo, linux_distro)
-        assert set(version_list) == {'4.3', '2020.1', '2021.1'}
-
-    def test_2021_1_with_centos8(self):
-        scylla_repo = self.url_base + '-enterprise/branch-2021.1/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
-        linux_distro = 'centos-8'
-        version_list = general_test(scylla_repo, linux_distro)
-        assert set(version_list) == {'4.3', '2021.1'}
-
-    def test_2022_1_with_centos8(self):
-        scylla_repo = self.url_base + \
-            '-enterprise/enterprise-2022.1/deb/unified/2022-06-03T00:22:55Z/scylladb-2022.1/scylla.list'
-        linux_distro = 'centos-8'
-        version_list = general_test(scylla_repo, linux_distro)
-        assert set(version_list) == {'5.0', '2021.1', '2022.1'}
-
-    def test_2024_1_with_centos9(self):
-        scylla_repo = self.url_base + '-enterprise/enterprise-2024.1/rpm/centos/latest/scylla.repo'
-        linux_distro = 'centos-9'
-        version_list = general_test(scylla_repo, linux_distro)
-        assert set(version_list) == {'5.4', '2024.1'}
-
-    def test_2022_2(self):
-        scylla_repo = self.url_base + '-enterprise/enterprise-2022.2/rpm/centos/2022-10-09T10:39:11Z/scylla.repo'
-        linux_distro = 'centos'
-        version_list = general_test(scylla_repo, linux_distro)
-        assert set(version_list) == {'5.1', '2022.1', '2022.2'}
-
-    def test_2024_1(self):
-        scylla_repo = self.url_base + '-enterprise/enterprise-2024.1/rpm/centos/latest/scylla.repo'
-        linux_distro = 'centos'
-        version_list = general_test(scylla_repo, linux_distro)
-        assert set(version_list) == {'5.4', '2022.2', '2023.1', '2024.1'}
-
-    def test_2024_2(self):
-        scylla_repo = self.url_base + '-enterprise/enterprise-2024.2/rpm/centos/latest/scylla.repo'
-        linux_distro = 'centos-9'
-        version_list = general_test(scylla_repo, linux_distro)
-        assert set(version_list) == {'2024.1', '2024.2', '6.0'}
-
-    def test_2024_2_ubuntu(self):
-        scylla_repo = self.url_base + '-enterprise/enterprise-2024.2/deb/unified/latest/scylladb-2024.2/scylla.list'
-        linux_distro = 'ubuntu-focal'
-        version_list = general_test(scylla_repo, linux_distro)
-        assert set(version_list) == {'6.0', '2024.1', '2024.2'}
-
-    def test_2025_1_dev(self):
-        scylla_repo = self.url_base + '/master/rpm/centos/2025-01-15T09:25:01Z/scylla.repo'
-        linux_distro = 'centos'
-        version_list = general_test(scylla_repo, linux_distro)
-        assert set(version_list) == {'6.2'}
-
-    def test_2025_1_release_ubuntu(self):
-        scylla_repo = self.url_base + '/branch-2025.1/deb/unified/2025-02-16T22:46:42Z/scylladb-2025.1/scylla.list'
-        linux_distro = 'ubuntu-focal'
-        version_list = general_test(scylla_repo, linux_distro)
-        assert {'2024.1', '2024.2', '6.2'}.issubset(set(version_list))
-
-    def test_2025_1_release_centos(self):
-        scylla_repo = self.url_base + '/branch-2025.1/rpm/centos/2025-02-23T16:19:08Z/scylla.repo'
-        linux_distro = 'centos-9'
-        version_list = general_test(scylla_repo, linux_distro)
-        assert {'2024.1', '2024.2', '6.2'}.issubset(set(version_list))
+download_url_base = 'http://downloads.scylladb.com'
+url_base = f'{download_url_base}/unstable/scylla'
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_master_rpm():
+    """
+    Test that master branch select on specific version for upgrade.
+    (not hardcoding the version, since it keep changing)
+    """
+    scylla_repo = url_base + '/master/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
+    linux_distro = 'centos'
+    version_list = general_test(scylla_repo, linux_distro)
+    assert len(version_list) == 1
+    assert ComparableScyllaVersion(version_list[0]) >= '2025.1'
+
+
+def test_master_deb():
+    """
+    Test that master branch select on specific version for upgrade.
+    (not hardcoding the version, since it keep changing)
+    """
+    scylla_repo = url_base + '/master/deb/unified/2025-02-16T22:46:42Z/scylladb-2025.1/scylla.list'
+    linux_distro = 'ubuntu-jammy'
+    version_list = general_test(scylla_repo, linux_distro)
+    assert len(version_list) == 1
+    assert ComparableScyllaVersion(version_list[0]) >= '2025.1'
+
+
+def test_2024_1_with_centos9():
+    """ Test that development branch of 2024.1 with centos9 is returned correct versions """
+    scylla_repo = url_base + '-enterprise/enterprise-2024.1/rpm/centos/latest/scylla.repo'
+    linux_distro = 'centos-9'
+    version_list = general_test(scylla_repo, linux_distro)
+    assert set(version_list) == {'5.4', '2024.1'}
+
+
+def test_2024_1():
+    """ Test that development branch of 2024.1 is returned correct versions """
+    scylla_repo = url_base + '-enterprise/enterprise-2024.1/rpm/centos/latest/scylla.repo'
+    linux_distro = 'centos'
+    version_list = general_test(scylla_repo, linux_distro)
+    assert set(version_list) == {'5.4', '2023.1', '2024.1'}
+
+
+def test_2024_2():
+    """ Test that development branch of 2024.2 is returned correct versions """
+    scylla_repo = url_base + '-enterprise/enterprise-2024.2/rpm/centos/latest/scylla.repo'
+    linux_distro = 'centos-9'
+    version_list = general_test(scylla_repo, linux_distro)
+    assert set(version_list) == {'6.0', '2024.1', '2024.2'}
+
+
+def test_2024_2_ubuntu():
+    """ Test that development branch of 2024.2 on ubuntu is returned correct versions """
+    scylla_repo = url_base + '-enterprise/enterprise-2024.2/deb/unified/latest/scylladb-2024.2/scylla.list'
+    linux_distro = 'ubuntu-focal'
+    version_list = general_test(scylla_repo, linux_distro)
+    assert set(version_list) == {'6.0', '2024.1', '2024.2'}
+
+
+def test_2025_1_dev():
+    """ Test that development branch of 2025.1 is returned correct versions """
+    scylla_repo = url_base + '/master/rpm/centos/2025-01-15T09:25:01Z/scylla.repo'
+    linux_distro = 'centos'
+    version_list = general_test(scylla_repo, linux_distro)
+    assert len(version_list) == 1
+    assert ComparableScyllaVersion(version_list[0]) >= '2025.1'
+
+
+def test_2025_1_release_ubuntu():
+    """ Test that 2025.1 release on ubuntu is returned correct versions """
+    scylla_repo = url_base + '/branch-2025.1/deb/unified/2025-02-16T22:46:42Z/scylladb-2025.1/scylla.list'
+    linux_distro = 'ubuntu-focal'
+    version_list = general_test(scylla_repo, linux_distro)
+    assert {'6.2', '2024.1', '2024.2'}.issubset(set(version_list))
+
+
+def test_2025_1_release_centos():
+    """ Test that 2025.1 release on centos is returned correct versions """
+    scylla_repo = url_base + '/branch-2025.1/rpm/centos/2025-02-23T16:19:08Z/scylla.repo'
+    linux_distro = 'centos-9'
+    version_list = general_test(scylla_repo, linux_distro)
+    assert {'6.2', '2024.1', '2024.2'}.issubset(set(version_list))

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -17,9 +17,16 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 LOGGER = logging.getLogger(__name__)
 
 
-# We support to migrate from specific OSS version to enterprise
-supported_src_oss = {'2021.1': '4.3', '2022.1': '5.0',
-                     '2022.2': '5.1', '2023.1': '5.2', '2024.1': '5.4', '2024.2': '6.0', '2025.1': '6.2'}
+# We add here special versions that are supported, but don't follow the default upgrade support matrix
+extra_supported_versions = {
+    '2021.1': ['4.3'],
+    '2022.1': ['5.0'],
+    '2022.2': ['5.1'],
+    '2023.1': ['5.2'],
+    '2024.1': ['5.4'],
+    '2024.2': ['6.0'],
+    '2025.1': ['6.2'],
+}
 # If new support distro shared repo with others, we need to assign the start support versions. eg: centos8
 start_support_versions = {'centos-8': {'scylla': '4.1', 'enterprise': '2021.1'},
                           'centos-9': {'scylla': '5.4', 'enterprise': '2024.1'}}
@@ -82,69 +89,82 @@ class UpgradeBaseVersion:
         LOGGER.info("Support start versions set: oss=%s enterprise=%s", self.oss_start_support_version,
                     self.ent_start_support_version)
 
-    def get_supported_scylla_base_versions(self, supported_versions) -> list:
+    def get_supported_scylla_base_versions(self, supported_versions: list[str]) -> list:
         """
         We have special base versions list for each release, and we don't support to upgraded from enterprise
         to opensource. This function is used to get the base versions list which will be used in the upgrade test.
 
-        @supported_version: all scylla release versions, the base versions will be filtered out from the supported_version
+        :param supported_versions: all scylla release versions, the base versions will be filtered out from the supported_version
         """
         LOGGER.info("Getting supported scylla base versions...")
-        oss_base_version = []
-        ent_base_version = []
+        source_available_base_version = []
 
-        oss_release_list = [v for v in supported_versions if (
-            not is_enterprise(v)) or ComparableScyllaVersion(v) >= '2025.1.dev']
-        oss_release_list = sorted(oss_release_list)
-        ent_release_list = [v for v in supported_versions if is_enterprise(v)]
+        source_available_release_list = [v for v in supported_versions if is_enterprise(v)]
 
         # The major version of unstable scylla, eg: 4.6.dev, 4.5, 2021.2.dev, 2021.1
         version = self.scylla_version
 
+        # Add the extra supported versions, which don't follow the default upgrade support matrix
+        source_available_base_version += extra_supported_versions.get(version, [])
+
         if version in supported_versions:
             # The dest version is a released opensource version
-            idx = ent_release_list.index(version)
-            oss_base_version.append(version)
-            oss_base_version.append(supported_src_oss.get(version))
+            idx = source_available_release_list.index(version)
             if idx != 0:
                 lts_version = re.compile(r'\d{4}\.1')  # lts = long term support
-                sts_version = re.compile(r'\d{4}\.2')  # sts = short term support
+                sts_version = re.compile(r'\d{4}\.[2345]')  # sts = short term support
 
                 if sts_version.search(version) or ComparableScyllaVersion(version) < '2023.1':
-                    # we need to support last LTS version
-                    oss_base_version += ent_release_list[idx - 1:][:2]
+                    # for short term version we need to support upgrade from last version only
+                    source_available_base_version += source_available_release_list[idx - 1:][:2]
                 elif lts_version.search(version):
-                    # we need to support last version + last LTS version
-                    idx = 2 if idx == 1 else idx
-                    oss_base_version += ent_release_list[idx - 2:][:2]
+                    # for long term version we need to support last version + last LTS version
+                    source_available_base_version += source_available_release_list[idx - 1:idx]
+                    source_available_base_version.append(
+                        next((_version for _version in reversed(source_available_release_list[:idx])
+                             if lts_version.search(_version)), None))
                 else:
                     LOGGER.warning('version format not the default - %s', version)
 
-        elif version == 'master':
-            oss_base_version.append(oss_release_list[-1])
-        elif re.match(r'\d+.\d+', version):
-            relevant_versions = [v for v in oss_release_list if ComparableScyllaVersion(v) < version]
-            # If dest version is smaller than the first supported opensource release,
-            # it might be an invalid dest version
-            oss_base_version.append(relevant_versions[-1])
+            source_available_base_version.append(version)
 
-        # Filter out unsupported version
-        oss_base_version = [v for v in oss_base_version if v in supported_versions]
-        ent_base_version = [v for v in ent_base_version if v in supported_versions]
+        elif version == "master":
+            # add 2 last enterprise versions, since one of them might be only rc version, and we'll need to filter it out
+            source_available_base_version.extend(source_available_release_list[-2:])
+        elif re.match(r'\d+.\d+', version):
+            relevant_versions = [v for v in source_available_release_list if ComparableScyllaVersion(v) < version]
+            # If dest version is smaller than the first supported release,
+            # it might be an invalid dest version
+            source_available_base_version.append(relevant_versions[-1])
+
+        # Filter out unsupported version, or Nones
+        source_available_base_version = [v for v in source_available_base_version if v in supported_versions]
 
         # if there's only release candidates in those repos, skip this version
-        oss_base_version = self.filter_rc_only_version(oss_base_version)
-        ent_base_version = self.filter_rc_only_version(ent_base_version)
-        LOGGER.info("Supported scylla base versions for: oss=%s enterprise=%s", oss_base_version, ent_base_version)
-        return list(set(oss_base_version + ent_base_version))
+        source_available_base_version = self.filter_rc_only_version(source_available_base_version)
+        LOGGER.info("Supported scylla base versions for: source_available=%s", source_available_base_version)
+        return list(set(source_available_base_version))
 
-    def filter_rc_only_version(self, base_version_list: list) -> list:
+    def filter_rc_only_version(self, base_version_list: list[str]) -> list[str]:
+        """
+        Filter out the base versions that only have release candidates (rc) versions.
+
+        if it's master branch, we also limit the base version to the latest one,
+        which isn't release candidates (rc) only release.
+
+        :param base_version_list: list of base versions to filter
+        """
         LOGGER.info("Filtering rc versions from base version list...")
         base_version_list = sorted(list(set(base_version_list)), key=ComparableScyllaVersion)
-        if base_version_list and self.scylla_version not in ('enterprise', 'master'):
-            filter_rc = [v for v in get_all_versions(self.repo_maps[base_version_list[-1]]) if 'rc' not in v]
-            if not filter_rc:
-                base_version_list = base_version_list[:-1]
+        filter_rc = [v for v in get_all_versions(self.repo_maps[base_version_list[-1]]) if 'rc' not in v]
+        if not filter_rc:
+            # if the release only has rc versions, we don't want to test it as a base version
+            base_version_list = base_version_list[:-1]
+        if self.scylla_version in ("master",):
+            # for master branch, we only want the latest version
+            # we don't test all the options, just the latest one
+            base_version_list = base_version_list[-1:]
+
         return base_version_list
 
     def get_version_list(self) -> tuple[list, list]:


### PR DESCRIPTION
from now on, we should be picking the OSS version as bases versions all of the code path and unittest for that are removed.

one can still manually select a specific branh to upgrade from if needed, but we won't be test that by default anymore.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟡 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-ami-test/21/ (selection of base as expected, even that test was failing)
- [x] 🟡 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-centos9-test/16/ (selection of base as expected, even that test was failing)
- [x] update unittest for this part
 
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
