### PR TITLE
fix(nemesis): ignore error from status while gossip is disabled

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5291,7 +5291,7 @@ class Nemesis(NemesisFlags):
             time.sleep(5)
             with nodetool_context(node=self.target_node, start_command="disablegossip", end_command="enablegossip"):
                 self.target_node.run_nodetool("statusgossip")
-                self.target_node.run_nodetool("status")
+                self.target_node.run_nodetool("status", ignore_status=True)
                 time.sleep(30)
                 self._major_compaction()
         self.target_node.run_nodetool("statusgossip")


### PR DESCRIPTION
in `disrupt_disable_binary_gossip_execute_major_compaction` we are doing `nodetool status` while gossip was disabled
since scylladb/scylladb@e364995, this status can fail, cause the gossip is disabled

it's agree we can ignore the error of that command, while gossip is down.

Ref: scylladb/scylladb#24670

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/148/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
