### PR TITLE
improvement(argus): add more logging when finilizing run

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1822,6 +1822,7 @@ def create_argus_test_run():
 @click.option("-s", "--jenkins-status", type=str, help="jenkins build status", required=True)
 def finish_argus_test_run(jenkins_status):
     try:
+        LOGGER.info("Finishing Argus TestRun with jenkins status %s", jenkins_status)
         params = SCTConfiguration()
         test_config = get_test_config()
         if not params.get('test_id'):
@@ -1835,6 +1836,7 @@ def finish_argus_test_run(jenkins_status):
             return
         new_status = TestStatus.FAILED
         if jenkins_status == "ABORTED":
+            LOGGER.info("Jenkins build status is ABORTED, setting Argus TestRun status to ABORTED")
             new_status = TestStatus.ABORTED
         test_config.argus_client().set_sct_run_status(new_status)
         test_config.argus_client().finalize_sct_run()


### PR DESCRIPTION
We fail to update Argus with aborted status and don't know exact culprit.

Added bit more logging to help investigation.

refs: https://github.com/scylladb/argus/issues/725

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
