### PR TITLE
fix(performance): run all tests with 'on_demand'

### DIFF
--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -49,7 +49,7 @@ def call(Map pipelineParams) {
 
             // Provisioning Configuration
             separator(name: 'PROVISIONING', sectionHeader: 'Provisioning Configuration')
-            string(defaultValue: "${pipelineParams.get('provision_type', 'spot')}",
+            string(defaultValue: "${pipelineParams.get('provision_type', 'on_demand')}",
                    description: 'on_demand|spot_fleet|spot',
                    name: 'provision_type')
 


### PR DESCRIPTION
Performance test should not be run with 'spot' instances. Change the default instance provision type to 'on_demand'

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
