### PR TITLE
fix(scale): scale longevity DB cluster properly

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -175,7 +175,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
                             target - current_cluster_size[dcx]) >= add_node_cnt else target - current_cluster_size[dcx]
                         InfoEvent(message=f"Adding next number of nodes {add_nodes_num} to dc_idx {dcx}").publish()
                         added_nodes.extend(self.db_cluster.add_nodes(
-                            count=add_nodes_num, enable_auto_bootstrap=True, dc_idx=dcx))
+                            count=add_nodes_num, enable_auto_bootstrap=True, dc_idx=dcx, rack=None))
 
                 self.monitors.reconfigure_scylla_monitoring()
                 up_timeout = MAX_TIME_WAIT_FOR_NEW_NODE_UP


### PR DESCRIPTION
 The `test_custom_time` longevity test uses only first rack
for scaling DB cluster up to the `cluster_target_size` size
which breaks rack-node mapping balance.
    
So, fix it by specifying explicitly the rack index be as `None`
to trigger the automatic balanced rack distribution.

Closes: #11946

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-scale-base-test-15-25-cluster-test-test#2](https://argus.scylladb.com/tests/scylla-cluster-tests/f2a08455-cb01-43e8-8a9c-77038a87ef84)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
