### PR TITLE
refactor(parallel object): move to it's own new file

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -39,7 +39,7 @@ from sdcm.cluster_k8s import (
     SCYLLA_OPERATOR_NAMESPACE
 )
 from sdcm.mgmt import TaskStatus
-from sdcm.utils.common import ParallelObject
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.k8s import (
     convert_cpu_units_to_k8s_value,
     convert_cpu_value_from_k8s_to_units,

--- a/ics_space_amplification_goal_test.py
+++ b/ics_space_amplification_goal_test.py
@@ -21,7 +21,8 @@ from sdcm.cluster import BaseNode
 from sdcm.db_stats import AVAIL_SIZE_METRIC, AVAIL_SIZE_METRIC_OLD, GB_SIZE
 from sdcm.sct_events import Severity
 from sdcm.sct_events.system import InfoEvent, TestFrameworkEvent
-from sdcm.utils.common import ParallelObject, skip_optional_stage
+from sdcm.utils.common import skip_optional_stage
+from sdcm.utils.parallel_object import ParallelObject
 from test_lib.compaction import CompactionStrategy, LOGGER
 
 KEYSPACE_NAME = 'keyspace1'

--- a/longevity_operator_multi_tenant_test.py
+++ b/longevity_operator_multi_tenant_test.py
@@ -14,7 +14,7 @@
 # Copyright (c) 2022 ScyllaDB
 
 from longevity_test import LongevityTest
-from sdcm.utils.common import ParallelObject
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.operator.multitenant_common import MultiTenantTestMixin
 
 

--- a/longevity_tombstone_gc_test.py
+++ b/longevity_tombstone_gc_test.py
@@ -4,7 +4,8 @@ import time
 from functools import partial
 
 from longevity_twcs_test import TWCSLongevityTest
-from sdcm.utils.common import ParallelObject, skip_optional_stage
+from sdcm.utils.common import skip_optional_stage
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.sstable.sstable_utils import SstableUtils
 
 

--- a/performance_regression_operator_multi_tenant_test.py
+++ b/performance_regression_operator_multi_tenant_test.py
@@ -14,7 +14,7 @@
 # Copyright (c) 2022 ScyllaDB
 
 from performance_regression_test import PerformanceRegressionTest
-from sdcm.utils.common import ParallelObject
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.operator.multitenant_common import MultiTenantTestMixin
 
 

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -27,7 +27,7 @@ from sdcm.sct_events import Severity
 from sdcm.sct_events.filters import EventsSeverityChangerFilter
 from sdcm.sct_events.loaders import CassandraStressEvent
 from sdcm.sct_events.system import HWPerforanceEvent, InfoEvent
-from sdcm.utils.common import ParallelObject
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.decorators import log_run_info, latency_calculator_decorator, optional_stage
 from sdcm.utils.nemesis_utils.indexes import wait_for_view_to_be_built
 

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -42,7 +42,6 @@ from sdcm.sct_events.events_device import EVENTS_LOG_DIR, RAW_EVENTS_LOG
 from sdcm.test_config import TestConfig
 from sdcm.utils.common import (
     S3Storage,
-    ParallelObject,
     list_instances_aws,
     list_instances_gce,
     remove_files,
@@ -54,6 +53,7 @@ from sdcm.utils.common import (
     get_sct_root_path,
     normalize_ipv6_url, create_remote_storage_dir,
 )
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.context_managers import environment
 from sdcm.utils.distro import Distro
 from sdcm.utils.decorators import retrying

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -105,8 +105,8 @@ from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations
 from sdcm.utils.common import (get_db_tables, generate_random_string,
                                reach_enospc_on_node, clean_enospc_on_node,
                                parse_nodetool_listsnapshots,
-                               update_authenticator, ParallelObject,
-                               ParallelObjectResult, sleep_for_percent_of_duration, get_views_of_base_table)
+                               update_authenticator, sleep_for_percent_of_duration, get_views_of_base_table)
+from sdcm.utils.parallel_object import ParallelObject, ParallelObjectResult
 from sdcm.utils.features import is_tablets_feature_enabled
 from sdcm.utils.quota import configure_quota_on_node_for_scylla_user_context, is_quota_enabled_on_node, enable_quota_on_node, \
     write_data_to_reach_end_of_quota

--- a/sdcm/provision/aws/capacity_reservation.py
+++ b/sdcm/provision/aws/capacity_reservation.py
@@ -21,7 +21,8 @@ from botocore.exceptions import ClientError
 import boto3
 
 from sdcm.exceptions import CapacityReservationError
-from sdcm.utils.common import all_aws_regions, ParallelObject
+from sdcm.utils.common import all_aws_regions
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.get_username import get_username
 
 LOGGER = logging.getLogger(__name__)

--- a/sdcm/provision/aws/dedicated_host.py
+++ b/sdcm/provision/aws/dedicated_host.py
@@ -24,7 +24,8 @@ import tenacity
 
 from sdcm.wait import exponential_retry
 from sdcm.utils.aws_utils import tags_as_ec2_tags
-from sdcm.utils.common import ParallelObject, all_aws_regions
+from sdcm.utils.common import all_aws_regions
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.test_config import TestConfig
 
 

--- a/sdcm/teardown_validators/sstables.py
+++ b/sdcm/teardown_validators/sstables.py
@@ -10,7 +10,8 @@ from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.filters import EventsSeverityChangerFilter
 from sdcm.sct_events.teardown_validators import ValidatorEvent, ScrubValidationErrorEvent
 from sdcm.teardown_validators.base import TeardownValidator
-from sdcm.utils.common import S3Storage, ParallelObject
+from sdcm.utils.common import S3Storage
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.s3_remote_uploader import upload_remote_files_directly_to_s3
 
 LOGGER = logging.getLogger(__name__)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -91,8 +91,9 @@ from sdcm.utils.aws_utils import init_monitoring_info_from_params, get_ec2_servi
 from sdcm.utils.ci_tools import get_job_name, get_job_url
 from sdcm.utils.common import format_timestamp, wait_ami_available, \
     download_dir_from_cloud, get_post_behavior_actions, get_testrun_status, download_encrypt_keys, rows_to_list, \
-    make_threads_be_daemonic_by_default, ParallelObject, change_default_password, \
+    make_threads_be_daemonic_by_default, change_default_password, \
     parse_python_thread_command, get_data_dir_path
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.cql_utils import cql_quote_if_needed, cql_unquote_if_needed
 from sdcm.utils.database_query_utils import PartitionsValidationAttributes, fetch_all_rows
 from sdcm.utils.features import is_tablets_feature_enabled

--- a/sdcm/utils/benchmarks.py
+++ b/sdcm/utils/benchmarks.py
@@ -19,7 +19,7 @@ from typing import NamedTuple
 from sdcm.es import ES
 from sdcm.remote import RemoteCmdRunnerBase, shell_script_cmd
 from sdcm.test_config import TestConfig
-from sdcm.utils.common import ParallelObject
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.git import clone_repo
 from sdcm.utils.metaclasses import Singleton
 from sdcm.utils.decorators import retrying

--- a/sdcm/utils/bisect_test.py
+++ b/sdcm/utils/bisect_test.py
@@ -17,7 +17,7 @@ from functools import wraps
 
 import boto3
 import requests
-from sdcm.utils.common import ParallelObject
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.sct_events.system import TestFrameworkEvent
 from sdcm.sct_events import Severity
 

--- a/sdcm/utils/cluster_tools.py
+++ b/sdcm/utils/cluster_tools.py
@@ -16,6 +16,7 @@ import logging
 from typing import TYPE_CHECKING
 from collections import defaultdict
 
+
 if TYPE_CHECKING:
     from sdcm.cluster import BaseCluster, BaseNode
 

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -14,7 +14,6 @@
 
 from __future__ import absolute_import, annotations
 
-import atexit
 import itertools
 import json
 import os
@@ -36,19 +35,16 @@ import uuid
 import zipfile
 import io
 import tempfile
-import traceback
 import ctypes
 import shlex
-from typing import Iterable, List, Callable, Optional, Dict, Union, Literal, Any, Type
+from typing import Iterable, List, Optional, Dict, Union, Literal, Any, Type
 from urllib.parse import urlparse, urljoin
 from unittest.mock import Mock
 from textwrap import dedent
 from contextlib import closing, contextmanager
-from functools import wraps, cached_property, lru_cache, singledispatch
+from functools import cached_property, lru_cache, singledispatch
 from collections import defaultdict, namedtuple
 import concurrent.futures
-from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
-from concurrent.futures.thread import _python_exit
 import hashlib
 from pathlib import Path
 from collections import OrderedDict
@@ -77,6 +73,7 @@ from sdcm.utils.aws_utils import (
     get_ssm_ami,
     get_by_owner_ami,
 )
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.ssh_agent import SSHAgent
 from sdcm.utils.decorators import retrying
 from sdcm import wait
@@ -424,204 +421,6 @@ def all_aws_regions(cached=False):
         return [region['RegionName'] for region in client.describe_regions()['Regions']]
 
 
-class ParallelObject:
-    """
-        Run function in with supplied args in parallel using thread.
-    """
-
-    def __init__(self, objects: Iterable, timeout: int = 6,
-                 num_workers: int = None, disable_logging: bool = False):
-        """Constructor for ParallelObject
-
-        Build instances of Parallel object. Item of objects is used as parameter for
-        disrupt_func which will be run in parallel.
-
-        :param objects: if item in object is list, it will be upacked to disrupt_func argument, ex *arg
-                if item in object is dict, it will be upacked to disrupt_func keyword argument, ex **kwarg
-                if item in object is any other type, will be passed to disrupt_func as is.
-                if function accept list as parameter, the item shuld be list of list item = [[]]
-
-        :param timeout: global timeout for running all
-        :param num_workers: num of parallel threads, defaults to None
-        :param disable_logging: disable logging for running disrupt_func, defaults to False
-        """
-        self.objects = objects
-        self.timeout = timeout
-        self.num_workers = num_workers
-        self.disable_logging = disable_logging
-        self._thread_pool = ThreadPoolExecutor(max_workers=self.num_workers)
-
-    def run(self, func: Callable, ignore_exceptions=False, unpack_objects: bool = False) -> List[ParallelObjectResult]:
-        """Run callable object "disrupt_func" in parallel
-
-        Allow to run callable object in parallel.
-        if ignore_exceptions is true,  return
-        list of FutureResult object instances which contains
-        two attributes:
-            - result - result of callable object execution
-            - exc - exception object, if happened during run
-        if ignore_exceptions is False, then running will
-        terminated on future where happened exception or by timeout
-        what has stepped first.
-
-        :param func: Callable object to run in parallel
-        :param ignore_exceptions: ignore exception and return result, defaults to False
-        :param unpack_objects: set to True when unpacking of objects to the disrupt_func as args or kwargs needed
-        :returns: list of FutureResult object
-        :rtype: {List[FutureResult]}
-        """
-
-        def func_wrap(fun):
-            @wraps(fun)
-            def inner(*args, **kwargs):
-                thread_name = threading.current_thread().name
-                fun_args = args
-                fun_kwargs = kwargs
-                fun_name = fun.__name__
-                LOGGER.debug("[{thread_name}] {fun_name}({fun_args}, {fun_kwargs})".format(thread_name=thread_name,
-                                                                                           fun_name=fun_name,
-                                                                                           fun_args=fun_args,
-                                                                                           fun_kwargs=fun_kwargs))
-                return_val = fun(*args, **kwargs)
-                LOGGER.debug("[{thread_name}] Done.".format(thread_name=thread_name))
-                return return_val
-
-            return inner
-
-        results = []
-
-        if not self.disable_logging:
-            LOGGER.debug("Executing in parallel: '{}' on {}".format(func.__name__, self.objects))
-            func = func_wrap(func)
-
-        futures = []
-
-        for obj in self.objects:
-            if unpack_objects and isinstance(obj, (list, tuple)):
-                futures.append((self._thread_pool.submit(func, *obj), obj))
-            elif unpack_objects and isinstance(obj, dict):
-                futures.append((self._thread_pool.submit(func, **obj), obj))
-            else:
-                futures.append((self._thread_pool.submit(func, obj), obj))
-        time_out = self.timeout
-        for future, target_obj in futures:
-            try:
-                result = future.result(time_out)
-            except FuturesTimeoutError as exception:
-                results.append(ParallelObjectResult(obj=target_obj, exc=exception, result=None))
-                time_out = 0.001  # if there was a timeout on one of the futures there is no need to wait for all
-            except Exception as exception:  # noqa: BLE001
-                results.append(ParallelObjectResult(obj=target_obj, exc=exception, result=None))
-            else:
-                results.append(ParallelObjectResult(obj=target_obj, exc=None, result=result))
-
-        self.clean_up(futures)
-
-        if ignore_exceptions:
-            return results
-
-        runs_that_finished_with_exception = [res for res in results if res.exc]
-        if runs_that_finished_with_exception:
-            raise ParallelObjectException(results=results)
-        return results
-
-    def call_objects(self, ignore_exceptions: bool = False) -> list["ParallelObjectResult"]:
-        """
-        Use the ParallelObject run() method to call a list of
-        callables in parallel. Rather than running a single function
-        with a number of objects as arguments in parallel, we're
-        calling a list of callables in parallel.
-
-        If we need to run multiple callables with some arguments, one
-        solution is to use partial objects to pack the callable with
-        its arguments, e.g.:
-
-        partial_func_1 = partial(print, "lorem")
-        partial_func_2 = partial(sum, (2, 3))
-        ParallelObject(objects=[partial_func_1, partial_func_2]).call_objects()
-
-        This can be useful if we need to tightly synchronise the
-        execution of multiple functions.
-        """
-        return self.run(lambda x: x(), ignore_exceptions=ignore_exceptions)
-
-    def clean_up(self, futures):
-        # if there are futures that didn't run  we cancel them
-        for future, _ in futures:
-            future.cancel()
-        self._thread_pool.shutdown(wait=False)
-        # we need to unregister internal function that waits for all threads to finish when interpreter exits
-        atexit.unregister(_python_exit)
-
-    @staticmethod
-    def run_named_tasks_in_parallel(tasks: dict[str, Callable],
-                                    timeout: int,
-                                    ignore_exceptions: bool = False) -> dict[str, ParallelObjectResult]:
-        """
-        Allows calling multiple Callables in parallel using Parallel
-        Object. Returns a dict with the results. Will raise an exception
-        if:
-        - ignore_exceptions is set to False and an exception was raised
-        during execution
-        - timeout is set and timeout was reached
-
-        Example:
-
-        Given:
-        tasks = {
-            "trigger": partial(time.sleep, 10))
-            "interrupt": partial(random.random)
-        }
-
-        Result:
-
-        {
-            "trigger": ParallelObjectResult >>> time.sleep result
-            "interrupt": ParallelObjectResult >>> random.random result
-        }
-        """
-        task_id_map = {str(id(task)): task_name for task_name, task in tasks.items()}
-        results_map = {}
-
-        task_results = ParallelObject(
-            objects=tasks.values(),
-            timeout=timeout if timeout else None
-        ).call_objects(ignore_exceptions=ignore_exceptions)
-
-        for result in task_results:
-            task_name = task_id_map.get(str(id(result.obj)))
-            results_map.update({task_name: result})
-
-        return results_map
-
-
-class ParallelObjectResult:
-    """Object for result of future in ParallelObject
-
-    Return as a result of ParallelObject.run method
-    and contain result of disrupt_func was run in parallel
-    and exception if it happened during run.
-    """
-
-    def __init__(self, obj, result=None, exc=None):
-        self.obj = obj
-        self.result = result
-        self.exc = exc
-
-
-class ParallelObjectException(Exception):
-    def __init__(self, results: List[ParallelObjectResult]):
-        super().__init__()
-        self.results = results
-
-    def __str__(self):
-        ex_str = ""
-        for res in self.results:
-            if res.exc:
-                ex_str += f"{res.obj}:\n {''.join(traceback.format_exception(type(res.exc), res.exc, res.exc.__traceback__))}"
-        return ex_str
-
-
 def docker_current_container_id() -> Optional[str]:
     with open("/proc/1/cgroup", encoding="utf-8") as cgroup:
         for line in cgroup:
@@ -889,7 +688,7 @@ def list_test_security_groups(tags_dict=None, region_name=None, group_as_region=
         if verbose:
             LOGGER.info("%s: done [%s/%s]", region, len(list(security_groups.keys())), len(aws_regions))
 
-    ParallelObject(aws_regions, timeout=100,  num_workers=len(aws_regions)
+    ParallelObject(aws_regions, timeout=100, num_workers=len(aws_regions)
                    ).run(get_security_groups_ips, ignore_exceptions=True)
 
     if not group_as_region:

--- a/sdcm/utils/operator/multitenant_common.py
+++ b/sdcm/utils/operator/multitenant_common.py
@@ -17,7 +17,7 @@ import copy
 import logging
 import time
 
-from sdcm.utils.common import ParallelObject
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.tester import silence
 from sdcm.utils.database_query_utils import PartitionsValidationAttributes
 

--- a/sdcm/utils/parallel_object.py
+++ b/sdcm/utils/parallel_object.py
@@ -1,0 +1,210 @@
+from __future__ import absolute_import, annotations
+
+import atexit
+import logging
+import threading
+import traceback
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
+from concurrent.futures.thread import _python_exit
+from functools import wraps
+from typing import Iterable, Callable, List
+
+LOGGER = logging.getLogger('utils')
+
+
+class ParallelObject:
+    """
+        Run function in with supplied args in parallel using thread.
+    """
+
+    def __init__(self, objects: Iterable, timeout: int = 6,
+                 num_workers: int = None, disable_logging: bool = False):
+        """Constructor for ParallelObject
+
+        Build instances of Parallel object. Item of objects is used as parameter for
+        disrupt_func which will be run in parallel.
+
+        :param objects: if item in object is list, it will be upacked to disrupt_func argument, ex *arg
+                if item in object is dict, it will be upacked to disrupt_func keyword argument, ex **kwarg
+                if item in object is any other type, will be passed to disrupt_func as is.
+                if function accept list as parameter, the item shuld be list of list item = [[]]
+
+        :param timeout: global timeout for running all
+        :param num_workers: num of parallel threads, defaults to None
+        :param disable_logging: disable logging for running disrupt_func, defaults to False
+        """
+        self.objects = objects
+        self.timeout = timeout
+        self.num_workers = num_workers
+        self.disable_logging = disable_logging
+        self._thread_pool = ThreadPoolExecutor(max_workers=self.num_workers)
+
+    def run(self, func: Callable, ignore_exceptions=False, unpack_objects: bool = False) -> List[ParallelObjectResult]:
+        """Run callable object "disrupt_func" in parallel
+
+        Allow to run callable object in parallel.
+        if ignore_exceptions is true,  return
+        list of FutureResult object instances which contains
+        two attributes:
+            - result - result of callable object execution
+            - exc - exception object, if happened during run
+        if ignore_exceptions is False, then running will
+        terminated on future where happened exception or by timeout
+        what has stepped first.
+
+        :param func: Callable object to run in parallel
+        :param ignore_exceptions: ignore exception and return result, defaults to False
+        :param unpack_objects: set to True when unpacking of objects to the disrupt_func as args or kwargs needed
+        :returns: list of FutureResult object
+        :rtype: {List[FutureResult]}
+        """
+
+        def func_wrap(fun):
+            @wraps(fun)
+            def inner(*args, **kwargs):
+                thread_name = threading.current_thread().name
+                fun_args = args
+                fun_kwargs = kwargs
+                fun_name = fun.__name__
+                LOGGER.debug("[{thread_name}] {fun_name}({fun_args}, {fun_kwargs})".format(thread_name=thread_name,
+                                                                                           fun_name=fun_name,
+                                                                                           fun_args=fun_args,
+                                                                                           fun_kwargs=fun_kwargs))
+                return_val = fun(*args, **kwargs)
+                LOGGER.debug("[{thread_name}] Done.".format(thread_name=thread_name))
+                return return_val
+
+            return inner
+
+        results = []
+
+        if not self.disable_logging:
+            LOGGER.debug("Executing in parallel: '{}' on {}".format(func.__name__, self.objects))
+            func = func_wrap(func)
+
+        futures = []
+
+        for obj in self.objects:
+            if unpack_objects and isinstance(obj, (list, tuple)):
+                futures.append((self._thread_pool.submit(func, *obj), obj))
+            elif unpack_objects and isinstance(obj, dict):
+                futures.append((self._thread_pool.submit(func, **obj), obj))
+            else:
+                futures.append((self._thread_pool.submit(func, obj), obj))
+        time_out = self.timeout
+        for future, target_obj in futures:
+            try:
+                result = future.result(time_out)
+            except FuturesTimeoutError as exception:
+                results.append(ParallelObjectResult(obj=target_obj, exc=exception, result=None))
+                time_out = 0.001  # if there was a timeout on one of the futures there is no need to wait for all
+            except Exception as exception:  # noqa: BLE001
+                results.append(ParallelObjectResult(obj=target_obj, exc=exception, result=None))
+            else:
+                results.append(ParallelObjectResult(obj=target_obj, exc=None, result=result))
+
+        self.clean_up(futures)
+
+        if ignore_exceptions:
+            return results
+
+        runs_that_finished_with_exception = [res for res in results if res.exc]
+        if runs_that_finished_with_exception:
+            raise ParallelObjectException(results=results)
+        return results
+
+    def call_objects(self, ignore_exceptions: bool = False) -> list["ParallelObjectResult"]:
+        """
+        Use the ParallelObject run() method to call a list of
+        callables in parallel. Rather than running a single function
+        with a number of objects as arguments in parallel, we're
+        calling a list of callables in parallel.
+
+        If we need to run multiple callables with some arguments, one
+        solution is to use partial objects to pack the callable with
+        its arguments, e.g.:
+
+        partial_func_1 = partial(print, "lorem")
+        partial_func_2 = partial(sum, (2, 3))
+        ParallelObject(objects=[partial_func_1, partial_func_2]).call_objects()
+
+        This can be useful if we need to tightly synchronise the
+        execution of multiple functions.
+        """
+        return self.run(lambda x: x(), ignore_exceptions=ignore_exceptions)
+
+    def clean_up(self, futures):
+        # if there are futures that didn't run  we cancel them
+        for future, _ in futures:
+            future.cancel()
+        self._thread_pool.shutdown(wait=False)
+        # we need to unregister internal function that waits for all threads to finish when interpreter exits
+        atexit.unregister(_python_exit)
+
+    @staticmethod
+    def run_named_tasks_in_parallel(tasks: dict[str, Callable],
+                                    timeout: int,
+                                    ignore_exceptions: bool = False) -> dict[str, ParallelObjectResult]:
+        """
+        Allows calling multiple Callables in parallel using Parallel
+        Object. Returns a dict with the results. Will raise an exception
+        if:
+        - ignore_exceptions is set to False and an exception was raised
+        during execution
+        - timeout is set and timeout was reached
+
+        Example:
+
+        Given:
+        tasks = {
+            "trigger": partial(time.sleep, 10))
+            "interrupt": partial(random.random)
+        }
+
+        Result:
+
+        {
+            "trigger": ParallelObjectResult >>> time.sleep result
+            "interrupt": ParallelObjectResult >>> random.random result
+        }
+        """
+        task_id_map = {str(id(task)): task_name for task_name, task in tasks.items()}
+        results_map = {}
+
+        task_results = ParallelObject(
+            objects=tasks.values(),
+            timeout=timeout if timeout else None
+        ).call_objects(ignore_exceptions=ignore_exceptions)
+
+        for result in task_results:
+            task_name = task_id_map.get(str(id(result.obj)))
+            results_map.update({task_name: result})
+
+        return results_map
+
+
+class ParallelObjectResult:
+    """Object for result of future in ParallelObject
+
+    Return as a result of ParallelObject.run method
+    and contain result of disrupt_func was run in parallel
+    and exception if it happened during run.
+    """
+
+    def __init__(self, obj, result=None, exc=None):
+        self.obj = obj
+        self.result = result
+        self.exc = exc
+
+
+class ParallelObjectException(Exception):
+    def __init__(self, results: List[ParallelObjectResult]):
+        super().__init__()
+        self.results = results
+
+    def __str__(self):
+        ex_str = ""
+        for res in self.results:
+            if res.exc:
+                ex_str += f"{res.obj}:\n {''.join(traceback.format_exception(type(res.exc), res.exc, res.exc.__traceback__))}"
+        return ex_str

--- a/sdcm/utils/raft/common.py
+++ b/sdcm/utils/raft/common.py
@@ -15,7 +15,7 @@ from sdcm.wait import wait_for
 
 from sdcm.sct_events.group_common_events import decorate_with_context, \
     ignore_ycsb_connection_refused
-from sdcm.utils.common import ParallelObject
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.raft import get_node_status_from_system_by
 from sdcm.cluster import BaseMonitorSet, NodeSetupFailed, BaseScyllaCluster, BaseNode
 from sdcm.exceptions import RaftTopologyCoordinatorNotFound

--- a/sdcm/utils/resources_cleanup.py
+++ b/sdcm/utils/resources_cleanup.py
@@ -29,7 +29,6 @@ from sdcm.provision.azure.provisioner import AzureProvisioner
 from sdcm.utils.argus import ArgusError, get_argus_client, terminate_resource_in_argus
 from sdcm.utils.aws_kms import AwsKms
 from sdcm.utils.common import (
-    ParallelObject,
     all_aws_regions,
     aws_tags_to_dict,
     get_post_behavior_actions,
@@ -46,6 +45,7 @@ from sdcm.utils.common import (
     list_resources_docker,
     list_test_security_groups,
 )
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.context_managers import environment
 from sdcm.utils.decorators import retrying
 from sdcm.utils.gce_utils import (

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -31,7 +31,8 @@ from botocore.client import Config
 from sdcm.utils.repo_parser import Parser
 
 from sdcm.remote import LOCALRUNNER
-from sdcm.utils.common import ParallelObject, DEFAULT_AWS_REGION
+from sdcm.utils.common import DEFAULT_AWS_REGION
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.sct_events.system import ScyllaRepoEvent
 from sdcm.utils.decorators import retrying
 from sdcm.utils.features import get_enabled_features

--- a/stop_compaction_test.py
+++ b/stop_compaction_test.py
@@ -26,7 +26,7 @@ from sdcm.rest.storage_service_client import StorageServiceClient
 from sdcm.sct_events.group_common_events import ignore_compaction_stopped_exceptions
 from sdcm.send_email import FunctionalEmailReporter
 from sdcm.tester import ClusterTester
-from sdcm.utils.common import ParallelObject
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.compaction_ops import CompactionOps, COMPACTION_TYPES
 LOGGER = logging.getLogger(__name__)
 

--- a/unit_tests/test_parallelobject.py
+++ b/unit_tests/test_parallelobject.py
@@ -6,7 +6,7 @@ import concurrent.futures
 
 import pytest
 
-from sdcm.utils.common import ParallelObject, ParallelObjectException
+from sdcm.utils.parallel_object import ParallelObject, ParallelObjectException
 
 LOGGER = logging.getLogger(name=__name__)
 

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -35,7 +35,7 @@ from sdcm.utils.issues import SkipPerIssues
 from sdcm.fill_db_data import FillDatabaseData
 from sdcm.sct_events import Severity
 from sdcm.stress_thread import CassandraStressThread
-from sdcm.utils.common import ParallelObject
+from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.decorators import retrying
 from sdcm.utils.sstable.sstable_utils import get_sstable_data_dump_command
 from sdcm.utils.user_profile import get_profile_content


### PR DESCRIPTION
The classes of ParallelObject, ParallelObjectResult and ParallelObjectException, are moved to it's own new file of sdcm/utils/parallel_object.py. 
This will prevent some circular import issues.
Refs: https://github.com/scylladb/scylla-cluster-tests/pull/11353

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
