### PR TITLE
feature(tests): Be strict when evaluating tests 

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1178,7 +1178,7 @@ cli.add_command(investigate)
 @click.option("-t", "--test", required=False, default="",
               help="Run specific test file from unit-tests directory")
 def unit_tests(test):
-    sys.exit(pytest.main(['-v', '-p', 'no:warnings', '-m', 'not integration', 'unit_tests/{}'.format(test)]))
+    sys.exit(pytest.main(['-v', '-m', 'not integration', 'unit_tests/{}'.format(test)]))
 
 
 @cli.command('integration-tests', help="Run all the SCT internal integration-tests")
@@ -1200,7 +1200,7 @@ def integration_tests(test):
         )
         local_cluster.setup_prerequisites()
 
-    sys.exit(pytest.main(['-v', '-p', 'no:warnings', '-m', 'integration', 'unit_tests/{}'.format(test)]))
+    sys.exit(pytest.main(['-v', '-m', 'integration', 'unit_tests/{}'.format(test)]))
 
 
 @cli.command('pre-commit', help="Run pre-commit checkers")
@@ -1263,7 +1263,7 @@ def run_test(argv, backend, config, logdir):
     if not target:
         print("argv is referring to the directory or file that contain tests, it can't be empty")
         sys.exit(1)
-    return_code = pytest.main(['-s', '-vv', '-rN', '-p', 'no:logging', '-p', 'no:warnings', target])
+    return_code = pytest.main(['-s', '-vv', '-rN', '-p', 'no:logging', target])
     sys.exit(return_code)
 
 
@@ -1288,7 +1288,7 @@ def run_pytest(target, backend, config, logdir):
     if not target:
         print("argv is referring to the directory or file that contain tests, it can't be empty")
         sys.exit(1)
-    return_code = pytest.main(['-s', '-v', f'--junit-xml={junit_file}', '-p', 'no:warnings', target])
+    return_code = pytest.main(['-s', '-v', f'--junit-xml={junit_file}', target])
     test_config = get_test_config()
     test_config.argus_client().sct_submit_junit_report(file_name=junit_file.name, raw_content=junit_file.read_text())
     sys.exit(return_code)

--- a/unit_tests/pytest.ini
+++ b/unit_tests/pytest.ini
@@ -1,2 +1,11 @@
 [pytest]
-addopts = --durations=20
+addopts = --strict-markers --durations=20
+markers =
+    integration: mark tests that are integration tests
+    sct_config: mark tests that require a specific Scylla configuration
+    docker_scylla_args: Arguments to pass to the Scylla Docker container
+    override_pass: overrides specific tests to pass
+    need_network: mark tests that require network access
+filterwarnings =
+    # Upgrade all warnings to errors, to catch more issues during development
+    error:.*:pytest.PytestUnhandledThreadExceptionWarning

--- a/unit_tests/test_coredump.py
+++ b/unit_tests/test_coredump.py
@@ -4,6 +4,8 @@ import time
 import tempfile
 from abc import abstractmethod
 
+import pytest
+
 from sdcm.cluster import BaseNode
 from sdcm.coredump import CoredumpExportSystemdThread, CoreDumpInfo, CoredumpExportFileThread, CoredumpThreadBase
 from unit_tests.lib.data_pickle import Pickler
@@ -84,6 +86,7 @@ class CoredumpExportFileTestThread(CoredumpExportFileThread):
         return Pickler.save_to_file(filepath, self._localize_results())
 
 
+@pytest.mark.usefixtures("events")
 class CoredumpExportTestBase(unittest.TestCase):
     maxDiff = None
     test_data_folder: str = None

--- a/unit_tests/test_decode_backtrace.py
+++ b/unit_tests/test_decode_backtrace.py
@@ -101,6 +101,8 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
         self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'system.log')
 
     def test_01_reactor_stall_is_not_decoded_if_disabled(self):
+        # Accesses the test_config to ensure it is initialized
+        self.test_config
         self.monitor_node.start_decode_on_monitor_node_thread()
         self._read_and_publish_events_no_decoding()
         self.monitor_node.termination_event.set()

--- a/unit_tests/test_docker_cmd_runner.py
+++ b/unit_tests/test_docker_cmd_runner.py
@@ -15,6 +15,8 @@ class DummyNode:
 
 
 class TestWatcher(StreamWatcher):
+    __test__ = False
+
     def __init__(self):
         self.submissions = []
 


### PR DESCRIPTION
Depends on #11606.

This PR introduces strict checks on the tests we do for the SCT. We did have a few hidden failures or exceptions which did not fail the test but indicates a test setup error, this forces these errors to be visible.

* Upgrade pytest.PytestUnhandledThreadExceptionWarning to error
  * This indicates hidden failure while test was running
  * Start collecting warnings so they could be filtered
* Use strict marks
  * Specify which marks we use
 
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Locally for unit-tests
- [ ] CI for integration

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
