### PR TITLE
fix(artifacts): use `scylla_io_setup` and not iotune directly

### DIFF
--- a/sdcm/utils/perftune_validator.py
+++ b/sdcm/utils/perftune_validator.py
@@ -1,10 +1,11 @@
+import math
 import logging
 import random
 import traceback
 from functools import cached_property
 
-
 import yaml
+from cassandra.cluster import defaultdict
 from deepdiff import DeepDiff
 
 from sdcm.sct_events import Severity
@@ -20,9 +21,8 @@ TEMP_PERFTUNE_YAML_PATH = "/tmp/perftune.yaml"
 PERFTUNE_EXPECTED_RESULTS_PATH = "defaults/perftune_results.json"
 
 
-def get_machine_architecture_type(node):
-    result = node.remoter.run("uname -m")
-    return result.stdout.strip()
+def count_bits(mask_string) -> int:
+    return sum([int(m, base=16).bit_count() for m in mask_string.split(",")])
 
 
 def get_number_of_cpu_cores(node) -> int:
@@ -31,37 +31,62 @@ def get_number_of_cpu_cores(node) -> int:
     return cores_num
 
 
+def get_number_of_irq_bits(node) -> int:
+    """
+    Calculate the number of IRQ bits based on the number of CPU cores and NUMA nodes.
+    The function uses the `hwloc` utility to determine the CPU topology and calculate the IRQ
+
+    based on the implementation in:
+    https://github.com/scylladb/seastar/blame/3412725d5487be6844fb723869e5444725ee40fe/scripts/perftune.py#L260
+    """
+    cores_per_irq_core = 16
+
+    node.install_package("hwloc")
+
+    cpu_mask_all = node.remoter.run('hwloc-calc all').stdout.strip()
+    numa_ids_list = node.remoter.run(f'hwloc-calc -I numa {cpu_mask_all}').stdout.strip().split(",")
+    num_cores0 = int(node.remoter.run(f'hwloc-calc --restrict {cpu_mask_all} --number-of core numa:0').stdout.strip())
+
+    num_cores_total = int(node.remoter.run(
+        f'hwloc-calc --restrict {cpu_mask_all} --number-of core machine:0').stdout.strip())
+    num_process_units_total = int(node.remoter.run(
+        f'hwloc-calc --restrict {cpu_mask_all} --number-of PU machine:0').stdout.strip())
+
+    if num_process_units_total <= 4:
+        return count_bits(cpu_mask_all)
+    elif num_cores_total <= 4:
+        return count_bits(node.remoter.run(f'hwloc-calc --restrict {cpu_mask_all} PU:0').stdout.strip())
+    elif num_cores_total <= cores_per_irq_core:
+        return count_bits(node.remoter.run(f'hwloc-calc --restrict {cpu_mask_all} core:0').stdout.strip())
+    else:
+        num_irq_cores = len(numa_ids_list) * math.ceil(num_cores0 / cores_per_irq_core)
+
+        hwloc_args = ""
+        numa_core_idx = defaultdict(int)
+
+        while num_irq_cores > 0:
+            for numa in numa_ids_list:
+                hwloc_args = f"{hwloc_args} node:{numa}.core:{numa_core_idx[numa]}"
+                num_irq_cores -= 1
+                numa_core_idx[numa] += 1
+
+        return count_bits(node.remoter.run(f"hwloc-calc --restrict {cpu_mask_all} {hwloc_args}").stdout.strip())
+
+
 class PerftuneExpectedResult:
-    def __init__(self, number_of_cpu_cores, nic_name, architecture):
+    def __init__(self, number_of_cpu_cores: int, nic_name: str, expected_irq_bits: int):
         self.nic_name = nic_name
         self.total_cpu_bits = number_of_cpu_cores
-        self.architecture = architecture
         self.expected_compute_bits: int = 0
+        self.expected_irq_bits = expected_irq_bits
 
         match number_of_cpu_cores:
             case 1 | 2 | 4:
                 self.expected_irq_bits: int = number_of_cpu_cores
                 self.expected_compute_bits: int = number_of_cpu_cores
-            case 8:
-                self.expected_irq_bits: int = 1
-            case 12 | 22 | 24 | 32:
-                self.expected_irq_bits: int = 2
-            case 16:
-                if self.architecture == "aarch64":
-                    self.expected_irq_bits: int = 1
-                else:
-                    self.expected_irq_bits: int = 2
-            case 44 | 48 | 64:
-                self.expected_irq_bits: int = 4
-            case 72 | 80 | 88 | 96 | 128 | 176:
-                self.expected_irq_bits: int = 8
 
         if self.expected_compute_bits == 0:
             self.expected_compute_bits: int = number_of_cpu_cores - self.expected_irq_bits
-
-    @staticmethod
-    def count_bits(mask_string) -> int:
-        return sum([int(m, base=16).bit_count() for m in mask_string.split(',')])
 
     def get_expected_options_file_contents(self) -> dict:
         return {
@@ -113,7 +138,7 @@ class PerftuneOutputChecker:
         self.executor = PerftuneExecutor(node, nic_name)
         self.expected_result = PerftuneExpectedResult(number_of_cpu_cores=get_number_of_cpu_cores(node),
                                                       nic_name=nic_name,
-                                                      architecture=get_machine_architecture_type(node))
+                                                      expected_irq_bits=get_number_of_irq_bits(node))
 
     @cached_property
     def systemd_version(self):
@@ -127,7 +152,7 @@ class PerftuneOutputChecker:
 
     def compare_cpu_mask(self) -> None:
         cpu_mask = self.executor.get_cpu_mask()
-        cpu_mask_bits = self.expected_result.count_bits(cpu_mask)
+        cpu_mask_bits = count_bits(cpu_mask)
         if cpu_mask_bits != self.expected_result.expected_compute_bits:
             PerftuneResultEvent(
                 message=f"Mismatched results when testing the output of the 'get-cpu-mask' command on {self.node}"
@@ -137,7 +162,7 @@ class PerftuneOutputChecker:
 
     def compare_irq_cpu_mask(self) -> None:
         irq_cpu_mask = self.executor.get_irq_cpu_mask()
-        irq_cpu_bits = self.expected_result.count_bits(irq_cpu_mask)
+        irq_cpu_bits = count_bits(irq_cpu_mask)
         if irq_cpu_bits != self.expected_result.expected_irq_bits:
             PerftuneResultEvent(
                 message=f"Mismatched results when testing the output of the 'get-irq-cpu-mask' command on "
@@ -147,8 +172,8 @@ class PerftuneOutputChecker:
                 severity=Severity.ERROR).publish()
 
     def compare_default_option_file(self, option_file_dict) -> None:
-        cpu_mask_bits = self.expected_result.count_bits(option_file_dict["cpu_mask"])
-        irq_cpu_bits = self.expected_result.count_bits(option_file_dict["irq_cpu_mask"])
+        cpu_mask_bits = count_bits(option_file_dict["cpu_mask"])
+        irq_cpu_bits = count_bits(option_file_dict["irq_cpu_mask"])
 
         if cpu_mask_bits != self.expected_result.total_cpu_bits:
             PerftuneResultEvent(

--- a/sdcm/utils/validators/iotune.py
+++ b/sdcm/utils/validators/iotune.py
@@ -49,10 +49,10 @@ class IOTuneValidator:
         with remote_file(self.node.remoter, io_props_path, sudo=True) as f:
             return yaml.safe_load(f)
 
-    def _run_io_tune(self, temp_props_path="/tmp/io_properties.yaml") -> IOProperties:
-        self.node.remoter.sudo(f"iotune  --evaluation-directory /var/lib/scylla --properties-file {temp_props_path}")
-        self.node_io_properties = self._read_io_properties(temp_props_path)
+    def _run_io_tune(self) -> IOProperties:
         self.preset_io_properties = self._read_io_properties()
+        self.node.remoter.sudo("scylla_io_setup", timeout=600)
+        self.node_io_properties = self._read_io_properties()
 
         preset_disk = next(iter(self.preset_io_properties.get("disks", [])), None)
         if not preset_disk:


### PR DESCRIPTION
since now there more logic as part of `scylla_io_setup` which is need to get correct results.

also stops using a temp file for the output, with the assumption this is the last phase of the test, and we don't
restart scylla after this point.

Fixes: #11605

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟡 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ami-test/35/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-azure-image-test/59/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-gce-image-test/12/
- [x] 🟢  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ami-arm-test/10/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
