### PR TITLE
fix(provision): wait for pending instances

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -339,7 +339,8 @@ class AWSCluster(cluster.BaseCluster):
         availability_zone = self.params.get('availability_zone').split(",")[az_idx] if az_idx is not None else None
         ec2 = ec2_client.EC2ClientWrapper(region_name=self.region_names[dc_idx])
         results = list_instances_aws(tags_dict={'TestId': test_id, 'NodeType': self.node_type}, running=True,
-                                     region_name=self.region_names[dc_idx], group_as_region=True, availability_zone=availability_zone)
+                                     region_name=self.region_names[dc_idx], group_as_region=True,
+                                     availability_zone=availability_zone, verbose=True)
         instances = results[self.region_names[dc_idx]]
 
         def sort_by_index(item):


### PR DESCRIPTION
Sometimes when test starts to fast, some instances might not be in running state before sct lists them. This causes that only part of instances are detected and test fails at later stages.

fix by waiting for pending instances to become running and returning them from `list_instances_aws` function.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11555

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [issue reproduced with fix in action](https://jenkins.scylladb.com/job/scylla-staging/job/lukasz/job/2025/job/scylla-enterprise-perf-regression-latency-650gb-with-nemesis/16/) (search logs for `Waiting for 2 pending instances in eu-west-3 to become running`)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
