### PR TITLE
fix(health checker): collect DC from gossip info

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2882,7 +2882,7 @@ class BaseNode(AutoSshContainerMixin):
             elif line.startswith('DC:'):
                 dc = line.replace('DC:', '').split(',')[0]
 
-            if schema and ip and status:
+            if schema and ip and status and dc:
                 if node := node_ip_map.get(ip):
                     gossip_node_schemas[node] = {'schema': schema, 'status': status, 'dc': dc}
                 elif status in self.GOSSIP_STATUSES_FILTER_OUT:


### PR DESCRIPTION
This commit ensures that the DC information is correctly parsed and collected, even when it appears after other data like schema, IP, or status. Previously, the parser would miss this information due to its location, but this change fixes that issue.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] [longevity-100gb-4h](url)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
