### PR TITLE
fix(longevity): Increase back node size in longevity-parallel-schema-changes-12h.yaml

### DIFF
--- a/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
@@ -16,7 +16,7 @@ stress_cmd: [
 n_db_nodes: 6
 n_loaders: 2
 
-instance_type_db: 'i4i.xlarge'
+instance_type_db: 'i4i.2xlarge'
 
 nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
 nemesis_selector: ["topology_changes", "schema_changes and not disruptive"]


### PR DESCRIPTION
They were wrongly decreased in d2c7558. Requested by @temichus.
(Rest of the changes in that commit should be ok :D)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] None

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
