### PR TITLE
feature(scylla-cloud): run stress load on Scylla cloud cluster

### DIFF
--- a/defaults/cloud_config.yaml
+++ b/defaults/cloud_config.yaml
@@ -1,5 +1,5 @@
 n_db_nodes: 3
-n_loaders: 0
+n_loaders: 1
 n_monitor_nodes: 0
 
 use_mgmt: false

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -17,7 +17,7 @@ a list of config files that would be used
 
 ## **cluster_backend** / SCT_CLUSTER_BACKEND
 
-backend that will be used, aws/gce/docker
+backend that will be used, aws/gce/azure/docker/xcloud
 
 **default:** N/A
 

--- a/jenkins-pipelines/oss/longevity/longevity-scylla-cloud-10gb-3h.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-scylla-cloud-10gb-3h.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    use_scylla_cloud: true,
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/longevity/longevity-10gb-3h.yaml'
+)

--- a/sdcm/cloud_api_client.py
+++ b/sdcm/cloud_api_client.py
@@ -339,6 +339,12 @@ class ScyllaCloudAPIClient:
         return self.request(
             'POST', f'/account/{account_id}/cluster/{cluster_id}/notifications/email', emails=emails)
 
+    def get_cluster_connection(self, *, account_id: int, cluster_id: int) -> dict[str, Any]:
+        """Get cluster connection details including credentials and endpoints"""
+        url = f'/account/{account_id}/cluster/connect'
+        params = {'clusterId': cluster_id}
+        return self.request('GET', url, params=params)
+
     ### Account cluster network related APIs ###
     def create_fw_rule(self, *, account_id: int, cluster_id: int, ip_address: str) -> dict[str, Any]:
         """Create a CIDR formatted firewall rule for a given cluster"""

--- a/sdcm/cluster_cloud.py
+++ b/sdcm/cluster_cloud.py
@@ -14,7 +14,7 @@
 import logging
 from functools import cached_property
 from types import SimpleNamespace
-from typing import Dict, Any
+from typing import Dict
 
 from sdcm import cluster, wait
 from sdcm.cloud_api_client import ScyllaCloudAPIClient, CloudProviderType
@@ -32,8 +32,14 @@ class CloudNode(cluster.BaseNode):
     METADATA_BASE_URL = None
     log = LOGGER
 
-    def __init__(self, cloud_instance_data: Dict[str, Any], parent_cluster,
-                 node_prefix='node', node_index=1, base_logdir=None, dc_idx=0, rack=0):
+    def __init__(self,
+                 cloud_instance_data: dict,
+                 parent_cluster: cluster.BaseScyllaCluster,
+                 node_prefix: str = 'node',
+                 node_index: int = 1,
+                 base_logdir: str | None = None,
+                 dc_idx: int = 0,
+                 rack: int = 0):
         self.node_index = node_index
         self._cloud_instance_data = cloud_instance_data
         self._api_client: ScyllaCloudAPIClient = parent_cluster._api_client
@@ -198,13 +204,20 @@ class CloudNode(cluster.BaseNode):
 class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
     """Scylla DB cluster running on Scylla Cloud"""
 
-    def __init__(self, cloud_api_client: ScyllaCloudAPIClient, user_prefix=None,
-                 n_nodes=3, params=None, node_type='scylla-db', add_nodes=True):
+    def __init__(self,
+                 cloud_api_client: ScyllaCloudAPIClient,
+                 user_prefix: str | None = None,
+                 n_nodes: int = 3,
+                 params: dict | None = None,
+                 node_type: str = 'scylla-db',
+                 add_nodes: bool = True,
+                 allowed_ips: list | None = None):
 
         self._api_client = cloud_api_client
         self._account_id = cloud_api_client.get_current_account_id()
         self._cluster_id = None
         self._cluster_request_id = None
+        self._allowed_ips = allowed_ips or []
 
         self._cluster_created = False
         self._pending_node_configs = []
@@ -231,7 +244,7 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
         # nodes provisioning and startup is managed by the Scylla Cloud itself
         return False
 
-    def _create_node(self, cloud_instance_data, node_index, dc_idx, rack):
+    def _create_node(self, cloud_instance_data: dict, node_index: int, dc_idx: int, rack: int) -> CloudNode:
         try:
             node = CloudNode(
                 cloud_instance_data=cloud_instance_data,
@@ -246,7 +259,13 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
         except Exception as e:
             raise ScyllaCloudError(f"Failed to create node: {e}") from e
 
-    def add_nodes(self, count, ec2_user_data='', dc_idx=0, rack=0, enable_auto_bootstrap=False, instance_type=None):
+    def add_nodes(self,
+                  count: int,
+                  ec2_user_data: str = '',
+                  dc_idx: int = 0,
+                  rack: int = 0,
+                  enable_auto_bootstrap: bool = False,
+                  instance_type: str | None = None) -> list[CloudNode]:
         """
         Add nodes to cluster. For cloud backend, this creates the entire cluster
         on first call, then performs resize for subsequent calls.
@@ -259,7 +278,12 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
             return self._resize_cluster(count, dc_idx, rack, instance_type)
         return self._create_cluster(count, dc_idx, rack, enable_auto_bootstrap, instance_type)
 
-    def _create_cluster(self, count, dc_idx, rack, enable_auto_bootstrap, instance_type):
+    def _create_cluster(self,
+                        count: int,
+                        dc_idx: int,
+                        rack: int,
+                        enable_auto_bootstrap: bool,
+                        instance_type: str | None) -> list[CloudNode]:
         self.log.info("Creating new Scylla Cloud cluster with %s nodes", count)
         cluster_config = self._prepare_cluster_config(count, instance_type)
 
@@ -269,13 +293,16 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
 
         self.log.debug("Cluster creation initiated. Cluster ID: %s", self._cluster_id)
         self._wait_for_cluster_ready()
+
+        self._get_cluster_credentials()
+
         nodes = self._init_nodes_from_cluster(count, dc_idx, rack)
         self._cluster_created = True
         self.log.info("Successfully created cluster %s with %s nodes", self._cluster_id, len(nodes))
 
         return nodes
 
-    def _init_nodes_from_cluster(self, count, dc_idx, rack):
+    def _init_nodes_from_cluster(self, count: int, dc_idx: int, rack: int) -> list[CloudNode]:
         """Decompose the created cluster into individual CloudNode objects"""
         cluster_nodes = self._api_client.get_cluster_nodes(
             account_id=self._account_id, cluster_id=self._cluster_id, enriched=True)
@@ -301,7 +328,7 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
             self.log.info("Created node %s with public IP: %s", node.name, node.public_ip_address)
         return created_nodes
 
-    def _prepare_cluster_config(self, node_count, instance_type):
+    def _prepare_cluster_config(self, node_count: int, instance_type: str) -> dict:
         cloud_provider = self.params.get('xcloud_provider').upper()
 
         provider_id = self._api_client.cloud_provider_ids[CloudProviderType(cloud_provider)]
@@ -314,7 +341,8 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
         instance_id = self._api_client.get_instance_id_by_name(
             cloud_provider_id=provider_id, region_id=region_id, instance_type_name=instance_type_name)
 
-        allowed_ips = [f"{self._api_client.client_ip}/32",]
+        allowed_ips = [f"{self._api_client.client_ip}/32"]
+        allowed_ips.extend(f"{ip}/32" for ip in self._allowed_ips)
 
         return {
             'account_id': self._account_id,
@@ -338,7 +366,7 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
             'scaling': {}
         }
 
-    def _wait_for_cluster_ready(self, timeout=600):
+    def _wait_for_cluster_ready(self, timeout: int = 600) -> None:
         self.log.info("Waiting for Scylla Cloud cluster to be ready")
 
         def check_cluster_status():
@@ -448,6 +476,22 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
         if down_nodes:
             raise cluster.ClusterNodesNotReady(
                 f"Nodes {','.join([node.name for node in down_nodes])} are not in ACTIVE/NORMAL state")
+
+    def _get_cluster_credentials(self):
+        """Retrieve default credentials for password authentification"""
+        connection_details = self._api_client.get_cluster_connection(
+            account_id=self._account_id, cluster_id=self._cluster_id)
+
+        creds = connection_details.get('credentials', {})
+        username = creds.get('username')
+        password = creds.get('password')
+        if username and password:
+            self.params.update({
+                'authenticator_user': username,
+                'authenticator_password': password
+            })
+        else:
+            self.log.error("No default username/password found in cluster connection details")
 
     def get_node_ips_param(self, public_ip=True):
         return 'xcloud_nodes_public_ip' if public_ip else 'xcloud_nodes_private_ip'

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -246,7 +246,7 @@ class SCTConfiguration(dict):
              help="a list of config files that would be used", appendable=False),
 
         dict(name="cluster_backend", env="SCT_CLUSTER_BACKEND", type=str,
-             help="backend that will be used, aws/gce/docker", appendable=False),
+             help="backend that will be used, aws/gce/azure/docker/xcloud", appendable=False),
 
         dict(name="test_method", env="SCT_TEST_METHOD", type=str,
              help="class.method used to run the test. Filled automatically with run-test sct command.",
@@ -2338,11 +2338,17 @@ class SCTConfiguration(dict):
         if cloud_provider == 'aws':
             return {
                 'region': self.region_names[0],
-                'instance_type_db': self.get('instance_type_db')}
+                'instance_type_db': self.get('instance_type_db'),
+                'instance_type_loader': self.get('instance_type_loader'),
+                'root_disk_size_loader': self.get('root_disk_size_loader'),
+                'root_disk_type_loader': self.get('root_disk_type_loader')}
         elif cloud_provider == 'gce':
             return {
                 'region': self.gce_datacenters[0],
-                'instance_type_db': self.get('gce_instance_type_db')}
+                'instance_type_db': self.get('gce_instance_type_db'),
+                'instance_type_loader': self.get('gce_instance_type_loader'),
+                'root_disk_size_loader': self.get('gce_root_disk_size_loader'),
+                'root_disk_type_loader': self.get('gce_root_disk_type_loader')}
         return {}
 
     @cached_property

--- a/sdcm/sct_provision/aws/layout.py
+++ b/sdcm/sct_provision/aws/layout.py
@@ -28,17 +28,21 @@ class SCTProvisionAWSLayout(SCTProvisionLayout, cluster_backend='aws'):
         return TestConfig()
 
     def provision(self):
+        use_scylla_cloud = self._params.get('cluster_backend') == 'xcloud'
+
         if self.placement_group:
             self.placement_group.provision()
         SCTCapacityReservation.reserve(self._params)
         SCTDedicatedHosts.reserve(self._params)
-        if self.db_cluster:
+
+        # skip DB cluster provisioning for Scylla Cloud
+        if not use_scylla_cloud and self.db_cluster:
             self.db_cluster.provision()
         if self.monitoring_cluster:
             self.monitoring_cluster.provision()
         if self.loader_cluster:
             self.loader_cluster.provision()
-        if self.cs_db_cluster:
+        if not use_scylla_cloud and self.cs_db_cluster:
             self.cs_db_cluster.provision()
 
     @cached_property

--- a/sdcm/sct_provision/region_definition_builder.py
+++ b/sdcm/sct_provision/region_definition_builder.py
@@ -124,6 +124,11 @@ class DefinitionBuilder(abc.ABC):
         n_db_nodes = self._get_node_count_for_each_region(str(self.params.get("n_db_nodes")))
         n_loader_nodes = self._get_node_count_for_each_region(str(self.params.get("n_loaders")))
         n_monitor_nodes = self._get_node_count_for_each_region(str(self.params.get("n_monitor_nodes")))
+
+        # skip DB node provisioning for Scylla Cloud
+        if self.params.get('cluster_backend') == 'xcloud':
+            n_db_nodes = [0] * len(self.regions)
+
         for region, db_nodes, loader_nodes, monitor_nodes in zip(self.regions, n_db_nodes, n_loader_nodes, n_monitor_nodes):
             region_definitions.append(
                 self.build_region_definition(region=region, availability_zone=availability_zone, n_db_nodes=db_nodes,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -792,6 +792,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
 
     @property
     def rack_names_per_datacenter_and_rack_idx_map(self):
+        if self.db_cluster is None:
+            return None
         if ready_nodes := [node for node in self.db_cluster.nodes if node._is_node_ready_run_scylla_commands()]:
             return self.db_cluster.get_rack_names_per_datacenter_and_rack_idx(db_nodes=ready_nodes)
         return None
@@ -2002,16 +2004,87 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
             else:
                 self.fail('Unsupported parameter type: {}'.format(type(n_loader_nodes)))
 
-        self.log.info("Creating Scylla Cloud cluster")
+        # create loaders first as their IPs should be allowed in Scylla Cloud cluster
+        cloud_provider = self.params.get('xcloud_provider').lower()
+
+        if loader_info['type'] is None:
+            loader_info['type'] = self.params.cloud_provider_params.get('instance_type_loader')
+        if loader_info['disk_size'] is None:
+            loader_info['disk_size'] = self.params.cloud_provider_params.get('root_disk_size_loader')
+
+        self.log.info("Creating LoaderSet for Scylla Cloud cluster on '%s' cloud provider", cloud_provider)
+        if cloud_provider == 'aws':
+            regions = [self.params.cloud_provider_params.get('region'), ]
+            services = get_ec2_services(regions)
+
+            user_credentials = self.params.get('user_credentials_path')
+            for _ in regions:
+                self.credentials.append(UserRemoteCredentials(key_file=user_credentials))
+
+            common_params = get_common_params(
+                params=self.params, regions=regions, credentials=self.credentials, services=services)
+
+            if loader_info['device_mappings'] is None:
+                if loader_info['disk_size']:
+                    loader_info['device_mappings'] = [{
+                        "DeviceName": ec2_ami_get_root_device_name(
+                            image_id=self.params.get('ami_id_loader').split()[0], region_name=regions[0]),
+                        "Ebs": {
+                            "VolumeType": 'gp3',
+                            "VolumeSize": int(loader_info['disk_size']),
+                        }
+                    }]
+                else:
+                    loader_info['device_mappings'] = []
+
+            self.loaders = LoaderSetAWS(
+                ec2_ami_id=self.params.get('ami_id_loader').split(),
+                ec2_ami_username=self.params.get('ami_loader_user'),
+                ec2_instance_type=loader_info['type'],
+                ec2_block_device_mappings=loader_info['device_mappings'],
+                n_nodes=loader_info['n_nodes'],
+                **common_params)
+        elif cloud_provider == 'gce':
+            gce_datacenter = self.params.cloud_provider_params.get('region')
+            loader_additional_disks = {'pd-ssd': self.params.get('gce_pd_ssd_disk_size_loader')}
+
+            user_credentials = self.params.get('user_credentials_path')
+            self.credentials.append(UserRemoteCredentials(key_file=user_credentials))
+
+            if loader_info['disk_type'] is None:
+                loader_info['disk_type'] = self.params.cloud_provider_params.get('root_disk_type_loader')
+
+            self.loaders = LoaderSetGCE(
+                gce_image=self.params.get('gce_image_loader'),
+                gce_image_type=loader_info.get('disk_type'),
+                gce_image_size=loader_info.get('disk_size'),
+                gce_n_local_ssd=loader_info.get('n_local_ssd'),
+                gce_instance_type=loader_info['type'],
+                gce_network=self.params.get('gce_network'),
+                gce_service=get_gce_compute_instances_client(),
+                gce_image_username=self.params.get('gce_image_username'),
+                credentials=self.credentials,
+                user_prefix=user_prefix,
+                n_nodes=loader_info['n_nodes'],
+                add_disks=loader_additional_disks,
+                params=self.params,
+                gce_datacenter=gce_datacenter.split() if isinstance(gce_datacenter, str) else [gce_datacenter])
+        else:
+            self.log.warning("Unsupported cloud provider '%s' for loaders, skipping loader provisioning", cloud_provider)
+            self.loaders = None
+
+        loader_ips = [
+            node.public_ip_address for node in self.loaders.nodes if node.public_ip_address
+        ] if self.loaders else []
+
+        self.log.info("Creating Scylla Cloud cluster with allowed IPs: client + %d loader nodes", len(loader_ips))
         self.db_cluster = ScyllaCloudCluster(
             cloud_api_client=cloud_api_client,
             user_prefix=user_prefix,
             n_nodes=db_info['n_nodes'][0],
             params=self.params,
-            add_nodes=True)
-
-        # TODO: implement loaders provisioning in Scylla Cloud
-        self.loaders = None
+            add_nodes=True,
+            allowed_ips=loader_ips)
 
         # TODO: implement routing of monitoring data to SCT monitor instance
         self.monitors = NoMonitorSet()

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -26,6 +26,10 @@ def call(Map pipelineParams) {
                description: 'aws|gce|azure|docker',
                name: 'backend')
 
+            booleanParam(defaultValue: pipelineParams.get('use_scylla_cloud', false),
+                        description: 'Use ScyllaDB Cloud as a backend. Only AWS and GCE cloud providers are supported.',
+                        name: 'use_scylla_cloud')
+
             string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
                description: 'Supported: us-east-1 | eu-west-1 | eu-west-2 | eu-north-1 | eu-central-1 | us-west-2 | random (randomly select region)',
                name: 'region')
@@ -314,6 +318,9 @@ def call(Map pipelineParams) {
                             dir('scylla-cluster-tests') {
                                 timeout(time: 30, unit: 'MINUTES') {
                                     if (params.backend == 'aws' || params.backend == 'azure') {
+                                        if (params.use_scylla_cloud) {
+                                            echo "ScyllaDB Cloud is used as DB cluster backend: provisioning loader nodes only on ${params.backend} backend"
+                                        }
                                         provisionResources(params, builder.region)
                                     } else if (params.backend.contains('docker')) {
                                         sh """

--- a/vars/provisionResources.groovy
+++ b/vars/provisionResources.groovy
@@ -14,6 +14,12 @@ def call(Map params, String region){
     export SCT_CONFIG_FILES=${test_config}
     export SCT_COLLECT_LOGS=false
 
+    # Set Scylla Cloud flag if enabled
+    if [[ "${params.use_scylla_cloud}" == "true" ]] ; then
+        export SCT_CLUSTER_BACKEND="xcloud"
+        export SCT_XCLOUD_PROVIDER="${params.backend}"
+    fi
+
     if [[ -n "${params.requested_by_user ? params.requested_by_user : ''}" ]] ; then
         export BUILD_USER_REQUESTED_BY=${params.requested_by_user}
     fi


### PR DESCRIPTION
This change builds upon SCT scylla cloud PoC - it adds the ability to instantiate a set of loader nodes for Scylla cloud backend and run the given stress load.

Additionally, it updates longevity pipeline to support running SCT tests on Scylla cloud backend in Jenkins.

Closes: https://github.com/scylladb/qa-tasks/issues/1914

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
