### PR TITLE
fix(nemesis): assertion added for case when no user table found

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2627,6 +2627,9 @@ class Nemesis(NemesisFlags):
             db_node=self.target_node, filter_out_table_with_counter=True,
             filter_out_mv=True)
 
+        if not ks_cfs:
+            raise UnsupportedNemesis('No non-system user tables found')
+
         keyspace_table = random.choice(ks_cfs) if ks_cfs else ks_cfs
         keyspace, table = keyspace_table.split('.')
         compaction_strategy = get_compaction_strategy(node=self.target_node, keyspace=keyspace, table=table)


### PR DESCRIPTION
minor change that asserts if no user table been found fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11217

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
