### PR TITLE
fix(cleanup): fix cleanup of AWS KMS key aliases

### DIFF
--- a/sdcm/provision/aws/dedicated_host.py
+++ b/sdcm/provision/aws/dedicated_host.py
@@ -205,16 +205,15 @@ class SCTDedicatedHosts:
     def release_by_tags(cls, tags_dict: dict, regions=None, dry_run=False) -> None:
         """Cancel all dedicated hosts with specific tags in AWS."""
 
-        tags_dict.pop('NodeType', None)
-
-        assert tags_dict, "tags_dict not provided (can't clean all hosts)"
+        local_tags_dict = {k: v for k, v in tags_dict.items() if k != "NodeType"}
+        assert local_tags_dict, "tags_dict not provided (can't clean all hosts)"
         if regions:
             aws_hosts = {}
             for region in regions:
                 aws_hosts |= cls.list_hosts(
-                    tags_dict=tags_dict, region_name=region, group_as_region=True)
+                    tags_dict=local_tags_dict, region_name=region, group_as_region=True)
         else:
-            aws_hosts = cls.list_hosts(tags_dict=tags_dict, group_as_region=True)
+            aws_hosts = cls.list_hosts(tags_dict=local_tags_dict, group_as_region=True)
 
         for region, hosts_list in aws_hosts.items():
             if not hosts_list:


### PR DESCRIPTION
One of the PRs (https://github.com/scylladb/scylla-cluster-tests/pull/9122) that was merged some time ago
added one more resource cleanup function
which was removing the `NodeType` key from the `tags_dict` shared dict object.
And the problem is that after this function SCT uses the same dict object in other cleanup functions such as deletion of AWS KMS key aliases.
Those functions directly depend on the presence of the `NodeType` dict key-value pair.
It's absence led to the skipping of attempts to cleanup resources.

So, fix the `release_by_tags` method of the `SCTDedicatedHosts` class
by not updating the shared dict object and make it use a local copy.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- https://jenkins.scylladb.com/job/sct-github-PRs-scan/job/scylla-cluster-tests/job/PR-11576/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
