### PR TITLE
fix(unittest): enlarge timeout in test_negative_prometheus_validation…

### DIFF
--- a/unit_tests/test_scan_operation_thread.py
+++ b/unit_tests/test_scan_operation_thread.py
@@ -146,7 +146,7 @@ def test_negative_prometheus_validation_error(events, cluster):
     )
     with patch.object(PrometheusDBStats, "__init__", return_value=None):
         with patch.object(PrometheusDBStats, "query", return_value=[{"values": [[0, "1"], [1, "1"]]}]):
-            with events.wait_for_n_events(events.get_events_logger(), count=2, timeout=2):
+            with events.wait_for_n_events(events.get_events_logger(), count=2, timeout=30):
                 ScanOperationThread(default_params)._run_next_operation()
             all_events = get_event_log_file(events)
             assert "Severity.NORMAL" in all_events[0] and "period_type=begin" in all_events[0]


### PR DESCRIPTION
…_error

the test was wait 2sec for all of the event it's expacting. in some situations it can take a bit more then that.

tested with
```
pytest unit_tests/test_scan_operation_thread.py --count 10 -n 4
```

Fixes: #11152

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] test locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
