### PR TITLE
fix(list-resources): use the correct metadata implementation

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -493,7 +493,7 @@ def list_resources(ctx, user, test_id, get_all, get_all_running, verbose, backen
             eks_table.align = "l"
             eks_table.sortby = 'CreateTime'
             for cluster in eks_clusters:
-                tags = gce_meta_to_dict(cluster.extra['metadata'])
+                tags = cluster.metadata
                 eks_table.add_row([cluster.name,
                                    tags.get('TestId', 'N/A') if tags else "N/A",
                                    cluster.region_name,


### PR DESCRIPTION
seems like this was broken for long long time now since we refactored out libcloud.

with this change we can usd hydra list-resources to list EKS cluster

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
