### PR TITLE
fix(_enable_disable_table_encryption): escape keyspace and table as needed

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -45,7 +45,7 @@ from argus.common.enums import NemesisStatus
 from sdcm.nemesis_registry import NemesisRegistry
 from sdcm.utils.action_logger import get_action_logger
 
-from sdcm.utils.cql_utils import cql_unquote_if_needed
+from sdcm.utils.cql_utils import cql_unquote_if_needed, cql_quote_if_needed
 from sdcm import wait
 from sdcm.audit import Audit, AuditConfiguration, AuditStore
 from sdcm.cluster import (
@@ -4365,7 +4365,7 @@ class Nemesis(NemesisFlags):
                 write_cmd = (
                     "scylla-bench -mode=write -workload=sequential -consistency-level=all -replication-factor=3"
                     " -partition-count=50 -clustering-row-count=100 -clustering-row-size=uniform:75..125"
-                    f" -keyspace {keyspace_name} -table {table_name} -timeout=120s -validate-data")
+                    f" -keyspace '{cql_quote_if_needed(keyspace_name)}' -table '{cql_quote_if_needed(table_name)}' -timeout=120s -validate-data")
                 run_write_scylla_bench_load(write_cmd)
                 upgrade_sstables(self.cluster.data_nodes)
 
@@ -4373,7 +4373,7 @@ class Nemesis(NemesisFlags):
                 read_cmd = (
                     "scylla-bench -mode=read -workload=sequential -consistency-level=all -replication-factor=3"
                     " -partition-count=50 -clustering-row-count=100 -clustering-row-size=uniform:75..125"
-                    f" -keyspace {keyspace_name} -table {table_name} -timeout=120s -validate-data"
+                    f" -keyspace '{cql_quote_if_needed(keyspace_name)}' -table '{cql_quote_if_needed(table_name)}' -timeout=120s -validate-data"
                     " -iterations=1 -concurrency=10 -connection-count=10 -rows-per-request=10")
                 read_thread = self.tester.run_stress_thread(stress_cmd=read_cmd, stop_test_on_failure=False)
                 self.tester.verify_stress_thread(read_thread, error_handler=self._nemesis_stress_failure_handler)

--- a/unit_tests/test_scylla_bench_thread.py
+++ b/unit_tests/test_scylla_bench_thread.py
@@ -28,6 +28,7 @@ pytestmark = [
         pytest.param("", id="regular"),
         pytest.param("-tls", id="tls", marks=[pytest.mark.docker_scylla_args(ssl=True)]),
         pytest.param("cloud-config", id="sni_proxy", marks=pytest.mark.skip(reason="manual test only")),
+        pytest.param("""-keyspace='"5_keyspace"' """, id="quoted_keyspace"),
     ],
 )
 def test_01_scylla_bench(request, docker_scylla, params, extra_cmd):


### PR DESCRIPTION
in cases we have keyspace with names that needs to be escaped s-b stress command were failing with the following:
```
Stress command completed with bad status 1: 2025/06/25 22:11:41
line 1:30 no viable alternative at input '5' (potentially executed: false)
```

this fix add escaping back as need to the keyspace or the tables for those commands

Fixes: #11273

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/146/
- [x] nemesis was passing with those changes, the actual issue with keyspace was test in integration test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
