### PR TITLE
fix(trigger): scylla version for nemesis test

### DIFF
--- a/vars/perfRegressionParallelPipelinebyRegion.groovy
+++ b/vars/perfRegressionParallelPipelinebyRegion.groovy
@@ -189,6 +189,8 @@ def call(Map pipelineParams) {
                                  def sub_tests = []
                                  def region = null
                                  def image_name_for_job = null
+                                 def rolling_upgrade_test = null
+                                 def microbenchmark = null
                                  if (scylla_version == "master" && !image_name){
                                     region = entry.region ?: 'us-east-1'
                                     def output = sh(script: "./docker/env/hydra.sh list-images -c ${cloud_provider} -r ${region} -o text", returnStdout: true).trim()
@@ -204,7 +206,6 @@ def call(Map pipelineParams) {
                                  }
 
                                 if (entry.job_name == job_name) {
-                                    println("job_name: ${entry.job_name}, sub_tests: ${entry.sub_tests}")
                                     for (def ver in entry.versions) {
                                         if (scylla_version?.trim() == ver || scylla_version?.trim().startsWith(ver + ".")) {
                                             version = params.scylla_version
@@ -217,11 +218,12 @@ def call(Map pipelineParams) {
                                         region = entry.region
                                         sub_tests = entry.sub_tests
                                         println("Found for job $job_name: region : $region, version: $version, sub_tests: $sub_tests")
-                                        break
+                                    } else {
+                                        continue
                                     }
                                     rolling_upgrade_test = entry.rolling_upgrade_test
                                     microbenchmark = entry.microbenchmark
-                                    if (rolling_upgrade_test || entry.microbenchmark) {
+                                    if (rolling_upgrade_test || microbenchmark) {
                                         image_name_for_job = null
                                     } else {
                                         image_name_for_job = image_name


### PR DESCRIPTION
It was a bug in the performance trigger.
The nemesis test is intentionally defined twice:
- once for releases (with a single sub-test)
- once for master (with three sub-tests). However, when the same job is defined multiple times, the process broke midway and does not to set the correct image_name. As a result, the job is triggered with 'master:latest' instead of using the image name.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [perf-regression-trigger-test](https://github.com/scylladb/scylla-cluster-tests/pull/11829)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
