### PR TITLE
fix(.pre-commit-config.yaml): disable detect-aws-credentials if no credentials

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
             )$
     -   id: check-json
     -   id: detect-aws-credentials
+        args: [--allow-missing-credentials]
     -   id: detect-private-key
         exclude: ^data_dir/ssl_conf/.*$
 


### PR DESCRIPTION
in some situations we do want to enable who doesn't have aws credentials to generate commits and able to run precommit (i.e. copilot)

for running tests we do need credentials, but that would be figured solved on it's own.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested it locally

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
