### PR TITLE
fix(full scan): wait more time before start the thread

### DIFF
--- a/sdcm/utils/operations_thread.py
+++ b/sdcm/utils/operations_thread.py
@@ -172,15 +172,15 @@ class OperationThread:
     def join(self, timeout=None):
         return self._thread.join(timeout)
 
-    def _wait_until_user_table_exists(self, timeout_min: int = 20):
+    def _wait_until_user_table_exists(self, timeout_min: int = 40):
         text = f'Waiting until {self.thread_params.ks_cf} user table exists'
         db_node = random.choice(self.thread_params.db_cluster.nodes)
 
         if self.thread_params.ks_cf.lower() == 'random':
             wait.wait_for(func=lambda: len(self.thread_params.db_cluster.get_non_system_ks_cf_list(db_node)) > 0,
-                          step=60, text=text, timeout=60 * timeout_min, throw_exc=False)
+                          step=60, text=text, timeout=60 * timeout_min, throw_exc=True)
             self.thread_params.ks_cf = self.thread_params.db_cluster.get_non_system_ks_cf_list(db_node)[0]
         else:
             wait.wait_for(func=lambda: self.thread_params.ks_cf in (
                 self.thread_params.db_cluster.get_non_system_ks_cf_list(db_node)
-            ), step=60, text=text, timeout=60 * timeout_min, throw_exc=False)
+            ), step=60, text=text, timeout=60 * timeout_min, throw_exc=True)


### PR DESCRIPTION
Due to potential issues with Docker Hub, the full scan operation thread may start before the required schema is created. When this occurs, an error message is generated.

To mitigate this, we currently wait for 20 minutes before starting the thread. To further reduce the likelihood of encountering this error, increase the timeout to 40 minutes.

Additionally, an exception should be thrown if the table is not available after waiting.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11850
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
