### PR TITLE
fix(events): keep the event structure, keep spaces

### DIFF
--- a/sdcm/sct_events/file_logger.py
+++ b/sdcm/sct_events/file_logger.py
@@ -126,7 +126,7 @@ class EventsFileLogger(BaseEventsProcess[Tuple[str, Any], None], multiprocessing
             try:
                 with log_file.open() as fobj:
                     for line in fobj:
-                        if line := line.strip():
+                        if line := line.rstrip():
                             if LINE_START_RE.match(line):
                                 if event:
                                     events_bucket.append("\n".join(event))


### PR DESCRIPTION
for some reason we we're triming spaces from begining of lines in events sent to argus

this should fix it

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
