### PR TITLE
improvement(sct.py): add SCT-runners cleanup support to clean-resources

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -665,7 +665,7 @@ If reuse_cluster is set it should hold test_id of the cluster that will be reuse
 
 ## **test_id** / SCT_TEST_ID
 
-test id to filter by. Could be used multiple times
+Set the test_id of the run manually. Use only from the env before running Hydra
 
 **default:** N/A
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -665,7 +665,7 @@ If reuse_cluster is set it should hold test_id of the cluster that will be reuse
 
 ## **test_id** / SCT_TEST_ID
 
-test id to filter by
+test id to filter by. Could be used multiple times
 
 **default:** N/A
 

--- a/sct.py
+++ b/sct.py
@@ -131,8 +131,9 @@ LOGGER = setup_stdout_logger()
 def sct_option(name, sct_name, **kwargs):
     sct_opt = SCTConfiguration.get_config_option(sct_name)
     multimple_use = kwargs.pop('multiple', False)
-    sct_opt.update(kwargs)
-    return click.option(name, type=sct_opt['type'], help=sct_opt['help'], multiple=multimple_use)
+    return click.option(name,
+                        type=kwargs.get('type', sct_opt['type']),
+                        help=kwargs.get('help', sct_opt['help']), multiple=multimple_use)
 
 
 def install_callback(ctx, _, value):

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -1197,7 +1197,20 @@ def get_sct_runner(cloud_provider: str, region_name: str, availability_zone: str
     raise Exception(f'Unsupported Cloud provider: `{cloud_provider}')
 
 
-def list_sct_runners(backend: str = None, test_runner_ip: str = None, verbose: bool = True) -> list[SctRunnerInfo]:
+def _get_runner_user_tag(sct_runner_info: SctRunnerInfo) -> str | None:
+    if sct_runner_info.cloud_provider == "aws":
+        tags = aws_tags_to_dict(sct_runner_info.instance.get("Tags", []))
+        return tags.get("RunByUser")
+    elif sct_runner_info.cloud_provider == "gce":
+        tags = gce_meta_to_dict(sct_runner_info.instance.metadata)
+        return tags.get("RunByUser")
+    elif sct_runner_info.cloud_provider == "azure":
+        if hasattr(sct_runner_info.instance, 'tags') and sct_runner_info.instance.tags:
+            return sct_runner_info.instance.tags.get("RunByUser")
+    return None
+
+
+def list_sct_runners(backend: str = None, test_runner_ip: str = None, user: str = None, test_id: str | tuple = None, verbose: bool = True) -> list[SctRunnerInfo]:
     if verbose:
         log = LOGGER.info
     else:
@@ -1213,18 +1226,36 @@ def list_sct_runners(backend: str = None, test_runner_ip: str = None, verbose: b
         sct_runner_classes = (AwsSctRunner, GceSctRunner, AzureSctRunner, )
     sct_runners = chain.from_iterable(cls.list_sct_runners(verbose=False) for cls in sct_runner_classes)
 
-    if test_runner_ip:
-        if sct_runner_info := next((runner for runner in sct_runners if test_runner_ip in runner.public_ips), None):
-            sct_runners = [sct_runner_info, ]
-        else:
+    filtered_runners = []
+    for runner in sct_runners:
+        if test_runner_ip and test_runner_ip not in runner.public_ips:
+            continue
+        if user and _get_runner_user_tag(runner) != user:
+            continue
+        if test_id:
+            if isinstance(test_id, (tuple, list)) and runner.test_id not in test_id:
+                continue
+            elif runner.test_id != test_id:
+                continue
+
+        filtered_runners.append(runner)
+
+    if not filtered_runners:
+        if test_runner_ip:
             LOGGER.warning("No SCT Runners were found (Backend: '%s', IP: '%s')", backend, test_runner_ip)
-            return []
-    else:
-        sct_runners = list(sct_runners)
+        elif user or test_id:
+            filter_desc = []
+            if user:
+                filter_desc.append(f"User: '{user}'")
+            if test_id:
+                filter_desc.append(
+                    f"TestIds: {list(test_id) if isinstance(test_id, (tuple, list)) else f'TestId: {test_id}'}")
+            LOGGER.warning("No SCT Runners were found (Backend: '%s', Filters: %s)", backend, ", ".join(filter_desc))
+        return []
 
-    log("%d SCT runner(s) found:\n    %s", len(sct_runners), "\n    ".join(map(str, sct_runners)))
+    log("%d SCT runner(s) found:\n    %s", len(filtered_runners), "\n    ".join(map(str, filtered_runners)))
 
-    return sct_runners
+    return filtered_runners
 
 
 def update_sct_runner_tags(backend: str = None, test_runner_ip: str = None, test_id: str = None, tags: dict = None):
@@ -1238,8 +1269,7 @@ def update_sct_runner_tags(backend: str = None, test_runner_ip: str = None, test
     if test_runner_ip:
         runner_to_update = list_sct_runners(backend=backend, test_runner_ip=test_runner_ip)
     elif test_id:
-        listed_runners = list_sct_runners(backend=backend, verbose=False)
-        runner_to_update = [runner for runner in listed_runners if runner.test_id == test_id]
+        runner_to_update = list_sct_runners(backend=backend, test_id=test_id, verbose=False)
 
     if not runner_to_update:
         LOGGER.warning("Could not find SCT runner with IP: %s, test_id: %s to update tags for.",
@@ -1288,10 +1318,12 @@ def _manage_runner_keep_tag_value(utc_now: datetime,
 def clean_sct_runners(test_status: str,
                       test_runner_ip: str = None,
                       backend: str = None,
+                      user: str = None,
+                      test_id: str | tuple = None,
                       dry_run: bool = False,
                       force: bool = False) -> None:
 
-    sct_runners_list = list_sct_runners(backend=backend, test_runner_ip=test_runner_ip)
+    sct_runners_list = list_sct_runners(backend=backend, test_runner_ip=test_runner_ip, user=user, test_id=test_id)
     timeout_flag = False
     runners_terminated = 0
     end_message = ""
@@ -1328,7 +1360,7 @@ def clean_sct_runners(test_status: str,
                                           timeout_flag=timeout_flag, sct_runner_info=sct_runner_info,
                                           dry_run=dry_run)
 
-        if sct_runner_info.keep:
+        if not force and sct_runner_info.keep:
             if "alive" in str(sct_runner_info.keep):
                 LOGGER.info("Skip %s because `keep' == `alive. No runners have been terminated'", sct_runner_info)
                 continue

--- a/unit_tests/test_hydra_sh.py
+++ b/unit_tests/test_hydra_sh.py
@@ -196,6 +196,16 @@ class LongevityPipelineTest:
         return f'clean-resources --post-behavior --test-id {self.test_id}'
 
     @cached_property
+    def clean_runner_instances_cmd(self):
+        if self.runner:
+            return f'{self.runner_arg}{self.clean_runner_instances_cmd_docker}'
+        return self.clean_runner_instances_cmd_docker
+
+    @cached_property
+    def clean_runner_instances_cmd_docker(self):
+        return f'clean-runner-instances --test-id {self.test_id} --backend {self.backend}'
+
+    @cached_property
     def send_email_cmd(self):
         # Command line of the hydra it self
         if self.runner:
@@ -337,6 +347,21 @@ class LongevityPipelineTest:
         ), self.test_tmp_dir
 
     @property
+    def test_case_clean_runner_instances(self):
+        self.set_test_home_dir_postfix('clean_runner_instances')
+        return HydraTestCaseParams(
+            name=f'{self.step_name_prefix}_clean_runner_instances',
+            cmd=self.clean_runner_instances_cmd,
+            expected=[
+                *self.after_runner_expected,
+                re.compile(f"{self.after_runner_docker_run_prefix} "
+                           f"eval './sct.py  {self.clean_runner_instances_cmd_docker}'")],
+            not_expected=[*self.after_runner_not_expected],
+            return_code=0,
+            env=self.get_longevity_env
+        ), self.test_tmp_dir
+
+    @property
     def test_case_send_email(self):
         self.set_test_home_dir_postfix('send_email')
         return HydraTestCaseParams(
@@ -356,7 +381,7 @@ class LongevityPipelineTest:
         Creates list of test case parameters that represent steps in longevity pipeline steps
         """
         return (self.test_case_show_conf, self.test_case_create_runner, self.test_case_run_test,
-                self.test_case_collect_logs, self.test_case_clean_resources)
+                self.test_case_collect_logs, self.test_case_clean_resources, self.test_case_clean_runner_instances)
 
 
 class TestHydraSh(unittest.TestCase):

--- a/unit_tests/test_sct_clean_commands.py
+++ b/unit_tests/test_sct_clean_commands.py
@@ -1,0 +1,224 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+import unittest
+from unittest.mock import patch
+import os
+
+from click.testing import CliRunner
+
+import sct
+
+
+class TestCleanResourcesCommand(unittest.TestCase):
+
+    ENV_VARS = {
+        'SCT_REGION_NAME': 'us-east-1',
+        'SCT_GCE_DATACENTER': 'us-central1-a',
+        'SCT_AZURE_REGION_NAME': 'eastus'
+    }
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    @patch('sct.clean_cloud_resources')
+    @patch('sct.clean_sct_runners')
+    @patch('sct.add_file_logger')
+    def test_clean_resources_with_clean_runners_flag_and_user(self, mock_logger, mock_clean_runners, mock_clean_resources):
+        """Test clean-resources with --clean-runners flag and --user option."""
+        mock_clean_resources.return_value = None
+        mock_clean_runners.return_value = None
+
+        with patch.dict(os.environ, self.ENV_VARS):
+            result = self.runner.invoke(
+                sct.clean_resources, ['--user', 'test.user', '--clean-runners', '--dry-run'])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_clean_runners.assert_called_once_with(
+            test_status="",
+            test_runner_ip=None,
+            backend=None,
+            user="test.user",
+            test_id=None,
+            dry_run=True,
+            force=True)
+        mock_clean_resources.assert_called_once()
+
+    @patch('sct.clean_cloud_resources')
+    @patch('sct.clean_sct_runners')
+    @patch('sct.add_file_logger')
+    def test_clean_resources_with_clean_runners_flag_and_test_id(self, mock_logger, mock_clean_runners, mock_clean_resources):
+        """Test clean-resources with --clean-runners flag and --test-id option."""
+        mock_clean_resources.return_value = None
+        mock_clean_runners.return_value = None
+
+        with patch.dict(os.environ, self.ENV_VARS):
+            result = self.runner.invoke(
+                sct.clean_resources, ['--test-id', 'test-123', '--clean-runners', '--backend', 'aws'])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_clean_runners.assert_called_once_with(
+            test_status="",
+            test_runner_ip=None,
+            backend="aws",
+            user=None,
+            test_id="test-123",
+            dry_run=False,
+            force=True)
+
+    @patch('sct.add_file_logger')
+    def test_clean_resources_clean_runners_requires_user_or_test_id(self, mock_logger):
+        """Test that --clean-runners requires --user or --test-id."""
+        result = self.runner.invoke(sct.clean_resources, ['--clean-runners'])
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("--clean-runners requires --user and/or --test-id", result.output)
+
+    @patch('sct.clean_cloud_resources')
+    @patch('sct.clean_sct_runners')
+    @patch('sct.add_file_logger')
+    def test_clean_resources_with_both_user_and_test_id(self, mock_logger, mock_clean_runners, mock_clean_resources):
+        """Test clean-resources with both --user and --test-id options."""
+        mock_clean_resources.return_value = None
+        mock_clean_runners.return_value = None
+
+        with patch.dict(os.environ, self.ENV_VARS):
+            result = self.runner.invoke(
+                sct.clean_resources,
+                ['--user', 'test.user', '--test-id', 'test-123', '--clean-runners', '--backend', 'gce'])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_clean_runners.assert_called_once_with(
+            test_status="",
+            test_runner_ip=None,
+            backend="gce",
+            user="test.user",
+            test_id="test-123",
+            dry_run=False,
+            force=True)
+
+    @patch('sct.clean_cloud_resources')
+    @patch('sct.add_file_logger')
+    def test_clean_resources_without_clean_runners_flag(self, mock_logger, mock_clean_resources):
+        """Test clean-resources without --clean-runners flag."""
+        mock_clean_resources.return_value = None
+
+        with patch.dict(os.environ, self.ENV_VARS):
+            result = self.runner.invoke(sct.clean_resources, ['--user', 'test.user'])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_clean_resources.assert_called_once()
+        with patch('sct.clean_sct_runners') as mock_clean_runners:
+            mock_clean_runners.assert_not_called()
+
+
+class TestCleanRunnerInstancesCommand(unittest.TestCase):
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    @patch('sct.clean_sct_runners')
+    @patch('sct.add_file_logger')
+    def test_clean_runner_instances_with_user(self, mock_logger, mock_clean_runners):
+        """Test clean-runner-instances with --user option."""
+        mock_clean_runners.return_value = None
+
+        result = self.runner.invoke(sct.clean_runner_instances, ['--user', 'test.user'])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_clean_runners.assert_called_once_with(
+            test_runner_ip='',
+            test_status=None,
+            backend=None,
+            user="test.user",
+            test_id=(),
+            dry_run=False,
+            force=False)
+
+    @patch('sct.clean_sct_runners')
+    @patch('sct.add_file_logger')
+    def test_clean_runner_instances_with_test_id(self, mock_logger, mock_clean_runners):
+        """Test clean-runner-instances with --test-id option."""
+        mock_clean_runners.return_value = None
+
+        result = self.runner.invoke(sct.clean_runner_instances, ['--test-id', 'test-123'])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_clean_runners.assert_called_once_with(
+            test_runner_ip='',
+            test_status=None,
+            backend=None,
+            user=None,
+            test_id=('test-123',),
+            dry_run=False,
+            force=False)
+
+    @patch('sct.clean_sct_runners')
+    @patch('sct.add_file_logger')
+    def test_clean_runner_instances_with_runner_ip(self, mock_logger, mock_clean_runners):
+        """Test clean-runner-instances with --runner-ip option."""
+        mock_clean_runners.return_value = None
+
+        result = self.runner.invoke(sct.clean_runner_instances, ['--runner-ip', '1.2.3.4'])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_clean_runners.assert_called_once_with(
+            test_runner_ip="1.2.3.4",
+            test_status=None,
+            backend=None,
+            user=None,
+            test_id=(),
+            dry_run=False,
+            force=False)
+
+    @patch('sct.clean_sct_runners')
+    @patch('sct.add_file_logger')
+    def test_clean_runner_instances_force(self, mock_logger, mock_clean_runners):
+        """Test clean-runner-instances with --force flag."""
+        mock_clean_runners.return_value = None
+
+        result = self.runner.invoke(sct.clean_runner_instances, ['--runner-ip', '1.2.3.4', '--force'])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_clean_runners.assert_called_once_with(
+            test_runner_ip="1.2.3.4",
+            test_status=None,
+            backend=None,
+            user=None,
+            test_id=(),
+            dry_run=False,
+            force=True)
+
+    @patch('sct.clean_sct_runners')
+    @patch('sct.add_file_logger')
+    def test_clean_runner_instances_all_options(self, mock_logger, mock_clean_runners):
+        """Test clean-runner-instances with all available options."""
+        mock_clean_runners.return_value = None
+
+        result = self.runner.invoke(sct.clean_runner_instances, [
+            '--runner-ip', '1.2.3.4',
+            '--test-status', 'timeout',
+            '--backend', 'gce',
+            '--user', 'test.user',
+            '--test-id', 'test-123',
+            '--dry-run',
+            '--force'])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_clean_runners.assert_called_once_with(
+            test_runner_ip="1.2.3.4",
+            test_status="timeout",
+            backend="gce",
+            user="test.user",
+            test_id=('test-123',),
+            dry_run=True,
+            force=True)

--- a/unit_tests/test_sct_runner.py
+++ b/unit_tests/test_sct_runner.py
@@ -1,0 +1,274 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+import unittest
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timezone
+
+from sdcm.sct_runner import (
+    list_sct_runners,
+    clean_sct_runners,
+    SctRunnerInfo,
+    AwsSctRunner,
+    GceSctRunner,
+    AzureSctRunner,
+)
+
+
+class TestListSctRunners(unittest.TestCase):
+    """Test the enhanced list_sct_runners function."""
+
+    def setUp(self):
+        self.aws_runner = SctRunnerInfo(
+            sct_runner_class=AwsSctRunner,
+            cloud_service_instance=None,
+            region_az="us-east-1a",
+            instance={"Tags": [{"Key": "RunByUser", "Value": "user1"}], "InstanceId": "i-aws1"},
+            instance_name="aws-runner-1",
+            public_ips=["1.2.3.4"],
+            test_id="test-id-1")
+
+        self.gce_runner = SctRunnerInfo(
+            sct_runner_class=GceSctRunner,
+            cloud_service_instance=None,
+            region_az="us-central1-a",
+            instance=MagicMock(metadata=MagicMock()),
+            instance_name="gce-runner-1",
+            public_ips=["5.6.7.8"],
+            test_id="test-id-2")
+
+        self.azure_runner = SctRunnerInfo(
+            sct_runner_class=AzureSctRunner,
+            cloud_service_instance=None,
+            region_az="eastus-1",
+            instance=MagicMock(tags={"RunByUser": "user2"}),
+            instance_name="azure-runner-1",
+            public_ips=["9.10.11.12"],
+            test_id="test-id-1")
+
+    @patch('sdcm.sct_runner.AwsSctRunner.list_sct_runners')
+    @patch('sdcm.sct_runner.GceSctRunner.list_sct_runners')
+    @patch('sdcm.sct_runner.AzureSctRunner.list_sct_runners')
+    def test_list_sct_runners_no_filters(self, mock_azure, mock_gce, mock_aws):
+        """Test listing all runners without filters."""
+        mock_aws.return_value = [self.aws_runner]
+        mock_gce.return_value = [self.gce_runner]
+        mock_azure.return_value = [self.azure_runner]
+
+        runners = list_sct_runners(verbose=False)
+
+        self.assertEqual(len(runners), 3)
+        self.assertIn(self.aws_runner, runners)
+        self.assertIn(self.gce_runner, runners)
+        self.assertIn(self.azure_runner, runners)
+
+    @patch('sdcm.sct_runner.AwsSctRunner.list_sct_runners')
+    @patch('sdcm.sct_runner.GceSctRunner.list_sct_runners')
+    @patch('sdcm.sct_runner.AzureSctRunner.list_sct_runners')
+    @patch('sdcm.sct_runner._get_runner_user_tag')
+    def test_list_sct_runners_filter_by_user(self, mock_get_user_tag, mock_azure, mock_gce, mock_aws):
+        """Test filtering runners by user."""
+        mock_aws.return_value = [self.aws_runner]
+        mock_gce.return_value = [self.gce_runner]
+        mock_azure.return_value = [self.azure_runner]
+
+        def side_effect(runner_info):
+            if runner_info == self.aws_runner:
+                return "user1"
+            elif runner_info == self.gce_runner:
+                return "user1"
+            elif runner_info == self.azure_runner:
+                return "user2"
+            return None
+        mock_get_user_tag.side_effect = side_effect
+
+        runners = list_sct_runners(user="user1", verbose=False)
+
+        self.assertEqual(len(runners), 2)
+        self.assertIn(self.aws_runner, runners)
+        self.assertIn(self.gce_runner, runners)
+        self.assertNotIn(self.azure_runner, runners)
+
+    @patch('sdcm.sct_runner.AwsSctRunner.list_sct_runners')
+    @patch('sdcm.sct_runner.GceSctRunner.list_sct_runners')
+    @patch('sdcm.sct_runner.AzureSctRunner.list_sct_runners')
+    def test_list_sct_runners_filter_by_test_id(self, mock_azure, mock_gce, mock_aws):
+        """Test filtering runners by test_id."""
+        mock_aws.return_value = [self.aws_runner]
+        mock_gce.return_value = [self.gce_runner]
+        mock_azure.return_value = [self.azure_runner]
+
+        runners = list_sct_runners(test_id="test-id-1", verbose=False)
+
+        self.assertEqual(len(runners), 2)
+        self.assertIn(self.aws_runner, runners)
+        self.assertNotIn(self.gce_runner, runners)
+        self.assertIn(self.azure_runner, runners)
+
+    @patch('sdcm.sct_runner.AwsSctRunner.list_sct_runners')
+    @patch('sdcm.sct_runner.GceSctRunner.list_sct_runners')
+    @patch('sdcm.sct_runner.AzureSctRunner.list_sct_runners')
+    def test_list_sct_runners_filter_by_ip(self, mock_azure, mock_gce, mock_aws):
+        """Test filtering runners by IP address."""
+        mock_aws.return_value = [self.aws_runner]
+        mock_gce.return_value = [self.gce_runner]
+        mock_azure.return_value = [self.azure_runner]
+
+        runners = list_sct_runners(test_runner_ip="5.6.7.8", verbose=False)
+
+        self.assertEqual(len(runners), 1)
+        self.assertNotIn(self.aws_runner, runners)
+        self.assertIn(self.gce_runner, runners)
+        self.assertNotIn(self.azure_runner, runners)
+
+    @patch('sdcm.sct_runner.AwsSctRunner.list_sct_runners')
+    @patch('sdcm.sct_runner.GceSctRunner.list_sct_runners')
+    @patch('sdcm.sct_runner.AzureSctRunner.list_sct_runners')
+    @patch('sdcm.sct_runner._get_runner_user_tag')
+    def test_list_sct_runners_mixed_filters(self, mock_get_user_tag, mock_azure, mock_gce, mock_aws):
+        """Test user and test_id filters."""
+        mock_aws.return_value = [self.aws_runner]
+        mock_gce.return_value = [self.gce_runner]
+        mock_azure.return_value = [self.azure_runner]
+
+        def side_effect(runner_info):
+            if runner_info == self.aws_runner:
+                return "user1"
+            elif runner_info == self.azure_runner:
+                return "user1"
+            return "other_user"
+        mock_get_user_tag.side_effect = side_effect
+
+        runners = list_sct_runners(user="user1", test_id="test-id-1", verbose=False)
+
+        self.assertEqual(len(runners), 2)
+        self.assertIn(self.aws_runner, runners)
+        self.assertNotIn(self.gce_runner, runners)
+        self.assertIn(self.azure_runner, runners)
+
+    @patch('sdcm.sct_runner.AwsSctRunner.list_sct_runners')
+    @patch('sdcm.sct_runner.GceSctRunner.list_sct_runners')
+    @patch('sdcm.sct_runner.AzureSctRunner.list_sct_runners')
+    def test_list_sct_runners_empty_results(self, mock_azure, mock_gce, mock_aws):
+        """Test no runners match filters."""
+        mock_aws.return_value = [self.aws_runner]
+        mock_gce.return_value = [self.gce_runner]
+        mock_azure.return_value = [self.azure_runner]
+
+        runners = list_sct_runners(test_id="non-existent-test-id", verbose=False)
+
+        self.assertEqual(len(runners), 0)
+
+    @patch('sdcm.sct_runner.AwsSctRunner.list_sct_runners')
+    def test_list_sct_runners_backend_filtering_aws(self, mock_aws):
+        """Test backend-specific filtering for AWS."""
+        mock_aws.return_value = [self.aws_runner]
+
+        with patch('sdcm.sct_runner.GceSctRunner.list_sct_runners') as mock_gce:
+            with patch('sdcm.sct_runner.AzureSctRunner.list_sct_runners') as mock_azure:
+                runners = list_sct_runners(backend="aws", verbose=False)
+
+                mock_aws.assert_called_once()
+                mock_gce.assert_not_called()
+                mock_azure.assert_not_called()
+                self.assertEqual(len(runners), 1)
+                self.assertIn(self.aws_runner, runners)
+
+
+class TestCleanSctRunners(unittest.TestCase):
+    """Test the clean_sct_runners function."""
+
+    def setUp(self):
+        self.mock_runner_with_keep = MagicMock(
+            keep="24",
+            keep_action="terminate",
+            launch_time=datetime.now(timezone.utc),
+            public_ips=["1.2.3.4"],
+            cloud_provider="aws",
+            instance_name="test-runner-1",
+            region_az="us-east-1a",
+            test_id="test-123")
+
+        self.mock_runner_no_keep = MagicMock(
+            keep=None,
+            keep_action=None,
+            launch_time=datetime.now(timezone.utc),
+            public_ips=["5.6.7.8"],
+            cloud_provider="gce",
+            instance_name="test-runner-2",
+            region_az="us-central1-a",
+            test_id="test-456")
+
+    @patch('sdcm.sct_runner.list_sct_runners')
+    def test_clean_sct_runners_by_user(self, mock_list_runners):
+        """Test cleanup filtered by user."""
+        mock_list_runners.return_value = [self.mock_runner_no_keep]
+
+        clean_sct_runners(test_status="", user="test_user", dry_run=True)
+        mock_list_runners.assert_called_once_with(backend=None, test_runner_ip=None, user="test_user", test_id=None)
+
+    @patch('sdcm.sct_runner.list_sct_runners')
+    def test_clean_sct_runners_by_test_id(self, mock_list_runners):
+        """Test cleanup filtered by test_id."""
+        mock_list_runners.return_value = [self.mock_runner_no_keep]
+
+        clean_sct_runners(test_status="", test_id="test-id-123", dry_run=True)
+        mock_list_runners.assert_called_once_with(backend=None, test_runner_ip=None, user=None, test_id="test-id-123")
+
+    @patch('sdcm.sct_runner.list_sct_runners')
+    def test_clean_sct_runners_mixed_filters(self, mock_list_runners):
+        """Test mix of user and test_id filters."""
+        mock_list_runners.return_value = [self.mock_runner_no_keep]
+
+        clean_sct_runners(
+            test_status="completed", user="test_user", test_id="test-id-123", backend="aws", dry_run=True)
+        mock_list_runners.assert_called_once_with(
+            backend="aws", test_runner_ip=None, user="test_user", test_id="test-id-123")
+
+    @patch('sdcm.sct_runner.ssh_run_cmd')
+    @patch('sdcm.sct_runner.list_sct_runners')
+    def test_clean_sct_runners_force(self, mock_list_runners, mock_ssh_cmd):
+        """Test force cleanup ignoring keep tags."""
+        mock_list_runners.return_value = [self.mock_runner_with_keep]
+        mock_ssh_cmd.return_value = MagicMock(stdout="")
+
+        clean_sct_runners(test_status="", user="test_user", force=True, dry_run=True)
+        mock_list_runners.assert_called_once()
+
+    @patch('sdcm.sct_runner.ssh_run_cmd')
+    @patch('sdcm.sct_runner.list_sct_runners')
+    def test_clean_sct_runners_respect_keep_tags(self, mock_list_runners, mock_ssh_cmd):
+        """Test keep tags are respected when clean is not forced."""
+        # runner with keep 'alive' tag
+        mock_runner_keep_alive = MagicMock(
+            keep="alive",
+            keep_action="terminate",
+            launch_time=datetime.now(timezone.utc),
+            public_ips=["1.2.3.4"],
+            cloud_provider="aws",
+            instance_name="test-runner-alive",
+            region_az="us-east-1a")
+
+        mock_list_runners.return_value = [mock_runner_keep_alive]
+        mock_ssh_cmd.return_value = MagicMock(stdout="")
+
+        clean_sct_runners(test_status="", user="test_user", force=False, dry_run=False)
+        mock_runner_keep_alive.terminate.assert_not_called()
+
+    @patch('sdcm.sct_runner.list_sct_runners')
+    def test_clean_sct_runners_no_runners_found(self, mock_list_runners):
+        """Test when no runners match filters."""
+        mock_list_runners.return_value = []
+
+        clean_sct_runners(test_status="", user="nonexistent_user", dry_run=True)
+        mock_list_runners.assert_called_once()


### PR DESCRIPTION
Add an option of cleaning SCT runners to clean-resources command. This should improve UX of the chore of test resources cleanup, epsecially peformed locally from dev machine.

Closes: https://github.com/scylladb/scylla-cluster-tests/issues/11265

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Tested locally a few cycles of creating/cleaning the sct-runner with this change:
- delete on aws by user:
```
❯ SCT_ENABLE_ARGUS=false ./sct.py create-runner-instance -c aws -r eu-west-1 -z a --instance-type 't3.micro' --root-disk-size-gb 80 -d 30 -t 11223344-1122-1122-2211-665544332211
...
Successfully connected the SCT Runner. Public IP: 3.252.201.231

❯ hydra list-resources --user dmytro.kruglov | grep 11223344
| sct-runner-1.11-instance-11223344 | eu-west-1a | running | 11223344-1122-1122-2211-665544332211 | dmytro.kruglov | Sun Jul 27 17:08:18 2025 |
...

❯ ./sct.py clean-resources --clean-runners --user dmytro.kruglov
...
1 SCT runner(s) found:
    [aws/eu-west-1a] sct-runner-1.11-instance-11223344 (i-0c04e97f94ee847dd), launched at July 27, 2025, 17:08:18 UTC, keep: 7, keep_action: terminate, public IPs are ['3.252.201.231']
...
Number of cleaned runners: 1
SCT runner cleanup for {'RunByUser': 'dmytro.kruglov', 'CreatedBy': 'SCT'} has been finished

❯ ./sct.py list-resources --user dmytro.kruglov | grep 11223344
❯
```
- delete on aws by test-id
```
 SCT_ENABLE_ARGUS=false ./sct.py create-runner-instance -c aws -r eu-west-1 -z a --instance-type 't3.micro' --root-disk-size-gb 80 -d 30 -t 12345678-1234-5678-1234-123456789012
...
Successfully connected the SCT Runner. Public IP: 18.202.236.63

❯ ./sct.py clean-resources --clean-runners --test-id 12345678-1234-5678-1234-123456789012
...
Looking for SCT runner instances (backend is 'None')...
1 SCT runner(s) found:
    [aws/eu-west-1a] sct-runner-1.11-instance-12345678 (i-042c9c8ba5b36311e), launched at July 27, 2025, 18:51:58 UTC, keep: 7, keep_action: terminate, public IPs are ['18.202.236.63']
...
SCT runner cleanup for {'TestId': '12345678-1234-5678-1234-123456789012'} has been finished
```
- delete on gce by user
```
❯ SCT_ENABLE_ARGUS=false ./sct.py create-runner-instance -c gce -r us-east1 --root-disk-size-gb 80 -d 30 -t 12345678-1234-5678-1234-123456789012
...
Successfully connected the SCT Runner. Public IP: 35.243.208.37

❯ ./sct.py clean-resources --clean-runners --user dmytro.kruglov
...
1 SCT runner(s) found:
    [gce/us-east1-c] sct-runner-1-11-instance-12345678, launched at July 27, 2025, 19:58:31 UTC, keep: 7, keep_action: terminate, public IPs are ['35.243.208.37']
...
SCT runner cleanup for {'RunByUser': 'dmytro.kruglov', 'CreatedBy': 'SCT'} has been finished
```
- delete without filters, should be rejected
```
❯ ./sct.py clean-resources --clean-runners
...
ERROR: --clean-runners requires --user and/or --test-id, to prevent accidentally deleting all SCT runners
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
