### PR TITLE
fix(libssh2): fix hanging ssh connection after the test

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3088,6 +3088,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         self.log.info('Test ID: {}'.format(self.test_config.test_id()))
         self._check_alive_routines_and_report_them()
         self._check_if_db_log_time_consistency_looks_good()
+        self.log.debug("Threads and processes at the end of the test:")
+        for t in threading.enumerate():
+            self.log.debug(f"Active thread: {t.name} (id={t.ident}, daemon={t.daemon}, repr={repr(t)})")
 
     @silence()
     def _check_if_db_log_time_consistency_looks_good(self):


### PR DESCRIPTION
When test ends it may hang due awaiting ssh command completion, while
connection was closed (when finishing a test).
This happened due `tail -f` running forever against HDR Histogram log
file.

Fix by ending this `tail -f` command with `pkill`, so reader thread ends
normally and closes all ssh connections.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11258

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [see jenkins](https://jenkins.scylladb.com/job/scylla-staging/job/lukasz/job/perf-regression-predefined-throughput-steps-sanity-vnodes/10) - ends without issues 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
