### PR TITLE
improvement(trigger): send ami name instead of scylla_version for master

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import, annotations
 
 import atexit
 import itertools
+import json
 import os
 import logging
 import random
@@ -1545,6 +1546,24 @@ def create_pretty_table(rows: list[str] | list[list[str]], field_names: list[str
         tbl.add_row(row)
 
     return tbl
+
+
+def images_dict_in_json_format(rows: list[str] | list[list[str]], field_names: list[str]) -> str:
+    """
+    Convert the rows to a JSON format string.
+    :param rows: list of rows to convert
+    :param field_names: list of field names for the JSON keys
+    :return: JSON formatted string
+    """
+    if not rows:
+        return "{"
+
+    images_dict = {}
+    for image in rows:
+        images_dict.update({image[1]: {field: image[num] for num, field in enumerate(field_names)}})
+    images_json = json.dumps(images_dict)
+
+    return images_json
 
 
 def get_branched_gce_images(


### PR DESCRIPTION
If scylla_version is 'master:latest', an AMI name must be provided. 
Subtests currently run sequentially, not in parallel. This can lead to inconsistencies where initial subtests use an older AMI while subsequent ones use a newly created AMI (if an update occurs during the first subtest's execution). To ensure all subtests run with the same version, we should send an AMI ID and execute all subtests with that specific version.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [perf-regression-predefined-throughput-steps-sanity-vnodes with "master:latest"](https://argus.scylladb.com/tests/scylla-cluster-tests/362b9e14-5608-4566-b9ef-4a454f2917c0) - was triggered with image name in `scylla_ami_id`. 

<img width="851" height="532" alt="Screenshot from 2025-07-31 17-40-05" src="https://github.com/user-attachments/assets/c853de9d-8cbe-4372-8549-f44d204b474c" />

Correct Scylla version was started up
<img width="1172" height="559" alt="Screenshot from 2025-07-31 17-41-55" src="https://github.com/user-attachments/assets/c20c4e88-fe72-4d0f-92e5-70e25cc7bf72" />

- [x] [perf-regression-predefined-throughput-steps-sanity-vnodes with release version](https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/performance/job/perf-regression-predefined-throughput-steps-sanity-vnodes/33/parameters/) was triggered with release version
<img width="820" height="437" alt="Screenshot from 2025-07-31 17-43-46" src="https://github.com/user-attachments/assets/42e7b676-5a57-4438-bab0-f9c7fbbce134" />


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
