### PR TITLE
Adds test of Scylla Manager Alternator restore

### DIFF
--- a/defaults/docker_images/ycsb/values_ycsb.yaml
+++ b/defaults/docker_images/ycsb/values_ycsb.yaml
@@ -1,2 +1,2 @@
 ycsb:
-  image: docker.io/scylladb/ycsb:0.2.0
+  image: docker.io/scylladb/ycsb:1.0.0

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -906,6 +906,15 @@ If true, spawn a docker with a dns server for the ycsb loader to point to
 **type:** boolean
 
 
+## **alternator_test_table** / SCT_ALTERNATOR_TEST_TABLE
+
+Dictionary of a test alternator table features:<br>name: str - the name of the table<br>lsi_name: str - the name of the local secondary index to create with a table<br>gsi_name: str - the name of the global secondary index to create with a table<br>tags: dict - the tags to apply to the created table<br>items: int - expected number of items in the table after prepare
+
+**default:** N/A
+
+**type:** dict
+
+
 ## **alternator_enforce_authorization** / SCT_ALTERNATOR_ENFORCE_AUTHORIZATION
 
 If true, enable the authorization check in dynamodb api (alternator)

--- a/jenkins-pipelines/manager/ubuntu24-manager-backup-alternator.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-backup-alternator.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    region: 'us-east-1',
+    test_name: 'mgmt_cli_test.ManagerBackupTests.test_alternator_backup_feature',
+    test_config: 'test-cases/manager/manager-regression-alternator-singleDC-set-distro.yaml',
+)

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -1045,7 +1045,7 @@ class ScyllaManagerTool(ScyllaManagerBase):
         return [[n, n.ip_address] for n in db_cluster.nodes]
 
     def add_cluster(self, name, host=None, db_cluster=None, client_encrypt=None, disable_automatic_repair=True,
-                    auth_token=None, credentials=None, force_non_ssl_session_port=False):
+                    auth_token=None, credentials=None, force_non_ssl_session_port=False, alternator_credentials=None):
         """
         :param name: cluster name
         :param host: cluster node IP
@@ -1056,6 +1056,7 @@ class ScyllaManagerTool(ScyllaManagerBase):
         :param auth_token: a token used to authenticate requests to the Agent
         :param credentials: a tuple of the username and password that are used to access the cluster.
         :param force_non_ssl_session_port: force SM to always use the non-SSL port for TLS-enabled cluster CQL sessions.
+        :param alternator_credentials: a tuple of the alternator access key and secret key that are used to access the Alternator API.
         :return: ManagerCluster
 
         Add a cluster to manager
@@ -1092,6 +1093,10 @@ class ScyllaManagerTool(ScyllaManagerBase):
         if credentials:
             username, password = credentials
             cmd += f" --username {username} --password {password}"
+
+        if alternator_credentials:
+            access_key_id, secret_access_key = alternator_credentials
+            cmd += f" --alternator-access-key-id='{access_key_id}' --alternator-secret-access-key='{secret_access_key}'"
 
         res_cluster_add = self.sctool.run(cmd, parse_table_res=False)
         if not res_cluster_add or 'Cluster added' not in res_cluster_add.stderr:

--- a/sdcm/mgmt/operations.py
+++ b/sdcm/mgmt/operations.py
@@ -701,6 +701,15 @@ class ManagerTestFunctionsMixIn(
             self.restore_backup_without_manager(mgr_cluster=mgr_cluster, snapshot_tag=snapshot_tag,
                                                 ks_tables_list=ks_tables_map)
 
+    def verify_alternator_backup_success(self, mgr_cluster, backup_task, delete_tables: list = None, timeout=None):
+        for table_name in delete_tables:
+            self.log.info(f'running delete on {table_name}')
+            self.alternator.delete_table(self.db_cluster.nodes[0], table_name=table_name, wait_until_table_removed=True)
+        self.restore_backup_with_task(mgr_cluster=mgr_cluster, snapshot_tag=backup_task.get_snapshot_tag(),
+                                      timeout=timeout, restore_schema=True)
+        self.restore_backup_with_task(mgr_cluster=mgr_cluster, snapshot_tag=backup_task.get_snapshot_tag(),
+                                      timeout=timeout, restore_data=True)
+
     def restore_backup_without_manager(self, mgr_cluster, snapshot_tag, ks_tables_list, location=None,
                                        precreated_backup=False):
         """Restore backup without Scylla Manager but using the `nodetool refresh` operation

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -633,6 +633,13 @@ class SCTConfiguration(dict):
                   "/master/docs/alternator/alternator.md#write-isolation-policies for more details"),
         dict(name="alternator_use_dns_routing", env="SCT_ALTERNATOR_USE_DNS_ROUTING", type=boolean,
              help="If true, spawn a docker with a dns server for the ycsb loader to point to"),
+        dict(name="alternator_test_table", env="SCT_ALTERNATOR_TEST_TABLE", type=dict,
+             help="""Dictionary of a test alternator table features:
+                    name: str - the name of the table
+                    lsi_name: str - the name of the local secondary index to create with a table
+                    gsi_name: str - the name of the global secondary index to create with a table
+                    tags: dict - the tags to apply to the created table
+                    items: int - expected number of items in the table after prepare"""),
         dict(name="alternator_enforce_authorization", env="SCT_ALTERNATOR_ENFORCE_AUTHORIZATION", type=boolean,
              help="If true, enable the authorization check in dynamodb api (alternator)"),
         dict(name="alternator_access_key_id", env="SCT_ALTERNATOR_ACCESS_KEY_ID", type=str,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1247,13 +1247,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         node = self.db_cluster.nodes[0]
         if self.params.get('alternator_port'):
             self.log.info("Going to create alternator tables")
-            if self.params.get('alternator_enforce_authorization'):
-                with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
-                    session.execute("CREATE ROLE %s WITH PASSWORD = %s AND login = true AND superuser = true",
-                                    (self.params.get('alternator_access_key_id'),
-                                     self.params.get('alternator_secret_access_key')))
+            self.alternator.set_credentials(node=node)
 
-            tablets_enabled = is_tablets_feature_enabled(self.db_cluster.nodes[0])
+            tablets_enabled = is_tablets_feature_enabled(node)
             prepare_cmd = self.params.get('prepare_write_cmd')
             stress_cmd = self.params.get('stress_cmd')
             is_ttl_in_workload = any('dynamodb.ttlKey' in str(cmd) for cmd in [prepare_cmd, stress_cmd])

--- a/sdcm/utils/alternator/__init__.py
+++ b/sdcm/utils/alternator/__init__.py
@@ -3,4 +3,4 @@ from sdcm.utils.alternator import consts
 from sdcm.utils.alternator import enums
 from sdcm.utils.alternator import schemas
 
-__all__ = ["api", "consts", "enums", "schemas"]
+__all__ = ["api", "consts", "enums", "schemas", "table_setup"]

--- a/sdcm/utils/alternator/api.py
+++ b/sdcm/utils/alternator/api.py
@@ -4,6 +4,7 @@ import logging
 from concurrent.futures.thread import ThreadPoolExecutor
 from itertools import chain
 from pprint import pformat
+import time
 from typing import NamedTuple, TYPE_CHECKING
 
 import boto3
@@ -81,6 +82,21 @@ class Alternator:
                 self.alternator_apis[endpoint_url] = AlternatorApi(resource=resource, client=client)
         return self.alternator_apis[endpoint_url]
 
+    def set_credentials(self, node):
+        if self.params.get('alternator_enforce_authorization'):
+            with node.parent_cluster.cql_connection_patient(node) as session:
+                session.execute("CREATE ROLE %s WITH PASSWORD = %s AND login = true AND superuser = true",
+                                (self.params.get('alternator_access_key_id'),
+                                    self.params.get('alternator_secret_access_key')))
+
+    def get_credentials(self, node):
+        access_key_id = self.params.get('alternator_access_key_id')
+        if self.params.get('alternator_enforce_authorization'):
+            return (access_key_id, self.get_salted_hash(node=node, username=access_key_id))
+        else:
+            access_key = self.params.get('alternator_secret_access_key')
+            return (access_key_id, access_key) if access_key_id and access_key else None
+
     def set_write_isolation(self, node, isolation, table_name=consts.TABLE_NAME):
         dynamodb_api = self.get_dynamodb_api(node=node)
         isolation = isolation if not isinstance(isolation, enums.WriteIsolation) else isolation.value
@@ -96,17 +112,42 @@ class Alternator:
 
     def create_table(self, node,
                      schema=enums.YCSBSchemaTypes.HASH_AND_RANGE, isolation=None, table_name=consts.TABLE_NAME,
-                     wait_until_table_exists=True, tablets_enabled: bool = False, **kwargs) -> Table:
+                     wait_until_table_exists=True, tablets_enabled: bool = False, lsi: str = None, gsi: str = None,
+                     tags: dict[str, str] = None, **kwargs) -> Table:
         if isinstance(schema, enums.YCSBSchemaTypes):
             schema = schema.value
         schema = schemas.ALTERNATOR_SCHEMAS[schema]
+        if lsi:
+            schema['LocalSecondaryIndexes'] = [
+                {
+                    'IndexName': lsi,
+                    'KeySchema': schema['KeySchema'],
+                    'Projection': {'ProjectionType': 'ALL'}
+                }
+            ]
+        if gsi:
+            schema['GlobalSecondaryIndexes'] = [
+                {
+                    'IndexName': gsi,
+                    'KeySchema': schema['KeySchema'],
+                    'Projection': {'ProjectionType': 'ALL'}
+                }
+            ]
+        tags_list = []
+        if tags:
+            tags_list.extend({'Key': k, 'Value': v} for k, v in tags.items())
+
         dynamodb_api = self.get_dynamodb_api(node=node)
         # Tablets feature is currently supported by Alternator, but disabled by default (since LWT is not supported).
         # It should be explicitly requested by the specified tag.
         # TODO: the 'tablets_enabled' parameter might become un-needed once Alternator tablets default is switched to be enabled.
         # This might be dependant on tablets LWT support issue (scylladb/scylladb#18068)
         if tablets_enabled:
-            kwargs['Tags'] = [{'Key': 'experimental:initial_tablets', 'Value': '0'}]
+            tags_list.append({'Key': 'experimental:initial_tablets', 'Value': '0'})
+
+        if tags_list:
+            kwargs['Tags'] = tags_list
+
         LOGGER.debug("Creating a new table '{}' using node '{}'".format(table_name, node.name))
         table = dynamodb_api.resource.create_table(
             TableName=table_name, BillingMode="PAY_PER_REQUEST", **schema, **kwargs)
@@ -121,6 +162,61 @@ class Alternator:
             self.set_write_isolation(node=node, isolation=isolation, table_name=table_name)
         LOGGER.debug("Table's schema and configuration are: {}".format(response))
         return table
+
+    def verify_tables_features(self, node, tables: dict = None, **kwargs):
+        if tables:
+            for table_name, schema in tables.items():
+                self.verify_table_features(node, table_name, schema=schema, **kwargs)
+
+    def verify_table_features(self, node, table_name=consts.TABLE_NAME, schema=enums.YCSBSchemaTypes.HASH_AND_RANGE,
+                              lsi: str = None, gsi: str = None, tags: dict[str, str] = None,
+                              wait_for_item_count: int = -1):
+        dynamodb_api = self.get_dynamodb_api(node=node)
+        table = dynamodb_api.client.describe_table(TableName=table_name)["Table"]
+
+        if isinstance(schema, enums.YCSBSchemaTypes):
+            schema = schema.value
+        schema = schemas.ALTERNATOR_SCHEMAS[schema]
+        assert table['KeySchema'] == schema['KeySchema'], "Table KeySchema does not match expected"
+
+        table['Tags'] = dynamodb_api.client.list_tags_of_resource(ResourceArn=table['TableArn'])['Tags']
+        for key, value in (tags or {}).items():
+            assert {'Key': key, 'Value': value} in table['Tags'], f"Expected tag {key}:{value} to be present"
+
+        if gsi is not None:
+            gsis = {idx['IndexName']: idx for idx in table.get('GlobalSecondaryIndexes', [])}
+            assert gsi in gsis.keys(), f"Expected GSI {gsi} to be present"
+            assert gsis[gsi]['KeySchema'] == schema['KeySchema'], f"GSI {gsi} KeySchema does not match expected"
+
+        if lsi is not None:
+            lsis = {idx['IndexName']: idx for idx in table.get('LocalSecondaryIndexes', [])}
+            assert lsi in lsis.keys(), f"Expected LSI {lsi} to be present"
+            assert lsis[lsi]['KeySchema'] == schema['KeySchema'], f"LSI {lsi} KeySchema does not match expected"
+
+        if wait_for_item_count >= 0:
+            def repeat_scan_until_count(count, index=None, attempts=40):
+                for attempt in range(attempts):
+                    if attempt > 0:
+                        time.sleep(attempt)
+                    c = 0
+                    start_key = {}
+                    while start_key is not None:
+                        response = dynamodb_api.client.scan(TableName=table_name, IndexName=index, Select='COUNT', **start_key) \
+                            if index else dynamodb_api.client.scan(TableName=table_name, Select='COUNT', **start_key)
+                        start_key = {'ExclusiveStartKey': response.get(
+                            'LastEvaluatedKey')} if 'LastEvaluatedKey' in response else None
+                        c += response['Count']
+                    if c == count:
+                        return True
+                return False
+            assert repeat_scan_until_count(count=wait_for_item_count, attempts=1), \
+                f"Table {table_name} did not reach {wait_for_item_count} items within the expected time"
+            if gsi is not None:
+                assert repeat_scan_until_count(count=wait_for_item_count, index=gsi), \
+                    f"GSI {gsi} did not reach {wait_for_item_count} items within the expected time"
+            if lsi is not None:
+                assert repeat_scan_until_count(count=wait_for_item_count, index=lsi), \
+                    f"LSI {lsi} did not reach {wait_for_item_count} items within the expected time"
 
     def update_table_ttl(self, node, table_name, enabled: bool = True):
         dynamodb_api = self.get_dynamodb_api(node=node)

--- a/sdcm/utils/alternator/table_setup.py
+++ b/sdcm/utils/alternator/table_setup.py
@@ -1,0 +1,31 @@
+from sdcm.utils.alternator import enums, consts
+from sdcm.utils.alternator.api import Alternator
+from contextlib import contextmanager
+
+
+def pre_create_alternator_backuped_tables(node, alternator: Alternator, params, **kwargs):
+    if params.get('alternator_port'):
+        alternator.set_credentials(node=node)
+
+        schema = params.get("dynamodb_primarykey_type")
+        table_name = params.get('alternator_test_table').get('name', consts.NO_LWT_TABLE_NAME)
+        alternator.create_table(node=node, schema=schema, isolation=enums.WriteIsolation.FORBID_RMW,
+                                table_name=table_name, **kwargs)
+
+        stress_cmd = params.get('stress_cmd')
+        stress_read_cmd = params.get('stress_read_cmd')
+        is_ttl_in_workload = any('dynamodb.ttlKey' in str(cmd) for cmd in [stress_cmd, stress_read_cmd])
+        if is_ttl_in_workload:
+            alternator.update_table_ttl(node=node, table_name=table_name)
+
+        return {table_name: schema}
+    return None
+
+
+@contextmanager
+def alternator_backuped_tables(node, alternator: Alternator, params, **kwargs):
+    tables = pre_create_alternator_backuped_tables(node, alternator, params, **kwargs)
+    yield tables
+    if tables is not None:
+        for table in tables.keys():
+            alternator.delete_table(node=node, table_name=table)

--- a/test-cases/manager/manager-regression-alternator-singleDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-alternator-singleDC-set-distro.yaml
@@ -1,0 +1,55 @@
+test_duration: 240
+
+round_robin: true
+
+stress_cmd:
+    "bin/ycsb load dynamodb -P workloads/workloadc -p table='.0-Usertable_Backup' -p dynamodb.ttlKey=TTL -p dynamodb.ttlDuration=86400
+    -p requestdistribution=sequential -p insertorder=ordered -p insertstart=0 -p dataintegrity=true -p recordcount=1000
+    -p fieldlengthdistribution=constant -p fieldnameprefix=\"#:1.-/[0]field\""
+
+stress_read_cmd: [
+    "bin/ycsb run dynamodb -P workloads/workloadc -p table='.0-Usertable_Backup' -p dynamodb.ttlKey=TTL -p dynamodb.ttlDuration=86400
+    -p requestdistribution=sequential -p insertorder=ordered -p insertstart=0 -p dataintegrity=true -p recordcount=1000 -p operationcount=1000
+    -p fieldlengthdistribution=constant -p fieldnameprefix=\"#:1.-/[0]field\"",
+    "bin/ycsb run dynamodb -P workloads/workloadc -p table='.0-Usertable_Backup:-Gsi_.0'
+    -p requestdistribution=sequential -p insertorder=ordered -p insertstart=0 -p dataintegrity=true -p recordcount=1000
+    -p fieldlengthdistribution=constant -p fieldnameprefix=\"#:1.-/[0]field\"",
+    "bin/ycsb run dynamodb -P workloads/workloadc -p table='.0-Usertable_Backup:1-.Lsi_'
+    -p requestdistribution=sequential -p insertorder=ordered -p insertstart=0 -p dataintegrity=true -p recordcount=1000
+    -p fieldlengthdistribution=constant -p fieldnameprefix=\"#:1.-/[0]field\"",
+]
+
+alternator_port: '8080'
+dynamodb_primarykey_type: HASH_AND_RANGE
+alternator_test_table:
+    name: '.0-Usertable_Backup'
+    lsi_name: '1-.Lsi_'
+    gsi_name: '-Gsi_.0'
+    tags:
+        key1: value1
+    items: 1000
+
+alternator_enforce_authorization: true
+alternator_access_key_id: 'alternator'
+alternator_secret_access_key: 'password'
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
+
+
+
+instance_type_db: 'i4i.large'
+instance_type_loader: 'c6i.large'
+
+region_name: 'us-east-1'
+n_db_nodes: '3'
+n_loaders: 1
+
+client_encrypt: true
+
+user_prefix: manager-regression
+space_node_threshold: 6442
+
+aws_instance_profile_name_db: 'qa-scylla-manager-backup-instance-profile'


### PR DESCRIPTION
This patch adds `test_alternator_backup_feature` which checks Scylla Manager's feature
for backing up and restoring Alternator data.
In general it copies workflow of previous CQL backup test `test_restore_backup_with_task`, but:
- it pre-creates Alternator table,
- it fills table and runs post-restore check using YSCB,
- table is deleted between backup and restore

Besides plain table+data restore, it checks additional (configurable with `alternator_test_table` option) features:
- restoring table tags
- table name including special characters
- restoring table with secondary indexes

Restored index content could be tested with:
    - YCSB updated to support index in read command (https://github.com/scylladb/YCSB/pull/20)
    - stress commands in `test-cases/manager/manager-regression-alternator-singleDC-set-distro.yaml`.
Before running stress commands, test waits for the indexes to achieve expected number of records.

When defined in configuration, the tests passes to Scylla Manager additional command line parameters
 `--alternator-access-key-id` `--alternator-secret-access-key`.

Fixes #11696

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
scylla 2025.1.7: https://argus.scylladb.com/tests/scylla-cluster-tests/60ebecb9-6891-40b8-be51-0f41832a5d6a
scylla 2025.2.2: https://argus.scylladb.com/tests/scylla-cluster-tests/d52d95d8-4626-4493-a1c9-36a7eac3783b
scylla 2025.3.1: https://argus.scylladb.com/tests/scylla-cluster-tests/4cff2c73-54e8-4810-b014-b497b48c2e70
scylla 2025.4.0: https://argus.scylladb.com/tests/scylla-cluster-tests/aa26fb8f-cf9d-42fd-83b4-44eee7f6bc57
scylla master:latest: https://argus.scylladb.com/tests/scylla-cluster-tests/35a7b70d-33c6-40d9-ae63-18bc3370888a

previous runs without secondary index YSCB patch:
- scylla master:latest https://argus.scylladb.com/tests/scylla-cluster-tests/f16b44d7-7ce6-4fee-bcc6-cedb11c837c7
- scylla 2025.3.1 https://argus.scylladb.com/tests/scylla-cluster-tests/3df93354-590d-4d53-b998-4950af699e71
- scylla 2025.2.2 https://argus.scylladb.com/tests/scylla-cluster-tests/d10d6c6b-85eb-4d85-9d49-f26b60136cd1
- scylla 2025.1.7 https://argus.scylladb.com/tests/scylla-cluster-tests/7f516714-1e98-4b9c-8782-2cc1d80f7924

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
