### PR TITLE
improvement(ReplicationStrategy): waits for schema agreement when RF changes are applied

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -237,7 +237,7 @@ class ArtifactsTest(ClusterTester):
                 "Skipping verifying the snitch due to the 'use_preinstalled_scylla' being set to False", target=self.node.name)
             return
 
-        describecluster_snitch = self.get_describecluster_info().snitch
+        describecluster_snitch = self.db_cluster.get_describecluster_info(self.node).snitch
         with self.node.remote_scylla_yaml() as scylla_yaml:
             scylla_yaml_snitch = scylla_yaml.endpoint_snitch
         expected_snitches = BACKENDS[backend_name]

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -32,7 +32,8 @@ import itertools
 import json
 import shlex
 from decimal import Decimal, ROUND_UP
-from typing import List, Optional, Dict, Union, Set, Iterable, ContextManager, Any, IO, AnyStr, Callable, Literal
+from typing import List, Optional, Dict, Union, Set, Iterable, ContextManager, Any, IO, AnyStr, Callable, Literal, \
+    NamedTuple
 from datetime import datetime, timezone
 from textwrap import dedent
 from functools import cached_property, wraps, lru_cache, partial
@@ -4144,6 +4145,18 @@ class ClusterNodesNotReady(Exception):
     pass
 
 
+class SchemaVersion(NamedTuple):
+    schema_id: str
+    node_ips: List[str]
+
+
+class ClusterInformation(NamedTuple):
+    name: str
+    snitch: str
+    partitioner: str
+    schema_versions: List[SchemaVersion]
+
+
 class BaseScyllaCluster:
     name: str
     nodes: List[BaseNode]
@@ -4535,6 +4548,58 @@ class BaseScyllaCluster:
         proper_yaml_output = "\n".join([line for line in res.stdout.splitlines() if ":" in line])
         info_res = yaml.safe_load(proper_yaml_output)
         return info_res
+
+    def get_describecluster_info(self, node: Optional[BaseNode] = None) -> Optional[ClusterInformation]:
+        """
+        Runs the 'nodetool describecluster' command on a node.
+
+        Example output:
+
+        nodetool describecluster
+
+        Cluster Information:
+             Name: Test Cluster
+             Snitch: org.apache.cassandra.locator.SimpleSnitch
+             Partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+             Schema versions:
+                     86a67fc7-1d7c-3dc3-9be9-9c86b27e2506: [172.17.0.2]
+
+        The output is then packaged into a ClusterInformation
+        namedtuple, for easier access to the fields.
+        """
+        if not node:
+            node = random.choice(self.nodes)
+        describecluster_output = node.run_nodetool(sub_cmd="describecluster")
+
+        if describecluster_output.ok:
+            desc_stdout = describecluster_output.stdout
+            name_pattern = re.compile("((?<=Name: )[\w _-]*)")
+            snitch_pattern = re.compile("((?<=Snitch: )[\w.]*)")
+            partitioner_pattern = re.compile(
+                "((?<=Partitioner: )[\w.]*)")
+            schema_versions_pattern = re.compile(
+                "([a-z0-9-]{36}: \[[\d., ]*\])")
+
+            name = name_pattern.search(desc_stdout).group()
+            snitch = snitch_pattern.search(desc_stdout).group()
+            partitioner = partitioner_pattern.search(desc_stdout).group()
+            schemas = schema_versions_pattern.findall(desc_stdout)
+            schema_versions = []
+            if schemas:
+                for item in schemas:
+                    split = item.split(":")
+                    schema_id = split[0].strip()
+                    node_ips = split[-1].strip()
+                    schema_versions.append(SchemaVersion(schema_id=schema_id, node_ips=node_ips))
+
+            return ClusterInformation(
+                name=name,
+                snitch=snitch,
+                partitioner=partitioner,
+                schema_versions=schema_versions
+            )
+
+        return None
 
     def check_cluster_health(self):
         # Task 1443: ClusterHealthCheck is bottle neck in scale test and create a lot of noise in 5000 tables test.

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -26,7 +26,7 @@ import traceback
 import unittest
 import unittest.mock
 from pathlib import Path
-from typing import NamedTuple, Optional, Union, List, Dict, Any
+from typing import Optional, Union, List, Dict, Any
 from uuid import uuid4
 from functools import wraps, cache
 import threading
@@ -296,18 +296,6 @@ def critical_failure_handler(signum, frame):
 
 
 signal.signal(signal.SIGUSR2, critical_failure_handler)
-
-
-class SchemaVersion(NamedTuple):
-    schema_id: str
-    node_ips: List[str]
-
-
-class ClusterInformation(NamedTuple):
-    name: str
-    snitch: str
-    partitioner: str
-    schema_versions: List[SchemaVersion]
 
 
 class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
@@ -2825,57 +2813,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         query = "SELECT truncated_at FROM system.truncated WHERE table_uuid={}".format(table_id)
         truncated_time = self.rows_to_list(session.execute(query))
         return truncated_time[0]
-
-    def get_describecluster_info(self) -> Optional[ClusterInformation]:
-        """
-        Runs the 'nodetool describecluster' command on a node.
-
-        Example output:
-
-        nodetool describecluster
-
-        Cluster Information:
-             Name: Test Cluster
-             Snitch: org.apache.cassandra.locator.SimpleSnitch
-             Partitioner: org.apache.cassandra.dht.Murmur3Partitioner
-             Schema versions:
-                     86a67fc7-1d7c-3dc3-9be9-9c86b27e2506: [172.17.0.2]
-
-        The output is then packaged into a ClusterInformation
-        namedtuple, for easier access to the fields.
-        """
-        node = self.db_cluster.get_node()
-        describecluster_output = node.run_nodetool(sub_cmd="describecluster")
-
-        if describecluster_output.ok:
-            desc_stdout = describecluster_output.stdout
-            name_pattern = re.compile("((?<=Name: )[\w _-]*)")
-            snitch_pattern = re.compile("((?<=Snitch: )[\w.]*)")
-            partitioner_pattern = re.compile(
-                "((?<=Partitioner: )[\w.]*)")
-            schema_versions_pattern = re.compile(
-                "([a-z0-9-]{36}: \[[\d., ]*\])")
-
-            name = name_pattern.search(desc_stdout).group()
-            snitch = snitch_pattern.search(desc_stdout).group()
-            partitioner = partitioner_pattern.search(desc_stdout).group()
-            schemas = schema_versions_pattern.findall(desc_stdout)
-            schema_versions = []
-            if schemas:
-                for item in schemas:
-                    split = item.split(":")
-                    schema_id = split[0].strip()
-                    node_ips = split[-1].strip()
-                    schema_versions.append(SchemaVersion(schema_id=schema_id, node_ips=node_ips))
-
-            return ClusterInformation(
-                name=name,
-                snitch=snitch,
-                partitioner=partitioner,
-                schema_versions=schema_versions
-            )
-
-        return None
 
     def get_nemesis_report(self, cluster):
         for current_nemesis in cluster.nemesis:

--- a/sdcm/utils/replication_strategy_utils.py
+++ b/sdcm/utils/replication_strategy_utils.py
@@ -8,6 +8,7 @@ from typing import Callable, Dict, TYPE_CHECKING
 from sdcm.utils.cql_utils import cql_quote_if_needed
 from sdcm.utils.database_query_utils import is_system_keyspace, LOGGER
 from sdcm.utils.tablets.common import wait_no_tablets_migration_running
+from sdcm.wait import wait_for
 
 if TYPE_CHECKING:
     from sdcm.cluster import BaseNode
@@ -41,10 +42,27 @@ class ReplicationStrategy:
         create_ks_statement = node.run_cqlsh(f"describe {keyspace}").stdout.splitlines()[1]
         return ReplicationStrategy.from_string(create_ks_statement)
 
+    @staticmethod
+    def _is_schema_in_agreement(node: 'BaseNode'):
+        """
+        Checks if all nodes in the cluster are in schema agreement.
+
+        This is determined by verifying that only one unique schema version exists
+        across the cluster. The presence of multiple schema versions indicates that a
+        schema change has not yet propagated to all nodes.
+        """
+
+        cluster_info = node.parent_cluster.get_describecluster_info()
+        if len(cluster_info.schema_versions) == 1:
+            return True
+        return False
+
     def apply(self, node: 'BaseNode', keyspace: str):
         cql = f'ALTER KEYSPACE {cql_quote_if_needed(keyspace)} WITH replication = {self}'
         with node.parent_cluster.cql_connection_patient(node, connect_timeout=300) as session:
             session.execute(cql, timeout=300)
+
+        wait_for(lambda: self._is_schema_in_agreement(node), step=5, timeout=60)
 
     @property
     def replication_factors(self) -> list:


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-cluster-tests/issues/9430

This PR uses `describecluster` to wait until all nodes in the cluster reach schema agreement when RF changes are applied.
To accomplish this, I moved the `get_describecluster_info` function from **tester** to **cluster**, as it logically belongs there.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] [AddRemoveDcNemesis](https://argus.scylladb.com/tests/scylla-cluster-tests/53086210-e8af-4aec-84aa-1fa9894fa7aa)
- [ ] [artifacts-amazon2023-arm-test (artifacts_test)](https://argus.scylladb.com/tests/scylla-cluster-tests/28ee192a-cd5d-4310-beed-2c2438d7ba51) Artifacts tests were indirectly affected when moving `get_describecluster_info`. I picked this one for testing

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
