### PR TITLE
fix(hdr analyze): HDR histogram summary

### DIFF
--- a/sdcm/utils/hdrhistogram.py
+++ b/sdcm/utils/hdrhistogram.py
@@ -1,3 +1,4 @@
+import concurrent
 import glob
 import os.path
 import time
@@ -139,12 +140,12 @@ class _HdrRangeHistogramBuilder:
             with ProcessPoolExecutor(max_workers=len(self.hdr_tags)) as executor:
                 futures = [
                     executor.submit(self.build_histogram_summary_by_tag, path, tag) for tag in self.hdr_tags]
-            scan_results = {}
-            for e, future in enumerate(futures):
-                result = future.result()
-                LOGGER.debug(f"Got result for {e} future for tag {self.hdr_tags[e]}")
-                if result:
-                    scan_results.update(result)
+                scan_results = {}
+                for e, future in enumerate(concurrent.futures.as_completed(futures, timeout=120)):
+                    result = future.result()
+                    LOGGER.debug(f"Got result for {e} future for tag {self.hdr_tags[e]}")
+                    if result:
+                        scan_results.update(result)
             return [scan_results]
         except Exception as e:
             LOGGER.error(f"Error building histogram summary for {path} with tags {self.hdr_tags}: {e}")


### PR DESCRIPTION
The HDR histogram summary build is intermittently freezing, which occasionally leads to test timeouts.
This commit aims to address and fix the issue.

Issue: https://github.com/scylladb/scylla-cluster-tests/issues/10262

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] [predefined-throughput-steps-sanity-vnodes](https://argus.scylladb.com/tests/scylla-cluster-tests/a325e9a0-871d-470b-9154-2605d77e6ca8)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
