### PR TITLE
feature(gce): Enable GCP Cloud KMS encryption with key rotation

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -2834,11 +2834,20 @@ options will be used for enable encryption at-rest for tables
 
 ## **kms_key_rotation_interval** / SCT_KMS_KEY_ROTATION_INTERVAL
 
-The time interval in minutes which gets waited before the KMS key rotation happens. Applied when the AWS KMS service is configured to be used.
+The time interval in minutes which gets waited before the KMS key rotation happens. Applied when the AWS KMS or GCP KMS service is configured to be used.
 
 **default:** N/A
 
 **type:** int
+
+
+## **enable_kms_key_rotation** / SCT_ENABLE_KMS_KEY_ROTATION
+
+Allows to disable KMS keys rotation. Applicable to GCP and Azure backends. In case of AWS backend its KMS keys will always be rotated as of now.
+
+**default:** N/A
+
+**type:** boolean
 
 
 ## **enterprise_disable_kms** / SCT_ENTERPRISE_DISABLE_KMS

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -87,6 +87,10 @@ from sdcm.snitch_configuration import SnitchConfig
 from sdcm.utils import properties
 from sdcm.utils.adaptive_timeouts import Operations, adaptive_timeout
 from sdcm.utils.aws_kms import AwsKms
+from sdcm.utils.gcp_kms import GcpKms
+from sdcm.provision.gce.kms_provider import GcpKmsProvider
+from google.cloud.exceptions import GoogleCloudError
+from sdcm.keystore import KeyStore
 from sdcm.utils.cql_utils import cql_quote_if_needed
 from sdcm.utils.benchmarks import ScyllaClusterBenchmarkManager
 from sdcm.utils.common import (
@@ -4788,6 +4792,34 @@ class BaseScyllaCluster:
             },
             daemon=True)
         kms_key_rotation_thread.start()
+        return None
+
+    def start_gcp_key_rotation_thread(self) -> None:
+        if self.params.get("cluster_backend") != 'gce':
+            return None
+        if not self.params.get("enable_kms_key_rotation"):
+            return None
+
+        test_id = str(self.test_config.test_id())
+
+        def _rotate():
+            gcp_credentials = KeyStore().get_gcp_credentials()
+            gcp_kms_config = KeyStore().get_gcp_kms_config()
+
+            project_id = gcp_credentials['project_id']
+            location = gcp_kms_config['keyring_location']
+            key_name = GcpKmsProvider.get_key_name_for_test(test_id)
+            gcp_kms = GcpKms(project_id, location, key_name)
+            while True:
+                time.sleep(self.params.get("kms_key_rotation_interval") * 60)
+                try:
+                    gcp_kms.rotate_key()
+                    self.log.info(f"GCP KMS key rotated for test {test_id}: {key_name}")
+                except GoogleCloudError as e:
+                    self.log.error(f"Failed to rotate GCP KMS key '{key_name}': {e}")
+
+        threading.Thread(target=_rotate, daemon=True, name='GcpKmsRotationThread').start()
+        self.log.info(f"Started GCP KMS rotation thread for test: {test_id}")
         return None
 
     def scylla_configure_non_root_installation(self, node, devname):

--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -71,7 +71,11 @@ class KeyStore:
 
     def get_gcp_service_accounts(self):
         project = os.environ.get('SCT_GCE_PROJECT') or 'gcp-sct-project-1'
-        return self.get_json(f"{project}_service_accounts.json")
+        service_accounts = self.get_json(f"{project}_service_accounts.json")
+        for sa in service_accounts:
+            if 'https://www.googleapis.com/auth/cloud-platform' not in sa['scopes']:
+                sa['scopes'].append('https://www.googleapis.com/auth/cloud-platform')
+        return service_accounts
 
     def get_scylladb_upload_credentials(self):
         return self.get_json("scylladb_upload.json")
@@ -113,6 +117,9 @@ class KeyStore:
 
     def get_azure_credentials(self):
         return self.get_json("azure.json")
+
+    def get_gcp_kms_config(self):
+        return self.get_json("gcp_kms_config.json")
 
     def get_argusdb_credentials(self):
         return self.get_json("argusdb_config_v2.json")

--- a/sdcm/provision/gce/kms_provider.py
+++ b/sdcm/provision/gce/kms_provider.py
@@ -1,0 +1,56 @@
+import logging
+from dataclasses import dataclass
+
+from google.cloud.exceptions import GoogleCloudError
+from sdcm.utils.gcp_kms import GcpKms
+from sdcm.keystore import KeyStore
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class GcpKmsProvider:
+
+    def __post_init__(self):
+        self._gcp_kms_config = KeyStore().get_gcp_kms_config()
+        gcp_credentials = KeyStore().get_gcp_credentials()
+        self._project_id = gcp_credentials['project_id']
+        self._location = self._gcp_kms_config['keyring_location']
+
+    @classmethod
+    def get_key_name_for_test(cls, test_id: str) -> str:
+        gcp_kms_config = KeyStore().get_gcp_kms_config()
+        num_of_keys = gcp_kms_config['num_of_keys']
+        key_number = (hash(test_id) % num_of_keys) + 1
+        return f"scylla-key-{key_number}"
+
+    @classmethod
+    def get_key_uri_for_test(cls, test_id: str) -> str:
+        gcp_kms_config = KeyStore().get_gcp_kms_config()
+        keyring_name = gcp_kms_config['keyring_name']
+        key_name = cls.get_key_name_for_test(test_id)
+        return f"{keyring_name}/{key_name}"
+
+    def get_or_create_keys_pool(self, test_id: str):
+        try:
+            num_of_keys = self._gcp_kms_config['num_of_keys']
+            for i in range(1, num_of_keys + 1):
+                key_name = f"scylla-key-{i}"
+                gcp_kms = GcpKms(self._project_id, self._location, key_name)
+                gcp_kms.get_or_create_key()
+                LOGGER.info("GCP KMS key ready in pool: %s", key_name)
+
+            key_name = self.get_key_name_for_test(test_id)
+            key_uri = self.get_key_uri_for_test(test_id)
+
+            key_info = {
+                'project_id': self._project_id,
+                'location': self._location,
+                'keyring_name': self._gcp_kms_config['keyring_name'],
+                'key_name': key_name,
+                'key_uri': key_uri
+            }
+            return key_info
+        except GoogleCloudError as e:
+            LOGGER.warning(f"Failed to setup GCP KMS key pool: {e}")
+            return None

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1440,7 +1440,11 @@ class SCTConfiguration(dict):
 
         dict(name="kms_key_rotation_interval", env="SCT_KMS_KEY_ROTATION_INTERVAL", type=int,
              help="The time interval in minutes which gets waited before the KMS key rotation happens."
-                  " Applied when the AWS KMS service is configured to be used."),
+                  " Applied when the AWS KMS or GCP KMS service is configured to be used."),
+
+        dict(name="enable_kms_key_rotation", env="SCT_ENABLE_KMS_KEY_ROTATION", type=boolean,
+             help="Allows to disable KMS keys rotation. Applicable to GCP and Azure backends. "
+                  "In case of AWS backend its KMS keys will always be rotated as of now."),
 
         dict(name="enterprise_disable_kms", env="SCT_ENTERPRISE_DISABLE_KMS", type=boolean,
              help="An escape hatch to disable KMS for enterprise run, when needed, "

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -49,6 +49,7 @@ from argus.client.sct.types import Package, EventsInfo, LogLink
 from argus.common.enums import TestStatus
 from sdcm import nemesis, cluster_docker, cluster_k8s, cluster_baremetal, db_stats, wait
 from sdcm.cloud_api_client import ScyllaCloudAPIClient
+from sdcm.provision.gce.kms_provider import GcpKmsProvider
 from sdcm.cluster import BaseCluster, NoMonitorSet, SCYLLA_DIR, TestConfig, UserRemoteCredentials, BaseLoaderSet, BaseMonitorSet, \
     BaseScyllaCluster, BaseNode, MINUTE_IN_SEC
 from sdcm.cluster_azure import ScyllaAzureCluster, LoaderSetAzure, MonitorSetAzure
@@ -885,6 +886,59 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         self.params["append_scylla_yaml"] = append_scylla_yaml
         return None
 
+    def prepare_gcp_kms(self) -> None:
+        scylla_version = self.params.scylla_version
+        if not scylla_version:
+            return None
+        version_supports_kms = ComparableScyllaVersion(scylla_version) >= '2023.1.3'
+        backend_support_kms = self.params.get('cluster_backend') in ('gce',)
+        kms_configured_in_sct = self.params.get('scylla_encryption_options')
+        test_uses_oracle = self.params.get("db_type") == "mixed_scylla"
+        should_enable_kms = (version_supports_kms and
+                             backend_support_kms and
+                             not kms_configured_in_sct and
+                             not test_uses_oracle and
+                             not self.params.get('enterprise_disable_kms'))
+
+        if should_enable_kms:
+            self.params['scylla_encryption_options'] = "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'GcpKeyProviderFactory', 'gcp_host': 'scylla-gcp-kms'}"
+        if not (scylla_encryption_options := self.params.get("scylla_encryption_options") or ''):
+            return None
+        gcp_host = (yaml.safe_load(scylla_encryption_options) or {}).get("gcp_host") or ''
+        if not gcp_host:
+            return None
+
+        test_id = str(self.test_config.test_id())
+        append_scylla_yaml = self.params.get("append_scylla_yaml") or {}
+        if "gcp_hosts" not in append_scylla_yaml:
+            append_scylla_yaml["gcp_hosts"] = {}
+
+        gcp_kms_provider = GcpKmsProvider()
+        key_info = gcp_kms_provider.get_or_create_keys_pool(test_id)
+        if not key_info:
+            self.log.error("Failed to setup GCP KMS key pool")
+            return
+
+        append_scylla_yaml["gcp_hosts"][gcp_host] = {
+            'gcp_project_id': key_info['project_id'],
+            'gcp_location': key_info['location'],
+            'master_key': key_info['key_uri']
+        }
+
+        append_scylla_yaml['user_info_encryption'] = {
+            'enabled': True,
+            'key_provider': 'GcpKeyProviderFactory',
+            'gcp_host': gcp_host,
+        }
+        append_scylla_yaml['system_info_encryption'] = {
+            'enabled': True,
+            'key_provider': 'GcpKeyProviderFactory',
+            'gcp_host': gcp_host,
+        }
+
+        self.params["append_scylla_yaml"] = append_scylla_yaml
+        return None
+
     def kafka_configure(self):
         if self.kafka_cluster:
             for connector_config in self.params.get('kafka_connectors'):
@@ -1014,6 +1068,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         if self.is_encrypt_keys_needed:
             self.download_encrypt_keys()
         self.prepare_kms_host()
+        self.prepare_gcp_kms()
 
         self.nemesis_allocator = NemesisNodeAllocator(self)
 
@@ -1108,6 +1163,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
             for db_cluster in self.db_clusters_multitenant:
                 if db_cluster:
                     db_cluster.start_kms_key_rotation_thread()
+                    db_cluster.start_gcp_key_rotation_thread()
 
             for future in as_completed(futures):
                 future.result()

--- a/sdcm/utils/gcp_kms.py
+++ b/sdcm/utils/gcp_kms.py
@@ -1,0 +1,56 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+import logging
+
+from google.cloud import kms
+from google.cloud.exceptions import GoogleCloudError
+from sdcm.keystore import KeyStore
+
+LOGGER = logging.getLogger(__name__)
+
+
+class GcpKms:
+
+    def __init__(self, project_id: str, location: str, key_name: str):
+        self._gcp_kms_config = KeyStore().get_gcp_kms_config()
+        self.key_name = key_name
+        self.project_id = project_id
+        self.location = location
+        keyring_name = self._gcp_kms_config['keyring_name']
+        self.keyring_name = keyring_name
+        self.keyring_path = (
+            f"projects/{project_id}/locations/{location}"
+            f"/keyRings/{keyring_name}"
+        )
+        self.key_path = f"{self.keyring_path}/cryptoKeys/{key_name}"
+        self.client = kms.KeyManagementServiceClient()
+
+    def create_test_key(self):
+        self.client.create_crypto_key(
+            parent=self.keyring_path,
+            crypto_key_id=self.key_name,
+            crypto_key={'purpose': kms.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT}
+        )
+        LOGGER.info(f"Created key: {self.key_name}")
+
+    def get_or_create_key(self):
+        try:
+            self.client.get_crypto_key(name=self.key_path)
+            LOGGER.info("Using existing GCP KMS key: %s", self.key_path)
+        except GoogleCloudError:
+            self.create_test_key()
+
+    def rotate_key(self):
+        self.client.create_crypto_key_version(parent=self.key_path, crypto_key_version={})
+        LOGGER.info("Rotated GCP KMS key '%s'", self.key_path)

--- a/test-cases/longevity/longevity-gcp-kms-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-gcp-kms-10gb-3h.yaml
@@ -1,0 +1,20 @@
+test_duration: 255
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5"
+             ]
+
+n_db_nodes: 3
+n_loaders: 1
+
+instance_type_db: 'n1-standard-8'
+instance_type_loader: 'n1-standard-4'
+gce_datacenter: 'us-central1-a'
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_seed: '111'
+nemesis_interval: 10
+
+user_prefix: 'longevity-gcp-kms-10gb-3h'
+space_node_threshold: 64424
+
+enterprise_disable_kms: false
+enable_kms_key_rotation: true
+kms_key_rotation_interval: 60


### PR DESCRIPTION
    Reuse existing `enterprise_disable_kms` to enable GCP EaR
    Pre-created keyring and keypool with 3 keys (scylla-key-1/2/3)
    Service accounts, keyring and keys are reusable across tests.
    Key rotation interval cofigured via  `enable_kms_key_rotation` option

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
