### PR TITLE
fix(azure): set stable dns servers

### DIFF
--- a/sdcm/provision/azure/virtual_network_provider.py
+++ b/sdcm/provision/azure/virtual_network_provider.py
@@ -54,6 +54,9 @@ class VirtualNetworkProvider:
                 "zones": [self._az] if self._az else [],
                 "address_space": {
                     "address_prefixes": ["10.0.0.0/16"],
+                },
+                "dhcp_options": {
+                    "dns_servers": ["8.8.8.8", "1.1.1.1"]
                 }
             }
         ).wait()


### PR DESCRIPTION
It happens Azure dns servers don't respond properly and fail some nemesis (e.g. `disrupt_load_and_stream` when downloading files from s3).

Fix by providing stable dns servers (google and cloudflare) in network configuration setting.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11724

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - provision test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
