### PR TITLE
fix(argus): remove session scope from finalize argus

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -338,7 +338,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
     monitors: BaseMonitorSet = None
     loaders: Union[BaseLoaderSet, LoaderSetAWS, LoaderSetGCE] = None
     db_cluster: Union[BaseCluster, BaseScyllaCluster] = None
-    argus_heartbeat_stop_signal = threading.Event()
 
     @property
     def k8s_cluster(self):
@@ -3316,7 +3315,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         pass
 
     @pytest.fixture(autouse=True)
-    def report_failures_as_event(self, request: pytest.FixtureRequest, event_system, validate):
+    def report_failures_as_event(self, request: pytest.FixtureRequest, event_system, validate, argus_finalize):
         yield
         if subtests_results := SUBTESTS_FAILURES.pop(request.node.nodeid, None):
             for report in subtests_results:
@@ -3336,7 +3335,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
                     severity=Severity.ERROR,
                 ).publish_or_dump(default_logger=self.log)
 
-    @pytest.fixture(autouse=True, name="argus_finalize", scope="session")
+    @pytest.fixture(autouse=True, name="argus_finalize")
     def fixture_argus_finalize(self):
         """
         Fixture to handle Argus cleanup operations after test completion.

--- a/unit_tests/test_longevity.py
+++ b/unit_tests/test_longevity.py
@@ -29,8 +29,6 @@ class DummyLongevityTest(LongevityTest):
     test_custom_time = None
     test_batch_custom_time = None
 
-    argus_heartbeat_stop_signal = threading.Event()
-
     @pytest.fixture(autouse=True)
     def fixture_params(self, params):
         self.params = params

--- a/unit_tests/test_tester.py
+++ b/unit_tests/test_tester.py
@@ -44,7 +44,6 @@ class ClusterTesterForTests(ClusterTester, EventsUtilsMixin):
     __test__ = True
 
     k8s_clusters = None
-    argus_heartbeat_stop_signal = threading.Event()
 
     def init_argus_run(self):
         self.argus_heartbeat_stop_signal = threading.Event()


### PR DESCRIPTION
Because argus_finalize fixture requires tester object to be instantiated, removed 'session' scope from it. Otherwise it causes problems with clearing out argus heartbeat thread (and caused artifact tests issues in the past).

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11589

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [failure example](https://argus.scylladb.com/tests/scylla-cluster-tests/abc18165-bc9d-42ec-9b8c-bff6b3445f27/events)
- [x] - [passing example](https://argus.scylladb.com/tests/scylla-cluster-tests/e1ff7422-4179-42bd-9585-51b3affe1628)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
