### PR TITLE
Revert "[Backport 2024.1] fix(upgrade_test): increase timeout for truncates"

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -3050,7 +3050,7 @@ class FillDatabaseData(ClusterTester):
 
     @staticmethod
     def cql_truncate_simple_tables(session, rows):
-        truncate_query = 'TRUNCATE TABLE truncate_table%d USING TIMEOUT 300s'
+        truncate_query = 'TRUNCATE TABLE truncate_table%d'
         for i in range(rows):
             session.execute(truncate_query % i)
 
@@ -3184,8 +3184,6 @@ class FillDatabaseData(ClusterTester):
 
     @retrying(n=3, sleep_time=20, allowed_exceptions=ProtocolException)
     def truncate_table(self, session, truncate):  # pylint: disable=no-self-use
-        if "using timeout" not in truncate.lower():
-            truncate = f"{truncate} USING TIMEOUT 300s"
         LOGGER.debug(truncate)
         session.execute(truncate)
 


### PR DESCRIPTION
Reverts scylladb/scylla-cluster-tests#11268

closes: https://github.com/scylladb/scylla-cluster-tests/issues/11341