### PR TITLE
feature(xcloud): introduce provising test CI

### DIFF
--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -1,7 +1,15 @@
 #!groovy
 import groovy.json.JsonSlurper
 
-def call(String backend, String region=null, String datacenter=null, String location=null) {
+def call(String backend, String region=null, String datacenter=null, String location=null, Map overrides=null) {
+    if (!(params instanceof Map)) {
+        params = params.collectEntries()
+    }
+    if (overrides == null){
+        overrides = [:]
+    }
+    params += overrides // merge, overrides take precedence
+
     if (!backend) {
         backend = 'aws'
         println("Backend is null or empty, defaulting to 'aws'")


### PR DESCRIPTION
this introce a way to use to validate xcloud support is working on any PR that might be touch related machinary

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
