### PR TITLE
ci(manager): update default ScyllaDB version to 2025.3

### DIFF
--- a/jenkins-pipelines/manager/ubuntu22-manager-install.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-install.jenkinsfile
@@ -9,6 +9,8 @@ managerPipeline(
     test_name: 'mgmt_cli_test.ManagerInstallationTests.test_manager_installed_and_functional',
     test_config: 'test-cases/manager/manager-installation-set-distro.yaml',
 
+    scylla_version: '2025.2',
+
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/manager/ubuntu22-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-sanity.jenkinsfile
@@ -9,6 +9,8 @@ managerPipeline(
     test_name: 'mgmt_cli_test.ManagerSanityTests.test_manager_sanity',
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
 
+    scylla_version: '2025.2',
+
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
@@ -7,6 +7,8 @@ managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
 
+    scylla_version: '2025.2',
+
     // Upgrade from the previous minor release (the last one)
     manager_version: '3.5',
     target_manager_version: 'master_latest',

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -78,7 +78,7 @@ def call(Map pipelineParams) {
 
             separator(name: 'SCYLLA_DB', sectionHeader: 'ScyllaDB Configuration Selection')
             string(defaultValue: '', description: 'AMI ID for ScyllaDB ', name: 'scylla_ami_id')
-            string(defaultValue: "${pipelineParams.get('scylla_version', '2025.2')}", description: '', name: 'scylla_version')
+            string(defaultValue: "${pipelineParams.get('scylla_version', '2025.3')}", description: '', name: 'scylla_version')
             // When branching to manager version branch, set scylla_version to the latest release
             string(defaultValue: '', description: '', name: 'scylla_repo')
             string(defaultValue: "${pipelineParams.get('gce_image_db', '')}",


### PR DESCRIPTION
It's the latest Scylla release, so, should be used by default in Manager pipelines.

At the same time continue to use 2025.2 for some Manager jobs run on Ubuntu to keep testing coverage for this Scylla version

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [sanity test with Scylla 2025.3](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master-clone/job/ubuntu24-sanity-test/17)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
