### PR TITLE
fix(pipelines): handle null backend value in new jobs

### DIFF
--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -1,7 +1,7 @@
 #! groovy
 
 def call(Map pipelineParams) {
-    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter, params.azure_region_name)
+    def builder = getJenkinsLabels(pipelineParams.get('backend', 'aws'), pipelineParams.get('region'), pipelineParams.get('gce_datacenter'), pipelineParams.get('azure_region_name'))
 
     pipeline {
         agent none

--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -2,6 +2,11 @@
 import groovy.json.JsonSlurper
 
 def call(String backend, String region=null, String datacenter=null, String location=null) {
+    if (!backend) {
+        backend = 'aws'
+        println("Backend is null or empty, defaulting to 'aws'")
+    }
+
     try {
         regionList = new JsonSlurper().parseText(region)
         region = regionList[0]

--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -4,7 +4,7 @@ def completed_stages = [:]
 def (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout) = [0,0,0,0,0]
 
 def call(Map pipelineParams) {
-    def builder = getJenkinsLabels(params.backend, params.region)
+    def builder = getJenkinsLabels(pipelineParams.get('backend', 'aws'), pipelineParams.get('region'))
 
     pipeline {
         agent {

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -5,7 +5,7 @@ def (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCl
 
 def call(Map pipelineParams) {
 
-    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter, params.azure_region_name)
+    def builder = getJenkinsLabels(pipelineParams.get('backend', 'aws'), pipelineParams.get('region'), pipelineParams.get('gce_datacenter'), pipelineParams.get('azure_region_name'))
     def functional_test = pipelineParams.functional_test
 
     pipeline {

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -37,7 +37,7 @@ def (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCl
 
 def call(Map pipelineParams) {
 
-    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter, params.azure_region_name)
+    def builder = getJenkinsLabels(pipelineParams.get('backend', 'aws'), pipelineParams.get('region'), pipelineParams.get('gce_datacenter'), pipelineParams.get('azure_region_name'))
 
     pipeline {
         agent {

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -5,7 +5,7 @@ def (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCl
 def base_versions_list = []
 
 def call(Map pipelineParams) {
-    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter)
+    def builder = getJenkinsLabels(pipelineParams.get('backend', 'aws'), pipelineParams.get('region'), pipelineParams.get('gce_datacenter'))
 
     pipeline {
         agent none

--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -4,7 +4,7 @@ import groovy.json.JsonSlurper
 def (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout) = [0,0,0,0,0]
 
 def call(Map pipelineParams) {
-    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter)
+    def builder = getJenkinsLabels(pipelineParams.get('backend', 'aws'), pipelineParams.get('region'), pipelineParams.get('gce_datacenter'))
 
     pipeline {
         agent none

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -6,7 +6,7 @@ def completed_stages = [:]
 (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout) = [0,0,0,0,0]
 
 def call(Map pipelineParams) {
-    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter, params.azure_region_name)
+    def builder = getJenkinsLabels(pipelineParams.get('backend', 'aws'), pipelineParams.get('region'), pipelineParams.get('gce_datacenter'), pipelineParams.get('azure_region_name'))
 
     pipeline {
         agent none


### PR DESCRIPTION
When Jenkins jobs are cloned, the first build receives `null` for the `backend` parameter, causing pipeline failures with the error:

```
No Jenkins builder label mapping found for backend 'null' (resolved to cloud_provider 'null')
```

This occurs because `getJenkinsLabels(params.backend, ...)` is called before the `parameters` block is processed in the 1st Jenkins build, leaving the `params` object unpopulated.

## Changes Made

**1. Enhanced `getJenkinsLabels.groovy` with null handling:**
```groovy
if (!backend) {
    backend = 'aws'
    println("Backend is null or empty, defaulting to 'aws'")
}
```

**2. Updated pipeline calls to use `pipelineParams` for better reliability:**
```groovy
// Before
def builder = getJenkinsLabels(params.backend, params.region, ...)

// After  
def builder = getJenkinsLabels(pipelineParams.get('backend', 'aws'), pipelineParams.get('region'), ...)
```

This affects 8 pipeline files: `longevityPipeline.groovy`, `managerPipeline.groovy`, `rollingUpgradePipeline.groovy`, `perfSearchBestConfigParallelPipeline.groovy`, `perfRegressionParallelPipeline.groovy`, `artifactsPipeline.groovy`, `jepsenPipeline.groovy`.

## Benefits

- **Eliminates manual workaround**: No need to manually add backend parameters to cloned jobs
- **Backward compatible**: Existing pipelines continue to work unchanged
- **Robust against Jenkins JENKINS-41929**: Better handling of first-build parameter initialization issues

The fix provides a sensible default ('aws') that aligns with most pipeline configurations while maintaining full backward compatibility.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11725

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [first build of a new job (copy of the same original job as in the issue)](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/test-new-job/1/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
