### PR TITLE
fix(cloud-init): Get cloud-init version info without sudo

### DIFF
--- a/sdcm/provision/helpers/cloud_init.py
+++ b/sdcm/provision/helpers/cloud_init.py
@@ -36,7 +36,7 @@ def wait_cloud_init_completes(remoter: RemoteCmdRunnerBase, instance: VmInstance
     errors_found = False
     remoter.is_up(60 * 5)
     # examples: 24.1.3-0ubuntu3.3, 19.3-46.amzn2.0.2
-    cloud_init_version = Version(remoter.sudo("cloud-init --version 2>&1").stdout.split()[1].split('-')[0])
+    cloud_init_version = Version(remoter.run("cloud-init --version 2>&1").stdout.split()[1].split('-')[0])
     # cloud-init supports json output from version 23.4, see:
     # https://cloudinit.readthedocs.io/en/latest/explanation/return_codes.html#id1
     if cloud_init_version >= Version("23.4"):

--- a/unit_tests/provisioner/test_provision_sct_resources.py
+++ b/unit_tests/provisioner/test_provision_sct_resources.py
@@ -20,7 +20,7 @@ from sdcm.test_config import TestConfig
 def test_can_provision_instances_according_to_sct_configuration(params, test_config, azure_service, fake_remoter):
     """Integration test for provisioning sct resources according to SCT configuration."""
     fake_remoter.result_map = {r"sudo cloud-init status --wait": Result(stdout="..... \n status: done", stderr="nic", exited=0),
-                               r"sudo cloud-init --version": Result(stdout="/bin/ 19.2-amzn", stderr="", exited=0),
+                               r"cloud-init --version 2>&1": Result(stdout="/bin/ 19.2-amzn", stderr="", exited=0),
                                r"ls /var/lib/sct/cloud-init": Result(stdout="done", exited=0)}
     tags = TestConfig.common_tags()
     provision_sct_resources(params=params, test_config=test_config, azure_service=azure_service)
@@ -58,7 +58,7 @@ def test_can_provision_instances_according_to_sct_configuration(params, test_con
 def test_fallback_on_demand_when_spot_fails(fallback_on_demand, params, test_config, azure_service, fake_remoter):
 
     fake_remoter.result_map = {r"sudo cloud-init status --wait": Result(stdout="..... \n status: done", stderr="nic", exited=0),
-                               r"sudo cloud-init --version": Result(stdout="/bin/ 19.2-amzn", stderr="", exited=0),
+                               r"cloud-init --version 2>&1": Result(stdout="/bin/ 19.2-amzn", stderr="", exited=0),
                                r"ls /var/lib/sct/cloud-init": Result(stdout="done", exited=0)}
     provision_sct_resources(params=params, test_config=test_config, azure_service=azure_service)
     provisioner_eastus = provisioner_factory.create_provisioner(


### PR DESCRIPTION
Get cloud-init version without sudo. For some strange reason, monitor-node throws host dns error, if we use sudo.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/11682

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/LakshmipathiGanapathi/job/per_table_hints/job/azure_longeviity/134/consoleText

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
