### PR TITLE
improvement(test_tester): Rewrite the test to use pytester

### DIFF
--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -176,23 +176,6 @@ def pytest_sessionfinish():
     logging.raiseExceptions = False
 
 
-@pytest.hookimpl(tryfirst=True, hookwrapper=True)
-def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
-    """
-    Hook to capture the test report and attach it to the test item,
-    so it can be accessed later during teardown or in fixtures.
-    """
-    outcome = yield
-    report: pytest.TestReport = outcome.get_result()
-    setattr(item, "rep_" + report.when, report)
-
-    if report.when in ("call", "teardown") and item.get_closest_marker("override_pass"):
-        # overite the results of specific under test_tester that are supposed to fail
-        report.outcome = "passed"
-
-    return report
-
-
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_logreport(report: pytest.TestReport):
     """

--- a/unit_tests/test_tester.py
+++ b/unit_tests/test_tester.py
@@ -10,14 +10,14 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2020 ScyllaDB
-
+import re
 import time
 import threading
+import unittest
 from unittest.mock import MagicMock
 import logging
 import pytest
 
-from sdcm.utils.decorators import retrying
 from sdcm.sct_events import Severity
 from sdcm.sct_events.health import ClusterHealthValidatorEvent
 from sdcm.tester import ClusterTester, silence, TestResultEvent
@@ -41,8 +41,6 @@ ClusterTester.__test__ = False
 
 
 class ClusterTesterForTests(ClusterTester, EventsUtilsMixin):
-    __test__ = True
-
     k8s_clusters = None
     argus_heartbeat_stop_signal = threading.Event()
 
@@ -55,6 +53,17 @@ class ClusterTesterForTests(ClusterTester, EventsUtilsMixin):
     @pytest.fixture(autouse=True, name='setup_logging')
     def fixture_setup_logging(self, tmp_path):
         self._init_logging(tmp_path / self.__class__.__name__)
+        self.kafka_cluster = None
+
+    @pytest.fixture(scope="function", autouse=True)
+    def fixture_mock_issues(self):
+        """
+        In Pytester the boto credentials are not set, so we mock the issue details, so we dont need them.
+        It is not important for the test anyway
+        """
+        with unittest.mock.patch("sdcm.utils.issues.SkipPerIssues.get_issue_details") as mock_issue_details:
+            mock_issue_details.return_value = None
+            yield
 
     def _init_logging(self, logdir):
         self.log = logging.getLogger(self.__class__.__name__)
@@ -118,12 +127,29 @@ class ClusterTesterForTests(ClusterTester, EventsUtilsMixin):
         yield
         self.teardown_events_processes()
 
+    @pytest.fixture(autouse=True, name="print_output")
+    def fixture_print_output(self, event_system, capsys):
+        # Parse error report to output only useful message
+        filter_message = re.compile(r"((?<=message=)|(?<=exception=)|(?<=error=)).*(?=( failed|$))")
+        yield
 
-@pytest.mark.xfail(reason="this test fails if run after `test_test_user_batch_custom_time`", strict=False)
+        with capsys.disabled():
+            print(f"\nEVENT_SUMMARY: {self.event_summary}")
+            print(f"TEST_STATUS: {self.final_event.test_status}")
+            for i, error in enumerate(self.events['ERROR']):
+                print(f"ERROR {i}: {filter_message.search(error).group(0)}")
+            for i, error in enumerate(self.events['CRITICAL']):
+                print(f"CRITICAL {i}: {filter_message.search(error).group(0)}")
+
+    def finalize_teardown(self):
+        pass
+
+
 class SubtestAndTeardownFailsTest(ClusterTesterForTests):
 
     def test(self):
         with self.subTest('SUBTEST1'):
+            # This wont create error in events
             raise ValueError('Subtest1 failed')
         with self.subTest('SUBTEST2'):
             raise ValueError('Subtest2 failed')
@@ -133,28 +159,9 @@ class SubtestAndTeardownFailsTest(ClusterTesterForTests):
     def save_email_data(self):
         raise ValueError()
 
-    @pytest.fixture(scope='function')
-    def validate(self, event_system):
-        yield
-        # While running from pycharm and from hydra run-test exception inside subTest won't stop the test,
-        #  under hydra unit_test it stops running it and you don't see exception from next subtest.
-
-        @retrying(n=5, sleep_time=1, allowed_exceptions=(AssertionError,))
-        def wait_for_summary():
-            assert self.event_summary == {"NORMAL": 2, "ERROR": 3}
-
-        wait_for_summary()
-        assert 'Subtest1 failed' in self.events['ERROR'][1]
-        assert 'save_email_data' in self.events['ERROR'][0]
-        assert self.final_event.test_status == 'FAILED'
-
-    def finalize_teardown(self):
-        pass
-
 
 class CriticalErrorNotCaughtTest(ClusterTesterForTests):
 
-    @pytest.mark.override_pass
     def test(self):
         try:
             ClusterHealthValidatorEvent.NodeStatus(
@@ -169,25 +176,12 @@ class CriticalErrorNotCaughtTest(ClusterTesterForTests):
         except Exception:  # noqa: BLE001
             pass
 
-    @pytest.fixture(autouse=True)
-    def validate(self, event_system):
-        yield
 
-        # While running from pycharm and from hydra run-test exception inside subTest won't stop the test,
-        #  under hydra unit_test it stops running it and you don't see exception from next subtest.
-        assert len(self.events['CRITICAL']) == 1
-        assert 'ClusterHealthValidatorEvent' in self.events['CRITICAL'][0]
-        assert self.final_event.test_status == 'FAILED'
-
-    def finalize_teardown(self):
-        pass
-
-
-@pytest.mark.xfail(reason="this test fails if run after `test_test_user_batch_custom_time`", strict=False)
 class SubtestAssertAndTeardownFailsTest(ClusterTesterForTests):
 
     def test(self):
         with self.subTest('SUBTEST1'):
+            # This wont create error in events
             assert False, 'Subtest1 failed'
         with self.subTest('SUBTEST2'):
             assert False, 'Subtest2 failed'
@@ -196,23 +190,6 @@ class SubtestAssertAndTeardownFailsTest(ClusterTesterForTests):
     @silence()
     def save_email_data(self):
         raise ValueError()
-
-    @pytest.fixture(autouse=True)
-    def validate(self, event_system):
-        yield
-
-        # While running from pycharm and from hydra run-test exception inside subTest won't stop the test,
-        #  under hydra unit_test it stops running it and you don't see exception from next subtest.
-        @retrying(n=5, sleep_time=1, allowed_exceptions=(AssertionError,))
-        def wait_for_summary():
-            assert self.event_summary == {'NORMAL': 2, 'ERROR': 3}
-        wait_for_summary()
-        assert "save_email_data" in self.events["ERROR"][0]
-        assert 'Subtest1 failed' in self.events['ERROR'][1]
-        assert self.final_event.test_status == 'FAILED'
-
-    def finalize_teardown(self):
-        pass
 
 
 class TeardownFailsTest(ClusterTesterForTests):
@@ -224,36 +201,13 @@ class TeardownFailsTest(ClusterTesterForTests):
     def save_email_data(self):
         raise ValueError()
 
-    @pytest.fixture(autouse=True)
-    def validate(self, event_system):
-        yield
-
-        assert self.event_summary == {'NORMAL': 2, 'ERROR': 1}
-        assert 'save_email_data' in self.final_event.events['ERROR'][0]
-        assert self.final_event.test_status == 'FAILED'
-
-    def finalize_teardown(self):
-        pass
-
 
 class SetupFailsTest(ClusterTesterForTests):
 
     def prepare_kms_host(self):
         raise RuntimeError('prepare_kms_host failed')
 
-    @pytest.mark.override_pass
     def test(self):
-        pass
-
-    @pytest.fixture(autouse=True)
-    def validate(self, event_system):
-        yield
-
-        assert self.event_summary == {'NORMAL': 2, 'ERROR': 1}
-        assert 'prepare_kms_host failed' in self.final_event.events['ERROR'][0]
-        assert self.final_event.test_status == 'FAILED'
-
-    def finalize_teardown(self):
         pass
 
 
@@ -266,28 +220,11 @@ class TestErrorTest(ClusterTesterForTests):
             message="Something went wrong"
         ).publish()
 
-    @pytest.fixture(autouse=True)
-    def validate(self, event_system):
-        yield
-
-        assert self.event_summary == {'NORMAL': 2, 'ERROR': 1}
-        assert self.final_event.test_status == 'FAILED'
-
-    def finalize_teardown(self):
-        pass
-
 
 class SuccessTest(ClusterTesterForTests):
 
     def test(self):
         pass
-
-    @pytest.fixture(autouse=True)
-    def validate(self, event_system):
-        yield
-
-        assert self.event_summary == {'NORMAL': 2}
-        assert self.final_event.test_status == 'SUCCESS'
 
 
 class SubtestsSuccessTest(ClusterTesterForTests):
@@ -298,9 +235,67 @@ class SubtestsSuccessTest(ClusterTesterForTests):
         with self.subTest('SUBTEST2'):
             pass
 
-    @pytest.fixture(autouse=True)
-    def validate(self, event_system):
-        yield
 
-        assert self.event_summary == {'NORMAL': 2}
-        assert self.final_event.test_status == 'SUCCESS'
+@pytest.mark.parametrize("test_class, results, outcomes", [
+    pytest.param(TeardownFailsTest, {"passed": 1}, [
+        "EVENT_SUMMARY: {'NORMAL': 2, 'ERROR': 1}",
+        "TEST_STATUS: FAILED",
+        "ERROR 0: save_email_data (silenced)"
+    ], id="TeardownFailsTest"),
+    pytest.param(SubtestsSuccessTest, {"passed": 1, "subtests": 2}, [
+        "EVENT_SUMMARY: {'NORMAL': 2}",
+        "TEST_STATUS: SUCCESS"
+    ], id="SubtestsSuccessTest"),
+    pytest.param(SuccessTest, {"passed": 1}, [
+        "EVENT_SUMMARY: {'NORMAL': 2}",
+        "TEST_STATUS: SUCCESS"
+    ], id="SuccessTest"),
+    pytest.param(TestErrorTest, {"passed": 1}, [
+        "EVENT_SUMMARY: {'NORMAL': 2, 'ERROR': 1}",
+        "TEST_STATUS: FAILED",
+        "ERROR 0: Something went wrong"
+    ], id="TestErrorTest"),
+    pytest.param(SetupFailsTest, {"failed": 1}, [
+        "EVENT_SUMMARY: {'NORMAL': 2, 'ERROR': 1}",
+        "TEST_STATUS: FAILED",
+        "ERROR 0: prepare_kms_host failed"
+    ], id="SetupFailsTest"),
+    pytest.param(CriticalErrorNotCaughtTest, {"passed": 1}, [
+        "EVENT_SUMMARY: {'NORMAL': 2, 'CRITICAL': 1}",
+        "TEST_STATUS: FAILED",
+        "CRITICAL 0: Reason to fail",
+    ], id="CriticalErrorNotCaughtTest"),
+    pytest.param(SubtestAndTeardownFailsTest, {"failed": 3}, [
+        "EVENT_SUMMARY: {'NORMAL': 2, 'ERROR': 1}",
+        "TEST_STATUS: FAILED",
+        "ERROR 0: save_email_data (silenced)",
+        "E           ValueError: Subtest1 failed",
+        "E           ValueError: Subtest2 failed",
+        "E       ValueError: Main test also failed"
+    ], id="SubtestAndTeardownFailsTest"),
+    pytest.param(SubtestAssertAndTeardownFailsTest, {"failed": 3}, [
+        "EVENT_SUMMARY: {'NORMAL': 2, 'ERROR': 1}",
+        "TEST_STATUS: FAILED",
+        "ERROR 0: save_email_data (silenced)",
+        "E           AssertionError: Subtest1 failed",
+        "E           AssertionError: Subtest2 failed",
+        "E       AssertionError: Main test also failed",
+    ], id="SubtestAssertAndTeardownFailsTest"),
+])
+def test_tester_subclass(pytester, test_class, results, outcomes):
+    # Create a pytest file with the test class. We cannot just use the class directly
+    # because it would not be collected. If we made it collectable it would be run as part of standard test run as well.
+    # Which we do not want, as it is intended only to be run with pytester
+    pytester.makepyfile(f"""
+        from unit_tests.conftest import *
+        from unit_tests.test_tester import {test_class.__name__}
+        {test_class.__name__}.__test__ = True
+    """)
+    result = pytester.runpytest_inprocess()
+    summary = result.parseoutcomes()
+    for status, count in results.items():
+        assert status in summary, f"Status '{status}' not found in results"
+        assert summary[status] == count, f"Status '{status}' count mismatch: expected {count}, got {summary[status]}"
+    output = result.stdout.str().splitlines()
+    for outcome in outcomes:
+        assert outcome in output


### PR DESCRIPTION
Current test_tester is testing results of test function, which results in:
* `Test` method showing in the output of the unit tests even though they are the ones being tested
* When something fails, it will manifest as a error in teardown
* We need to have `override_pass` mark/hack to make sure the actual method always pass

My solution to this problem is to use pytester which will run the test function in separate test process, from which we can then extract the data and compare with the expected outcome.

#### Pros
* Separates what is being tested from the test
* Clear failure logs
* No more need for `override_pass`
* More compact
   * Less bloat in the test classes
   * Less line overall  

#### Cons
* Longer running time
   * Each of the cases will setup pytest again

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
