### PR TITLE
test(unit test): unit test for exclusive connection

### DIFF
--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -93,11 +93,7 @@ def prom_address():
     yield start_metrics_server()
 
 
-@pytest.fixture(name='docker_scylla', scope='function')
-def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # noqa: PLR0914
-    docker_scylla_args = {}
-    if test_marker := request.node.get_closest_marker("docker_scylla_args"):
-        docker_scylla_args = test_marker.kwargs
+def configure_scylla_node(docker_scylla_args: dict, params):  # noqa: PLR0914
     ssl = docker_scylla_args.get('ssl')
     docker_network = docker_scylla_args.get('docker_network')
     # make sure the path to the file is base on the host path, and not as the docker internal path i.e. /sct/
@@ -123,8 +119,13 @@ def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # noqa: PLR0
                          f' -v {ssl_dir}:{SCYLLA_SSL_CONF_DIR}:z'
                          f' --user root {env_vars} --entrypoint /entry.sh')
 
+    if seeds := docker_scylla_args.get("seeds"):
+        seeds = f" --seeds={seeds}"
+    else:
+        seeds = ""
+
     scylla = RemoteDocker(LocalNode("scylla", cluster), image_name=docker_version,
-                          command_line=f"--smp 1 {alternator_flags}",
+                          command_line=f"--smp 1 {alternator_flags}{seeds}",
                           extra_docker_opts=extra_docker_opts, docker_network=docker_network)
 
     if ssl:
@@ -164,6 +165,27 @@ def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # noqa: PLR0
     wait.wait_for(func=db_alternator_up, step=1, text='Waiting for DB services to be up alternator)',
                   timeout=120, throw_exc=True)
 
+    return scylla
+
+
+@pytest.fixture(name='docker_scylla', scope='function')
+def fixture_docker_scylla(request: pytest.FixtureRequest, params):  # noqa: PLR0914
+    docker_scylla_args = {}
+    if test_marker := request.node.get_closest_marker("docker_scylla_args"):
+        docker_scylla_args = test_marker.kwargs
+    scylla = configure_scylla_node(docker_scylla_args, params)
+    yield scylla
+
+    scylla.kill()
+
+
+@pytest.fixture(name='docker_scylla_2', scope='function')
+def fixture_docker_2_scylla(request: pytest.FixtureRequest, docker_scylla, params):  # noqa: PLR0914
+    docker_scylla_args = {}
+    if test_marker := request.node.get_closest_marker("docker_scylla_args"):
+        docker_scylla_args = test_marker.kwargs
+    docker_scylla_args['seeds'] = docker_scylla.ip_address
+    scylla = configure_scylla_node(docker_scylla_args, params)
     yield scylla
 
     scylla.kill()

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -974,6 +974,30 @@ def test_is_table_has_no_sstables(docker_scylla, params, events):
                                  f"Actual snapshot content: {sorted(snapshot_content_list)}")
 
 
+@pytest.mark.integration
+def test_exclusive_connection(docker_scylla, docker_scylla_2, params, events):
+    """
+    Test exclusive CQL connection creation for each node in the cluster.
+    Ensures that the session connects to the correct node.
+    Run 10 times to increase the chance of catching intermittent issues.
+    """
+    cluster = DummyScyllaCluster([docker_scylla, docker_scylla_2])
+    cluster.params = params
+
+    for i in range(10):
+        for node in cluster.nodes:
+            with cluster.cql_connection_patient_exclusive(node) as session:
+                print(f"Iteration {i}, Node {node.cql_address}")
+                local = session.execute("SELECT host_id, rpc_address FROM system.local").one()
+                peers = session.execute("SELECT host_id, peer, rpc_address FROM system.peers").one()
+                assert local.rpc_address == node.cql_address, (
+                    f"Local rpc_address: {local.rpc_address}, expected: {node.cql_address}"
+                )
+                assert peers.rpc_address != node.cql_address, (
+                    f"Peers rpc_address: {peers.rpc_address}, expected not: {node.cql_address}"
+                )
+
+
 class TestNodetool(unittest.TestCase):
     def test_describering_parsing(self):
         """ Test "nodetool describering" output parsing """


### PR DESCRIPTION
Test exclusive CQL connection creation for each node in the cluster. Ensures that the session connects to the correct node. Run 10 times to increase the chance of catching intermittent issues.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
