### PR TITLE
fix(pipelines): read backends directly from params

### DIFF
--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -1,7 +1,7 @@
 #! groovy
 
 def call(Map pipelineParams) {
-    def builder = getJenkinsLabels(pipelineParams.get('backend', 'aws'), pipelineParams.get('region'), pipelineParams.get('gce_datacenter'), pipelineParams.get('azure_region_name'))
+    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter, params.azure_region_name)
 
     pipeline {
         agent none

--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -4,7 +4,7 @@ def completed_stages = [:]
 def (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout) = [0,0,0,0,0]
 
 def call(Map pipelineParams) {
-    def builder = getJenkinsLabels(pipelineParams.get('backend', 'aws'), pipelineParams.get('region'))
+    def builder = getJenkinsLabels(params.backend, params.region)
 
     pipeline {
         agent {

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -5,7 +5,7 @@ def (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCl
 
 def call(Map pipelineParams) {
 
-    def builder = getJenkinsLabels(pipelineParams.get('backend', 'aws'), pipelineParams.get('region'), pipelineParams.get('gce_datacenter'), pipelineParams.get('azure_region_name'))
+    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter, params.azure_region_name)
     def functional_test = pipelineParams.functional_test
 
     pipeline {

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -37,7 +37,7 @@ def (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCl
 
 def call(Map pipelineParams) {
 
-    def builder = getJenkinsLabels(pipelineParams.get('backend', 'aws'), pipelineParams.get('region'), pipelineParams.get('gce_datacenter'), pipelineParams.get('azure_region_name'))
+    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter, params.azure_region_name)
 
     pipeline {
         agent {

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -5,7 +5,7 @@ def (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCl
 def base_versions_list = []
 
 def call(Map pipelineParams) {
-    def builder = getJenkinsLabels(pipelineParams.get('backend', 'aws'), pipelineParams.get('region'), pipelineParams.get('gce_datacenter'))
+    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter)
 
     pipeline {
         agent none

--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -4,7 +4,7 @@ import groovy.json.JsonSlurper
 def (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout) = [0,0,0,0,0]
 
 def call(Map pipelineParams) {
-    def builder = getJenkinsLabels(pipelineParams.get('backend', 'aws'), pipelineParams.get('region'), pipelineParams.get('gce_datacenter'))
+    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter)
 
     pipeline {
         agent none

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -6,7 +6,7 @@ def completed_stages = [:]
 (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout) = [0,0,0,0,0]
 
 def call(Map pipelineParams) {
-    def builder = getJenkinsLabels(pipelineParams.get('backend', 'aws'), pipelineParams.get('region'), pipelineParams.get('gce_datacenter'), pipelineParams.get('azure_region_name'))
+    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter, params.azure_region_name)
 
     pipeline {
         agent none


### PR DESCRIPTION
Read backends from 'params' map to properly use them later, when accessing jenkins_labels map to select a builder.
Reverts part of the changes made in
https://github.com/scylladb/scylla-cluster-tests/commit/0c48c9b5afdcd8373e807364be74591e12d7426e

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [artifacts-azure-image-test](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/artifacts-azure-image-test/2/)
- [x] [first build of a new job](https://jenkins.scylladb.com/job/scylla-master/job/nemesis/job/longevity-5gb-1h-ClusterRollingRestart-aws-test/) - regression check to ensure that fix for new jobs is working after this partial revert

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
