### PR TITLE
refactor(restart_scylla): remove storing metrics in argus

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -85,7 +85,7 @@ from sdcm.sct_events.continuous_event import ContinuousEventsRegistry
 from sdcm.sct_events.system import AwsKmsEvent
 from sdcm.snitch_configuration import SnitchConfig
 from sdcm.utils import properties
-from sdcm.utils.adaptive_timeouts import Operations, adaptive_timeout
+from sdcm.utils.adaptive_timeouts import Operations, adaptive_timeout, AdaptiveTimeoutStore
 from sdcm.utils.aws_kms import AwsKms
 from sdcm.utils.cql_utils import cql_quote_if_needed
 from sdcm.utils.benchmarks import ScyllaClusterBenchmarkManager
@@ -2586,7 +2586,8 @@ class BaseNode(AutoSshContainerMixin):
         verify_up_timeout = verify_up_timeout or self.verify_up_timeout
         if verify_up_before:
             self.wait_db_up(timeout=verify_up_timeout)
-        with adaptive_timeout(operation=Operations.RESTART_SCYLLA, node=self, timeout=timeout):
+        with adaptive_timeout(operation=Operations.RESTART_SCYLLA, node=self, timeout=timeout,
+                              stats_storage=AdaptiveTimeoutStore()):
             self.restart_service(service_name='scylla-server', timeout=timeout * 2)
         if verify_up_after:
             self.wait_db_up(timeout=verify_up_timeout)


### PR DESCRIPTION
Scylla restart timings are stored in Argus. This looks redundant as this process usually is short. Also we don't do it for stopping and starting scylla.

Remove storing in Argus restart_scylla metrics.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - https://argus.scylladb.com/tests/scylla-cluster-tests/0df29b68-c3c7-496e-9804-c98cd0d7576d/results
- [ ] - https://argus.scylladb.com/tests/scylla-cluster-tests/c111928e-ab83-4288-a999-8ffa61a63149

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
