### PR TITLE
fix(logdir import): Move create-logging and log-directory to a fixture

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -170,8 +170,6 @@ except ImportError as import_exc:
     cluster_cloud = None
     CLUSTER_CLOUD_IMPORT_ERROR = str(import_exc)
 
-configure_logging(exception_handler=handle_exception, variables={'log_dir': TestConfig().logdir()})
-
 try:
     from botocore.vendored.requests.packages.urllib3.contrib.pyopenssl import extract_from_urllib3
 
@@ -3156,8 +3154,12 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
 
         self.log.info('Test ID: {}'.format(self.test_config.test_id()))
 
+    @pytest.fixture(scope="session", autouse=True)
+    def configure_logging_fixture(self):
+        configure_logging(exception_handler=handle_exception, variables={'log_dir': TestConfig().logdir()})
+
     @pytest.fixture(autouse=True, name='setup_logging')
-    def fixture_setup_logging(self):
+    def fixture_setup_logging(self, configure_logging_fixture):
         self._init_logging()
 
     @pytest.fixture(autouse=True, name='event_system')


### PR DESCRIPTION
Since nemesis.py importing of sdcm.mgmt.operations also imports tester.py, it causes re-linking sct logdir to a wrong directory of other pipeline step. Avoiding that by using a conftest fixture that is executed only once per test in a session level. 
Fixes: #11546

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->

Tested in:
[ubuntu24-installation-test](https://argus.scylladb.com/tests/scylla-cluster-tests/86d55f48-f74a-4c23-ad4c-de371d97adf5
)
[ubuntu-24-upgrade](https://argus.scylladb.com/tests/scylla-cluster-tests/d4b37728-fb67-4ec4-8dbb-5c409d679ddb)
[test_manager_backup](https://argus.scylladb.com/tests/scylla-cluster-tests/76a60824-9ce6-41a3-ac04-4c1746b0cbd7)
[10gb-3h-longevity - test failure](https://argus.scylladb.com/tests/scylla-cluster-tests/393d32db-f830-4382-b0e8-ebcafbc6fc27)
==> the longevity can be manually interrupted (since no need for nemesis run of a 3 hours). Just verify the logs are collected and email is send appropriately after test failure.
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
