### PR TITLE
fix(test): fix missing argus_heartbeat_stop_signal

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -340,6 +340,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
     monitors: BaseMonitorSet = None
     loaders: Union[BaseLoaderSet, LoaderSetAWS, LoaderSetGCE] = None
     db_cluster: Union[BaseCluster, BaseScyllaCluster] = None
+    argus_heartbeat_stop_signal = threading.Event()
 
     @property
     def k8s_cluster(self):


### PR DESCRIPTION
Due uncertain reason argus_heartbeat_stop_signal was missing during teardown and failing tests.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11586

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/2025/job/artifacts-ami-test/13/
- [ ] - https://jenkins.scylladb.com/job/scylla-staging/job/lukasz/job/2025/job/artifacts-ubuntu2204-test/2/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
