### PR TITLE
fix(ci-triggers): Fix tier1 oss CI triggers

### DIFF
--- a/jenkins-pipelines/oss/sct_triggers/tier1-aws-custom-time-trigger.xml
+++ b/jenkins-pipelines/oss/sct_triggers/tier1-aws-custom-time-trigger.xml
@@ -59,7 +59,7 @@ stress_duration=$stress_duration</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>../tier1/longevity-mv-si-4days-streaming-test,../tier1/longevity-schema-topology-changes-12h-test,../tier1/longevity-twcs-48h-test,../tier1/longevity-multidc-schema-topology-changes-12h-test,../tier1/longevity-50gb-3days-test,../tier1/longevity-150gb-asymmetric-cluster-12h-test</projects>
+          <projects>../tier1/longevity-mv-si-4days-streaming-test,../tier1/longevity-schema-topology-changes-12h-test,../tier1/longevity-twcs-48h-test,../tier1/longevity-50gb-3days-test,../tier1/longevity-150gb-asymmetric-cluster-12h-test</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>
@@ -67,22 +67,7 @@ stress_duration=$stress_duration</properties>
         <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
           <configs>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-              <properties>scylla_version=$scylla_version
-test_name=jepsen-test-all
-post_behavior_db_nodes=destroy
-post_behavior_monitor_nodes=destroy</properties>
-              <textParamValueOnNewLine>false</textParamValueOnNewLine>
-            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-          </configs>
-          <projects>../tier1/jepsen-all-test</projects>
-          <condition>SUCCESS</condition>
-          <triggerWithNoParameters>false</triggerWithNoParameters>
-          <triggerFromChildProjects>false</triggerFromChildProjects>
-        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-          <configs>
-            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-              <properties>scylla_version=$scylla_version
+              <properties>scylla_version=%(sct_branch)s:latest
 provision_type=on_demand
 post_behavior_db_nodes=destroy
 post_behavior_monitor_nodes=destroy
@@ -90,7 +75,7 @@ stress_duration=$stress_duration</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>../longevity/longevity-multidc-schema-topology-changes-12h-test</projects>
+          <projects>../tier1/longevity-multidc-schema-topology-changes-12h-test</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>

--- a/jenkins-pipelines/oss/sct_triggers/tier1-gce-custom-time-trigger.xml
+++ b/jenkins-pipelines/oss/sct_triggers/tier1-gce-custom-time-trigger.xml
@@ -51,6 +51,22 @@ stress_duration=$stress_duration</properties>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>
         </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>gce_image_db=$gce_image_db
+scylla_version=$scylla_version
+test_name=jepsen-test-all
+post_behavior_db_nodes=destroy
+post_behavior_monitor_nodes=destroy</properties>
+              <textParamValueOnNewLine>false</textParamValueOnNewLine>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>../tier1/jepsen-all-test</projects>
+          <condition>SUCCESS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <triggerFromChildProjects>false</triggerFromChildProjects>
+        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
       </configs>
     </hudson.plugins.parameterizedtrigger.BuildTrigger>
   </publishers>

--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -34,6 +34,9 @@ def call(Map pipelineParams) {
             string(defaultValue: '',
                    description: 'a Scylla repo to run against',
                    name: 'scylla_repo')
+            string(defaultValue: '',
+                   description: 'GCE image for ScyllaDB ',
+                   name: 'gce_image_db')
 
             string(defaultValue: '',
                    description: 'a link to the git repository with Jepsen Scylla tests',
@@ -177,8 +180,10 @@ def call(Map pipelineParams) {
                                     export SCT_SCYLLA_VERSION="${params.scylla_version}"
                                 elif [[ ! -z "${params.scylla_repo}" ]]; then
                                     export SCT_SCYLLA_REPO="${params.scylla_repo}"
+                                elif [[ ! -z "${params.gce_image_db}" ]]; then
+                                    export SCT_GCE_IMAGE_DB="${params.gce_image_db}"
                                 else
-                                    echo "need to choose one of SCT_SCYLLA_VERSION | SCT_SCYLLA_REPO"
+                                    echo "need to choose one of SCT_SCYLLA_VERSION | SCT_SCYLLA_REPO | SCT_GCE_IMAGE_DB"
                                     exit 1
                                 fi
 


### PR DESCRIPTION
Changes:
- Move the `jepsen-all-test` CI job from the AWS to GCE trigger file because it is GCE-only CI job.
- Make the `jepsen-all-test` trigger respect the `gce_image_db` trigger parameter.
- Make the `longevity-multidc-schema-topology-changes-12h-test` CI job use hardcoded `latest` value for release branch.
  It is needed because reusing the `scylla_version` or `ami_id` params
  we will get only single-dc values, which are not applicable here.
- Remove duplication of the `longevity-multidc-schema-topology-changes-12h-test` config from the
  single-dc config block.
-  Add `gce_image_db` pipeline parameter support to the `jepsen` pipeline.

Closes: https://github.com/scylladb/scylla-cluster-tests/issues/11415

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
