### PR TITLE
fix(performance): disable parallel node operations

### DIFF
--- a/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
@@ -34,6 +34,7 @@ use_hdrhistogram: true
 use_placement_group: true
 use_capacity_reservation: true
 email_subject_postfix: 'latency during operations'
+parallel_node_operations: false  # doing this to align the measurement
 cluster_health_check: false
 stress_image:
   cassandra-stress: 'scylladb/cassandra-stress:3.17.5'


### PR DESCRIPTION
Disable parallel node operations in performance nemesis tests.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
