### PR TITLE
fix(database_events): Set ALLOCATION_MEMERY AS WARNING

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -18,7 +18,7 @@ FullPartitionScanReversedOrderEvent: ERROR
 FullPartitionScanEvent: ERROR
 TombstoneGcVerificationEvent: ERROR
 FullScanAggregateEvent: ERROR
-DatabaseLogEvent.OVERSIZED_ALLOCATION: ERROR
+DatabaseLogEvent.OVERSIZED_ALLOCATION: WARNING
 DatabaseLogEvent.WARNING: WARNING
 DatabaseLogEvent.NO_SPACE_ERROR: ERROR
 DatabaseLogEvent.UNKNOWN_VERB: WARNING

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -83,7 +83,7 @@ class ReactorStalledMixin(Generic[T_log_event]):
 
 
 # cause this is warning level, it's need to be before WARNING being suppressed
-DatabaseLogEvent.add_subevent_type("OVERSIZED_ALLOCATION", severity=Severity.ERROR,
+DatabaseLogEvent.add_subevent_type("OVERSIZED_ALLOCATION", severity=Severity.WARNING,
                                    regex="seastar_memory - oversized allocation:")
 DatabaseLogEvent.add_subevent_type("WARNING", severity=Severity.SUPPRESS,
                                    regex=r"(^WARNING|!\s*?WARNING).*\[shard.*\]")


### PR DESCRIPTION
To remove error events noise from 2025.3 sct jobs, set allocation memory error events as noise

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
