### PR TITLE
Set cloud image to 4.11.0 scylladb-monitor-4-11-0-2025-07-21t09-39-20z

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -7,7 +7,7 @@ instance_type_loader: 'c6i.xlarge'
 instance_type_monitor: 't3.large'
 ami_id_loader: 'resolve:ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id'
 # manual on updating monitor images see: docs/monitoring-images.md
-ami_id_monitor: 'scylladb-monitor-4-11-0-2025-07-13t06-48-19z'
+ami_id_monitor: 'scylladb-monitor-4-11-0-2025-07-21t09-39-20z'
 
 availability_zone: 'a'
 root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -5,7 +5,8 @@ gce_project: '' # empty mean default one, can be overwritten to use different on
 
 gce_image_db: '' # so we can use `scylla_version` as needed
 gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64'
-gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-11-0-2025-07-13t06-48-19z'
+gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-11-0-2025-07-21t09-39-20z'
+
 gce_image_username: 'scylla-test'
 
 gce_instance_type_loader: 'e2-standard-2'


### PR DESCRIPTION
Grafana announced a couple of CVEs, new image was created with the only change is the grafana and prometheus versions