### PR TITLE
fix(clean_aws): correct the logic of cleanups of volumes

### DIFF
--- a/utils/cloud_cleanup/aws/clean_aws.py
+++ b/utils/cloud_cleanup/aws/clean_aws.py
@@ -220,7 +220,7 @@ def clean_instances(region_name, duration):
 
 
 def keep_alive_volume(volume):
-    if volume.create_time < datetime.datetime.now(tz=pytz.utc) + datetime.timedelta(hours=1):
+    if volume.create_time > (datetime.datetime.now(tz=pytz.utc) - datetime.timedelta(hours=1)):
         # skipping if created recently and might miss tags yet
         return True
     # checking tags


### PR DESCRIPTION
the logic was backwards, and was working for any resources created in the last hour, but not for anything older.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
