### PR TITLE
feature(perf-test): throttle/limit performance test per region

### DIFF
--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -133,6 +133,12 @@ def call(Map pipelineParams) {
                      '\tSCT_USE_MGMT=false'
                      ),
                  name: 'extra_environment_variables')
+            booleanParam(defaultValue: false,
+                         description: 'if true, use job throttling to limit the number of concurrent builds',
+                         name: 'use_job_throttling')
+            string(defaultValue: null,
+                description: 'if set would override the default job throttling category',
+                name: 'job_throttle_category')
 
             // BYO ScyllaDB Configuration
             separator(name: 'BYO_SCYLLA', sectionHeader: 'BYO ScyllaDB Configuration')
@@ -258,6 +264,9 @@ def call(Map pipelineParams) {
                         } else {
                             sub_tests = [pipelineParams.test_name]
                         }
+                        // select the step function to use for throttling, if not throttling, it's a no-op
+                        def throttle_closure = params.use_job_throttling ? this.&throttle : { labels, closure -> closure() }
+                        def job_throttle_category = params.job_throttle_category ?: "SCT-perf-${builder.region}"
                         for (t in sub_tests) {
                             def perf_test
                             def sub_test = t
@@ -492,7 +501,9 @@ def call(Map pipelineParams) {
                                 }
                             }
                         }
-                        parallel tasks
+                        throttle_closure([job_throttle_category]) {
+                            parallel tasks
+                        }
                     }
                 }
             }


### PR DESCRIPTION
using the jenkins `throttle-concurrents` plugin, we gonna limit the performance test, to not run more then one test per region.

hopefully it would help in both having enough capacity for tests, and improve the situation with test falling into the same hosts as other tests, and interfering with results.

Ref: https://plugins.jenkins.io/throttle-concurrents/

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟡  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/scylla-enterprise-perf-regression-predefined-throughput-steps-vnodes/52/ worked as expected, test go stuck on teardown cause of known issue

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
