### PR TITLE
improvement(sdcm/utils/common.py): Add `public` flag to upload_file

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1823,8 +1823,9 @@ def fetch_junit(runner_ip, backend):
 @cli.command("upload", help="Upload arbitrary log/screenshot to s3 corresponding to the test_id")
 @click.option("--test-id", type=str, required=True)
 @click.option("--use-argus/--no-use-argus", default=True)
+@click.option("--public/--no-public", default=False)
 @click.argument("file-path", type=str, required=True)
-def upload_artifact_file(test_id: str, file_path: str, use_argus: bool):
+def upload_artifact_file(test_id: str, file_path: str, use_argus: bool, public: bool):
     add_file_logger()
     if use_argus:
         params = SCTConfiguration()
@@ -1849,7 +1850,7 @@ def upload_artifact_file(test_id: str, file_path: str, use_argus: bool):
         s3_path = f"{test_id}/{subfolder}"
         LOGGER.info("Going to upload %s to S3...", file.absolute())
         s3 = S3Storage()
-        file_url = s3.upload_file(file.absolute(), s3_path)
+        file_url = s3.upload_file(file.absolute(), s3_path, public)
         LOGGER.info("Uploaded %s to %s", file.absolute(), file_url)
         client.submit_sct_logs([LogLink(log_name=file.name, log_link=file_url)])
         if file.suffix in image_exts:

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1752,4 +1752,4 @@ def upload_archive_to_s3(archive_path: str, storing_path: str) -> Optional[str]:
     if not check_archive(LocalCmdRunner(), archive_path):
         LOGGER.error("File `%s' will not be uploaded", archive_path)
         return None
-    return S3Storage().upload_file(file_path=archive_path, dest_dir=storing_path)
+    return S3Storage().upload_file(file_path=archive_path, dest_dir=storing_path, public=False)

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -281,7 +281,7 @@ class S3Storage():
                                                                                       file_name=file_name,
                                                                                       bucket_name=bucket_name)
 
-    def upload_file(self, file_path, dest_dir=''):
+    def upload_file(self, file_path, dest_dir='', public=True):
         s3_url = self.generate_url(file_path, dest_dir)
         s3_obj = "{}/{}".format(dest_dir, os.path.basename(file_path))
         try:
@@ -290,8 +290,9 @@ class S3Storage():
                                      Key=s3_obj,
                                      Config=self.transfer_config)
             LOGGER.info("Uploaded to {0}".format(s3_url))
-            LOGGER.info("Set public read access")
-            self.set_public_access(key=s3_obj)
+            if public:
+                LOGGER.info("Set public read access")
+                self.set_public_access(key=s3_obj)
             return s3_url
         except Exception as details:  # noqa: BLE001
             LOGGER.debug("Unable to upload to S3: %s", details)


### PR DESCRIPTION
This commit adds a new flag corresponding to whether or not to make file
uploaded to S3 public (default: True). It also updates usage to make log
files private and keep the screenshots public. In addition, the `upload`
command was updated to include an option to set file as public (default:
True).

Task: scylladb/qa-tasks#1874

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Jenkins](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/alexey-argus-testing/131/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
