### PR TITLE
improvement(healthcheck): wrap healthcheck with adaptive timeout

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4574,8 +4574,11 @@ class BaseScyllaCluster:
             # Don't run health check in case parallel nemesis.
             # TODO: find how to recognize, that nemesis on the node is running
             if self.nemesis_count == 1:
-                for node in self.nodes:
-                    node.check_node_health()
+                node_for_timeout = next((n for n in self.nodes if not n.running_nemesis), self.nodes[0])
+                with adaptive_timeout(Operations.HEALTHCHECK, node=node_for_timeout,
+                                      timeout=len(self.nodes) * 30):
+                    for node in self.nodes:
+                        node.check_node_health()
             else:
                 chc_event.message = "Test runs with parallel nemesis. Nodes health checks are disabled."
                 return

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5687,7 +5687,6 @@ def disrupt_method_wrapper(method, is_exclusive=False):  # noqa: PLR0915
                         nodes_set.log_message(
                             "{end_symbol} {msg} {end_symbol}".format(end_symbol='=' * 12, msg=end_msg))
 
-            args[0].cluster.check_cluster_health()
             num_data_nodes_after = len(args[0].cluster.data_nodes)
             num_zero_nodes_after = len(args[0].cluster.zero_nodes)
             if num_data_nodes_before != num_data_nodes_after:

--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -100,6 +100,7 @@ class Operations(Enum):
     SERVICE_LEVEL_PROPAGATION = ("service_level_propagation", _get_service_level_propagation_timeout,
                                  ("timeout", "service_level_for_test_step"))
     TABLET_MIGRATION = ("tablet_migration", _get_soft_timeout, ("timeout",))
+    HEALTHCHECK = ("healthcheck", _get_soft_timeout, ("timeout",))
 
 
 class TestInfoServices:


### PR DESCRIPTION
In order to track the duration of healthchecks, put adaptive timeout around it.
Because healthcheck is executed right before disruption, removed healthcheck after nemesis run. This way we don't run it twice for each nemesis.

closes: https://github.com/scylladb/scylla-cluster-tests/issues/9170

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - https://argus.scylladb.com/tests/scylla-cluster-tests/05f35cf2-8715-4e22-8482-292cc7378a57/results

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
