### PR TITLE
fix(test_tester): Use standardized Events system 

### DIFF
--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -45,9 +45,7 @@ pytest_plugins = ["pytester"]
 
 @pytest.fixture(scope='module')
 def events():
-    class LocalMixing(EventsUtilsMixin):
-        pass
-    mixing = LocalMixing()
+    mixing = EventsUtilsMixin()
     mixing.setup_events_processes(events_device=True, events_main_device=False, registry_patcher=True)
     yield mixing
 


### PR DESCRIPTION
By using standardized events system as we do in other tests, we get rid of scenarios where `test_tester` fails due to previous uncleaned tests.

Also small improvements to `events` fixture. Can extract into separate PR if needed

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
