### PR TITLE
fix(health checker): warn if node is missed in peers table

### DIFF
--- a/sdcm/utils/health_checker.py
+++ b/sdcm/utils/health_checker.py
@@ -137,12 +137,12 @@ def check_schema_version(gossip_info, peers_details, nodes_status, current_node)
         return
 
     if not peers_details:
-        LOGGER.warning("SYSTEM.PEERS info is not availble. Search for the warning above. "
+        LOGGER.warning("SYSTEM.PEERS info is not available. Search for the warning above. "
                        "Verify schema version can\'t be performed")
         return
 
     if not gossip_info:
-        LOGGER.warning("Gossip info is not availble. Search for the warning above. "
+        LOGGER.warning("Gossip info is not available. Search for the warning above. "
                        "Verify schema version can\'t be performed")
         return
 
@@ -159,11 +159,13 @@ def check_schema_version(gossip_info, peers_details, nodes_status, current_node)
 
         is_target = current_node.print_node_running_nemesis(node.ip_address)
         if node not in peers_details.keys():
+            # The selection of peer nodes is non-deterministic, making the contents of the system.peers table unpredictable.
+            # Log a warning if a node is absent from the SYSTEM.PEERS table.
             LOGGER.debug(debug_message)
             yield ClusterHealthValidatorEvent.NodeSchemaVersion(
-                severity=Severity.ERROR,
+                severity=Severity.WARNING,
                 node=current_node.name,
-                error=f"Current node {current_node}. "
+                message=f"Current node {current_node}. "
                 f"Node {node}{is_target} exists in the gossip but missed in SYSTEM.PEERS.",
             )
             continue


### PR DESCRIPTION
The selection of peer nodes is non-deterministic, making the contents of the system.peers table unpredictable.
Log a warning if a node is absent from the SYSTEM.PEERS table.

Create WARNING event instead of ERROR. It should not fail the test

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [rolling-upgrade-ubuntu2404-test](https://argus.scylladb.com/tests/scylla-cluster-tests/0919e57f-14d0-43d8-987b-ace412a78806)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
