### PR TITLE
fix(backport): runCleanupResource.groovy had leftovers merge conflict

### DIFF
--- a/vars/runCleanupResource.groovy
+++ b/vars/runCleanupResource.groovy
@@ -16,17 +16,10 @@ def call(Map params, String region){
 
     export SCT_CONFIG_FILES=${test_config}
     export SCT_CLUSTER_BACKEND="${params.backend}"
-<<<<<<< HEAD
 
-||||||| parent of 12f9dfea4 (fix(pipelines): don't set `instance_provision` with null)
-
-    export SCT_INSTANCE_PROVISION=${params.provision_type}
-
-=======
     if [[ -n "${params.provision_type ? params.provision_type : ''}" ]] ; then
         export SCT_INSTANCE_PROVISION=${params.provision_type}
     fi
->>>>>>> 12f9dfea4 (fix(pipelines): don't set `instance_provision` with null)
     if [[ -n "${params.region ? params.region : ''}" ]] ; then
         export SCT_REGION_NAME=${current_region}
     fi


### PR DESCRIPTION
there was a mistake in one backport and the conflict leftover were missed, this commit fix the conflict in this file

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
