### PR TITLE
feature(cloud_backend): add a new backend for Scylla cloud

### DIFF
--- a/defaults/cloud_config.yaml
+++ b/defaults/cloud_config.yaml
@@ -1,0 +1,7 @@
+n_db_nodes: 3
+n_loaders: 0
+n_monitor_nodes: 0
+
+use_mgmt: false
+
+use_cloud_manager: true

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -3613,3 +3613,39 @@ Store adaptive timeout metrics in Argus. Disabled for performance tests only.
 **default:** True
 
 **type:** boolean
+
+
+## **xcloud_credentials_path** / SCT_XCLOUD_CREDENTIALS_PATH
+
+Path to Scylla Cloud credentials file, if stored locally
+
+**default:** N/A
+
+**type:** str (appendable)
+
+
+## **xcloud_env** / SCT_XCLOUD_ENV
+
+Scylla Cloud environment (e.g., lab).
+
+**default:** N/A
+
+**type:** str (appendable)
+
+
+## **xcloud_provider** / SCT_XCLOUD_PROVIDER
+
+Cloud provider for Scylla Cloud deployment (aws, gce)
+
+**default:** N/A
+
+**type:** str (appendable)
+
+
+## **xcloud_replication_factor** / SCT_XCLOUD_REPLICATION_FACTOR
+
+Replication factor for Scylla Cloud cluster (default: 3)
+
+**default:** N/A
+
+**type:** int

--- a/sdcm/cloud_api_client.py
+++ b/sdcm/cloud_api_client.py
@@ -1,0 +1,557 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+import json
+import logging
+import requests
+from enum import Enum
+from functools import cached_property
+from pprint import pformat
+from requests.adapters import HTTPAdapter
+from urllib.parse import urljoin
+from typing import Any, Literal
+
+from urllib3.util.retry import Retry
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ScyllaCloudAPIError(Exception):
+    """Base exception for Scylla Cloud API errors"""
+
+
+class CloudProviderType(Enum):
+    AWS = 'AWS'
+    GCP = 'GCP'
+
+
+class ScyllaCloudAPIClient:
+    """REST API client for Scylla Cloud operations"""
+
+    exception_class: Exception = ScyllaCloudAPIError
+
+    def __init__(self, api_url: str, auth_token: str, raise_for_status: bool = False):
+        self.api_url = api_url.rstrip('/')
+        self.auth_token = auth_token.strip()
+        self.raise_for_status = raise_for_status
+        self.session = self._create_session()
+
+        self.session.headers.update({
+            'Authorization': f'Bearer {self.auth_token}',
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'})
+
+        LOGGER.info("Initialized Scylla Cloud API client for %s", self.api_url)
+
+    @staticmethod
+    def _create_session(retries: int = 5) -> requests.Session:
+        """Create a requests session with retry configuration"""
+        retry_strategy = Retry(
+            total=retries,
+            backoff_factor=1,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"])
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+
+        session = requests.Session()
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+
+        return session
+
+    def request(self, method: str, endpoint: str, /, params=None, **body) -> dict | None:
+        """
+        Make HTTP request to Scylla Cloud API
+
+        :param method: HTTP method
+        :param endpoint: API endpoint (relative to API endpoint URL)
+        :param params: query parameters to be sent in url
+        :param body: keyword args to be sent as JSON body
+        """
+        url = urljoin(self.api_url, endpoint.lstrip('/'))
+
+        LOGGER.debug("Making %s request to %s with query parameters %s and payload %s",
+                     method, url, pformat(params), pformat(body))
+        response = self.session.request(method, url, params=params, json=body)
+
+        if self.raise_for_status:
+            response.raise_for_status()
+
+        if not response.text:
+            return None
+        response = response.json()
+        if error := self.get_error(response):
+            raise self.exception_class(error)
+
+        LOGGER.debug("Got response:\n%s", json.dumps(response, indent=4))
+        return self._parse_response_data(response)
+
+    @staticmethod
+    def _parse_response_data(response_json: dict[str, Any]) -> dict[str, Any]:
+        """Parse API response handling the top level 'data' attribute in response"""
+        return response_json.get('data', response_json)
+
+    @staticmethod
+    def get_error(response: dict) -> str | None:
+        """Extract error message from API response"""
+        return response.get("error")
+
+    ### Deployment related APIs ###
+    def get_cloud_providers(self) -> dict[str, Any]:
+        """Get details about supported cloud providers"""
+        return self.request("GET", "deployment/cloud-providers")["cloudProviders"]
+
+    def get_scylla_versions(self, defaults: bool = False) -> dict[str, Any]:
+        """List available ScyllaDB Cloud versions"""
+        url = "deployment/scylla-versions"
+        params = {}
+        if defaults:
+            params['defaults'] = 'true'
+        return self.request("GET", url, params=params)
+
+    @cached_property
+    def current_scylla_version(self) -> dict:
+        """Get the latest ScyllaDB Cloud version that can be used to create a new cluster"""
+        return next(v for v in reversed(self.get_scylla_versions()) if v["newCluster"] == "ENABLED")
+
+    def get_regions(self, *, cloud_provider_id: int, defaults: bool = False) -> dict[str, Any]:
+        """Get regions supported by a given cloud provider"""
+        url = f'/deployment/cloud-provider/{cloud_provider_id}/regions'
+        params = {}
+        if defaults:
+            params['defaults'] = 'true'
+        return self.request('GET', url, params=params)
+
+    def get_region_id_by_name(self, *, cloud_provider_id: int, region_name: str) -> int:
+        """Get the ID of a cloud provider region by its name"""
+        regions = self.get_regions(cloud_provider_id=cloud_provider_id)['regions']
+        return next(region for region in regions if region["externalId"] == region_name)["id"]
+
+    def get_instance_types(
+            self, *, cloud_provider_id: int, region_id: int, defaults: bool = False) -> dict[str, Any]:
+        """Get instance types available for a given cloud provider and region"""
+        url = f'/deployment/cloud-provider/{cloud_provider_id}/region/{region_id}'
+        params = {}
+        if defaults:
+            params['defaults'] = 'true'
+        return self.request('GET', url, params=params)
+
+    def get_instance_id_by_name(
+            self, *, cloud_provider_id: int, region_id: int, instance_type_name: str) -> int:
+        """Get the ID of an instance type by its name in a given cloud provider and region"""
+        instance_types = self.get_instance_types(
+            cloud_provider_id=cloud_provider_id, region_id=region_id)['instances']
+        try:
+            return next(t for t in instance_types if t["externalId"] == instance_type_name)["id"]
+        except StopIteration:
+            raise ScyllaCloudAPIError(
+                f"Instance type '{instance_type_name}' not found in region_id: {region_id} for cloud_provider_id: "
+                f"{cloud_provider_id}, available instance types: {', '.join(t['externalId'] for t in instance_types)}")
+
+    @cached_property
+    def cloud_provider_ids(self) -> dict[CloudProviderType, int]:
+        """Get a mapping of cloud provider names to their IDs"""
+        return {CloudProviderType(p["name"]): p["id"] for p in self.get_cloud_providers()}
+
+    @cached_property
+    def client_ip(self) -> str:
+        return self.request("GET", "deployment/client-ip")["clientIp"]
+
+    ### Account related APIs ###
+    def get_active_accounts(self, *, account_id: int) -> list[dict[str, Any]]:
+        """From given account list active cloud-accounts for all cloud-providers"""
+        return self.request('GET', f'/account/{account_id}/cloud-account')
+
+    def get_account_details(self) -> dict[str, Any]:
+        """Get details of the account tied to the authorized user"""
+        return self.request('GET', '/account/default')
+
+    def get_current_account_id(self) -> int:
+        """Get the ID of the account tied to the authorized user"""
+        account_details = self.get_account_details()
+        return account_details.get('accountId', 1)  # TODO: is 1 a valid default account ID?
+
+    def set_account_notifications_email(self, *, account_id: int, emails: list[str]) -> dict[str, Any]:
+        """Set the email address(es) used for account notifications"""
+        return self.request('POST', f'/account/{account_id}/notifications/email', emails=emails)
+
+    ### Cluster related APIs ###
+    def get_cluster_requests(self, *, account_id: int, cluster_id: int) -> list[dict[str, Any]]:
+        """list of cluster requests created in the context of a given account"""
+        return self.request('GET', f'/account/{account_id}/cluster/{cluster_id}/request')
+
+    def get_cluster_request_details(self, *, account_id: int, request_id: int) -> dict[str, Any]:
+        """Get details of a specific cluster request"""
+        return self.request('GET', f'/account/{account_id}/cluster/request/{request_id}')
+
+    def create_cluster_request(  # noqa: PLR0913
+        self,
+        *,
+        account_id: int,
+        cluster_name: str,
+        scylla_version: str,
+        cidr_block: str | None,
+        broadcast_type: Literal["PRIVATE", "PUBLIC"],
+        allowed_ips: list[str],
+        cloud_provider_id: int,
+        region_id: int,
+        instance_id: int,
+        replication_factor: int,
+        number_of_nodes: int,
+        account_credential_id: int,
+        free_trial: bool,
+        user_api_interface: Literal["CQL", "ALTERNATOR"],
+        enable_dns_association: bool,
+        jump_start: bool,
+        encryption_at_rest: dict | None,
+        maintenance_windows: list[dict],
+        scaling: dict[str, str],
+    ) -> dict[str, Any]:
+        """
+        Create cluster-create request.
+
+        :param account_id: account ID to create the cluster for
+        :param cluster_name: name of the cluster
+        :param scylla_version: scylla version to deploy
+        :param cidr_block: CIDR block for the cluster
+        :param broadcast_type: type of broadcast (PRIVATE or PUBLIC)
+        :param allowed_ips: list of CIDR formatted firewall rules for the cluster
+        :param cloud_provider_id: ID of the cloud provider
+        :param region_id: ID of the cloud provider region
+        :param instance_id: ID of the instance type
+        :param replication_factor: cluster replication factor
+        :param number_of_nodes: number of nodes in the cluster
+        :param account_credential_id: ID of the account credential
+        :param free_trial: whether to create a free tier cluster (Default: False)
+        :param user_api_interface: API interface to use (CQL or ALTERNATOR)
+        :param enable_dns_association: whether to enable DNS on the cluster and creation of the DNS records
+            for the seed nodes at cluster creation time (Default: True)
+        :param jump_start: whether to enable jump start for the cluster (Default: False)
+        :param encryption_at_rest: encryption at rest configuration
+        :param maintenance_windows: list of maintenance windows specifications
+        :param scaling: scaling configuration
+
+        :return: created cluster details
+        """
+        response = self.request(
+            'POST',
+            f'/account/{account_id}/cluster',
+            clusterName=cluster_name,
+            scyllaVersion=scylla_version,
+            cidrBlock=cidr_block,
+            broadcastType=broadcast_type,
+            allowedIPs=allowed_ips,
+            cloudProviderId=cloud_provider_id,
+            regionId=region_id,
+            instanceId=instance_id,
+            replicationFactor=replication_factor,
+            numberOfNodes=number_of_nodes,
+            accountCredentialId=account_credential_id,
+            freeTier=free_trial,
+            userApiInterface=user_api_interface,
+            enableDnsAssociation=enable_dns_association,
+            jumpStart=jump_start,
+            encryptionAtRest=encryption_at_rest,
+            maintenanceWindows=maintenance_windows,
+            scaling=scaling,)
+        return self._parse_response_data(response)
+
+    def get_clusters(self, *, account_id: int, metrics: str = '', enriched: bool = False) -> list[dict[str, Any]]:
+        """List all clusters for a given account"""
+        url = f'/account/{account_id}/clusters'
+        params = {}
+        if enriched:
+            params['enriched'] = 'true'
+        if metrics:
+            params['metrics'] = metrics
+        return self.request('GET', url, params=params)['clusters']
+
+    def get_cluster_details(self, *, account_id: int, cluster_id: int, enriched: bool = False) -> dict[str, Any]:
+        """Get details of a cluster"""
+        url = f'/account/{account_id}/cluster/{cluster_id}'
+        params = {}
+        if enriched:
+            params['enriched'] = 'true'
+        return self.request('GET', url, params=params)['cluster']
+
+    def get_cluster_id_by_name(self, *, account_id: int, cluster_name: str) -> int | None:
+        if clusters := self.get_clusters(account_id=account_id):
+            return next(cluster for cluster in clusters if cluster["clusterName"] == cluster_name)["id"]
+        return None
+
+    def get_cluster_nodes(self, *, account_id: int, cluster_id: int, enriched: bool = False) -> list[dict[str, Any]]:
+        """Get the list of cluster nodes"""
+        url = f'/account/{account_id}/cluster/{cluster_id}/nodes'
+        params = {}
+        if enriched:
+            params['enriched'] = 'true'
+        return self.request('GET', url, params=params)['nodes']
+
+    def get_cluster_dcs(self, *, account_id: int, cluster_id: int, enriched: bool = False) -> list[dict[str, Any]]:
+        """Get the list of data centers used by a cluster"""
+        url = f'/account/{account_id}/cluster/{cluster_id}/dcs'
+        params = {}
+        if enriched:
+            params['enriched'] = 'true'
+        return self.request('GET', url, params=params)['dataCenters']
+
+    def delete_cluster(self, *, account_id: int,  cluster_id: int, cluster_name: str) -> dict[str, Any]:
+        """Delete a cluster"""
+        return self.request('POST', f'/account/{account_id}/cluster/{cluster_id}/delete',
+                            clusterName=cluster_name)
+
+    def resize_cluster(self, *, account_id: int, cluster_id: int, dc_nodes: list[dict]) -> dict[str, Any]:
+        """
+       `Create cluster-create request.
+
+        :param account_id: ID of the account
+        :param cluster_id: ID of the cluster to resize
+        :param dc_nodes: list of the requested changes for each DC
+            [
+                {
+                    "dcId": int,
+                    "wantedSize": int,
+                    "instanceTypeId": int
+                },
+                ...
+            ]
+        """
+        return self.request(
+            'POST', f'/account/{account_id}/cluster/{cluster_id}/resize', dcNodes=dc_nodes)
+
+    def update_cluster_name(self, *, account_id: int, cluster_id: int, new_name: str) -> dict[str, Any]:
+        """Update the name of a cluster"""
+        return self.request('PATCH', f'/account/{account_id}/cluster/{cluster_id}/name', name=new_name)
+
+    def set_cluster_notifications_email(self, *, account_id: int, cluster_id: int, emails: list[str]) -> dict[str, Any]:
+        """Set the email address(es) used for cluster notifications"""
+        return self.request(
+            'POST', f'/account/{account_id}/cluster/{cluster_id}/notifications/email', emails=emails)
+
+    ### Account cluster network related APIs ###
+    def create_fw_rule(self, *, account_id: int, cluster_id: int, ip_address: str) -> dict[str, Any]:
+        """Create a CIDR formatted firewall rule for a given cluster"""
+        return self.request('POST',
+                            f'/account/{account_id}/cluster/{cluster_id}/network/firewall/allowed',
+                            ipAddress=ip_address)
+
+    def get_fw_rules(self, *, account_id: int, cluster_id: int) -> list[dict[str, Any]]:
+        """Get the list of firewall rules for a given cluster"""
+        return self.request(
+            'GET', f'/account/{account_id}/cluster/{cluster_id}/network/firewall/allowed')
+
+    def delete_fw_rule(self, *, account_id: int, cluster_id: int, rule_id: int) -> dict[str, Any]:
+        """Delete a firewall rule in a given cluster"""
+        return self.request(
+            'DELETE', f'/account/{account_id}/cluster/{cluster_id}/network/firewall/allowed/{rule_id}')
+
+    def get_vpc_peers(self, *, account_id: int, cluster_id: int) -> list[dict[str, Any]]:
+        """Get list of all VPC peers for a given cluster"""
+        return self.request('GET', f'/account/{account_id}/cluster/{cluster_id}/network/vpc/peer')
+
+    def create_vpc_peer(
+            self,
+            *,
+            account_id: int,
+            cluster_id: int,
+            vpc_id: str,
+            cidr_block: str,
+            owner_id: str,
+            region_id: int,
+            dc_id: int,
+            allow_cql: bool,
+            asynchronous: bool = False
+    ) -> dict[str, Any]:
+        """
+        Create a VPC peer for a given cluster.
+
+        :param account_id: ID of the account
+        :param cluster_id: ID of the cluster
+        :param vpc_id: ID of the VPC to peer with
+        :param cidr_block: single address or list of comma separated CIDR block addresses for the VPC peer
+        :param owner_id: owner ID of the VPC (AWS account ID or GCP project ID)
+        :param region_id: ID of the region where the VPC is located
+        :param dc_id: ID of the data center where the VPC is located
+        :param allow_cql: whether to allow CQL traffic over the VPC peer
+        :param asynchronous: whether to perform the operation asynchronously (Default: False)
+        """
+        url = f'/account/{account_id}/cluster/{cluster_id}/network/vpc/peer'
+        params = {}
+        if asynchronous:
+            params['asynchronous'] = 'true'
+        return self.request(
+            'POST',
+            url,
+            vpcId=vpc_id,
+            cidrBlock=cidr_block,
+            ownerId=owner_id,
+            regionId=region_id,
+            dcId=dc_id,
+            allowCql=allow_cql,
+            params=params)
+
+    def get_vpc_peer_details(self, *, account_id: int, cluster_id: int, peer_id: str) -> dict[str, Any]:
+        """Get details of a VPC peer for a given cluster"""
+        return self.request(
+            'GET', f'/account/{account_id}/cluster/{cluster_id}/network/vpc/peer/{peer_id}')
+
+    def update_vpc_peer(
+            self,
+            *,
+            account_id: int,
+            cluster_id: int,
+            peer_id: str,
+            status: str,
+            cidr_block: str
+    ) -> dict[str, Any]:
+        """
+        Update a VPC peer for a given cluster.
+
+        :param account_id: ID of the account
+        :param cluster_id: ID of the cluster
+        :param peer_id: ID of the VPC peer to update
+        :param status: new status of the VPC peer ("ACTIVE" or "INACTIVE")
+        :param cidr_block: new single address or list of comma separated CIDR block addresses for the VPC peer
+        """
+        return self.request(
+            'PUT',
+            f'/account/{account_id}/cluster/{cluster_id}/network/vpc/peer/{peer_id}',
+            status=status,
+            cidrBlock=cidr_block)
+
+    def delete_vpc_peer(self, *, account_id: int, cluster_id: int, peer_id: str) -> dict[str, Any]:
+        """Delete a VPC peer for a given cluster"""
+        return self.request(
+            'DELETE', f'/account/{account_id}/cluster/{cluster_id}/network/vpc/peer/{peer_id}')
+
+    ### Account cluster network connection related APIs ###
+    def get_network_connections(
+            self, *, account_id: int, cluster_id: int, type: str = '', dc: int | None = None
+    ) -> list[dict[str, Any]]:
+        """Get the list of network connections for a given cluster"""
+        url = f'/account/{account_id}/cluster/{cluster_id}/network/vpc/connection'
+        params = {}
+        if type:
+            params['type'] = type
+        if dc:
+            params['dc'] = dc
+        return self.request('GET', url, params=params)
+
+    def create_network_connection(
+            self,
+            *,
+            account_id: int,
+            cluster_id: int,
+            cidr_list: list[str],
+            dc_id: int,
+            data: dict[str, Any],
+            name: str,
+            connection_type: Literal["AWS_TGW_ATTACHMENT"]
+    ) -> dict[str, Any]:
+        """
+        Create a network connection for a given cluster.
+
+        :param account_id: ID of the account
+        :param cluster_id: ID of the cluster
+        :param cidr_list: list of networks to be accessible through this connection
+        :param dc_id: ID of the data center where the connection will be established
+        :param data: data for the connection
+            {
+                "ramARN": str,  # AWS arn of the RAM
+                "tgwID": str,   # ID of the TGW connection
+            }
+        :param name: name of the connection
+        :param connection_type: type of the connection (only "AWS_TGW_ATTACHMENT" for now)
+        """
+        url = f'/account/{account_id}/cluster/{cluster_id}/network/vpc/connection'
+        return self.request(
+            'POST',
+            url,
+            cidrList=cidr_list,
+            clusterDCID=dc_id,
+            data=data,
+            name=name,
+            type=connection_type)
+
+    def get_network_connection_details(
+            self, *, account_id: int, cluster_id: int, connection_id: str
+    ) -> dict[str, Any]:
+        """Get details of a network connection for a given cluster"""
+        return self.request(
+            'GET', f'/account/{account_id}/cluster/{cluster_id}/network/vpc/connection/{connection_id}')
+
+    def update_network_connection(
+            self,
+            *,
+            account_id: int,
+            cluster_id: int,
+            connection_id: str,
+            cidr_list: list[str],
+            name: str,
+            status: Literal["ACTIVE", "INACTIVE"],
+    ) -> dict[str, Any]:
+        """
+        Update a network connection for a given cluster.
+
+        :param account_id: ID of the account
+        :param cluster_id: ID of the cluster
+        :param connection_id: ID of the network connection to update
+        :param cidr_list: list of networks to be accessible through this connection
+        :param name: new name for the connection
+        :param status: new status of the connection ("ACTIVE" or "INACTIVE")
+        """
+        return self.request(
+            'PATCH',
+            f'/account/{account_id}/cluster/{cluster_id}/network/vpc/connection/{connection_id}',
+            cidrList=cidr_list,
+            name=name,
+            status=status)
+
+    def recreate_network_connection(
+            self,
+            *,
+            account_id: int,
+            cluster_id: int,
+            connection_id: str,
+            cidr_list: list[str],
+            data: dict[str, Any],
+            name: str,
+            status: Literal["ACTIVE", "INACTIVE"]
+    ) -> dict[str, Any]:
+        """Recreate a network connection for a given cluster.
+
+        :param account_id: ID of the account
+        :param cluster_id: ID of the cluster
+        :param connection_id: ID of the network connection to recreate
+        :param cidr_list: list of networks to be accessible through this connection
+        :param data: data for the connection
+            {
+                "ramARN": str,  # AWS arn of the RAM
+                "tgwID": str,   # ID of the TGW connection
+            }
+        :param name: new name for the connection
+        :param status: new status of the connection ("ACTIVE" or "INACTIVE")
+        """
+        return self.request(
+            'PUT',
+            f'/account/{account_id}/cluster/{cluster_id}/network/vpc/connection/{connection_id}',
+            cidrList=cidr_list,
+            data=data,
+            name=name,
+            status=status)
+
+    def delete_network_connection(self, *, account_id: int, cluster_id: int, connection_id: str) -> dict[str, Any]:
+        """Delete a network connection for a given cluster"""
+        return self.request(
+            'DELETE', f'/account/{account_id}/cluster/{cluster_id}/network/vpc/connection/{connection_id}')

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -402,7 +402,7 @@ class BaseNode(AutoSshContainerMixin):
         self._init_port_mapping()
 
         self.set_keep_alive()
-        if self.node_type == "db" and not self.is_kubernetes() \
+        if self.node_type == "db" and not self.is_kubernetes() and not self.is_cloud() \
                 and self.parent_cluster.params.get("print_kernel_callstack"):
             if self.is_docker():
                 LOGGER.warning("Enabling the 'print_kernel_callstack' on docker backend is not supported")
@@ -817,6 +817,10 @@ class BaseNode(AutoSshContainerMixin):
 
     @staticmethod
     def is_gce() -> bool:
+        return False
+
+    @staticmethod
+    def is_cloud() -> bool:
         return False
 
     def scylla_pkg(self):

--- a/sdcm/cluster_cloud.py
+++ b/sdcm/cluster_cloud.py
@@ -1,0 +1,453 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+import logging
+from functools import cached_property
+from types import SimpleNamespace
+from typing import Dict, Any
+
+from sdcm import cluster, wait
+from sdcm.cloud_api_client import ScyllaCloudAPIClient, CloudProviderType
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ScyllaCloudError(Exception):
+    """Exception for Scylla Cloud related errors"""
+
+
+class CloudNode(cluster.BaseNode):
+    """A node running on Scylla Cloud"""
+
+    METADATA_BASE_URL = None
+    log = LOGGER
+
+    def __init__(self, cloud_instance_data: Dict[str, Any], parent_cluster,
+                 node_prefix='node', node_index=1, base_logdir=None, dc_idx=0, rack=0):
+        self.node_index = node_index
+        self._cloud_instance_data = cloud_instance_data
+        self._api_client: ScyllaCloudAPIClient = parent_cluster._api_client
+        self._account_id = parent_cluster._account_id
+        self._cluster_id = parent_cluster._cluster_id
+
+        self._node_id = cloud_instance_data.get('id')
+        self._instance_name = cloud_instance_data.get('name', f'{node_prefix}-{node_index}')
+
+        self._public_ip = cloud_instance_data.get('publicIp')
+        self._private_ip = cloud_instance_data.get('privateIp')
+
+        name = f"{node_prefix}-{dc_idx}-{node_index}".lower()
+        super().__init__(
+            name=name,
+            parent_cluster=parent_cluster,
+            base_logdir=base_logdir,
+            node_prefix=node_prefix,
+            dc_idx=dc_idx,
+            rack=rack
+        )
+
+    def __str__(self):
+        return f'CloudNode {self.name} [{self.public_ip_address} | {self.private_ip_address}]{self._dc_info_str()}'
+
+    @cached_property
+    def network_interfaces(self):
+        return [{
+            'public_ip': self._public_ip,
+            'private_ip': self._private_ip,
+            'interface_name': 'eth0'
+        }]
+
+    def _refresh_instance_state(self):
+        try:
+            node_details = self._api_client.get_cluster_nodes(
+                account_id=self._account_id,
+                cluster_id=self._cluster_id)
+            for node_data in node_details:
+                if node_data.get('id') == self._node_id:
+                    self._cloud_instance_data = node_data
+                    self._public_ip = node_data.get('publicIp', self._public_ip)
+                    self._private_ip = node_data.get('privateIp', self._private_ip)
+                    break
+
+            return [self._public_ip], [self._private_ip]
+        except Exception as e:  # noqa: BLE001
+            self.log.warning("Failed to refresh instance state: %s", e)
+            return [self._public_ip], [self._private_ip]
+
+    @property
+    def public_ip_address(self):
+        return self._public_ip
+
+    @property
+    def private_ip_address(self):
+        return self._private_ip
+
+    @property
+    def ipv6_ip_address(self):
+        return None
+
+    @property
+    def vm_region(self):
+        return self._cloud_instance_data.get('region', 'unknown')
+
+    @property
+    def region(self):
+        return self.vm_region
+
+    @property
+    def datacenter(self):
+        return f"datacenter{self.dc_idx + 1}"
+
+    def _get_ipv6_ip_address(self):
+        return None
+
+    def wait_for_cloud_init(self):
+        # TODO: Implement waiting for cloud-init completion for Scylla Cloud
+        self.log.debug("Skip waiting for cloud-init on scylla-cloud, no approach to SSHing nodes for now")
+
+    def _init_port_mapping(self):
+        pass
+
+    def set_keep_alive(self):
+        # TODO: Implement keep alive tagging for Scylla Cloud
+        self.log.info("Setting keep alive for node %s", self.name)
+        return True
+
+    def restart(self):
+        raise NotImplementedError("There is no public Scylla Cloud API for node restart.\n"
+                                  "This should be implemented after approach to accessing cloud nodes is defined")
+
+    def terminate(self):
+        raise NotImplementedError("Individual node termination is not supported in Scylla Cloud.\n"
+                                  "Use cluster resize operations instead.")
+
+    def check_spot_termination(self):
+        return 0  # no spot instances in Scylla Cloud
+
+    @property
+    def is_spot(self):
+        return False
+
+    @cached_property
+    def tags(self) -> Dict[str, str]:
+        return {
+            **super().tags,
+            "NodeIndex": str(self.node_index),
+            "CloudProvider": "scylla-cloud",
+            "NodeId": str(self._node_id)
+        }
+
+    @property
+    def private_dns_name(self):
+        return self.private_ip_address
+
+    @property
+    def public_dns_name(self):
+        return self.public_ip_address
+
+    def _init_remoter(self, ssh_login_info):
+        # TODO: Implement remoter initialization for Scylla Cloud
+        self.log.debug(
+            "Skip initializing remoter abstraction on scylla-cloud, pending until approach to SSHing/accessing nodes is developed")
+
+    def wait_ssh_up(self, verbose=True, timeout=500):
+        # TODO: Implement waiting for SSH up for Scylla Cloud
+        self.log.debug("Skip waiting for SSH up on scylla-cloud, pending until approach to SSHing nodes is developed")
+
+    def wait_db_up(self, verbose=True, timeout=3600):
+        # TODO: Implement waiting for DB up for Scylla Cloud
+        self.log.debug("Skip waiting for DB up on scylla-cloud, pending until approach to SSHing/accessing nodes is developed")
+
+    def do_default_installations(self):
+        # TODO: Implement default installations for Scylla Cloud
+        self.log.debug(
+            "Skip default installations on scylla-cloud, pending until approach to SSHing/accessing nodes is developed")
+
+    def configure_remote_logging(self):
+        # TODO: Implement remote logging configuration for Scylla Cloud
+        self.log.debug(
+            "Skip configuring remote logging on scylla-cloud, pending until API/approach to collect logs is developed")
+
+    def start_coredump_thread(self):
+        # TODO: Implement coredump thread for Scylla Cloud
+        self.log.debug(
+            "Skip starting coredump thread on scylla-cloud, pending until approach to SSHing/accessing nodes is developed")
+
+    @staticmethod
+    def is_cloud() -> bool:
+        return True
+
+    @cached_property
+    def raft(self):
+        """Override BaseNode.raft property to return a dummy raft object for PoC purposes"""
+        return SimpleNamespace(
+            is_enabled=True,
+            is_ready=lambda: True)
+
+
+class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
+    """Scylla DB cluster running on Scylla Cloud"""
+
+    def __init__(self, cloud_api_client: ScyllaCloudAPIClient, user_prefix=None,
+                 n_nodes=3, params=None, node_type='scylla-db', add_nodes=True):
+
+        self._api_client = cloud_api_client
+        self._account_id = cloud_api_client.get_current_account_id()
+        self._cluster_id = None
+        self._cluster_request_id = None
+
+        self._cluster_created = False
+        self._pending_node_configs = []
+        if self.test_config.REUSE_CLUSTER and self._cluster_id:
+            self._cluster_created = True
+
+        cluster_prefix = cluster.prepend_user_prefix(user_prefix, 'db-cluster')
+        node_prefix = cluster.prepend_user_prefix(user_prefix, 'db-node')
+
+        super().__init__(
+            cluster_prefix=cluster_prefix,
+            node_prefix=node_prefix,
+            n_nodes=n_nodes,
+            params=params,
+            region_names=params.cloud_provider_params.get('region'),
+            node_type=node_type,
+            add_nodes=add_nodes)
+
+        if self.test_config.REUSE_CLUSTER and self._cluster_id:
+            self._reuse_existing_cluster()
+
+    @property
+    def parallel_startup(self):
+        # nodes provisioning and startup is managed by the Scylla Cloud itself
+        return False
+
+    def _create_node(self, cloud_instance_data, node_index, dc_idx, rack):
+        try:
+            node = CloudNode(
+                cloud_instance_data=cloud_instance_data,
+                parent_cluster=self,
+                node_prefix=self.node_prefix,
+                node_index=node_index,
+                base_logdir=self.logdir,
+                dc_idx=dc_idx,
+                rack=rack)
+            node.init()
+            return node
+        except Exception as e:
+            raise ScyllaCloudError(f"Failed to create node: {e}") from e
+
+    def add_nodes(self, count, ec2_user_data='', dc_idx=0, rack=0, enable_auto_bootstrap=False, instance_type=None):
+        """
+        Add nodes to cluster. For cloud backend, this creates the entire cluster
+        on first call, then performs resize for subsequent calls.
+        """
+        if not count:
+            return []
+
+        self.log.info("Adding %s nodes to Scylla Cloud cluster", count)
+        if self._cluster_created:
+            return self._resize_cluster(count, dc_idx, rack, instance_type)
+        return self._create_cluster(count, dc_idx, rack, enable_auto_bootstrap, instance_type)
+
+    def _create_cluster(self, count, dc_idx, rack, enable_auto_bootstrap, instance_type):
+        self.log.info("Creating new Scylla Cloud cluster with %s nodes", count)
+        cluster_config = self._prepare_cluster_config(count, instance_type)
+
+        self._cluster_request_id = self._api_client.create_cluster_request(**cluster_config)['requestId']
+        self._cluster_id = self._api_client.get_cluster_request_details(
+            account_id=self._account_id, request_id=self._cluster_request_id)['clusterId']
+
+        self.log.debug("Cluster creation initiated. Cluster ID: %s", self._cluster_id)
+        self._wait_for_cluster_ready()
+        nodes = self._init_nodes_from_cluster(count, dc_idx, rack)
+        self._cluster_created = True
+        self.log.info("Successfully created cluster %s with %s nodes", self._cluster_id, len(nodes))
+
+        return nodes
+
+    def _init_nodes_from_cluster(self, count, dc_idx, rack):
+        """Decompose the created cluster into individual CloudNode objects"""
+        cluster_nodes = self._api_client.get_cluster_nodes(
+            account_id=self._account_id, cluster_id=self._cluster_id, enriched=True)
+        if not cluster_nodes:
+            raise ScyllaCloudError("No nodes found in the cluster")
+        if len(cluster_nodes) < count:
+            self.log.warning("Expected %s nodes, but found %s", count, len(cluster_nodes))
+
+        self.log.info("Initializing %s individual CloudNode node objects", count)
+        created_nodes = []
+        for i, node_data in enumerate(cluster_nodes[:count]):
+            self._node_index += 1
+            node_rack = self._node_index % self.racks_count if rack is None else rack
+
+            node = self._create_node(
+                cloud_instance_data=node_data,
+                node_index=self._node_index,
+                dc_idx=dc_idx,
+                rack=node_rack)
+            self.nodes.append(node)
+            created_nodes.append(node)
+
+            self.log.info("Created node %s with public IP: %s", node.name, node.public_ip_address)
+        return created_nodes
+
+    def _prepare_cluster_config(self, node_count, instance_type):
+        cloud_provider = self.params.get('xcloud_provider').upper()
+
+        provider_id = self._api_client.cloud_provider_ids[CloudProviderType(cloud_provider)]
+
+        region_name = self.params.cloud_provider_params.get('region')
+        region_id = self._api_client.get_region_id_by_name(
+            cloud_provider_id=provider_id, region_name=region_name)
+
+        instance_type_name = instance_type or self.params.cloud_provider_params.get('instance_type_db')
+        instance_id = self._api_client.get_instance_id_by_name(
+            cloud_provider_id=provider_id, region_id=region_id, instance_type_name=instance_type_name)
+
+        allowed_ips = [f"{self._api_client.client_ip}/32",]
+
+        return {
+            'account_id': self._account_id,
+            'cluster_name': self.name,
+            'scylla_version': self.params.get('scylla_version'),
+            'cidr_block': None,
+            'broadcast_type': "PUBLIC",
+            'allowed_ips': allowed_ips,
+            'cloud_provider_id': provider_id,
+            'region_id': region_id,
+            'instance_id': instance_id,
+            'replication_factor': self.params.get('xcloud_replication_factor'),
+            'number_of_nodes': node_count,
+            'account_credential_id': self.params.get('xcloud_credential_id'),
+            'free_trial': False,
+            'user_api_interface': "CQL",
+            'enable_dns_association': True,
+            'jump_start': False,
+            'encryption_at_rest': None,
+            'maintenance_windows': [],
+            'scaling': {}
+        }
+
+    def _wait_for_cluster_ready(self, timeout=600):
+        self.log.info("Waiting for Scylla Cloud cluster to be ready")
+
+        def check_cluster_status():
+            try:
+                cluster_details = self._api_client.get_cluster_details(
+                    account_id=self._account_id, cluster_id=self._cluster_id, enriched=True)
+                status = cluster_details.get('status', '').upper()
+                self.log.debug("Cluster status: %s", status)
+                return status == 'ACTIVE'
+            except Exception as e:  # noqa: BLE001
+                self.log.debug("Error checking cluster status: %s", e)
+                return False
+
+        wait.wait_for(
+            func=check_cluster_status,
+            step=15,
+            text="Waiting for cluster to be ready",
+            timeout=timeout,
+            throw_exc=True)
+        self.log.info("Scylla Cloud cluster is ready")
+
+    def _resize_cluster(self, count, dc_idx, rack, instance_type):
+        """Handle subsequent add_nodes calls using cluster resize operations"""
+        self.log.info("Resizing cluster to add %s nodes", count)
+        raise NotImplementedError("Not yet implemented in POC")
+
+    def destroy(self):
+        self.log.info("Destroying Scylla Cloud cluster %s", self.name)
+        if self._cluster_id:
+            self._api_client.delete_cluster(
+                account_id=self._account_id, cluster_id=self._cluster_id, cluster_name=self.name)
+
+    def _reuse_existing_cluster(self):
+        """Decompose the existing cluster into individual CloudNode objects"""
+        self.log.info("Reusing existing Scylla Cloud cluster: %s", self._cluster_id)
+        try:
+            cluster_details = self._api_client.get_cluster_details(
+                account_id=self._account_id, cluster_id=self._cluster_id)
+            self.name = cluster_details.get('clusterName', self.name)
+            self.log.info("Found existing cluster: %s", self.name)
+
+            cluster_nodes = self._api_client.get_cluster_nodes(
+                account_id=self._account_id, cluster_id=self._cluster_id, enriched=True)
+
+            self.log.debug("Reusing %s nodes from existing cluster", len(cluster_nodes))
+            for i, node_data in enumerate(cluster_nodes):
+                node_index = i + 1
+                rack = node_index % self.racks_count
+                node = self._create_node(
+                    cloud_instance_data=node_data,
+                    node_index=node_index,
+                    dc_idx=0,
+                    rack=rack)
+                self.nodes.append(node)
+            self._cluster_created = True
+        except Exception as e:
+            raise ScyllaCloudError(f"Failed to reuse cluster: {e}") from e
+
+    @staticmethod
+    def _wait_for_preinstalled_scylla(node):
+        pass
+
+    def node_startup(self, node, verbose=False, timeout=3600):
+        self.log.info("Starting up Scylla Cloud node %s", node.name)
+        node.wait_db_up(verbose=verbose, timeout=timeout)
+
+    def node_setup(self, node, verbose=False, timeout=3600):
+        self.log.info("Setting up Scylla Cloud node %s", node.name)
+        node.wait_ssh_up(verbose=verbose, timeout=timeout)
+
+    @cluster.wait_for_init_wrap
+    def wait_for_init(self, node_list=None, verbose=False, timeout=None, check_node_health=True):
+        node_list = node_list if node_list else self.nodes
+        self.wait_for_nodes_up_and_normal(nodes=node_list)
+
+    def update_seed_provider(self):
+        # TODO: Implement seed provider update logic for Scylla Cloud
+        self.log.debug(
+            "Skip updating seed provider on Scylla Cloud, pending until approach to SSHing/accessing nodes is developed")
+
+    def validate_seeds_on_all_nodes(self):
+        # TODO: Implement seed validation logic for Scylla Cloud
+        self.log.debug("Skip validating seeds on Scylla Cloud, pending until approach to SSHing/accessing nodes is developed")
+
+    def start_nemesis(self, interval=None, cycles_count: int = -1):
+        # TODO: Enable nemesis start for Scylla Cloud
+        self.log.info('Skip starting nemesis on Scylla Cloud')
+
+    def check_nodes_up_and_normal(self, nodes=None, verification_node=None):
+        """Checks via Scylla Cloud API that nodes are in ACTIVE/NORMAL state"""
+        if not nodes:
+            nodes = self.nodes
+
+        cluster_nodes = self._api_client.get_cluster_nodes(account_id=self._account_id, cluster_id=self._cluster_id)
+        api_nodes_by_id = {node_data['id']: node_data for node_data in cluster_nodes}
+
+        down_nodes = []
+        for node in nodes:
+            api_node_data = api_nodes_by_id.get(node._node_id)
+            node_status = api_node_data.get('status', '').upper()
+            node_state = api_node_data.get('state', '').upper()
+            self.log.debug(f"Node {node.name}: status={node_status}, state={node_state}")
+
+            if node_status != 'ACTIVE' or node_state != 'NORMAL':
+                down_nodes.append(node)
+
+        if down_nodes:
+            raise cluster.ClusterNodesNotReady(
+                f"Nodes {','.join([node.name for node in down_nodes])} are not in ACTIVE/NORMAL state")
+
+    def get_node_ips_param(self, public_ip=True):
+        return 'xcloud_nodes_public_ip' if public_ip else 'xcloud_nodes_private_ip'

--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -123,6 +123,9 @@ class KeyStore:
     def get_baremetal_config(self, config_name: str):
         return self.get_json(f"{config_name}.json")
 
+    def get_cloud_rest_credentials(self, environment: str = "lab"):
+        return self.get_json(f"scylla_cloud_sct_api_creds_{environment}.json")
+
     @staticmethod
     def calculate_s3_etag(file: BinaryIO, chunk_size=8 * 1024 * 1024):
         """Calculates the S3 custom e-tag (a specially formatted MD5 hash)"""

--- a/sdcm/utils/cloud_api_utils.py
+++ b/sdcm/utils/cloud_api_utils.py
@@ -1,0 +1,30 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+import json
+import logging
+from pathlib import Path
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_cloud_rest_credentials_from_file(file_path: str) -> dict:
+    """Retrieve Scylla Cloud REST credentials from a file"""
+    path = Path(file_path).expanduser()
+    if not path.exists():
+        raise ValueError(f"Scylla Cloud REST credentials file not found: {file_path}")
+
+    with path.open('r', encoding='utf-8') as creds_file:
+        creds = json.load(creds_file)
+    return creds


### PR DESCRIPTION
This change is a PoC of introducing a new backend for SCT, to be able to provision a cluster in Scylla Cloud with SCT only (i.e. without the need to use siren-tests framework).

The list of implemented items:
- **Scylla cloud API client for SCT**
It covers all the public APIs, as defined in https://cloud.docs.scylladb.com/stable/api.html, but for now only part of them have been used/tested in the scope of this PoC
- **Scylla cloud backend**
It implements the existing approach to defining backends in SCT - defines abstractions for Cloud node, Cloud cluster, Scylla cloud cluster.
Due to the managed nature of cloud backend and inability to access public cloud cluster nodes by SSH, the node_setup, node_init sequences are mainly skipped. Once we have a way to access cloud cluster nodes we can add the needed setup/init actions.
- **cleanup for cloud cluster**
For now it allows to cleanup cloud cluster only by testID, where testID is a part of cluster name. Later when approach to add tags/metadata to cloud cluster is defined, we can improve the cleanup procedure.
- **a set of configurations options,** specific to cloud backend, and a simple dedicated backend config.

Current implementation details to take into account:
- static API token of specific user (mine) for lab environment is used. it is stored in SCT Keystore bucket, but can also be read from a local file. Later we can create a dedicated test user (for different cloud environments if needed)
- the cluster is created with nodes having public IPs, but they are not accessible at the moment. As a next step/improvement we would need to add code for defining firewall rules to allow the needed traffic (Scylla cloud public API has methods for this)

The current implementation allows to perform only the basic cluster creation/cleanup. Running a load against scylla-cloud provisioned cluster, collecting logs, etc. are out of scope of this task
and are to be implemented in the subsequent series of tasks.

Refs: https://github.com/scylladb/qa-tasks/issues/1911

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
Executed simple test locally (existing pipelines are not adjusted to run against scylla cloud backend):
- adjusted a bit the `pr-provision-test` test config (commented out stress commands and set number of loaders to 0 - ability to run a load test will be added later)
```
--- a/test-cases/PR-provision-test.yaml
+++ b/test-cases/PR-provision-test.yaml
@@ -6,15 +6,15 @@ data_validation: |
   max_partitions_in_test_table: 10
   partition_range_with_data_validation: 0-10
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=1m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5",
-             "cassandra-stress counter_write cl=QUORUM duration=1m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=TimeWindowCompactionStrategy)' -mode cql3 native -rate threads=5 -pop seq=1..10000000"
-             ]
+#stress_cmd: ["cassandra-stress write cl=QUORUM duration=1m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5",
+#             "cassandra-stress counter_write cl=QUORUM duration=1m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=TimeWindowCompactionStrategy)' -mode cql3 native -rate threads=5 -pop seq=1..10000000"
+#             ]
+#
+#prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -max-rate=300 -replication-factor=3 -partition-count=10 -clustering-row-count=100 -clustering-row-size=5120 -concurrency=7 -rows-per-request=10",
+#                     "scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=10 -clustering-row-count=100 -clustering-row-size=5120 -rows-per-request=10 -concurrency=7 -max-rate=32000 -duration=1m"
+#                    ]
 
-prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -max-rate=300 -replication-factor=3 -partition-count=10 -clustering-row-count=100 -clustering-row-size=5120 -concurrency=7 -rows-per-request=10",
-                     "scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=10 -clustering-row-count=100 -clustering-row-size=5120 -rows-per-request=10 -concurrency=7 -max-rate=32000 -duration=1m"
-                    ]
-
-n_loaders: 1
+n_loaders: 0
```

- executed test_custom_time longevity test, which simply provisions cloud cluster for now
```
❯ SCT_CLOUD_ENV=lab SCT_CLOUD_PROVIDER=aws SCT_CLOUD_REGION=eu-west-1 SCT_CONFIG_FILES='["test-cases/PR-provision-test.yaml"]' SCT_ENABLE_ARGUS=false SCT_SCYLLA_VERSION=2025.2.0 ./sct.py run-test longevity_test.LongevityTest.test_custom_time --backend cloud
logged in as arn:aws:sts::797456418907:assumed-role/DeveloperAccessRole/dmytro.kruglov@scylladb.com
New directory created: /home/dmitriy/sct-results/20250716-111440-054248
Symlink `/home/dmitriy/sct-results/latest' updated to `/home/dmitriy/sct-results/20250716-111440-054248'
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.10.0, pytest-8.3.4, pluggy-1.5.0 -- /home/dmitriy/.pyenv/versions/sct310/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /home/dmitriy/Work/Scylla/sct_cloud_poc
configfile: pyproject.toml
plugins: anyio-4.9.0, random-order-1.0.4, typeguard-4.3.0
collecting ... collected 1 item

longevity_test.py::LongevityTest::test_custom_time < t:2025-07-16 11:14:44,258 f:base.py         l:376  c:sdcm.sct_events.base p:INFO  > The run can be interrupted by following critical events:
< t:2025-07-16 11:14:44,258 f:base.py         l:376  c:sdcm.sct_events.base p:INFO  >   * ClusterHealthValidatorEvent.NodeStatus
< t:2025-07-16 11:14:44,258 f:base.py         l:376  c:sdcm.sct_events.base p:INFO  >   * ClusterHealthValidatorEvent.ScyllaCloudClusterServerDiagnostic
< t:2025-07-16 11:14:44,258 f:base.py         l:376  c:sdcm.sct_events.base p:INFO  >   * DataValidatorEvent.UpdatedRowsValidator
...

PASSED< t:2025-07-16 11:18:25,719 f:tester.py       l:3205 c:LongevityTest        p:INFO  > ================================= TEST RESULTS =================================
< t:2025-07-16 11:18:25,719 f:tester.py       l:3205 c:LongevityTest        p:INFO  > ================================================================================
< t:2025-07-16 11:18:25,719 f:tester.py       l:3205 c:LongevityTest        p:INFO  > SUCCESS :)
< t:2025-07-16 11:18:30,953 f:setup.py        l:86   c:sdcm.sct_events.setup p:INFO  > Statistics of sent/received events (by device): {
< t:2025-07-16 11:18:30,953 f:setup.py        l:86   c:sdcm.sct_events.setup p:INFO  >     "EventsProcessesRegistry[log_dir=/home/dmitriy/sct-results/20250716-111440-054248,id=0x7eac21e8a020,default=True][EVENTS_FILE_LOGGER]": 79,
< t:2025-07-16 11:18:30,953 f:setup.py        l:86   c:sdcm.sct_events.setup p:INFO  >     "EventsProcessesRegistry[log_dir=/home/dmitriy/sct-results/20250716-111440-054248,id=0x7eac21e8a020,default=True][EVENTS_GRAFANA_ANNOTATOR]": 79,
< t:2025-07-16 11:18:30,953 f:setup.py        l:86   c:sdcm.sct_events.setup p:INFO  >     "EventsProcessesRegistry[log_dir=/home/dmitriy/sct-results/20250716-111440-054248,id=0x7eac21e8a020,default=True][EVENTS_GRAFANA_AGGREGATOR]": 7,
< t:2025-07-16 11:18:30,953 f:setup.py        l:86   c:sdcm.sct_events.setup p:INFO  >     "EventsProcessesRegistry[log_dir=/home/dmitriy/sct-results/20250716-111440-054248,id=0x7eac21e8a020,default=True][EVENTS_GRAFANA_POSTMAN]": 7,
< t:2025-07-16 11:18:30,953 f:setup.py        l:86   c:sdcm.sct_events.setup p:INFO  >     "EventsProcessesRegistry[log_dir=/home/dmitriy/sct-results/20250716-111440-054248,id=0x7eac21e8a020,default=True][EVENTS_COUNTER_ID]": 79,
< t:2025-07-16 11:18:30,953 f:setup.py        l:86   c:sdcm.sct_events.setup p:INFO  >     "EventsProcessesRegistry[log_dir=/home/dmitriy/sct-results/20250716-111440-054248,id=0x7eac21e8a020,default=True][EVENTS_HANDLER]": 79,
< t:2025-07-16 11:18:30,953 f:setup.py        l:86   c:sdcm.sct_events.setup p:INFO  >     "EventsProcessesRegistry[log_dir=/home/dmitriy/sct-results/20250716-111440-054248,id=0x7eac21e8a020,default=True][MainDevice]": 79
< t:2025-07-16 11:18:30,953 f:setup.py        l:86   c:sdcm.sct_events.setup p:INFO  > }


=========================================================================================== 1 passed in 230.82s (0:03:50) ===========================================================================================

❯ grep PR-provision-test ~/sct-results/latest/sct.log
...
< t:2025-07-16 11:17:57,915 f:cluster_cloud.py l:333  c:sdcm.cluster         p:DEBUG > ScyllaCloudCluster:PR-provision-test-dmitriy-db-cluster-699e9324: Cluster status: BOOTSTRAPPING
< t:2025-07-16 11:18:14,116 f:cloud_api_client.py l:97   c:sdcm.cloud_api_client p:DEBUG >             "clusterName": "PR-provision-test-dmitriy-db-cluster-699e9324",
< t:2025-07-16 11:18:14,116 f:cluster_cloud.py l:333  c:sdcm.cluster         p:DEBUG > ScyllaCloudCluster:PR-provision-test-dmitriy-db-cluster-699e9324: Cluster status: ACTIVE
< t:2025-07-16 11:18:14,116 f:cluster_cloud.py l:345  c:sdcm.cluster         p:INFO  > ScyllaCloudCluster:PR-provision-test-dmitriy-db-cluster-699e9324: Scylla Cloud cluster is ready
< t:2025-07-16 11:18:14,837 f:cluster_cloud.py l:274  c:sdcm.cluster         p:INFO  > ScyllaCloudCluster:PR-provision-test-dmitriy-db-cluster-699e9324: Initializing 3 individual CloudNode node objects
< t:2025-07-16 11:18:14,863 f:cluster_cloud.py l:288  c:sdcm.cluster         p:INFO  > ScyllaCloudCluster:PR-provision-test-dmitriy-db-cluster-699e9324: Created node pr-provision-test-dmitriy-db-node-699e9324-0-1 with public IP: 54.247.105.207
< t:2025-07-16 11:18:14,877 f:cluster_cloud.py l:288  c:sdcm.cluster         p:INFO  > ScyllaCloudCluster:PR-provision-test-dmitriy-db-cluster-699e9324: Created node pr-provision-test-dmitriy-db-node-699e9324-0-2 with public IP: 54.73.146.246
< t:2025-07-16 11:18:14,891 f:cluster_cloud.py l:288  c:sdcm.cluster         p:INFO  > ScyllaCloudCluster:PR-provision-test-dmitriy-db-cluster-699e9324: Created node pr-provision-test-dmitriy-db-node-699e9324-0-3 with public IP: 52.214.195.68
< t:2025-07-16 11:18:14,891 f:cluster_cloud.py l:261  c:sdcm.cluster         p:INFO  > ScyllaCloudCluster:PR-provision-test-dmitriy-db-cluster-699e9324: Successfully created cluster 242 with 3 nodes
...
```

- the created cluster
<img width="1834" height="970" alt="Screenshot from 2025-07-16 11-48-36" src="https://github.com/user-attachments/assets/59740652-1fdf-438d-9cdd-42a7d3da0e9c" />

- executed cleanup for cloud clusters
```
❯ cat ~/sct-results/latest/test_id
699e9324-98ec-462c-87ac-ca8ae3745ce9

❯ SCT_CLOUD_ENV=lab ./sct.py clean-resources --test-id 699e9324-98ec-462c-87ac-ca8ae3745ce9 -b cloud
logged in as arn:aws:sts::797456418907:assumed-role/DeveloperAccessRole/dmytro.kruglov@scylladb.com
New directory created: /home/dmitriy/sct-results/20250716-115101-926871-clean-resources
Clean all resources for following Test IDs: ('699e9324-98ec-462c-87ac-ca8ae3745ce9%',)
Failed to load configuration files: []
The run can be interrupted by following critical events:
  * ClusterHealthValidatorEvent.NodeStatus
  * ClusterHealthValidatorEvent.ScyllaCloudClusterServerDiagnostic
  * DataValidatorEvent.UpdatedRowsValidator
...

Capacity reservation is not enabled. Skipping reservation.
Dedicated hosts is not enabled. Skipping reservation phase.
Initialized Scylla Cloud API client for https://api-v2.ext.lab.scylla.cloud
Initialized Scylla Cloud API client for https://api-v2.ext.lab.scylla.cloud
Found 1 cluster(s) in Scylla Cloud account
Found 1 cluster(s) to delete
Going to delete cluster PR-provision-test-dmitriy-db-cluster-699e9324 (ID: 242)
Unable to initialize Argus: Malformed UUID provided
Cleanup for the {'TestId': '699e9324-98ec-462c-87ac-ca8ae3745ce9'} resources has been finished
```


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
