### PR TITLE
fix(cluster.py): remove scylla_repo_loader usage and docker installation

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5050,29 +5050,8 @@ class BaseLoaderSet():
                           ">> /etc/security/limits.d/20-coredump.conf\"")
         if result.exit_status == 0:
             self.log.debug('Skip loader setup for using a prepared AMI')
-            return
-
-        elif node.distro.is_debian11:
-            node.install_package(package_name='openjdk-11-jre openjdk-11-jre-headless')
-
-        scylla_repo_loader = self.params.get('scylla_repo_loader')
-        if not scylla_repo_loader:
-            scylla_repo_loader = self.params.get('scylla_repo')
-        node.download_scylla_repo(scylla_repo_loader)
-        node.install_package(f'{node.scylla_pkg()}-tools')
-
-        node.wait_cs_installed(verbose=verbose)
-
-        # install docker
-        docker_install = dedent("""
-            curl -fsSL get.docker.com --retry 5 --retry-max-time 300 -o get-docker.sh
-            sh get-docker.sh
-            systemctl enable docker
-            systemctl start docker
-        """)
-        node.remoter.run('sudo bash -cxe "%s"' % docker_install)
-
-        node.remoter.run('sudo usermod -aG docker $USER', change_context=True)
+        else:
+            node.remoter.run('sudo usermod -aG docker $USER', change_context=True)
 
         # Login to Docker Hub.
         docker_hub_login(remoter=node.remoter)


### PR DESCRIPTION
This change deletes usage of scylla_repo_loader option and installation of docker in sdcm.cluster.BaseLoaderSet.node_setup, which was recently removed, but then accidentally brought back during backport of
PR https://github.com/scylladb/scylla-cluster-tests/pull/11607

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
