### PR TITLE
improvement(template-longevity-5gb-1h-base): increase n_db_nodes: 6

### DIFF
--- a/configurations/nemesis/longevity-5gb-1h-nemesis.yaml
+++ b/configurations/nemesis/longevity-5gb-1h-nemesis.yaml
@@ -12,7 +12,7 @@ stress_cmd:
     - "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
     - "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"
 
-n_db_nodes: 3
+n_db_nodes: 6
 n_loaders: 1
 seeds_num: 3
 

--- a/templates/test_config/template-longevity-5gb-1h-base.yaml.j2
+++ b/templates/test_config/template-longevity-5gb-1h-base.yaml.j2
@@ -12,7 +12,7 @@ stress_cmd:
     - "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
     - "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=10000 -clustering-row-count=555 -clustering-row-size=uniform:128..2048 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=30s -retry-number=30 -retry-interval=80ms,1s -iterations 0 -duration=60m -validate-data"
 
-n_db_nodes: 3
+n_db_nodes: 6
 n_loaders: 1
 seeds_num: 3
 


### PR DESCRIPTION
Typical setup for SCT tests is 3 racks with 2 nodes each. Inceasing number of nodes fixes some Individual Nemeses tests. For example IsolateNodeWithProcessSignalNemesis removes node, which previously failed due to RF=3 and original number of nodes equal to 3.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/689aef58-7d97-4b3b-ab04-f7c417d6b545

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
