### PR TITLE
improvement(distro): allow running on Mint 22 distro

### DIFF
--- a/sdcm/utils/distro.py
+++ b/sdcm/utils/distro.py
@@ -41,7 +41,7 @@ KNOWN_OS = (
     ("UBUNTU", "ubuntu", ["20.04", "21.04", "21.10", "22.04", "24.04"], DistroBase.DEBIAN),
     ("SLES", "sles", ["15"], DistroBase.UNKNOWN),
     ("FEDORA", "fedora", ["34", "35", "36"], DistroBase.RHEL),
-    ("MINT", "linuxmint", ["20", "21"], DistroBase.DEBIAN),
+    ("MINT", "linuxmint", ["20", "21", "22"], DistroBase.DEBIAN),
 
 )
 


### PR DESCRIPTION
`Mind22` distro uses `Ubuntu24` as a basis and doesn't require any other
changes except the distro name check.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
