### PR TITLE
test: new test configuration for LWT with tablets testing

### DIFF
--- a/data_dir/latte/lwt_load.rn
+++ b/data_dir/latte/lwt_load.rn
@@ -1,0 +1,116 @@
+use latte::*;
+
+const TOTAL_ROWS = latte::param!("rows", 10_000_000);
+const RF = latte::param!("replication_factor", 3);
+const TABLETS = latte::param!("tablets", true);
+const KS = latte::param!("keyspace", "lwt_keyspace");
+const TABLE = latte::param!("table", "lwt_io");
+const ROWS_PER_PARTITION = latte::param!("rows_per_partition", 1000);
+const PARTITION_SIZES = "100:1";
+const COMPACTION_STRATEGY = latte::param!("compaction_strategy", "IncrementalCompactionStrategy");
+const DELETE_PCT = latte::param!("delete_pct", 50);
+const HALF_ROWS = TOTAL_ROWS / 2;
+
+pub async fn schema(db) {
+    db.execute(`
+        CREATE KEYSPACE IF NOT EXISTS ${KS}
+        WITH replication = {
+          'class'              : 'NetworkTopologyStrategy',
+          'replication_factor' : ${RF}
+        }
+        AND tablets = {'enabled': ${TABLETS}}
+    `).await?;
+
+
+    db.execute(
+        `CREATE TABLE IF NOT EXISTS ${KS}.${TABLE} (\
+            pk bigint,\
+            ck bigint,\
+            a int,\
+            pad text,\
+            PRIMARY KEY (pk, ck)) \
+         WITH compaction = { 'class' : '${COMPACTION_STRATEGY}' }
+    `)
+    .await?;
+}
+
+pub async fn prepare(db) {
+
+    db.init_partition_row_distribution_preset(
+        "main", TOTAL_ROWS, ROWS_PER_PARTITION, PARTITION_SIZES,
+    ).await?;
+
+    db.prepare(
+        "ins",
+        `INSERT INTO ${KS}.${TABLE} (pk, ck, a, pad) VALUES (?,?,?,?)`
+    ).await?;
+
+    db.prepare(
+        "del_part",
+        `DELETE FROM ${KS}.${TABLE} WHERE pk = ?`
+    ).await?;
+
+    db.prepare(
+        "update_if_lesser_threshold",
+        `UPDATE ${KS}.${TABLE} SET pad = ? WHERE pk = ? AND ck = ? IF a <= ${HALF_ROWS}`
+    ).await?;
+
+    db.prepare(
+        "upd_if_higher_threshold",
+        `UPDATE ${KS}.${TABLE} SET pad = ? WHERE pk = ? AND ck = ? IF a > ${HALF_ROWS}`
+    ).await?;
+
+    db.prepare(
+        "sel_lwt",
+        `SELECT a, pad FROM ${KS}.${TABLE} WHERE pk = ? AND ck = ?`
+    ).await?;
+}
+
+fn pad(i) {
+    latte::text(i, 200)
+}
+
+pub async fn lwt_insert(db, i) {
+    let partition = db.get_partition_info("main", i).await;
+    let pk = hash(partition.idx);
+    let ck = hash(i);
+    let a  = hash_range(i, 1_000_000);
+
+    db.execute_prepared("ins", [pk, ck, a, pad(i)]).await
+}
+
+
+pub async fn lwt_delete_partitions(db, i) {
+    let partition  = db.get_partition_info("main", i).await;
+    let pk = hash(partition.idx);
+    let bucket = hash_range(partition.idx, 100);
+
+    if bucket < DELETE_PCT {
+        db.execute_prepared("del_part", [pk]).await?;
+    } else {
+        let ck = hash(i);
+        db.execute_prepared("sel_lwt", [pk, ck]).await?;
+    }
+}
+
+
+pub async fn upd_first_part(db, i) {
+    let partition = db.get_partition_info("main", i).await;
+    let pk   = hash(partition.idx);
+    let ck   = hash(i);
+    db.execute_prepared("update_if_lesser_threshold", [pad(i), pk, ck]).await
+}
+
+pub async fn upd_second_part(db, i) {
+    let partition = db.get_partition_info("main", i).await;
+    let pk   = hash(partition.idx);
+    let ck   = hash(i);
+    db.execute_prepared("upd_if_higher_threshold", [pad(i), pk, ck]).await
+}
+
+pub async fn lwt_read(db, i) {
+    let partition = db.get_partition_info("main", i).await;
+    let pk = hash(partition.idx);
+    let ck = hash(i);
+    db.execute_prepared("sel_lwt", [pk, ck]).await
+}

--- a/test-cases/longevity/longevity-lwt-basic-24h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-24h.yaml
@@ -1,12 +1,35 @@
-test_duration: 1500
-prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=30" ]
-stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=1440m -mode native cql3 -rate threads=20",
-             "cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=1440m -mode native cql3 -rate threads=20"
-            ]
-stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=1440m -mode native cql3 -rate threads=20" ]
+test_duration: 360
+
+prepare_write_cmd:
+  - >-
+    latte run -f lwt_insert -P rows_per_partition=1000 --rate 2500 --duration=5000000 --start-cycle 0 --tag lwt-insert-1
+    data_dir/latte/lwt_load.rn
+
+  - >-
+    latte run -f lwt_insert -P rows_per_partition=1000 --rate 2500 --duration=5000000 --start-cycle 5000001 --tag lwt-insert-2
+    data_dir/latte/lwt_load.rn
+
+stress_cmd:
+  - >-
+    latte run -f upd_first_part --serial-consistency=LOCAL_SERIAL --threads=1 --rate=500 --concurrency=900 --duration=360m --tag upd-first-part
+    data_dir/latte/lwt_load.rn
+
+  - >-
+    latte run -f upd_second_part --serial-consistency=LOCAL_SERIAL --threads=1 --rate=500 --concurrency=900 --duration=360m --tag upd-second-part
+    data_dir/latte/lwt_load.rn
+
+  - >-
+    latte run -f lwt_read --consistency=LOCAL_SERIAL --threads=1 --rate=800 --concurrency=900 --duration=360m --tag lwt-read
+    data_dir/latte/lwt_load.rn
+
+  - >-
+    latte run -f lwt_delete_partitions -P delete_pct=50 --rate 20  --concurrency=10 --duration=360m --tag lwt-delete-partitions
+    data_dir/latte/lwt_load.rn
+
 
 n_db_nodes: 6
-n_loaders: 3
+simulated_racks: 3
+n_loaders: 2
 round_robin: true
 
 instance_type_db: 'i4i.large'
@@ -14,6 +37,7 @@ gce_instance_type_db: 'n2-highmem-8'
 gce_n_local_ssd_disk_db: 8
 
 nemesis_class_name: 'SisyphusMonkey'
+nemesis_selector: ["topology_changes", "schema_changes and not disruptive"]
 nemesis_seed: '021'
 nemesis_during_prepare: false
 space_node_threshold: 64424


### PR DESCRIPTION
this commit changes test configuration from c-s to latte and adds latte script for loader nodes with LWT queries and rows deletion to trigger merge/split tablet process

fixes: https://github.com/scylladb/qa-tasks/issues/1920

### Testing
https://jenkins.scylladb.com/job/scylla-staging/job/eugene_test_folder/job/lwt_testing/119/


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
