### PR TITLE
[Azure] Add fallback to SDK for VM reboot when walinuxagent fails

### DIFF
--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -157,15 +157,33 @@ class VirtualMachineProvider:
 
     def reboot(self, name: str, wait: bool = True, hard: bool = False) -> None:
         LOGGER.info("Triggering reboot of instance: %s", name)
-        flags = "-ff" if hard else "-f"
-        self.run_command(name, f"reboot {flags}")
-        start_time = time.time()
-        while wait and time.time() - start_time < 600:  # 10 minutes
-            time.sleep(10)
-            instance_view = self._azure_service.compute.virtual_machines.instance_view(
-                self._resource_group_name, vm_name=name)
-            if instance_view and instance_view.statuses[-1].display_status == 'VM running':
-                break
+
+        # Try walinuxagent approach first
+        try:
+            flags = "-ff" if hard else "-f"
+            self.run_command(name, f"reboot {flags}")
+            LOGGER.debug("Successfully triggered reboot via walinuxagent for instance: %s", name)
+        except Exception as ex:  # noqa: BLE001
+            # Fallback to Azure SDK when walinuxagent is not available or fails
+            LOGGER.warning("Failed to reboot instance %s via walinuxagent (%s), falling back to Azure SDK", name, ex)
+            if hard:
+                LOGGER.warning("Hard reboot requested but Azure SDK does not distinguish between hard and soft reboot")
+            task = self._azure_service.compute.virtual_machines.begin_restart(self._resource_group_name, vm_name=name)
+            if wait:
+                LOGGER.info("Waiting for SDK-triggered reboot of instance: %s...", name)
+                task.wait()
+                LOGGER.info("Instance %s has been rebooted via Azure SDK.", name)
+                return
+
+        # Wait for walinuxagent-triggered reboot to complete
+        if wait:
+            start_time = time.time()
+            while time.time() - start_time < 600:  # 10 minutes
+                time.sleep(10)
+                instance_view = self._azure_service.compute.virtual_machines.instance_view(
+                    self._resource_group_name, vm_name=name)
+                if instance_view and instance_view.statuses[-1].display_status == 'VM running':
+                    break
 
     def add_tags(self, name: str, tags: Dict[str, str]) -> VirtualMachine:
         """Adds tags to instance (with waiting for completion)"""

--- a/unit_tests/test_azure_vm_provider_reboot.py
+++ b/unit_tests/test_azure_vm_provider_reboot.py
@@ -1,0 +1,96 @@
+from uuid import uuid4
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdcm.provision.azure.virtual_machine_provider import VirtualMachineProvider
+from sdcm.sct_runner import AzureSctRunner
+from sdcm.provision import AzureProvisioner
+from sdcm.utils.decorators import retrying
+
+
+@pytest.fixture
+def provider():
+    provider = VirtualMachineProvider(
+        _resource_group_name="test-rg",
+        _region="eastus",
+        _az="1",
+        _azure_service=MagicMock(),
+    )
+    provider._cache = {"vm1": MagicMock(name="vm1")}
+    return provider
+
+
+@patch("sdcm.provision.azure.virtual_machine_provider.VirtualMachineProvider.run_command")
+def test_reboot_soft_success(mock_run_command, provider):
+    provider._azure_service.compute.virtual_machines.instance_view.return_value.statuses = [
+        MagicMock(display_status="VM running")]
+    provider.reboot("vm1", wait=True, hard=False)
+    mock_run_command.assert_called_once_with("vm1", "reboot -f")
+    provider._azure_service.compute.virtual_machines.begin_restart.assert_not_called()
+
+
+@patch("sdcm.provision.azure.virtual_machine_provider.VirtualMachineProvider.run_command", side_effect=Exception("fail"))
+def test_reboot_fallback_to_sdk(mock_run_command, provider):
+    mock_task = MagicMock()
+    provider._azure_service.compute.virtual_machines.begin_restart.return_value = mock_task
+    provider._azure_service.compute.virtual_machines.instance_view.return_value.statuses = [
+        MagicMock(display_status="VM running")]
+    provider.reboot("vm1", wait=True, hard=True)
+    provider._azure_service.compute.virtual_machines.begin_restart.assert_called_once_with("test-rg", vm_name="vm1")
+    mock_task.wait.assert_called_once()
+
+
+@patch("sdcm.provision.azure.virtual_machine_provider.VirtualMachineProvider.run_command")
+def test_reboot_no_wait(mock_run_command, provider):
+    provider.reboot("vm1", wait=False, hard=False)
+    mock_run_command.assert_called_once_with("vm1", "reboot -f")
+    provider._azure_service.compute.virtual_machines.begin_restart.assert_not_called()
+
+
+@pytest.fixture
+def azure_vm():
+    """
+    Fixture to provision a real Azure VM using AzureSctRunner and clean it up after the test.
+    Yields (vm_name, resource_group, region, az, instance, provider)
+    """
+    region = "eastus"
+    az = "1"
+    test_id = str(uuid4())
+    test_name = "reboot-integration"
+    test_duration = 30  # minutes
+
+    runner = AzureSctRunner(region_name=region, availability_zone=az, params=None)
+    instance = runner.create_instance(
+        test_id=test_id,
+        test_name=test_name,
+        test_duration=test_duration,
+    )
+    assert instance is not None, "Failed to provision Azure VM for integration test."
+
+    vm_name = instance.name if hasattr(instance, "name") else instance.vm_name
+    provisioner = AzureProvisioner.discover_regions(test_id=test_id)
+    resource_group = provisioner[0]._resource_group_name
+
+    try:
+        yield vm_name, resource_group, region, az, instance, provisioner[0]
+    finally:
+        provisioner[0].cleanup(wait=True)
+
+
+@pytest.mark.integration
+@pytest.mark.provisioning
+def test_reboot_integration(azure_vm):
+    """
+    Integration test: Provision a real Azure VM using AzureSctRunner, reboot it, and verify it comes back online.
+    Requires valid Azure credentials and may incur cloud costs.
+    """
+    vm_name, resource_group, region, az, instance, provisioner = azure_vm
+    provisioner.reboot_instance(vm_name, wait=True, hard=False)
+
+    @retrying(n=5, sleep_time=5, allowed_exceptions=(AssertionError, ), message="Waiting for node to come back up after reboot.")
+    def wait_for_node_up():
+        statuses = provisioner._azure_service.compute.virtual_machines.instance_view(resource_group, vm_name).statuses
+        assert any(s.display_status == "VM running" for s in statuses), "Node did not come back up after reboot."
+
+    wait_for_node_up()


### PR DESCRIPTION
When walinuxagent is not installed or disabled on Azure VMs (e.g., when using non-official Scylla images), the current reboot implementation fails. This PR adds a fallback mechanism to Azure SDK's `begin_restart` method.

## Problem

PR #6628 introduced dependency on walinuxagent for VM reboots to achieve immediate reboots via `run_command`, but didn't account for scenarios where walinuxagent is unavailable:

- Custom/non-official images may not have walinuxagent installed
- walinuxagent may be disabled without ability to enable it
- Network issues may prevent walinuxagent communication

## Solution

Added graceful fallback to Azure SDK when walinuxagent fails:

```python
# Try walinuxagent approach first (existing behavior)
try:
    flags = "-ff" if hard else "-f"
    self.run_command(name, f"reboot {flags}")
    LOGGER.debug("Successfully triggered reboot via walinuxagent for instance: %s", name)
except Exception as ex:
    # Fallback to Azure SDK when walinuxagent is not available or fails
    LOGGER.warning("Failed to reboot instance %s via walinuxagent (%s), falling back to Azure SDK", name, ex)
    if hard:
        LOGGER.warning("Hard reboot requested but Azure SDK does not distinguish between hard and soft reboot")
    task = self._azure_service.compute.virtual_machines.begin_restart(self._resource_group_name, vm_name=name)
    # ... wait logic
```

## Key Benefits

✅ **Backward Compatible**: Preserves existing behavior when walinuxagent is available  
✅ **Resilient**: Handles all walinuxagent failure scenarios gracefully  
✅ **Minimal**: Only 18 lines added, surgical modification to existing code  
✅ **Debuggable**: Clear logging shows which reboot method was used and why  
✅ **Reliable**: Two independent reboot mechanisms provide redundancy  

## Changes Made

- Modified `reboot` method in `sdcm/provision/azure/virtual_machine_provider.py`
- Added exception handling around `run_command` call
- Implemented fallback using existing `begin_restart` SDK method
- Preserved wait logic for both code paths
- Added comprehensive logging for debugging and operations

Fixes #10044.

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.