### PR TITLE
fix(skip issue): get issue from scylla-drivers repo

### DIFF
--- a/.github/workflows/cache-issues.yaml
+++ b/.github/workflows/cache-issues.yaml
@@ -13,7 +13,7 @@ jobs:
       - run: |
           mkdir -p issues
           mkdir -p issues/pull-requests
-          for repo in scylladb scylla-enterprise scylla-manager scylla-operator scylla-cluster-tests scylla-dtest qa-tasks scylla-tools-java siren ; do
+          for repo in scylladb scylla-enterprise scylla-manager scylla-operator scylla-cluster-tests scylla-dtest qa-tasks scylla-tools-java siren scylla-drivers ; do
             gh issue list --state all --json number,state,labels,title --limit 30000 --template '{{range .}}{{.number}},{{.state}},{{range .labels}}{{.name}}|{{end}},{{.title}}{{println ""}}{{end}}' --repo scylladb/$repo > issues/scylladb_$repo.csv
             gh pr list --state all --json number,state,labels,title --limit 30000 --template '{{range .}}{{.number}},{{.state}},{{range .labels}}{{.name}}|{{end}},{{.title}}{{println ""}}{{end}}' --repo scylladb/$repo > issues/pull-requests/scylladb_$repo.csv
           done


### PR DESCRIPTION
SkipPerIssue fails when the issue from scylla-drivers repo is not cached.
Add the scylla-drivers repository to the cache.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
