### PR TITLE
improvement(provision_resources): Handle provision errors for Argus

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -235,13 +235,19 @@ def provision_resources(backend, test_name: str, config: str):
         click.echo("No need provision logging service")
 
     click.echo(f"Provision {backend} cloud resources")
-    if backend == "aws":
-        layout = SCTProvisionLayout(params=params)
-        layout.provision()
-    elif backend == "azure":
-        provision_sct_resources(params=params, test_config=test_config)
-    else:
-        raise ValueError(f"backend {backend} is not supported")
+    try:
+        if backend == "aws":
+            layout = SCTProvisionLayout(params=params)
+            layout.provision()
+        elif backend == "azure":
+            provision_sct_resources(params=params, test_config=test_config)
+        else:
+            raise ValueError(f"backend {backend} is not supported")
+    except Exception:
+        LOGGER.error("Unable to provision resources - aborting the test...", exc_info=True)
+        test_config.init_argus_client(params)
+        test_config.argus_client().set_sct_run_status(TestStatus.TEST_ERROR)
+        sys.exit(1)
 
 
 @cli.command("clean-aws-kms-aliases", help="clean AWS KMS old aliases")


### PR DESCRIPTION
Since we don't handle errors that happen during provisioning via the
Event system Argus doesn't really know what happened in case of capacity
issues during provisioning stage. This commit addresses this by setting
Argus status as "TEST ERROR" in case of any error during the
provisioning.

Fixes #11204

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] [Jenkins](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/alexey-argus-testing/133/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
