### PR TITLE
Support the latest Manager release 3.5.1

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -158,8 +158,8 @@ jepsen_test_count: 1
 jepsen_test_run_policy: all
 
 max_events_severities: ""
-scylla_mgmt_agent_version: '3.5.0'
-mgmt_docker_image: 'scylladb/scylla-manager:3.5.0'
+scylla_mgmt_agent_version: '3.5.1'
+mgmt_docker_image: 'scylladb/scylla-manager:3.5.1'
 k8s_log_api_calls: false
 k8s_deploy_monitoring: false
 k8s_minio_storage_size: '10Gi'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -352,7 +352,7 @@ Branch of scylla db enterprise to install. Options in defaults/manager_versions.
 
 
 
-**default:** 3.5.0
+**default:** 3.5.1
 
 **type:** str
 
@@ -2035,7 +2035,7 @@ Number of nodes in monitoring pool that will be used for scylla-operator's deplo
 
 Scylla manager docker image, i.e. 'scylladb/scylla-manager:2.2.1'
 
-**default:** scylladb/scylla-manager:3.5.0
+**default:** scylladb/scylla-manager:3.5.1
 
 **type:** str (appendable)
 

--- a/jenkins-pipelines/manager/debian11-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian11-manager-upgrade.jenkinsfile
@@ -9,7 +9,9 @@ managerPipeline(
 
     scylla_version: '2025.1',
 
-    manager_version: '3.4',
+    // Upgrade from some old Manager release which is still used in production
+    // Use Metabase to check it (https://scylladb.metabaseapp.com/question/1685-manager-version)
+    manager_version: '3.4.2',
     target_manager_version: 'master_latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',

--- a/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
 
     // Upgrade from previous minor release (choose non-last patch release which is still used in production)
     // Use Metabase to check it (https://scylladb.metabaseapp.com/question/1685-manager-version)
-    manager_version: '3.4.1',
+    manager_version: '3.5.0',
     target_manager_version: 'master_latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',

--- a/jenkins-pipelines/manager/ubuntu24-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-upgrade.jenkinsfile
@@ -8,7 +8,7 @@ managerPipeline(
     region: 'us-east-1',
 
     // Upgrade from the latest patch release
-    manager_version: '3.5',
+    manager_version: '3.5.1',
     target_manager_version: 'master_latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',


### PR DESCRIPTION
This PR updates the Scylla Manager version from 3.5.0 to 3.5.1 across the codebase to support the latest Manager release. The change involves updating version references in Jenkins pipeline configurations, documentation, and default configuration files.

- Updates manager version references from 3.5.0 to 3.5.1
- Updates Ubuntu 20 pipeline to use Manager 3.5.0 instead of 3.4.1 for upgrade testing
- Updates Debian 11 pipeline to use Manager 3.4.2 instead of 3.4 for upgrade testing

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
Not required

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
