### PR TITLE
feature(skip_on_capacity_issues): check cluster layout before skipping

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -3417,6 +3417,15 @@ When enabled, loaders will look for nodes on the same rack.
 **type:** boolean
 
 
+## **capacity_errors_check_mode** / SCT_CAPACITY_ERRORS_CHECK_MODE
+
+how to check if to continue test execution when capacity errors are detected.<br>per-initial_config - check if cluster layout is same as initial configuration, if not stop test execution<br>disabled - continue test execution even if capacity errors are detected
+
+**default:** N/A
+
+**type:** str (appendable)
+
+
 ## **use_dns_names** / SCT_USE_DNS_NAMES
 
 Use dns names instead of ip addresses for nodes in cluster

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1169,7 +1169,8 @@ class Nemesis(NemesisFlags):
             instance_type = self.cluster.params.get("zero_token_instance_type_db") or instance_type
             add_node_func_args.update({"is_zero_node": is_zero_node, "instance_type": instance_type})
 
-        new_nodes = skip_on_capacity_issues(self.cluster.add_nodes)(**add_node_func_args)
+        new_nodes = skip_on_capacity_issues(db_cluster=self.tester.db_cluster)(
+            self.cluster.add_nodes)(**add_node_func_args)
         self.monitoring_set.reconfigure_scylla_monitoring()
         try:
             with adaptive_timeout(Operations.NEW_NODE, node=self.cluster.data_nodes[0], timeout=timeout):
@@ -4659,7 +4660,8 @@ class Nemesis(NemesisFlags):
             "disruption_name": self.current_disruption,
             **({"is_zero_node": is_zero_node} if is_zero_node else {})
         }
-        new_node = skip_on_capacity_issues(self.cluster.add_nodes)(**add_node_func_args)[0]
+        new_node = skip_on_capacity_issues(db_cluster=self.tester.db_cluster)(
+            self.cluster.add_nodes)(**add_node_func_args)[0]
         with new_node.remote_scylla_yaml() as scylla_yml:
             scylla_yml.rpc_address = new_node.ip_address
             scylla_yml.seed_provider = [SeedProvider(class_name='org.apache.cassandra.locator.SimpleSeedProvider',
@@ -5223,7 +5225,7 @@ class Nemesis(NemesisFlags):
         """
         self.cluster.wait_all_nodes_un()
 
-        new_node: BaseNode = skip_on_capacity_issues(self.cluster.add_nodes)(
+        new_node: BaseNode = skip_on_capacity_issues(db_cluster=self.tester.db_cluster)(self.cluster.add_nodes)(
             count=1,
             dc_idx=self.target_node.dc_idx,
             enable_auto_bootstrap=True,

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -23,6 +23,7 @@ import logging
 import getpass
 import pathlib
 import tempfile
+
 import yaml
 import copy
 from copy import deepcopy
@@ -1701,6 +1702,12 @@ class SCTConfiguration(dict):
              Provide number of racks to simulate."""),
         dict(name="rack_aware_loader", env="SCT_RACK_AWARE_LOADER", type=boolean,
              help="When enabled, loaders will look for nodes on the same rack."),
+
+        dict(name="capacity_errors_check_mode", env="SCT_CAPACITY_ERRORS_CHECK_MODE", type=str,
+             choices=["per-initial_config", "disabled"],
+             help="""how to check if to continue test execution when capacity errors are detected.
+                per-initial_config - check if cluster layout is same as initial configuration, if not stop test execution
+                disabled - continue test execution even if capacity errors are detected"""),
 
         dict(name="use_dns_names", env="SCT_USE_DNS_NAMES", type=boolean,
              help="""Use dns names instead of ip addresses for nodes in cluster"""),

--- a/sdcm/utils/cluster_tools.py
+++ b/sdcm/utils/cluster_tools.py
@@ -10,12 +10,58 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2025 ScyllaDB
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
 from collections import defaultdict
 
+if TYPE_CHECKING:
+    from sdcm.cluster import BaseCluster, BaseNode
 
-def group_nodes_by_dc_idx(nodes: list['BaseNode']) -> dict[int, list['BaseNode']]:  # noqa: F821
+LOGGER = logging.getLogger(__name__)
+
+
+def group_nodes_by_dc_idx(nodes: list[BaseNode]) -> dict[int, list[BaseNode]]:  # noqa: F821
     """ Group nodes by dc_idx """
     nodes_by_dc_idx = defaultdict(list)
     for node in nodes:
         nodes_by_dc_idx[node.dc_idx].append(node)
     return nodes_by_dc_idx
+
+
+def check_cluster_layout(db_cluster: BaseCluster) -> bool:  # noqa: F821
+    """
+    Check if the cluster layout is balanced according to the initial configuration.
+    """
+    nodes_by_dc_idx = group_nodes_by_dc_idx(db_cluster.nodes)
+    capacity_errors_check_mode = db_cluster.params.get("capacity_errors_check_mode") or "per-initial_config"
+
+    db_nodes_config_count = [int(i) for i in str(db_cluster.params.get("n_db_nodes") or 0).split(" ")]
+
+    if capacity_errors_check_mode == "per-initial_config":
+        for dc_idx, nodes_in_dc in nodes_by_dc_idx.items():
+            racks = defaultdict(int)
+            for node in nodes_in_dc:
+                racks[node.rack] += 1
+            # Check if the number of nodes in each rack matches the initial configuration
+            if len(racks) != db_cluster.racks_count:
+                LOGGER.debug(f"Datacenter {dc_idx=} rack distribution: {dict(racks)}")
+                return False
+            try:
+                current_dc_config_count = db_nodes_config_count[dc_idx]
+            except IndexError:
+                # if this index isn't in config, treat it as 0 nodes
+                current_dc_config_count = 0
+            # Check if all racks have the same number of nodes
+            if current_dc_config_count != len(nodes_in_dc):
+                LOGGER.debug(
+                    f"Datacenter {dc_idx=} rack distribution: {dict(racks)}, config count: {current_dc_config_count}, {len(nodes_in_dc)=}")
+                return False
+        return True
+    elif capacity_errors_check_mode == "disabled":
+        # If capacity errors check is disabled, we assume the cluster is balanced
+        return True
+    else:
+        raise ValueError(f"Unknown capacity_errors_check_mode: {capacity_errors_check_mode}. "
+                         "Supported modes are: 'per-initial_config', 'disabled'.")

--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -10,6 +10,7 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2020 ScyllaDB
+from __future__ import annotations
 
 import sys
 import time
@@ -18,7 +19,7 @@ import datetime
 import json
 import os
 from functools import wraps, partial, cached_property
-from typing import Optional, Callable
+from typing import Optional, Callable, TYPE_CHECKING
 
 from botocore.exceptions import ClientError
 
@@ -28,6 +29,10 @@ from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.event_counter import EventCounterContextManager
 from sdcm.exceptions import UnsupportedNemesis
 from sdcm.sct_events.system import TestFrameworkEvent
+from sdcm.utils.cluster_tools import check_cluster_layout
+
+if TYPE_CHECKING:
+    from sdcm.cluster import BaseCluster
 
 LOGGER = logging.getLogger(__name__)
 
@@ -360,19 +365,48 @@ def static_init(cls):
     return cls
 
 
-def skip_on_capacity_issues(func: callable) -> callable:
+def skip_on_capacity_issues(func: Callable | None = None, db_cluster: BaseCluster | None = None):
     """
-    Decorator to skip nemesis that fail due to capacity issues
+    Decorator to skip nemesis that fail due to capacity issues.
+    Can be used with or without parameters:
+        @skip_on_capacity_issues
+        def foo(...): ...
+    or
+        @skip_on_capacity_issues(db_cluster=cluster)
+        def foo(...): ...
     """
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except ClientError as ex:
-            if "InsufficientInstanceCapacity" in str(ex):
-                raise UnsupportedNemesis("Capacity Issue") from ex
-            raise
-    return wrapper
+    def decorator(inner_func):
+        @wraps(inner_func)
+        def wrapper(*args, **kwargs):
+            cluster = db_cluster
+            # Try to get db_cluster from inner_func's bound instance if not provided
+            if cluster is None and args:
+                bound_self = getattr(inner_func, "__self__", None)
+                if bound_self and hasattr(bound_self, "nodes"):
+                    cluster = bound_self
+                else:
+                    for arg in args:
+                        if hasattr(arg, "nodes"):  # crude check for cluster-like object
+                            cluster = arg
+                            break
+            try:
+                return inner_func(*args, **kwargs)
+            except ClientError as ex:
+                if "InsufficientInstanceCapacity" in str(ex):
+                    if not check_cluster_layout(cluster):
+                        TestFrameworkEvent(
+                            source=inner_func.__name__,
+                            message=f"Test failed due to capacity issues: {ex} cluster is unbalanced, continuing with test would yield unknown results",
+                            severity=Severity.CRITICAL
+                        ).publish()
+                    else:
+                        raise UnsupportedNemesis("Capacity Issue") from ex
+                raise
+        return wrapper
+
+    if func is not None and callable(func):
+        return decorator(func)
+    return decorator
 
 
 def critical_on_capacity_issues(func: callable) -> callable:
@@ -386,7 +420,7 @@ def critical_on_capacity_issues(func: callable) -> callable:
             return func(*args, **kwargs)
         except ClientError as ex:
             if "InsufficientInstanceCapacity" in str(ex):
-                TestFrameworkEvent(source=callable.__name__,
+                TestFrameworkEvent(source=func.__name__,
                                    message=f"Test failed due to capacity issues: {ex} "
                                    "cluster is probably unbalanced, continuing with test would yield unknown results",
                                    severity=Severity.CRITICAL).publish()

--- a/unit_tests/test_utils_cluster_tools.py
+++ b/unit_tests/test_utils_cluster_tools.py
@@ -1,0 +1,77 @@
+from sdcm.utils.cluster_tools import group_nodes_by_dc_idx, check_cluster_layout
+from unittest.mock import MagicMock
+
+
+def test_nodes_grouped_by_dc_idx_are_correctly_grouped():
+    """Test that nodes are grouped by their dc_idx correctly."""
+    nodes = [
+        MagicMock(dc_idx=1),
+        MagicMock(dc_idx=1),
+        MagicMock(dc_idx=2),
+    ]
+    grouped_nodes = group_nodes_by_dc_idx(nodes)
+    assert len(grouped_nodes) == 2
+    assert len(grouped_nodes[1]) == 2
+    assert len(grouped_nodes[2]) == 1
+
+
+def test_check_cluster_layout():
+    """Test that a cluster that matches the initial configuration."""
+    db_cluster = MagicMock(nodes=[
+        MagicMock(dc_idx=0, rack="rack1"),
+        MagicMock(dc_idx=0, rack="rack1"),
+        MagicMock(dc_idx=0, rack="rack2"),
+        MagicMock(dc_idx=0, rack="rack2"),
+    ])
+    db_cluster.params = {"capacity_errors_check_mode": "per-initial_config", "n_db_nodes": "4"}
+    db_cluster.racks_count = 2
+    assert check_cluster_layout(db_cluster) is True
+
+
+def test_check_cluster_layout_on_two_dcs():
+    """Test that a cluster with two datacenters is matching initial configuration."""
+    db_cluster = MagicMock(nodes=[
+        MagicMock(dc_idx=0, rack="rack1"),
+        MagicMock(dc_idx=0, rack="rack2"),
+        MagicMock(dc_idx=1, rack="rack1"),
+        MagicMock(dc_idx=1, rack="rack2"),
+    ])
+    db_cluster.params = {"capacity_errors_check_mode": "per-initial_config", "n_db_nodes": "2 2"}
+    db_cluster.racks_count = 2
+    assert check_cluster_layout(db_cluster) is True
+
+
+def test_check_cluster_layout_unbalanced_racks():
+    """Test that a cluster that does match configuration returns True. even if racks are unbalanced."""
+
+    db_cluster = MagicMock(nodes=[
+        MagicMock(dc_idx=0, rack="rack1"),
+        MagicMock(dc_idx=0, rack="rack1"),
+        MagicMock(dc_idx=0, rack="rack2"),
+    ])
+    db_cluster.params = {"capacity_errors_check_mode": "per-initial_config", "n_db_nodes": "3"}
+    db_cluster.racks_count = 2
+    assert check_cluster_layout(db_cluster) is True
+
+
+def test_check_cluster_layout_unbalanced_on_two_dcs():
+    """Test that a cluster that doesn't match configuration across two datacenters returns False."""
+    db_cluster = MagicMock(nodes=[
+        MagicMock(dc_idx=0, rack="rack1"),
+        MagicMock(dc_idx=0, rack="rack1"),
+        MagicMock(dc_idx=0, rack="rack2"),
+        MagicMock(dc_idx=0, rack="rack2"),
+        MagicMock(dc_idx=1, rack="rack1"),
+        MagicMock(dc_idx=1, rack="rack1"),
+        MagicMock(dc_idx=1, rack="rack2"),
+    ])
+    db_cluster.params = {"capacity_errors_check_mode": "per-initial_config", "n_db_nodes": "4 4"}
+    db_cluster.racks_count = 2
+    assert check_cluster_layout(db_cluster) is False
+
+
+def test_cluster_with_no_nodes():
+    """Test that a cluster with no nodes is considered correct layout."""
+    db_cluster = MagicMock(nodes=[])
+    db_cluster.params = {"capacity_errors_check_mode": "per-initial_config"}
+    assert check_cluster_layout(db_cluster) is True


### PR DESCRIPTION
since just skipping to next nemesis on those cases can cause situation we are continuing a test in a very unbalanced way, we should stop the test completely.

before we introduced a decorator that can generate a critcal event to stop the test, and applied it only in one nemesis.

this change is introducing a rack balance check, and if cluster isn't balanced after the capacitry error issue, it would raise critical event and not skip the nemesis

Fixes: #11350

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
- [x] 🟢 https://argus.scylladb.com/tests/scylla-cluster-tests/ea0360c3-c6af-4ea1-8d54-08c654ef9d48/events


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
