### PR TITLE
test(decorator): add log print outs

### DIFF
--- a/performance_regression_gradual_grow_throughput.py
+++ b/performance_regression_gradual_grow_throughput.py
@@ -307,6 +307,7 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
                                                       cycle_name=current_throttle_step))(self.run_step))
             results, _ = run_step(stress_cmds=workload.cs_cmd_tmpl, current_throttle=current_throttle,
                                   num_threads=num_threads, step_duration=workload.step_duration)
+            self.log.debug("All c-s commands results collected and saved in Argus")
 
             calculate_result = self._calculate_average_max_latency(results)
             self.update_test_details()

--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -288,14 +288,17 @@ def latency_calculator_decorator(original_function: Optional[Callable] = None, *
                 result["hdr_summary"] = tester.get_hdrhistogram(
                     hdr_tags=hdr_tags, stress_operation=workload,
                     start_time=start, end_time=end)
+                LOGGER.debug("HDR summary added to results: %s", result["hdr_summary"])
             except Exception as err:  # noqa: BLE001
                 LOGGER.error("Failed to get hdrhistogram error: %s", err)
                 result["hdr_summary"] = {}
             hdr_throughput = 0
             for summary, values in result["hdr_summary"].items():
                 hdr_throughput += values["throughput"]
+            LOGGER.debug("HDR throughput: %s", hdr_throughput)
             result["cycle_hdr_throughput"] = round(hdr_throughput)
             result["reactor_stalls_stats"] = reactor_stall_stats
+            LOGGER.debug("Reactor stalls stats: %s", reactor_stall_stats)
             error_thresholds = tester.params.get("latency_decorator_error_thresholds")
             if "steady" in func_name.lower():
                 if 'Steady State' not in latency_results:
@@ -312,6 +315,8 @@ def latency_calculator_decorator(original_function: Optional[Callable] = None, *
                     )
             else:
                 latency_results[func_name]['cycles'].append(result)
+                LOGGER.debug("latency_results: %s", latency_results)
+                LOGGER.debug("Send to Argus")
                 send_result_to_argus(
                     argus_client=tester.test_config.argus_client(),
                     workload=workload,
@@ -322,9 +327,12 @@ def latency_calculator_decorator(original_function: Optional[Callable] = None, *
                     start_time=start,
                     error_thresholds=error_thresholds,
                 )
+                LOGGER.debug("Saved in Argus")
 
+            LOGGER.debug("Write results into file")
             with open(latency_results_file_path, 'w', encoding="utf-8") as file:
                 json.dump(latency_results, file)
+            LOGGER.debug("Results written into file")
 
             return res
 


### PR DESCRIPTION
The Build HDR histogram summary is intermittently freezing (issue https://github.com/scylladb/scylla-cluster-tests/issues/10262). To assist with the investigation, log print statements have been added to latency_calculator_decorator.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
