### PR TITLE
fix(cqlshrc): update cqlshrc only once

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -11,6 +11,7 @@
 #
 # Copyright (c) 2016 ScyllaDB
 import shutil
+import configparser
 from collections import defaultdict
 from copy import deepcopy
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -68,7 +69,9 @@ from sdcm.provision.aws.dedicated_host import SCTDedicatedHosts
 from sdcm.provision.azure.provisioner import AzureProvisioner
 from sdcm.provision.network_configuration import ssh_connection_ip_type
 from sdcm.provision.provisioner import provisioner_factory
-from sdcm.provision.helpers.certificate import create_ca, update_certificate, cleanup_ssl_config
+from sdcm.provision.helpers.certificate import (
+    create_ca, update_certificate, cleanup_ssl_config, CLIENT_FACING_CERTFILE,
+    CLIENT_FACING_KEYFILE, CA_CERT_FILE, SCYLLA_SSL_CONF_DIR)
 from sdcm.reporting.elastic_reporter import ElasticRunReporter
 from sdcm.reporting.tooling_reporter import PythonDriverReporter
 from sdcm.scan_operation_thread import ScanOperationThread
@@ -207,6 +210,23 @@ def teardown_on_exception(method):
             raise
 
     return wrapper
+
+
+def update_cqlshrc(cqlshrc_file: str) -> None:
+    """Update cqlshrc file according to SSL configuration of the test"""
+    config = configparser.ConfigParser()
+    config.read(cqlshrc_file)
+
+    config.setdefault('connection', {})['ssl'] = 'true'
+    config.setdefault('ssl', {})
+    config['ssl'] = {
+        'validate': 'true',
+        'certfile': f'{SCYLLA_SSL_CONF_DIR / CA_CERT_FILE.name}',
+        'userkey': f'{SCYLLA_SSL_CONF_DIR / CLIENT_FACING_KEYFILE.name}',
+        'usercert': f'{SCYLLA_SSL_CONF_DIR / CLIENT_FACING_CERTFILE.name}'
+    }
+    with open(cqlshrc_file, 'w', encoding='utf-8') as file:
+        config.write(file)
 
 
 class silence:
@@ -982,6 +1002,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         if (not self.params.get("cluster_backend").startswith("k8s") and
                 any([self.params.get('client_encrypt'), self.params.get('server_encrypt')])):
             create_ca(self.localhost)
+            if self.params.get('client_encrypt'):
+                cqlshrc_file = get_data_dir_path('ssl_conf', 'client', 'cqlshrc')
+                update_cqlshrc(cqlshrc_file)
 
         # download rpms for update_db_packages
         if self.params.get('update_db_packages'):


### PR DESCRIPTION
This change moves updating cqshrc config to ClusterTester.setUp, to have it executed only once, before creation of cluster nodes.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11409

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [pr-provision tests with enabled encryption](https://argus.scylladb.com/tests/scylla-cluster-tests/99e17ecb-9fae-4fb5-bedc-0d6ee7ab0036)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
