### PR TITLE
fix(doctor): define default timeouts in cqlshrc

### DIFF
--- a/data_dir/ssl_conf/client/cqlshrc
+++ b/data_dir/ssl_conf/client/cqlshrc
@@ -1,4 +1,6 @@
 [connection]
+timeout = 120
+request_timeout = 60
 factory = cqlshlib.ssl.ssl_transport_factory
 
 [ssl]


### PR DESCRIPTION
when we use cqlsh from SCT we use specific command line timeout options, when scylla-doctor is using cqlsh it wasn't and getting into some cases that it times out on connection to the cluster.

this change is adding the same default we have within SCT, into cqlshrc file, so also the scylla-doctor would be using the same values

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
