### PR TITLE
Revert "[Backport 2025.3] fix(nemesis_unique_sequence): unset running nemesis between steps"

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4581,10 +4581,8 @@ class Nemesis(NemesisFlags):
             InfoEvent(message='FinishEvent - Manager repair was Skipped').publish()
         time.sleep(sleep_time_between_ops)
         InfoEvent(message='Starting grow disruption').publish()
-        new_nodes = self._grow_cluster(rack=None)
+        self._grow_cluster(rack=None)
         InfoEvent(message='Finished grow disruption').publish()
-        for node in new_nodes:
-            self.node_allocator.unset_running_nemesis(node, self.current_disruption)
         time.sleep(sleep_time_between_ops)
         InfoEvent(message='Starting terminate_and_replace disruption').publish()
         self._terminate_and_replace_node()
@@ -4592,7 +4590,7 @@ class Nemesis(NemesisFlags):
         time.sleep(sleep_time_between_ops)
         InfoEvent(message='Starting shrink disruption').publish()
         self._shrink_cluster(rack=None)
-        InfoEvent(message='Finished shrink disruption').publish()
+        InfoEvent(message='Starting shrink disruption').publish()
 
     def _k8s_disrupt_memory_stress(self):
         """Uses chaos-mesh experiment based on https://github.com/chaos-mesh/memStress"""


### PR DESCRIPTION
Reverts scylladb/scylla-cluster-tests#11731