### PR TITLE
fix(pull_image): correctly check if node is a docker container

### DIFF
--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -162,7 +162,7 @@ class RemoteDocker(BaseNode):
     @cache
     def pull_image(node, image):
         # Login docker-hub before pull, in case node authentication is expired or not logged-in.
-        docker_hub_login(remoter=node.remoter, use_sudo=node.is_docker)
+        docker_hub_login(remoter=node.remoter, use_sudo=node.is_docker())
         remote_cmd = node.remoter.sudo if RemoteDocker.running_in_docker(
             node) and not RemoteDocker.running_in_podman(node) else node.remoter.run
         remote_cmd(f"docker pull {image}", verbose=True, retry=3)


### PR DESCRIPTION
Previously, the `docker_hub_login` method in `RemoteDocker.pull_image` was incorrectly using `node.is_docker` as a property. Since `is_docker` is implemented as a method, accessing it without parentheses always evaluated to True value.

This change ensures `node.is_docker()` is properly called, so the `docker_hub_login` behaves as intended.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [pr-provision-test-docker](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/pr-provision-test/92/)
- [x] :green_circle: [pr-provision-docker](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/pr-provision-test/91/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
