### PR TITLE
feature(gemini): use new gemini version 2.0

### DIFF
--- a/defaults/docker_images/gemini/values_gemini.yaml
+++ b/defaults/docker_images/gemini/values_gemini.yaml
@@ -1,2 +1,2 @@
 gemini:
-  image: scylladb/gemini:1.9.3
+  image: scylladb/gemini:2.0.0

--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -18,7 +18,7 @@ gemini_cmd: |
   --mode mixed
 
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
-gemini_log_cql_statements: false
+gemini_log_cql_statements: true
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i4i.16xlarge'

--- a/test-cases/gemini/gemini-3h-cdc-postimage-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-postimage-write.yaml
@@ -13,6 +13,6 @@ gemini_cmd: |
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 gemini_table_options:
   - "cdc={'enabled': true, 'postimage': true}"
-gemini_log_cql_statements: false
+gemini_log_cql_statements: true
 
 db_type: scylla

--- a/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
@@ -13,6 +13,6 @@ gemini_cmd: |
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 gemini_table_options:
   - "cdc={'enabled': true, 'preimage': true}"
-gemini_log_cql_statements: false
+gemini_log_cql_statements: true
 
 db_type: scylla

--- a/test-cases/gemini/gemini-3h-cdc-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-write.yaml
@@ -13,6 +13,6 @@ gemini_cmd: |
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 gemini_table_options:
   - "cdc={'enabled': true}"
-gemini_log_cql_statements: false
+gemini_log_cql_statements: true
 
 db_type: scylla

--- a/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
@@ -20,7 +20,7 @@ gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'
 gemini_table_options:
   - "cdc={'enabled': true, 'preimage': true, 'postimage': true}"
   - "compaction={'class': 'IncrementalCompactionStrategy'}"
-gemini_log_cql_statements: false
+gemini_log_cql_statements: true
 
 stress_cdclog_reader_cmd: "cdc-stressor -duration 215m -stream-query-round-duration 30s"
 

--- a/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
@@ -19,7 +19,7 @@ gemini_cmd: |
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 gemini_table_options:
   - "compaction={'class': 'IncrementalCompactionStrategy'}"
-gemini_log_cql_statements: false
+gemini_log_cql_statements: true
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i4i.8xlarge'

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -17,7 +17,7 @@ gemini_cmd: |
   --mode mixed
 
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
-gemini_log_cql_statements: false
+gemini_log_cql_statements: true
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i4i.8xlarge'

--- a/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
@@ -16,7 +16,7 @@ gemini_cmd: |
   --mode mixed
 
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
-gemini_log_cql_statements: false
+gemini_log_cql_statements: true
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i4i.8xlarge'

--- a/test-cases/gemini/gemini-8h-large-num-columns.yaml
+++ b/test-cases/gemini/gemini-8h-large-num-columns.yaml
@@ -24,6 +24,6 @@ gemini_cmd: |
   --verbose
 
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
-gemini_log_cql_statements: false
+gemini_log_cql_statements: true
 
 db_type: scylla

--- a/test-cases/gemini/gemini-basic-3h-ics.yaml
+++ b/test-cases/gemini/gemini-basic-3h-ics.yaml
@@ -16,7 +16,7 @@ gemini_cmd: |
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 gemini_table_options:
   - "compaction={'class': 'IncrementalCompactionStrategy'}"
-gemini_log_cql_statements: false
+gemini_log_cql_statements: true
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i4i.8xlarge'

--- a/test-cases/gemini/gemini-basic-3h.yaml
+++ b/test-cases/gemini/gemini-basic-3h.yaml
@@ -13,7 +13,7 @@ gemini_cmd: |
   --mode mixed
 
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
-gemini_log_cql_statements: false
+gemini_log_cql_statements: true
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i4i.8xlarge'

--- a/unit_tests/test_gemini_thread.py
+++ b/unit_tests/test_gemini_thread.py
@@ -61,41 +61,9 @@ def test_01_gemini_thread(request, docker_scylla, params):
         gemini_thread.kill()
 
     request.addfinalizer(cleanup_thread)
-
-    default_options = [
-        "--oracle-replication-strategy=\"{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}\"",
-        "--table-options=\"gc_grace_seconds=60\"",
-        "--table-options=\"cdc = {'enabled': true, 'ttl': 0}\"",
-        "--level=info",
-        "--request-timeout=3s",
-        "--connect-timeout=60s",
-        "--consistency=QUORUM",
-        "--async-objects-stabilization-backoff=10ms",
-        "--async-objects-stabilization-attempts=10",
-        "--dataset-size=large",
-        "--oracle-host-selection-policy=token-aware",
-        "--test-host-selection-policy=token-aware",
-        "--drop-schema=true",
-        "--fail-fast=true",
-        "--materialized-views=false",
-        "--use-lwt=false",
-        "--use-counters=false",
-        "--max-tables=1",
-        "--max-columns=16",
-        "--min-columns=8",
-        "--max-partition-keys=6",
-        "--min-partition-keys=2",
-        "--max-clustering-keys=4",
-        "--min-clustering-keys=2",
-        "--partition-key-distribution=uniform",
-        "--token-range-slices=10000",
-        "--partition-key-buffer-reuse-size=128",
-        "--statement-log-file-compression=zstd",
-    ]
-
     gemini_cmd = gemini_thread._generate_gemini_command()
 
-    for option in default_options + options:
+    for option in options:
         assert option in gemini_cmd
 
     gemini_thread.run()


### PR DESCRIPTION
- Enable Statement Logger on all workloads statements are logged now in Oracle Cluster, this removes the problem, performance bottlenck of logging to file and gives us better tracability

- Removing --fail-fast flag, this flag still exists in gemini but is not used for anything, every workload should migrate to --max-errors-to-store flags, which gives better control if and how gemini will fail

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- :green_circle: https://argus.scylladb.com/tests/scylla-cluster-tests/e1ea4694-6754-4e1f-9bde-48e987e03e2d (3 Hour Run with Nemesis)
- :green_circle: https://argus.scylladb.com/tests/scylla-cluster-tests/27e79388-87d6-409c-9f07-588eda98b19f (10 Hour Run with Nemesis)
- :green_circle: https://argus.scylladb.com/tests/scylla-cluster-tests/1d07f19a-495c-49e0-8b69-bb2ed0801490 (10 Hour Run with Nemesis different Seed)
- :green_circle: https://argus.scylladb.com/tests/scylla-cluster-tests/9563facb-5d36-48bf-9958-a8ca2f845155 (3 Hour Run without Nemesis)
- :green_circle: https://argus.scylladb.com/tests/scylla-cluster-tests/9c533fc0-4e1f-4ecd-9adf-46aa49a196e9 (Another 3 Hour Run Without nemesis

Currently there will be no backports of gemini the the release branches, as we need it to run for a month to iron out bugs that might (will) surface, after that point we will backport relevant release branches.


### Changes to the gemini flags

- Remove `--fail-fast` as explained above why
- Changed `partition-key-buffer-reuse-size` from `128` to `256` -> increases the throughput, and since we removed most (that we know of) memory leaks, there is not point in not using higher value here
- Added `io-worker-pool` -> number of IO Worker threads that will execute Scylla read/write requests (new flags from v2)
- `max-errors-to-store=N` is set by default to `1000` -> after which point (if 1000 errors happen -> read or write) gemini will fail, this does not mean gemini will be considered a success if there is <N error, even if one error is there, gemini will exit with status 1 indicating something is wrong, this just makes gemini work for longer periods of time, since not every error is gemini's fault

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
