### PR TITLE
improvement(SchemaDisagreementHandler): Proxy SStable link with argus

### DIFF
--- a/sdcm/sct_events/handlers/schema_disagreement.py
+++ b/sdcm/sct_events/handlers/schema_disagreement.py
@@ -17,6 +17,7 @@ import time
 from sdcm.sct_events import Severity
 from sdcm.sct_events.handlers import EventHandler
 from sdcm.sct_events.loaders import CassandraStressLogEvent, SchemaDisagreementErrorEvent
+from sdcm.utils.argus import create_proxy_argus_s3_url
 from sdcm.utils.sstable.s3_uploader import upload_sstables_to_s3
 
 LOGGER = logging.getLogger(__name__)
@@ -45,8 +46,9 @@ class SchemaDisagreementHandler(EventHandler):
                 gossip_info = gossip_info or node.get_gossip_info()
                 peers_info = peers_info or node.get_peers_info()
                 try:
-                    link = upload_sstables_to_s3(node, keyspace='system_schema', test_id=tester_obj.test_id)
-                    event.add_sstable_link(link)
+                    link = upload_sstables_to_s3(node, keyspace='system_schema',
+                                                 test_id=tester_obj.test_id, public=False)
+                    event.add_sstable_link(create_proxy_argus_s3_url(link, True))
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.error("failed to upload system_schema sstables for node %s: %s", node.name, exc)
             event.add_gossip_info(gossip_info)

--- a/sdcm/utils/sstable/s3_uploader.py
+++ b/sdcm/utils/sstable/s3_uploader.py
@@ -9,7 +9,7 @@ from sdcm.utils.s3_remote_uploader import upload_remote_files_directly_to_s3
 LOGGER = logging.getLogger(__name__)
 
 
-def upload_sstables_to_s3(node: CollectingNode | BaseNode, keyspace: str, test_id: str, tables: list | None = None):
+def upload_sstables_to_s3(node: CollectingNode | BaseNode, keyspace: str, test_id: str, tables: list | None = None, public: bool = True):
     """Uploads given keyspace/tables sstables snapshot to s3.
 
     Uploaded snapshots will be visible in show-logs command for given test_id."""
@@ -27,7 +27,7 @@ def upload_sstables_to_s3(node: CollectingNode | BaseNode, keyspace: str, test_i
         s3_link = upload_remote_files_directly_to_s3(
             node.ssh_login_info, snapshot_paths, s3_bucket=S3Storage.bucket_name,
             s3_key=f"{test_id}/{snapshot_date}/sstables-{snapshot_date}-{node.name}-{keyspace}.tar.gz",
-            max_size_gb=400, public_read_acl=True)
+            max_size_gb=400, public_read_acl=public)
         if s3_link:
             LOGGER.info("Successfully uploaded sstables on node %s for keyspace %s", node.name, keyspace)
         node.remoter.run(f"nodetool clearsnapshot -t {snapshot_tag} {keyspace}")


### PR DESCRIPTION
Make sstable file upload private and proxy it via argus generic proxy.

Task: scylladb/qa-tasks#1874

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
