### PR TITLE
fix(check-generated-code-updates): skip org check for specfic bots

### DIFF
--- a/.github/workflows/check-generated-code-updates.yaml
+++ b/.github/workflows/check-generated-code-updates.yaml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - name: Check user for team affiliation
         uses: tspascoal/get-user-teams-membership@v3
+        if: github.event.pull_request.user.login != 'renovate[bot]'
         id: teamAffiliation
         with:
           GITHUB_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}


### PR DESCRIPTION
to avoid those kind of errors:

```
 - Could not resolve to a User with the login of 'renovate[bot]'.
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
