### PR TITLE
feature(scylla-cloud): add support to connect with machines

### DIFF
--- a/defaults/cloud_config.yaml
+++ b/defaults/cloud_config.yaml
@@ -17,4 +17,4 @@ xcloud_vpc_peering:
   cidr_subnet_size: 24
 
 # TODO: remove this when vector.dev logging is enabled by default
-logs_transport: 'ssh'
+logs_transport: 'vector'

--- a/defaults/cloud_config.yaml
+++ b/defaults/cloud_config.yaml
@@ -15,3 +15,6 @@ xcloud_vpc_peering:
   enabled: true
   cidr_pool_base: '172.31.0.0/16'
   cidr_subnet_size: 24
+
+# TODO: remove this when vector.dev logging is enabled by default
+logs_transport: 'ssh'

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2926,7 +2926,7 @@ class BaseNode(AutoSshContainerMixin):
                       connect_timeout=connect_timeout, ssl_params=ssl_params)
 
         # cqlsh uses rpc_address/broadcast_rps_address.
-        host = '' if self.is_docker() else self.cql_address
+        host = '' if self.is_docker() or self.is_cloud() else self.cql_address
         # escape double quotes, that might be on keyspace/tables names
         command = '"{}"'.format(command.strip().replace('"', '\\"'))
 

--- a/sdcm/localhost.py
+++ b/sdcm/localhost.py
@@ -21,12 +21,13 @@ from sdcm.utils.gce_utils import GcloudContainerMixin
 from sdcm.utils.ldap import LDAP_PORT, LDAP_SSL_PORT, LdapContainerMixin
 from sdcm.utils.syslogng import SyslogNGContainerMixin
 from sdcm.utils.vector_dev import VectorDevContainerMixin
+from sdcm.utils.internal_modules import XCloudConnectivityContainerMixin
 
 LOGGER = logging.getLogger(__name__)
 
 
 class LocalHost(SyslogNGContainerMixin, GcloudContainerMixin, HelmContainerMixin, LdapContainerMixin,
-                JavaContainerMixin, VectorDevContainerMixin):
+                JavaContainerMixin, VectorDevContainerMixin, XCloudConnectivityContainerMixin):
     def __init__(self, user_prefix: Optional[str] = None, test_id: Optional[str] = None) -> None:
         self._containers = {}
         self.tags = {}

--- a/sdcm/remote/base.py
+++ b/sdcm/remote/base.py
@@ -207,7 +207,7 @@ class CommandRunner(metaclass=ABCMeta):
                          "-o UserKnownHostsFile=%s -o BatchMode=yes "
                          "-o ConnectTimeout=%d -o ServerAliveInterval=%d "
                          "-l %s -p %d %s")
-        if key_file is not None:
+        if key_file:
             base_command += ' -i %s' % os.path.expanduser(key_file)
         assert connect_timeout > 0  # can't disable the timeout
         return base_command % (opts, hosts_file, connect_timeout,

--- a/sdcm/remote/remote_base.py
+++ b/sdcm/remote/remote_base.py
@@ -34,7 +34,7 @@ from .local_cmd_runner import LocalCmdRunner
 class RemoteCmdRunnerBase(CommandRunner):
     port: int = 22
     connect_timeout: int = 60
-    key_file: str = ""
+    key_file: Optional[str] = None
     extra_ssh_options: str = ""
     auth_sleep_time = 30
     proxy_host: str = None

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1913,7 +1913,7 @@ class SCTConfiguration(dict):
                     'mgmt_docker_image', 'eks_service_ipv4_cidr', 'eks_vpc_cni_version', 'eks_role_arn',
                     'eks_cluster_version', 'eks_nodegroup_role_arn'],
 
-        'xcloud': ['user_prefix', 'xcloud_env', 'xcloud_provider', 'scylla_version'],
+        'xcloud': ['user_prefix', 'xcloud_provider', 'scylla_version'],
     }
 
     defaults_config_files = {

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -241,6 +241,12 @@ class TestConfig(metaclass=Singleton):
         cls.VECTOR_ADDRESS = (address, port)
 
     @classmethod
+    def configure_xcloud_connectivity(cls, node, params):
+        if node.xcloud_connect_supported(params):
+            ContainerManager.run_container(node, "xcloud_connect", params=params)
+            node.xcloud_connect_wait_to_be_ready()
+
+    @classmethod
     def get_startup_script(cls) -> str:
         host_port = cls.get_logging_service_host_port()
         if not host_port or not host_port[0]:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1018,6 +1018,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
             self.test_config.configure_syslogng(self.localhost)
         if self.params.get("logs_transport") == 'vector':
             self.test_config.configure_vector(self.localhost)
+        if self.params.get("cluster_backend") == 'xcloud':
+            self.test_config.configure_xcloud_connectivity(self.localhost, self.params)
+
         self.alternator: alternator.api.Alternator = alternator.api.Alternator(sct_params=self.params)
         self.alternator = alternator.api.Alternator(sct_params=self.params)
 

--- a/sdcm/utils/internal_modules.py
+++ b/sdcm/utils/internal_modules.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+# Add scylla-qa-internal to the Python path using pathlib
+# TODO: make this support multiple paths if needed
+scylla_qa_internal_path = str((Path(__file__).parent.parent.parent / 'scylla-qa-internal').resolve())
+if scylla_qa_internal_path not in sys.path:
+    sys.path.insert(0, scylla_qa_internal_path)
+
+# Import the internal modules
+try:
+    from xcloud_internal.connectivity import XCloudConnectivityContainerMixin
+except ImportError:
+    not_supported_message = (
+        "XCloud connectivity is not available in this environment. "
+        "Ensure that the xcloud_internal module is installed and accessible."
+    )
+    # If xcloud_internal is not available, define a dummy mixin
+
+    class XCloudConnectivityContainerMixin:
+        def xcloud_connect_container_run_args(self):
+            raise NotImplementedError(not_supported_message)
+
+        def xcloud_connect_wait_to_be_ready(self):
+            pass
+
+        @staticmethod
+        def xcloud_connect_supported(params):
+            return False
+
+        @property
+        def xcloud_connect(self):
+            raise NotImplementedError(not_supported_message)
+
+        def xcloud_connect_get_ssh_address(self, node):
+            raise NotImplementedError(not_supported_message)
+
+__all__ = ["XCloudConnectivityContainerMixin"]


### PR DESCRIPTION
this commit introduce `XCloudConnectivityContainerMixin` that would have the machinery to grant us the access to the db machines that we are working with.

Depends: #11746

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢  AWS -  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/pr-provision-test/10/
- [x] 🟢  GCE - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/pr-provision-test/11/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
