### PR TITLE
fix(racks): Increase amount of nodes for `custom-d1/workflow1` config

### DIFF
--- a/test-cases/longevity/longevity-gce-custom-d1-workload1-hybrid-raid.yaml
+++ b/test-cases/longevity/longevity-gce-custom-d1-workload1-hybrid-raid.yaml
@@ -1,5 +1,5 @@
 test_duration: 900
-n_db_nodes: 8
+n_db_nodes: 9
 n_loaders: 2
 
 


### PR DESCRIPTION
After the merge of the PR https://github.com/scylladb/scylla-cluster-tests/pull/10641 which made the rack count be `3`
by default in the config for the `custom-d1/workflow1` scenario,
it stopped being balanced from the rack-node relation point of view.

So, fix it by making cluster size be `1*9` instead of the `1*8`.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
