### PR TITLE
fix(trigger): missed comma in performance trigger

### DIFF
--- a/vars/perfRegressionParallelPipelinebyRegion.groovy
+++ b/vars/perfRegressionParallelPipelinebyRegion.groovy
@@ -125,7 +125,7 @@ def call(Map pipelineParams) {
                                 labels: ['master-daily']
                             ],
                             [
-                                job_name: 'scylla-master/perf-regression/scylla-release-perf-regression-alternator'
+                                job_name: 'scylla-master/perf-regression/scylla-release-perf-regression-alternator',
                                 region: '',
                                 versions: [],
                                 sub_tests: [],


### PR DESCRIPTION
The change is presented recently in https://github.com/scylladb/scylla-cluster-tests/pull/10927 cause to trigger failure. The comma is missed in the list.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
