### PR TITLE
test(rackaware): add support rackaware for python driver

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5360,6 +5360,19 @@ class Nemesis(NemesisFlags):
     def disrupt_refuse_connection_with_send_sigstop_signal_to_scylla_on_banned_node(self):
         self._refuse_connection_from_banned_node(use_iptables=False)
 
+    def switch_target_node_to_another_rack(self):
+        """
+            Switches the target node to a rack different than loader node rack.
+
+            This method selects a node from a different rack than the loader node rack
+            and sets it as the new target node. It is useful for testing rack-aware scenarios.
+        """
+        if self.cluster.params.get("rack_aware_loader") and self.target_node.parent_cluster.racks_count > 1:
+            loader_rack = self.loaders.nodes[0].rack
+            target_node_rack = [node.rack for node in self.cluster.nodes if node.rack != loader_rack][0]
+            self.set_target_node(rack=target_node_rack)
+            self.log.info("Target node rack %s, loader rack %s", self.target_node.rack, loader_rack)
+
     def _refuse_connection_from_banned_node(self, use_iptables=False):
         """Banned node could not connect with rest nodes in cluster
 
@@ -5379,6 +5392,12 @@ class Nemesis(NemesisFlags):
             raise UnsupportedNemesis("Raft feature: consistent-topology-changes is not enabled")
         if self._is_it_on_kubernetes():
             raise UnsupportedNemesis("Skip test for K8S because no supported yet")
+
+        if SkipPerIssues("scylladb/scylla-drivers#95", self.cluster.params):
+            # until https://github.com/scylladb/scylla-drivers/issues/95 would be solved
+            # we should disable the target node switching
+            self.switch_target_node_to_another_rack()
+
         keyspace_name = "banned_keyspace"
         table_name = "table1"
 


### PR DESCRIPTION
Add support of rackaware for python driver

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->

- [x] [longevity-100gb-4h-rackaware](https://argus.scylladb.com/tests/scylla-cluster-tests/861a9c89-afcf-4823-a016-74e188802d93)
- [x] [longevity-100gb-4h-rackaware](https://argus.scylladb.com/tests/scylla-cluster-tests/30896639-e337-4e06-af5b-0aff4f320f4a) with nemesis `disrupt_refuse_connection_with_send_sigstop_signal_to_scylla_on_banned_node`

<img width="657" height="346" alt="Screenshot from 2025-07-28 15-35-05" src="https://github.com/user-attachments/assets/b00746f5-db24-4ed2-ae84-a4caef7b9d39" />

- [x] https://github.com/scylladb/scylla-cluster-tests/pull/11520#issuecomment-3154554268
- [x] [longevity-100gb-4h](https://argus.scylladb.com/tests/scylla-cluster-tests/fe900413-e4e8-4499-8d7a-ff85aad70b0f) - not rackaware test, validate that cql connection is not broken

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
