### PR TITLE
feature(vectore-store): add support of VS for docker backend

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,7 +175,7 @@ pipeline {
                 }
             }
             options {
-                timeout(time: 40, unit: 'MINUTES')
+                timeout(time: 45, unit: 'MINUTES')
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -311,3 +311,11 @@ mgmt_snapshots_preparer_params:
   sequence_end: ''
 
 adaptive_timeout_store_metrics: true
+
+# Vector Search defaults
+n_vs_nodes: 0
+vs_port: 6080
+vs_scylla_port: 9042
+vs_threads: 2
+vs_docker_image: 'scylladb/vector-store'
+vs_version: 'latest'

--- a/docker/scylla-sct/entry.sh
+++ b/docker/scylla-sct/entry.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+set -x
+
 if [[ ! $(grep 'skip_wait_for_gossip_to_settle' /etc/scylla/scylla.yaml) ]]; then echo "skip_wait_for_gossip_to_settle: 0" >> /etc/scylla/scylla.yaml ; fi
 
+# TODO: Remove conditional setting of auth parameters when authentication is implemented in vector-store
+if [[ "${VECTOR_SEARCH_TEST:-}" != "true" ]]; then
 cat <<EOM >> /etc/scylla/scylla.yaml
 
 alternator_enforce_authorization: true
@@ -10,6 +14,7 @@ authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
 EOM
+fi
 
 sed -e '/enable_tablets:.*/s/true/false/g' -i /etc/scylla/scylla.yaml
 sed -e '/tablets_mode_for_new_keyspaces:.*/s/enabled/disabled/g' -i /etc/scylla/scylla.yaml

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -2058,6 +2058,24 @@ local docker network to use, if there's need to have db cluster connect to other
 **type:** str (appendable)
 
 
+## **vs_docker_image** / SCT_VS_DOCKER_IMAGE
+
+Vector Store docker image repo
+
+**default:** scylladb/vector-store
+
+**type:** str (appendable)
+
+
+## **vs_version** / SCT_VS_VERSION
+
+Vector Store version / docker image tag
+
+**default:** latest
+
+**type:** str (appendable)
+
+
 ## **s3_baremetal_config** / SCT_S3_BAREMETAL_CONFIG
 
 
@@ -3647,5 +3665,41 @@ Cloud provider for Scylla Cloud deployment (aws, gce)
 Replication factor for Scylla Cloud cluster (default: 3)
 
 **default:** N/A
+
+**type:** int
+
+
+## **n_vs_nodes** / SCT_N_VS_NODES
+
+Number of vector store nodes (0 = VS is disabled)
+
+**default:** N/A
+
+**type:** int
+
+
+## **vs_port** / SCT_VS_PORT
+
+Vector Store API port
+
+**default:** 6080
+
+**type:** int
+
+
+## **vs_scylla_port** / SCT_VS_SCYLLA_PORT
+
+ScyllaDB connection port for Vector Store
+
+**default:** 9042
+
+**type:** int
+
+
+## **vs_threads** / SCT_VS_THREADS
+
+Vector indexing threads (default: number of CPU cores)
+
+**default:** 2
 
 **type:** int

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -362,6 +362,8 @@ class ScyllaYaml(BaseModel):
 
     reader_concurrency_semaphore_cpu_concurrency: int = None
 
+    vector_store_uri: str = None
+
     def model_dump(
         self,
         *,

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1083,6 +1083,12 @@ class SCTConfiguration(dict):
         dict(name="docker_network", env="SCT_DOCKER_NETWORK", type=str,
              help="local docker network to use, if there's need to have db cluster connect to other services running in docker"),
 
+        dict(name="vs_docker_image", env="SCT_VS_DOCKER_IMAGE", type=str,
+             help="Vector Store docker image repo"),
+
+        dict(name="vs_version", env="SCT_VS_VERSION", type=str,
+             help="Vector Store version / docker image tag"),
+
         # baremetal config options
 
         dict(name="s3_baremetal_config", env="SCT_S3_BAREMETAL_CONFIG", type=str,
@@ -1802,6 +1808,19 @@ class SCTConfiguration(dict):
 
         dict(name="xcloud_replication_factor", env="SCT_XCLOUD_REPLICATION_FACTOR", type=int,
              help="Replication factor for Scylla Cloud cluster (default: 3)"),
+
+        dict(name="n_vs_nodes", env="SCT_N_VS_NODES", type=int,
+             help="Number of vector store nodes (0 = VS is disabled)"),
+
+        dict(name="vs_port", env="SCT_VS_PORT", type=int,
+             help="Vector Store API port"),
+
+        dict(name="vs_scylla_port", env="SCT_VS_SCYLLA_PORT", type=int,
+             help="ScyllaDB connection port for Vector Store"),
+
+        dict(name="vs_threads", env="SCT_VS_THREADS", type=int,
+             help="Vector indexing threads (default: number of CPU cores)"),
+
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',

--- a/sdcm/utils/vector_store_client.py
+++ b/sdcm/utils/vector_store_client.py
@@ -1,0 +1,90 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+import logging
+import requests
+import time
+
+LOGGER = logging.getLogger(__name__)
+
+
+class VectorStoreClient:
+    """HTTP client for Vector Store API"""
+
+    def __init__(self, base_url: str, timeout: int = 30):
+        self.base_url = base_url.rstrip('/')
+        self.timeout = timeout
+        self.session = requests.Session()
+
+    def request(self, method: str, endpoint: str, **kwargs) -> requests.Response:
+        """Make HTTP request with error handling"""
+        url = f"{self.base_url}{endpoint}"
+        kwargs.setdefault('timeout', self.timeout)
+
+        LOGGER.debug("Making %s request to %s", method, url)
+        response = self.session.request(method, url, **kwargs)
+
+        LOGGER.debug("Response: %s %s", response.status_code, response.reason)
+        response.raise_for_status()
+        return response
+
+    def get_status(self) -> dict:
+        """Get Vector Store operational status"""
+        return self.request('GET', '/api/v1/status').json()
+
+    def get_info(self) -> dict:
+        """Get Vector Store service information"""
+        return self.request('GET', '/api/v1/info').json()
+
+    def get_indexes(self) -> list[dict]:
+        """Get list of all vector indexes"""
+        return self.request('GET', '/api/v1/indexes').json()
+
+    def ann_search(self, keyspace: str, index: str, embedding: list[float], limit: int = 10) -> dict:
+        """Perform Approximate Nearest Neighbor search
+
+        :param keyspace: ScyllaDB keyspace name
+        :param index: vector index name
+        :param embedding: query vector (list of floats)
+        :param limit: maximum number of results to return
+
+        :returns dict: search results with 'primary_keys' and 'distances' fields
+        """
+        payload = {
+            'embedding': embedding,
+            'limit': limit}
+        return self.request('POST', f'/api/v1/indexes/{keyspace}/{index}/ann', json=payload).json()
+
+    def get_index_count(self, keyspace: str, index: str) -> int:
+        """Get number of embeddings in a vector index"""
+        return self.request('GET', f'/api/v1/indexes/{keyspace}/{index}/count').json()
+
+    def wait_for_ready(self, timeout: int = 300, check_interval: int = 5) -> bool:
+        """Wait for Vector Store to become ready (to have status SERVING or INDEXING_VECTORS)"""
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            try:
+                status = self.get_status()
+                if status in ('SERVING', 'BOOTSTRAPPING'):
+                    LOGGER.info("Vector Store is ready (status: %s)", status)
+                    return True
+            except Exception:  # noqa: BLE001
+                pass
+            LOGGER.debug("Vector Store is not ready yet")
+            time.sleep(check_interval)
+
+        LOGGER.error("Vector Store did not become ready within %s seconds", timeout)
+        return False
+
+    def close(self):
+        self.session.close()

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -14,13 +14,17 @@
 import os
 import logging
 import collections
+import subprocess
+from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from sdcm import wait, sct_config
 from sdcm.localhost import LocalHost
 from sdcm.cluster import BaseNode
+from sdcm.cluster_docker import VectorStoreSetDocker
 from sdcm.prometheus import start_metrics_server
 from sdcm.provision import provisioner_factory
 from sdcm.provision.helpers.certificate import (
@@ -29,6 +33,7 @@ from sdcm.provision.helpers.certificate import (
 from sdcm.remote import RemoteCmdRunnerBase
 from sdcm.sct_events.continuous_event import ContinuousEventsRegistry
 from sdcm.sct_provision import region_definition_builder
+from sdcm.test_config import TestConfig
 from sdcm.utils.docker_remote import RemoteDocker
 from sdcm.utils.subtest_utils import SUBTESTS_FAILURES
 
@@ -41,6 +46,37 @@ from unit_tests.lib.alternator_utils import ALTERNATOR_PORT
 
 
 pytest_plugins = ["pytester"]
+
+
+@contextmanager
+def mock_remote_scylla_yaml(scylla_node):
+    """A mock for remote_scylla_yaml that can actually modify scylla.yaml in running container"""
+
+    scylla_yaml = SimpleNamespace()
+    yield scylla_yaml
+
+    changes_applied = []
+    container_id = scylla_node.docker_id
+    try:
+        for key, value in vars(scylla_yaml).items():
+            if value is not None:
+                yaml_key, yaml_value = key, str(value)
+                # remove existing occurrences of the key and add a new value
+                remove_cmd = [
+                    'docker', 'exec', container_id, 'bash', '-c',
+                    f'sed -i "/^{yaml_key}:/d" /etc/scylla/scylla.yaml']
+                subprocess.run(remove_cmd, capture_output=True, text=True, check=False)
+                add_cmd = [
+                    'docker', 'exec', container_id, 'bash', '-c',
+                    f'echo "{yaml_key}: {yaml_value}" >> /etc/scylla/scylla.yaml']
+                result = subprocess.run(add_cmd, capture_output=True, text=True, check=False)
+
+                if result.returncode == 0:
+                    changes_applied.append(f"{yaml_key}: {yaml_value}")
+                else:
+                    logging.error("Failed to apply scylla.yaml change %s: %s", yaml_key, result.stderr)
+    except Exception as e:  # noqa: BLE001
+        logging.error("Error in mock_remote_scylla_yaml: %s", e)
 
 
 @pytest.fixture(scope='module')
@@ -58,7 +94,7 @@ def prom_address():
 
 
 @pytest.fixture(name='docker_scylla', scope='function')
-def fixture_docker_scylla(request: pytest.FixtureRequest, params):
+def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # noqa: PLR0914
     docker_scylla_args = {}
     if test_marker := request.node.get_closest_marker("docker_scylla_args"):
         docker_scylla_args = test_marker.kwargs
@@ -71,8 +107,9 @@ def fixture_docker_scylla(request: pytest.FixtureRequest, params):
     entryfile_path = entryfile_path / 'docker' / 'scylla-sct' / ('entry_ssl.sh' if ssl else 'entry.sh')
 
     alternator_flags = f"--alternator-port {ALTERNATOR_PORT} --alternator-write-isolation=always"
-    docker_version = docker_scylla_args.get(
-        'image', "docker.io/scylladb/scylla-nightly:2025.2.0-dev-0.20250302.0343235aa269")
+
+    default_image = "docker.io/scylladb/scylla-nightly:2025.2.0-dev-0.20250302.0343235aa269"
+    docker_version = docker_scylla_args.get('scylla_docker_image') or docker_scylla_args.get('image', default_image)
     cluster = LocalScyllaClusterDummy(params=params)
 
     ssl_dir = (Path(__file__).parent.parent / 'data_dir' / 'ssl_conf').absolute()
@@ -81,9 +118,10 @@ def fixture_docker_scylla(request: pytest.FixtureRequest, params):
         localhost = LocalHost(user_prefix='unit_test_fake_user', test_id='unit_test_fake_test_id')
         create_ca(localhost)
 
+    env_vars = '-e VECTOR_SEARCH_TEST=true' if docker_scylla_args.get('scylla_docker_image') else ''
     extra_docker_opts = (f'-p {ALTERNATOR_PORT} -p {BaseNode.CQL_PORT} --cpus="1" -v {entryfile_path}:/entry.sh:z'
                          f' -v {ssl_dir}:{SCYLLA_SSL_CONF_DIR}:z'
-                         ' --entrypoint /entry.sh')
+                         f' --user root {env_vars} --entrypoint /entry.sh')
 
     scylla = RemoteDocker(LocalNode("scylla", cluster), image_name=docker_version,
                           command_line=f"--smp 1 {alternator_flags}",
@@ -105,6 +143,9 @@ def fixture_docker_scylla(request: pytest.FixtureRequest, params):
     DummyRemoter = collections.namedtuple('DummyRemoter', ['run', 'sudo'])
     scylla.remoter = DummyRemoter(run=scylla.run, sudo=scylla.run)
 
+    scylla.is_running = lambda: bool(getattr(scylla, 'docker_id', None))
+    scylla.remote_scylla_yaml = lambda: mock_remote_scylla_yaml(scylla)
+
     def db_up():
         try:
             return scylla.is_port_used(port=BaseNode.CQL_PORT, service_name="scylla-server")
@@ -122,9 +163,88 @@ def fixture_docker_scylla(request: pytest.FixtureRequest, params):
     wait.wait_for(func=db_up, step=1, text='Waiting for DB services to be up', timeout=120, throw_exc=True)
     wait.wait_for(func=db_alternator_up, step=1, text='Waiting for DB services to be up alternator)',
                   timeout=120, throw_exc=True)
+
     yield scylla
 
     scylla.kill()
+
+
+@pytest.fixture(name='docker_vector_store', scope='function')
+def fixture_docker_vector_store(request: pytest.FixtureRequest, docker_scylla, params):
+    docker_scylla_args = {}
+    if test_marker := request.node.get_closest_marker("docker_scylla_args"):
+        docker_scylla_args = test_marker.kwargs
+
+    if not docker_scylla_args.get('vs_docker_image'):
+        yield None
+        return
+
+    # restart the container to reload scylla.yaml config
+    def reload_config_for_test():
+        docker_scylla.node.remoter.run(f"docker restart {docker_scylla.docker_id}")
+    docker_scylla.reload_config = reload_config_for_test
+
+    cluster = docker_scylla.parent_cluster
+    os.environ.setdefault('_SCT_TEST_LOGDIR', '/tmp/test_vector_search_logs')
+
+    class MockTester:
+        def __init__(self):
+            self.rack_names_per_datacenter_and_rack_idx_map = {}
+    TestConfig.set_tester_obj(MockTester())
+
+    vs_docker_image_version = docker_scylla_args.get('vs_docker_image', 'scylladb/vector-store:latest')
+    vs_docker_image, vs_version = (
+        vs_docker_image_version.rsplit(':', 1) if ':' in vs_docker_image_version
+        else (vs_docker_image_version, 'latest'))
+
+    params.update({
+        'n_vs_nodes': 1,
+        'vs_port': 6080,
+        'vs_scylla_port': 9042,
+        'vs_threads': 2,
+        'docker_network': docker_scylla_args.get('docker_network') or 'bridge',
+        'user_prefix': 'test-vector',
+        'vs_docker_image': vs_docker_image,
+        'vs_version': vs_version})
+
+    def destroy_vector_store_cluster(vs_cluster):
+        if vs_cluster:
+            try:
+                vs_cluster.destroy()
+            except Exception:  # noqa: BLE001
+                logging.warning("Failed to destroy Vector Store cluster", exc_info=True)
+
+    vector_store_cluster = None
+    try:
+        vector_store_cluster = VectorStoreSetDocker(
+            params=params,
+            vs_docker_image=params.get('vs_docker_image'),
+            vs_docker_image_tag=params.get('vs_version'),
+            cluster_prefix='test-vector-store',
+            n_nodes=1)
+
+        vector_store_cluster.configure_with_scylla_cluster(cluster)
+        for node in vector_store_cluster.nodes:
+            if not node.wait_for_vector_store_ready():
+                raise RuntimeError(f"Vector Store service on {node.name} failed to start")
+
+        # restart scylla container to apply vector store URI changes
+        scylla_node = cluster.nodes[0]
+        restart_result = subprocess.run(
+            ['docker', 'restart', scylla_node.docker_id], capture_output=True, text=True, check=False)
+        if restart_result.returncode != 0:
+            raise RuntimeError(f"Container restart failed: {restart_result.stderr}")
+        wait.wait_for(
+            func=lambda: scylla_node.is_port_used(port=BaseNode.CQL_PORT, service_name="scylla-server"),
+            step=2, timeout=60, text="Waiting for Scylla container to restart")
+
+        yield vector_store_cluster
+
+    except Exception:  # noqa: BLE001
+        destroy_vector_store_cluster(vector_store_cluster)
+        raise
+    finally:
+        destroy_vector_store_cluster(vector_store_cluster)
 
 
 @pytest.fixture

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -412,6 +412,7 @@ class ScyllaYamlTest(unittest.TestCase):
                 'tablets_mode_for_new_keyspaces': None,
                 'force_gossip_topology_changes': None,
                 'reader_concurrency_semaphore_cpu_concurrency': None,
+                'vector_store_uri': None
             }
         )
 

--- a/unit_tests/test_vector_store.py
+++ b/unit_tests/test_vector_store.py
@@ -1,0 +1,172 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+import uuid
+import time
+import random
+import pytest
+import logging
+
+pytestmark = [
+    pytest.mark.usefixtures("events"),
+    pytest.mark.integration,
+    pytest.mark.docker_scylla_args(
+        scylla_docker_image="scylladb/scylla-nightly:2025.4.0-dev-0.20250811.e14c5e3890de",
+        vs_docker_image="scylladb/vector-store:latest"
+    ),
+]
+
+LOGGER = logging.getLogger(__name__)
+
+
+def create_vector_table(db_cluster: 'LocalScyllaClusterDummy') -> None:  # noqa: F821
+    """Create vector table and index"""
+    node = db_cluster.nodes[0]
+    with db_cluster.cql_connection_patient(node) as session:
+        session.execute("CREATE KEYSPACE IF NOT EXISTS vector_test "
+                        "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
+        session.execute("CREATE TABLE IF NOT EXISTS vector_test.embeddings "
+                        "(id UUID PRIMARY KEY, "
+                        "vector VECTOR<FLOAT, 5>, "
+                        "metadata text) "
+                        "WITH cdc = {'enabled': true}")
+        session.execute("CREATE INDEX IF NOT EXISTS embeddings_vector_idx "
+                        "ON vector_test.embeddings (vector) USING 'vector_index' "
+                        "WITH OPTIONS = { 'similarity_function': 'DOT_PRODUCT' }")
+
+
+def insert_test_vectors(db_cluster: 'LocalScyllaClusterDummy', count: int = 100, vector_dim: int = 5) -> list:  # noqa: F821
+    """Insert test data with vector embeddings"""
+    test_vectors = []
+    with db_cluster.cql_connection_patient(db_cluster.nodes[0]) as session:
+        insert_stmt = session.prepare(
+            "INSERT INTO vector_test.embeddings (id, vector, metadata) VALUES (?, ?, ?)")
+
+        for i in range(count):
+            vector = [random.uniform(-1.0, 1.0) for _ in range(vector_dim)]
+            # normalize vector
+            magnitude = sum(x ** 2 for x in vector) ** 0.5
+            if magnitude > 0:
+                vector = [x / magnitude for x in vector]
+
+            vector_id = uuid.uuid4()
+            metadata = f"test_item_{i}"
+
+            session.execute(insert_stmt, (vector_id, vector, metadata))
+            test_vectors.append({'id': vector_id, 'vector': vector, 'metadata': metadata})
+
+    return test_vectors
+
+
+def wait_for_vector_indexing(vector_client: 'VectorStoreClient', timeout: int = 300) -> None:  # noqa: F821
+    """Wait for vector store to discover and index the new data"""
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        indexes = vector_client.get_indexes()
+        vector_test_indexes = [idx for idx in indexes
+                               if idx.get('keyspace') == 'vector_test'
+                               and idx.get('index') == 'embeddings_vector_idx']
+        if vector_test_indexes:
+            try:
+                if vector_client.get_index_count('vector_test', 'embeddings_vector_idx') > 0:
+                    return
+            except Exception as e:  # noqa: BLE001
+                LOGGER.debug(f"Index not ready yet: {e}")
+        time.sleep(5)
+
+    raise RuntimeError(f"Vector indexing did not complete within {timeout} seconds")
+
+
+def test_vector_store_deployment(docker_scylla, docker_vector_store, params):
+    """Test vector store deployment, connecting to ScyllaDB and that VS endpoints are available"""
+    db_cluster, vs_cluster = docker_scylla.parent_cluster, docker_vector_store
+
+    assert db_cluster.nodes[0].is_running()
+    assert len(vs_cluster.nodes) == 1
+    assert vs_cluster.nodes[0].is_running()
+
+    vector_client = vs_cluster.nodes[0].get_vector_store_api_client()
+
+    # status, info and indexes endpoints
+    assert vector_client.get_status() in ('SERVING', 'BOOTSTRAPPING')
+    assert isinstance(vector_client.get_info(), dict)
+    assert isinstance(vector_client.get_indexes(), list)
+
+
+def test_vector_search(docker_scylla, docker_vector_store, params):  # noqa: PLR0914
+    """Test of vector search"""
+    db_cluster, vs_cluster = docker_scylla.parent_cluster, docker_vector_store
+
+    create_vector_table(db_cluster)
+    test_vectors = insert_test_vectors(db_cluster)
+    vector_client = vs_cluster.nodes[0].get_vector_store_api_client()
+    wait_for_vector_indexing(vector_client)
+
+    query_vector = test_vectors[0]['vector']
+
+    # vector search via API
+    search_results = vector_client.ann_search(
+        keyspace='vector_test', index='embeddings_vector_idx', embedding=query_vector, limit=10)
+    primary_keys = search_results.get('primary_keys', {}).get('id', [])
+    assert len(primary_keys) > 0, "No search results returned for API search"
+    assert 'distances' in search_results, "No distances in API search results"
+    closest_distance = search_results['distances'][0]
+    assert closest_distance < 0.001, f"Self-search distance too high for API search: {closest_distance}. Expected near 0."
+
+    # direct CQL query vector search
+    with db_cluster.cql_connection_patient(db_cluster.nodes[0]) as session:
+        cql_query = (
+            f"SELECT id, metadata FROM vector_test.embeddings "
+            f"ORDER BY vector ANN OF {query_vector} LIMIT 10")
+        cql_rows = list(session.execute(cql_query))
+
+        expected_count = min(10, len(test_vectors))
+        assert len(cql_rows) == expected_count, f"Expected {expected_count} CQL results, got {len(cql_rows)}"
+        # compare API and CQL results, the first result should be the same
+        api_first_id = primary_keys[0]
+        cql_first_id = str(cql_rows[0].id)
+        assert api_first_id == cql_first_id, f"API and CQL first result mismatch: {api_first_id} != {cql_first_id}"
+
+    # API search with different limits
+    for limit in [1, 5, 20]:
+        results = vector_client.ann_search(
+            keyspace='vector_test', index='embeddings_vector_idx', embedding=query_vector, limit=limit)
+        primary_keys = results.get('primary_keys', {}).get('id', [])
+        actual_count = len(primary_keys)
+        expected_count = min(limit, len(test_vectors))
+        assert actual_count == expected_count, f"Expected {expected_count} results, got {actual_count}"
+
+    # API index count request
+    count = vector_client.get_index_count('vector_test', 'embeddings_vector_idx')
+    assert count == len(test_vectors), f"Expected {len(test_vectors)} vectors, got {count}"
+
+
+def test_vector_search_error_handling(docker_scylla, docker_vector_store, params):
+    """Test error handling when performing vector search operations"""
+    db_cluster, vs_cluster = docker_scylla.parent_cluster, docker_vector_store
+    vector_client = vs_cluster.nodes[0].get_vector_store_api_client()
+
+    create_vector_table(db_cluster)
+    insert_test_vectors(db_cluster, count=10)
+    wait_for_vector_indexing(vector_client)
+
+    # too few dimensions
+    with pytest.raises(Exception):
+        vector_client.ann_search(
+            keyspace='vector_test', index='embeddings_vector_idx', embedding=[0.1, 0.2], limit=5)
+
+    # search on non-existent index
+    test_vector = [random.uniform(-1.0, 1.0) for _ in range(128)]
+    with pytest.raises(Exception):
+        vector_client.ann_search(
+            keyspace='nonexistent', index='nonexistent_idx', embedding=test_vector, limit=5)


### PR DESCRIPTION
This change introduces support of vector-store service deployment on docker backend.

A few notes to take into account:
- the feature is not yet merged into scylladb master, so the custom dev build of scylla with support of VS was used for implementation (and its testing).
Once VS is merged we would need to revise this implementation.
- vectore-store service image is not yet published, so the image is built by SCT when VectorStoreSetDocker is initialized.
This is a temporary solution. Once the the image is published we will switch to consuming the released image.

Closes: https://github.com/scylladb/scylla-cluster-tests/issues/11483

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] integration tests
- [x] [pr-provision-test-docker with enabled VS](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/pr-provision-test/154/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
