### PR TITLE
fix(test): skip gemini metric validation in upgrade test

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -656,8 +656,9 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         if self.enable_cdc_for_tables:
             gemini_cmd += " --table-options \"cdc={'enabled': true}\""
         gemini_thread = self.run_gemini(gemini_cmd)
-        self.metric_has_data(
-            metric_query='gemini_cql_requests', n=10)
+        if SkipPerIssues("https://github.com/scylladb/scylla-cluster-tests/issues/11534", params=self.params):
+            self.metric_has_data(
+                metric_query='gemini_cql_requests', n=10)
 
         with ignore_upgrade_schema_errors():
 


### PR DESCRIPTION
Recent Gemini update caused `gemini_cql_requests` metric missing in prometheus.

Fix by skipping this check until root cause is found and fixed.

refs: https://github.com/scylladb/scylla-cluster-tests/issues/11534

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - https://argus.scylladb.com/tests/scylla-cluster-tests/cd38bfe0-b541-4b67-9f01-e671475b1fac

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
