### PR TITLE
fix(ollingUpgradePipeline): remove `scylla_repo` from params

### DIFF
--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -204,6 +204,8 @@ def call(Map pipelineParams) {
                             def base_version = version
                             params_mapping[base_version] = params.collectEntries { param -> [param.key, param.value] }
                             params_mapping[base_version].put('scylla_version', base_version)
+                            // since scylla-pkg might pass this one, we are not supporting it here, as we always starts by version
+                            params_mapping[base_version].remove('scylla_repo')
 
                             // those params are not in the job params, so user can`t change them
                             // but they are coming from the pipelineParams, i.e. hardcoded per use case


### PR DESCRIPTION
since scylla-pkg is passing along both `scylla_repo` and `new_scylla_repo` we end up in situation we are having a conflict of input parameters

this change is removing the `scylla_repo` from params in the rolling upgrade pipelines

Fixes: #11851

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-ubuntu2404-test/5/ (with scylla_repo)
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-ubuntu2404-test/6/ (without scylla_repo

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
