### PR TITLE
fix(trigger): remove quotes in timer

### DIFF
--- a/vars/perfRegressionParallelPipelinebyRegion.groovy
+++ b/vars/perfRegressionParallelPipelinebyRegion.groovy
@@ -1,6 +1,11 @@
 def call(Map pipelineParams) {
+    def builder = getJenkinsLabels("aws", "eu-west-1")
     pipeline {
-        agent any
+        agent {
+            label {
+                   label builder.label
+            }
+        }
         parameters {
             string(name: 'scylla_version', defaultValue: '', description: 'Scylla version to test')
             string(name: 'base_versions', defaultValue: '', description: 'Base versions')
@@ -11,8 +16,8 @@ def call(Map pipelineParams) {
         triggers {
             parameterizedCron (
                 '''
-                    00 6 * * 0 %scylla_version="master:latest";labels_selector=master-weekly
-                    0 23 */21 * * %scylla_version="master:latest";labels_selector=master-3weeks
+                    00 6 * * 0 %scylla_version=master:latest;labels_selector=master-weekly
+                    0 23 */21 * * %scylla_version=master:latest;labels_selector=master-3weeks
                 '''
             )
         }


### PR DESCRIPTION
1. Scylla version in timer is defined with quotes mistakenly. In prevent to trigger the jobs as it can't find master version. Remove the quotes.

2. Define builder

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
