### PR TITLE
fix(pull_image): correctly check if node is a docker container

### DIFF
--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -142,7 +142,7 @@ class RemoteDocker(BaseNode):
     @staticmethod
     @cache
     def pull_image(node, image):
-        prefix = "sudo" if node.is_docker else ""
+        prefix = "sudo" if node.is_docker() else ""
         node.remoter.run(
             f'{prefix} docker pull {image}', verbose=True, retry=3)
 


### PR DESCRIPTION
`node.is_docker` was incorrectly accessed as a property. Since `is_docker` is implemented as a method, accessing it without parentheses always evaluated to True.

This change ensures `node.is_docker()` is properly called, so pulling image is executed under proper user context.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
