### PR TITLE
improvement(s3_remote_uploader): Add support for additional ACLs

### DIFF
--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -79,6 +79,9 @@ class KeyStore:
     def get_qa_users(self):
         return self.get_json("qa_users.json")
 
+    def get_acl_grantees(self):
+        return self.get_json("bucket-users.json")
+
     def get_ssh_key_pair(self, name):
         return SSHKey(name=name,
                       public_key=self.get_file_contents(file_name=f"{name}.pub"),

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -291,12 +291,16 @@ class S3Storage():
                                      Key=s3_obj,
                                      Config=self.transfer_config)
             LOGGER.info("Uploaded to {0}".format(s3_url))
+
+            for user, canonical_id in KeyStore().get_acl_grantees().items():
+                LOGGER.info("Setting ACL for user %s", user)
+                boto3.client("s3").put_object_acl(Bucket=self.bucket_name, Key=s3_obj, GrantRead=f"id={canonical_id}")
             if public:
                 LOGGER.info("Set public read access")
                 self.set_public_access(key=s3_obj)
             return s3_url
         except Exception as details:  # noqa: BLE001
-            LOGGER.debug("Unable to upload to S3: %s", details)
+            LOGGER.warning("Unable to upload to S3: %s", details, exc_info=True)
             return ""
 
     def set_public_access(self, key):

--- a/sdcm/utils/s3_remote_uploader.py
+++ b/sdcm/utils/s3_remote_uploader.py
@@ -19,6 +19,8 @@ import boto3
 from botocore.response import StreamingBody
 from ssh2.session import Session
 
+from sdcm.keystore import KeyStore
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -82,6 +84,9 @@ def upload_remote_files_directly_to_s3(ssh_info: dict[str, str], files: List[str
     chan_response = SshOutAsFile(chan)
     s3 = boto3.client("s3")
     s3.upload_fileobj(chan_response, s3_bucket, s3_key, ExtraArgs=extra_args)
+    for user, canonical_id in KeyStore.get_acl_grantees().items():
+        LOGGER.info("Setting ACL for user %s", user)
+        s3.put_object_acl(Bucket=s3_bucket, Key=s3_key, GrantRead=f"id={canonical_id}")
     link = f"https://{s3_bucket}.s3.amazonaws.com/{s3_key}"
     LOGGER.info("Uploaded successfully to %s", link)
     return link


### PR DESCRIPTION
This commit adds a support for ACLs to be specified during remote file
upload for logs and such, allowing Argus and other users to read files
uploaded by non-qa users of the framework, e.g. siren-tests.

Fixes #11893

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [Jenkins](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/alexey-argus-testing/140/)


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
