### PR TITLE
tester.py: downgrade 'no such container' errors on teardown

### DIFF
--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -23,7 +23,7 @@ from sdcm.sct_events.event_handler import start_events_handler
 from sdcm.sct_events.grafana import start_grafana_pipeline
 from sdcm.sct_events.filters import DbEventsFilter, EventsSeverityChangerFilter
 from sdcm.sct_events.database import DatabaseLogEvent
-from sdcm.sct_events.loaders import CassandraStressLogEvent
+from sdcm.sct_events.loaders import CassandraStressEvent, CassandraStressLogEvent
 from sdcm.sct_events.file_logger import start_events_logger
 from sdcm.sct_events.events_device import start_events_main_device
 from sdcm.sct_events.events_analyzer import start_events_analyzer
@@ -157,6 +157,16 @@ def enable_default_filters(sct_config: SCTConfiguration):
                    line=r".*raft_topology - topology change coordinator fiber got error std::runtime_error"
                         r" \(raft topology: exec_global_command\(barrier\) failed with seastar::rpc::closed_error"
                         r" \(connection is closed\)\)").publish()
+
+
+def enable_teardown_filters():
+    # If a nemesis happens to start a cassandra stress container just as teardown starts,
+    # it is possible the container is removed faster than the nemesis can be stopped,
+    # and it will try to use it and fail.
+    EventsSeverityChangerFilter(new_severity=Severity.WARNING,
+                                event_class=CassandraStressEvent,
+                                regex=r'.*Error response from daemon: No such container.*',
+                                extra_time_to_expiration=60).publish()
 
 
 __all__ = ("start_events_device", "stop_events_device", "enable_default_filters")

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -104,7 +104,7 @@ from sdcm.results_analyze import PerformanceResultsAnalyzer, SpecifiedStatsPerfo
     LatencyDuringOperationsPerformanceAnalyzer
 from sdcm.sct_config import init_and_verify_sct_config
 from sdcm.sct_events import Severity
-from sdcm.sct_events.setup import start_events_device, stop_events_device, enable_default_filters
+from sdcm.sct_events.setup import enable_teardown_filters, start_events_device, stop_events_device, enable_default_filters
 from sdcm.sct_events.system import InfoEvent, TestFrameworkEvent, TestResultEvent, TestTimeoutEvent
 from sdcm.sct_events.file_logger import get_events_grouped_by_category, get_logger_event_summary
 from sdcm.sct_events.events_analyzer import stop_events_analyzer
@@ -3036,6 +3036,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
 
     def tearDown(self):
         self.teardown_started = True
+        enable_teardown_filters()
         with silence(parent=self, name='Sending test end event'):
             InfoEvent(message="TEST_END").publish()
         self.save_schema()


### PR DESCRIPTION
If a nemesis happens to start a cassandra stress container just as teardown starts, it is possible the container is removed faster than the nemesis can be stopped, and it will try to use it and fail.

Added `enable_teardown_filters`, a parallel to `enable_default_filters`.

Example of occurrence: https://jenkins.scylladb.com/job/scylla-2025.2/job/features/job/FIPS/job/longevity-100gb-4h-fips-test/12/consoleFull

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
