### PR TITLE
ix(run_nemesis): move run_nemesis routine to node_allocator

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -32,7 +32,6 @@ import itertools
 import json
 import shlex
 from decimal import Decimal, ROUND_UP
-from importlib import import_module
 from typing import List, Optional, Dict, Union, Set, Iterable, ContextManager, Any, IO, AnyStr, Callable
 from datetime import datetime, timezone
 from textwrap import dedent
@@ -4739,9 +4738,9 @@ class BaseScyllaCluster:
                         message=f"Failed to rotate AWS KMS key for the '{kms_key_alias_name}' alias",
                         traceback=traceback.format_exc()).publish()
                 try:
-                    nemesis_class = self.nemesis[0] if self.nemesis else getattr(
-                        import_module('sdcm.nemesis'), "Nemesis")
-                    with nemesis_class.run_nemesis(node_list=db_cluster.data_nodes, nemesis_label="KMS encryption check") as target_node:
+                    nemesis_node_allocator = self.test_config.tester_obj().nemesis_allocator
+                    with nemesis_node_allocator.run_nemesis(nemesis_label="KMS encryption check",
+                                                            node_list=db_cluster.data_nodes) as target_node:
                         self.log.debug("Target node for 'rotate_kms_key' is %s", target_node.name)
 
                         ks_cf_list = db_cluster.get_non_system_ks_cf_list(

--- a/sdcm/kcl_thread.py
+++ b/sdcm/kcl_thread.py
@@ -21,7 +21,6 @@ import threading
 from functools import cached_property
 from typing import Dict
 
-from sdcm.nemesis import Nemesis
 from sdcm.stress_thread import DockerBasedStressThread
 from sdcm.stress.base import format_stress_cmd_error
 from sdcm.utils.docker_remote import RemoteDocker
@@ -134,8 +133,12 @@ class CompareTablesSizesThread(DockerBasedStressThread):
             dst_table = self._options.get('dst_table')
             end_time = time.time() + self._timeout
 
+            cluster = self.node_list[0].parent_cluster
+            nemesis_node_allocator = cluster.test_config.tester_obj().nemesis_allocator
+
             while not self._stop_event.is_set():
-                with Nemesis.run_nemesis(node_list=self.node_list, nemesis_label="Compare tables size by cf-stats") as node:
+                with nemesis_node_allocator.run_nemesis(nemesis_label="Compare tables size by cf-stats",
+                                                        node_list=self.node_list) as node:
                     node.run_nodetool('flush')
 
                     dst_size = node.get_cfstats(dst_table)['Number of partitions (estimate)']

--- a/sdcm/utils/nemesis_utils/__init__.py
+++ b/sdcm/utils/nemesis_utils/__init__.py
@@ -1,4 +1,5 @@
 import enum
+from uuid import uuid4
 
 
 class NEMESIS_TARGET_POOLS(enum.Enum):
@@ -11,3 +12,10 @@ class DefaultValue:
     """
     This is class is intended to be used as default value for the cases when None is not applicable
     """
+
+
+def unique_disruption_name(disruption: str) -> str:
+    """Generates a unique disruption label to be able to differentiate between multiple parallel disruptions."""
+    if "_" in disruption:
+        disruption = "".join(p.capitalize() for p in disruption.replace("disrupt_", "").split("_"))
+    return f"{disruption}-{uuid4().hex[:8]}"


### PR DESCRIPTION
After introducing nemesis node allocator feature, the `Nemesis.run_nemesis` was converted from a static method to an instance method, to be able to access
node_allocator attribute of a nemesis object. However, this was not an optimal design, as node_allocator is a singleton that is always available once tester object is initialized.

This change fixes this design by moving `run_nemesis` routine from Nemesis class to node_allocator abstraction. This allows `run_nemesis` to be used without
requiring a nemesis object, while also preserving backward compatibility.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11325

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [rolling-upgrade-ami-arm-test](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/rolling-upgrade-ami-arm-test/3/)
- [x] :orange_circle: [longevity-100gb-4h-test with 2 parallel nemeses, one 'non disruptive' and 'topology changes' selectors](https://argus.scylladb.com/tests/scylla-cluster-tests/7a45d479-8945-402a-9328-6696804e8eba).
The test has a failed nemesis, but it is due to known issue, not related to this change.
Among executed nemeses there a few, which execute run_nemesis (the version refactored in this change), e.g.:
```
❯ egrep -i 'node_allocator' sct-7a45d479.log | grep Block
< t:2025-07-07 20:37:32,534 f:node_allocator.py l:129  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > RefuseConnectionWithBlockScyllaPortsOnBannedNode-25a96f6c: selected target node longevity-100gb-4h-sync-par-db-node-7a45d479-2. Marked it as running nemesis.
< t:2025-07-07 20:37:35,554 f:node_allocator.py l:129  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > BlockScyllaPorts-7e3c7bda: selected target node longevity-100gb-4h-sync-par-db-node-7a45d479-3. Marked it as running nemesis.
< t:2025-07-07 21:34:53,861 f:node_allocator.py l:151  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > RefuseConnectionWithBlockScyllaPortsOnBannedNode-25a96f6c: set running nemesis for node longevity-100gb-4h-sync-par-db-node-7a45d479-7.
< t:2025-07-07 23:31:44,762 f:node_allocator.py l:161  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > BlockScyllaPorts-7e3c7bda: unset running nemesis for node longevity-100gb-4h-sync-par-db-node-7a45d479-3.
< t:2025-07-07 23:33:47,638 f:node_allocator.py l:189  c:sdcm.utils.nemesis_utils.node_allocator p:INFO  > RefuseConnectionWithBlockScyllaPortsOnBannedNode-25a96f6c: unset running nemesis from nodes: ['longevity-100gb-4h-sync-par-db-node-7a45d479-2', 'longevity-100gb-4h-sync-par-db-node-7a45d479-7']
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
