### PR TITLE
fix(provision): remove counter commands from provision tests

### DIFF
--- a/test-cases/PR-provision-test-docker.yaml
+++ b/test-cases/PR-provision-test-docker.yaml
@@ -1,6 +1,5 @@
 test_duration: 60
 stress_cmd: ["cassandra-stress write cl=ONE duration=1m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=10 -pop seq=1..10000000 -log interval=5",
-             "cassandra-stress counter_write cl=ONE duration=1m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=1) compaction(strategy=TimeWindowCompactionStrategy)' -mode cql3 native -rate threads=5 -pop seq=1..10000000"
              ]
 
 n_loaders: 1
@@ -15,7 +14,3 @@ nemesis_interval: 1
 user_prefix: 'PR-provision-docker'
 
 use_mgmt: false
-
-append_scylla_yaml:
-  enable_tablets: false  # counters are not supported with tablets
-  tablets_mode_for_new_keyspaces: 'disabled'  # counters are not supported with tablets

--- a/test-cases/PR-provision-test.yaml
+++ b/test-cases/PR-provision-test.yaml
@@ -7,7 +7,6 @@ data_validation: |
   partition_range_with_data_validation: 0-10
 
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=1m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5",
-             "cassandra-stress counter_write cl=QUORUM duration=1m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=TimeWindowCompactionStrategy)' -mode cql3 native -rate threads=5 -pop seq=1..10000000"
              ]
 
 prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -max-rate=300 -replication-factor=3 -partition-count=10 -clustering-row-count=100 -clustering-row-size=5120 -concurrency=7 -rows-per-request=10",
@@ -28,7 +27,3 @@ user_prefix: 'PR-provision-test'
 instance_provision: 'spot'
 
 use_preinstalled_scylla: true
-
-append_scylla_yaml:
-  enable_tablets: false  # counters are not supported with tablets
-  tablets_mode_for_new_keyspaces: 'disabled'  # counters are not supported with tablets


### PR DESCRIPTION
counters isn't supported now by tablets, removing those commands
to avoid the complexity of handling the variations around them.

they are not that important for the goal of those tests

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested while developing xcloud on #11760

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
