### PR TITLE
fix(integration_tests): Fix warnings in integration tests

### DIFF
--- a/sdcm/provision/scylla_yaml/cluster_builder.py
+++ b/sdcm/provision/scylla_yaml/cluster_builder.py
@@ -30,7 +30,7 @@ class ScyllaYamlClusterAttrBuilder(ScyllaYamlAttrBuilderBase):
 
     @computed_field
     @property
-    def hinted_handoff_enabled(self) -> Optional[str]:
+    def hinted_handoff_enabled(self) -> Optional[bool]:
         param_hinted_handoff = str(self.params.get('hinted_handoff')).lower()
         if param_hinted_handoff in ('enabled', 'true', '1'):
             return True

--- a/sdcm/stress/latte_thread.py
+++ b/sdcm/stress/latte_thread.py
@@ -34,7 +34,7 @@ from sdcm.utils.common import get_sct_root_path
 from sdcm.utils.docker_remote import RemoteDocker
 from sdcm.utils.remote_logger import HDRHistogramFileLogger
 
-LATTE_FN_NAME_RE = '(?:-f|--function)[ =]([\w\s\d:,]+)|--functions[ =]([\w\s\d:,]+)'
+LATTE_FN_NAME_RE = r'(?:-f|--function)[ =]([\w\s\d:,]+)|--functions[ =]([\w\s\d:,]+)'
 LATTE_TAG_RE = r'--tag(?:\s+|=)([\w-]+(?:,[\w-]+)*)\b'
 LOGGER = logging.getLogger(__name__)
 

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -27,6 +27,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class TestConfig(metaclass=Singleton):
+    __test__ = False  # This class is not a test case
+
     TEST_DURATION = 60
     TEST_WARMUP_TEARDOWN = 60
     SYSLOGNG_LOG_THROTTLE_PER_SECOND = 10000

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2987,12 +2987,12 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
 
         if describecluster_output.ok:
             desc_stdout = describecluster_output.stdout
-            name_pattern = re.compile("((?<=Name: )[\w _-]*)")
-            snitch_pattern = re.compile("((?<=Snitch: )[\w.]*)")
+            name_pattern = re.compile(r"((?<=Name: )[\w _-]*)")
+            snitch_pattern = re.compile(r"((?<=Snitch: )[\w.]*)")
             partitioner_pattern = re.compile(
-                "((?<=Partitioner: )[\w.]*)")
+                r"((?<=Partitioner: )[\w.]*)")
             schema_versions_pattern = re.compile(
-                "([a-z0-9-]{36}: \[[\d., ]*\])")
+                r"([a-z0-9-]{36}: \[[\d., ]*\])")
 
             name = name_pattern.search(desc_stdout).group()
             snitch = snitch_pattern.search(desc_stdout).group()

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -146,7 +146,7 @@ class ScyllaYamlClusterAttrBuilderTest(ScyllaYamlClusterAttrBuilderBase):
                     'intra_node_comm_public': False,
                     'authenticator': 'com.scylladb.auth.SaslauthdAuthenticator',
                     'authorizer': 'CassandraAuthorizer',
-                    'alternator_port': True,
+                    'alternator_port': "1",
                     'use_ldap_authorization': True,
                     'ldap_server_type': 'openldap',
                     'internode_encryption': False,
@@ -158,7 +158,7 @@ class ScyllaYamlClusterAttrBuilderTest(ScyllaYamlClusterAttrBuilderBase):
             expected_as_dict={
                 'cluster_name': 'test-cluster',
                 'alternator_enforce_authorization': False,
-                'alternator_port': True,
+                'alternator_port': "1",
                 'alternator_write_isolation': 'always_use_lwt',
                 'authenticator': 'com.scylladb.auth.SaslauthdAuthenticator',
                 'authorizer': 'CassandraAuthorizer',
@@ -189,7 +189,7 @@ class ScyllaYamlClusterAttrBuilderTest(ScyllaYamlClusterAttrBuilderBase):
                     'intra_node_comm_public': False,
                     'authenticator': 'com.scylladb.auth.SaslauthdAuthenticator',
                     'authorizer': 'CassandraAuthorizer',
-                    'alternator_port': False,
+                    'alternator_port': None,
                     'use_ldap_authorization': True,
                     'ldap_server_type': 'ms_ad',
                     'internode_encryption': True,
@@ -201,7 +201,6 @@ class ScyllaYamlClusterAttrBuilderTest(ScyllaYamlClusterAttrBuilderBase):
             expected_as_dict={
                 'cluster_name': 'test-cluster',
                 'alternator_enforce_authorization': False,
-                'alternator_port': False,
                 'authenticator': 'com.scylladb.auth.SaslauthdAuthenticator',
                 'authorizer': 'CassandraAuthorizer',
                 'endpoint_snitch': 'org.apache.cassandra.locator.GossipingPropertyFileSnitch',
@@ -628,11 +627,12 @@ class IntegrationTests(unittest.TestCase):
 
     @parameterized.expand([
         (
+            config_name,
             os.path.join(BASE_FOLDER, config_name),
             os.path.join(BASE_FOLDER, config_name.replace('.yaml', '.result.json')),
         ) for config_name in os.listdir(BASE_FOLDER) if config_name.endswith('.yaml')
     ])
-    def test_integration_node(self, config_path, result_path):
+    def test_integration_node(self, _, config_path, result_path):
         with open(result_path, encoding="utf-8") as result_file:
             expected_node_config = result_file.read()
         self._run_test(config_path, expected_node_config=expected_node_config,
@@ -640,11 +640,12 @@ class IntegrationTests(unittest.TestCase):
 
     @parameterized.expand([
         (
+            config_name,
             os.path.join(BASE_FOLDER, "multi_network_interfaces",  config_name),
             os.path.join(BASE_FOLDER, "multi_network_interfaces", config_name.replace('.yaml', '.result.json')),
         ) for config_name in os.listdir(os.path.join(BASE_FOLDER, "multi_network_interfaces")) if config_name.endswith('.yaml')
     ])
-    def test_integration_node_multi_interface(self, config_path, result_path):
+    def test_integration_node_multi_interface(self, _, config_path, result_path):
         with open(result_path, encoding="utf-8") as result_file:
             expected_node_config = result_file.read()
         self._run_test(config_path, expected_node_config=expected_node_config, region_names='["eu-west-1"]')

--- a/unit_tests/test_wait.py
+++ b/unit_tests/test_wait.py
@@ -265,7 +265,7 @@ class TestWaitForLogLines:
         t = threading.Thread(target=write_to_file, args=(file_path, lines))
         t.daemon = True
         file_path.touch()
-        expected_match = "Timeout occurred while waiting for end log line \['end'\] on node: node_1. Context: Wait end line"
+        expected_match = r"Timeout occurred while waiting for end log line \['end'\] on node: node_1. Context: Wait end line"
         with pytest.raises(TimeoutError, match=expected_match), \
                 wait_for_log_lines(node=node, start_line_patterns=["start"], end_line_patterns=["end"], start_timeout=0.4, end_timeout=0.7, error_msg_ctx="Wait end line"):
             t.start()


### PR DESCRIPTION
Extract fixes from uncovered by #11627 into separate PR.

* Regex without specifying Raw string throws SyntaxWarning
* TestConfig is used in Integration tests and executed as test
* ScyllaYaml and its tests sometimes used bad types
* improve `test_scylla_yaml_builders.py` paralelized runs name
   * First argument is used as a name in `@parameterized`
   * Instead of full path to file, now it shows only config name

<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Locally
- [x] CI in #11627

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
