### PR TITLE
feature(artifacts): add pipelines to cover rhel10

### DIFF
--- a/configurations/arm/rhel10.yaml
+++ b/configurations/arm/rhel10.yaml
@@ -1,0 +1,5 @@
+ami_id_db_scylla: 'resolve:owner:309956199498/arm64/RHEL-10*arm64*'
+instance_type_db: 'im4gn.xlarge'
+use_preinstalled_scylla: false
+# enhanced network isn't supported
+append_scylla_setup_args: ' --no-ec2-check '

--- a/jenkins-pipelines/oss/artifacts/artifacts-rhel10-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-rhel10-arm.jenkinsfile
@@ -1,0 +1,14 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: '''["test-cases/artifacts/rhel10.yaml", "configurations/arm/rhel10.yaml"]''',
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'spot',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/oss/artifacts/artifacts-rhel10.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-rhel10.jenkinsfile
@@ -1,0 +1,14 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/rhel10.yaml',
+    backend: 'aws',
+    region: 'eu-west-1',
+    provision_type: 'spot',
+
+    timeout: [time: 60, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/sdcm/utils/distro.py
+++ b/sdcm/utils/distro.py
@@ -33,7 +33,7 @@ class DistroBase(enum.Enum):
 # (enum_prefix, os name, versions list (format is either "major.minor" or "major"), boolean - debian_like == True else rhel_like)
 KNOWN_OS = (
     ("CENTOS", "centos", ["7", "8", "9"], DistroBase.RHEL),
-    ("RHEL", "rhel", ["7", "8", "9"], DistroBase.RHEL),
+    ("RHEL", "rhel", ["7", "8", "9", "10"], DistroBase.RHEL),
     ("OEL", "ol", ["7", "8", "9"], DistroBase.RHEL),
     ("AMAZON", "amzn", ["2023"], DistroBase.RHEL),
     ("ROCKY", "rocky", ["8", "9"], DistroBase.RHEL),

--- a/test-cases/artifacts/rhel10.yaml
+++ b/test-cases/artifacts/rhel10.yaml
@@ -1,0 +1,19 @@
+backtrace_decoding: false
+cluster_backend: 'aws'
+ami_db_scylla_user: 'ec2-user'
+ami_id_db_scylla: 'resolve:owner:309956199498/x86_64/RHEL-10*x86_64*'
+instance_type_db: 'i4i.large'
+root_disk_size_db: 50
+instance_provision: 'spot'
+instance_provision_fallback_on_demand: true
+logs_transport: 'vector'
+n_db_nodes: 1
+n_loaders: 0
+n_monitor_nodes: 0
+nemesis_class_name: 'NoOpMonkey'
+scylla_linux_distro: 'centos'
+test_duration: 60
+user_prefix: 'artifacts-rhel10'
+use_preinstalled_scylla: false
+
+user_credentials_path: '~/.ssh/scylla_test_id_ed25519'


### PR DESCRIPTION
image are taking from AWS for now, still need to configured GCE to be able to pick the same images from there.

two cases introduce on for x86, and one for arm64

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] test x86 job
- [ ] test arm64 job

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
