### PR TITLE
Revert "Support scylla-doctor on offline non-root tests"

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -502,6 +502,13 @@ class ArtifactsTest(ClusterTester):
                 "Scylla Doctor test is skipped for encrypted environment due to issue field-engineering#2280")
             return
 
+        if self.db_cluster.nodes[0].is_nonroot_install and \
+                SkipPerIssues("https://github.com/scylladb/scylla-cluster-tests/issues/10540", self.params):
+            self.log.info("Scylla Doctor test is skipped for non-root test due to issue field-engineering#2254. ")
+            self.actions_log.info(
+                "Scylla Doctor test is skipped for non-root test due to issue field-engineering#2254.")
+            return
+
         if self.node.parent_cluster.cluster_backend == "docker":
             self.log.info("Scylla Doctor check in SCT isn't yet supported for docker backend")
             self.actions_log.info("Scylla Doctor check in SCT isn't yet supported for docker backend")

--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -397,6 +397,12 @@ class ArtifactsTest(ClusterTester):
                 assert node_info_service.cpu_load_5
                 assert node_info_service.get_node_boot_time_seconds()
 
+        if self.params.get("run_scylla_doctor"):
+            with self.logged_subtest("check scylla_doctor results"):
+                self.run_scylla_doctor()
+        else:
+            self.log.info("Running scylla-doctor is disabled")
+
         # We don't install any time sync service in docker, so the test is unnecessary:
         # https://github.com/scylladb/scylla/tree/master/dist/docker/etc/supervisord.conf.d
         if backend != "docker":
@@ -488,12 +494,6 @@ class ArtifactsTest(ClusterTester):
         if backend == 'docker':
             with self.logged_subtest("Check docker latest tags"):
                 self.verify_docker_latest_match_release()
-
-        if self.params.get("run_scylla_doctor"):
-            with self.logged_subtest("Run scylla-doctor on the installation"):
-                self.run_scylla_doctor()
-        else:
-            self.log.info("Running scylla-doctor is disabled")
 
     def run_scylla_doctor(self):
         if self.params.get('client_encrypt') and SkipPerIssues("https://github.com/scylladb/field-engineering/issues/2280", self.params):

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2158,7 +2158,6 @@ class BaseNode(AutoSshContainerMixin):
             else:
                 install_cmds = dedent("""
                     tar xvfz ./unified_package.tar.gz
-                    echo 'export PATH="$HOME/scylladb/share/cassandra/bin:$HOME/scylladb/bin:$PATH"' >> ~/.bashrc
                     cd ./scylla-*
                     ./install.sh --nonroot
                     cd -

--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -26,35 +26,6 @@ class ScyllaDoctor:
     SCYLLA_DOCTOR_OFFLINE_BUCKET_PREFIX = "downloads/scylla-doctor/tar/"
     SCYLLA_DOCTOR_OFFLINE_BIN = "scylla_doctor.pyz"
     SCYLLA_DOCTOR_OFFLINE_CONF = "scylla_doctor.conf"
-    SCYLLA_DOCTOR_DISABLED_OFFLINE_COLLECTORS = dedent("""
-        [GossipInfoCollector]
-        ; Doesn't work with systemd-user service
-        run = no
-        [TokenMetadataHostsMappingCollector]
-        ; Doesn't work with systemd-user service
-        run = no
-        [ScyllaClusterStatusCollector]
-        ; Doesn't work with systemd-user service
-        run = no
-        [ScyllaClusterSchemaCollector]
-        ; Doesn't work with systemd-user service
-        run = no
-        [KernelRingBufferCollector]
-        ; Requires root privileges
-        run = no
-        [ScyllaLimitNOFILECollector]
-        ; Requires root privileges
-        run = no
-        [ScyllaSystemConfigurationFilesCollector]
-        ; Requires root installation with configs in /etc
-        run = no
-        [PerftuneYamlDefaultCollector]
-        ; Depends on ScyllaSystemConfigurationFilesCollector
-        run = no
-        [PerftuneSystemConfigurationCollector]
-        ; perftune script requires root
-        run = no
-    """)
 
     def __init__(self, node: BaseNode, test_config: TestConfig, offline_install=False):
         self.node = node
@@ -107,7 +78,7 @@ class ScyllaDoctor:
         self.node.remoter.run(f"curl -JL {self.SCYLLA_DOCTOR_OFFLINE_DOWNLOAD_URI}{package_path} | tar -xvz")
         self.scylla_doctor_exec = f"{self.current_dir}/{self.SCYLLA_DOCTOR_OFFLINE_BIN}"
 
-    def update_scylla_doctor_config(self, prefix: str, additional_config=""):
+    def update_scylla_doctor_config(self, prefix: str):
         with remote_file(self.node.remoter, f"{self.current_dir}/{self.SCYLLA_DOCTOR_OFFLINE_CONF}") as f:
             config = dedent(f"""
                 [DefaultPaths]
@@ -115,8 +86,6 @@ class ScyllaDoctor:
                 scylla_directory_config = {prefix}/scylladb/etc/scylla
                 scylla_directory_configs = {prefix}/scylladb/etc/scylla.d
                 scylla_directory_var = {prefix}/scylladb
-
-                {additional_config}
             """)
             LOGGER.info("Updating scylla-doctor-config file...\n%s", config)
 
@@ -134,8 +103,7 @@ class ScyllaDoctor:
             self.download_scylla_doctor()
             if self.node.is_nonroot_install:
                 self.python3_path = self.find_local_python3_binary(self.current_dir)
-                self.update_scylla_doctor_config(
-                    self.current_dir, additional_config=self.SCYLLA_DOCTOR_DISABLED_OFFLINE_COLLECTORS)
+                self.update_scylla_doctor_config(self.current_dir)
         else:
             self.node.install_package('scylla-doctor')
 


### PR DESCRIPTION
Reverts scylladb/scylla-cluster-tests#11524

seems to be failing after it was merged, reverting it:

```
>       assert not failed_collectors, f"Failed collectors: {failed_collectors}. Scylla doctor version: {self.version}"
E       AssertionError: Failed collectors: {'CqlshCollector': {'status': 1, 'data': {}, 'output': [], 'message': 'calling cqlsh failed, please check cql authentication configuration', 'mask': []}, 'ClientConnectionCollector': {'status': 1, 'data': {}, 'output': [], 'message': 'Required CqlshCollector Collector has not run successfully', 'mask': ['*']}, 'RaftGroup0Collector': {'status': 1, 'data': {}, 'output': [], 'message': 'Required CqlshCollector Collector has not run successfully', 'mask': []}, 'ScyllaBinaryCollector': {'status': 1, 'data': {}, 'output': [], 'message': "'scylla' binary was not found in $PATH", 'mask': []}, 'ScyllaClusterSchemaDescriptionCollector': {'status': 1, 'data': {}, 'output': [], 'message': 'Required CqlshCollector Collector has not run successfully', 'mask': []}, 'ScyllaClusterSystemKeyspacesCollector': {'status': 1, 'data': {}, 'output': [], 'message': 'Required CqlshCollector Collector has not run successfully', 'mask': []}, 'ScyllaClusterTablesDescriptionCollector': {'status': 1, 'data': {}, 'output': [], 'message': 'Required CqlshCollector Collector has not run successfully', 'mask': []}, 'ScyllaVersionCollector': {'status': 1, 'data': {}, 'output': [], 'message': "Unexpected exception: [Errno 2] No such file or directory: 'scylla'", 'mask': []}, 'SystemClusterStatusCollector': {'status': 1, 'data': {}, 'output': [], 'message': 'Required CqlshCollector Collector has not run successfully', 'mask': []}, 'SystemConfigCollector': {'status': 1, 'data': {}, 'output': [], 'message': 'Required CqlshCollector Collector has not run successfully', 'mask': [['client_encryption_options', '*', 'certificate'], ['client_encryption_options', '*', 'keyfile'], ['client_encryption_options', '*', 'truststore'], ['server_encryption_options', '*', 'certificate'], ['server_encryption_options', '*', 'keyfile'], ['server_encryption_options', '*', 'truststore'], ['broadcast_address', '*'], ['api_address', '*'], ['listen_address', '*'], ['alternator_address', '*'], ['rpc_address', '*'], ['broadcast_rpc_address', '*'], ['initial_token', '*'], ['replace_node_first_boot', '*'], ['replace_address', '*'], ['replace_address_first_boot', '*'], ['ignore_dead_nodes_for_replace', '*']]}, 'SystemPeersLocalCollector': {'status': 1, 'data': {}, 'output': [], 'message': 'Required CqlshCollector Collector has not run successfully', 'mask': []}}. Scylla doctor version: version: 1.6
utils/scylla_doctor.py:214: AssertionError
```



[Argus](https://argus.scylladb.com/test/34c430ea-9b06-48a5-beb4-9ecd53033dc1/runs?additionalRuns[]=f5de367e-e867-4c69-8033-c92e23ff0748)

Scylla version: `2025.4.0~dev-20250901.5910ad3c6d4` with build-id ``





Kernel Version: `6.14.0-1014-gcp`

<details>
<summary>
Extra information
</summary>

## Installation details

Cluster size: 1 nodes (n2-standard-2)

Scylla Nodes used in this run:

    - artifacts-ubuntu2404-jenkins-db-node-f5de367e-0-1 (35.196.125.133 | 10.142.0.37) (shards: 2)



OS / Image: `https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64` (gce: N/A)

Test: `artifacts-ubuntu2404-nonroot-test`
Test id: `f5de367e-e867-4c69-8033-c92e23ff0748`
Test name: `scylla-master/artifacts-offline-install/artifacts-ubuntu2404-nonroot-test`

    Test method: `artifacts_test`

Test config file(s):

- [ubuntu2404.yaml](https://github.com/scylladb/scylla-cluster-tests/blob/93fb6bb16f339cc731a7667e75629374a68f9a60/test-cases/artifacts/ubuntu2404.yaml)


## Logs:

    - **[db-cluster-f5de367e.tar.zst](https://argus.scylladb.com/api/v1/tests/scylla-cluster-tests/f5de367e-e867-4c69-8033-c92e23ff0748/log/db-cluster-f5de367e.tar.zst/download)**


    - **[schema-logs-f5de367e.tar.zst](https://argus.scylladb.com/api/v1/tests/scylla-cluster-tests/f5de367e-e867-4c69-8033-c92e23ff0748/log/schema-logs-f5de367e.tar.zst/download)**


    - **[sct-runner-events-f5de367e.tar.zst](https://argus.scylladb.com/api/v1/tests/scylla-cluster-tests/f5de367e-e867-4c69-8033-c92e23ff0748/log/sct-runner-events-f5de367e.tar.zst/download)**


    - **[sct-f5de367e.log.tar.zst](https://argus.scylladb.com/api/v1/tests/scylla-cluster-tests/f5de367e-e867-4c69-8033-c92e23ff0748/log/sct-f5de367e.log.tar.zst/download)**


    - **[builder-f5de367e.log.tar.gz](https://argus.scylladb.com/api/v1/tests/scylla-cluster-tests/f5de367e-e867-4c69-8033-c92e23ff0748/log/builder-f5de367e.log.tar.gz/download)**


[Jenkins job URL](https://jenkins.scylladb.com/job/scylla-master/job/artifacts-offline-install/job/artifacts-ubuntu2404-nonroot-test/415/)
</details>

                            