### PR TITLE
improvement(actions_log): added more actions log lines

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -16,7 +16,7 @@ import re
 from contextlib import contextmanager
 from functools import cached_property
 import json
-from typing import Iterator, Any
+from typing import Iterator
 from unittest import SkipTest
 
 import yaml
@@ -65,9 +65,8 @@ class ArtifactsTest(ClusterTester):
         super().tearDown()
 
     @contextmanager
-    def logged_subtest(self, action: str,
-                       trace_id:  str | None = None, metadata: dict[str, Any] | None = None) -> Iterator[None]:
-        with self.actions_log.action_scope(action, self.node.name, trace_id, metadata):
+    def logged_subtest(self, action: str) -> Iterator[None]:
+        with self.actions_log.action_scope(action):
             with self.subTest(msg=action):
                 yield
 
@@ -80,7 +79,7 @@ class ArtifactsTest(ClusterTester):
         Validate reported version
         prev_id: check if new version is created
         """
-        self.actions_log.info("Validating scylla version in housekeepingdb", target=self.node.name)
+        self.actions_log.info("Validating scylla version in housekeepingdb")
         assert self.node.uuid, "Node UUID wasn't created"
 
         row = self.housekeeping.get_most_recent_record(query=f"SELECT id, version, ip, statuscode "
@@ -114,7 +113,7 @@ class ArtifactsTest(ClusterTester):
                 assert row[0] > prev_id, f"New row wasn't saved in {self.CHECK_VERSION_TABLE}"
             else:
                 assert row[0] == prev_id, f"New row was saved in {self.CHECK_VERSION_TABLE} unexpectedly"
-        self.actions_log.info("Scylla version in housekeepingdb is validated", target=self.node.name)
+        self.actions_log.info("Scylla version in housekeepingdb is validated")
         return row[0] if row else 0
 
     @property
@@ -144,7 +143,7 @@ class ArtifactsTest(ClusterTester):
             transport_str = c_s_transport_str(
                 self.params.get('peer_verification'), self.params.get('client_encrypt_mtls'))
             stress_cmd += f" -transport '{transport_str}'"
-        with self.actions_log.action_scope("running cassandra-stress", target=self.node.name, metadata={"stress_cmd": stress_cmd}):
+        with self.actions_log.action_scope("running cassandra-stress"):
             result = self.node.remoter.run(stress_cmd)
             assert "java.io.IOException" not in result.stdout
             assert "java.io.IOException" not in result.stderr
@@ -234,7 +233,7 @@ class ArtifactsTest(ClusterTester):
         if not self.params.get("use_preinstalled_scylla"):
             self.log.info("Skipping verifying the snitch due to the 'use_preinstalled_scylla' being set to False")
             self.actions_log.info(
-                "Skipping verifying the snitch due to the 'use_preinstalled_scylla' being set to False", target=self.node.name)
+                "Skipping verifying the snitch due to the 'use_preinstalled_scylla' being set to False")
             return
 
         describecluster_snitch = self.get_describecluster_info().snitch
@@ -275,7 +274,7 @@ class ArtifactsTest(ClusterTester):
 
     def verify_nvme_write_cache(self) -> None:
         if self.write_back_cache is None or self.node.parent_cluster.is_additional_data_volume_used():
-            self.actions_log.info("Skipped verifying NVMe write cache", target=self.node.name)
+            self.actions_log.info("Skipped verifying NVMe write cache")
             return
         expected_write_cache_value = "write back" if self.write_back_cache else "write through"
 
@@ -354,7 +353,7 @@ class ArtifactsTest(ClusterTester):
                     )
                 except SkipTest as exc:
                     self.log.info("Skipping IOTuneValidation due to %s", exc.args)
-                    self.actions_log.info("Skipped IOTuneValidation", target=self.node.name)
+                    self.actions_log.info("Skipped IOTuneValidation")
                 except Exception:  # noqa: BLE001
                     self.log.error("IOTuneValidator failed", exc_info=True)
                     TestFrameworkEvent(source={self.__class__.__name__},
@@ -515,7 +514,7 @@ class ArtifactsTest(ClusterTester):
             return
 
         for node in self.db_cluster.nodes:
-            with self.actions_log.action_scope("installing and running Scylla Doctor", target=node.name):
+            with self.actions_log.action_scope("installing and running Scylla Doctor"):
                 scylla_doctor = ScyllaDoctor(node, self.test_config, bool(self.params.get('unified_package')))
                 scylla_doctor.install_scylla_doctor()
                 scylla_doctor.argus_collect_sd_package()

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -241,7 +241,7 @@ class Nemesis(NemesisFlags):
         self.cluster: Union[BaseCluster, BaseScyllaCluster] = tester_obj.db_cluster
         self.loaders = tester_obj.loaders
         self.monitoring_set = tester_obj.monitors
-        nemesis_thread_name = f"Nemesis{uuid4()}"
+        nemesis_thread_name = f"Nemesis{uuid4().hex[:8]}"
         self.actions_log = get_action_logger(source=nemesis_thread_name)
         self.action_log_scope = self.actions_log.action_scope
         self.target_node: BaseNode = None
@@ -461,7 +461,7 @@ class Nemesis(NemesisFlags):
                                          extra_time_to_expiration=30):
             self.log.info('Kill all scylla processes in %s', self.target_node)
             with DbNodeLogger(self.cluster.nodes, "kill all scylla processes", target_node=self.target_node), \
-                    self.action_log_scope("pkill -9 scylla", target=self.target_node.name):
+                    self.action_log_scope(f"pkill -9 scylla on {self.target_node.name} node"):
                 self.target_node.remoter.sudo("pkill -9 scylla", ignore_status=True)
 
             # Wait for the process to be down before waiting for service to be restarted
@@ -470,7 +470,7 @@ class Nemesis(NemesisFlags):
             # Let's wait for the target Node to have their services re-started
             self.log.info('Waiting scylla services to be restarted after we killed them...')
             self.target_node.wait_db_up(timeout=14400)
-            self.actions_log.info("scylla process restarted", target=self.target_node.name)
+            self.actions_log.info(f"scylla process restarted on {self.target_node.name}")
             if (self.cluster.params.get('use_mgmt')
                     and SkipPerIssues('scylladb/scylla-manager#2813', params=self.tester.params)):
                 # Workaround for https://github.com/scylladb/scylla-manager/issues/2813
@@ -479,13 +479,13 @@ class Nemesis(NemesisFlags):
                 self.target_node.start_service(service_name='scylla-manager-agent', timeout=600, ignore_status=True)
             self.log.info('Waiting JMX services to be restarted after we killed them...')
             self.target_node.wait_jmx_up()
-        with self.action_log_scope("Wait for schema agreement", target=self.target_node.name):
+        with self.action_log_scope(f"Wait for schema agreement on {self.target_node.name}"):
             self.cluster.wait_for_schema_agreement()
 
     @decorate_with_context(ignore_raft_topology_cmd_failing)
     @target_all_nodes
     def disrupt_stop_wait_start_scylla_server(self, sleep_time=300):
-        with self.action_log_scope("Stop Scylla", target=self.target_node.name):
+        with self.action_log_scope(f"Stop Scylla on {self.target_node.name} node"):
             self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
         self.log.info("Sleep for %s seconds", sleep_time)
         time.sleep(sleep_time)
@@ -493,15 +493,15 @@ class Nemesis(NemesisFlags):
             # Kubernetes brings node up automatically, no need to start it up
             self.target_node.wait_node_fully_start(timeout=sleep_time)
             return
-        with self.action_log_scope("Start Scylla", target=self.target_node.name):
+        with self.action_log_scope(f"Start Scylla on {self.target_node.name} node"):
             self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
     @decorate_with_context(ignore_ycsb_connection_refused)
     @target_all_nodes
     def disrupt_stop_start_scylla_server(self):
-        with self.action_log_scope("Stop Scylla", target=self.target_node.name):
+        with self.action_log_scope(f"Stop Scylla on {self.target_node.name}"):
             self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
-        with self.action_log_scope("Start Scylla", target=self.target_node.name):
+        with self.action_log_scope(f"Start Scylla on  {self.target_node.name}"):
             self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
     @staticmethod
@@ -579,7 +579,7 @@ class Nemesis(NemesisFlags):
         ks_cf = f"{compaction_args.keyspace}.{compaction_args.columnfamily}"
         with DbNodeLogger(self.cluster.nodes, "start and stop major compaction", target_node=self.target_node,
                           additional_info=f"on {ks_cf}"), \
-                self.action_log_scope(f"start and stop major compaction on {ks_cf}", target=self.target_node.name):
+                self.action_log_scope(f"start and stop major compaction on {ks_cf} table on {self.target_node.name} node"):
             results = ParallelObject.run_named_tasks_in_parallel(
                 tasks={"trigger": trigger_func, "watcher": watch_func},
                 timeout=compaction_args.timeout + 5,
@@ -592,7 +592,7 @@ class Nemesis(NemesisFlags):
         )
 
     def clear_snapshots(self) -> None:
-        with self.action_log_scope("Clear snapshots", target=self.target_node.name):
+        with self.action_log_scope(f"Clear snapshots  on {self.target_node.name}"):
             result = self.target_node.run_nodetool("clearsnapshot")
         self.log.debug(result)
 
@@ -625,7 +625,7 @@ class Nemesis(NemesisFlags):
                              stop_func=compaction_args.compaction_ops.stop_scrub_compaction)
         ks_cf = f"{compaction_args.keyspace}.{compaction_args.columnfamily}"
         with DbNodeLogger(self.cluster.nodes, "start and stop scrub compaction", target_node=self.target_node), \
-                self.action_log_scope(f"start and stop scrub compaction on {ks_cf}", target=self.target_node.name):
+                self.action_log_scope(f"start and stop scrub compaction on {ks_cf} table on {self.target_node.name} node"):
             results = ParallelObject.run_named_tasks_in_parallel(
                 tasks={"trigger": trigger_func, "watcher": watch_func},
                 timeout=compaction_args.timeout + 5,
@@ -669,7 +669,7 @@ class Nemesis(NemesisFlags):
 
         ks_cf = f"{compaction_args.keyspace}.{compaction_args.columnfamily}"
         with DbNodeLogger(self.cluster.nodes, "start and stop cleanup compaction", target_node=self.target_node), \
-                self.action_log_scope(f"start and stop cleanup compaction on {ks_cf}", target=self.target_node.name):
+                self.action_log_scope(f"start and stop cleanup compaction on {ks_cf} table on {self.target_node.name} node"):
             results = ParallelObject.run_named_tasks_in_parallel(
                 tasks={"trigger": trigger_func, "watcher": watch_func},
                 timeout=compaction_args.timeout + 5,
@@ -712,7 +712,7 @@ class Nemesis(NemesisFlags):
 
         ks_cf = f"{compaction_args.keyspace}.{compaction_args.columnfamily}"
         with DbNodeLogger(self.cluster.nodes, "start and stop validation compaction", target_node=self.target_node), \
-                self.action_log_scope(f"start and stop validation compaction on {ks_cf}", target=self.target_node.name):
+                self.action_log_scope(f"start and stop validation compaction on {ks_cf} on {self.target_node.name} node"):
             results = ParallelObject.run_named_tasks_in_parallel(
                 tasks={"trigger": trigger_func, "watcher": watch_func},
                 timeout=compaction_args.timeout + 5,
@@ -733,7 +733,7 @@ class Nemesis(NemesisFlags):
             DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE,
                            line="Can't find a column family with UUID", node=self.target_node):
             with DbNodeLogger(self.cluster.nodes, "restart node", target_node=self.target_node), \
-                    self.action_log_scope("Restart the node", target=self.target_node.name):
+                    self.action_log_scope(f"Restart {self.target_node.name} node"):
                 self.target_node.restart()
 
         self.target_node.wait_node_fully_start(timeout=28800)  # 8 hours
@@ -742,7 +742,7 @@ class Nemesis(NemesisFlags):
     @target_all_nodes
     def disrupt_resetlocalschema(self):
         rlocal_schema_res = self.target_node.follow_system_log(patterns=["schema_tables - Schema version changed to"])
-        with self.action_log_scope("Reset local schema", target=self.target_node.name):
+        with self.action_log_scope(f"Reset local schema on {self.target_node.name}"):
             self.target_node.run_nodetool("resetlocalschema")
 
         assert wait_for(
@@ -761,7 +761,7 @@ class Nemesis(NemesisFlags):
     @target_all_nodes
     def disrupt_hard_reboot_node(self):
         self.reboot_node(target_node=self.target_node, hard=True)
-        with self.action_log_scope("Wait for node to be fully started", target=self.target_node.name):
+        with self.action_log_scope(f"Wait for {self.target_node.name} node to be fully started"):
             self.target_node.wait_node_fully_start()
 
     @target_all_nodes
@@ -778,7 +778,7 @@ class Nemesis(NemesisFlags):
 
         num_of_reboots = random.randint(2, 10)
         InfoEvent(message=f'MultipleHardRebootNode {self.target_node}').publish()
-        self.actions_log.info(f"Rebooting node {num_of_reboots} times", target=self.target_node.name)
+        self.actions_log.info(f"Rebooting node {self.target_node.name} {num_of_reboots} times")
         for i in range(num_of_reboots):
             self.log.debug("Rebooting %s out of %s times", i + 1, num_of_reboots)
             cdc_expected_error = self.target_node.follow_system_log(patterns=cdc_expected_error_patterns)
@@ -814,13 +814,13 @@ class Nemesis(NemesisFlags):
     @target_all_nodes
     def disrupt_soft_reboot_node(self):
         self.reboot_node(target_node=self.target_node, hard=False)
-        with self.action_log_scope("Wait for node to be fully started", target=self.target_node.name):
+        with self.action_log_scope(f"Wait for {self.target_node.name} node to be fully started"):
             self.target_node.wait_node_fully_start()
 
     @decorate_with_context(ignore_ycsb_connection_refused)
     @target_all_nodes
     def disrupt_rolling_restart_cluster(self, random_order=False):
-        with self.action_log_scope("Rolling restart cluster", metadata={"random_order": random_order}):
+        with self.action_log_scope(f"Rolling restart cluster. random order: {random_order}"):
             self.cluster.restart_scylla(random_order=random_order)
 
     def disrupt_switch_between_password_authenticator_and_saslauthd_authenticator_and_back(self):
@@ -846,8 +846,7 @@ class Nemesis(NemesisFlags):
             else:
                 raise UnsupportedNemesis(
                     'This nemesis only supports to switch between SaslauthdAuthenticator and PasswordAuthenticator')
-        with self.action_log_scope("Switch Authenticator", target=self.target_node.name,
-                                   metadata={"from": orig_auth, "to": opposite_auth}):
+        with self.action_log_scope(f"Switch Authenticator from {orig_auth} to {opposite_auth}"):
             update_authenticator(self.cluster.nodes, opposite_auth)
         try:
             # Run connect a new session after authenticator switch, and run a short workload
@@ -857,8 +856,7 @@ class Nemesis(NemesisFlags):
             # Wait 2 mins to let the workloads run with new Authenticator,
             # then switch Authenticator back to original
             time.sleep(120)
-            with self.action_log_scope("Switch Authenticator back", target=self.target_node.name,
-                                       metadata={"from": opposite_auth, "to": orig_auth}):
+            with self.action_log_scope(f"Switch Authenticator back from {opposite_auth} to {orig_auth}"):
                 update_authenticator(self.cluster.nodes, orig_auth)
             # Run connect a new session after authenticator switch, drop the test keyspace
             with self.cluster.cql_connection_patient(self.target_node) as session:
@@ -881,8 +879,7 @@ class Nemesis(NemesisFlags):
         with self.target_node.remote_scylla_yaml() as scylla_yaml:
             current = scylla_yaml.internode_compression
         new_value = get_internode_compression_new_value_randomly(current)
-        self.actions_log.info("Changing inter node compression",
-                              metadata={"from": current, "to": new_value})
+        self.actions_log.info(f"Changing inter node compression from {current} to {new_value}")
         for node in self.cluster.nodes:
             self.log.debug(f"Changing {node} inter node compression to {new_value}")
             with node.remote_scylla_yaml() as scylla_yaml:
@@ -906,10 +903,10 @@ class Nemesis(NemesisFlags):
         murmur3_partitioner_ignore_msb_bits = 15
         self.log.info(f'Restart node with resharding. New murmur3_partitioner_ignore_msb_bits value: '
                       f'{murmur3_partitioner_ignore_msb_bits}')
-        with self.action_log_scope("Restart with resharding", target=self.target_node.name):
+        with self.action_log_scope(f"Restart with resharding on {self.target_node.name}"):
             self.target_node.restart_node_with_resharding(
                 murmur3_partitioner_ignore_msb_bits=murmur3_partitioner_ignore_msb_bits)
-        with self.action_log_scope("Wait node fully start", target=self.target_node.name):
+        with self.action_log_scope(f"Wait {self.target_node.name} node fully start"):
             self.target_node.wait_node_fully_start()
 
         # Wait 5 minutes our before return back the default value
@@ -917,7 +914,7 @@ class Nemesis(NemesisFlags):
             'Wait 5 minutes our before return murmur3_partitioner_ignore_msb_bits back the default value (12)')
         time.sleep(360)
         self.log.info('Set back murmur3_partitioner_ignore_msb_bits value to 12')
-        with self.action_log_scope("Restart with resharding to original state", target=self.target_node.name):
+        with self.action_log_scope(f"Restart with resharding to original state on {self.target_node.name} node"):
             self.target_node.restart_node_with_resharding()
 
     def replace_full_file_name_to_prefix(self, one_file, ks_cf_for_destroy):
@@ -1003,7 +1000,7 @@ class Nemesis(NemesisFlags):
         self.log.debug("Chosen tables: %s", tables)
 
         # Stop scylla service before deleting sstables to avoid partial deletion of files that are under compaction
-        with self.action_log_scope("Stop Scylla", target=self.target_node.name):
+        with self.action_log_scope(f"Stop Scylla on {self.target_node.name}"):
             self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
 
         try:
@@ -1034,10 +1031,10 @@ class Nemesis(NemesisFlags):
                 sstables_amount_to_destroy -= 1
                 destroyed_files += 1
                 self.log.debug('Files {} were destroyed'.format(file_for_destroy))
-            self.actions_log.info(f"removed {destroyed_files} files in tables: {tables}", target=self.target_node.name)
+            self.actions_log.info(f"removed {destroyed_files} files in tables: {tables} on {self.target_node.name}")
 
         finally:
-            with self.action_log_scope("Start Scylla", target=self.target_node.name):
+            with self.action_log_scope(f"Start Scylla on {self.target_node.name} node"):
                 self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
     def disrupt(self):
@@ -1064,13 +1061,13 @@ class Nemesis(NemesisFlags):
     def disrupt_destroy_data_then_rebuild(self):
         self._destroy_data_and_restart_scylla()
         # try to save the node
-        with self.action_log_scope("Rebuild after destroy data", target=self.target_node.name):
+        with self.action_log_scope(f"Rebuild after destroy data on {self.target_node.name} node"):
             self.repair_nodetool_rebuild()
 
     @decorate_with_context(ignore_ycsb_connection_refused)
     @target_all_nodes
     def disrupt_nodetool_drain(self):
-        with self.action_log_scope("Draining Scylla", target=self.target_node.name):
+        with self.action_log_scope(f"Draining Scylla on {self.target_node.name} node"):
             result = self.target_node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True)
         self.target_node.run_nodetool("status", ignore_status=True, verbose=True,
                                       warning_event_on_exception=(Exception,))
@@ -1079,7 +1076,7 @@ class Nemesis(NemesisFlags):
             # workaround for issue #7332: don't interrupt test and don't raise exception
             # for UnexpectedExit, Failure and CommandTimedOut if "scylla-server stop" failed
             # or scylla-server was stopped gracefully.
-            with self.action_log_scope("Restart Scylla", target=self.target_node.name):
+            with self.action_log_scope(f"Restart Scylla on {self.target_node.name} node"):
                 self.target_node.stop_scylla_server(verify_up=False, verify_down=True, ignore_status=True)
                 self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
@@ -1181,7 +1178,7 @@ class Nemesis(NemesisFlags):
         try:
             with adaptive_timeout(Operations.NEW_NODE, node=self.cluster.data_nodes[0], timeout=timeout):
                 self.cluster.wait_for_init(node_list=[new_node], timeout=timeout, check_node_health=False)
-            self.actions_log.info("New node initialized", metadata={"name": new_node.name})
+            self.actions_log.info(f"New node initialized: {new_node.name}")
             self.cluster.clean_replacement_node_options(new_node)
             self.cluster.set_seeds()
             self.cluster.update_seed_provider()
@@ -1193,7 +1190,7 @@ class Nemesis(NemesisFlags):
         self.cluster.wait_for_nodes_up_and_normal(nodes=[new_node])
         new_node.wait_node_fully_start()
         InfoEvent(message="FinishEvent - New Node is up and normal").publish()
-        self.actions_log.info("New node is up and normal", metadata={"name": new_node.name})
+        self.actions_log.info(f"New node is up and normal: {new_node.name}")
         return new_node
 
     def _add_and_init_new_cluster_nodes(self, count, timeout=MAX_TIME_WAIT_FOR_NEW_NODE_UP, rack=None, instance_type: str = None, is_zero_node: bool = False) -> list[BaseNode]:
@@ -1213,7 +1210,7 @@ class Nemesis(NemesisFlags):
             instance_type = self.cluster.params.get("zero_token_instance_type_db") or instance_type
             add_node_func_args.update({"is_zero_node": is_zero_node, "instance_type": instance_type})
 
-        with self.action_log_scope("Add new nodes", metadata={"count": count, "rack": rack, "instance_type": instance_type}):
+        with self.action_log_scope(f"Add {count} new nodes on {rack} rack, {instance_type} type"):
             new_nodes = skip_on_capacity_issues(db_cluster=self.tester.db_cluster)(
                 self.cluster.add_nodes)(**add_node_func_args)
         self.monitoring_set.reconfigure_scylla_monitoring()
@@ -1221,7 +1218,7 @@ class Nemesis(NemesisFlags):
         try:
             with adaptive_timeout(Operations.NEW_NODE, node=self.cluster.data_nodes[0], timeout=timeout):
                 self.cluster.wait_for_init(node_list=new_nodes, timeout=timeout, check_node_health=False)
-            self.actions_log.info("New nodes initialized", metadata={"names": nodes_names})
+            self.actions_log.info(f"New nodes initialized: {nodes_names}")
             self.cluster.set_seeds()
             self.cluster.update_seed_provider()
         except (NodeSetupFailed, NodeSetupTimeout):
@@ -1234,12 +1231,12 @@ class Nemesis(NemesisFlags):
             new_node.wait_native_transport()
         self.cluster.wait_for_nodes_up_and_normal(nodes=new_nodes)
         InfoEvent(message="FinishEvent - New Nodes are up and normal").publish()
-        self.actions_log.info("New nodes are up and normal", metadata={"names": nodes_names})
+        self.actions_log.info(f"New nodes are up and normal: {nodes_names}")
         return new_nodes
 
     @decorate_with_context([ignore_ycsb_connection_refused, ignore_raft_topology_cmd_failing])
     def _terminate_cluster_node(self, node):
-        with self.action_log_scope("Terminate node", target=node.name):
+        with self.action_log_scope(f"Terminate {node.name} node"):
             self.cluster.terminate_node(node)
         self.monitoring_set.reconfigure_scylla_monitoring()
 
@@ -1249,8 +1246,8 @@ class Nemesis(NemesisFlags):
             self.set_target_node(allow_only_last_node_in_rack=True)
 
         target_is_seed = self.target_node.is_seed
-        with self.action_log_scope("Decommission node", target=self.target_node.name,
-                                   metadata={"is_zero_token_node": self.target_node._is_zero_token_node}):
+        with self.action_log_scope(f"Decommission {self.target_node.name} node."
+                                   f" is_zero_token_node: {self.target_node._is_zero_token_node}"):
             dc_topology_rf_change = self.cluster.decommission(self.target_node)
         new_node = None
         if add_node:
@@ -1267,7 +1264,7 @@ class Nemesis(NemesisFlags):
             if new_node.is_seed != target_is_seed:
                 new_node.set_seed_flag(target_is_seed)
                 self.cluster.update_seed_provider()
-            self.actions_log.info("new node added", metadata={"name": new_node.name})
+            self.actions_log.info(f"new node added: {new_node.name}")
             if dc_topology_rf_change:
                 dc_topology_rf_change.revert_to_original_keyspaces_rf(node_to_wait_for_balance=new_node)
             self.nodetool_cleanup_on_all_nodes_parallel()
@@ -1523,7 +1520,7 @@ class Nemesis(NemesisFlags):
 
     @target_all_nodes
     def disrupt_terminate_and_replace_node(self):
-        with self.action_log_scope("Terminate and replace node", target=self.target_node.name):
+        with self.action_log_scope(f"Terminate and replace {self.target_node.name} node"):
             self._terminate_and_replace_node()
 
     def _terminate_and_replace_node(self):
@@ -1604,7 +1601,7 @@ class Nemesis(NemesisFlags):
 
     def _major_compaction(self):
         with (adaptive_timeout(Operations.MAJOR_COMPACT, self.target_node, timeout=8000),
-              self.action_log_scope("Major compaction", target=self.target_node.name)):
+              self.action_log_scope(f"Major compaction on {self.target_node.name} node")):
             self.target_node.run_nodetool("compact")
 
     def disrupt_major_compaction(self):
@@ -1629,12 +1626,12 @@ class Nemesis(NemesisFlags):
             map_files_to_node = SstableLoadUtils.distribute_test_files_to_cluster_nodes(nodes=self.cluster.data_nodes,
                                                                                         test_data=test_data)
             for sstables_info, load_on_node in map_files_to_node:
-                self.actions_log.info('Uploading sstables', target=load_on_node.name)
+                self.actions_log.info(f"Uploading sstables to {load_on_node.name}")
                 SstableLoadUtils.upload_sstables(load_on_node, test_data=sstables_info, table_name="standard1")
                 # NOTE: on K8S logs may appear with a delay, so add a bigger timeout for it.
                 #       See https://github.com/scylladb/scylla-cluster-tests/issues/6314
                 kwargs = {"start_timeout": 1800, "end_timeout": 1800} if self._is_it_on_kubernetes() else {}
-                with self.action_log_scope('Loading and streaming sstables', target=load_on_node.name):
+                with self.action_log_scope(f"Loading and streaming sstables on {load_on_node.name} node"):
                     SstableLoadUtils.run_load_and_stream(load_on_node, **kwargs)
 
     @target_all_nodes
@@ -1671,13 +1668,13 @@ class Nemesis(NemesisFlags):
             for node in self.cluster.data_nodes:
                 SstableLoadUtils.upload_sstables(node, test_data=test_data[0], table_name="standard1",
                                                  is_cloud_cluster=self.cluster.params.get("db_type") == 'cloud_scylla')
-                with self.action_log_scope('Running nodetool refresh', target=node.name):
+                with self.action_log_scope(f"Running nodetool refresh on {node.name} node"):
                     system_log_follower = SstableLoadUtils.run_refresh(node, test_data=test_data[0])
                 # NOTE: resharding happens only if we have more than 1 core.
                 #       We may have 1 core in a K8S multitenant setup.
                 # If tablets in use, skipping resharding validation since it doesn't work the same as vnodes
                 if shards_num > 1 and not is_tablets_feature_enabled(self.cluster.data_nodes[0]):
-                    self.actions_log.info('Validating resharding after refresh', target=node.name)
+                    self.actions_log.info(f"Validating resharding after refresh on {node.name}")
                     SstableLoadUtils.validate_resharding_after_refresh(
                         node=node, system_log_follower=system_log_follower)
 
@@ -1699,14 +1696,14 @@ class Nemesis(NemesisFlags):
             experiment = IOFaultChaosExperiment(node, duration="300s", error=DiskError.NO_SPACE_LEFT_ON_DEVICE, error_probability=100,
                                                 methods=["write", "flush"],
                                                 volume_path="/var/lib/scylla")
-            with self.action_log_scope("Creating IOFault (NO_SPACE_LEFT_ON_DEVICE) experiment", target=node.name):
+            with self.action_log_scope(f"Starting IOFault (NO_SPACE_LEFT_ON_DEVICE) experiment on {node.name} node"):
                 experiment.start()
                 experiment.wait_until_finished()
             # wait some time before restarting to prevent supervisorctl error.
             time.sleep(30)
         finally:
             no_space_errors = list(no_space_errors_in_log)
-            self.actions_log.info("Restarting scylla-server", target=node.name)
+            self.actions_log.info(f"Restarting scylla-server on {node.name}")
             node.restart_scylla_server(verify_up_after=True)
             assert no_space_errors, "There are no 'No space left on device' errors in db log during enospc disruption."
 
@@ -1731,11 +1728,11 @@ class Nemesis(NemesisFlags):
 
                     try:
                         with DbNodeLogger(self.cluster.nodes, "fill disk space", target_node=node):
-                            self.actions_log.info("Filling disk space to reach enospc error", target=node.name)
+                            self.actions_log.info(f"Filling disk space to reach enospc error on {node.name}")
                             reach_enospc_on_node(target_node=node)
                     finally:
                         with DbNodeLogger(self.cluster.nodes, "clean disk space", target_node=node):
-                            self.actions_log.info("Cleaning disk space with scylla restart", target=node.name)
+                            self.actions_log.info(f"Cleaning disk space with scylla restart on {node.name}")
                             clean_enospc_on_node(target_node=node, sleep_time=sleep_time)
 
     @target_all_nodes
@@ -1764,7 +1761,7 @@ class Nemesis(NemesisFlags):
         result = node.remoter.run('cat /proc/mounts')
         if '/var/lib/scylla' not in result.stdout:
             raise UnsupportedNemesis("Scylla doesn't use an individual storage, skip end of quota test")
-        self.actions_log.info("enabling quota on node", target=node.name)
+        self.actions_log.info(f"enabling quota on node {node.name}")
         enable_quota_on_node(node)
         quota_enabled = is_quota_enabled_on_node(node)
         if not quota_enabled:
@@ -1772,11 +1769,11 @@ class Nemesis(NemesisFlags):
 
         with ignore_disk_quota_exceeded_errors(node):
             with configure_quota_on_node_for_scylla_user_context(node) as quota_size:
-                self.actions_log.info("reach end of quota on node", target=node.name)
+                self.actions_log.info(f"reach end of quota on node {node.name}")
                 write_data_to_reach_end_of_quota(node, quota_size)
             LOGGER.debug('Sleep 15 seconds before restart scylla-server')
             time.sleep(15)
-            self.actions_log.info("Restarting scylla", target=node.name)
+            self.actions_log.info(f"Restarting scylla on {node.name}")
             node.restart_scylla_server()
             node.wait_db_up()
 
@@ -1803,13 +1800,11 @@ class Nemesis(NemesisFlags):
             role.attached_service_level.session = session
             role.session = session
             try:
-                self.actions_log.info("Dropping service level",
-                                      metadata={"service_level": role.attached_service_level_name})
+                self.actions_log.info(f"Dropping service level {role.attached_service_level_name}")
                 role.attached_service_level.drop(if_exists=False)
                 time.sleep(300)  # let load to run without service level for 5 minutes
             finally:
-                self.actions_log.info("Re-creating service level",
-                                      metadata={"service_level": role.attached_service_level_name})
+                self.actions_log.info(f"Re-creating service level {role.attached_service_level_name}")
                 role.attach_service_level(
                     ServiceLevel(session=session,
                                  name=SERVICE_LEVEL_NAME_TEMPLATE % (removed_shares, random.randint(0, 10)),
@@ -1907,7 +1902,7 @@ class Nemesis(NemesisFlags):
     def repair_nodetool_repair(self, node=None, publish_event=True):
         node = node if node else self.target_node
         with adaptive_timeout(Operations.REPAIR, node, timeout=HOUR_IN_SEC * 48), \
-                self.action_log_scope("Start nodetool repair", target=node.name):
+                self.action_log_scope(f"Start nodetool repair on {node.name} node"):
             node.run_nodetool(sub_cmd="repair", publish_event=publish_event)
 
     def run_repair_on_nodes(self, nodes: list,  ignore_down_hosts=False, publish_event=True):
@@ -1919,7 +1914,7 @@ class Nemesis(NemesisFlags):
             for node in nodes:
                 try:
                     with adaptive_timeout(Operations.REPAIR, node, timeout=HOUR_IN_SEC * 3), \
-                            self.action_log_scope("nodetool repair -pr", target=node.name):
+                            self.action_log_scope(f"nodetool repair -pr on {node.name} node"):
                         node.run_nodetool(sub_cmd="repair -pr", publish_event=publish_event)
                 except Exception as err:  # pylint: disable=broad-except  # noqa: BLE001
                     self.log.warning(f"Repair failed to complete on node: {node}, with error: {str(err)}")
@@ -1988,7 +1983,7 @@ class Nemesis(NemesisFlags):
         table = 'standard1'
 
         ks_cf = f"{keyspace_truncate}.{table}"
-        self.actions_log.info("Preparing test table for truncate nemesis", metadata={"ks_cf": ks_cf})
+        self.actions_log.info(f"Preparing test table for truncate nemesis: {ks_cf}")
         self._prepare_test_table(ks=keyspace_truncate)
 
         # In order to workaround issue #4924 when truncate timeouts, we try to flush before truncate.
@@ -1997,8 +1992,7 @@ class Nemesis(NemesisFlags):
         # do the actual truncation
         truncate_timeout = 600
         truncate_cmd_timeout_suffix = self._truncate_cmd_timeout_suffix(truncate_timeout)
-        with self.action_log_scope("Truncate table using cqlsh", target=self.target_node.name,
-                                   metadata={"timeout": truncate_timeout, "ks_cf": ks_cf}):
+        with self.action_log_scope(f"Truncate {ks_cf} table using cqlsh"):
             self.target_node.run_cqlsh(
                 cmd=f'TRUNCATE {keyspace_truncate}.{table}{truncate_cmd_timeout_suffix}',
                 timeout=truncate_timeout)
@@ -2020,8 +2014,7 @@ class Nemesis(NemesisFlags):
                      "-clustering-row-count=5555 -clustering-row-size=uniform:10..20 -concurrency=10 " + \
                      "-connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=60s " + \
                      f"-keyspace {ks_name} -table {table}"
-        self.actions_log.info("Preparing test table for truncate with scylla-bench",
-                              metadata={"ks_cf": ks_cf})
+        self.actions_log.info(f"Preparing test table for truncate with scylla-bench: {ks_cf}")
         bench_thread = self.tester.run_stress_thread(
             stress_cmd=stress_cmd, stop_test_on_failure=False)
         self.tester.verify_stress_thread(bench_thread, error_handler=self._nemesis_stress_failure_handler)
@@ -2032,8 +2025,7 @@ class Nemesis(NemesisFlags):
         # do the actual truncation
         truncate_timeout = 600
         truncate_cmd_timeout_suffix = self._truncate_cmd_timeout_suffix(truncate_timeout)
-        with self.action_log_scope("Truncate table using cqlsh", target=self.target_node.name,
-                                   metadata={"timeout": truncate_timeout, "ks_cf": ks_cf}):
+        with self.action_log_scope(f"Truncate {ks_cf} table using cqlsh"):
             self.target_node.run_cqlsh(
                 cmd=f'TRUNCATE {ks_name}.{table}{truncate_cmd_timeout_suffix}',
                 timeout=truncate_timeout)
@@ -2057,8 +2049,7 @@ class Nemesis(NemesisFlags):
 
         cmd = "ALTER TABLE {keyspace_table} WITH {name} = {val};".format(
             keyspace_table=keyspace_table, name=name, val=val)
-        self.actions_log.info('Modify table property',
-                              metadata={"ks_cf": keyspace_table, "property": name, "value": val})
+        self.actions_log.info(f"Modify table property on {keyspace_table}: {name} = {val}")
         with self.cluster.cql_connection_patient(self.target_node) as session:
             session.execute(cmd)
 
@@ -2156,9 +2147,7 @@ class Nemesis(NemesisFlags):
                 session.execute(cmd)
         except Exception as exc:  # noqa: BLE001
             self.log.debug(f"Add/Remove Column Nemesis: CQL query '{cmd}' execution has failed with error '{str(exc)}'")
-            self.actions_log.info("Failed to add/drop column", metadata={
-                "error": str(exc),
-            })
+            self.actions_log.info(f"Failed to add/drop column: {str(exc)}")
             return False
         return True
 
@@ -2199,20 +2188,14 @@ class Nemesis(NemesisFlags):
         # TBD: Scylla does not support DROP and ADD in the same statement
         ks_cf = f"{self._add_drop_column_target_table[0]}.{self._add_drop_column_target_table[1]}"
         if drop:
-            self.actions_log.info('Dropping columns', metadata={
-                "ks_cf": ks_cf,
-                "columns_count": len(drop)
-            })
+            self.actions_log.info(f"Dropping {len(drop)} columns from {ks_cf} table")
             cmd = f"ALTER TABLE {self._add_drop_column_target_table[1]} DROP ( {', '.join(drop)} );"
             if self._add_drop_column_run_cql_query(cmd, self._add_drop_column_target_table[0]):
                 for column_name in drop:
                     column_type = added_columns_info['column_names'][column_name]
                     del added_columns_info['column_names'][column_name]
         if add:
-            self.actions_log.info('Adding columns', metadata={
-                "ks_cf": ks_cf,
-                "columns_count": len(add)
-            })
+            self.actions_log.info(f"Adding {len(add)} columns to {ks_cf} table")
             cmd = f"ALTER TABLE {self._add_drop_column_target_table[1]} " \
                 f"ADD ( {', '.join(['%s %s' % (col[0], col[1]) for col in add])} );"
             if self._add_drop_column_run_cql_query(cmd, self._add_drop_column_target_table[0]):
@@ -2381,10 +2364,7 @@ class Nemesis(NemesisFlags):
         if not partitions_for_delete:
             raise UnsupportedNemesis('Not found partitions for delete. Nemesis can not be run')
 
-        self.actions_log.info('Deleting half of partition', metadata={
-            "ks_cf": ks_cf,
-            "partitions_count": len(partitions_for_delete)
-        })
+        self.actions_log.info(f"Deleting half ({len(partitions_for_delete)}) of partitions on {ks_cf} table")
         queries = []
         for pkey, ckey in partitions_for_delete.items():
             queries.append(f"delete from {ks_cf} where pk = {pkey} and ck > {int(ckey[1] / 2)}")
@@ -2405,11 +2385,9 @@ class Nemesis(NemesisFlags):
         queries = []
         verification_queries = []
         partition_percentage = random.randint(25, 75) / 100
-        self.actions_log.info('Deleting partitions using timestamp', metadata={
-            "ks_cf": ks_cf,
-            "partitions_count": len(partitions_for_delete),
-            "partition_percentage": partition_percentage
-        })
+        self.actions_log.info(f"Deleting partitions using timestamp in {ks_cf} table."
+                              f" Partitions count: {len(partitions_for_delete)}, "
+                              f"partitions percentage: {partition_percentage}")
         for pkey, _ in partitions_for_delete.items():
             self.log.debug("Using USING TIMESTAMP clause in the deletion for this partition: %s", pkey)
             timestamp, clustering_key = self.get_random_timestamp_from_partition(
@@ -2446,10 +2424,8 @@ class Nemesis(NemesisFlags):
         if not clustering_keys:
             clustering_keys = range(min_clustering_key, max_clustering_key)
 
-        self.actions_log.info('Delete same range in the few partitions', metadata={
-            "ks_cf": ks_cf,
-            "partitions_count": len(partitions_for_delete)
-        })
+        self.actions_log.info(f"Delete same range in the few partitions in {ks_cf} table. "
+                              f"Partitions count: {len(partitions_for_delete)}")
         queries = []
         for pkey in partitions_for_delete.keys():
             queries.append(f"delete from {ks_cf} where pk = {pkey} and ck >= {clustering_keys[0]} "
@@ -2471,10 +2447,8 @@ class Nemesis(NemesisFlags):
         if not partitions_for_delete:
             raise UnsupportedNemesis('Not found partitions for delete. Nemesis can not be run')
 
-        self.actions_log.info('Delete partitions', metadata={
-            "ks_cf": ks_cf,
-            "partitions_count": len(partitions_for_delete)
-        })
+        self.actions_log.info(f"Delete partitions in {ks_cf} table. "
+                              f"Partitions count: {len(partitions_for_delete)}")
         queries = []
         for partition_key in partitions_for_delete.keys():
             queries.append(f"delete from {ks_cf} where pk = {partition_key}")
@@ -2494,10 +2468,8 @@ class Nemesis(NemesisFlags):
             self.log.error('No partitions for delete found!')
             raise UnsupportedNemesis("DeleteOverlappingRowRangesMonkey: No partitions for delete found!")
 
-        self.actions_log.info('Delete random row ranges in few partitions', metadata={
-            "ks_cf": ks_cf,
-            "partitions_count": len(partitions_for_delete)
-        })
+        self.actions_log.info(f"Delete random row ranges in few partitions in {ks_cf} table. "
+                              f"Partitions count: {len(partitions_for_delete)}")
         queries = []
         for pkey, ckey in partitions_for_delete.items():
             for _ in range(random.randint(3, 20)):  # Get a random number of ranges to delete.
@@ -2606,11 +2578,8 @@ class Nemesis(NemesisFlags):
             node=self.target_node, ks=keyspace, cf=table) else 'ALTER MATERIALIZED VIEW '
         cmd = alter_command_prefix + f" {keyspace_table} WITH tombstone_gc = {new_gc_mode_as_dict};"
         self.log.debug("Alter GC mode query to execute: %s", cmd)
-        self.actions_log.info("Toggle table GC mode",
-                              metadata={"ks_cf": keyspace_table,
-                                        "from": current_gc_mode.value,
-                                        "to": new_gc_mode.value}
-                              )
+        self.actions_log.info(f"Toggle table GC mode for {keyspace_table} table"
+                              f" from {current_gc_mode.value} to {new_gc_mode.value}")
         self.target_node.run_cqlsh(cmd)
 
     def toggle_table_ics(self):
@@ -2645,11 +2614,8 @@ class Nemesis(NemesisFlags):
         cmd = alter_command_prefix + \
             " {keyspace_table} WITH compaction = {new_compaction_strategy_as_dict};".format(**locals())
         self.log.debug("Toggle table ICS query to execute: {}".format(cmd))
-        self.actions_log.info("Toggle table ICS",
-                              metadata={"ks_cf": keyspace_table,
-                                        "from": cur_compaction_strategy.value,
-                                        "to": new_compaction_strategy.value}
-                              )
+        self.actions_log.info(f"Toggle table ICS for {keyspace_table} table"
+                              f" from {cur_compaction_strategy.value} to {new_compaction_strategy.value}")
         try:
             self.target_node.run_cqlsh(cmd)
         except (UnexpectedExit, Libssh2UnexpectedExit) as unexpected_exit:
@@ -2922,14 +2888,14 @@ class Nemesis(NemesisFlags):
         sleep_timeout = int(0.02 * self.tester.params["test_duration"])
         time.sleep(sleep_timeout)
 
-        with self.action_log_scope("Stopping Scylla"):
+        with self.action_log_scope(f"Stopping Scylla on {self.target_node.name}"):
             self.target_node.stop_scylla()
 
         reshape_twcs_records = self.target_node.follow_system_log(
             patterns=["need reshape. Starting reshape process",
                       "Reshaping",
                       f"Reshape {ks_cs_settings['name']} .* Reshaped"])
-        with self.action_log_scope("Starting Scylla"):
+        with self.action_log_scope(f"Starting Scylla on {self.target_node.name}"):
             self.target_node.start_scylla()
 
         reshape_twcs_records = list(reshape_twcs_records)
@@ -2950,8 +2916,7 @@ class Nemesis(NemesisFlags):
         # to reshape sstables on other nodes
         for node in self.cluster.data_nodes:
             num_sstables_before_change = len(node.get_list_of_sstables(keyspace, table, suffix="-Data.db"))
-            with self.action_log_scope("Run major compaction", target=node.name,
-                                       metadata={"ks_cf": ks_cs_settings["name"]}):
+            with self.action_log_scope(f"Run {keyspace}.{table} major compaction on {node.name}"):
                 node.run_nodetool("compact", args=f"{keyspace} {table}")
             num_sstables_after_change = len(node.get_list_of_sstables(keyspace, table, suffix="-Data.db"))
             self.log.info("Number of sstables before: %s and after %s change twcs settings on node: %s",
@@ -3213,8 +3178,7 @@ class Nemesis(NemesisFlags):
         self._delete_existing_backups(mgr_cluster)
         if backup_specific_tables:
             non_test_keyspaces = [cql_unquote_if_needed(ks) for ks in self.cluster.get_test_keyspaces()]
-            self.actions_log.info("Starting Scylla Manager backup task",
-                                  metadata={"keyspaces": non_test_keyspaces})
+            self.actions_log.info(f"Starting Scylla Manager backup task for keyspaces: {non_test_keyspaces}")
             mgr_task = mgr_cluster.create_backup_task(location_list=[location, ], keyspace_list=non_test_keyspaces)
         else:
             self.actions_log.info("Starting Scylla Manager backup task for all keyspaces")
@@ -3223,7 +3187,7 @@ class Nemesis(NemesisFlags):
         assert mgr_task is not None, "Backup task wasn't created"
 
         status = mgr_task.wait_and_get_final_status(timeout=54000, step=5, only_final=True)
-        self.actions_log.info("Scylla Manager backup task finished", metadata={"status": str(status)})
+        self.actions_log.info(f"Scylla Manager backup task finished with status: {status}")
         if status == TaskStatus.DONE:
             self.log.info("Task: %s is done.", mgr_task.id)
         elif status in (TaskStatus.ERROR, TaskStatus.ERROR_FINAL):
@@ -3252,7 +3216,7 @@ class Nemesis(NemesisFlags):
         self.actions_log.info("Starting Scylla Manager repair task")
         mgr_task = mgr_cluster.create_repair_task(ignore_down_hosts=ignore_down_hosts)
         task_final_status = mgr_task.wait_and_get_final_status(timeout=86400)  # timeout is 24 hours
-        self.actions_log.info("Scylla Manager repair task finished", metadata={"status": str(task_final_status)})
+        self.actions_log.info(f"Scylla Manager repair task finished with status: {task_final_status}")
         if task_final_status != TaskStatus.DONE:
             progress_full_string = mgr_task.progress_string(
                 parse_table_res=False, is_verify_errorless_result=True).stdout
@@ -3272,8 +3236,7 @@ class Nemesis(NemesisFlags):
         @raise_event_on_failure
         def silenced_nodetool_repair_to_fail():
             try:
-                self.actions_log.info("Starting nodetool repair expected to be aborted",
-                                      target=self.target_node.name)
+                self.actions_log.info(f"Starting nodetool repair on {self.target_node.name} expected to be aborted")
                 self.target_node.run_nodetool("repair", verbose=True,
                                               warning_event_on_exception=(UnexpectedExit, Libssh2UnexpectedExit),
                                               error_message="Repair failed as expected. ",
@@ -3318,7 +3281,7 @@ class Nemesis(NemesisFlags):
                                line="Failed to repair",
                                node=self.target_node):
                 with DbNodeLogger(self.cluster.nodes, "abort repair streaming", target_node=self.target_node), \
-                        self.action_log_scope("Abort repair streaming", target=self.target_node.name):
+                        self.action_log_scope(f"Abort repair streaming on {self.target_node.name} node"):
                     self.target_node.remoter.run(
                         "curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json'"
                         " http://127.0.0.1:10000/storage_service/force_terminate_repair"
@@ -3343,10 +3306,10 @@ class Nemesis(NemesisFlags):
             raise UnsupportedNemesis('For this nemesis to work, `hinted_handoff` needs to be set to `enabled`')
 
         start_time = time.time()
-        self.actions_log.info("Stopping Scylla", target=self.target_node.name)
+        self.actions_log.info(f"Stopping Scylla on {self.target_node.name}")
         self.target_node.stop_scylla()
         time.sleep(10)
-        self.actions_log.info("Starting Scylla", target=self.target_node.name)
+        self.actions_log.info(f"Starting Scylla on {self.target_node.name}")
         self.target_node.start_scylla()
 
         # Wait until all other nodes see the target node as UN
@@ -3516,8 +3479,7 @@ class Nemesis(NemesisFlags):
             raise ValueError(f"Failed to get nodetool command. Error: {exc}") from exc
 
         self.log.debug(f'Take snapshot with command: {nodetool_cmd}')
-        with self.action_log_scope("Take snapshot", target=self.target_node.name,
-                                   metadata={"nodetool_cmd": nodetool_cmd}):
+        with self.action_log_scope(f"Take snapshot on {self.target_node.name} with '{nodetool_cmd}' command"):
             result = self.target_node.run_nodetool(nodetool_cmd)
         self.log.debug(result)
         if "snapshot name" not in result.stdout:
@@ -3634,8 +3596,7 @@ class Nemesis(NemesisFlags):
                 experiment = NetworkBandwidthLimitExperiment(
                     self.target_node, duration, rate=rate_limit, limit=limit, buffer=10000)
         with DbNodeLogger(self.cluster.nodes, f"network {interruption} interruption", target_node=self.target_node), \
-                self.action_log_scope("Network interruption", target=self.target_node.name,
-                                      metadata={"duration": duration}):
+                self.action_log_scope(f"Network interruption on {self.target_node.name} for {duration}s"):
             experiment.start()
             experiment.wait_until_finished()
         self.cluster.wait_all_nodes_un()
@@ -3684,8 +3645,8 @@ class Nemesis(NemesisFlags):
         option_name, selected_option = random.choice(list_of_tc_options)
         wait_time = random.choice(list_of_timeout_options)
 
-        self.actions_log.info("Network interruption start", target=self.target_node.name,
-                              metadata={"option": option_name, "wait_time": wait_time})
+        self.actions_log.info(f"Network interruption start on {self.target_node.name},"
+                              f" option: {option_name}, wait time: {wait_time}")
         if self.target_node.systemd_version < 256:
             context_manager = EventsSeverityChangerFilter(
                 new_severity=Severity.WARNING, event_class=CoreDumpEvent, regex=r".*executable=.*networkd.*",
@@ -3704,7 +3665,7 @@ class Nemesis(NemesisFlags):
             finally:
                 self.target_node.traffic_control(None)
                 self.cluster.wait_all_nodes_un()
-        self.actions_log.info("Network random interruption finished", target=self.target_node.name)
+        self.actions_log.info(f"Network random interruption finished on node {self.target_node.name}")
 
     def _disrupt_network_block_k8s(self, list_of_timeout_options):
         duration = f"{random.choice(list_of_timeout_options)}s"
@@ -3720,7 +3681,7 @@ class Nemesis(NemesisFlags):
     def disrupt_network_block(self):
         list_of_timeout_options = [10, 60, 120, 300, 500]
         if self._is_it_on_kubernetes():
-            with self.action_log_scope("Block network", target=self.target_node.name):
+            with self.action_log_scope(f"Block network on {self.target_node.name} node"):
                 self._disrupt_network_block_k8s(list_of_timeout_options)
             return
 
@@ -3740,7 +3701,7 @@ class Nemesis(NemesisFlags):
         selected_option = "--loss 100%"
         wait_time = random.choice(list_of_timeout_options)
         self.log.debug("BlockNetwork: [%s] for %dsec", selected_option, wait_time)
-        self.actions_log.info("Network block start", target=self.target_node.name, metadata={"wait_time": wait_time})
+        self.actions_log.info(f"Network block start on {self.target_node.name} node, wait_time: {wait_time}")
         with context_manager:
             self.target_node.traffic_control(None)
             try:
@@ -3751,7 +3712,7 @@ class Nemesis(NemesisFlags):
             finally:
                 self.target_node.traffic_control(None)
                 self.cluster.wait_all_nodes_un()
-        self.actions_log.info("Network block finished", target=self.target_node.name)
+        self.actions_log.info(f"Network block finished on {self.target_node.name} node")
 
     @target_all_nodes
     def disrupt_remove_node_then_add_node(self):
@@ -3804,7 +3765,7 @@ class Nemesis(NemesisFlags):
             ignore_stream_mutation_errors_due_to_issue = contextlib.nullcontext
 
         with ignore_ycsb_connection_refused(), ignore_stream_mutation_errors_due_to_issue():
-            self.actions_log.info("Stop node and make sure is DN", target=node_to_remove.name)
+            self.actions_log.info(f"Stop {node_to_remove.name} node and make sure is DN")
             node_to_remove.stop_scylla_server(verify_up=False, verify_down=True)
             self._terminate_cluster_node(node_to_remove)
 
@@ -3829,7 +3790,7 @@ class Nemesis(NemesisFlags):
         with DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR, line="failed to repair"):
             self.run_repair_on_nodes(nodes=up_normal_nodes, ignore_down_hosts=True)
 
-        with self.action_log_scope("Remove the node", target=node_to_remove.name):
+        with self.action_log_scope(f"Remove {node_to_remove.name} node"):
             exit_status = remove_node()
         # if remove node command failed by any reason,
         # we will remove the terminated node from
@@ -4064,7 +4025,7 @@ class Nemesis(NemesisFlags):
         ignore_ipv6_failure_to_assign,
         issue_refs=['https://github.com/scylladb/scylladb/issues/20387'])
     def reboot_node(self, target_node, hard=True, verify_ssh=True):
-        with self.action_log_scope(f"Reboot node. hard: {hard}", target=target_node.name):
+        with self.action_log_scope(f"Reboot {target_node.name} node. hard: {hard}"):
             target_node.reboot(hard=hard, verify_ssh=verify_ssh)
         if self.tester.params.get('print_kernel_callstack'):
             save_kallsyms_map(node=target_node)
@@ -4080,14 +4041,14 @@ class Nemesis(NemesisFlags):
 
         try:
             self.target_node.stop_network_interface()
-            self.actions_log.info("Taking network interface down", target=self.target_node.name)
+            self.actions_log.info(f"Taking {self.target_node.name} node network interface down")
             time.sleep(wait_time)
         finally:
-            self.actions_log.info("Brigning network interface up", target=self.target_node.name)
+            self.actions_log.info(f"Brigning {self.target_node.name} node network interface up")
             self.target_node.start_network_interface()
-            with self.action_log_scope("Wait all nodes up and normal", target=self.target_node.name):
+            with self.action_log_scope("Wait all nodes up and normal"):
                 self.cluster.wait_all_nodes_un()
-        self.actions_log.info("Network interface down/up finished", target=self.target_node.name)
+        self.actions_log.info(f"Network interface down/up finished on {self.target_node.name} node")
 
     def _call_disrupt_func_after_expression_logged(self,
                                                    log_follower: Iterable[str],
@@ -4153,9 +4114,9 @@ class Nemesis(NemesisFlags):
                 self.log.error('Unexpected exception raised in checking decommission status: %s', exc)
 
             self.log.info('Decommission might complete before stopping it. Re-add a new node')
-            self.actions_log.info("Add new node start", target=self.target_node.name)
+            self.actions_log.info("Add new node start")
             new_node = self._add_and_init_new_cluster_nodes(count=1, rack=self.target_node.rack)[0]
-            self.actions_log.info("Add new node finished", target=new_node.name)
+            self.actions_log.info(f"Add new node finished: {new_node.name}")
             if new_node.is_seed != target_is_seed:
                 new_node.set_seed_flag(target_is_seed)
                 self.cluster.update_seed_provider()
@@ -4192,16 +4153,16 @@ class Nemesis(NemesisFlags):
                 FailedDecommissionOperationMonitoring(target_node=self.target_node,
                                                       verification_node=verification_node,
                                                       timeout=full_operations_timeout), \
-                    self.action_log_scope("Reboot node during decommission streaming", target=self.target_node.name):
+                    self.action_log_scope(f"Reboot {self.target_node.name} node during decommission streaming"):
 
                 ParallelObject(objects=[trigger, watcher], timeout=full_operations_timeout).call_objects()
             if new_node := decommission_post_action():
                 new_node.wait_node_fully_start()
-                with self.action_log_scope("New node rebuild", target=new_node.name):
+                with self.action_log_scope(f"New node {new_node.name} rebuild"):
                     new_node.run_nodetool("rebuild", long_running=True, retry=0)
             else:
                 self.target_node.wait_node_fully_start()
-                with self.action_log_scope("Run rebuild", target=self.target_node.name):
+                with self.action_log_scope(f"Run rebuild on {self.target_node.name}"):
                     self.target_node.run_nodetool(sub_cmd="rebuild", long_running=True, retry=0)
 
     def start_and_interrupt_repair_streaming(self):
@@ -4226,13 +4187,13 @@ class Nemesis(NemesisFlags):
             disrupt_func_kwargs={"target_node": self.target_node, "hard": True, "verify_ssh": True},
             delay=1
         )
-        with self.action_log_scope("Repair data after destroy", target=self.target_node.name):
+        with self.action_log_scope(f"Repair data after destroy on {self.target_node.name} node"):
             ParallelObject(objects=[trigger, watcher], timeout=timeout).call_objects()
 
         self.target_node.wait_node_fully_start()
 
         with adaptive_timeout(Operations.REBUILD, self.target_node, timeout=HOUR_IN_SEC * 48):
-            with self.action_log_scope("Rebuild data after destroy", target=self.target_node.name):
+            with self.action_log_scope(f"Rebuild data after destroy on {self.target_node.name} node"):
                 self.target_node.run_nodetool("rebuild", long_running=True, retry=0)
 
     def start_and_interrupt_rebuild_streaming(self):
@@ -4261,11 +4222,11 @@ class Nemesis(NemesisFlags):
             timeout=timeout,
             delay=1
         )
-        with self.action_log_scope("Rebuild data after destroy", target=self.target_node.name):
+        with self.action_log_scope(f"Rebuild data after destroy on {self.target_node.name} node"):
             ParallelObject(objects=[trigger, watcher], timeout=timeout + 60).call_objects()
         self.target_node.wait_node_fully_start(timeout=300)
         with adaptive_timeout(Operations.REBUILD, self.target_node, timeout=HOUR_IN_SEC * 48):
-            with self.action_log_scope("Rebuild data after destroy", target=self.target_node.name):
+            with self.action_log_scope(f"Rebuild data after destroy on {self.target_node.name} node"):
                 self.target_node.run_nodetool("rebuild", long_running=True, retry=0)
 
     def disrupt_decommission_streaming_err(self):
@@ -4322,7 +4283,7 @@ class Nemesis(NemesisFlags):
         self.log.debug("Rebuild sstables by scrub with `--skip-corrupted`, corrupted partitions will be skipped.")
         with ignore_scrub_invalid_errors(), adaptive_timeout(Operations.SCRUB, self.target_node, timeout=HOUR_IN_SEC * 48):
             for ks in self.cluster.get_test_keyspaces():
-                with self.action_log_scope("Scrub keyspace", target=self.target_node.name, metadata={"keyspace": ks}):
+                with self.action_log_scope(f"Scrub {ks} keyspace on {self.target_node.name} node"):
                     self.target_node.run_nodetool("scrub", args=f"--skip-corrupted {ks}")
 
         self.clear_snapshots()
@@ -4330,7 +4291,7 @@ class Nemesis(NemesisFlags):
     @latency_calculator_decorator(legend="Adding new nodes")
     def add_new_nodes(self, count, rack=None, instance_type: str = None) -> list[BaseNode]:
         nodes = self._add_and_init_new_cluster_nodes(count, rack=rack, instance_type=instance_type)
-        self.actions_log.info("New nodes added", target=", ".join(node.name for node in nodes))
+        self.actions_log.info(f'New nodes added: {", ".join(node.name for node in nodes)}')
         wait_no_tablets_migration_running(nodes[0])
         return nodes
 
@@ -4338,7 +4299,7 @@ class Nemesis(NemesisFlags):
     def decommission_nodes(self, nodes):
 
         def _decommission(node):
-            with self.action_log_scope("Decommission node", target=node.name):
+            with self.action_log_scope(f"Decommission {node.name} node"):
                 self.cluster.decommission(node)
 
         num_workers = None if (self.cluster.parallel_node_operations and nodes[0].raft.is_enabled) else 1
@@ -4399,7 +4360,7 @@ class Nemesis(NemesisFlags):
         # pass on the exact nodes only if we have specific types for them
         new_nodes = new_nodes if self.tester.params.get('nemesis_grow_shrink_instance_type') else None
         if duration := self.tester.params.get('nemesis_double_load_during_grow_shrink_duration'):
-            with self.action_log_scope("Double load after grow cluster", target=self.target_node.name):
+            with self.action_log_scope("Double load after grow cluster"):
                 self._double_cluster_load(duration)
         self._shrink_cluster(rack=None, new_nodes=new_nodes)
 
@@ -4419,7 +4380,7 @@ class Nemesis(NemesisFlags):
             rack = 0
         add_nodes_number = self.tester.params.get('nemesis_add_node_cnt')
         new_nodes = []
-        with self.action_log_scope("Grow cluster", metadata={"count": add_nodes_number}):
+        with self.action_log_scope(f"Grow cluster by {add_nodes_number} nodes"):
             if self.cluster.parallel_node_operations:
                 new_nodes = self.add_new_nodes(count=add_nodes_number, rack=rack,
                                                instance_type=self.tester.params.get('nemesis_grow_shrink_instance_type'))
@@ -4521,8 +4482,7 @@ class Nemesis(NemesisFlags):
 
         # Create table with encryption
         keyspace_name, table_name = cql_unquote_if_needed(self.cluster.get_test_keyspaces()[0]), 'tmp_encrypted_table'
-        self.actions_log.info("Create encrypted table",
-                              metadata={"keyspace": keyspace_name, "table": table_name})
+        self.actions_log.info(f"Create encrypted table: {keyspace_name}.{table_name}")
         with self.cluster.cql_connection_patient(self.target_node, keyspace=keyspace_name) as session:
             # NOTE: scylla-bench expects following table structure:
             #       (pk bigint, ck bigint, v blob, PRIMARY KEY(pk, ck)) WITH compression = { }
@@ -4564,8 +4524,7 @@ class Nemesis(NemesisFlags):
             ), EventsSeverityChangerFilter(
                 new_severity=Severity.WARNING, event_class=DatabaseLogEvent, extra_time_to_expiration=30,
                 regex=".*sstable - Error while linking SSTable.*filesystem error: stat failed: No such file or directory.*"), \
-                    self.action_log_scope("Write data with scylla-bench", target=self.target_node.name,
-                                          metadata={"cmd": write_cmd}):
+                    self.action_log_scope(f"Write data with scylla-bench using cmd: {write_cmd}"):
                 write_thread = self.tester.run_stress_thread(stress_cmd=write_cmd, stop_test_on_failure=False)
                 self.tester.verify_stress_thread(write_thread, error_handler=self._nemesis_stress_failure_handler)
 
@@ -4585,14 +4544,13 @@ class Nemesis(NemesisFlags):
                     " -partition-count=50 -clustering-row-count=100 -clustering-row-size=uniform:75..125"
                     f" -keyspace '{cql_quote_if_needed(keyspace_name)}' -table '{cql_quote_if_needed(table_name)}' -timeout=120s -validate-data"
                     " -iterations=1 -concurrency=10 -connection-count=10 -rows-per-request=10")
-                with self.action_log_scope("Read data with scylla-bench", target=self.target_node.name,
-                                           metadata={"cmd": read_cmd}):
+                with self.action_log_scope(f"Read data with scylla-bench with {read_cmd}"):
                     read_thread = self.tester.run_stress_thread(stress_cmd=read_cmd, stop_test_on_failure=False)
                     self.tester.verify_stress_thread(read_thread, error_handler=self._nemesis_stress_failure_handler)
 
                 # Rotate KMS key
                 if enable_kms_key_rotation and aws_kms and kms_key_alias_name and i == 0:
-                    self.actions_log.info("Rotate AWS KMS key", metadata={"alias_name": kms_key_alias_name})
+                    self.actions_log.info(f"Rotate AWS KMS key. Alias name: {kms_key_alias_name}")
                     aws_kms.rotate_kms_key(kms_key_alias_name)
 
             # Check that sstables of that table are really encrypted
@@ -4606,8 +4564,7 @@ class Nemesis(NemesisFlags):
             # if encryption is enabled by default, we currently can't disable it
             if not user_info_encryption_enabled:
                 # Disable encryption for the encrypted table
-                self.actions_log.info("Disable encryption for the table",
-                                      metadata={"keyspace": keyspace_name, "table": table_name})
+                self.actions_log.info(f"Disable encryption for {keyspace_name}.{table_name}")
                 with self.cluster.cql_connection_patient(self.target_node, keyspace=keyspace_name) as session:
                     query = f"ALTER TABLE {table_name} WITH scylla_encryption_options = {{'key_provider': 'none'}};"
                     session.execute(query)
@@ -4629,8 +4586,7 @@ class Nemesis(NemesisFlags):
                 check_encryption_fact(sstable_util, False)
         finally:
             # Delete table
-            self.actions_log.info("Delete encrypted table",
-                                  metadata={"keyspace": keyspace_name, "table": table_name})
+            self.actions_log.info(f"Delete encrypted table {keyspace_name}.{table_name}")
             with self.cluster.cql_connection_patient(self.target_node, keyspace=keyspace_name) as session:
                 session.execute(f"DROP TABLE {table_name};")
 
@@ -4670,7 +4626,7 @@ class Nemesis(NemesisFlags):
                     patterns=[f'messaging_service - Reloaded {{"{ssl_files_location}"}}'])
                 update_certificate(node)
                 node.remoter.send_files(src=str(node.ssl_conf_dir / TLSAssets.DB_CERT), dst='/tmp')
-                self.actions_log.info("Update certificate file", target=node.name)
+                self.actions_log.info(f"Update certificate file on {node.name} node")
                 node.remoter.run(f"sudo cp -f /tmp/{TLSAssets.DB_CERT} {ssl_files_location}")
                 new_crt = node.remoter.run(f"cat {ssl_files_location}").stdout
                 if in_place_crt == new_crt:
@@ -4739,7 +4695,7 @@ class Nemesis(NemesisFlags):
                                             workers=1, size="100%", time_to_reach=f"{time_to_reach_secs}s")
         with DbNodeLogger(self.cluster.nodes, "start memory stress",
                           target_node=self.target_node, additional_info="allocate 100% of total memory"), \
-                self.action_log_scope("Memory stress by allocating 100% memory", target=self.target_node.name):
+                self.action_log_scope(f"Memory stress by allocating 100% memory on {self.target_node.name}"):
             experiment.start()
             experiment.wait_until_finished()
 
@@ -4772,7 +4728,7 @@ class Nemesis(NemesisFlags):
         self.log.info('Try to allocate 90% total memory, the allocated memory will be swaped out')
         with DbNodeLogger(self.cluster.nodes, "start memory stress",
                           target_node=self.target_node, additional_info="allocate 90% of total memory"), \
-                self.action_log_scope("Memory stress by allocating 90% memory", target=self.target_node.name):
+                self.action_log_scope(f"Memory stress by allocating 90% memory on {self.target_node.name} node"):
             self.target_node.remoter.run(
                 "stress-ng --vm-bytes $(awk '/MemTotal/{printf \"%d\\n\", $2 * 0.9;}' < /proc/meminfo)k --vm-keep -m 1 -t 100")
 
@@ -4852,8 +4808,7 @@ class Nemesis(NemesisFlags):
         """
         cmd = f"ALTER TABLE {keyspace}.{table} WITH cdc = {cdc_settings};"
         self.log.debug(f"Alter command: {cmd}")
-        self.actions_log.info("Alter table cdc properties",
-                              metadata={"keyspace": keyspace, "table": table, "cdc_settings": cdc_settings})
+        self.actions_log.info(f"Alter table cdc properties on {keyspace}.{table} with cdc settings: {cdc_settings}")
         with self.cluster.cql_connection_patient(self.target_node) as session:
             session.execute(cmd)
         # wait applying cdc configuration
@@ -4909,11 +4864,11 @@ class Nemesis(NemesisFlags):
             f"-mode cql3 native compression=lz4 -rate threads=5 -pop seq=1..100000 -log interval=5"
         write_thread = self.tester.run_stress_thread(stress_cmd=write_cmd, round_robin=True, stop_test_on_failure=False)
         self.tester.verify_stress_thread(write_thread, error_handler=self._nemesis_stress_failure_handler)
-        with self.action_log_scope("Verify multi DC keyspace data", target=self.target_node.name):
+        with self.action_log_scope("Verify multi DC keyspace data"):
             self._verify_multi_dc_keyspace_data(consistency_level="ALL")
         # flush data to ensure it is seen in monitoring
         for node in self.cluster.nodes:
-            with self.action_log_scope("Flush data in keyspace_new_dc", target=node.name):
+            with self.action_log_scope(f"Flush data in keyspace_new_dc on {node.name} node"):
                 node.run_nodetool("flush keyspace_new_dc")
 
     def _verify_multi_dc_keyspace_data(self, consistency_level: str = "ALL"):
@@ -4939,8 +4894,7 @@ class Nemesis(NemesisFlags):
             if keyspace == "system_auth" and replication_strategy.replication_factors[0] != len(nodes_by_region[region]):
                 self.log.warning(f"system_auth keyspace is not replicated on all nodes "
                                  f"({replication_strategy.replication_factors[0]}/{len(nodes_by_region[region])}).")
-            with self.action_log_scope("Switching replication strategy to Network", target=self.target_node.name,
-                                       metadata={"keyspace": keyspace}):
+            with self.action_log_scope(f"Switching {keyspace} replication strategy to Network"):
                 network_replication = NetworkTopologyReplicationStrategy(
                     **{dc_name: replication_strategy.replication_factors[0]})
                 network_replication.apply(node, keyspace)
@@ -4995,27 +4949,25 @@ class Nemesis(NemesisFlags):
                                         start_line_patterns=["rebuild.*started with keyspaces=", "Rebuild starts"],
                                         end_line_patterns=["rebuild.*finished with keyspaces=", "Rebuild succeeded"],
                                         start_timeout=60, end_timeout=600), \
-                        self.action_log_scope("Run rebuild on the new datacenter", target=new_node.name,
-                                              metadata={"nodetool_cmd": cmd}):
+                        self.action_log_scope(f"Run rebuild on the new datacenter with cmd: {cmd}"):
                     new_node.run_nodetool(sub_cmd=cmd, long_running=True, retry=0)
                 InfoEvent(message='Running full cluster repair on each data node').publish()
                 cmd = "repair -pr"
                 for cluster_node in self.cluster.data_nodes:
-                    with self.action_log_scope("Run repair", target=cluster_node.name,
-                                               metadata={"nodetool_cmd": cmd}):
+                    with self.action_log_scope(f"Run repair on {cluster_node.name} node with cmd: {cmd}"):
                         cluster_node.run_nodetool(sub_cmd=cmd, publish_event=True)
                 datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())
-                with self.action_log_scope("Run write and then read data to multiDC keyspace", target=self.target_node.name):
+                with self.action_log_scope("Run write and then read data to multiDC keyspace"):
                     self._write_read_data_to_multi_dc_keyspace(datacenters)
 
-            with self.action_log_scope("Decommission of the new node", target=new_node.name):
+            with self.action_log_scope(f"Decommission of the new node {new_node.name}"):
                 self.cluster.decommission(new_node)
             node_added = False
             self.node_allocator.unset_running_nemesis(new_node, self.current_disruption)
 
             datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())
             assert not [dc for dc in datacenters if dc.endswith("_nemesis_dc")], "new datacenter was not unregistered"
-            with self.action_log_scope("Verify keyspace data after decommissioning", target=self.target_node.name):
+            with self.action_log_scope("Verify keyspace data after decommissioning"):
                 self._verify_multi_dc_keyspace_data(consistency_level="QUORUM")
 
     def get_cassandra_stress_write_cmds(self):
@@ -5242,8 +5194,7 @@ class Nemesis(NemesisFlags):
             try:
                 with DbNodeLogger(self.cluster.nodes, "create index",
                                   target_node=self.target_node, additional_info=f"on {ks}.{cf}.{column}"), \
-                    self.action_log_scope("Create index",
-                                          metadata={"ks_cf": f"{ks}.{cf}", "column": column}):
+                        self.action_log_scope(f"Create {ks}.{cf} {column} index"):
                     index_name = create_index(session, ks, cf, column)
             except InvalidRequest as exc:
                 LOGGER.warning(exc)
@@ -5259,7 +5210,7 @@ class Nemesis(NemesisFlags):
             finally:
                 with DbNodeLogger(self.cluster.nodes, "drop_index",
                                   target_node=self.target_node, additional_info=f"index: {index_name}"):
-                    self.actions_log.info("Drop index", metadata={"index": index_name})
+                    self.actions_log.info(f"Drop {index_name} index")
                     drop_index(session, ks, index_name)
 
     @target_data_nodes
@@ -5303,18 +5254,15 @@ class Nemesis(NemesisFlags):
                     raise UnsupportedNemesis(
                         'A supported column for creating MV is not found. nemesis can\'t run')
                 self.log.info("Stopping Scylla on node %s", self.target_node.name)
-                self.actions_log.info("Stop Scylla", target=self.target_node.name)
+                self.actions_log.info(f"Stop Scylla on {self.target_node.name} node")
                 self.target_node.stop_scylla()
                 InfoEvent(message=f'Create a materialized-view for table {ks_name}.{base_table_name}').publish()
                 try:
                     with EventsFilter(event_class=DatabaseLogEvent,
                                       regex='.*Error applying view update.*',
                                       extra_time_to_expiration=180), \
-                            self.action_log_scope("Create materialized view",
-                                                  metadata={"base_table": f"{ks_name}.{base_table_name}",
-                                                            "view_name": view_name,
-                                                            "column": column,
-                                                            "primary_key_columns": primary_key_columns}):
+                            self.action_log_scope(f"Create {view_name} materialized view "
+                                                  f"on {ks_name}.{base_table_name} {column} {primary_key_columns}"):
                         self.tester.create_materialized_view(ks_name, base_table_name, view_name, [column],
                                                              primary_key_columns, session,
                                                              mv_columns=[column] + primary_key_columns)
@@ -5324,14 +5272,13 @@ class Nemesis(NemesisFlags):
                     raise
                 try:
                     self.log.info("Starting Scylla on node %s", self.target_node.name)
-                    self.actions_log.info("Start Scylla", target=self.target_node.name)
+                    self.actions_log.info(f"Start Scylla on {self.target_node.name} node")
                     self.target_node.start_scylla()
-                    with self.action_log_scope("Run repair on node", target=self.target_node.name):
+                    with self.action_log_scope(f"Run repair on {self.target_node.name} node"):
                         self.target_node.run_nodetool(sub_cmd="repair -pr")
                     with adaptive_timeout(operation=Operations.CREATE_MV, node=self.target_node, timeout=14400) as timeout, \
-                            self.action_log_scope("Wait for materialized view to be built",
-                                                  metadata={"view_name": f"{ks_name}.{view_name}"},
-                                                  target=self.target_node.name):
+                            self.action_log_scope(f"Wait for {ks_name}.{view_name} materialized view to be built on "
+                                                  f"{self.target_node.name} node"):
                         wait_for_view_to_be_built(self.target_node, ks_name, view_name, timeout=timeout * 2)
                     session.execute(SimpleStatement(f'SELECT * FROM {ks_name}.{view_name} limit 1', fetch_size=10))
                     sleep_for_percent_of_duration(self.tester.test_duration * 60, percent=1,
@@ -5377,9 +5324,8 @@ class Nemesis(NemesisFlags):
             tables=[],
         )
         try:
-            with self.action_log_scope("Enable full audit", metadata={"store": store,
-                                                                      "categories": audit_config.categories,
-                                                                      "keyspaces": keyspaces_for_audit}):
+            with self.action_log_scope(f"Enable {store} audit "
+                                       f"on categories: {audit_config.categories} in {keyspaces_for_audit} keyspace"):
                 audit.configure(audit_config)
             keyspace_name = keyspaces_for_audit[0]
             errors = []
@@ -5400,8 +5346,7 @@ class Nemesis(NemesisFlags):
                 stress_cmd=read_cmd, round_robin=True, stop_test_on_failure=False)
             self.tester.verify_stress_thread(read_thread, error_handler=self._nemesis_stress_failure_handler)
             InfoEvent(message='Verifying Audit table contents').publish()
-            self.actions_log.info("Verifying Audit log contents",
-                                  metadata={"category": "DML"})
+            self.actions_log.info("Verifying DML Audit log contents")
             rows = audit.get_audit_log(from_datetime=audit_start, category="DML", limit_rows=1500)
             # filter out USE keyspace rows due to https://github.com/scylladb/scylla-enterprise/issues/3169
             rows = [row for row in rows if not row.operation.startswith("USE")]
@@ -5409,8 +5354,7 @@ class Nemesis(NemesisFlags):
                 errors.append(f"Audit log for DML contains {len(rows)} rows while should contain 1000 rows")
                 for row in rows:
                     LOGGER.error("DML audit log row: %s", row)
-            self.actions_log.info("Verifying Audit log contents",
-                                  metadata={"category": "QUERY"})
+            self.actions_log.info("Verifying QUERY Audit log contents")
             rows = audit.get_audit_log(from_datetime=audit_start, category="QUERY", limit_rows=1500)
             if len(rows) != 1000:
                 errors.append(f"Audit log for QUERY contains {len(rows)} rows while should contain 1000 rows")
@@ -5419,14 +5363,14 @@ class Nemesis(NemesisFlags):
         except Exception as ex:
             LOGGER.error("Exception while testing full audit: %s", ex)
             audit_config.categories = ["DCL", "DDL", "AUTH", "ADMIN"]
-            with self.action_log_scope("Reconfiguring audit", metadata={"categories": audit_config.categories}):
+            with self.action_log_scope(f"Reconfiguring audit with {audit_config.categories} categories"):
                 audit.configure(audit_config)
             raise
 
         InfoEvent("Reducing audit categories and setting back audited keyspaces").publish()
 
         audit_config.categories = ["DCL", "DDL", "AUTH", "ADMIN"]
-        with self.action_log_scope("Reconfiguring audit", metadata={"categories": audit_config.categories}):
+        with self.action_log_scope(f"Reconfiguring audit with {audit_config.categories} categories"):
             audit.configure(audit_config)
         table_name = "audit_cf"
         audit_start = datetime.datetime.now() - datetime.timedelta(seconds=5)
@@ -5480,7 +5424,7 @@ class Nemesis(NemesisFlags):
             rack=self.target_node.rack,
             disruption_name=self.current_disruption)[0]
         self.monitoring_set.reconfigure_scylla_monitoring()
-        self.actions_log.info("Added new node", target=new_node.name)
+        self.actions_log.info(f"Added new node : {new_node.name}")
         terminate_pattern = self.target_node.raft.get_random_log_message(operation=TopologyOperations.BOOTSTRAP,
                                                                          seed=self.nemesis_seed)
         bootstrapabortmanager = NodeBootstrapAbortManager(bootstrap_node=new_node, verification_node=self.target_node,
@@ -5492,7 +5436,7 @@ class Nemesis(NemesisFlags):
             bootstrapabortmanager.clean_and_restart_bootstrap_after_abort()
 
             if not new_node.db_up() or (new_node.db_up() and not self.target_node.raft.is_cluster_topology_consistent()):
-                with self.action_log_scope("Clean unbootrapped node", target=new_node.name):
+                with self.action_log_scope(f"Clean unbootrapped {new_node.name} node"):
                     bootstrapabortmanager.clean_unbootstrapped_node()
                 raise BootstrapStreamErrorFailure(f"Node {new_node.name} failed to bootstrap. See log for more details")
 
@@ -5507,7 +5451,7 @@ class Nemesis(NemesisFlags):
                                                  node_list=un_nodes) as verification_node, \
                     FailedDecommissionOperationMonitoring(target_node=new_node, verification_node=verification_node,
                                                           timeout=monitoring_decommission_timeout):
-                with self.action_log_scope("Decommission node", target=new_node.name):
+                with self.action_log_scope(f"Decommission {new_node.name} node"):
                     self.cluster.decommission(new_node, timeout=decommission_timeout)
 
     def disrupt_disable_binary_gossip_execute_major_compaction(self):
@@ -5534,7 +5478,7 @@ class Nemesis(NemesisFlags):
         except Exception:
             # NOTE: restart the target node because it was the remedy for the problems with CQL workability
             self.log.warning("'%s' node will be restarted to make the CQL work again", self.target_node)
-            self.actions_log.info("Restarting node", target=self.target_node.name)
+            self.actions_log.info(f"Restarting {self.target_node.name} node")
             self.target_node.restart_scylla_server()
             raise
 
@@ -5573,15 +5517,15 @@ class Nemesis(NemesisFlags):
             elif coordinator_node != self.target_node:
                 self.switch_target_node(coordinator_node)
             self.log.debug("Coordinator node: %s, %s", coordinator_node, coordinator_node.name)
-            with self.action_log_scope("Stop Scylla coordinator node", target=coordinator_node.name):
+            with self.action_log_scope(f"Stop Scylla coordinator {coordinator_node.name} node"):
                 self.target_node.stop_scylla()
             self.log.debug("Wait random timeout %s to new coordinator will be elected", election_wait_timeout)
             time.sleep(election_wait_timeout)
             with self.node_allocator.run_nemesis(nemesis_label="SearchCoordinator") as verification_node:
                 new_coordinator_node = get_topology_coordinator_node(verification_node)
-                self.actions_log.info("New coordinator node elected", target=new_coordinator_node.name)
+                self.actions_log.info(f"New coordinator node elected: {new_coordinator_node.name}")
             self.log.debug("New coordinator node: %s, %s", new_coordinator_node, new_coordinator_node.name)
-            with self.action_log_scope("Start Scylla on old coordinator node", target=coordinator_node.name):
+            with self.action_log_scope(f"Start Scylla on old coordinator {coordinator_node.name} node"):
                 self.target_node.start_scylla()
             assert self.target_node != new_coordinator_node, \
                 f"New coordinator node was not elected while old one {coordinator_node.name} was stopped"
@@ -5663,13 +5607,13 @@ class Nemesis(NemesisFlags):
 
             with simulate_node_unavailability(self.target_node):
                 # target node stopped by Contextmanger. Wait while its status will be updated
-                self.actions_log.info(f"Blocked node with {simulate_node_unavailability.__name__}",
-                                      target=self.target_node.name)
+                self.actions_log.info(f"Blocked {self.target_node.name} node"
+                                      f" with {simulate_node_unavailability.__name__}")
                 wait_for(node_operations.is_node_seen_as_down, step=5, timeout=600, throw_exc=True,
                          down_node=self.target_node, verification_node=working_node, text=f"Wait other nodes see {self.target_node.name} as DOWN...")
                 self.log.debug("Remove node %s : hostid: %s with blocked scylla from cluster",
                                self.target_node.name, target_host_id)
-                self.actions_log.info("Remove node from cluster", target=self.target_node.name)
+                self.actions_log.info(f"Remove {self.target_node.name} node from cluster")
                 working_node.run_nodetool(f"removenode {target_host_id}", retry=0, long_running=True)
                 assert node_operations.is_node_removed_from_cluster(removed_node=self.target_node, verification_node=working_node), \
                     f"Node {self.target_node.name} with host id {target_host_id} was not removed. See log errors"
@@ -5680,7 +5624,7 @@ class Nemesis(NemesisFlags):
             assert self.target_node.db_up(), f"Scylla was not up on node {self.target_node.name}"
 
             with self.cluster.cql_connection_exclusive(node=self.target_node) as session:
-                self.actions_log.info("Execute query on banned node",)
+                self.actions_log.info("Execute query on banned node")
                 for key in random.sample(range(1, 100001), 1000):
                     try:
                         stmt = SimpleStatement(f"INSERT INTO {keyspace_name}.{table_name} (key, name) VALUES ({key}, 'name{key}');",
@@ -5819,8 +5763,7 @@ def disrupt_method_wrapper(method, is_exclusive=False):  # noqa: PLR0915
 
             with DisruptionEvent(nemesis_name=args[0].base_disruption_name,
                                  node=args[0].target_node, publish_event=True) as nemesis_event, \
-                    args[0].actions_log.action_scope("Disrupt method", target=args[0].target_node.name,
-                                                     metadata={"disrupt_method_name": current_disruption}):
+                    args[0].actions_log.action_scope(f"Disruption {method_name} on {args[0].target_node.name}"):
                 nemesis_info = argus_create_nemesis_info(nemesis=args[0], class_name=class_name,
                                                          method_name=method_name, start_time=start_time)
                 try:

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -460,7 +460,8 @@ class Nemesis(NemesisFlags):
                                          regex=".*Connection reset by peer.*",
                                          extra_time_to_expiration=30):
             self.log.info('Kill all scylla processes in %s', self.target_node)
-            with DbNodeLogger(self.cluster.nodes, "kill all scylla processes", target_node=self.target_node):
+            with DbNodeLogger(self.cluster.nodes, "kill all scylla processes", target_node=self.target_node), \
+                    self.action_log_scope("pkill -9 scylla", target=self.target_node.name):
                 self.target_node.remoter.sudo("pkill -9 scylla", ignore_status=True)
 
             # Wait for the process to be down before waiting for service to be restarted
@@ -469,6 +470,7 @@ class Nemesis(NemesisFlags):
             # Let's wait for the target Node to have their services re-started
             self.log.info('Waiting scylla services to be restarted after we killed them...')
             self.target_node.wait_db_up(timeout=14400)
+            self.actions_log.info("scylla process restarted", target=self.target_node.name)
             if (self.cluster.params.get('use_mgmt')
                     and SkipPerIssues('scylladb/scylla-manager#2813', params=self.tester.params)):
                 # Workaround for https://github.com/scylladb/scylla-manager/issues/2813
@@ -477,25 +479,30 @@ class Nemesis(NemesisFlags):
                 self.target_node.start_service(service_name='scylla-manager-agent', timeout=600, ignore_status=True)
             self.log.info('Waiting JMX services to be restarted after we killed them...')
             self.target_node.wait_jmx_up()
-        self.cluster.wait_for_schema_agreement()
+        with self.action_log_scope("Wait for schema agreement", target=self.target_node.name):
+            self.cluster.wait_for_schema_agreement()
 
     @decorate_with_context(ignore_raft_topology_cmd_failing)
     @target_all_nodes
     def disrupt_stop_wait_start_scylla_server(self, sleep_time=300):
-        self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
+        with self.action_log_scope("Stop Scylla", target=self.target_node.name):
+            self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
         self.log.info("Sleep for %s seconds", sleep_time)
         time.sleep(sleep_time)
         if self._is_it_on_kubernetes():
             # Kubernetes brings node up automatically, no need to start it up
             self.target_node.wait_node_fully_start(timeout=sleep_time)
             return
-        self.target_node.start_scylla_server(verify_up=True, verify_down=False)
+        with self.action_log_scope("Start Scylla", target=self.target_node.name):
+            self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
     @decorate_with_context(ignore_ycsb_connection_refused)
     @target_all_nodes
     def disrupt_stop_start_scylla_server(self):
-        self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
-        self.target_node.start_scylla_server(verify_up=True, verify_down=False)
+        with self.action_log_scope("Stop Scylla", target=self.target_node.name):
+            self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
+        with self.action_log_scope("Start Scylla", target=self.target_node.name):
+            self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
     @staticmethod
     def _handle_start_stop_compaction_results(trigger_and_watcher_futures: dict[str, ParallelObjectResult],
@@ -569,9 +576,10 @@ class Nemesis(NemesisFlags):
                              watch_for="User initiated compaction started on behalf of",
                              timeout=compaction_args.timeout,
                              stop_func=compaction_args.compaction_ops.stop_major_compaction)
-
+        ks_cf = f"{compaction_args.keyspace}.{compaction_args.columnfamily}"
         with DbNodeLogger(self.cluster.nodes, "start and stop major compaction", target_node=self.target_node,
-                          additional_info=f"on {compaction_args.keyspace}.{compaction_args.columnfamily}"):
+                          additional_info=f"on {ks_cf}"), \
+                self.action_log_scope(f"start and stop major compaction on {ks_cf}", target=self.target_node.name):
             results = ParallelObject.run_named_tasks_in_parallel(
                 tasks={"trigger": trigger_func, "watcher": watch_func},
                 timeout=compaction_args.timeout + 5,
@@ -584,8 +592,8 @@ class Nemesis(NemesisFlags):
         )
 
     def clear_snapshots(self) -> None:
-        self.log.info("Clear snapshots if there are some of them")
-        result = self.target_node.run_nodetool("clearsnapshot")
+        with self.action_log_scope("Clear snapshots", target=self.target_node.name):
+            result = self.target_node.run_nodetool("clearsnapshot")
         self.log.debug(result)
 
     def disrupt_start_stop_scrub_compaction(self):
@@ -615,7 +623,9 @@ class Nemesis(NemesisFlags):
                              watch_for="Scrubbing",
                              timeout=compaction_args.timeout,
                              stop_func=compaction_args.compaction_ops.stop_scrub_compaction)
-        with DbNodeLogger(self.cluster.nodes, "start and stop scrub compaction", target_node=self.target_node):
+        ks_cf = f"{compaction_args.keyspace}.{compaction_args.columnfamily}"
+        with DbNodeLogger(self.cluster.nodes, "start and stop scrub compaction", target_node=self.target_node), \
+                self.action_log_scope(f"start and stop scrub compaction on {ks_cf}", target=self.target_node.name):
             results = ParallelObject.run_named_tasks_in_parallel(
                 tasks={"trigger": trigger_func, "watcher": watch_func},
                 timeout=compaction_args.timeout + 5,
@@ -657,7 +667,9 @@ class Nemesis(NemesisFlags):
                              watch_for="Cleaning",
                              stop_func=compaction_args.compaction_ops.stop_cleanup_compaction)
 
-        with DbNodeLogger(self.cluster.nodes, "start and stop cleanup compaction", target_node=self.target_node):
+        ks_cf = f"{compaction_args.keyspace}.{compaction_args.columnfamily}"
+        with DbNodeLogger(self.cluster.nodes, "start and stop cleanup compaction", target_node=self.target_node), \
+                self.action_log_scope(f"start and stop cleanup compaction on {ks_cf}", target=self.target_node.name):
             results = ParallelObject.run_named_tasks_in_parallel(
                 tasks={"trigger": trigger_func, "watcher": watch_func},
                 timeout=compaction_args.timeout + 5,
@@ -698,7 +710,9 @@ class Nemesis(NemesisFlags):
                              timeout=compaction_args.timeout,
                              stop_func=compaction_args.compaction_ops.stop_validation_compaction)
 
-        with DbNodeLogger(self.cluster.nodes, "start and stop validation compaction", target_node=self.target_node):
+        ks_cf = f"{compaction_args.keyspace}.{compaction_args.columnfamily}"
+        with DbNodeLogger(self.cluster.nodes, "start and stop validation compaction", target_node=self.target_node), \
+                self.action_log_scope(f"start and stop validation compaction on {ks_cf}", target=self.target_node.name):
             results = ParallelObject.run_named_tasks_in_parallel(
                 tasks={"trigger": trigger_func, "watcher": watch_func},
                 timeout=compaction_args.timeout + 5,
@@ -723,13 +737,13 @@ class Nemesis(NemesisFlags):
                 self.target_node.restart()
 
         self.target_node.wait_node_fully_start(timeout=28800)  # 8 hours
-        with self.action_log_scope("Repair the node", target=self.target_node.name):
-            self.repair_nodetool_repair()
+        self.repair_nodetool_repair()
 
     @target_all_nodes
     def disrupt_resetlocalschema(self):
         rlocal_schema_res = self.target_node.follow_system_log(patterns=["schema_tables - Schema version changed to"])
-        self.target_node.run_nodetool("resetlocalschema")
+        with self.action_log_scope("Reset local schema", target=self.target_node.name):
+            self.target_node.run_nodetool("resetlocalschema")
 
         assert wait_for(
             func=lambda: list(rlocal_schema_res),
@@ -738,6 +752,7 @@ class Nemesis(NemesisFlags):
             throw_exc=False,
         ), "Schema version has not been recalculated"
 
+        self.actions_log.info("Schema version has been recalculated")
         # Check schema version on the nodes will be preformed after nemesis by ClusterHealthChecker
         # Waiting 60 sec: this time is defined by Tomasz
         self.log.debug("Sleep for 60 sec: the other nodes should pull new version")
@@ -746,7 +761,8 @@ class Nemesis(NemesisFlags):
     @target_all_nodes
     def disrupt_hard_reboot_node(self):
         self.reboot_node(target_node=self.target_node, hard=True)
-        self.target_node.wait_node_fully_start()
+        with self.action_log_scope("Wait for node to be fully started", target=self.target_node.name):
+            self.target_node.wait_node_fully_start()
 
     @target_all_nodes
     def disrupt_multiple_hard_reboot_node(self) -> None:
@@ -762,6 +778,7 @@ class Nemesis(NemesisFlags):
 
         num_of_reboots = random.randint(2, 10)
         InfoEvent(message=f'MultipleHardRebootNode {self.target_node}').publish()
+        self.actions_log.info(f"Rebooting node {num_of_reboots} times", target=self.target_node.name)
         for i in range(num_of_reboots):
             self.log.debug("Rebooting %s out of %s times", i + 1, num_of_reboots)
             cdc_expected_error = self.target_node.follow_system_log(patterns=cdc_expected_error_patterns)
@@ -797,12 +814,14 @@ class Nemesis(NemesisFlags):
     @target_all_nodes
     def disrupt_soft_reboot_node(self):
         self.reboot_node(target_node=self.target_node, hard=False)
-        self.target_node.wait_node_fully_start()
+        with self.action_log_scope("Wait for node to be fully started", target=self.target_node.name):
+            self.target_node.wait_node_fully_start()
 
     @decorate_with_context(ignore_ycsb_connection_refused)
     @target_all_nodes
     def disrupt_rolling_restart_cluster(self, random_order=False):
-        self.cluster.restart_scylla(random_order=random_order)
+        with self.action_log_scope("Rolling restart cluster", metadata={"random_order": random_order}):
+            self.cluster.restart_scylla(random_order=random_order)
 
     def disrupt_switch_between_password_authenticator_and_saslauthd_authenticator_and_back(self):
         """
@@ -827,15 +846,20 @@ class Nemesis(NemesisFlags):
             else:
                 raise UnsupportedNemesis(
                     'This nemesis only supports to switch between SaslauthdAuthenticator and PasswordAuthenticator')
-        update_authenticator(self.cluster.nodes, opposite_auth)
+        with self.action_log_scope("Switch Authenticator", target=self.target_node.name,
+                                   metadata={"from": orig_auth, "to": opposite_auth}):
+            update_authenticator(self.cluster.nodes, opposite_auth)
         try:
             # Run connect a new session after authenticator switch, and run a short workload
+            self.actions_log.info("Run a short workload after Authenticator switch")
             self._prepare_test_table(ks='keyspace_for_authenticator_switch', table='standard1')
         finally:
             # Wait 2 mins to let the workloads run with new Authenticator,
             # then switch Authenticator back to original
             time.sleep(120)
-            update_authenticator(self.cluster.nodes, orig_auth)
+            with self.action_log_scope("Switch Authenticator back", target=self.target_node.name,
+                                       metadata={"from": opposite_auth, "to": orig_auth}):
+                update_authenticator(self.cluster.nodes, orig_auth)
             # Run connect a new session after authenticator switch, drop the test keyspace
             with self.cluster.cql_connection_patient(self.target_node) as session:
                 session.execute('DROP KEYSPACE keyspace_for_authenticator_switch')
@@ -857,12 +881,15 @@ class Nemesis(NemesisFlags):
         with self.target_node.remote_scylla_yaml() as scylla_yaml:
             current = scylla_yaml.internode_compression
         new_value = get_internode_compression_new_value_randomly(current)
+        self.actions_log.info("Changing inter node compression",
+                              metadata={"from": current, "to": new_value})
         for node in self.cluster.nodes:
             self.log.debug(f"Changing {node} inter node compression to {new_value}")
             with node.remote_scylla_yaml() as scylla_yaml:
                 scylla_yaml.internode_compression = new_value
             self.log.info(f"Restarting node {node}")
             node.restart_scylla_server()
+        self.actions_log.info("changed inter node compression")
 
     @decorate_with_context(ignore_ycsb_connection_refused)
     def disrupt_restart_with_resharding(self):
@@ -879,16 +906,19 @@ class Nemesis(NemesisFlags):
         murmur3_partitioner_ignore_msb_bits = 15
         self.log.info(f'Restart node with resharding. New murmur3_partitioner_ignore_msb_bits value: '
                       f'{murmur3_partitioner_ignore_msb_bits}')
-        self.target_node.restart_node_with_resharding(
-            murmur3_partitioner_ignore_msb_bits=murmur3_partitioner_ignore_msb_bits)
-        self.target_node.wait_node_fully_start()
+        with self.action_log_scope("Restart with resharding", target=self.target_node.name):
+            self.target_node.restart_node_with_resharding(
+                murmur3_partitioner_ignore_msb_bits=murmur3_partitioner_ignore_msb_bits)
+        with self.action_log_scope("Wait node fully start", target=self.target_node.name):
+            self.target_node.wait_node_fully_start()
 
         # Wait 5 minutes our before return back the default value
         self.log.debug(
             'Wait 5 minutes our before return murmur3_partitioner_ignore_msb_bits back the default value (12)')
         time.sleep(360)
         self.log.info('Set back murmur3_partitioner_ignore_msb_bits value to 12')
-        self.target_node.restart_node_with_resharding()
+        with self.action_log_scope("Restart with resharding to original state", target=self.target_node.name):
+            self.target_node.restart_node_with_resharding()
 
     def replace_full_file_name_to_prefix(self, one_file, ks_cf_for_destroy):
         # The file name like: /var/lib/scylla/data/scylla_bench/test-f60e4f30c98f11e98d46000000000002/mc-220-big-Data.db
@@ -987,6 +1017,7 @@ class Nemesis(NemesisFlags):
             self.log.debug("SStables amount to destroy (%s percent of all SStables): %s", sstables_to_destroy_perc,
                            sstables_amount_to_destroy)
 
+            destroyed_files = 0
             while sstables_amount_to_destroy > 0:
                 file_for_destroy = random.choice(all_files_to_destroy)
                 if not (file_group_for_destroy := self.replace_full_file_name_to_prefix(one_file=file_for_destroy,
@@ -1001,7 +1032,9 @@ class Nemesis(NemesisFlags):
                         'Files were not removed. The nemesis can\'t be run. Error: {}'.format(result))
                 all_files_to_destroy.remove(file_for_destroy)
                 sstables_amount_to_destroy -= 1
+                destroyed_files += 1
                 self.log.debug('Files {} were destroyed'.format(file_for_destroy))
+            self.actions_log.info(f"removed {destroyed_files} files in tables: {tables}", target=self.target_node.name)
 
         finally:
             with self.action_log_scope("Start Scylla", target=self.target_node.name):
@@ -1031,12 +1064,14 @@ class Nemesis(NemesisFlags):
     def disrupt_destroy_data_then_rebuild(self):
         self._destroy_data_and_restart_scylla()
         # try to save the node
-        self.repair_nodetool_rebuild()
+        with self.action_log_scope("Rebuild after destroy data", target=self.target_node.name):
+            self.repair_nodetool_rebuild()
 
     @decorate_with_context(ignore_ycsb_connection_refused)
     @target_all_nodes
     def disrupt_nodetool_drain(self):
-        result = self.target_node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True)
+        with self.action_log_scope("Draining Scylla", target=self.target_node.name):
+            result = self.target_node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True)
         self.target_node.run_nodetool("status", ignore_status=True, verbose=True,
                                       warning_event_on_exception=(Exception,))
 
@@ -1044,8 +1079,9 @@ class Nemesis(NemesisFlags):
             # workaround for issue #7332: don't interrupt test and don't raise exception
             # for UnexpectedExit, Failure and CommandTimedOut if "scylla-server stop" failed
             # or scylla-server was stopped gracefully.
-            self.target_node.stop_scylla_server(verify_up=False, verify_down=True, ignore_status=True)
-            self.target_node.start_scylla_server(verify_up=True, verify_down=False)
+            with self.action_log_scope("Restart Scylla", target=self.target_node.name):
+                self.target_node.stop_scylla_server(verify_up=False, verify_down=True, ignore_status=True)
+                self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
     @target_all_nodes
     def disrupt_ldap_connection_toggle(self):
@@ -1056,13 +1092,12 @@ class Nemesis(NemesisFlags):
         if not self.cluster.params.get('ldap_server_type') == LdapServerType.OPENLDAP:
             raise UnsupportedNemesis('This nemesis is supported only for open-Ldap. Skipping')
 
-        self.log.info('Will now pause the LDAP container')
+        self.actions_log.info('Pausing the LDAP container')
         ContainerManager.pause_container(self.tester.localhost, 'ldap')
-        self.log.info('Will now sleep 180 seconds')
+        self.actions_log.info('Sleeping 180 seconds')
         time.sleep(180)
-        self.log.info('Will now resume the LDAP container')
+        self.actions_log.info('Resuming the LDAP container')
         ContainerManager.unpause_container(self.tester.localhost, 'ldap')
-        self.log.info('finished with nemesis')
 
     @target_all_nodes
     def disrupt_disable_enable_ldap_authorization(self):
@@ -1088,12 +1123,13 @@ class Nemesis(NemesisFlags):
             raise LdapNotRunning("LDAP server was supposed to be running, but it is not")
 
         InfoEvent(message='Disable LDAP Authorization Configuration').publish()
+        self.actions_log.info('Disabling LDAP authorization configuration')
         for node in self.cluster.nodes:
             remove_ldap_configuration_from_node(node)
-        self.log.info('Will now pause the LDAP container')
+        self.actions_log.info('Pausing the LDAP container')
         ContainerManager.pause_container(self.tester.localhost, 'ldap')
 
-        self.log.debug('Will wait few minutes with LDAP disabled, before re-enabling it')
+        self.actions_log.info('Sleep 10 minutes with LDAP disabled')
         time.sleep(600)
 
         def add_ldap_configuration_to_node(node):
@@ -1102,8 +1138,9 @@ class Nemesis(NemesisFlags):
                 scylla_yaml.update(ldap_config)
             node.restart_scylla_server()
 
-        self.log.info('Will now resume the LDAP container')
+        self.actions_log.info('Resuming the LDAP container')
         ContainerManager.unpause_container(self.tester.localhost, 'ldap')
+        self.actions_log.info('Enabling back the LDAP authorization configuration')
         for node in self.cluster.nodes:
             add_ldap_configuration_to_node(node)
 
@@ -1126,7 +1163,8 @@ class Nemesis(NemesisFlags):
             "disruption_name": self.current_disruption,
             **({"is_zero_node": is_zero_node} if is_zero_node else {})
         }
-        new_node = critical_on_capacity_issues(self.cluster.add_nodes)(**add_node_func_args)[0]
+        with self.action_log_scope("Add a new node"):
+            new_node = critical_on_capacity_issues(self.cluster.add_nodes)(**add_node_func_args)[0]
         self.monitoring_set.reconfigure_scylla_monitoring()
 
         # since we need this logic before starting a node, and in `use_preinstalled_scylla: false` case
@@ -1143,6 +1181,7 @@ class Nemesis(NemesisFlags):
         try:
             with adaptive_timeout(Operations.NEW_NODE, node=self.cluster.data_nodes[0], timeout=timeout):
                 self.cluster.wait_for_init(node_list=[new_node], timeout=timeout, check_node_health=False)
+            self.actions_log.info("New node initialized", metadata={"name": new_node.name})
             self.cluster.clean_replacement_node_options(new_node)
             self.cluster.set_seeds()
             self.cluster.update_seed_provider()
@@ -1154,6 +1193,7 @@ class Nemesis(NemesisFlags):
         self.cluster.wait_for_nodes_up_and_normal(nodes=[new_node])
         new_node.wait_node_fully_start()
         InfoEvent(message="FinishEvent - New Node is up and normal").publish()
+        self.actions_log.info("New node is up and normal", metadata={"name": new_node.name})
         return new_node
 
     def _add_and_init_new_cluster_nodes(self, count, timeout=MAX_TIME_WAIT_FOR_NEW_NODE_UP, rack=None, instance_type: str = None, is_zero_node: bool = False) -> list[BaseNode]:
@@ -1173,12 +1213,15 @@ class Nemesis(NemesisFlags):
             instance_type = self.cluster.params.get("zero_token_instance_type_db") or instance_type
             add_node_func_args.update({"is_zero_node": is_zero_node, "instance_type": instance_type})
 
-        new_nodes = skip_on_capacity_issues(db_cluster=self.tester.db_cluster)(
-            self.cluster.add_nodes)(**add_node_func_args)
+        with self.action_log_scope("Add new nodes", metadata={"count": count, "rack": rack, "instance_type": instance_type}):
+            new_nodes = skip_on_capacity_issues(db_cluster=self.tester.db_cluster)(
+                self.cluster.add_nodes)(**add_node_func_args)
         self.monitoring_set.reconfigure_scylla_monitoring()
+        nodes_names = ",".join([new_node.name for new_node in new_nodes])
         try:
             with adaptive_timeout(Operations.NEW_NODE, node=self.cluster.data_nodes[0], timeout=timeout):
                 self.cluster.wait_for_init(node_list=new_nodes, timeout=timeout, check_node_health=False)
+            self.actions_log.info("New nodes initialized", metadata={"names": nodes_names})
             self.cluster.set_seeds()
             self.cluster.update_seed_provider()
         except (NodeSetupFailed, NodeSetupTimeout):
@@ -1191,11 +1234,13 @@ class Nemesis(NemesisFlags):
             new_node.wait_native_transport()
         self.cluster.wait_for_nodes_up_and_normal(nodes=new_nodes)
         InfoEvent(message="FinishEvent - New Nodes are up and normal").publish()
+        self.actions_log.info("New nodes are up and normal", metadata={"names": nodes_names})
         return new_nodes
 
     @decorate_with_context([ignore_ycsb_connection_refused, ignore_raft_topology_cmd_failing])
     def _terminate_cluster_node(self, node):
-        self.cluster.terminate_node(node)
+        with self.action_log_scope("Terminate node", target=node.name):
+            self.cluster.terminate_node(node)
         self.monitoring_set.reconfigure_scylla_monitoring()
 
     def _nodetool_decommission(self, add_node=True):
@@ -1204,7 +1249,8 @@ class Nemesis(NemesisFlags):
             self.set_target_node(allow_only_last_node_in_rack=True)
 
         target_is_seed = self.target_node.is_seed
-        with self.action_log_scope("Decommission node", target=self.target_node.name):
+        with self.action_log_scope("Decommission node", target=self.target_node.name,
+                                   metadata={"is_zero_token_node": self.target_node._is_zero_token_node}):
             dc_topology_rf_change = self.cluster.decommission(self.target_node)
         new_node = None
         if add_node:
@@ -1213,19 +1259,18 @@ class Nemesis(NemesisFlags):
                 add_node_kwargs.update({"is_zero_node": True})
             # When adding node after decommission the node is declared as up only after it completed bootstrapping,
             # increasing the timeout for now
-            self.actions_log.info("Add a new node start", target=self.target_node.name)
-            new_node = self._add_and_init_new_cluster_nodes(**add_node_kwargs)[0]
-            self.actions_log.info("Add a new node finished", target=new_node.name)
+            with self.action_log_scope("Add a new node"):
+                new_node = self._add_and_init_new_cluster_nodes(**add_node_kwargs)[0]
             # after decomission and add_node, the left nodes have data that isn't part of their tokens anymore.
             # In order to eliminate cases that we miss a "data loss" bug because of it, we cleanup this data.
             # This fix important when just user profile is run in the test and "keyspace1" doesn't exist.
             if new_node.is_seed != target_is_seed:
                 new_node.set_seed_flag(target_is_seed)
                 self.cluster.update_seed_provider()
+            self.actions_log.info("new node added", metadata={"name": new_node.name})
             if dc_topology_rf_change:
                 dc_topology_rf_change.revert_to_original_keyspaces_rf(node_to_wait_for_balance=new_node)
-            with self.action_log_scope("Cleanup all nodes in parallel", target=new_node.name):
-                self.nodetool_cleanup_on_all_nodes_parallel()
+            self.nodetool_cleanup_on_all_nodes_parallel()
         return new_node
 
     @target_all_nodes
@@ -1478,7 +1523,8 @@ class Nemesis(NemesisFlags):
 
     @target_all_nodes
     def disrupt_terminate_and_replace_node(self):
-        self._terminate_and_replace_node()
+        with self.action_log_scope("Terminate and replace node", target=self.target_node.name):
+            self._terminate_and_replace_node()
 
     def _terminate_and_replace_node(self):
         def get_node_state(node_ip: str) -> List["str"] | None:
@@ -1537,8 +1583,8 @@ class Nemesis(NemesisFlags):
             raise UnsupportedNemesis('Disabled due to https://github.com/scylladb/scylladb/issues/18059 not fixed yet')
 
         # prepare test tables and fill test data
+        self.actions_log.info("Preparing test tables")
         for i in range(10):
-            self.log.debug('Prepare test tables if they do not exist')
             self._prepare_test_table(ks=f'drop_table_during_repair_ks_{i}', table='standard1')
             self.cluster.wait_for_schema_agreement()
 
@@ -1550,13 +1596,15 @@ class Nemesis(NemesisFlags):
                 for i in range(10):
                     time.sleep(random.randint(0, 300))
                     with self.cluster.cql_connection_patient(self.target_node, connect_timeout=600) as session:
+                        self.actions_log.info(f'Dropping table drop_table_during_repair_ks_{i}.standard1')
                         session.execute(SimpleStatement(
                             f'DROP TABLE drop_table_during_repair_ks_{i}.standard1'), timeout=300)
             finally:
                 thread.result()
 
     def _major_compaction(self):
-        with adaptive_timeout(Operations.MAJOR_COMPACT, self.target_node, timeout=8000):
+        with (adaptive_timeout(Operations.MAJOR_COMPACT, self.target_node, timeout=8000),
+              self.action_log_scope("Major compaction", target=self.target_node.name)):
             self.target_node.run_nodetool("compact")
 
     def disrupt_major_compaction(self):
@@ -1581,11 +1629,13 @@ class Nemesis(NemesisFlags):
             map_files_to_node = SstableLoadUtils.distribute_test_files_to_cluster_nodes(nodes=self.cluster.data_nodes,
                                                                                         test_data=test_data)
             for sstables_info, load_on_node in map_files_to_node:
+                self.actions_log.info('Uploading sstables', target=load_on_node.name)
                 SstableLoadUtils.upload_sstables(load_on_node, test_data=sstables_info, table_name="standard1")
                 # NOTE: on K8S logs may appear with a delay, so add a bigger timeout for it.
                 #       See https://github.com/scylladb/scylla-cluster-tests/issues/6314
                 kwargs = {"start_timeout": 1800, "end_timeout": 1800} if self._is_it_on_kubernetes() else {}
-                SstableLoadUtils.run_load_and_stream(load_on_node, **kwargs)
+                with self.action_log_scope('Loading and streaming sstables', target=load_on_node.name):
+                    SstableLoadUtils.run_load_and_stream(load_on_node, **kwargs)
 
     @target_all_nodes
     def disrupt_nodetool_refresh(self, big_sstable: bool = False):
@@ -1621,11 +1671,13 @@ class Nemesis(NemesisFlags):
             for node in self.cluster.data_nodes:
                 SstableLoadUtils.upload_sstables(node, test_data=test_data[0], table_name="standard1",
                                                  is_cloud_cluster=self.cluster.params.get("db_type") == 'cloud_scylla')
-                system_log_follower = SstableLoadUtils.run_refresh(node, test_data=test_data[0])
+                with self.action_log_scope('Running nodetool refresh', target=node.name):
+                    system_log_follower = SstableLoadUtils.run_refresh(node, test_data=test_data[0])
                 # NOTE: resharding happens only if we have more than 1 core.
                 #       We may have 1 core in a K8S multitenant setup.
                 # If tablets in use, skipping resharding validation since it doesn't work the same as vnodes
                 if shards_num > 1 and not is_tablets_feature_enabled(self.cluster.data_nodes[0]):
+                    self.actions_log.info('Validating resharding after refresh', target=node.name)
                     SstableLoadUtils.validate_resharding_after_refresh(
                         node=node, system_log_follower=system_log_follower)
 
@@ -1647,12 +1699,14 @@ class Nemesis(NemesisFlags):
             experiment = IOFaultChaosExperiment(node, duration="300s", error=DiskError.NO_SPACE_LEFT_ON_DEVICE, error_probability=100,
                                                 methods=["write", "flush"],
                                                 volume_path="/var/lib/scylla")
-            experiment.start()
-            experiment.wait_until_finished()
+            with self.action_log_scope("Creating IOFault (NO_SPACE_LEFT_ON_DEVICE) experiment", target=node.name):
+                experiment.start()
+                experiment.wait_until_finished()
             # wait some time before restarting to prevent supervisorctl error.
             time.sleep(30)
         finally:
             no_space_errors = list(no_space_errors_in_log)
+            self.actions_log.info("Restarting scylla-server", target=node.name)
             node.restart_scylla_server(verify_up_after=True)
             assert no_space_errors, "There are no 'No space left on device' errors in db log during enospc disruption."
 
@@ -1677,9 +1731,11 @@ class Nemesis(NemesisFlags):
 
                     try:
                         with DbNodeLogger(self.cluster.nodes, "fill disk space", target_node=node):
+                            self.actions_log.info("Filling disk space to reach enospc error", target=node.name)
                             reach_enospc_on_node(target_node=node)
                     finally:
                         with DbNodeLogger(self.cluster.nodes, "clean disk space", target_node=node):
+                            self.actions_log.info("Cleaning disk space with scylla restart", target=node.name)
                             clean_enospc_on_node(target_node=node, sleep_time=sleep_time)
 
     @target_all_nodes
@@ -1708,7 +1764,7 @@ class Nemesis(NemesisFlags):
         result = node.remoter.run('cat /proc/mounts')
         if '/var/lib/scylla' not in result.stdout:
             raise UnsupportedNemesis("Scylla doesn't use an individual storage, skip end of quota test")
-
+        self.actions_log.info("enabling quota on node", target=node.name)
         enable_quota_on_node(node)
         quota_enabled = is_quota_enabled_on_node(node)
         if not quota_enabled:
@@ -1716,9 +1772,11 @@ class Nemesis(NemesisFlags):
 
         with ignore_disk_quota_exceeded_errors(node):
             with configure_quota_on_node_for_scylla_user_context(node) as quota_size:
+                self.actions_log.info("reach end of quota on node", target=node.name)
                 write_data_to_reach_end_of_quota(node, quota_size)
             LOGGER.debug('Sleep 15 seconds before restart scylla-server')
             time.sleep(15)
+            self.actions_log.info("Restarting scylla", target=node.name)
             node.restart_scylla_server()
             node.wait_db_up()
 
@@ -1745,21 +1803,17 @@ class Nemesis(NemesisFlags):
             role.attached_service_level.session = session
             role.session = session
             try:
+                self.actions_log.info("Dropping service level",
+                                      metadata={"service_level": role.attached_service_level_name})
                 role.attached_service_level.drop(if_exists=False)
                 time.sleep(300)  # let load to run without service level for 5 minutes
             finally:
+                self.actions_log.info("Re-creating service level",
+                                      metadata={"service_level": role.attached_service_level_name})
                 role.attach_service_level(
                     ServiceLevel(session=session,
                                  name=SERVICE_LEVEL_NAME_TEMPLATE % (removed_shares, random.randint(0, 10)),
                                  shares=removed_shares).create())
-
-    def _deprecated_disrupt_stop_start(self):
-        # TODO: We don't support fully stopping the AMI instance anymore
-        # TODO: This nemesis has to be rewritten to just stop/start scylla server
-        self.log.info('StopStart %s', self.target_node)
-        self.target_node.restart()
-
-    # Nemesis running code
 
     @cached_property
     def all_disrupt_methods(self):
@@ -1864,7 +1918,8 @@ class Nemesis(NemesisFlags):
         if not self.cluster.params.get('use_mgmt') and not self.cluster.params.get('use_cloud_manager'):
             for node in nodes:
                 try:
-                    with adaptive_timeout(Operations.REPAIR, node, timeout=HOUR_IN_SEC * 3):
+                    with adaptive_timeout(Operations.REPAIR, node, timeout=HOUR_IN_SEC * 3), \
+                            self.action_log_scope("nodetool repair -pr", target=node.name):
                         node.run_nodetool(sub_cmd="repair -pr", publish_event=publish_event)
                 except Exception as err:  # pylint: disable=broad-except  # noqa: BLE001
                     self.log.warning(f"Repair failed to complete on node: {node}, with error: {str(err)}")
@@ -1884,7 +1939,8 @@ class Nemesis(NemesisFlags):
 
         parallel_objects = ParallelObject(self.cluster.nodes, num_workers=min(
             32, len(self.cluster.nodes)), timeout=HOUR_IN_SEC * 48)
-        parallel_objects.run(_nodetool_cleanup)
+        with self.action_log_scope("Cleanup all nodes in parallel"):
+            parallel_objects.run(_nodetool_cleanup)
 
     @target_all_nodes
     def disrupt_nodetool_cleanup(self):
@@ -1931,6 +1987,8 @@ class Nemesis(NemesisFlags):
         keyspace_truncate = 'ks_truncate'
         table = 'standard1'
 
+        ks_cf = f"{keyspace_truncate}.{table}"
+        self.actions_log.info("Preparing test table for truncate nemesis", metadata={"ks_cf": ks_cf})
         self._prepare_test_table(ks=keyspace_truncate)
 
         # In order to workaround issue #4924 when truncate timeouts, we try to flush before truncate.
@@ -1939,9 +1997,11 @@ class Nemesis(NemesisFlags):
         # do the actual truncation
         truncate_timeout = 600
         truncate_cmd_timeout_suffix = self._truncate_cmd_timeout_suffix(truncate_timeout)
-        self.target_node.run_cqlsh(
-            cmd=f'TRUNCATE {keyspace_truncate}.{table}{truncate_cmd_timeout_suffix}',
-            timeout=truncate_timeout)
+        with self.action_log_scope("Truncate table using cqlsh", target=self.target_node.name,
+                                   metadata={"timeout": truncate_timeout, "ks_cf": ks_cf}):
+            self.target_node.run_cqlsh(
+                cmd=f'TRUNCATE {keyspace_truncate}.{table}{truncate_cmd_timeout_suffix}',
+                timeout=truncate_timeout)
 
     def disrupt_truncate_large_partition(self):
         """
@@ -1955,10 +2015,13 @@ class Nemesis(NemesisFlags):
             raise UnsupportedNemesis("Unsupported nemesis due to scylladb/scylladb#20356")
         ks_name = 'ks_truncate_large_partition'
         table = 'test_table'
+        ks_cf = f"{ks_name}.{table}"
         stress_cmd = "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10 " + \
                      "-clustering-row-count=5555 -clustering-row-size=uniform:10..20 -concurrency=10 " + \
                      "-connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=60s " + \
                      f"-keyspace {ks_name} -table {table}"
+        self.actions_log.info("Preparing test table for truncate with scylla-bench",
+                              metadata={"ks_cf": ks_cf})
         bench_thread = self.tester.run_stress_thread(
             stress_cmd=stress_cmd, stop_test_on_failure=False)
         self.tester.verify_stress_thread(bench_thread, error_handler=self._nemesis_stress_failure_handler)
@@ -1969,9 +2032,11 @@ class Nemesis(NemesisFlags):
         # do the actual truncation
         truncate_timeout = 600
         truncate_cmd_timeout_suffix = self._truncate_cmd_timeout_suffix(truncate_timeout)
-        self.target_node.run_cqlsh(
-            cmd=f'TRUNCATE {ks_name}.{table}{truncate_cmd_timeout_suffix}',
-            timeout=truncate_timeout)
+        with self.action_log_scope("Truncate table using cqlsh", target=self.target_node.name,
+                                   metadata={"timeout": truncate_timeout, "ks_cf": ks_cf}):
+            self.target_node.run_cqlsh(
+                cmd=f'TRUNCATE {ks_name}.{table}{truncate_cmd_timeout_suffix}',
+                timeout=truncate_timeout)
 
     def _modify_table_property(self, name, val, filter_out_table_with_counter=False, keyspace_table=None):
         disruption_name = "".join([p.strip().capitalize() for p in name.split("_")])
@@ -1992,7 +2057,8 @@ class Nemesis(NemesisFlags):
 
         cmd = "ALTER TABLE {keyspace_table} WITH {name} = {val};".format(
             keyspace_table=keyspace_table, name=name, val=val)
-        self.log.debug('_modify_table_property: %s', cmd)
+        self.actions_log.info('Modify table property',
+                              metadata={"ks_cf": keyspace_table, "property": name, "value": val})
         with self.cluster.cql_connection_patient(self.target_node) as session:
             session.execute(cmd)
 
@@ -2090,6 +2156,9 @@ class Nemesis(NemesisFlags):
                 session.execute(cmd)
         except Exception as exc:  # noqa: BLE001
             self.log.debug(f"Add/Remove Column Nemesis: CQL query '{cmd}' execution has failed with error '{str(exc)}'")
+            self.actions_log.info("Failed to add/drop column", metadata={
+                "error": str(exc),
+            })
             return False
         return True
 
@@ -2128,13 +2197,22 @@ class Nemesis(NemesisFlags):
         if not add and not drop:
             return
         # TBD: Scylla does not support DROP and ADD in the same statement
+        ks_cf = f"{self._add_drop_column_target_table[0]}.{self._add_drop_column_target_table[1]}"
         if drop:
+            self.actions_log.info('Dropping columns', metadata={
+                "ks_cf": ks_cf,
+                "columns_count": len(drop)
+            })
             cmd = f"ALTER TABLE {self._add_drop_column_target_table[1]} DROP ( {', '.join(drop)} );"
             if self._add_drop_column_run_cql_query(cmd, self._add_drop_column_target_table[0]):
                 for column_name in drop:
                     column_type = added_columns_info['column_names'][column_name]
                     del added_columns_info['column_names'][column_name]
         if add:
+            self.actions_log.info('Adding columns', metadata={
+                "ks_cf": ks_cf,
+                "columns_count": len(add)
+            })
             cmd = f"ALTER TABLE {self._add_drop_column_target_table[1]} " \
                 f"ADD ( {', '.join(['%s %s' % (col[0], col[1]) for col in add])} );"
             if self._add_drop_column_run_cql_query(cmd, self._add_drop_column_target_table[0]):
@@ -2303,6 +2381,10 @@ class Nemesis(NemesisFlags):
         if not partitions_for_delete:
             raise UnsupportedNemesis('Not found partitions for delete. Nemesis can not be run')
 
+        self.actions_log.info('Deleting half of partition', metadata={
+            "ks_cf": ks_cf,
+            "partitions_count": len(partitions_for_delete)
+        })
         queries = []
         for pkey, ckey in partitions_for_delete.items():
             queries.append(f"delete from {ks_cf} where pk = {pkey} and ck > {int(ckey[1] / 2)}")
@@ -2323,6 +2405,11 @@ class Nemesis(NemesisFlags):
         queries = []
         verification_queries = []
         partition_percentage = random.randint(25, 75) / 100
+        self.actions_log.info('Deleting partitions using timestamp', metadata={
+            "ks_cf": ks_cf,
+            "partitions_count": len(partitions_for_delete),
+            "partition_percentage": partition_percentage
+        })
         for pkey, _ in partitions_for_delete.items():
             self.log.debug("Using USING TIMESTAMP clause in the deletion for this partition: %s", pkey)
             timestamp, clustering_key = self.get_random_timestamp_from_partition(
@@ -2359,6 +2446,10 @@ class Nemesis(NemesisFlags):
         if not clustering_keys:
             clustering_keys = range(min_clustering_key, max_clustering_key)
 
+        self.actions_log.info('Delete same range in the few partitions', metadata={
+            "ks_cf": ks_cf,
+            "partitions_count": len(partitions_for_delete)
+        })
         queries = []
         for pkey in partitions_for_delete.keys():
             queries.append(f"delete from {ks_cf} where pk = {pkey} and ck >= {clustering_keys[0]} "
@@ -2380,6 +2471,10 @@ class Nemesis(NemesisFlags):
         if not partitions_for_delete:
             raise UnsupportedNemesis('Not found partitions for delete. Nemesis can not be run')
 
+        self.actions_log.info('Delete partitions', metadata={
+            "ks_cf": ks_cf,
+            "partitions_count": len(partitions_for_delete)
+        })
         queries = []
         for partition_key in partitions_for_delete.keys():
             queries.append(f"delete from {ks_cf} where pk = {partition_key}")
@@ -2399,7 +2494,10 @@ class Nemesis(NemesisFlags):
             self.log.error('No partitions for delete found!')
             raise UnsupportedNemesis("DeleteOverlappingRowRangesMonkey: No partitions for delete found!")
 
-        self.log.debug('Delete random row ranges in few partitions')
+        self.actions_log.info('Delete random row ranges in few partitions', metadata={
+            "ks_cf": ks_cf,
+            "partitions_count": len(partitions_for_delete)
+        })
         queries = []
         for pkey, ckey in partitions_for_delete.items():
             for _ in range(random.randint(3, 20)):  # Get a random number of ranges to delete.
@@ -2497,7 +2595,8 @@ class Nemesis(NemesisFlags):
 
         keyspace_table = random.choice(all_ks_cfs)
         keyspace, table = keyspace_table.split('.')
-        if get_gc_mode(node=self.target_node, keyspace=keyspace, table=table) != GcMode.REPAIR:
+        current_gc_mode = get_gc_mode(node=self.target_node, keyspace=keyspace, table=table)
+        if current_gc_mode != GcMode.REPAIR:
             new_gc_mode = GcMode.REPAIR
         else:
             new_gc_mode = GcMode.TIMEOUT
@@ -2506,7 +2605,12 @@ class Nemesis(NemesisFlags):
         alter_command_prefix = 'ALTER TABLE ' if not is_cf_a_view(
             node=self.target_node, ks=keyspace, cf=table) else 'ALTER MATERIALIZED VIEW '
         cmd = alter_command_prefix + f" {keyspace_table} WITH tombstone_gc = {new_gc_mode_as_dict};"
-        self.log.info("Alter GC mode query to execute: %s", cmd)
+        self.log.debug("Alter GC mode query to execute: %s", cmd)
+        self.actions_log.info("Toggle table GC mode",
+                              metadata={"ks_cf": keyspace_table,
+                                        "from": current_gc_mode.value,
+                                        "to": new_gc_mode.value}
+                              )
         self.target_node.run_cqlsh(cmd)
 
     def toggle_table_ics(self):
@@ -2541,6 +2645,11 @@ class Nemesis(NemesisFlags):
         cmd = alter_command_prefix + \
             " {keyspace_table} WITH compaction = {new_compaction_strategy_as_dict};".format(**locals())
         self.log.debug("Toggle table ICS query to execute: {}".format(cmd))
+        self.actions_log.info("Toggle table ICS",
+                              metadata={"ks_cf": keyspace_table,
+                                        "from": cur_compaction_strategy.value,
+                                        "to": new_compaction_strategy.value}
+                              )
         try:
             self.target_node.run_cqlsh(cmd)
         except (UnexpectedExit, Libssh2UnexpectedExit) as unexpected_exit:
@@ -2549,7 +2658,8 @@ class Nemesis(NemesisFlags):
                 raise UnsupportedNemesis(err_msg) from unexpected_exit
             raise unexpected_exit
 
-        self.cluster.wait_for_schema_agreement()
+        with self.action_log_scope("Waiting for schema agreement"):
+            self.cluster.wait_for_schema_agreement()
 
     def modify_table_compaction(self):
         """
@@ -2806,24 +2916,28 @@ class Nemesis(NemesisFlags):
         self._modify_table_property(name="gc_grace_seconds",
                                     val=ks_cs_settings["gc"], keyspace_table=ks_cs_settings["name"])
 
-        self.cluster.wait_for_schema_agreement()
+        with self.action_log_scope("Waiting for schema agreement"):
+            self.cluster.wait_for_schema_agreement()
         # wait timeout  equal 2% of test duration for generating sstables with timewindow settings
         sleep_timeout = int(0.02 * self.tester.params["test_duration"])
         time.sleep(sleep_timeout)
 
-        self.target_node.stop_scylla()
+        with self.action_log_scope("Stopping Scylla"):
+            self.target_node.stop_scylla()
 
         reshape_twcs_records = self.target_node.follow_system_log(
             patterns=["need reshape. Starting reshape process",
                       "Reshaping",
                       f"Reshape {ks_cs_settings['name']} .* Reshaped"])
-
-        self.target_node.start_scylla()
+        with self.action_log_scope("Starting Scylla"):
+            self.target_node.start_scylla()
 
         reshape_twcs_records = list(reshape_twcs_records)
         if not reshape_twcs_records:
             self.log.warning("Log message with sstables for reshape was not found. Autocompaction already"
                              "compact sstables by timewindows")
+            self.actions_log.info("TWCS reshape was not needed")
+        self.actions_log.info("TWCS reshape completed")
         self.log.debug("Reshape log %s", reshape_twcs_records)
 
         num_sstables_after_change = len(self.target_node.get_list_of_sstables(keyspace, table, suffix="-Data.db"))
@@ -2836,7 +2950,9 @@ class Nemesis(NemesisFlags):
         # to reshape sstables on other nodes
         for node in self.cluster.data_nodes:
             num_sstables_before_change = len(node.get_list_of_sstables(keyspace, table, suffix="-Data.db"))
-            node.run_nodetool("compact", args=f"{keyspace} {table}")
+            with self.action_log_scope("Run major compaction", target=node.name,
+                                       metadata={"ks_cf": ks_cs_settings["name"]}):
+                node.run_nodetool("compact", args=f"{keyspace} {table}")
             num_sstables_after_change = len(node.get_list_of_sstables(keyspace, table, suffix="-Data.db"))
             self.log.info("Number of sstables before: %s and after %s change twcs settings on node: %s",
                           num_sstables_before_change, num_sstables_after_change, node.name)
@@ -2856,7 +2972,8 @@ class Nemesis(NemesisFlags):
         disrupt_func()
 
     def _run_manager_backup(self, mgr_cluster, object_storage_upload_mode: ObjectStorageUploadMode, timeout: int) -> BackupTask:
-        task = run_manager_backup(mgr_cluster, self.tester.locations, object_storage_upload_mode, timeout)
+        with self.action_log_scope("Scylla Manager backup"):
+            task = run_manager_backup(mgr_cluster, self.tester.locations, object_storage_upload_mode, timeout)
         return task
 
     def _manager_backup_and_report(self, object_storage_upload_mode: ObjectStorageUploadMode, label) -> BackupTask:
@@ -2888,8 +3005,8 @@ class Nemesis(NemesisFlags):
         time_postfix = datetime.datetime.now().strftime("_%m%d_%H%M")
         label_with_time = f"{label}{time_postfix}"
         task = self._manager_backup_and_report(object_storage_upload_mode, label_with_time)
-        self.log.info("Delete Manager backup snapshot")
-        task.delete_backup_snapshot()
+        with self.action_log_scope("Delete Manager backup snapshot"):
+            task.delete_backup_snapshot()
 
     def get_manager_tool(self):
         return mgmt.get_scylla_manager_tool(manager_node=self.tester.monitors.nodes[0])
@@ -3096,13 +3213,17 @@ class Nemesis(NemesisFlags):
         self._delete_existing_backups(mgr_cluster)
         if backup_specific_tables:
             non_test_keyspaces = [cql_unquote_if_needed(ks) for ks in self.cluster.get_test_keyspaces()]
+            self.actions_log.info("Starting Scylla Manager backup task",
+                                  metadata={"keyspaces": non_test_keyspaces})
             mgr_task = mgr_cluster.create_backup_task(location_list=[location, ], keyspace_list=non_test_keyspaces)
         else:
+            self.actions_log.info("Starting Scylla Manager backup task for all keyspaces")
             mgr_task = mgr_cluster.create_backup_task(location_list=[location, ])
 
         assert mgr_task is not None, "Backup task wasn't created"
 
         status = mgr_task.wait_and_get_final_status(timeout=54000, step=5, only_final=True)
+        self.actions_log.info("Scylla Manager backup task finished", metadata={"status": str(status)})
         if status == TaskStatus.DONE:
             self.log.info("Task: %s is done.", mgr_task.id)
         elif status in (TaskStatus.ERROR, TaskStatus.ERROR_FINAL):
@@ -3128,8 +3249,10 @@ class Nemesis(NemesisFlags):
     def _mgmt_repair_cli(self, ignore_down_hosts=None):
         self.log.debug("Manager repair started")
         mgr_cluster = self.cluster.get_cluster_manager()
+        self.actions_log.info("Starting Scylla Manager repair task")
         mgr_task = mgr_cluster.create_repair_task(ignore_down_hosts=ignore_down_hosts)
         task_final_status = mgr_task.wait_and_get_final_status(timeout=86400)  # timeout is 24 hours
+        self.actions_log.info("Scylla Manager repair task finished", metadata={"status": str(task_final_status)})
         if task_final_status != TaskStatus.DONE:
             progress_full_string = mgr_task.progress_string(
                 parse_table_res=False, is_verify_errorless_result=True).stdout
@@ -3149,13 +3272,15 @@ class Nemesis(NemesisFlags):
         @raise_event_on_failure
         def silenced_nodetool_repair_to_fail():
             try:
+                self.actions_log.info("Starting nodetool repair expected to be aborted",
+                                      target=self.target_node.name)
                 self.target_node.run_nodetool("repair", verbose=True,
                                               warning_event_on_exception=(UnexpectedExit, Libssh2UnexpectedExit),
                                               error_message="Repair failed as expected. ",
                                               publish_event=False,
                                               long_running=True, retry=0)
             except (UnexpectedExit, Libssh2UnexpectedExit):
-                self.log.info('Repair failed as expected')
+                self.actions_log.info('Repair failed as expected')
             except Exception:
                 self.log.error('Repair failed due to the unknown error')
                 raise
@@ -3218,8 +3343,10 @@ class Nemesis(NemesisFlags):
             raise UnsupportedNemesis('For this nemesis to work, `hinted_handoff` needs to be set to `enabled`')
 
         start_time = time.time()
+        self.actions_log.info("Stopping Scylla", target=self.target_node.name)
         self.target_node.stop_scylla()
         time.sleep(10)
+        self.actions_log.info("Starting Scylla", target=self.target_node.name)
         self.target_node.start_scylla()
 
         # Wait until all other nodes see the target node as UN
@@ -3229,13 +3356,13 @@ class Nemesis(NemesisFlags):
                 if node is not self.target_node:
                     self.cluster.check_nodes_up_and_normal(nodes=[self.target_node], verification_node=node)
             return True
-
+        self.actions_log.info("Wait until all other nodes see the target node as UN")
         wait.wait_for(func=target_node_reported_un_by_others,
                       timeout=300,
                       step=5,
                       throw_exc=True,
                       text='Wait for target_node to be seen as UN by others')
-
+        self.actions_log.info("All other nodes see the target node as UN")
         time.sleep(120)  # Wait to complete hints sending
         assert self.tester.hints_sending_in_progress() is False, "Hints are sent too slow"
         self.tester.verify_no_drops_and_errors(starting_from=start_time)
@@ -3389,7 +3516,9 @@ class Nemesis(NemesisFlags):
             raise ValueError(f"Failed to get nodetool command. Error: {exc}") from exc
 
         self.log.debug(f'Take snapshot with command: {nodetool_cmd}')
-        result = self.target_node.run_nodetool(nodetool_cmd)
+        with self.action_log_scope("Take snapshot", target=self.target_node.name,
+                                   metadata={"nodetool_cmd": nodetool_cmd}):
+            result = self.target_node.run_nodetool(nodetool_cmd)
         self.log.debug(result)
         if "snapshot name" not in result.stdout:
             raise Exception(f"Snapshot name wasn't found in {nodetool_cmd} output:\n{result.stdout}")
@@ -3482,31 +3611,31 @@ class Nemesis(NemesisFlags):
             case "delay":
                 delay_in_msecs = random.randrange(50, 300)
                 jitter = delay_in_msecs * 0.2
-                LOGGER.info("Delaying network - duration: %s delay: %s ms",
-                            duration, delay_in_msecs)
+                self.actions_log.info(f"Interruption by network delay - delay: {delay_in_msecs} ms")
                 experiment = NetworkDelayExperiment(self.target_node, duration,
                                                     f"{delay_in_msecs}ms", correlation=20, jitter=f"{jitter}ms")
             case "loss":
                 loss_percentage = random.randrange(1, 15)
-                LOGGER.info("Dropping network packets - duration: %s loss_percentage: %s%%",
-                            duration, loss_percentage)
+                self.actions_log.info(f"Interruption by dropping network packets - loss_percentage: {loss_percentage}%")
                 experiment = NetworkPacketLossExperiment(
                     self.target_node, duration, loss_percentage, correlation=20)
             case "corrupt":
                 corrupt_percentage = random.randrange(1, 15)
-                LOGGER.info("Corrupting network packets - duration: %s corrupt_percentage: %s%%",
-                            duration, corrupt_percentage)
+                self.actions_log.info(
+                    f"Interruption by corrupting network packets - corrupt_percentage: {corrupt_percentage}%")
                 experiment = NetworkCorruptExperiment(self.target_node, duration,
                                                       corrupt_percentage, correlation=20)
             case "rate":
                 rate, suffix = rate_limit[:-4], rate_limit[-4:]
                 limit_base = int(rate) * 1024 * (1024 if suffix == "mbps" else 1)
                 limit = limit_base * 20
-                LOGGER.info("Limiting network bandwidth - duration: %s rate: %s limit: %s",
-                            duration, rate_limit, limit)
+                self.actions_log.info(
+                    f"Interruption by limiting network bandwidth - rate: {rate_limit}, limit: {limit}")
                 experiment = NetworkBandwidthLimitExperiment(
                     self.target_node, duration, rate=rate_limit, limit=limit, buffer=10000)
-        with DbNodeLogger(self.cluster.nodes, f"network {interruption} interruption", target_node=self.target_node):
+        with DbNodeLogger(self.cluster.nodes, f"network {interruption} interruption", target_node=self.target_node), \
+                self.action_log_scope("Network interruption", target=self.target_node.name,
+                                      metadata={"duration": duration}):
             experiment.start()
             experiment.wait_until_finished()
         self.cluster.wait_all_nodes_un()
@@ -3555,6 +3684,8 @@ class Nemesis(NemesisFlags):
         option_name, selected_option = random.choice(list_of_tc_options)
         wait_time = random.choice(list_of_timeout_options)
 
+        self.actions_log.info("Network interruption start", target=self.target_node.name,
+                              metadata={"option": option_name, "wait_time": wait_time})
         if self.target_node.systemd_version < 256:
             context_manager = EventsSeverityChangerFilter(
                 new_severity=Severity.WARNING, event_class=CoreDumpEvent, regex=r".*executable=.*networkd.*",
@@ -3573,6 +3704,7 @@ class Nemesis(NemesisFlags):
             finally:
                 self.target_node.traffic_control(None)
                 self.cluster.wait_all_nodes_un()
+        self.actions_log.info("Network random interruption finished", target=self.target_node.name)
 
     def _disrupt_network_block_k8s(self, list_of_timeout_options):
         duration = f"{random.choice(list_of_timeout_options)}s"
@@ -3588,7 +3720,8 @@ class Nemesis(NemesisFlags):
     def disrupt_network_block(self):
         list_of_timeout_options = [10, 60, 120, 300, 500]
         if self._is_it_on_kubernetes():
-            self._disrupt_network_block_k8s(list_of_timeout_options)
+            with self.action_log_scope("Block network", target=self.target_node.name):
+                self._disrupt_network_block_k8s(list_of_timeout_options)
             return
 
         if not self.cluster.extra_network_interface:
@@ -3607,6 +3740,7 @@ class Nemesis(NemesisFlags):
         selected_option = "--loss 100%"
         wait_time = random.choice(list_of_timeout_options)
         self.log.debug("BlockNetwork: [%s] for %dsec", selected_option, wait_time)
+        self.actions_log.info("Network block start", target=self.target_node.name, metadata={"wait_time": wait_time})
         with context_manager:
             self.target_node.traffic_control(None)
             try:
@@ -3617,6 +3751,7 @@ class Nemesis(NemesisFlags):
             finally:
                 self.target_node.traffic_control(None)
                 self.cluster.wait_all_nodes_un()
+        self.actions_log.info("Network block finished", target=self.target_node.name)
 
     @target_all_nodes
     def disrupt_remove_node_then_add_node(self):
@@ -3668,12 +3803,9 @@ class Nemesis(NemesisFlags):
         else:
             ignore_stream_mutation_errors_due_to_issue = contextlib.nullcontext
 
-        with ignore_ycsb_connection_refused(), ignore_stream_mutation_errors_due_to_issue(), \
-                self.action_log_scope("Terminate a node", target=node_to_remove.name):
-            # node stop and make sure its "DN"
+        with ignore_ycsb_connection_refused(), ignore_stream_mutation_errors_due_to_issue():
+            self.actions_log.info("Stop node and make sure is DN", target=node_to_remove.name)
             node_to_remove.stop_scylla_server(verify_up=False, verify_down=True)
-
-            # terminate node
             self._terminate_cluster_node(node_to_remove)
 
         @retrying(n=3, sleep_time=5, message="Removing node from cluster...")
@@ -3694,9 +3826,7 @@ class Nemesis(NemesisFlags):
         up_normal_nodes = self.cluster.get_nodes_up_and_normal(verification_node)
         # Repairing will result in a best effort repair due to the terminated node,
         # and as a result requires ignoring repair errors
-        with DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR,
-                            line="failed to repair"), \
-                self.action_log_scope("Repair all nodes", target=self.target_node.name):
+        with DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR, line="failed to repair"):
             self.run_repair_on_nodes(nodes=up_normal_nodes, ignore_down_hosts=True)
 
         with self.action_log_scope("Remove the node", target=node_to_remove.name):
@@ -3934,7 +4064,8 @@ class Nemesis(NemesisFlags):
         ignore_ipv6_failure_to_assign,
         issue_refs=['https://github.com/scylladb/scylladb/issues/20387'])
     def reboot_node(self, target_node, hard=True, verify_ssh=True):
-        target_node.reboot(hard=hard, verify_ssh=verify_ssh)
+        with self.action_log_scope(f"Reboot node. hard: {hard}", target=target_node.name):
+            target_node.reboot(hard=hard, verify_ssh=verify_ssh)
         if self.tester.params.get('print_kernel_callstack'):
             save_kallsyms_map(node=target_node)
 
@@ -3949,10 +4080,14 @@ class Nemesis(NemesisFlags):
 
         try:
             self.target_node.stop_network_interface()
+            self.actions_log.info("Taking network interface down", target=self.target_node.name)
             time.sleep(wait_time)
         finally:
+            self.actions_log.info("Brigning network interface up", target=self.target_node.name)
             self.target_node.start_network_interface()
-            self.cluster.wait_all_nodes_un()
+            with self.action_log_scope("Wait all nodes up and normal", target=self.target_node.name):
+                self.cluster.wait_all_nodes_un()
+        self.actions_log.info("Network interface down/up finished", target=self.target_node.name)
 
     def _call_disrupt_func_after_expression_logged(self,
                                                    log_follower: Iterable[str],
@@ -4126,10 +4261,12 @@ class Nemesis(NemesisFlags):
             timeout=timeout,
             delay=1
         )
-        ParallelObject(objects=[trigger, watcher], timeout=timeout + 60).call_objects()
+        with self.action_log_scope("Rebuild data after destroy", target=self.target_node.name):
+            ParallelObject(objects=[trigger, watcher], timeout=timeout + 60).call_objects()
         self.target_node.wait_node_fully_start(timeout=300)
         with adaptive_timeout(Operations.REBUILD, self.target_node, timeout=HOUR_IN_SEC * 48):
-            self.target_node.run_nodetool("rebuild", long_running=True, retry=0)
+            with self.action_log_scope("Rebuild data after destroy", target=self.target_node.name):
+                self.target_node.run_nodetool("rebuild", long_running=True, retry=0)
 
     def disrupt_decommission_streaming_err(self):
         """
@@ -4185,7 +4322,8 @@ class Nemesis(NemesisFlags):
         self.log.debug("Rebuild sstables by scrub with `--skip-corrupted`, corrupted partitions will be skipped.")
         with ignore_scrub_invalid_errors(), adaptive_timeout(Operations.SCRUB, self.target_node, timeout=HOUR_IN_SEC * 48):
             for ks in self.cluster.get_test_keyspaces():
-                self.target_node.run_nodetool("scrub", args=f"--skip-corrupted {ks}")
+                with self.action_log_scope("Scrub keyspace", target=self.target_node.name, metadata={"keyspace": ks}):
+                    self.target_node.run_nodetool("scrub", args=f"--skip-corrupted {ks}")
 
         self.clear_snapshots()
 
@@ -4364,6 +4502,7 @@ class Nemesis(NemesisFlags):
             scylla_encryption_options |= {'kms_host': kms_host_name}
             aws_kms = AwsKms(region_names=self.cluster.params.region_names)
             aws_kms.create_alias(kms_key_alias_name)
+            self.actions_log.info("Reconfigure Scylla nodes to use AWS KMS")
             for node in self.cluster.nodes:
                 is_restart_needed = False
                 with node.remote_scylla_yaml() as scylla_yml:
@@ -4378,10 +4517,12 @@ class Nemesis(NemesisFlags):
                         is_restart_needed = True
                 if is_restart_needed:
                     node.restart_scylla()
+            self.actions_log.info("Reconfigured Scylla nodes to use AWS KMS")
 
         # Create table with encryption
         keyspace_name, table_name = cql_unquote_if_needed(self.cluster.get_test_keyspaces()[0]), 'tmp_encrypted_table'
-        self.log.info("Create '%s.%s' table with server encryption", keyspace_name, table_name)
+        self.actions_log.info("Create encrypted table",
+                              metadata={"keyspace": keyspace_name, "table": table_name})
         with self.cluster.cql_connection_patient(self.target_node, keyspace=keyspace_name) as session:
             # NOTE: scylla-bench expects following table structure:
             #       (pk bigint, ck bigint, v blob, PRIMARY KEY(pk, ck)) WITH compression = { }
@@ -4394,6 +4535,7 @@ class Nemesis(NemesisFlags):
             session.execute(create_table_query_cmd)
 
         def upgrade_sstables(nodes):
+            self.actions_log.info("Upgrade sstables for the new encrypted table on all nodes")
             for node in nodes:
                 self.log.info("Upgradesstables on the '%s' node for the new encrypted table", node.name)
                 # NOTE: 'flush' is needed in case there are no sstables yet
@@ -4403,6 +4545,7 @@ class Nemesis(NemesisFlags):
                 node.remoter.run('nodetool flush -- system_schema', verbose=True)
                 time.sleep(2)
                 node.remoter.run(f'nodetool upgradesstables -a -- {keyspace_name} {table_name}', verbose=True)
+            self.actions_log.info("Upgraded sstables for the new encrypted table on all nodes")
 
         @retrying(n=4, sleep_time=30, allowed_exceptions=(AssertionError, ))
         def check_encryption_fact(sstable_util_instance, expected_bool_value):
@@ -4419,8 +4562,10 @@ class Nemesis(NemesisFlags):
                     new_severity=Severity.WARNING, event_class=ScyllaBenchEvent, extra_time_to_expiration=30,
                     regex=r".*Error during truncate: seastar::rpc::remote_verb_error \(filesystem error.*"
             ), EventsSeverityChangerFilter(
-                    new_severity=Severity.WARNING, event_class=DatabaseLogEvent, extra_time_to_expiration=30,
-                    regex=".*sstable - Error while linking SSTable.*filesystem error: stat failed: No such file or directory.*"):
+                new_severity=Severity.WARNING, event_class=DatabaseLogEvent, extra_time_to_expiration=30,
+                regex=".*sstable - Error while linking SSTable.*filesystem error: stat failed: No such file or directory.*"), \
+                    self.action_log_scope("Write data with scylla-bench", target=self.target_node.name,
+                                          metadata={"cmd": write_cmd}):
                 write_thread = self.tester.run_stress_thread(stress_cmd=write_cmd, stop_test_on_failure=False)
                 self.tester.verify_stress_thread(write_thread, error_handler=self._nemesis_stress_failure_handler)
 
@@ -4440,11 +4585,14 @@ class Nemesis(NemesisFlags):
                     " -partition-count=50 -clustering-row-count=100 -clustering-row-size=uniform:75..125"
                     f" -keyspace '{cql_quote_if_needed(keyspace_name)}' -table '{cql_quote_if_needed(table_name)}' -timeout=120s -validate-data"
                     " -iterations=1 -concurrency=10 -connection-count=10 -rows-per-request=10")
-                read_thread = self.tester.run_stress_thread(stress_cmd=read_cmd, stop_test_on_failure=False)
-                self.tester.verify_stress_thread(read_thread, error_handler=self._nemesis_stress_failure_handler)
+                with self.action_log_scope("Read data with scylla-bench", target=self.target_node.name,
+                                           metadata={"cmd": read_cmd}):
+                    read_thread = self.tester.run_stress_thread(stress_cmd=read_cmd, stop_test_on_failure=False)
+                    self.tester.verify_stress_thread(read_thread, error_handler=self._nemesis_stress_failure_handler)
 
                 # Rotate KMS key
                 if enable_kms_key_rotation and aws_kms and kms_key_alias_name and i == 0:
+                    self.actions_log.info("Rotate AWS KMS key", metadata={"alias_name": kms_key_alias_name})
                     aws_kms.rotate_kms_key(kms_key_alias_name)
 
             # Check that sstables of that table are really encrypted
@@ -4458,7 +4606,8 @@ class Nemesis(NemesisFlags):
             # if encryption is enabled by default, we currently can't disable it
             if not user_info_encryption_enabled:
                 # Disable encryption for the encrypted table
-                self.log.info("Disable encryption for the '%s.%s' table", keyspace_name, table_name)
+                self.actions_log.info("Disable encryption for the table",
+                                      metadata={"keyspace": keyspace_name, "table": table_name})
                 with self.cluster.cql_connection_patient(self.target_node, keyspace=keyspace_name) as session:
                     query = f"ALTER TABLE {table_name} WITH scylla_encryption_options = {{'key_provider': 'none'}};"
                     session.execute(query)
@@ -4480,7 +4629,8 @@ class Nemesis(NemesisFlags):
                 check_encryption_fact(sstable_util, False)
         finally:
             # Delete table
-            self.log.info("Delete '%s.%s' table with server encryption", keyspace_name, table_name)
+            self.actions_log.info("Delete encrypted table",
+                                  metadata={"keyspace": keyspace_name, "table": table_name})
             with self.cluster.cql_connection_patient(self.target_node, keyspace=keyspace_name) as session:
                 session.execute(f"DROP TABLE {table_name};")
 
@@ -4520,6 +4670,7 @@ class Nemesis(NemesisFlags):
                     patterns=[f'messaging_service - Reloaded {{"{ssl_files_location}"}}'])
                 update_certificate(node)
                 node.remoter.send_files(src=str(node.ssl_conf_dir / TLSAssets.DB_CERT), dst='/tmp')
+                self.actions_log.info("Update certificate file", target=node.name)
                 node.remoter.run(f"sudo cp -f /tmp/{TLSAssets.DB_CERT} {ssl_files_location}")
                 new_crt = node.remoter.run(f"cat {ssl_files_location}").stdout
                 if in_place_crt == new_crt:
@@ -4587,9 +4738,10 @@ class Nemesis(NemesisFlags):
         experiment = MemoryStressExperiment(pod=self.target_node, duration=f"{duration}s",
                                             workers=1, size="100%", time_to_reach=f"{time_to_reach_secs}s")
         with DbNodeLogger(self.cluster.nodes, "start memory stress",
-                          target_node=self.target_node, additional_info="allocate 100% of total memory"):
+                          target_node=self.target_node, additional_info="allocate 100% of total memory"), \
+                self.action_log_scope("Memory stress by allocating 100% memory", target=self.target_node.name):
             experiment.start()
-        experiment.wait_until_finished()
+            experiment.wait_until_finished()
 
     @decorate_with_context(ignore_reactor_stall_errors)
     @target_all_nodes
@@ -4619,7 +4771,8 @@ class Nemesis(NemesisFlags):
 
         self.log.info('Try to allocate 90% total memory, the allocated memory will be swaped out')
         with DbNodeLogger(self.cluster.nodes, "start memory stress",
-                          target_node=self.target_node, additional_info="allocate 90% of total memory"):
+                          target_node=self.target_node, additional_info="allocate 90% of total memory"), \
+                self.action_log_scope("Memory stress by allocating 90% memory", target=self.target_node.name):
             self.target_node.remoter.run(
                 "stress-ng --vm-bytes $(awk '/MemTotal/{printf \"%d\\n\", $2 * 0.9;}' < /proc/meminfo)k --vm-keep -m 1 -t 100")
 
@@ -4699,6 +4852,8 @@ class Nemesis(NemesisFlags):
         """
         cmd = f"ALTER TABLE {keyspace}.{table} WITH cdc = {cdc_settings};"
         self.log.debug(f"Alter command: {cmd}")
+        self.actions_log.info("Alter table cdc properties",
+                              metadata={"keyspace": keyspace, "table": table, "cdc_settings": cdc_settings})
         with self.cluster.cql_connection_patient(self.target_node) as session:
             session.execute(cmd)
         # wait applying cdc configuration
@@ -5086,7 +5241,9 @@ class Nemesis(NemesisFlags):
                 raise UnsupportedNemesis("No column found to create index on")
             try:
                 with DbNodeLogger(self.cluster.nodes, "create index",
-                                  target_node=self.target_node, additional_info=f"on {ks}.{cf}.{column}"):
+                                  target_node=self.target_node, additional_info=f"on {ks}.{cf}.{column}"), \
+                    self.action_log_scope("Create index",
+                                          metadata={"ks_cf": f"{ks}.{cf}", "column": column}):
                     index_name = create_index(session, ks, cf, column)
             except InvalidRequest as exc:
                 LOGGER.warning(exc)
@@ -5094,13 +5251,15 @@ class Nemesis(NemesisFlags):
                     "Tried to create already existing index. See log for details")
             try:
                 with adaptive_timeout(operation=Operations.CREATE_INDEX, node=self.target_node, timeout=14400) as timeout:
-                    wait_for_index_to_be_built(self.target_node, ks, index_name, timeout=timeout * 2)
+                    with self.action_log_scope("Wait for index to be built"):
+                        wait_for_index_to_be_built(self.target_node, ks, index_name, timeout=timeout * 2)
                 verify_query_by_index_works(session, ks, cf, column)
                 sleep_for_percent_of_duration(self.tester.test_duration * 60, percent=1,
                                               min_duration=300, max_duration=2400)
             finally:
                 with DbNodeLogger(self.cluster.nodes, "drop_index",
                                   target_node=self.target_node, additional_info=f"index: {index_name}"):
+                    self.actions_log.info("Drop index", metadata={"index": index_name})
                     drop_index(session, ks, index_name)
 
     @target_data_nodes
@@ -5144,12 +5303,18 @@ class Nemesis(NemesisFlags):
                     raise UnsupportedNemesis(
                         'A supported column for creating MV is not found. nemesis can\'t run')
                 self.log.info("Stopping Scylla on node %s", self.target_node.name)
+                self.actions_log.info("Stop Scylla", target=self.target_node.name)
                 self.target_node.stop_scylla()
                 InfoEvent(message=f'Create a materialized-view for table {ks_name}.{base_table_name}').publish()
                 try:
                     with EventsFilter(event_class=DatabaseLogEvent,
                                       regex='.*Error applying view update.*',
-                                      extra_time_to_expiration=180):
+                                      extra_time_to_expiration=180), \
+                            self.action_log_scope("Create materialized view",
+                                                  metadata={"base_table": f"{ks_name}.{base_table_name}",
+                                                            "view_name": view_name,
+                                                            "column": column,
+                                                            "primary_key_columns": primary_key_columns}):
                         self.tester.create_materialized_view(ks_name, base_table_name, view_name, [column],
                                                              primary_key_columns, session,
                                                              mv_columns=[column] + primary_key_columns)
@@ -5159,15 +5324,21 @@ class Nemesis(NemesisFlags):
                     raise
                 try:
                     self.log.info("Starting Scylla on node %s", self.target_node.name)
+                    self.actions_log.info("Start Scylla", target=self.target_node.name)
                     self.target_node.start_scylla()
-                    self.target_node.run_nodetool(sub_cmd="repair -pr")
-                    with adaptive_timeout(operation=Operations.CREATE_MV, node=self.target_node, timeout=14400) as timeout:
+                    with self.action_log_scope("Run repair on node", target=self.target_node.name):
+                        self.target_node.run_nodetool(sub_cmd="repair -pr")
+                    with adaptive_timeout(operation=Operations.CREATE_MV, node=self.target_node, timeout=14400) as timeout, \
+                            self.action_log_scope("Wait for materialized view to be built",
+                                                  metadata={"view_name": f"{ks_name}.{view_name}"},
+                                                  target=self.target_node.name):
                         wait_for_view_to_be_built(self.target_node, ks_name, view_name, timeout=timeout * 2)
                     session.execute(SimpleStatement(f'SELECT * FROM {ks_name}.{view_name} limit 1', fetch_size=10))
                     sleep_for_percent_of_duration(self.tester.test_duration * 60, percent=1,
                                                   min_duration=300, max_duration=2400)
                 finally:
-                    drop_materialized_view(session, ks_name, view_name)
+                    with self.action_log_scope("Drop materialized view"):
+                        drop_materialized_view(session, ks_name, view_name)
 
     def disrupt_toggle_audit_syslog(self):
         self._disrupt_toggle_audit(store="syslog")
@@ -5192,6 +5363,7 @@ class Nemesis(NemesisFlags):
         audit = Audit(self.cluster)
 
         if audit.is_enabled():
+            self.actions_log.info("Disabling audit as it was already enabled")
             audit.disable()
             raise UnsupportedNemesis("Audit was enabled -> disabling it")
 
@@ -5205,7 +5377,10 @@ class Nemesis(NemesisFlags):
             tables=[],
         )
         try:
-            audit.configure(audit_config)
+            with self.action_log_scope("Enable full audit", metadata={"store": store,
+                                                                      "categories": audit_config.categories,
+                                                                      "keyspaces": keyspaces_for_audit}):
+                audit.configure(audit_config)
             keyspace_name = keyspaces_for_audit[0]
             errors = []
             audit_start = datetime.datetime.now() - datetime.timedelta(seconds=5)
@@ -5225,6 +5400,8 @@ class Nemesis(NemesisFlags):
                 stress_cmd=read_cmd, round_robin=True, stop_test_on_failure=False)
             self.tester.verify_stress_thread(read_thread, error_handler=self._nemesis_stress_failure_handler)
             InfoEvent(message='Verifying Audit table contents').publish()
+            self.actions_log.info("Verifying Audit log contents",
+                                  metadata={"category": "DML"})
             rows = audit.get_audit_log(from_datetime=audit_start, category="DML", limit_rows=1500)
             # filter out USE keyspace rows due to https://github.com/scylladb/scylla-enterprise/issues/3169
             rows = [row for row in rows if not row.operation.startswith("USE")]
@@ -5232,6 +5409,8 @@ class Nemesis(NemesisFlags):
                 errors.append(f"Audit log for DML contains {len(rows)} rows while should contain 1000 rows")
                 for row in rows:
                     LOGGER.error("DML audit log row: %s", row)
+            self.actions_log.info("Verifying Audit log contents",
+                                  metadata={"category": "QUERY"})
             rows = audit.get_audit_log(from_datetime=audit_start, category="QUERY", limit_rows=1500)
             if len(rows) != 1000:
                 errors.append(f"Audit log for QUERY contains {len(rows)} rows while should contain 1000 rows")
@@ -5240,13 +5419,15 @@ class Nemesis(NemesisFlags):
         except Exception as ex:
             LOGGER.error("Exception while testing full audit: %s", ex)
             audit_config.categories = ["DCL", "DDL", "AUTH", "ADMIN"]
-            audit.configure(audit_config)
+            with self.action_log_scope("Reconfiguring audit", metadata={"categories": audit_config.categories}):
+                audit.configure(audit_config)
             raise
 
         InfoEvent("Reducing audit categories and setting back audited keyspaces").publish()
 
         audit_config.categories = ["DCL", "DDL", "AUTH", "ADMIN"]
-        audit.configure(audit_config)
+        with self.action_log_scope("Reconfiguring audit", metadata={"categories": audit_config.categories}):
+            audit.configure(audit_config)
         table_name = "audit_cf"
         audit_start = datetime.datetime.now() - datetime.timedelta(seconds=5)
         with self.cluster.cql_connection_patient(node=self.target_node) as session:
@@ -5299,9 +5480,9 @@ class Nemesis(NemesisFlags):
             rack=self.target_node.rack,
             disruption_name=self.current_disruption)[0]
         self.monitoring_set.reconfigure_scylla_monitoring()
+        self.actions_log.info("Added new node", target=new_node.name)
         terminate_pattern = self.target_node.raft.get_random_log_message(operation=TopologyOperations.BOOTSTRAP,
                                                                          seed=self.nemesis_seed)
-
         bootstrapabortmanager = NodeBootstrapAbortManager(bootstrap_node=new_node, verification_node=self.target_node,
                                                           actions_log=self.actions_log)
 
@@ -5331,14 +5512,18 @@ class Nemesis(NemesisFlags):
 
     def disrupt_disable_binary_gossip_execute_major_compaction(self):
         with nodetool_context(node=self.target_node, start_command="disablebinary", end_command="enablebinary"):
+            self.actions_log.info("Executed nodetool disablebinary")
             self.target_node.run_nodetool("statusbinary")
             self.target_node.run_nodetool("status")
             time.sleep(5)
             with nodetool_context(node=self.target_node, start_command="disablegossip", end_command="enablegossip"):
+                self.actions_log.info("Executed nodetool disablegossip")
                 self.target_node.run_nodetool("statusgossip")
                 self.target_node.run_nodetool("status", ignore_status=True)
                 time.sleep(30)
                 self._major_compaction()
+                self.actions_log.info("Executing enablegossip")
+            self.actions_log.info("Executing enablebinary")
         self.target_node.run_nodetool("statusgossip")
         self.target_node.run_nodetool("statusbinary")
         time.sleep(30)
@@ -5349,6 +5534,7 @@ class Nemesis(NemesisFlags):
         except Exception:
             # NOTE: restart the target node because it was the remedy for the problems with CQL workability
             self.log.warning("'%s' node will be restarted to make the CQL work again", self.target_node)
+            self.actions_log.info("Restarting node", target=self.target_node.name)
             self.target_node.restart_scylla_server()
             raise
 
@@ -5387,13 +5573,16 @@ class Nemesis(NemesisFlags):
             elif coordinator_node != self.target_node:
                 self.switch_target_node(coordinator_node)
             self.log.debug("Coordinator node: %s, %s", coordinator_node, coordinator_node.name)
-            self.target_node.stop_scylla()
+            with self.action_log_scope("Stop Scylla coordinator node", target=coordinator_node.name):
+                self.target_node.stop_scylla()
             self.log.debug("Wait random timeout %s to new coordinator will be elected", election_wait_timeout)
             time.sleep(election_wait_timeout)
             with self.node_allocator.run_nemesis(nemesis_label="SearchCoordinator") as verification_node:
                 new_coordinator_node = get_topology_coordinator_node(verification_node)
+                self.actions_log.info("New coordinator node elected", target=new_coordinator_node.name)
             self.log.debug("New coordinator node: %s, %s", new_coordinator_node, new_coordinator_node.name)
-            self.target_node.start_scylla()
+            with self.action_log_scope("Start Scylla on old coordinator node", target=coordinator_node.name):
+                self.target_node.start_scylla()
             assert self.target_node != new_coordinator_node, \
                 f"New coordinator node was not elected while old one {coordinator_node.name} was stopped"
 
@@ -5474,10 +5663,13 @@ class Nemesis(NemesisFlags):
 
             with simulate_node_unavailability(self.target_node):
                 # target node stopped by Contextmanger. Wait while its status will be updated
+                self.actions_log.info(f"Blocked node with {simulate_node_unavailability.__name__}",
+                                      target=self.target_node.name)
                 wait_for(node_operations.is_node_seen_as_down, step=5, timeout=600, throw_exc=True,
                          down_node=self.target_node, verification_node=working_node, text=f"Wait other nodes see {self.target_node.name} as DOWN...")
                 self.log.debug("Remove node %s : hostid: %s with blocked scylla from cluster",
                                self.target_node.name, target_host_id)
+                self.actions_log.info("Remove node from cluster", target=self.target_node.name)
                 working_node.run_nodetool(f"removenode {target_host_id}", retry=0, long_running=True)
                 assert node_operations.is_node_removed_from_cluster(removed_node=self.target_node, verification_node=working_node), \
                     f"Node {self.target_node.name} with host id {target_host_id} was not removed. See log errors"
@@ -5488,6 +5680,7 @@ class Nemesis(NemesisFlags):
             assert self.target_node.db_up(), f"Scylla was not up on node {self.target_node.name}"
 
             with self.cluster.cql_connection_exclusive(node=self.target_node) as session:
+                self.actions_log.info("Execute query on banned node",)
                 for key in random.sample(range(1, 100001), 1000):
                     try:
                         stmt = SimpleStatement(f"INSERT INTO {keyspace_name}.{table_name} (key, name) VALUES ({key}, 'name{key}');",
@@ -5498,6 +5691,7 @@ class Nemesis(NemesisFlags):
                             "Query from banned node was executed succesful with Consistency.QUORUM")
                     except (NoHostAvailable, OperationTimedOut, Unavailable) as exc:
                         self.log.debug("Query failed with error: %s as expected", exc)
+                        self.actions_log.info("Query failed as expected")
 
             # Pass only active nodes for connection. Workaround for issue:
             # https://github.com/scylladb/python-driver/issues/484

--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -248,16 +248,13 @@ class SctEvent:
             return
         get_events_main_device(_registry=self._events_processes_registry).publish_event(self)
         if self.severity.value > Severity.WARNING.value:
-            metadata = {"base": self.base}
+            event_type = self.base
             if self.type:
-                metadata["type"] = self.type
+                event_type += f".{self.type}"
             if self.subtype:
-                metadata["subtype"] = self.subtype
+                event_type += f".{self.subtype}"
             ACTION_LOGGER.error(
-                f"{self.severity.name} Event",
-                trace_id=self.event_id,
-                target=getattr(self, 'node', None),
-                metadata=metadata
+                f"{event_type} {self.severity.name} Event (id={self.event_id}) on node: {getattr(self, 'node', None)}"
             )
         self._ready_to_publish = False
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2684,7 +2684,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
             if tablets_config:
                 cmd += ' AND TABLETS = %s' % tablets_config
             execution_result = session.execute(cmd)
-            self.actions_log.info("Keyspace created", metadata={"keyspace": keyspace_name, "statement": cmd})
+            self.actions_log.info(f"Keyspace {keyspace_name} created with statement: {cmd}")
 
         if execution_result:
             self.log.debug("keyspace creation result: {}".format(execution_result.response_future))
@@ -2743,7 +2743,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         self.log.debug('CQL query to execute: {}'.format(query))
         with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0], keyspace=keyspace_name) as session:
             session.execute(query)
-        self.actions_log.info("Created table", metadata={"table_name": name, "query": query})
+        self.actions_log.info(f"Created {name} table with statement: {query}")
         time.sleep(0.2)
 
     def truncate_cf(self, ks_name: str, table_name: str, session: Session, truncate_timeout_sec: int | None = None):

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -183,13 +183,13 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         truncate_query = 'SELECT COUNT(*) FROM {}'
         tables_name = self.get_tables_name_of_keyspace(session=session, keyspace_name='truncate_ks')
         for table_name in tables_name:
-            self.actions_log.info("Start read data from tables", target=table_name)
+            self.actions_log.info(f"Start read data from {table_name} tables")
             try:
                 count = self._query_from_one_table(session=session, query=truncate_query, table_name=table_name)
                 self.assertEqual(str(count[0][0]), '0',
                                  msg='Expected that there is no data in the table truncate_ks.{}, but found {} rows'
                                  .format(table_name, count[0][0]))
-                self.actions_log.info("Finish read data from tables", target=table_name)
+                self.actions_log.info(f"Finish read data from {table_name} tables ")
             except Exception as details:  # noqa: BLE001
                 InfoEvent(message=f"Failed read data from {table_name} tables. Error: {str(details)}. Traceback: {traceback.format_exc()}",
                           severity=Severity.ERROR).publish()
@@ -223,7 +223,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
                             ignore_raft_topology_cmd_failing])
     # https://github.com/scylladb/scylla/issues/10447#issuecomment-1194155163
     def _upgrade_node(self, node, upgrade_sstables=True, new_scylla_repo=None, new_version=None):  # noqa: PLR0915
-        self.actions_log.info("Starting node upgrade", target=node.name)
+        self.actions_log.info(f"Starting {node.name} node upgrade")
         new_scylla_repo = new_scylla_repo or self.params.get('new_scylla_repo')
         new_version = new_version or self.params.get('new_version')
         upgrade_node_packages = self.params.get('upgrade_node_packages')
@@ -239,28 +239,28 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         if self.params.get("enable_views_with_tablets_on_upgrade"):
             scylla_yaml_updates.update({"experimental_features": ["views-with-tablets"]})
 
-        self.actions_log.info('Upgrading a Node', target=node.name)
+        self.actions_log.info(f'Upgrading {node.name} Node')
         # We assume that if update_db_packages is not empty we install packages from there.
         # In this case we don't use upgrade based on new_scylla_repo(ignored sudo yum update scylla...)
         result = node.remoter.run('scylla --version')
         self.orig_ver = result.stdout.strip()
 
         if upgrade_node_packages:
-            self.actions_log.info('Started upgrade_node_packages', target=node.name)
+            self.actions_log.info('Started upgrade_node_packages')
             # update_scylla_packages
-            self.actions_log.info("sending upgrade packages to node", target=node.name)
-            with self.actions_log.action_scope('sending upgrade packages to node', target=node.name):
+            self.actions_log.info("sending upgrade packages to node")
+            with self.actions_log.action_scope('sending upgrade packages to node'):
                 node.remoter.send_files(upgrade_node_packages, '/tmp/scylla', verbose=True)
             # node.remoter.run('sudo yum update -y --skip-broken', connect_timeout=900)
             node.remoter.run('sudo yum install python34-PyYAML -y')
             # replace the packages
             node.remoter.run(r'rpm -qa scylla\*')
             # flush all memtables to SSTables
-            with self.actions_log.action_scope("stopping node", target=node.name):
+            with self.actions_log.action_scope("stopping node"):
                 node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True, long_running=True, retry=0)
                 node.run_nodetool("snapshot")
                 node.stop_scylla_server()
-            with self.actions_log.action_scope("upgrading packages", target=node.name):
+            with self.actions_log.action_scope("upgrading packages"):
                 node.remoter.run('sudo rpm -UvhR --oldpackage /tmp/scylla/*development*', ignore_status=True)
                 node.remoter.run('sudo rpm -URvh --replacefiles /tmp/scylla/*.rpm | true')
                 node.remoter.run(r'rpm -qa scylla\*')
@@ -275,7 +275,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             assert new_scylla_repo.startswith('http')
             node.download_scylla_repo(new_scylla_repo)
             # flush all memtables to SSTables
-            with self.actions_log.action_scope("stop node", target=node.name):
+            with self.actions_log.action_scope("stop node"):
                 node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True, long_running=True, retry=0)
                 node.run_nodetool("snapshot")
                 node.stop_scylla_server(verify_down=False)
@@ -306,7 +306,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
 
                 if self.params.get('use_preinstalled_scylla'):
                     scylla_pkg_ver += f" {scylla_pkg}-machine-image"
-            with self.actions_log.action_scope("updating packages", target=node.name):
+            with self.actions_log.action_scope("updating packages"):
                 if node.distro.is_rhel_like:
                     node.remoter.run(r'sudo yum update {}\* -y'.format(scylla_pkg_ver))
                 else:
@@ -319,15 +319,15 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         node.remoter.sudo(
             f"sed -i 's/--num-io-queues/--num-io-groups/' {node.add_install_prefix('/etc/scylla.d/io.conf')}")
 
-        with self.actions_log.action_scope("reload systemd and run scylla sysconfig setup", target=node.name):
+        with self.actions_log.action_scope("reload systemd and run scylla sysconfig setup"):
             check_reload_systemd_config(node)
             node.run_scylla_sysconfig_setup()
         if scylla_yaml_updates:
-            with self.actions_log.action_scope("update_scylla_yaml", target=node.name, metadata={"updates": scylla_yaml_updates}):
+            with self.actions_log.action_scope(f"update_scylla_yaml with: {scylla_yaml_updates}"):
                 self._update_scylla_yaml_on_node(node_to_update=node, updates=scylla_yaml_updates)
         node.forget_scylla_version()
         node.drop_raft_property()
-        with self.actions_log.action_scope("start_scylla_server", target=node.name):
+        with self.actions_log.action_scope("start_scylla_server"):
             node.start_scylla_server(verify_up_timeout=500)
         self.db_cluster.get_db_nodes_cpu_mode()
         result = node.remoter.run('scylla --version')
@@ -339,7 +339,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             self.upgradesstables_if_command_available(node)
 
         self.db_cluster.wait_all_nodes_un()
-        self.actions_log.info("Upgrade node completed", target=node.name)
+        self.actions_log.info(f"Upgrade {node.name} node completed")
 
     def upgrade_os(self, nodes):
         def upgrade(node):
@@ -360,11 +360,11 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
                             ignore_topology_change_coordinator_errors,
                             ignore_raft_topology_cmd_failing])
     def _rollback_node(self, node, upgrade_sstables=True):
-        self.actions_log.info("Starting node rollback", target=node.name)
+        self.actions_log.info(f"Starting {node.name} node rollback")
         result = node.remoter.run('scylla --version')
         orig_ver = result.stdout.strip()
         # flush all memtables to SSTables
-        with self.actions_log.action_scope("stop node", target=node.name):
+        with self.actions_log.action_scope("stop node"):
             node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True, long_running=True, retry=0)
             # backup the data
             node.run_nodetool("snapshot")
@@ -382,7 +382,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
 
         if re.findall(r'\d+.\d+', self.orig_ver)[0] == re.findall(r'\d+.\d+', self.new_ver)[0]:
             self.upgrade_rollback_mode = 'minor_release'
-        self.actions_log.info('downgrading packages', target=node.name)
+        self.actions_log.info('downgrading packages')
 
         if self.upgrade_rollback_mode == 'reinstall' or not node.distro.is_rhel_like:
             scylla_pkg_ver = node.scylla_pkg()
@@ -410,7 +410,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
 
         result = node.remoter.run('scylla --version')
         new_ver = result.stdout.strip()
-        self.actions_log.info('finished downgrading packages', target=node.name)
+        self.actions_log.info('finished downgrading packages')
 
         node.remoter.run('sudo cp /etc/scylla/scylla.yaml-backup /etc/scylla/scylla.yaml')
 
@@ -426,7 +426,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             self.upgradesstables_if_command_available(node)
 
         self.db_cluster.wait_all_nodes_un()
-        self.actions_log.info("Node rollback completed", target=node.name)
+        self.actions_log.info(f"Node {node.name} rollback completed")
 
     def upgradesstables_if_command_available(self, node, queue=None):
         upgradesstables_available = False
@@ -434,7 +434,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             'nodetool help | grep -q upgradesstables && echo "yes" || echo "no"')
         if "yes" in upgradesstables_supported.stdout:
             upgradesstables_available = True
-            with self.actions_log.action_scope("Upgrading SSTables", target=node.name):
+            with self.actions_log.action_scope("Upgrading SSTables"):
                 node.run_nodetool(sub_cmd="upgradesstables")
         if queue:
             queue.put(upgradesstables_available)
@@ -512,18 +512,17 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         stress_cmd = self._cs_add_node_flag(self.params.get('stress_cmd'))
         self.run_stress_thread(stress_cmd=stress_cmd)
 
-        self.actions_log.info('Waiting for cassandra-stress to populate data', metadata={"wait_time_seconds": 600})
+        self.actions_log.info('Waiting for cassandra-stress to populate data')
         time.sleep(600)
 
-        self.actions_log.info('Starting cassandra-stress read workload', metadata={"duration": "60m"})
+        self.actions_log.info('Starting cassandra-stress read workload for 60m')
         # YAML: stress_cmd_1: cassandra-stress read cl=QUORUM duration=60m
         # -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)'
         # -mode cql3 native -rate threads=100 -pop seq=1..10000000
         stress_cmd_1 = self._cs_add_node_flag(self.params.get('stress_cmd_1'))
         stress_queue = self.run_stress_thread(stress_cmd=stress_cmd_1)
 
-        self.actions_log.info('Waiting for cassandra-stress to start before upgrade',
-                              metadata={"wait_time_seconds": 300})
+        self.actions_log.info('Waiting for cassandra-stress to start before upgrade')
         time.sleep(300)
 
         nodes_num = len(self.db_cluster.nodes)
@@ -546,7 +545,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         if pre_fill:
             self.actions_log.info('Populating DB with tables and data')
             self.fill_db_data()
-        self.actions_log.info('Running queries to verify data', metadata={"stage": note})
+        self.actions_log.info(f'Running queries to verify data (stage: {note})')
         self.verify_db_data()
         if rewrite_data:
             self.actions_log.info('Re-populating DB with tables and data')
@@ -594,7 +593,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         self.actions_log.info('Preparing test keyspaces and tables')
         # prepare test keyspaces and tables before upgrade to avoid schema change during mixed cluster.
         self.prepare_keyspaces_and_tables()
-        self.actions_log.info('Running stress-bench to create schemas', metadata={"issue": "#11459"})
+        self.actions_log.info('Running s-b to create schemas to avoid #11459')
         large_partition_stress_during_upgrade = self.params.get('stress_before_upgrade')
         sb_create_schema = self.run_stress_thread(stress_cmd=f'{large_partition_stress_during_upgrade} -duration=1m')
         self.verify_stress_thread(sb_create_schema)
@@ -630,7 +629,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         self.actions_log.info('Running stress workload before upgrade')
         if self.should_do_complex_profile():
             # complex workload: prepare write
-            self.actions_log.info('Starting complex cassandra-stress workload to prepare data', metadata={"size": "5M"})
+            self.actions_log.info('Starting complex c-s workload (5M) to prepare data')
             stress_cmd_complex_prepare = self.params.get('stress_cmd_complex_prepare')
             complex_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_complex_prepare)
 
@@ -642,11 +641,10 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         self.actions_log.info('Finished checking paged query before upgrading nodes')
 
         # prepare write workload
-        self.actions_log.info('Starting prepare write workload', metadata={"size": "10000000"})
+        self.actions_log.info('Starting prepare write workload (n=10000000)')
         prepare_write_stress = self.params.get('prepare_write_stress')
         prepare_write_cs_thread_pool = self.run_stress_thread(stress_cmd=prepare_write_stress)
-        self.actions_log.info('Waiting for cassandra-stress to start before upgrade',
-                              metadata={"wait_time_seconds": 60})
+        self.actions_log.info('Waiting for cassandra-stress to start before upgrade')
         self.metric_has_data(
             metric_query='sct_cassandra_stress_write_gauge{type="ops", keyspace="keyspace1"}'
                          'or sct_cql_stress_cassandra_stress_write_gauge{type="ops", keyspace="keyspace1"}', n=5)
@@ -672,7 +670,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             self.verify_stress_thread(prepare_write_cs_thread_pool)
 
             # read workload (cl=QUORUM)
-            self.actions_log.info('Starting read workload with QUORUM consistency', metadata={"size": "10000000"})
+            self.actions_log.info('Starting read workload (cl=QUORUM n=10000000)')
             stress_cmd_read_cl_quorum = self.params.get('stress_cmd_read_cl_quorum')
             read_stress_queue = self.run_stress_thread(stress_cmd=stress_cmd_read_cl_quorum)
             # wait for the read workload to finish
@@ -682,7 +680,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
                                                           step=step+' - after upgraded one node')
 
             # read workload
-            self.actions_log.info('Starting read workload', metadata={"duration": "10m"})
+            self.actions_log.info('Starting read workload for 10m')
             stress_cmd_read_10m = self.params.get('stress_cmd_read_10m')
             read_10m_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_read_10m)
 
@@ -690,7 +688,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             large_partition_stress_during_upgrade = self.params.get('stress_before_upgrade')
             self.run_stress_thread(stress_cmd=large_partition_stress_during_upgrade)
 
-            self.actions_log.info('Waiting for workloads to start before upgrade', metadata={"wait_time_seconds": 60})
+            self.actions_log.info('Waiting 60s for workloads to start before upgrade')
             time.sleep(60)
 
             step = 'Step2 - Upgrade Second Node '
@@ -707,11 +705,10 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
                                                           step=step+' - after upgraded two nodes')
 
             # read workload (60m)
-            self.actions_log.info('Starting read workload', metadata={"duration": "60m"})
+            self.actions_log.info('Starting read workload for 60m')
             stress_cmd_read_60m = self.params.get('stress_cmd_read_60m')
             read_60m_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_read_60m)
-            self.actions_log.info('Waiting for cassandra-stress to start before rollback',
-                                  metadata={"wait_time_seconds": 60})
+            self.actions_log.info('Waiting 60s for cassandra-stress to start before rollback')
             time.sleep(60)
 
             self.actions_log.info('Step3 - Rollback Second Node')
@@ -873,13 +870,12 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         self.actions_log.info("Step5.1 - raft topology upgrade procedure done")
 
     def _start_and_wait_for_node_upgrade(self, node: BaseNode, step: int) -> None:
-        self.actions_log.info(f"Step {step} - Upgrade node", target=node.name, metadata={"dc": node.dc_idx})
+        self.actions_log.info(f"Step {step} - Upgrade {node.name} node in {node.dc_idx} dc")
         self.upgrade_node(node, upgrade_sstables=self.params.get('upgrade_sstables'))
         node.check_node_health()
 
     def _start_and_wait_for_node_rollback(self, node: BaseNode, step: int) -> None:
-        self.actions_log.info(f"Step {step} - "
-                              f"Rollback node", target=node.name, metadata={"dc": node.dc_idx})
+        self.actions_log.info(f"Step {step} - Rollback {node.name} node in {node.dc_idx} dc")
         self.rollback_node(node, upgrade_sstables=self.params.get('upgrade_sstables'))
         node.check_node_health()
 


### PR DESCRIPTION
In order to make investigations easier, added more action logs covering more disruptions.
Also simplified the approach by inlining target and metadata to log lines.
 
closes: https://github.com/scylladb/qa-tasks/issues/1952

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [longevity test](https://argus.scylladb.com/tests/scylla-cluster-tests/02537784-665e-4f5b-b930-be8c8f30c7f0)
- [x] - [artifact test](https://argus.scylladb.com/tests/scylla-cluster-tests/4d00490d-c47c-441a-88ed-b989d24e7692)
- [x] - [upgrade test](https://argus.scylladb.com/tests/scylla-cluster-tests/8c5b94c5-8d64-491b-bc14-76a747156b01)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
