### PR TITLE
fix(remote_get_file): add error details

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -145,7 +145,7 @@ def remote_get_file(remoter, src, dst, hash_expected=None, retries=1, user_agent
     while retries > 0 and _remote_get_hash(remoter, dst) != hash_expected:
         _remote_get_file(remoter, src, dst, user_agent)
         retries -= 1
-    assert _remote_get_hash(remoter, dst) == hash_expected
+    assert _remote_get_hash(remoter, dst) == hash_expected, f"failed to get remote file due hash mismatch: {dst}"
 
 
 def get_first_view_with_name_like(view_name_substr: str, session) -> tuple:


### PR DESCRIPTION
When downloading remote file with `remote_get_file`, there was no details about file being downloaded when error happened.

Add descriptive error message for remote file hash verification failure.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11477

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
