### PR TITLE
improvement(latte): use host network and disable secure computing mode

### DIFF
--- a/sdcm/stress/latte_thread.py
+++ b/sdcm/stress/latte_thread.py
@@ -230,6 +230,8 @@ class LatteStressThread(DockerBasedStressThread):
             self.docker_image_name,
             command_line="-c 'tail -f /dev/null'",
             extra_docker_opts=(
+                "--network=host "
+                "--security-opt seccomp=unconfined "
                 f"--entrypoint /bin/bash {cpu_options} --label shell_marker={self.shell_marker}"
                 f" -v {remote_hdr_file_name_full_path}:/{remote_hdr_file_name}"
             ),


### PR DESCRIPTION
Latte docker container was using docker network and `secure computing mode` linux feature.
Both are redundant and decrease overall performance.
We need to have as better perf as possible for performance tests.

Ref: https://github.com/scylladb/qa-tasks/issues/1659

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-latte-perf-regression-predefined-throughput-steps-rust-vnodes#2](https://argus.scylladb.com/tests/scylla-cluster-tests/e1972d94-2182-4bf8-b4af-b157d2ce272a)
- [scylla-staging/valerii/vp-latte-perf-regression-predefined-throughput-steps-rust-vnodes#3](https://argus.scylladb.com/tests/scylla-cluster-tests/7d3e44aa-9736-4492-ba00-d21fa7993643)
- [scylla-staging/valerii/vp-latte-perf-regression-predefined-throughput-steps-rust-vnodes#4](https://argus.scylladb.com/tests/scylla-cluster-tests/1696dd29-ad77-4277-9ea5-672a778d5880)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
