### PR TITLE
fix(test): downgrade gemini for upgrade tests

### DIFF
--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -98,7 +98,6 @@ class GeminiStressThread(DockerBasedStressThread):
             "token-range-slices": 10000,
             "partition-key-buffer-reuse-size": 128,
             "statement-log-file-compression": "zstd",
-            "io-worker-pool": 2048,  # Number of threads to perform IO operations (mainly Scylla reads/writes)
             "max-errors-to-store": 1000,  # Number of error to make gemini fail, after N error, gemini will stop immediately with error
         }
 

--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -16,6 +16,7 @@ gemini_cmd: |
   --warmup 2h
   --concurrency 50
   --mode mixed
+  --io-worker-pool 2048
 
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 gemini_log_cql_statements: true

--- a/test-cases/gemini/gemini-basic-3h.yaml
+++ b/test-cases/gemini/gemini-basic-3h.yaml
@@ -11,6 +11,7 @@ gemini_cmd: |
   --warmup 5m
   --concurrency 50
   --mode mixed
+  --io-worker-pool 2048
 
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 gemini_log_cql_statements: true

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -43,3 +43,7 @@ gemini_seed: 66
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
 use_preinstalled_scylla: false
+
+stress_image:
+  gemini: 'scylladb/gemini:1.9.3'
+gemini_log_cql_statements: false


### PR DESCRIPTION
In upgrade tests Gemini fails with error 137 without leaving a trace why. It works in typical scenario.

Temporary workaround by downgrading Gemini to known working version before we find the root cause.

refs: https://github.com/scylladb/scylla-cluster-tests/issues/11534

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/2025/job/rolling-upgrade-ami-test/5/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
