### PR TITLE
fix(pydantic): fix warning about `s/dict/model_dump/`

### DIFF
--- a/sdcm/utils/features.py
+++ b/sdcm/utils/features.py
@@ -10,9 +10,15 @@
 # See LICENSE for more details.
 #
 #
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 from cassandra.cluster import Session
+
+if TYPE_CHECKING:
+    from sdcm.cluster import BaseNode
 
 CONSISTENT_TOPOLOGY_CHANGES_FEATURE = "SUPPORTS_CONSISTENT_TOPOLOGY_CHANGES"
 CONSISTENT_CLUSTER_MANAGEMENT_FEATURE = "SUPPORTS_RAFT_CLUSTER_MANAGEMENT"
@@ -75,12 +81,12 @@ def is_consistent_topology_changes_feature_enabled(session: Session) -> bool:
     return CONSISTENT_TOPOLOGY_CHANGES_FEATURE in get_enabled_features(session)
 
 
-def is_tablets_feature_enabled(node) -> bool:
+def is_tablets_feature_enabled(node: BaseNode) -> bool:
     """ Check whether tablets enabled
     """
     with node.remote_scylla_yaml() as scylla_yaml:
         # for backward compatibility of 2024.1 and earlier
-        scylla_conf = scylla_yaml.dict()
+        scylla_conf = scylla_yaml.model_dump()
         if "tablets" in (scylla_conf.get("experimental_features") or []):
             return True
         if scylla_conf.get("enable_tablets"):


### PR DESCRIPTION
one more place we missed (implemented as the time we upgrade pydantic)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
