### PR TITLE
fix(trigger): missed '{'

### DIFF
--- a/vars/perfRegressionParallelPipelinebyRegion.groovy
+++ b/vars/perfRegressionParallelPipelinebyRegion.groovy
@@ -193,15 +193,16 @@ def call(Map pipelineParams) {
                             if (region && version && sub_tests) {
                                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                                     println("Building job: $job_name with sub_test: ${sub_tests}, region: ${region}")
-                                    build job: job_name, wait: false, parameters: [
-                                        string(name: 'scylla_version', value: params.scylla_version),
-                                        string(name: 'base_versions', value: params.base_versions),
-                                        string(name: 'provision_type', value: 'on_demand'),
-                                        string(name: 'new_scylla_repo', value: params.new_scylla_repo),
-                                        string(name: 'use_job_throttling', value: params.use_job_throttling),
-                                        string(name: 'sub_tests', value: groovy.json.JsonOutput.toJson(sub_tests)),
-                                        string(name: 'region', value: region)
-                                    ]
+                                        build job: job_name, wait: false, parameters: [
+                                            string(name: 'scylla_version', value: params.scylla_version),
+                                            string(name: 'base_versions', value: params.base_versions),
+                                            string(name: 'provision_type', value: 'on_demand'),
+                                            string(name: 'new_scylla_repo', value: params.new_scylla_repo),
+                                            string(name: 'use_job_throttling', value: params.use_job_throttling),
+                                            string(name: 'sub_tests', value: groovy.json.JsonOutput.toJson(sub_tests)),
+                                            string(name: 'region', value: region)
+                                        ]
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Last commit broke the trigger and caused to error: expecting '}', found ''

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/perf-regression-trigger-test/2/console

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
