### PR TITLE
fix(upgrade_test): increase timeout for upgrade_os

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -164,7 +164,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
     # would be recalculated after all the cluster finish upgrade
     expected_sstable_format_version = 'mc'
 
-    system_upgrade_timeout = 6 * 60
+    system_upgrade_timeout = 10 * 60
 
     def should_do_complex_profile(self) -> bool:
         """


### PR DESCRIPTION
The timeout should be more permissive due to relying on external systems and networks.

Occurred https://argus.scylladb.com/tests/scylla-cluster-tests/34c12208-6d86-471a-9822-cca12cb02694 and https://argus.scylladb.com/tests/scylla-cluster-tests/677d0d08-2026-4e5b-ae19-27f3de16c209

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
