### PR TITLE
fix(nemesis_unique_sequence): unset running nemesis between steps

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4509,8 +4509,10 @@ class Nemesis(NemesisFlags):
             InfoEvent(message='FinishEvent - Manager repair was Skipped').publish()
         time.sleep(sleep_time_between_ops)
         InfoEvent(message='Starting grow disruption').publish()
-        self._grow_cluster(rack=None)
+        new_nodes = self._grow_cluster(rack=None)
         InfoEvent(message='Finished grow disruption').publish()
+        for node in new_nodes:
+            self.node_allocator.unset_running_nemesis(node, self.current_disruption)
         time.sleep(sleep_time_between_ops)
         InfoEvent(message='Starting terminate_and_replace disruption').publish()
         self._terminate_and_replace_node()
@@ -4518,7 +4520,7 @@ class Nemesis(NemesisFlags):
         time.sleep(sleep_time_between_ops)
         InfoEvent(message='Starting shrink disruption').publish()
         self._shrink_cluster(rack=None)
-        InfoEvent(message='Starting shrink disruption').publish()
+        InfoEvent(message='Finished shrink disruption').publish()
 
     def _k8s_disrupt_memory_stress(self):
         """Uses chaos-mesh experiment based on https://github.com/chaos-mesh/memStress"""


### PR DESCRIPTION
Node allocator logic of unsetting running nemesis is missed after 'grow_cluster' step of disrupt_run_unique_sequence, eventually leading to no nodes available to allocate for 'shrink_cluster' step of the sequence. This change fixes the problem by properly releasing the new nodes from tracking by nemesis node allocator.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11660

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-5gb-1h + unique sequence (no simulated racks)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-100gb-4h-test-temp/7/)
- [x] [longevity-5gb-1h + unique sequence (with simulated racks)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-100gb-4h-test-temp/8/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
