### PR TITLE
fix(artifact): prevent teardown race condition

### DIFF
--- a/sdcm/utils/remote_logger.py
+++ b/sdcm/utils/remote_logger.py
@@ -86,6 +86,7 @@ class SSHLoggerBase(LoggerBase):
 
     def stop(self, timeout: float | None = None) -> None:
         self._termination_event.set()
+        self._remoter.run(f"kill -9 -{self.remote_pid}", ignore_status=True)
         if self._thread.running():
             self._thread.cancel()
 
@@ -102,12 +103,29 @@ class SSHLoggerBase(LoggerBase):
     def _is_ready_to_retrieve(self) -> bool:
         return self._remoter.is_up()
 
+    @property
+    def remote_pid(self) -> str:
+        """
+        Returns the PID of the remote logger process.
+        This is used to ensure that the logger is running and to manage its lifecycle.
+        """
+        remote_pid_file = f"/tmp/logger_{os.getpid()}.pid"
+        if not self._remoter.run(f"test -f {remote_pid_file}", ignore_status=True).ok:
+            return ""
+        return self._remoter.run(f"cat {remote_pid_file}").stdout.strip()
+
     def _retrieve(self, since: str) -> None:
         self._log.debug(self.RETRIEVE_LOG_MESSAGE_TEMPLATE.format(
             log_file=self._target_log_file, since=since or "the beginning"))
         try:
+            # Write the remote PID to a file before running the logger command
+            remote_pid_file = f"/tmp/logger_{os.getpid()}.pid"
+            cmd = self._logger_cmd_template.format(since=f'--since "{since}" ' if since else '')
+            remote_cmd = (f"cat <<'EOF' > /tmp/logger_cmd_{os.getpid()}.sh\n{cmd}\nEOF\n"
+                          f"setsid bash /tmp/logger_cmd_{os.getpid()}.sh & echo $! > {remote_pid_file}; wait"
+                          )
             self._remoter.run(
-                cmd=self._logger_cmd_template.format(since=f'--since "{since}" ' if since else ""),
+                cmd=remote_cmd,
                 verbose=self.VERBOSE_RETRIEVE,
                 ignore_status=True,
                 log_file=self._target_log_file,


### PR DESCRIPTION
when `log_trasport: ssh` is used, we are using threds based on `SSHLoggerBase` which recently changed to using thread and not processes.

since threads aren't killed directly, we need to stop the communication at the host end.

this change add a way to capture pid of the command, and use it for killing it on the host as needed.

Fixes: #11496

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 test locally with amazon2023 artifact test (that uses ssh as log transport)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
