### PR TITLE
fix(logging): suppress errors on attempts to log to offline nodes

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3223,7 +3223,7 @@ class BaseNode(AutoSshContainerMixin):
         try:
             self.remoter.run(
                 f'logger -p {level} -t scylla-cluster-tests {shlex.quote(message)}',
-                ignore_status=True, verbose=False, retry=0, timeout=10)
+                ignore_status=True, verbose=False, retry=0, timeout=10, suppress_errors=True)
         except Exception:  # noqa: BLE001
             pass
 

--- a/sdcm/remote/kubernetes_cmd_runner.py
+++ b/sdcm/remote/kubernetes_cmd_runner.py
@@ -227,8 +227,9 @@ class KubernetesCmdRunner(RemoteCmdRunnerBase):
                                     container=self.container, timeout=300)
         return True
 
-    def _run_on_retryable_exception(self, exc: Exception, new_session: bool) -> bool:
-        self.log.error(exc, exc_info=exc)
+    def _run_on_retryable_exception(self, exc: Exception, new_session: bool, suppress_errors: bool = False) -> bool:
+        if not suppress_errors:
+            self.log.error(exc, exc_info=exc)
         if isinstance(exc, self.exception_retryable):
             raise RetryableNetworkException(str(exc), original=exc)
         return True

--- a/sdcm/remote/remote_base.py
+++ b/sdcm/remote/remote_base.py
@@ -623,7 +623,7 @@ class RemoteCmdRunnerBase(CommandRunner):
         pass
 
     @abstractmethod
-    def _run_on_retryable_exception(self, exc: Exception, new_session: bool) -> bool:
+    def _run_on_retryable_exception(self, exc: Exception, new_session: bool, suppress_errors: bool = False) -> bool:
         pass
 
     def _run_on_exception(self, exc: Exception, verbose: bool, ignore_status: bool) -> bool:
@@ -655,6 +655,7 @@ class RemoteCmdRunnerBase(CommandRunner):
             retry: int = 1,
             watchers: List[StreamWatcher] | None = None,
             change_context: bool = False,
+            suppress_errors: bool = False,
             timestamp_logs: bool = False
             ) -> Result:
         """
@@ -670,6 +671,7 @@ class RemoteCmdRunnerBase(CommandRunner):
         :param change_context: If True, next run will trigger reconnect on all threads.
           Needed for cases when environment context is changed by the command,
           for example group has been added to the user.
+        :param suppress_errors: If True, suppress errors logging for retryable exceptions
         :param timestamp_logs: If True, log entries will be timestamped
         :return:
         """
@@ -683,7 +685,7 @@ class RemoteCmdRunnerBase(CommandRunner):
             try:
                 return self._run_execute(cmd, timeout, ignore_status, verbose, new_session, watchers)
             except self.exception_retryable as exc:
-                if self._run_on_retryable_exception(exc, new_session):
+                if self._run_on_retryable_exception(exc, new_session, suppress_errors):
                     raise
             except Exception as exc:  # noqa: BLE001
                 if self._run_on_exception(exc, verbose, ignore_status):

--- a/sdcm/remote/remote_cmd_runner.py
+++ b/sdcm/remote/remote_cmd_runner.py
@@ -125,8 +125,9 @@ class RemoteCmdRunner(RemoteCmdRunnerBase, ssh_transport='fabric', default=True)
                 (cmd, self.hostname, self.connect_timeout)
             )
 
-    def _run_on_retryable_exception(self, exc: Exception, new_session: bool) -> bool:
-        self.log.error(exc, exc_info=exc)
+    def _run_on_retryable_exception(self, exc: Exception, new_session: bool, suppress_errors: bool = False) -> bool:
+        if not suppress_errors:
+            self.log.error(exc, exc_info=exc)
         self.ssh_is_up.clear()
         if self._is_error_retryable(str(exc)):
             raise RetryableNetworkException(str(exc), original=exc)

--- a/sdcm/remote/remote_libssh_cmd_runner.py
+++ b/sdcm/remote/remote_libssh_cmd_runner.py
@@ -62,8 +62,9 @@ class RemoteLibSSH2CmdRunner(RemoteCmdRunnerBase, ssh_transport='libssh2'):
                     pass
         return False
 
-    def _run_on_retryable_exception(self, exc: Exception, new_session: bool) -> bool:
-        self.log.error(exc, exc_info=exc)
+    def _run_on_retryable_exception(self, exc: Exception, new_session: bool, suppress_errors: bool = False) -> bool:
+        if not suppress_errors:
+            self.log.error(exc, exc_info=exc)
         if isinstance(exc, FailedToRunCommand) and not new_session:
             self.log.debug('Reestablish the session...')
             try:

--- a/unit_tests/lib/fake_remoter.py
+++ b/unit_tests/lib/fake_remoter.py
@@ -56,5 +56,5 @@ class FakeRemoter(RemoteCmdRunnerBase):
     def is_up(self, timeout: float = 30):
         return True
 
-    def _run_on_retryable_exception(self, exc: Exception, new_session: bool) -> bool:
+    def _run_on_retryable_exception(self, exc: Exception, new_session: bool, suppress_errors: bool = False) -> bool:
         return True


### PR DESCRIPTION
Add a flag to remoter.run method and the underlying _run_on_retryable_exception() retrier. This helps to avoid numerous 'failed to open channel' errors in SCT logs when such failures are expected (e.g. when accessing offline nodes during restarts, decommissioning, etc.).
The new flag is disabled by default, but in this change it is permanently enabled in cluster.BaseNode.log_message, to suppress the noise in SCT logs caused by DB nodes logging during disruptive nemeses.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11097

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity_test with disrupt_unique_sequence](https://argus.scylladb.com/tests/scylla-cluster-tests/917be8c4-3c0c-454b-b739-b80b96cf99ab)
This run produced 0 error log records for attempts to log messages on offline DB nodes:
```
❯ grep '\-t scylla-cluster-tests' sct-917be8c4.log | wc -l
0
```
In contrast to run of this exact test (the same job parameters) without this fix:
```
❯ grep '\-t scylla-cluster-tests' sct-b1182922.log | wc -l
21
❯ grep '\-t scylla-cluster-tests' sct-b1182922.log
< t:2025-08-11 12:45:22,691 f:remote_libssh_cmd_runner.py l:66   c:RemoteLibSSH2CmdRunner p:ERROR > Command: "logger -p info -t scylla-cluster-tests 'executing nodetool /usr/bin/nodetool  info  on longevity-5gb-1h-NemesisSequence-fi-db-node-b1182922-2 [10.4.9.189]'"
Command: "logger -p info -t scylla-cluster-tests 'executing nodetool /usr/bin/nodetool  info  on longevity-5gb-1h-NemesisSequence-fi-db-node-b1182922-2 [10.4.9.189]'"
< t:2025-08-11 12:45:22,691 f:remote_libssh_cmd_runner.py l:66   c:RemoteLibSSH2CmdRunner p:ERROR > Command: "logger -p info -t scylla-cluster-tests 'executing nodetool /usr/bin/nodetool  info  on longevity-5gb-1h-NemesisSequence-fi-db-node-b1182922-2 [10.4.9.189]'"
...
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
