### PR TITLE
fix(cloud-init): if using scylla-machine-image assume apt-daily-* disabled

### DIFF
--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -279,7 +279,10 @@ def install_syslogng_exporter():
 def disable_daily_apt_triggers():
     return dedent("""\
     if apt-get --help >/dev/null 2>&1 ; then
-        if [ ! -f /tmp/disable_daily_apt_triggers_done ]; then
+        smi_installed=false
+        dpkg -s scylla-machine-image &> /dev/null && smi_installed=true
+        dpkg -s scylla-enterprise-machine-image &> /dev/null && smi_installed=true
+        if [ ! -f /tmp/disable_daily_apt_triggers_done && ! $smi_installed ]; then
             rm -f /etc/apt/apt.conf.d/*unattended-upgrades /etc/apt/apt.conf.d/*auto-upgrades || true
             rm -f /etc/apt/apt.conf.d/*periodic /etc/apt/apt.conf.d/*update-notifier || true
             systemctl stop apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service || true


### PR DESCRIPTION
skip this part if scylla-machine-image is used, assuming it's already doing those disables out of the box

Fixes: #11312

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
