### PR TITLE
feature(rolling-upgrades): update the base versions rules

### DIFF
--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ami.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ami.jenkinsfile
@@ -10,5 +10,6 @@ rollingUpgradePipeline(
     use_preinstalled_scylla: true,
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
-    internode_compression: 'all'
+    internode_compression: 'all',
+    base_version_all_sts_versions: true
 )

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-centos9.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-centos9.jenkinsfile
@@ -8,7 +8,7 @@ rollingUpgradePipeline(
     base_versions: '',  // auto mode
     linux_distro: 'centos-9',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-9',
-
+    base_version_all_sts_versions: true,
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
     test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-artifacts.yaml", "configurations/gce/n2-highmem-16.yaml"]''',
 )

--- a/sct.py
+++ b/sct.py
@@ -856,7 +856,8 @@ def list_repos(dist_type, dist_version):
 @click.option('-d', '--linux-distro', type=str, help='Linux Distribution type')
 @click.option('-o', '--only-print-versions', type=bool, default=False, required=False, help='')
 @click.option('-b', '--backend', type=click.Choice(SCTConfiguration.available_backends), help="Backend to use")
-def get_scylla_base_versions(scylla_version, scylla_repo, linux_distro, only_print_versions, backend):
+@click.option('--base_version_all_sts_versions', is_flag=True, default=False, help='Whether to include all supported STS versions as base versions')
+def get_scylla_base_versions(scylla_version, scylla_repo, linux_distro, only_print_versions, backend, base_version_all_sts_versions):
     """
     Upgrade test try to upgrade from multiple supported base versions, this command is used to
     get the base versions according to the scylla repo and distro type, then we don't need to hardcode
@@ -870,7 +871,7 @@ def get_scylla_base_versions(scylla_version, scylla_repo, linux_distro, only_pri
     if not linux_distro or linux_distro == "null":
         linux_distro = test_defaults.get("scylla_linux_distro")
 
-    version_detector = UpgradeBaseVersion(scylla_repo, linux_distro, scylla_version)
+    version_detector = UpgradeBaseVersion(scylla_repo, linux_distro, scylla_version, base_version_all_sts_versions)
 
     if not version_detector.dist_type == 'centos' and version_detector.dist_version is None:
         click.secho("when passing --dist-type=debian/ubuntu need to pass --dist-version as well", fg='red')

--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -10,10 +10,11 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2021 ScyllaDB
+from unittest.mock import patch
 
+import pytest
 
 from sdcm.utils.version_utils import ComparableScyllaVersion
-
 from utils.get_supported_scylla_base_versions import UpgradeBaseVersion
 
 """
@@ -22,13 +23,13 @@ the supported Scylla versions for upgrades based on the provided repository, bac
 """
 
 
-def general_test(scylla_repo='', linux_distro='', cloud_provider=None):
+def general_test(scylla_repo='', linux_distro='', cloud_provider=None, base_version_all_sts_versions=False):
     """
     General test function to retrieve the list of supported Scylla versions for upgrade.
     """
     scylla_version = None
 
-    version_detector = UpgradeBaseVersion(scylla_repo, linux_distro, scylla_version)
+    version_detector = UpgradeBaseVersion(scylla_repo, linux_distro, scylla_version, base_version_all_sts_versions)
     version_detector.set_start_support_version(cloud_provider)
     _, version_list = version_detector.get_version_list()
     return version_list
@@ -104,7 +105,7 @@ def test_2025_1_dev():
 
 
 def test_2025_1_release_ubuntu():
-    """ Test that 2025.1 release on ubuntu is returned correct versions """
+    """ Test that 2025.1 release on Ubuntu returns correct versions """
     scylla_repo = url_base + '/branch-2025.1/deb/unified/2025-02-16T22:46:42Z/scylladb-2025.1/scylla.list'
     linux_distro = 'ubuntu-focal'
     version_list = general_test(scylla_repo, linux_distro)
@@ -117,3 +118,143 @@ def test_2025_1_release_centos():
     linux_distro = 'centos-9'
     version_list = general_test(scylla_repo, linux_distro)
     assert {'6.2', '2024.1', '2024.2'}.issubset(set(version_list))
+
+
+def test_2025_3_release_ubuntu():
+    """ Test that 2025.3 release on Ubuntu returns correct versions """
+    scylla_repo = url_base + '/branch-2025.3/deb/unified/2026-02-16T22:46:42Z/scylladb-2025.3/scylla.list'
+    linux_distro = 'ubuntu-focal'
+    version_list = general_test(scylla_repo, linux_distro)
+    assert {'2025.1', '2025.2', '2025.3'}.issubset(set(version_list))
+
+
+def test_2025_3_release_centos():
+    """ Test that 2025.3 release on centos returns correct versions """
+    scylla_repo = url_base + '/branch-2025.3/rpm/centos/2025-02-23T16:19:08Z/scylla.repo'
+    linux_distro = 'centos-9'
+    version_list = general_test(scylla_repo, linux_distro)
+    assert {'2025.1', '2025.2', '2025.3'}.issubset(set(version_list))
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "target_branch": "2025.1",
+            "target_rc_only": False,
+            "base_version_all_sts_versions": False,
+            "supported_versions": ["2024.1", "2024.2", "2025.1", "2025.2", "2025.3", "2025.4"],
+            "expected_version_set": {"2024.1", "2025.1", "2024.2"},
+        },
+        {
+            "target_branch": "2025.2",
+            "target_rc_only": False,
+            "base_version_all_sts_versions": False,
+            "supported_versions": ["2024.1", "2024.2", "2025.1", "2025.2", "2025.3", "2025.4"],
+            "expected_version_set": {"2025.1", "2025.2"}},
+        {
+            "target_branch": "2025.3",
+            "target_rc_only": False,
+            "base_version_all_sts_versions": False,
+            "supported_versions": ["2024.1", "2024.2", "2025.1", "2025.2", "2025.3", "2025.4"],
+            "expected_version_set": {"2025.1", "2025.2", "2025.3"}
+        },
+        {
+            "target_branch": "2025.4",
+            "target_rc_only": True,
+            "base_version_all_sts_versions": True,
+            "supported_versions": ["2024.1", "2024.2", "2025.1", "2025.2", "2025.3", "2025.4"],
+            "expected_version_set": {"2025.1", "2025.2", "2025.3"}
+        },
+        {
+            "target_branch": "2025.4",
+            "target_rc_only": False,
+            "base_version_all_sts_versions": True,
+            "supported_versions": ["2024.1", "2024.2", "2025.1", "2025.2", "2025.3", "2025.4"],
+            "expected_version_set": {"2025.1", "2025.2", "2025.3", "2025.4"}
+        },
+        {
+            "target_branch": "2026.1",
+            "target_rc_only": True,
+            "base_version_all_sts_versions": True,
+            "supported_versions": ["2024.1", "2024.2", "2025.1", "2025.2", "2025.3", "2025.4", "2026.1"],
+            "expected_version_set": {"2025.1", "2025.2", "2025.3", "2025.4"},
+        },
+        {
+            "target_branch": "2026.1",
+            "target_rc_only": False,
+            "base_version_all_sts_versions": True,
+            "supported_versions": ["2024.1", "2024.2", "2025.1", "2025.2", "2025.3", "2025.4", "2026.1"],
+            "expected_version_set": {"2025.1", "2025.2", "2025.3", "2025.4", "2026.1"},
+        },
+        {
+            "target_branch": "2026.1",
+            "target_rc_only": False,
+            "base_version_all_sts_versions": False,
+            "supported_versions": ["2024.1", "2024.2", "2025.1", "2025.2", "2025.3", "2025.4", "2026.1"],
+            "expected_version_set": {"2025.1", "2025.4", "2026.1"},
+        },
+    ],
+)
+def test_upgrade_matrix_stages(test_case):
+    """
+    Test that target branch release on Ubuntu returns correct versions while mocking available versions.
+
+    This test validates the upgrade matrix logic by testing different scenarios:
+
+    Args:
+        test_case (dict): A dictionary containing:
+            - target_branch (str): The target Scylla version branch being tested (e.g., "2025.1")
+            - target_rc_only (bool): Whether only RC (release candidate) versions are available for the target branch
+            - supported_versions (list): List of all Scylla versions that are mocked to be available in the system
+            - expected_version_set (set): Expected set of versions that should be returned as valid upgrade paths
+            - base_version_all_sts_versions(bool, optional): Whether to consider all STS versions as base versions (default is False)
+
+    The test logic:
+    - When target_rc_only is True, it simulates that only RC versions exist for the target branch
+    - When target_rc_only is False, it simulates that stable releases exist for the target branch
+    - The upgrade matrix should return appropriate versions based on upgrade compatibility rules
+    """
+    target_branch = test_case["target_branch"]
+    target_rc_only = test_case["target_rc_only"]
+    supported_versions = test_case["supported_versions"]
+    expected_version_set = test_case["expected_version_set"]
+    base_version_all_sts_versions = test_case.get("base_version_all_sts_versions", False)
+
+    scylla_repo = url_base + \
+        f"/branch-{target_branch}/deb/unified/2026-02-16T22:46:42Z/scylladb-{target_branch}/scylla.list"
+    linux_distro = 'ubuntu-focal'
+    # Mock get_all_versions and get_s3_scylla_repos_mapping to simulate available versions
+
+    mock_versions = supported_versions
+    mock_repo_map = {v: f"mock_url/{v}" for v in mock_versions}
+    if target_rc_only:
+        mock_versions = [f"{target_branch}.0~rc1", ]
+    with patch('utils.get_supported_scylla_base_versions.get_all_versions', return_value=mock_versions), \
+            patch('utils.get_supported_scylla_base_versions.get_s3_scylla_repos_mapping', return_value=mock_repo_map):
+        version_list = general_test(scylla_repo, linux_distro,
+                                    base_version_all_sts_versions=base_version_all_sts_versions)
+    assert set(version_list) == expected_version_set
+
+
+def test_master_all_sts_versions():
+    """Test master branch returns both last LTS and last STS when base_version_all_sts_versions is True."""
+    scylla_repo = url_base + '/master/rpm/centos/2025-08-01T00:00:00Z/scylla.repo'
+    linux_distro = 'centos'
+    # Provide a repo map with multiple enterprise versions including LTS and STS
+    mock_supported_versions = [
+        '2024.1',  # LTS previous year
+        '2024.2',  # STS
+        '2024.5',  # STS later in year
+        '2025.1',  # LTS current year
+        '2025.2',  # Latest STS
+    ]
+    mock_repo_map = {v: f'mock_url/{v}' for v in mock_supported_versions}
+    # get_all_versions should return at least one non-rc artifact per version
+    with patch('utils.get_supported_scylla_base_versions.get_all_versions', return_value=["2024.1", "2024.2", "2025.1", "2025.2", "2025.3", "2025.4", "2026.1"]), \
+            patch('utils.get_supported_scylla_base_versions.get_s3_scylla_repos_mapping', return_value=mock_repo_map):
+        version_detector = UpgradeBaseVersion(scylla_repo, linux_distro, None, base_version_all_sts_versions=True)
+        version_detector.set_start_support_version(None)
+        _, version_list = version_detector.get_version_list()
+    # Expect last LTS (2025.1) and last STS (2025.2)
+    assert set(version_list) == {'2025.1', '2025.2'}

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -8,6 +8,10 @@ def completed_stages = [:]
 def call(Map pipelineParams) {
     def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter, params.azure_region_name)
 
+    // since this is a boolean param, we need to handle its default value upfront, we can't do it in the parameters section
+    // we'll keep it as boolean to simplify its usage later on
+    def base_version_all_sts_versions = pipelineParams.get('base_version_all_sts_versions', false)
+
     pipeline {
         agent none
 
@@ -43,7 +47,9 @@ def call(Map pipelineParams) {
 	        string(defaultValue: "${pipelineParams.get('azure_image_db', '')}", description: 'Azure image for ScyllaDB ', name: 'azure_image_db')
 
             string(defaultValue: '', description: '', name: 'new_scylla_repo')
-
+            booleanParam(defaultValue: base_version_all_sts_versions,
+                         description: 'Whether to include all supported STS versions as base versions',
+                         name: 'base_version_all_sts_versions')
             separator(name: 'PROVISIONING', sectionHeader: 'Provisioning Configuration')
             string(defaultValue: "${pipelineParams.get('provision_type', 'spot')}",
                    description: 'on_demand|spot_fleet|spot',
@@ -149,7 +155,8 @@ def call(Map pipelineParams) {
                                             base_versions_list,
                                             pipelineParams.linux_distro,
                                             params.new_scylla_repo,
-                                            params.backend
+                                            params.backend,
+                                            params.base_version_all_sts_versions
                                         )
                                         (testDuration,
                                          testRunTimeout,

--- a/vars/supportedUpgradeFromVersions.groovy
+++ b/vars/supportedUpgradeFromVersions.groovy
@@ -1,17 +1,22 @@
 #!groovy
 
-def call(List base_versions_list, String linux_distro, String new_scylla_repo, String backend) {
-    if (base_versions_list.size() == 0) {  // auto mode, get the supported base versions list by a hydra command
-        def result = sh (returnStdout: true,
-                         script: """ ./docker/env/hydra.sh get-scylla-base-versions --only-print-versions true \
-                                     --linux-distro ${linux_distro} --scylla-repo ${new_scylla_repo} \
-                                     --backend ${backend} """)
+// Returns list of base versions either provided explicitly or discovered via hydra script.
+def call(List base_versions_list, String linux_distro, String new_scylla_repo, String backend, Boolean base_version_all_sts_versions) {
+    if (base_versions_list.isEmpty()) { // auto mode: discover supported base versions
+        def result = sh(
+            returnStdout: true,
+            script: """./docker/env/hydra.sh get-scylla-base-versions --only-print-versions true \
+                --linux-distro ${linux_distro} --scylla-repo ${new_scylla_repo} \
+                --backend ${backend} \
+                ${base_version_all_sts_versions ? '--base_version_all_sts_versions' : ''}
+            """
+        ).trim()
         printf('Docker get-scylla-base-versions output:\n%s', result)
         def last_line = result.split('\n')[-1]
         if (last_line.matches("Base\\sVersions:\\s*[\\d\\w\\W]*")) {
             return last_line.replaceAll('Base Versions: ', '').split(' ')
         } else {
-        println("Did not find a valid base versions string!")
+            println("Did not find a valid base versions string!")
             throw new Exception("Didn't get valid base versions automatically!")
         }
     }


### PR DESCRIPTION
now that we have at least 4 short terms versions a year, we should now support upgrade from any of the STS version up to the last LTS version.

this gonna make the matrix more complex as we have more version between every LTS version

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-ubuntu2404-test/13/pipeline-overview/ (master)
- [x] 🟢 :   https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-ubuntu2404-test/14/pipeline-overview/ (upgrade to release 2025.4)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
