### PR TITLE
fix(nemesis): skip CreateIndexNemesis on unsupported Scylla versions

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5026,8 +5026,8 @@ class Nemesis(NemesisFlags):
 
         # Disable MV tests with tablets.
         if is_tablets_feature_enabled(self.target_node):
-            if SkipPerIssues(issues="https://github.com/scylladb/scylla-enterprise/issues/5461", params=self.tester.params):
-                raise UnsupportedNemesis("https://github.com/scylladb/scylla-enterprise/issues/5461")
+            if ComparableScyllaVersion(self.target_node.scylla_version) <= ComparableScyllaVersion("2025.3"):
+                raise UnsupportedNemesis("MV/SI for tablets are not supported for Scylla 2025.3 and older versions")
 
         with self.cluster.cql_connection_patient(self.target_node, connect_timeout=300) as session:
 


### PR DESCRIPTION
A followup of https://github.com/scylladb/scylla-cluster-tests/pull/11612#issuecomment-3154667277.
Before SCT was dependent on the [1] GH issue which was tracking the situation of not supported MVs with tablets.
And it was closed with assumption that the support will appear in 2025.3 But, it didn't land there.
So, update the skip condition to make it be skipped for any Scylla that is 2025.3 or older and uses tablets.

[1] https://github.com/scylladb/scylla-enterprise/issues/5461

Closes: https://github.com/scylladb/scylla-cluster-tests/issues/11611

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
