### PR TITLE
Support scylla-doctor on offline non-root tests (Take 2)

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -502,13 +502,6 @@ class ArtifactsTest(ClusterTester):
                 "Scylla Doctor test is skipped for encrypted environment due to issue field-engineering#2280")
             return
 
-        if self.db_cluster.nodes[0].is_nonroot_install and \
-                SkipPerIssues("https://github.com/scylladb/scylla-cluster-tests/issues/10540", self.params):
-            self.log.info("Scylla Doctor test is skipped for non-root test due to issue field-engineering#2254. ")
-            self.actions_log.info(
-                "Scylla Doctor test is skipped for non-root test due to issue field-engineering#2254.")
-            return
-
         if self.node.parent_cluster.cluster_backend == "docker":
             self.log.info("Scylla Doctor check in SCT isn't yet supported for docker backend")
             self.actions_log.info("Scylla Doctor check in SCT isn't yet supported for docker backend")

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2158,6 +2158,8 @@ class BaseNode(AutoSshContainerMixin):
             else:
                 install_cmds = dedent("""
                     tar xvfz ./unified_package.tar.gz
+                    echo 'export PATH="$HOME/scylladb/share/cassandra/bin:$HOME/scylladb/bin:$PATH"' >> ~/.bashrc
+                    echo 'export PATH="$HOME/scylladb/share/cassandra/bin:$HOME/scylladb/bin:$PATH"' >> ~/.bash_profile
                     cd ./scylla-*
                     ./install.sh --nonroot
                     cd -

--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -75,7 +75,7 @@ class ScyllaDoctor:
         if not self.node.is_nonroot_install:
             result = self.node.remoter.sudo(sd_command, verbose=False)
         else:
-            result = self.node.remoter.run(f"{self.python3_path} {sd_command}", verbose=False)
+            result = self.node.remoter.run(f"bash -lce '{self.python3_path} {sd_command}'", verbose=False)
         return result.stdout.strip()
 
     @cached_property


### PR DESCRIPTION
This PR changes some configuration options and adjusts PATH settings on nonroot 
installations of artifacts tests, allowing scylla-doctor to run here successfuly.
Some scylla-doctor collectors are disabled because either they require root privileges,
they assume system wide installation, or they depends on those that do. 

This is the second attempt at this PR as previous one didn't work for Ubuntu-based distros.
It also accounts for new version of Scylla Doctor and disables additional collectors that
don't work on non-root installs.

- **fix(artifacts_test.py): Remove offline non-root scylla_doctor skip**
- **improvement(sdcm/cluster.py): Add offline install to PATH**
- **improvement(scylla_doctor/nonroot): Disable non-working collectors**
- **fix(scylla_doctor): Always use a login session for non-root commands**

Closes #10540
Fixes scylladb/qa-tasks#1683

### Testing
 - [x] [Ubuntu2404](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/alexey/job/artifacts-ubuntu2404-nonroot-test/21/)
 - [x] [Centos9](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/artifacts-centos9-nonroot-test/22/)
### PR pre-checks (self review)
 - [x] I added the relevant backport labels
 - [x] I didn't leave commented-out/debugging code