### PR TITLE
fix(perf): use `workload` var properly

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -836,13 +836,13 @@ class PerformanceRegressionTest(ClusterTester, loader_utils.LoaderUtilsMixin):
         end_time = time.time()
 
         histogram_total_data = self.get_hdrhistogram(
-            hdr_tags=hdr_tags, stress_operation=workload.value,
+            hdr_tags=hdr_tags, stress_operation=workload,
             start_time=start_time, end_time=end_time)
         self.update_hdrhistograms(histogram_name="test_histogram",
                                   histogram_data=histogram_total_data)
 
         histogram_data_by_interval = self.get_hdrhistogram_by_interval(
-            hdr_tags=hdr_tags, stress_operation=workload.value,
+            hdr_tags=hdr_tags, stress_operation=workload,
             start_time=start_time, end_time=end_time)
 
         self.update_hdrhistograms(histogram_name='test_histogram_by_interval',


### PR DESCRIPTION
One of the merged PRs (https://github.com/scylladb/scylla-cluster-tests/pull/10817) broke some of rarely used perf methods
by not complete update of the `workload` var usage.

The `workload` was `enum` and then was transformed into `str`.
But 2 places in the code continued expecting it to be `enum`s.

So, fix it to be expected as `str`.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
