### PR TITLE
fix(1-1-restore): add new backup snapshot for Staging Cloud env

### DIFF
--- a/defaults/manager_restore_benchmark_snapshots.yaml
+++ b/defaults/manager_restore_benchmark_snapshots.yaml
@@ -191,7 +191,7 @@ sizes:  # size of backed up dataset in GB
 
   ### Cloud(Siren) cluster backups
 
-  aws_single_50gb:
+  aws_single_50gb_qa:
     tag: "sm_20250807105835UTC"
     locations:
       - "us-east-1:s3:scylla-cloud-backup-284-306-96tvd9-manager-tests"
@@ -214,7 +214,7 @@ sizes:  # size of backed up dataset in GB
       account_credential_id: 1
       sm_cluster_id: "808e3f91-7c65-4706-b5b3-06b9eaec2e84"
 
-  aws_multi_50gb_byoa:
+  aws_multi_50gb_byoa_qa:
     tag: "sm_20250806161516UTC"
     locations:
       - "eu-west-1:s3:scylla-cloud-backup-278-298-9b4qi5-manager-tests"
@@ -238,7 +238,7 @@ sizes:  # size of backed up dataset in GB
       account_credential_id: 1150
       sm_cluster_id: "53035d14-80b2-4999-8ef8-c23a0f72757e"
 
-  aws_multi_0gb_byoa:
+  aws_multi_0gb_byoa_qa:
     tag: "sm_20250729180522UTC"
     locations:
       - "eu-west-1:s3:scylla-cloud-backup-269-284-9wj31g-manager-tests"
@@ -262,7 +262,7 @@ sizes:  # size of backed up dataset in GB
       account_credential_id: 1150
       sm_cluster_id: "b115b262-cf22-4d0b-9ab4-ec8ae45f8a84"
 
-  gcp_single_50gb:
+  gcp_single_50gb_qa:
     tag: "sm_20250807110840UTC"
     locations:
       - "us-east1:gcs:scylla-cloud-backup-282-305-dw80f9-manager-tests"
@@ -285,7 +285,7 @@ sizes:  # size of backed up dataset in GB
       account_credential_id: 200
       sm_cluster_id: "27a615e8-b1ca-4e72-8e48-09f0d93ae438"
 
-  gcp_multi_50gb_byok:
+  gcp_multi_50gb_byok_qa:
     tag: "sm_20250807165015UTC"
     locations:
       - "us-east1:gcs:scylla-cloud-backup-288-312-4bo09m-manager-tests"
@@ -308,3 +308,26 @@ sizes:  # size of backed up dataset in GB
     one_one_restore_params:
       account_credential_id: 200
       sm_cluster_id: "39aacb96-842c-4800-8875-94af66adfe8d"
+
+  aws_single_50gb_byoa_staging:
+    tag: "sm_20250820162820UTC"
+    locations:
+      - "us-east-1:s3:scylla-cloud-backup-21054-21158-q28vz7-manager-tests"
+    exp_timeout: 3600  # 1 hour
+    scylla_version: "2025.2.1"
+    number_of_nodes: 3
+    prohibit_verification_read: false
+    dataset:
+      schema:
+        "50gb_ics_quorum_1024_1_2025_2_1":
+          - standard1: 50
+      num_of_rows: 52428800
+      compaction: "IncrementalCompactionStrategy"
+      cl: "QUORUM"
+      col_size: 1024
+      col_n: 1
+      replication: "NetworkTopologyStrategy"
+      rf: 3
+    one_one_restore_params:
+      account_credential_id: 8968
+      sm_cluster_id: "5bde9d5d-52e6-439c-a716-4121849d73b8"


### PR DESCRIPTION
Added new backup snapshot for AWS BYOA single DC cluster in Siren Staging environment.

Reworked naming approach to differentiate snapshots from QA and Staging Cloud environments.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [1-1-restore test](https://argus.scylladb.com/tests/scylla-cluster-tests/3a92e162-0de1-4420-8aa4-3bc82c96c950)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
