### PR TITLE
fix(logging): move instance type logging to node logger

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1109,13 +1109,20 @@ class BaseNode(AutoSshContainerMixin):
         return f' ({", ".join(dc_info)})' if dc_info else ""
 
     def __str__(self):
-        # TODO: when new network_configuration will be supported by all backends, copy this function from sdcm.cluster_aws.AWSNode.__str__
-        #  to here
-        return 'Node %s [%s | %s%s]%s' % (
+        # If multiple network interface is defined on the node (AWS), private address in the `nodetool status`
+        # is IP that defined in broadcast_address. Keep this output in correlation with `nodetool status`
+        if (self.scylla_network_configuration and
+                self.scylla_network_configuration.broadcast_address_ip_type == "private"):
+            node_private_ip = self.scylla_network_configuration.broadcast_address
+        else:
+            node_private_ip = self.private_ip_address
+
+        return 'Node %s [%s | %s%s] (Type: %s)%s' % (
             self.name,
             self.public_ip_address,
-            self.private_ip_address,
+            node_private_ip,
             " | %s" % self.ipv6_ip_address if self.test_config.IP_SSH_CONNECTIONS == "ipv6" else "",
+            self._instance_type,
             self._dc_info_str())
 
     def restart(self):
@@ -4860,9 +4867,9 @@ class BaseScyllaCluster:
         if install_scylla:
             self._scylla_install(node)
         else:
-            self.log.info("Waiting for preinstalled Scylla")
+            node.log.info("Waiting for preinstalled Scylla")
             self._wait_for_preinstalled_scylla(node)
-            self.log.info("Done waiting for preinstalled Scylla")
+            node.log.info("Done waiting for preinstalled Scylla")
         if self.params.get('print_kernel_callstack'):
             save_kallsyms_map(node=node)
         if node.is_nonroot_install:
@@ -4939,7 +4946,7 @@ class BaseScyllaCluster:
         if self.is_additional_data_volume_used():
             result = node.remoter.sudo(cmd="scylla_io_setup")
             if result.ok:
-                self.log.info("Scylla_io_setup result: %s", result.stdout)
+                node.log.info("Scylla_io_setup result: %s", result.stdout)
 
         if self.params.get('force_run_iotune'):
             node.remoter.sudo(
@@ -4983,12 +4990,12 @@ class BaseScyllaCluster:
 
     def node_startup(self, node: BaseNode, verbose: bool = False, timeout: int = 3600):
         if not self.test_config.REUSE_CLUSTER:
-            self.log.debug('io.conf before reboot: %s', node.remoter.sudo(
+            node.log.debug('io.conf before reboot: %s', node.remoter.sudo(
                 f'cat {node.add_install_prefix("/etc/scylla.d/io.conf")}').stdout)
             node.start_scylla_server(verify_up=False)
             if self.params.get("jmx_heap_memory"):
                 node.restart_scylla_jmx()
-            self.log.debug(
+            node.log.debug(
                 'io.conf right after reboot: %s', node.remoter.sudo(f'cat {node.add_install_prefix("/etc/scylla.d/io.conf")}').stdout)
             if self.params.get('use_mgmt') and self.node_type == "scylla-db":
                 node.remoter.sudo(shell_script_cmd("""\
@@ -5416,7 +5423,7 @@ class BaseLoaderSet():
 
     def node_setup(self, node, verbose=False, **kwargs):
 
-        self.log.info('Setup in BaseLoaderSet')
+        node.log.info('Setup in BaseLoaderSet')
         node.wait_ssh_up(verbose=verbose)
 
         if node.distro.is_rhel_like:
@@ -5434,7 +5441,7 @@ class BaseLoaderSet():
         node_exporter_setup.install(node)
 
         if self.params.get("bare_loaders"):
-            self.log.info("Don't install anything because bare loaders requested")
+            node.log.info("Don't install anything because bare loaders requested")
             return
 
         if self.params.get('client_encrypt'):
@@ -5453,7 +5460,7 @@ class BaseLoaderSet():
         node.remoter.sudo("bash -cxe \"echo '*\t\thard\tcore\t\tunlimited\n*\t\tsoft\tcore\t\tunlimited' "
                           ">> /etc/security/limits.d/20-coredump.conf\"")
         if result.exit_status == 0:
-            self.log.debug('Skip loader setup for using a prepared AMI')
+            node.log.debug('Skip loader setup for using a prepared AMI')
         else:
             node.remoter.run('sudo usermod -aG docker $USER', change_context=True)
 
@@ -5643,7 +5650,7 @@ class BaseMonitorSet:
             json.dump(json.loads(json_data), file, indent=2)
 
     def node_setup(self, node, **kwargs):
-        self.log.info('TestConfig in BaseMonitorSet')
+        node.log.info('TestConfig in BaseMonitorSet')
         node.wait_ssh_up()
 
         if node.distro.is_rhel_like:

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -117,9 +117,8 @@ class AWSCluster(cluster.BaseCluster):
                          )
 
     def __str__(self):
-        return 'Cluster %s (AMI: %s Type: %s)' % (self.name,
-                                                  self._ec2_ami_id,
-                                                  self._ec2_instance_type)
+        return 'Cluster %s (AMI: %s)' % (self.name,
+                                         self._ec2_ami_id)
 
     @property
     def instance_profile_name(self) -> str | None:
@@ -468,21 +467,6 @@ class AWSNode(cluster.BaseNode):
                          base_logdir=base_logdir,
                          node_prefix=node_prefix,
                          dc_idx=dc_idx, rack=rack)
-
-    def __str__(self):
-        # If multiple network interface is defined on the node, private address in the `nodetool status` is IP that defined in
-        # broadcast_address. Keep this output in correlation with `nodetool status`
-        if self.scylla_network_configuration.broadcast_address_ip_type == "private":
-            node_private_ip = self.scylla_network_configuration.broadcast_address
-        else:
-            node_private_ip = self.private_ip_address
-
-        return 'Node %s [%s | %s%s]%s' % (
-            self.name,
-            self.public_ip_address,
-            node_private_ip,
-            " | %s" % self.ipv6_ip_address if self.test_config.IP_SSH_CONNECTIONS == "ipv6" else "",
-            self._dc_info_str())
 
     @cached_property
     def network_configuration(self):

--- a/sdcm/cluster_cloud.py
+++ b/sdcm/cluster_cloud.py
@@ -69,8 +69,8 @@ class CloudNode(cluster.BaseNode):
             rack=rack
         )
 
-    def __str__(self):
-        return f'CloudNode {self.name} [{self.public_ip_address} | {self.private_ip_address}]{self._dc_info_str()}'
+        instance_info = cloud_instance_data.get('instance', {})
+        self._instance_type = instance_info.get('externalId', 'CloudManaged')
 
     @cached_property
     def network_interfaces(self):

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -313,7 +313,6 @@ class GCECluster(cluster.BaseCluster):
             for disk_type, disk_size in self._add_disks.items():
                 if int(disk_size):
                     identifier += '%s: %s | ' % (disk_type, disk_size)
-        identifier += 'Type: %s' % self._gce_instance_type
         return identifier
 
     def _get_disk_url(self, disk_type='pd-standard', dc_idx=0):


### PR DESCRIPTION
Previously, when logging the instance type through cluster logger, the type logged was the one set at cluster object instantiation. If a new node of different type was added during a test, its type was not logged (the inittial type was still used).
The change moves logging of instace types from cluster to node logger.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [elasticity-90-percent-scale-out-larger-test](https://argus.scylladb.com/tests/scylla-cluster-tests/92f983c1-1e2a-4419-a894-136f77fb8dea/logs)
The logs show have proper instance type of initial nodes and e.g. after growth:
```
❯ grep 'Node.*db-node.*Type: i4i.large.*Waiting for preinstalled' sct-92f983c1.log
< t:2025-09-08 10:19:44,675 f:cluster.py      l:4870 c:sdcm.cluster_aws     p:INFO  > Node elasticity-test-ubuntu-db-node-92f983c1-1 [54.154.29.105 | 10.4.1.5] (Type: i4i.large): Waiting for preinstalled Scylla
< t:2025-09-08 10:19:46,669 f:cluster.py      l:4870 c:sdcm.cluster_aws     p:INFO  > Node elasticity-test-ubuntu-db-node-92f983c1-2 [54.194.62.166 | 10.4.1.236] (Type: i4i.large): Waiting for preinstalled Scylla
< t:2025-09-08 10:19:46,679 f:cluster.py      l:4870 c:sdcm.cluster_aws     p:INFO  > Node elasticity-test-ubuntu-db-node-92f983c1-3 [54.171.69.96 | 10.4.2.107] (Type: i4i.large): Waiting for preinstalled Scylla
❯ grep 'Node.*db-node.*Type: i4i.4xlarge.*Waiting for preinstalled' sct-92f983c1.log
< t:2025-09-08 15:03:38,789 f:cluster.py      l:4870 c:sdcm.cluster_aws     p:INFO  > Node elasticity-test-ubuntu-db-node-92f983c1-4 [54.229.121.155 | 10.4.2.129] (Type: i4i.4xlarge): Waiting for preinstalled Scylla
< t:2025-09-08 15:03:38,801 f:cluster.py      l:4870 c:sdcm.cluster_aws     p:INFO  > Node elasticity-test-ubuntu-db-node-92f983c1-6 [3.253.45.77 | 10.4.2.139] (Type: i4i.4xlarge): Waiting for preinstalled Scylla
< t:2025-09-08 15:03:39,297 f:cluster.py      l:4870 c:sdcm.cluster_aws     p:INFO  > Node elasticity-test-ubuntu-db-node-92f983c1-5 [34.241.192.240 | 10.4.2.156] (Type: i4i.4xlarge): Waiting for preinstalled Scylla
```

Also executed a provision test for xcloud backend locally, to ensure that generic logging of node details works for cloud claster nodes as well. Some nodes log entries with instance type:
```
< t:2025-09-08 11:54:55,211 f:cluster_cloud.py l:173  c:sdcm.cluster_cloud   p:DEBUG > Node pr-provision-test-dmitriy-db-node-9f2fd286-0-1 [34.249.117.128 | 172.31.0.164] (Type: i4i.large): Skip initializing remoter abstraction on scylla-cloud, pending until approach to SSHing/accessing nodes is developed
< t:2025-09-08 11:54:55,211 f:cluster_cloud.py l:178  c:sdcm.cluster_cloud   p:DEBUG > Node pr-provision-test-dmitriy-db-node-9f2fd286-0-1 [34.249.117.128 | 172.31.0.164] (Type: i4i.large): Skip waiting for SSH up on scylla-cloud, pending until approach to SSHing nodes is developed
< t:2025-09-08 11:54:55,211 f:cluster_cloud.py l:129  c:sdcm.cluster_cloud   p:DEBUG > Node pr-provision-test-dmitriy-db-node-9f2fd286-0-1 [34.249.117.128 | 172.31.0.164] (Type: i4i.large): Skip waiting for cloud-init on scylla-cloud, no approach to SSHing nodes for now
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
