### PR TITLE
fix(perftune_validator): handle empty output in count_bits

### DIFF
--- a/sdcm/utils/perftune_validator.py
+++ b/sdcm/utils/perftune_validator.py
@@ -22,7 +22,10 @@ PERFTUNE_EXPECTED_RESULTS_PATH = "defaults/perftune_results.json"
 
 
 def count_bits(mask_string) -> int:
-    return sum([int(m, base=16).bit_count() for m in mask_string.split(",")])
+    return sum([
+        int(m, base=16).bit_count() if m else 0
+        for m in mask_string.split(",")
+    ])
 
 
 def get_number_of_cpu_cores(node) -> int:

--- a/unit_tests/test_perftune_validator_count_bits.py
+++ b/unit_tests/test_perftune_validator_count_bits.py
@@ -1,0 +1,29 @@
+from sdcm.utils.perftune_validator import count_bits
+
+
+def test_single_mask():
+    assert count_bits('0x00000001') == 1
+    assert count_bits('0x0000000F') == 4
+    assert count_bits('0x00000000') == 0
+
+
+def test_multiple_masks():
+    assert count_bits('0x00000001,0x00000001') == 2
+    assert count_bits('0x0000000F,0x0000000F') == 8
+    assert count_bits('0x00000001,0x00000000') == 1
+
+
+def test_empty_mask():
+    assert count_bits('') == 0
+    assert count_bits(',') == 0
+    assert count_bits(',,,') == 0
+
+
+def test_mixed_empty_and_valid():
+    assert count_bits('0x00000001,,0x00000001') == 2
+    assert count_bits('0x00070000,0x00000007,,0x00070000,0x00000007') == 12
+
+
+def test_leading_trailing_commas():
+    assert count_bits(',0x00000001,') == 1
+    assert count_bits(',0x00000001,,') == 1


### PR DESCRIPTION
in some cases the output from `hwloc` is somthing like `0x0000f,,0xffffff` code wasn't expecting empty data with the list retrived

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] unittest

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
