### PR TITLE
fix(tablets): not wait for no tablets splits

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3629,6 +3629,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
             self.log.debug("resize_type all results: %s", results_set)
             assert results_set == {'none'} or not results_set, (
                 "Tablet splits or merges still in progress: %s" % results_set)
+
+        if not is_tablets_feature_enabled(self.db_cluster.nodes[0]):
+            self.log.debug("Tablets are not enabled, skipping wait for no tablets splits")
+            return
+
         _is_no_tablets_splits()
 
     def metric_has_data(self, metric_query, n=80, sleep_time=60, ):


### PR DESCRIPTION
If tablets are not configurated, it's not needed to wait for no tablets splits. it may cause to test failure.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11554

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
