### PR TITLE
fix(test_parallelobject): Increase rand_timeouts by one

### DIFF
--- a/unit_tests/test_parallelobject.py
+++ b/unit_tests/test_parallelobject.py
@@ -57,7 +57,7 @@ def dummy_func_with_several_parameters(timeout, msg):
 
 class ParallelObjectTester(unittest.TestCase):
     max_timout = 3
-    rand_timeouts = random.sample(range(1, max_timout + 1), max_timout)
+    rand_timeouts = random.sample(range(2, max_timout + 2), max_timout)
     unpacking_args = [[t, f"test{i}"] for i, t in enumerate(rand_timeouts)]
     list_as_arg = [[[t, f"test{i}"]] for i, t in enumerate(rand_timeouts)]
     unpacking_kwargs = [{"timeout": t, "msg": f"test{i}"} for i, t in enumerate(rand_timeouts)]
@@ -80,7 +80,7 @@ class ParallelObjectTester(unittest.TestCase):
         test_timeout = min(self.rand_timeouts)
         start_time = time.time()
         with self.assertRaises(ParallelObjectException) as exp:
-            parallel_object = ParallelObject(self.rand_timeouts, timeout=test_timeout,
+            parallel_object = ParallelObject(self.rand_timeouts, timeout=test_timeout - 1,
                                              num_workers=len(self.rand_timeouts))
             parallel_object.run(dummy_func_return_tuple)
         assert any(isinstance(e.exc, concurrent.futures.TimeoutError) for e in exp.exception.results)


### PR DESCRIPTION
Now the minimal timeout is 2 and the test_timeout is now 1,
 meaning it will always be lower than actual running time.
This should fix instability errors with this test.

I am not sure if this is the correct way how to fix this test, but it works, but I might be misunderstanding purpose of the test and the feature.

Fixes #11596 

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Locally, 100x times

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
