### PR TITLE
fix(perf_simple): separate the index for write tests

### DIFF
--- a/configurations/performance/perf_simple/perf_simple_write_option.yaml
+++ b/configurations/performance/perf_simple/perf_simple_write_option.yaml
@@ -1,1 +1,2 @@
 perf_simple_query_extra_command: '--write'
+custom_es_index: 'microbenchmarkingtest_write'


### PR DESCRIPTION
since we are reporting into the same index, the logic that compare to history and send mail about it, is generating missleading data

this commit change the index of the write test into a new one so the result won't be mixing anymore.

Fix: #11295

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
