### PR TITLE
fix(manager): up SM DB version to 2025.2

### DIFF
--- a/defaults/manager_versions.yaml
+++ b/defaults/manager_versions.yaml
@@ -14,11 +14,8 @@ manager_repos_by_version:
 
 scylla_backend_repo_by_version:
   "2025":
-    rhel: 'https://downloads.scylladb.com/rpm/centos/scylla-2025.1.repo'
-    debian: 'https://downloads.scylladb.com/deb/debian/scylla-2025.1.list'
+    rhel: 'https://downloads.scylladb.com/rpm/centos/scylla-2025.2.repo'
+    debian: 'https://downloads.scylladb.com/deb/debian/scylla-2025.2.list'
   "2024":
     rhel: 'https://downloads.scylladb.com/rpm/centos/scylla-2024.2.repo'
     debian: 'https://downloads.scylladb.com/deb/debian/scylla-2024.2.list'
-  "2023":
-    rhel: 'https://downloads.scylladb.com/rpm/centos/scylla-2023.1.repo'
-    debian: 'https://downloads.scylladb.com/deb/debian/scylla-2023.1.list'

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -9,7 +9,7 @@ ip_ssh_connections: 'private'
 scylla_repo: ''
 
 manager_version: '3.6'
-manager_scylla_backend_version: '2024'
+manager_scylla_backend_version: '2025'
 # Notice: that centos (default monitor), ubuntu 22, ubuntu 20 and debian 11 monitors use 2024, while debian 10 ubuntu 18 use 2023, since we support both
 
 round_robin: false

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -343,7 +343,7 @@ Branch of scylla manager server and agent to upgrade to. Options in defaults/man
 
 Branch of scylla db enterprise to install. Options in defaults/manager_versions.yaml
 
-**default:** 2024
+**default:** 2025
 
 **type:** str
 

--- a/unit_tests/test_sdcm_mgmt_common.py
+++ b/unit_tests/test_sdcm_mgmt_common.py
@@ -7,7 +7,7 @@ class TestManagerVersions:
     def test_get_manager_scylla_backend_returns_repo_address(self):
         url = get_manager_scylla_backend("2025", Distro.UBUNTU22)
 
-        assert url == 'https://downloads.scylladb.com/deb/debian/scylla-2025.1.list'
+        assert url == 'https://downloads.scylladb.com/deb/debian/scylla-2025.2.list'
 
     def test_get_manager_repo_from_defaults_returns_repo_address(self):
         url = get_manager_repo_from_defaults("3.6", Distro.UBUNTU22)


### PR DESCRIPTION
SM DB version will be updated from 2024.2 to 2025.2 in Cloud. 
So, to keep up with setup in Cloud, the version is updated here as well.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [basic dataset for sanity](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master-clone/job/ubuntu24-sanity-test/15/)
- [x] [Increased dataset of 200GB before compaction, backup and restore test](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master-clone/job/ubuntu24-sanity-test-large-dataset/2/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code