### PR TITLE
fix(gemini): metrics not beining read properly after 2.0

### DIFF
--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -44,6 +44,4 @@ gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'
 
 use_preinstalled_scylla: false
 
-stress_image:
-  gemini: 'scylladb/gemini:1.9.3'
 gemini_log_cql_statements: false

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -657,7 +657,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             gemini_cmd += " --table-options \"cdc={'enabled': true}\""
         gemini_thread = self.run_gemini(gemini_cmd)
         self.metric_has_data(
-            metric_query='gemini_cql_requests', n=10)
+            metric_query='sum(increase(gemini_cql_requests[1m]))', n=10)
 
         with ignore_upgrade_schema_errors():
 


### PR DESCRIPTION
In 2.0 gemini, more thing were added to `gemini_cql_requests` metrics, mainly the `method` which contained what statement type is executed. This broke the upgrade tests, as in upgrade test the first value returned from prometheus is used to check `> 0`, but the prometheus ordered the metric labels in alphabetical order, making the metric currently checked to be *almost* always zero, thus failing the check and killing gemini thinking it's not running (but it actually is).

Now fetching the `InsertStatement` label makes sure that this check will succeed (maybe not on the first try as it is not yet inserting, but after a couple of try will succeed).

Closing #11534 

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- :green_circle: https://argus.scylladb.com/tests/scylla-cluster-tests/bb8ff3e6-cc34-4d4a-ad2c-94e31fb6896b (Previous check of the metrics -> not backwards compatible)
- :green_circle: https://argus.scylladb.com/tests/scylla-cluster-tests/da0ee7be-90c6-49af-84fd-4fffc034e0d2 (backwards compatible way of checking)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
