### PR TITLE
Support scylla-doctor on offline non-root tests

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -397,12 +397,6 @@ class ArtifactsTest(ClusterTester):
                 assert node_info_service.cpu_load_5
                 assert node_info_service.get_node_boot_time_seconds()
 
-        if self.params.get("run_scylla_doctor"):
-            with self.logged_subtest("check scylla_doctor results"):
-                self.run_scylla_doctor()
-        else:
-            self.log.info("Running scylla-doctor is disabled")
-
         # We don't install any time sync service in docker, so the test is unnecessary:
         # https://github.com/scylladb/scylla/tree/master/dist/docker/etc/supervisord.conf.d
         if backend != "docker":
@@ -494,6 +488,12 @@ class ArtifactsTest(ClusterTester):
         if backend == 'docker':
             with self.logged_subtest("Check docker latest tags"):
                 self.verify_docker_latest_match_release()
+
+        if self.params.get("run_scylla_doctor"):
+            with self.logged_subtest("Run scylla-doctor on the installation"):
+                self.run_scylla_doctor()
+        else:
+            self.log.info("Running scylla-doctor is disabled")
 
     def run_scylla_doctor(self):
         if self.params.get('client_encrypt') and SkipPerIssues("https://github.com/scylladb/field-engineering/issues/2280", self.params):

--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -502,13 +502,6 @@ class ArtifactsTest(ClusterTester):
                 "Scylla Doctor test is skipped for encrypted environment due to issue field-engineering#2280")
             return
 
-        if self.db_cluster.nodes[0].is_nonroot_install and \
-                SkipPerIssues("https://github.com/scylladb/scylla-cluster-tests/issues/10540", self.params):
-            self.log.info("Scylla Doctor test is skipped for non-root test due to issue field-engineering#2254. ")
-            self.actions_log.info(
-                "Scylla Doctor test is skipped for non-root test due to issue field-engineering#2254.")
-            return
-
         if self.node.parent_cluster.cluster_backend == "docker":
             self.log.info("Scylla Doctor check in SCT isn't yet supported for docker backend")
             self.actions_log.info("Scylla Doctor check in SCT isn't yet supported for docker backend")

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2156,6 +2156,7 @@ class BaseNode(AutoSshContainerMixin):
             else:
                 install_cmds = dedent("""
                     tar xvfz ./unified_package.tar.gz
+                    echo 'export PATH="$HOME/scylladb/share/cassandra/bin:$HOME/scylladb/bin:$PATH"' >> ~/.bashrc
                     cd ./scylla-*
                     ./install.sh --nonroot
                     cd -

--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -26,6 +26,35 @@ class ScyllaDoctor:
     SCYLLA_DOCTOR_OFFLINE_BUCKET_PREFIX = "downloads/scylla-doctor/tar/"
     SCYLLA_DOCTOR_OFFLINE_BIN = "scylla_doctor.pyz"
     SCYLLA_DOCTOR_OFFLINE_CONF = "scylla_doctor.conf"
+    SCYLLA_DOCTOR_DISABLED_OFFLINE_COLLECTORS = dedent("""
+        [GossipInfoCollector]
+        ; Doesn't work with systemd-user service
+        run = no
+        [TokenMetadataHostsMappingCollector]
+        ; Doesn't work with systemd-user service
+        run = no
+        [ScyllaClusterStatusCollector]
+        ; Doesn't work with systemd-user service
+        run = no
+        [ScyllaClusterSchemaCollector]
+        ; Doesn't work with systemd-user service
+        run = no
+        [KernelRingBufferCollector]
+        ; Requires root privileges
+        run = no
+        [ScyllaLimitNOFILECollector]
+        ; Requires root privileges
+        run = no
+        [ScyllaSystemConfigurationFilesCollector]
+        ; Requires root installation with configs in /etc
+        run = no
+        [PerftuneYamlDefaultCollector]
+        ; Depends on ScyllaSystemConfigurationFilesCollector
+        run = no
+        [PerftuneSystemConfigurationCollector]
+        ; perftune script requires root
+        run = no
+    """)
 
     def __init__(self, node: BaseNode, test_config: TestConfig, offline_install=False):
         self.node = node
@@ -78,7 +107,7 @@ class ScyllaDoctor:
         self.node.remoter.run(f"curl -JL {self.SCYLLA_DOCTOR_OFFLINE_DOWNLOAD_URI}{package_path} | tar -xvz")
         self.scylla_doctor_exec = f"{self.current_dir}/{self.SCYLLA_DOCTOR_OFFLINE_BIN}"
 
-    def update_scylla_doctor_config(self, prefix: str):
+    def update_scylla_doctor_config(self, prefix: str, additional_config=""):
         with remote_file(self.node.remoter, f"{self.current_dir}/{self.SCYLLA_DOCTOR_OFFLINE_CONF}") as f:
             config = dedent(f"""
                 [DefaultPaths]
@@ -86,6 +115,8 @@ class ScyllaDoctor:
                 scylla_directory_config = {prefix}/scylladb/etc/scylla
                 scylla_directory_configs = {prefix}/scylladb/etc/scylla.d
                 scylla_directory_var = {prefix}/scylladb
+
+                {additional_config}
             """)
             LOGGER.info("Updating scylla-doctor-config file...\n%s", config)
 
@@ -103,7 +134,8 @@ class ScyllaDoctor:
             self.download_scylla_doctor()
             if self.node.is_nonroot_install:
                 self.python3_path = self.find_local_python3_binary(self.current_dir)
-                self.update_scylla_doctor_config(self.current_dir)
+                self.update_scylla_doctor_config(
+                    self.current_dir, additional_config=self.SCYLLA_DOCTOR_DISABLED_OFFLINE_COLLECTORS)
         else:
             self.node.install_package('scylla-doctor')
 


### PR DESCRIPTION
This PR changes some configuration options and adjusts PATH settings on nonroot 
installations of artifacts tests, allowing scylla-doctor to run here successfuly.
Some scylla-doctor collectors are disabled because either they require root privileges,
they assume system wide installation, or they depends on those that do. 

- **fix(artifacts_test.py): Remove offline non-root scylla_doctor skip**
- **improvement(sdcm/cluster.py): Add offline install to PATH**
- **improvement(scylla_doctor/nonroot): Disable non-working collectors**
- **improvement(artifacts_test): Run scylla-doctor last**

Closes #10540
Fixes scylladb/qa-tasks#1683

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Jenkins](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/artifacts-centos9-nonroot-test/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
