### PR TITLE
feature(libssh2): support connection to ssh server with none auth

### DIFF
--- a/sdcm/remote/libssh2_client/__init__.py
+++ b/sdcm/remote/libssh2_client/__init__.py
@@ -347,7 +347,7 @@ class Client:
             self.keepalive_thread.start()
 
     def _auth(self):
-        if self.pkey is not None:
+        if self.pkey:
             self._pkey_auth()
             return
         if self.allow_agent:
@@ -357,7 +357,22 @@ class Client:
                 return
             except Exception:  # noqa: BLE001
                 pass
-        self._password_auth()
+        if self.password:
+            self._password_auth()
+            return
+        # If no pkey, no agent, and no password, try none auth
+        self._none_auth()
+
+    def _none_auth(self):
+        try:
+            output = self.session.eagain(
+                self.session.userauth_list,
+                args=(self.user,),
+                timeout=self.timings.auth_timeout
+            )
+            print(output)
+        except Exception as error:
+            raise AuthenticationException("None authentication failed") from error
 
     def _pkey_auth(self):
         self.session.eagain(

--- a/unit_tests/test_ssh_server.py
+++ b/unit_tests/test_ssh_server.py
@@ -1,0 +1,76 @@
+import os
+import pytest
+import subprocess
+import time
+import socket
+
+from sdcm.remote.remote_cmd_runner import RemoteCmdRunnerBase
+from sdcm.utils.decorators import retrying
+
+
+@pytest.fixture(scope="module")
+def ssh_server_container(tmp_path_factory):
+    exposed_port = 22
+    dockerfile_content = f"""
+    FROM ubuntu:25.10
+    RUN apt-get update && apt-get install -y openssh-server
+    RUN echo 'root:root' | chpasswd
+    RUN useradd -m test
+    RUN passwd -d test
+    RUN echo 'PermitRootLogin yes' > /etc/ssh/sshd_config \
+        && echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config \
+        && echo 'PermitEmptyPasswords yes' >> /etc/ssh/sshd_config \
+        && echo 'AuthenticationMethods none' >> /etc/ssh/sshd_config \
+        && echo 'UsePAM no' >> /etc/ssh/sshd_config
+    EXPOSE {exposed_port}
+    CMD ["/usr/sbin/sshd", "-D"]
+    """
+
+    tmpdir = tmp_path_factory.mktemp("ssh_server")
+    dockerfile_path = os.path.join(tmpdir, "Dockerfile")
+    with open(dockerfile_path, "w") as f:
+        f.write(dockerfile_content)
+    image_tag = "ssh_server_test:latest"
+    subprocess.run(["docker", "build", "-t", image_tag, tmpdir], check=True)
+    container_name = f"ssh_server_test_{os.getpid()}"
+    run_cmd = [
+        "docker", "run", "-d", "--name", container_name, image_tag
+    ]
+    container_id = subprocess.check_output(run_cmd).decode().strip()
+
+    inspect_cmd = ["docker", "inspect", "-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", container_id]
+    for _ in range(10):
+        ip = subprocess.check_output(inspect_cmd).decode().strip()
+        if ip:
+            break
+        time.sleep(0.5)
+    else:
+        subprocess.run(["docker", "rm", "-f", container_id], check=True)
+        raise RuntimeError("Could not get container IP address")
+
+    @retrying(n=20, sleep_time=0.5)
+    def wait_for_ssh_ready():
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(0.5)
+        try:
+            s.connect((ip, exposed_port))
+            s.close()
+        except (OSError, ConnectionRefusedError):
+            raise RuntimeError(f"SSH port 22 not open on container {container_id} ({ip})")
+
+    try:
+        wait_for_ssh_ready()
+        yield {"hostname": ip, "user": "test", "port": exposed_port}
+    finally:
+        subprocess.run(["docker", "rm", "-f", container_id], check=True)
+
+
+@pytest.mark.parametrize("ssh_transport", ["libssh2", "fabric"])
+@pytest.mark.integration
+def test_ssh_server(ssh_server_container, ssh_transport):
+    ssh_login_info = ssh_server_container
+    RemoteCmdRunnerBase.set_default_ssh_transport(ssh_transport)
+    remoter = RemoteCmdRunnerBase.create_remoter(**ssh_login_info)
+
+    res = remoter.run("ls -l /", retry=0)
+    print(res)


### PR DESCRIPTION
following the support on the fabric, this commit is adding the same supoort of no key or password auth, with the assumption the the `libssh2_userauth_list` api actually doing what's needed for it to work

this commit also introduce an integration test that test both fabric and libssh2 ssh transport to be working with nono auth

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] add integration test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
