### PR TITLE
fix(show-monitor): support jobs with older logs urls

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -315,7 +315,7 @@ class S3Storage():
     def download_file(self, link, dst_dir):
         """Download file from S3 bucket or Argus proxy link."""
 
-        if not self.s3_host_name_regex.match(urlparse(link).hostname):
+        if not self.s3_host_name_regex.match(link):
             # get the actual s3 link from Argus first
             creds = KeyStore().get_argus_rest_credentials()
             headers = {"Authorization": f"token {creds['token']}", **creds["extra_headers"]}


### PR DESCRIPTION
9cbf27873be9e3db9c96a6e78ddaf45caae32c1d got the logic wrong and was apply the regex ontop of the hostname only, while it was trying to match a full url with the `http` prefix.

we failed to noticed it, since we didn't test both options with the new urls, and without. and it was backported before the change of the urls, assuming it's not an issue.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
