### PR TITLE
fix(github-actions): repalce `github.actor` with `github.event.pull_request.user.login`

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -21,16 +21,16 @@ jobs:
     steps:
       - name: Check user for team affiliation
         uses: tspascoal/get-user-teams-membership@v3
-        if: github.actor != 'renovate[bot]'
+        if: github.event.pull_request.user.login != 'renovate[bot]'
         id: teamAffiliation
         with:
           GITHUB_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}
-          username: ${{ github.actor }}
+          username: ${{ github.event.pull_request.user.login }}
           team: 'dev'
 
   build_image:
     needs: check_org_membership
-    if: ( github.actor == 'renovate[bot]' || needs.check_org_membership.outputs.isTeamMember == 'true' ) && contains(github.event.pull_request.labels.*.name, 'New Hydra Version')
+    if: ( github.event.pull_request.user.login == 'renovate[bot]' || needs.check_org_membership.outputs.isTeamMember == 'true' ) && contains(github.event.pull_request.labels.*.name, 'New Hydra Version')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/check-generated-code-updates.yaml
+++ b/.github/workflows/check-generated-code-updates.yaml
@@ -17,7 +17,7 @@ jobs:
         id: teamAffiliation
         with:
           GITHUB_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}
-          username: ${{ github.actor }}
+          username: ${{ github.event.pull_request.user.login }}
           team: ${{ secrets.SCT_ACTION_GITHUB_TEAM }}
 
   run_validations:


### PR DESCRIPTION
Ref: https://www.synacktiv.com/publications/github-actions-exploitation-dependabot

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
