### PR TITLE
fix(microbenchmark): add logging

### DIFF
--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -11,6 +11,7 @@
 #
 # Copyright (c) 2024 ScyllaDB
 import json
+import logging
 import time
 from datetime import timezone, datetime
 
@@ -21,6 +22,8 @@ from argus.client.generic_result import GenericResultTable, ColumnMetadata, Resu
 
 from sdcm.sct_events.event_counter import STALL_INTERVALS
 from sdcm.sct_events.system import FailedResultEvent
+
+LOGGER = logging.getLogger(__name__)
 
 LATENCY_ERROR_THRESHOLDS = {
     "replace_node": {


### PR DESCRIPTION
Missed logging in argus_results.py module in branch-perf-v15. It caused to the microbenchmark test failure

Example of failed test: https://argus.scylladb.com/tests/scylla-cluster-tests/da668069-db96-4bce-bd49-d8fd650b942a

```
2025-06-22 03:13:20.077: (TestFrameworkEvent Severity.ERROR) period_type=one-time event_id=5217dff2-d4dd-4d10-9a30-9b3ef2feb1f1, source=PerfSimpleQueryTest.test_perf_simple_query (microbenchmarking_test.PerfSimpleQueryTest)() message=Traceback (most recent call last):
File "/home/ubuntu/scylla-cluster-tests/microbenchmarking_test.py", line 46, in test_perf_simple_query
send_perf_simple_query_result_to_argus(self.test_config.argus_client(), results, error_thresholds)
File "/home/ubuntu/scylla-cluster-tests/sdcm/argus_results.py", line 265, in send_perf_simple_query_result_to_argus
LOGGER.debug("result_table.validation_rules result: %s", result_table.validation_rules)
NameError: name 'LOGGER' is not defined
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] [perf-simple-query-weekly-microbenchmark_arm64](https://argus.scylladb.com/tests/scylla-cluster-tests/40707c02-dd95-43e0-8a48-5906a1e2ab49)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
