### PR TITLE
test(longevity): add RackAwarePolicy test for scylla-bench

### DIFF
--- a/configurations/longevity-twcs-2h-rackaware-validation.yaml
+++ b/configurations/longevity-twcs-2h-rackaware-validation.yaml
@@ -1,0 +1,13 @@
+# This configuration is created to be run on top of "longevity-twcs-3h.yaml"
+test_duration: 180
+stress_duration: 120
+
+# One loader per DC is must for RACK validation tests
+n_loaders: 1
+
+rack_aware_loader: true
+
+# teardown validators
+teardown_validators:
+  rackaware:
+    enabled: true

--- a/jenkins-pipelines/oss/longevity/longevity-twcs-2h-rackaware.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-twcs-2h-rackaware.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: "longevity_twcs_test.TWCSLongevityTest.test_twcs_longevity",
+    test_config: """["test-cases/longevity/longevity-twcs-3h.yaml", "configurations/longevity-twcs-2h-rackaware-validation.yaml"]""",
+)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3999,6 +3999,13 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         for event_str in all_events["NORMAL"]:
             if "type=RackAwarePolicy" in event_str:
                 return True
+
+        # TODO: temporary workaround to test rack-aware policy with stress tool, different from cassandra-stress.
+        #  It is because tools like scylla-bench does not print info about RackAwarePolicy using, like cassandra-stress prints.
+        #  https://github.com/scylladb/scylla-bench/issues/198
+        if self.params.get("rack_aware_loader"):
+            return True
+
         return False
 
     @property


### PR DESCRIPTION
Adds a new test case using `scylla-bench` to perform end-to-end validation of the `RackAwarePolicy`.

Run `scylla-bench` workload command configured to use RackAwarePolicy.

Task: https://github.com/scylladb/qa-tasks/issues/1915

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-twcs-2h-rackaware (short)](https://argus.scylladb.com/tests/scylla-cluster-tests/037395ec-3e09-4248-b0bd-983e4a1bf4ad)
scylla-bench command is configured with rack-awarness
```
scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=4000 -clustering-row-count=10000 -clustering-row-size=200 -concurrency=100 -rows-per-request=1 -start-timestamp=1753166038353619898 -connection-count 100 -max-rate 30000 --timeout 120s -retry-number=30 -retry-interval=80ms,1s -duration=10m  -nodes 10.12.1.49,10.12.0.76,10.12.3.27,10.12.2.164,10.12.2.69,10.12.1.72 -rack=RACK0  -datacenter=us-east-1
```

Only relevant DB nodes received CQL reads initiated by user
<img width="450" height="394" alt="Screenshot from 2025-07-22 10-35-09" src="https://github.com/user-attachments/assets/1f31ca43-a4b2-460b-bb6e-71828dd8fa5f" />



- [x] [longevity-twcs-2h-rackaware (full)](https://argus.scylladb.com/tests/scylla-cluster-tests/3844a551-6165-436a-94e5-0d8f3e5fe9e3)
Validation results from log - User-initiated CQL reads were routed to a nodes in a loader AZ, as expected:
```
< t:2025-06-26 11:53:26,269 f:rackaware.py    l:138  c:sdcm.teardown_validators.rackaware p:DEBUG > 
Non-system CQl read amounts are being routed to a node in a loader-less AZ: 9
< t:2025-06-26 11:53:26,269 f:rackaware.py    l:140  c:sdcm.teardown_validators.rackaware p:DEBUG > 
Non-system CQl read amounts are being routed to a node in a loader AZ: 21117604
< t:2025-06-26 11:53:26,269 f:rackaware.py    l:141  c:sdcm.teardown_validators.rackaware p:DEBUG > 
User-initiated CQL reads as a percentage of all CQL reads: 4.2618453136725256e-05
```


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
