### PR TITLE
Fix skipping part of remote log output

### DIFF
--- a/sdcm/utils/remote_logger.py
+++ b/sdcm/utils/remote_logger.py
@@ -177,7 +177,7 @@ class HDRHistogramFileLogger(SSHLoggerBase):
 
     @cached_property
     def _logger_cmd_template(self) -> str:
-        return f"tail -f {self._remote_log_file}"
+        return f"tail -f {self._remote_log_file} -c +0"
 
     def validate_and_collect_hdr_file(self):
         """
@@ -313,7 +313,7 @@ class SSHGeneralFileLogger(SSHLoggerBase):
 
     @cached_property
     def _logger_cmd_template(self) -> str:
-        return f"sudo tail -f {self.REMOTE_LOG_PATH}"
+        return f"sudo tail -f {self.REMOTE_LOG_PATH} -c +0"
 
 
 class SSHScyllaFileLogger(SSHGeneralFileLogger):


### PR DESCRIPTION
SSHLooger instances use `tail -f` to fetch content of the file over ssh. This might occasionally skip part of the log - if the remote command producing the log starts quickly and outputs a lot of log instanstly running `tail -f` might skip beggining of the log file (as `tail -f` will emit only N last lines and then follow file changes). We add `-c +0` parameter, which tells `tail -f` to start following file from byte 0 counting from beginning.

### Testing
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/evgeniy/job/perf-regression-alternator/job/scylla-master-perf-regression-alternator-latency-test/336/ (and plenty before) runs with this patch.
