### PR TITLE
fix(build-docker-image.yaml): should only work if PR is labeled

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -30,7 +30,7 @@ jobs:
 
   build_image:
     needs: check_org_membership
-    if: github.actor == 'renovate[bot]' || (needs.check_org_membership.outputs.isTeamMember == 'true' && contains(github.event.pull_request.labels.*.name, 'New Hydra Version'))
+    if: ( github.actor == 'renovate[bot]' || needs.check_org_membership.outputs.isTeamMember == 'true' ) && contains(github.event.pull_request.labels.*.name, 'New Hydra Version')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
by mistke it wasn't enforced on all cases, and we might run and build image, even when wasn't intended

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
