### PR TITLE
improvement(images): do not rebuild scylladb image

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -391,10 +391,11 @@ class ArtifactsTest(ClusterTester):
         with self.logged_subtest("check cqlsh installation"):
             self.check_cqlsh()
 
-        with self.logged_subtest("check node_exporter liveness"):
-            node_info_service = NodeLoadInfoServices().get(self.node)
-            assert node_info_service.cpu_load_5
-            assert node_info_service.get_node_boot_time_seconds()
+        if backend != 'docker':
+            with self.logged_subtest("check node_exporter liveness"):
+                node_info_service = NodeLoadInfoServices().get(self.node)
+                assert node_info_service.cpu_load_5
+                assert node_info_service.get_node_boot_time_seconds()
 
         if self.params.get("run_scylla_doctor"):
             with self.logged_subtest("check scylla_doctor results"):
@@ -463,7 +464,7 @@ class ArtifactsTest(ClusterTester):
             # So we don't need to stop and to start it again
             self.check_scylla()
 
-            if not self.node.is_nonroot_install:
+            if not self.node.is_nonroot_install and backend != 'docker':
                 self.log.info("Validate version after stop/start")
                 with self.actions_log.action_scope("Validate version after stop/start"):
                     self.check_housekeeping_service_status(backend=backend)
@@ -477,7 +478,7 @@ class ArtifactsTest(ClusterTester):
             self.node.restart_scylla(verify_up_after=True)
             self.check_scylla()
 
-            if not self.node.is_nonroot_install:
+            if not self.node.is_nonroot_install and backend != 'docker':
                 self.log.info("Validate version after restart")
                 self.check_housekeeping_service_status(backend=backend)
                 self.check_scylla_version_in_housekeepingdb(prev_id=version_id_after_stop,

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -19,6 +19,7 @@ from functools import cached_property
 
 from sdcm import cluster
 from sdcm.remote import LOCALRUNNER
+from sdcm.remote.docker_cmd_runner import DockerCmdRunner
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.filters import DbEventsFilter
 from sdcm.utils.docker_utils import get_docker_bridge_gateway, Container, ContainerManager, DockerException
@@ -40,7 +41,7 @@ class ScyllaDockerRequirementError(cluster.ScyllaRequirementError, DockerExcepti
 class NodeContainerMixin:
     @cached_property
     def node_container_image_tag(self):
-        return self.parent_cluster.node_container_image_tag
+        return self.parent_cluster.source_image
 
     def node_container_image_dockerfile_args(self):
         return dict(path=self.parent_cluster.node_container_context_path)
@@ -87,10 +88,19 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):
             assert int(container.labels["NodeIndex"]) == node_index, "Container labeled with wrong index."
             self._containers["node"] = container
 
+    def _init_remoter(self, ssh_login_info):
+        self.remoter = DockerCmdRunner(self)
+
+    def _init_port_mapping(self):
+        pass
+
     def _set_keep_duration(self, duration_in_hours: int) -> None:
         pass
 
     def wait_for_cloud_init(self):
+        pass
+
+    def wait_ssh_up(self, verbose=True, timeout=500):
         pass
 
     @property
@@ -106,7 +116,8 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):
         #                          device_index=0
         #                          )]
 
-    def is_docker(self):
+    @staticmethod
+    def is_docker():
         return True
 
     @cached_property
@@ -140,21 +151,27 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):
         ContainerManager.get_container(self, "node").restart()
 
     def get_service_status(self, service_name: str, timeout: int = 500, ignore_status=False):
-        return self.remoter.sudo('sh -c "{0} || {0}.service"'.format(f"supervisorctl status {service_name}"),
-                                 timeout=timeout, ignore_status=ignore_status)
+        container_status = ContainerManager.get_container(self, "node").attrs['State']['Status']
+        # return similar interface to what supervisorctl would return
+        return type('ServiceStatus', (), {
+            'stdout': f"{service_name} {container_status}",
+            'stderr': "",
+            'ok': container_status in ['running', 'active', 'RUNNING']
+        })
 
     def start_scylla_server(self, verify_up=True, verify_down=False, timeout=300, verify_up_timeout=None):
         verify_up_timeout = verify_up_timeout or self.verify_up_timeout
         if verify_down:
             self.wait_db_down(timeout=timeout)
-        self.remoter.sudo('sh -c "{0} || {0}-server"'.format("supervisorctl start scylla"),
-                          timeout=timeout)
+
+        container = ContainerManager.get_container(self, "node")
+        if container.status != 'running':
+            self.log.info("Starting Docker container %s", container.name)
+            container.start()
+            ContainerManager.wait_for_status(self, "node", status="running")
+
         if verify_up:
             self.wait_db_up(timeout=verify_up_timeout)
-
-        # Need to start the scylla-housekeeping service manually because of autostart of this service is disabled
-        # for the docker backend. See, for example, docker/scylla-sct/ubuntu/Dockerfile
-        self.start_scylla_housekeeping_service(timeout=timeout)
 
     @cluster.log_run_info
     def start_scylla(self, verify_up=True, verify_down=False, timeout=300):
@@ -163,24 +180,15 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):
     def stop_scylla_server(self, verify_up=False, verify_down=True, timeout=300, ignore_status=False):
         if verify_up:
             self.wait_db_up(timeout=timeout)
+
+        container = ContainerManager.get_container(self, "node")
+        self.log.info(f"Stopping Docker container {container.name}")
         # ignoring WARN messages upon stopping - https://github.com/scylladb/scylla-cluster-tests/issues/10633
         with DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line="WARN "):
-            self.remoter.sudo('sh -c "{0} || {0}-server"'.format("supervisorctl stop scylla"),
-                              timeout=timeout)
+            container.stop(timeout=timeout)
+
         if verify_down:
             self.wait_db_down(timeout=timeout)
-
-        # Need to start the scylla-housekeeping service manually because of autostart of this service is disabled
-        # for the docker backend. See, for example, docker/scylla-sct/ubuntu/Dockerfile
-        self.stop_scylla_housekeeping_service(timeout=timeout)
-
-    def stop_scylla_housekeeping_service(self, timeout=300):
-        self.remoter.sudo('sh -c "{0} || {0}-server"'.format("supervisorctl stop scylla-housekeeping"),
-                          timeout=timeout)
-
-    def start_scylla_housekeeping_service(self, timeout=300):
-        self.remoter.sudo('sh -c "{0} || {0}-server"'.format("supervisorctl start scylla-housekeeping"),
-                          timeout=timeout)
 
     @cluster.log_run_info
     def stop_scylla(self, verify_up=False, verify_down=True, timeout=300):
@@ -192,15 +200,15 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):
         if verify_up_before:
             self.wait_db_up(timeout=verify_up_timeout)
 
-        # Need to restart the scylla-housekeeping service manually because of autostart of this service is disabled
-        # for the docker backend. See, for example, docker/scylla-sct/ubuntu/Dockerfile
-        self.stop_scylla_housekeeping_service(timeout=timeout)
+        container = ContainerManager.get_container(self, "node")
+        self.log.info(f"Restarting Docker container {container.name}")
         # ignoring WARN messages upon stopping - https://github.com/scylladb/scylla-cluster-tests/issues/10633
         with DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line="WARN "):
-            self.remoter.sudo('sh -c "{0} || {0}-server"'.format("supervisorctl restart scylla"), timeout=timeout)
+            container.restart(timeout=timeout)
+            ContainerManager.wait_for_status(self, "node", status="running")
+
         if verify_up_after:
             self.wait_db_up(timeout=verify_up_timeout)
-        self.start_scylla_housekeeping_service(timeout=timeout)
 
     @cluster.log_run_info
     def restart_scylla(self, verify_up_before=False, verify_up_after=True, timeout=1800) -> None:
@@ -218,6 +226,28 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):
     def region(self):
         return "docker"
 
+    def do_default_installations(self):
+        self.install_sudo()
+        self.install_package("tar")
+        super().do_default_installations()
+
+    def install_sudo(self, user: str = 'scylla', verbose=False):
+        """Install and configure passwordless sudo"""
+        pkg_mgr = 'microdnf' if self.distro.is_rhel_like else 'apt'
+        self.remoter.run(f'{pkg_mgr} install -y sudo', verbose=verbose, ignore_status=True, user='root')
+
+        self.remoter.run("mkdir -p /etc/sudoers.d", user='root', ignore_status=True, verbose=verbose)
+        sudoers_file = f"/etc/sudoers.d/{user}-nopasswd"
+        sudoers_content = f"{user} ALL=(ALL) NOPASSWD: ALL"
+        self.remoter.run(f"echo '{sudoers_content}' > {sudoers_file}", user='root', verbose=verbose, ignore_status=True)
+        self.remoter.run(f"chmod 440 {sudoers_file}", user='root', verbose=verbose, ignore_status=True)
+
+        verify_result = self.remoter.run("sudo -n true", ignore_status=True, verbose=verbose)
+        if verify_result.ok:
+            self.log.debug("Passwordless sudo configured successfully for user %s", user)
+        else:
+            self.log.warning("Passwordless sudo verification failed: %s", verify_result.stderr)
+
 
 class DockerCluster(cluster.BaseCluster):
     node_container_user = "scylla-test"
@@ -232,7 +262,6 @@ class DockerCluster(cluster.BaseCluster):
                  n_nodes: Union[list, int] = 3,
                  params: dict = None) -> None:
         self.source_image = f"{docker_image}:{docker_image_tag}"
-        self.node_container_image_tag = f"scylla-sct:{node_type}-{str(self.test_config.test_id())[:8]}"
         self.node_container_key_file = node_key_file
 
         super().__init__(cluster_prefix=cluster_prefix,
@@ -259,11 +288,9 @@ class DockerCluster(cluster.BaseCluster):
                           node_index=node_index)
 
         if container is None:
-            ContainerManager.build_container_image(node, "node")
-
-        ContainerManager.run_container(node, "node", seed_ip=self.nodes[0].public_ip_address if node_index else None)
-        ContainerManager.wait_for_status(node, "node", status="running")
-        ContainerManager.ssh_copy_id(node, "node", self.node_container_user, self.node_container_key_file)
+            ContainerManager.run_container(
+                node, "node", seed_ip=self.nodes[0].public_ip_address if node_index else None)
+            ContainerManager.wait_for_status(node, "node", status="running")
 
         node.init()
 
@@ -317,23 +344,19 @@ class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):
                          params=params)
 
     def node_setup(self, node, verbose=False, timeout=3600):
-        node.wait_ssh_up(verbose=verbose)
-
         node.is_scylla_installed(raise_if_not_installed=True)
-
         self.check_aio_max_nr(node)
-
         if self.test_config.BACKTRACE_DECODING:
             node.install_scylla_debuginfo()
 
+        node.install_package("procps-ng")
         node.config_setup(append_scylla_args=self.get_scylla_args())
-
-        node.stop_scylla_server(verify_down=False)
-        node.remoter.sudo('rm -Rf /var/lib/scylla/data/*')  # Clear data folder to drop wrong cluster name data.
+        node.restart_scylla(verify_up_before=True)
 
     def node_startup(self, node, verbose=False, timeout=3600):
-        node.start_scylla_server(verify_up=False)
-
+        if not ContainerManager.is_running(node, "node"):
+            container = ContainerManager.get_container(node, "node")
+            container.start()
         node.wait_db_up(verbose=verbose, timeout=timeout)
         for event in check_nodes_status(nodes_status=node.get_nodes_status(),
                                         current_node=node,
@@ -389,14 +412,49 @@ class LoaderSetDocker(cluster.BaseLoaderSet, DockerCluster):
                                params=params)
 
     def node_setup(self, node: DockerNode, verbose=False, **kwargs):
-        node.wait_ssh_up(verbose=verbose)
         node.remoter.sudo("apt update", verbose=True, ignore_status=True)
         node.remoter.sudo("apt install -y openjdk-8-jre", verbose=True, ignore_status=True)
         node.remoter.sudo("ln -sf /usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/bin/java* /etc/alternatives/java",
                           verbose=True, ignore_status=True)
 
+        self._install_docker_cli(node, verbose=verbose)
         if self.params.get('client_encrypt'):
             node.config_client_encrypt()
+
+    def _install_docker_cli(self, node, verbose=False):
+        result = node.remoter.run("docker --version", ignore_status=True, verbose=False)
+        if result.ok:
+            self.log.debug("Docker CLI already installed on loader node: %s", result.stdout.strip())
+            return
+
+        self.log.debug("Installing Docker CLI on loader node")
+
+        commands = (
+            [
+                'apt update',
+                'apt install -y gnupg2 software-properties-common lsb-release',
+                'curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -',
+                'add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"',
+                'apt update',
+                'apt install -y docker-ce-cli'
+            ]
+            if node.distro.is_debian_like
+            else [
+                'curl -L https://download.docker.com/linux/centos/docker-ce.repo -o /etc/yum.repos.d/docker-ce.repo',
+                'microdnf -y update',
+                'microdnf -y install docker-ce-cli'
+            ])
+
+        for cmd in commands:
+            result = node.remoter.run(cmd, timeout=300, verbose=verbose, ignore_status=True, retry=3, user='root')
+            if not result.ok:
+                raise RuntimeError(f"Command {cmd} failed with error: {result.stderr.strip()}")
+
+        verify = node.remoter.run("docker --version", ignore_status=True)
+        if verify.ok:
+            self.log.info("Docker CLI installed successfully: %s", verify.stdout.strip())
+        else:
+            raise RuntimeError("Docker CLI installation verification failed")
 
 
 class DockerMonitoringNode(cluster.BaseNode):
@@ -430,9 +488,6 @@ class DockerMonitoringNode(cluster.BaseNode):
         self.remoter = LOCALRUNNER
 
     def _init_port_mapping(self):
-        pass
-
-    def wait_ssh_up(self, verbose=True, timeout=500):
         pass
 
     def update_repo_cache(self):

--- a/sdcm/remote/docker_cmd_runner.py
+++ b/sdcm/remote/docker_cmd_runner.py
@@ -1,0 +1,244 @@
+import time
+import tarfile
+from io import BytesIO
+from typing import TYPE_CHECKING
+from shlex import quote
+from pathlib import Path
+
+from invoke.runners import Result
+from invoke.exceptions import UnexpectedExit
+from invoke.watchers import StreamWatcher
+
+from sdcm.remote.base import CommandRunner, RetryableNetworkException
+from sdcm.utils.decorators import retrying
+from sdcm.utils.docker_utils import ContainerManager
+
+
+if TYPE_CHECKING:
+    from sdcm.cluster_docker import DockerNode
+
+
+class DockerCmdRunner(CommandRunner):
+    """Command runner for executing commands inside a Docker container on the node"""
+
+    def __init__(self, node: 'DockerNode'):
+        super().__init__(user='scylla-test', hostname=node.name)
+        self.node = node
+        self._container = None
+
+    def _get_container(self):
+        """Retrieve and cache the Docker container associated with the node"""
+        if self._container:
+            try:
+                self._container.reload()
+                if self._container.status != 'running':
+                    # reset cache
+                    self._container = None
+            except Exception:  # noqa: BLE001
+                self._container = None
+
+        if not self._container:
+            self._container = ContainerManager.get_container(self.node, "node")
+            if not self._container:
+                raise RuntimeError(f"Container for node {self.node.name} could not be resolved by ContainerManager.")
+
+        return self._container
+
+    @property
+    def connection(self):
+        return self._get_container()
+
+    def _create_connection(self):
+        self._get_container()
+
+    def is_up(self, timeout: float | None = None) -> bool:
+        """Check if the Docker container associated with the node is running"""
+        try:
+            return ContainerManager.is_running(self.node, "node")
+        except Exception:  # noqa: BLE001
+            return False
+
+    def run(
+        self, cmd: str, timeout: float | None = None, ignore_status: bool = False, verbose: bool = True,
+        new_session: bool = False, log_file: str | None = None, retry: int = 1,
+        watchers: list[StreamWatcher] | None = None, change_context: bool = False, user: str | None = ''
+    ) -> Result:
+        """Execute a command inside a Docker container"""
+        watchers_list = self._setup_watchers(verbose, log_file, watchers)
+
+        @retrying(n=retry, sleep_time=3, allowed_exceptions=(RetryableNetworkException,))
+        def _run():
+            return self._execute_command(cmd, timeout, ignore_status, verbose, watchers_list, user)
+
+        result = _run()
+        self._print_command_results(result, verbose, ignore_status)
+        return result
+
+    def _execute_command(
+        self, cmd: str, timeout: float | None, ignore_status: bool, verbose: bool,
+        watchers: list[StreamWatcher], user: str | None = ''
+    ) -> Result:
+        start_time = time.perf_counter()
+
+        if verbose:
+            self.log.debug('<%s>: Docker exec command: "%s"', self.node.name, cmd)
+
+        container = self._get_container()
+
+        if not container or container.status != 'running':
+            err_msg = f"Container {container.name if container else 'unknown'} for node {self.node.name} is not running."
+            self.log.error(err_msg)
+            result = Result(command=cmd, exited=127, stdout="", stderr=err_msg)
+            result.duration = time.perf_counter() - start_time
+            if not ignore_status:
+                raise UnexpectedExit(result)
+            return result
+
+        try:
+            exec_output = container.exec_run(["sh", "-c", cmd], tty=False, demux=True, stream=False, user=user)
+            stdout_bytes, stderr_bytes = exec_output.output if isinstance(exec_output.output, tuple) else (b"", b"")
+
+            result = Result(
+                command=cmd,
+                exited=exec_output.exit_code,
+                stdout=stdout_bytes.decode(errors='replace') if stdout_bytes else "",
+                stderr=stderr_bytes.decode(errors='replace') if stderr_bytes else "")
+            result.duration = time.perf_counter() - start_time
+            result.exit_status = exec_output.exit_code
+
+            if verbose:
+                self.log.debug('<%s>: Docker exec result (status=%d, duration=%.2fs)\nStdout:\n%s\nStderr:\n%s',
+                               self.node.name, result.exited, result.duration, result.stdout, result.stderr)
+            if result.exited != 0 and not ignore_status:
+                raise UnexpectedExit(result)
+
+            return result
+
+        except UnexpectedExit:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            duration = time.perf_counter() - start_time
+            self.log.error("Exception during docker exec on %s for command '%s': %s",
+                           self.node.name, cmd, str(exc), exc_info=True)
+            result = Result(command=cmd, exited=255, stdout="", stderr=str(exc))
+            result.duration = duration
+            if not ignore_status:
+                raise UnexpectedExit(result) from exc
+            return result
+
+    @staticmethod
+    def _create_tar_stream(src: str, dst: str) -> BytesIO:
+        """Create a tar stream from a file or directory"""
+        tar_stream = BytesIO()
+        src_path = Path(src)
+        with tarfile.open(fileobj=tar_stream, mode='w') as tar:
+            if src_path.is_dir():
+                for file_path in src_path.rglob('*'):
+                    if file_path.is_file():
+                        tar.add(str(file_path), arcname=str(file_path.relative_to(src_path.parent)))
+            else:
+                arcname = Path(dst).name if not dst.endswith('/') else src_path.name
+                tar.add(str(src_path), arcname=arcname)
+        tar_stream.seek(0)
+        return tar_stream
+
+    @staticmethod
+    def _extract_tar_stream(tar_bytes: BytesIO, dst: str):
+        """Extract a tar stream to the destination path"""
+        dst_path = Path(dst)
+        with tarfile.open(fileobj=tar_bytes, mode='r') as tar:
+            if dst_path.is_dir() or str(dst).endswith('/'):
+                dst_path.mkdir(parents=True, exist_ok=True)
+                tar.extractall(path=str(dst_path))
+            else:
+                members = tar.getmembers()
+                if len(members) == 1 and members[0].isfile():
+                    dst_path.parent.mkdir(parents=True, exist_ok=True)
+                    with open(dst_path, 'wb') as out_f:
+                        tar_member = tar.extractfile(members[0])
+                        if tar_member:
+                            out_f.write(tar_member.read())
+                else:
+                    dst_path.parent.mkdir(parents=True, exist_ok=True)
+                    tar.extractall(path=str(dst_path.parent))
+
+    @retrying(n=3, sleep_time=5, allowed_exceptions=(Exception,))
+    def send_files(
+        self, src: str, dst: str, delete_dst: bool = False, preserve_symlinks: bool = False,
+        verbose: bool = False, timeout: float = 300, **kwargs
+    ) -> bool:
+        """Sends files from the local filesystem to a specified path inside a Docker container"""
+        container = self._get_container()
+
+        if verbose:
+            self.log.debug("Sending local '%s' to container '%s:%s'", src, container.name, dst)
+
+        try:
+            if delete_dst:
+                self.run(f"rm -rf {quote(dst)}", ignore_status=True, verbose=False)
+
+            tar_stream = self._create_tar_stream(src, dst)
+            dst_path = Path(dst)
+            extraction_dir = dst if dst.endswith('/') or not dst_path.suffix else str(dst_path.parent)
+            self.run(f"mkdir -p {quote(extraction_dir)}", ignore_status=True, verbose=False)
+            container.put_archive(path=extraction_dir, data=tar_stream)
+
+            if verbose:
+                self.log.info("Sent '%s' to '%s:%s'", src, container.name, dst)
+            return True
+
+        except Exception as e:
+            self.log.error("Failed to send '%s' to container '%s:%s': %s",
+                           src, container.name, dst, str(e), exc_info=True)
+            return False
+
+    @retrying(n=3, sleep_time=5, allowed_exceptions=(Exception,))
+    def receive_files(
+        self, src: str, dst: str, delete_dst: bool = False, preserve_perm: bool = True,
+        preserve_symlinks: bool = False, timeout: float = 300, **kwargs
+    ) -> bool:
+        """Receives files from a specified path inside a Docker container to the local filesystem"""
+        container = self._get_container()
+
+        try:
+            dst_path = Path(dst)
+            if delete_dst and dst_path.exists():
+                if dst_path.is_dir():
+                    import shutil
+                    shutil.rmtree(dst_path)
+                else:
+                    dst_path.unlink()
+
+            tar_stream_bits, _ = container.get_archive(src)
+            tar_bytes = BytesIO()
+            for chunk in tar_stream_bits:
+                tar_bytes.write(chunk)
+            tar_bytes.seek(0)
+
+            self._extract_tar_stream(tar_bytes, dst)
+            self.log.info("Received '%s:%s' to local '%s'", container.name, src, dst)
+            return True
+
+        except Exception as e:
+            self.log.error("Failed to receive from container '%s:%s' to local '%s': %s",
+                           container.name, src, dst, str(e), exc_info=True)
+            return False
+
+    def sudo(
+        self, cmd: str, timeout: float | None = None, ignore_status: bool = False, verbose: bool = True,
+        new_session: bool = False, log_file: str | None = None, retry: int = 1,
+        watchers: list[StreamWatcher] | None = None, user: str | None = 'root'
+    ) -> Result:
+        return self.run(cmd=cmd, timeout=timeout, ignore_status=ignore_status,
+                        verbose=verbose, new_session=new_session, log_file=log_file,
+                        retry=retry, watchers=watchers, user=user)
+
+    def file_exists(self, file_path: str) -> bool:
+        result = self.run(f"test -e {quote(file_path)}", ignore_status=True, verbose=False)
+        return result.ok
+
+    def get_init_arguments(self) -> dict:
+        return {'node_name': self.node.name, 'type': 'DockerCmdRunner'}
+
+    def __del__(self):
+        self._container = None

--- a/sdcm/utils/docker_utils.py
+++ b/sdcm/utils/docker_utils.py
@@ -541,9 +541,12 @@ def docker_hub_login(remoter: CommandRunner, use_sudo: bool = False) -> None:
         remoter.log.debug("not in jenkins, skipping login to docker hub")
         return
     docker_hub_creds = get_docker_hub_credentials()
-    password_file = remoter.run("mktemp").stdout.strip()
-    with remote_file(remoter=remoter, remote_path=password_file) as fobj:
+    password_file = remote_cmd("mktemp").stdout.strip()
+    if use_sudo:
+        remote_cmd(f"chmod 644 '{password_file}'")
+
+    with remote_file(remoter=remoter, remote_path=password_file, sudo=use_sudo) as fobj:
         fobj.write(docker_hub_creds["password"])
     remoter.log.debug("Login to Docker Hub as `%s'", docker_hub_creds["username"])
     remote_cmd(f"docker login --username {docker_hub_creds['username']} --password-stdin < '{password_file}'")
-    remoter.run(f"rm '{password_file}'")
+    remote_cmd(f"rm '{password_file}'")

--- a/unit_tests/test_docker_cmd_runner.py
+++ b/unit_tests/test_docker_cmd_runner.py
@@ -1,0 +1,203 @@
+import tarfile
+import tempfile
+import unittest
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+from invoke.exceptions import UnexpectedExit
+from invoke.watchers import StreamWatcher
+
+from sdcm.remote.docker_cmd_runner import DockerCmdRunner
+
+
+class DummyNode:
+    name = 'dummy-node'
+
+
+class TestWatcher(StreamWatcher):
+    def __init__(self):
+        self.submissions = []
+
+    def submit(self, output):
+        self.submissions.append(output)
+
+
+class TestDockerCmdRunner(unittest.TestCase):
+    def setUp(self):
+        self.node = DummyNode()
+        self.runner = DockerCmdRunner(self.node)
+        self.runner._container = MagicMock()
+        self.runner.log = MagicMock()
+
+    @patch('sdcm.remote.docker_cmd_runner.ContainerManager')
+    def test_get_container_no_cache(self, mock_cm):
+        mock_container = MagicMock()
+        mock_cm.get_container.return_value = mock_container
+
+        runner = DockerCmdRunner(self.node)
+        runner._container = None
+        result = runner._get_container()
+
+        self.assertEqual(result, runner._container)
+        mock_cm.get_container.assert_called_once_with(self.node, "node")
+
+    @patch('sdcm.remote.docker_cmd_runner.ContainerManager')
+    def test_get_container_cached_running(self, mock_cm):
+        mock_container = MagicMock(status='running')
+
+        runner = DockerCmdRunner(self.node)
+        runner._container = mock_container
+        result = runner._get_container()
+
+        self.assertEqual(result, mock_container)
+        mock_container.reload.assert_called_once()
+        mock_cm.get_container.assert_not_called()
+
+    @patch('sdcm.remote.docker_cmd_runner.ContainerManager')
+    def test_get_container_cached_not_running(self, mock_cm):
+        old_container = MagicMock(status='exited')
+        new_container = MagicMock()
+        mock_cm.get_container.return_value = new_container
+
+        runner = DockerCmdRunner(self.node)
+        runner._container = old_container
+        result = runner._get_container()
+
+        self.assertEqual(result, new_container)
+        self.assertEqual(result, runner._container)
+        old_container.reload.assert_called_once()
+        mock_cm.get_container.assert_called_once_with(self.node, "node")
+
+    @patch('sdcm.remote.docker_cmd_runner.ContainerManager')
+    def test_get_container_not_found(self, mock_cm):
+        mock_cm.get_container.return_value = None
+
+        runner = DockerCmdRunner(self.node)
+        runner._container = None
+
+        with self.assertRaises(RuntimeError, msg="could not be resolved"):
+            runner._get_container()
+
+        mock_cm.get_container.assert_called_once_with(self.node, "node")
+
+    def test_connection(self):
+        with patch.object(self.runner, '_get_container') as mock_get:
+            mock_container = MagicMock()
+            mock_get.return_value = mock_container
+
+            result = self.runner.connection
+
+            self.assertEqual(result, mock_container)
+            mock_get.assert_called_once()
+
+    @patch('sdcm.remote.docker_cmd_runner.ContainerManager')
+    def test_container_is_up(self, mock_cm):
+        mock_cm.is_running.return_value = True
+        self.assertTrue(self.runner.is_up())
+        mock_cm.is_running.assert_called_once_with(self.node, "node")
+
+        mock_cm.is_running.return_value = False
+        self.assertFalse(self.runner.is_up())
+
+    def test_execute_command_success(self):
+        """Test _execute_command with successful execution"""
+        mock_container = MagicMock(status='running')
+        mock_container.exec_run.return_value = MagicMock(
+            exit_code=0,
+            output=(b'hello world', b''))
+
+        with patch.object(self.runner, '_get_container', return_value=mock_container):
+            result = self.runner._execute_command('echo hello', 30, False, True, [])
+
+        self.assertEqual(result.exited, 0)
+        self.assertEqual(result.stdout, 'hello world')
+        self.assertEqual(result.stderr, '')
+        self.assertGreater(result.duration, 0)
+        mock_container.exec_run.assert_called_once_with(
+            ["sh", "-c", "echo hello"], tty=False, demux=True, stream=False, user='')
+
+    def test_execute_command_with_stderr(self):
+        mock_container = MagicMock(status='running')
+        mock_container.exec_run.return_value = MagicMock(
+            exit_code=1,
+            output=(b'', b'error message'))
+
+        with patch.object(self.runner, '_get_container', return_value=mock_container):
+            with self.assertRaises(UnexpectedExit):
+                self.runner._execute_command('false', 30, False, True, [])
+
+    @patch('sdcm.remote.docker_cmd_runner.retrying')
+    def test_run(self, mock_retrying):
+        mock_retrying.return_value = lambda f: f  # No-op decorator
+
+        with (patch.object(self.runner, '_execute_command') as mock_exec,
+              patch.object(self.runner, '_setup_watchers') as mock_setup,
+              patch.object(self.runner, '_print_command_results') as mock_print):
+            mock_result = MagicMock()
+            mock_exec.return_value = mock_result
+            mock_setup.return_value = []
+            result = self.runner.run('echo hello', timeout=30, verbose=True)
+
+        self.assertEqual(result, mock_result)
+        mock_setup.assert_called_once_with(True, None, None)
+        mock_exec.assert_called_once_with('echo hello', 30, False, True, [], '')
+        mock_print.assert_called_once_with(mock_result, True, False)
+
+    @patch('sdcm.remote.docker_cmd_runner.retrying')
+    def test_send_files(self, mock_retrying):
+        mock_retrying.return_value = lambda f: f
+
+        mock_container = MagicMock()
+        mock_container.name = 'test-container'
+
+        with (tempfile.NamedTemporaryFile(mode='w', delete=True) as temp_file,
+              patch.object(self.runner, '_get_container', return_value=mock_container),
+              patch.object(self.runner, 'run') as mock_run,
+              patch.object(self.runner, '_create_tar_stream') as mock_create_tar):
+            temp_file.write('test data')
+            temp_file.flush()
+
+            mock_tar_stream = BytesIO(b'tar data')
+            mock_create_tar.return_value = mock_tar_stream
+            mock_run.return_value = MagicMock(ok=True)
+
+            result = self.runner.send_files(temp_file.name, '/dest/path')
+
+        self.assertTrue(result)
+        mock_container.put_archive.assert_called_once()
+        mock_create_tar.assert_called_once_with(temp_file.name, '/dest/path')
+
+    @patch('sdcm.remote.docker_cmd_runner.retrying')
+    def test_receive_files(self, mock_retrying):
+        mock_retrying.return_value = lambda f: f
+
+        tar_stream = BytesIO()
+        with tarfile.open(fileobj=tar_stream, mode='w') as tar:
+            info = tarfile.TarInfo('file.txt')
+            content = b'hello world'
+            info.size = len(content)
+            tar.addfile(info, BytesIO(content))
+        tar_stream.seek(0)
+
+        mock_container = MagicMock()
+        mock_container.name = 'test-container'
+        tar_data = tar_stream.getvalue()
+        mock_container.get_archive.return_value = ([tar_data], {})
+
+        with (tempfile.NamedTemporaryFile(mode='w+', delete=True) as temp_file,
+              patch.object(self.runner, '_get_container', return_value=mock_container)):
+            result = self.runner.receive_files('/src/file.txt', temp_file.name)
+
+            self.assertTrue(result)
+            temp_file.seek(0)
+            self.assertEqual(temp_file.read(), 'hello world')
+
+    def test_sudo_with_non_root_user(self):
+        with patch.object(self.runner, 'run', return_value=MagicMock()) as mock_run:
+            cmd = 'ls -la'
+            result = self.runner.sudo(cmd, user='testuser')
+
+            self.assertEqual(result, mock_run.return_value)
+            mock_run.assert_called_once_with(
+                cmd=f'{cmd}', timeout=None, ignore_status=False, verbose=True,
+                new_session=False, log_file=None, retry=1, watchers=None,  user='testuser')


### PR DESCRIPTION
Re-applying the PR which was previously reverted due to regression for regular, non-docker, scenario (was visible on regular pr-provision-test):

The change drops rebuilding scylladb image as `scylla-sct` image. Instead, scylladb docker image is used as is for the docker backend. For that purpose the new DockerCmdRunner abstraction was introduced, to allow operating docker based nodes directly using docker API (instead of sshing into container)

Additionally, artifacts_test was updated to skip subtests/operations for the services, which are no longer supported by scylladb docker image (or are about to be dropped) - node-exporter and scylla-hosekeeping .

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [pr-provision-test (on aws)](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/pr-provision-test/87/)
- [x] :green_circle: [pr-provision-docker-test](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/pr-provision-test/88/)
- [x] :green_circle: [artifacts-docker-test](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/artifacts-docker-test/22/)
- [x] :green_circle: [artifacts-ubuntu2204-test](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/artifacts-ubuntu2204-test/15/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
