### PR TITLE
fix(azure): don't delete NIC upon VM creation

### DIFF
--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -76,7 +76,7 @@ class VirtualMachineProvider:
                 "network_profile": {
                     "network_interfaces": [{
                         "id": nic_id,
-                        "properties": {"deleteOption": "Delete"}
+                        "properties": {"deleteOption": "Detach"}
                     }],
                 },
             }
@@ -126,6 +126,7 @@ class VirtualMachineProvider:
                 if err.code == 'OperationPreempted':
                     raise OperationPreemptedError(err)  # spot instance preemption, abort provision immediately
             except AzureError as err:
+                LOGGER.error("Error when waiting for creation of VM %s: %s", definition.name, str(err))
                 error_to_raise = err
         if error_to_raise:
             raise ProvisionError(error_to_raise)


### PR DESCRIPTION
When provisioning instances on Azure, NIC was deleted along with VM. This causes wrong error message after retrying creation.

Made NIC to be detached rather than deleted upon VM preemption and improved logging to better debug issues in future.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/5198

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
