### PR TITLE
test(Manager Restore): Added object_storage_method (rclone/native)

### DIFF
--- a/configurations/object_storage.yaml
+++ b/configurations/object_storage.yaml
@@ -1,0 +1,7 @@
+append_scylla_yaml:
+  auto_snapshot: false
+  object_storage_endpoints:
+    - name: s3.us-east-1.amazonaws.com
+      port: 443
+      https: true
+      aws_region: us-east-1

--- a/defaults/manager_restore_benchmark_snapshots.yaml
+++ b/defaults/manager_restore_benchmark_snapshots.yaml
@@ -169,11 +169,11 @@ sizes:  # size of backed up dataset in GB
       rf: 3
     one_one_restore_params: None
   2tb_1t_ics:
-    tag: "sm_20240816185129UTC"
+    tag: "sm_20250807135410UTC"
     locations:
       - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
     exp_timeout: 57600  # 16 hours
-    scylla_version: "2024.2.0-rc1"
+    scylla_version: "2025.3"
     number_of_nodes: 3
     prohibit_verification_read: false
     dataset:

--- a/jenkins-pipelines/manager/restore_benchmark/ubuntu22-manager-1tb-1t-3nodes.jenkinsfile
+++ b/jenkins-pipelines/manager/restore_benchmark/ubuntu22-manager-1tb-1t-3nodes.jenkinsfile
@@ -7,8 +7,8 @@ managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
     provision_type: 'on_demand',
-    test_name: 'mgmt_cli_test.ManagerRestoreBenchmarkTests.test_restore_benchmark',
-    test_config: '''["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/manager/1TB_dataset.yaml"]''',
+    test_name: 'mgmt_cli_test.ManagerRestoreBenchmarkTests.test_restore_native_benchmark',
+    test_config: '''["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/manager/1TB_dataset.yaml", "configurations/object_storage.yaml"]''',
     mgmt_reuse_backup_snapshot_name: '1tb_1t_ics',
 
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/restore_benchmark/ubuntu22-manager-1tb-2t-9nodes.jenkinsfile
+++ b/jenkins-pipelines/manager/restore_benchmark/ubuntu22-manager-1tb-2t-9nodes.jenkinsfile
@@ -7,8 +7,8 @@ managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
     provision_type: 'on_demand',
-    test_name: 'mgmt_cli_test.ManagerRestoreBenchmarkTests.test_restore_benchmark',
-    test_config: '''["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/manager/1TB_dataset.yaml"]''',
+    test_name: 'mgmt_cli_test.ManagerRestoreBenchmarkTests.test_restore_native_benchmark',
+    test_config: '''["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/manager/1TB_dataset.yaml", "configurations/object_storage.yaml"]''',
     mgmt_reuse_backup_snapshot_name: '1tb_2t_twcs',
 
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/ubuntu24-manager-backup-restore-custom-dataset.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-backup-restore-custom-dataset.jenkinsfile
@@ -6,8 +6,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
-    test_name: 'mgmt_cli_test.ManagerRestoreBenchmarkTests.test_restore_benchmark',
-    test_config: '''["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/manager/ubuntu24.yaml"]''',
+    test_name: 'mgmt_cli_test.ManagerRestoreBenchmarkTests.test_restore_native_benchmark',
+    test_config: '''["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/object_storage.yaml", "configurations/manager/ubuntu24.yaml"]''',
 
     mgmt_restore_extra_params: "--batch-size 2 --parallel 1",
     mgmt_agent_backup_config: "{'checkers': 100, 'transfers': 2, 'low_level_retries': 20}"

--- a/jenkins-pipelines/oss/vnodes/backup/ubuntu22-manager-1tb-2t-9nodes-vnodes.jenkinsfile
+++ b/jenkins-pipelines/oss/vnodes/backup/ubuntu22-manager-1tb-2t-9nodes-vnodes.jenkinsfile
@@ -7,8 +7,8 @@ managerPipeline(
     backend: 'aws',
     region: 'us-east-1',
     provision_type: 'on_demand',
-    test_name: 'mgmt_cli_test.ManagerRestoreBenchmarkTests.test_restore_benchmark',
-    test_config: '''["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/manager/1TB_dataset.yaml", "configurations/tablets_disabled.yaml"]''',
+    test_name: 'mgmt_cli_test.ManagerRestoreBenchmarkTests.test_restore_native_benchmark',
+    test_config: '''["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/manager/1TB_dataset.yaml", "configurations/tablets_disabled.yaml", "configurations/object_storage.yaml"]''',
     mgmt_reuse_backup_snapshot_name: '1tb_2t_twcs',
 
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-manager-native-backup-nemesis.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-manager-native-backup-nemesis.jenkinsfile
@@ -8,5 +8,5 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_manager_backup_test.PerformanceRegressionManagerBackupTest.test_manager_backup",
-    test_config: """["test-cases/performance/perf-regression-latency-backup-nemesis.yaml", "configurations/kms-ear.yaml", "configurations/performance/latency-decorator-error-thresholds-nemesis-ent-tablets.yaml", "configurations/manager/manager_native_backup_nemesis.yaml", "configurations/manager/2TB_backup_dataset.yaml"]""",
+    test_config: """["test-cases/performance/perf-regression-latency-backup-nemesis.yaml", "configurations/kms-ear.yaml", "configurations/performance/latency-decorator-error-thresholds-nemesis-ent-tablets.yaml", "configurations/manager/manager_native_backup_nemesis.yaml", "configurations/manager/2TB_backup_dataset.yaml", "configurations/object_storage.yaml"]""",
 )

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-manager-rclone-backup-nemesis.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-manager-rclone-backup-nemesis.jenkinsfile
@@ -8,5 +8,5 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_manager_backup_test.PerformanceRegressionManagerBackupTest.test_manager_backup",
-    test_config: """["test-cases/performance/perf-regression-latency-backup-nemesis.yaml", "configurations/kms-ear.yaml", "configurations/performance/latency-decorator-error-thresholds-nemesis-ent-tablets.yaml", "configurations/manager/manager_rclone_backup_nemesis.yaml", "configurations/manager/2TB_backup_dataset.yaml"]""",
+    test_config: """["test-cases/performance/perf-regression-latency-backup-nemesis.yaml", "configurations/kms-ear.yaml", "configurations/performance/latency-decorator-error-thresholds-nemesis-ent-tablets.yaml", "configurations/manager/manager_rclone_backup_nemesis.yaml", "configurations/manager/2TB_backup_dataset.yaml",  "configurations/object_storage.yaml"]""",
 )

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -24,7 +24,7 @@ from sdcm.argus_results import (send_manager_benchmark_results_to_argus, send_ma
 from sdcm.mgmt import ScyllaManagerError, TaskStatus, HostStatus, HostSsl, HostRestStatus
 from sdcm.mgmt.argus_report import report_to_argus, ManagerReportType
 from sdcm.mgmt.cli import RestoreTask
-from sdcm.mgmt.common import reconfigure_scylla_manager, get_persistent_snapshots, get_backup_size
+from sdcm.mgmt.common import reconfigure_scylla_manager, get_persistent_snapshots, get_backup_size, ObjectStorageUploadMode
 from sdcm.provision.helpers.certificate import TLSAssets
 from sdcm.nemesis import MgmtRepair
 from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations
@@ -1003,7 +1003,7 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
                     resource_to_add=f"arn:aws:s3:::{location.split(':')[-1]}",
                 )
 
-    def test_backup_and_restore_only_data(self):
+    def test_backup_and_restore_only_data(self, object_storage_method: ObjectStorageUploadMode):
         """The test is extensively used for restore benchmarking purposes and consists of the following steps:
         1. Populate the cluster with data (currently operates with datasets of 500GB, 1TB, 2TB, 5TB);
         2. Run the backup task and wait for its completion;
@@ -1031,7 +1031,7 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
 
         extra_params = self.get_restore_extra_parameters()
         task = self.restore_backup_with_task(mgr_cluster=mgr_cluster, snapshot_tag=backup_task.get_snapshot_tag(),
-                                             timeout=110000, restore_data=True, extra_params=extra_params)
+                                             timeout=110000, restore_data=True, extra_params=extra_params, object_storage_method=object_storage_method)
         self.manager_test_metrics.restore_time = task.duration
 
         manager_version_timestamp = manager_tool.sctool.client_version_timestamp
@@ -1039,7 +1039,7 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
 
         self.run_verification_read_stress()
 
-    def test_restore_from_precreated_backup(self, snapshot_name: str, restore_outside_manager: bool = False):
+    def test_restore_from_precreated_backup(self, snapshot_name: str, object_storage_method: ObjectStorageUploadMode = None, restore_outside_manager: bool = False):
         """The test restores the schema and data from a pre-created backup and runs the verification read stress.
         1. Define the backup to restore from
         2. Run restore schema to empty cluster
@@ -1086,11 +1086,13 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
                 )
             restore_time = timer.duration
         else:
-            self.log.info("Restoring the data with standard L&S approach")
+            self.log.info("Restoring the data")
             extra_params = self.get_restore_extra_parameters()
             task = self.restore_backup_with_task(mgr_cluster=mgr_cluster, snapshot_tag=snapshot_data.tag,
-                                                 timeout=snapshot_data.exp_timeout, restore_data=True,
-                                                 location_list=locations, extra_params=extra_params)
+                                                 restore_data=True,
+                                                 timeout=snapshot_data.exp_timeout,
+                                                 location_list=locations, extra_params=extra_params,
+                                                 object_storage_method=object_storage_method)
             restore_time = task.duration
             manager_version_timestamp = mgr_cluster.sctool.client_version_timestamp
             self._send_restore_results_to_argus(task, manager_version_timestamp, dataset_label=snapshot_name)
@@ -1104,18 +1106,33 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
         else:
             self.log.info("Skipping verification read stress because of the test or snapshot configuration")
 
-    def test_restore_benchmark(self):
-        """Benchmark restore operation.
+    def test_restore_native_benchmark(self):
+        """Benchmark restore operation using Native method.
 
         The test suggests two flows - populate the cluster with data, create the backup, and then restore it or
         restore from a pre-created backup.
         """
         if reuse_snapshot_name := self.params.get('mgmt_reuse_backup_snapshot_name'):
-            self.log.info("Executing test_restore_from_precreated_backup...")
-            self.test_restore_from_precreated_backup(reuse_snapshot_name)
+            self.log.info("Executing test_restore_from_precreated_backup with method Native...")
+            self.test_restore_from_precreated_backup(
+                reuse_snapshot_name, object_storage_method=ObjectStorageUploadMode.NATIVE)
         else:
-            self.log.info("Executing test_backup_and_restore_only_data...")
-            self.test_backup_and_restore_only_data()
+            self.log.info("Executing test_backup_and_restore_only_data with method Native...")
+            self.test_backup_and_restore_only_data(object_storage_method=ObjectStorageUploadMode.NATIVE)
+
+    def test_restore_rclone_benchmark(self):
+        """Benchmark restore operation using rClone method.
+
+        The test suggests two flows - populate the cluster with data, create the backup, and then restore it or
+        restore from a pre-created backup.
+        """
+        if reuse_snapshot_name := self.params.get('mgmt_reuse_backup_snapshot_name'):
+            self.log.info("Executing test_restore_from_precreated_backup with method rClone...")
+            self.test_restore_from_precreated_backup(
+                reuse_snapshot_name, object_storage_method=ObjectStorageUploadMode.RCLONE)
+        else:
+            self.log.info("Executing test_backup_and_restore_only_data with method rClone...")
+            self.test_backup_and_restore_only_data(object_storage_method=ObjectStorageUploadMode.RCLONE)
 
     def test_restore_data_without_manager(self):
         """The test restores the schema and data from a pre-created backup.
@@ -1209,7 +1226,8 @@ class ManagerOneToOneRestore(ManagerTestFunctionsMixIn):
             cs_verify_cmds = self.build_cs_read_cmd_from_snapshot_details(snapshot_data)
             self.run_and_verify_stress_in_threads(cs_cmds=cs_verify_cmds)
         else:
-            self.log.info("Skipping verification read stress because of the test or snapshot configuration")
+            self.log.info(f"Skipping verification read stress because of the test or snapshot configuration,"
+                          f" mgmt_skip_post_restore_stress_read: {self.params.get('mgmt_skip_post_restore_stress_read')}, snapshot prohibit_verification_read: {snapshot_data.prohibit_verification_read}")
 
 
 class ManagerBackupRestoreConcurrentTests(ManagerTestFunctionsMixIn):

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -603,7 +603,7 @@ class ManagerCluster(ScyllaManagerBase):
         self.id = value
 
     def create_restore_task(self, restore_schema=False, restore_data=False, location_list=None, snapshot_tag=None,
-                            dc_mapping=None, extra_params=None):
+                            dc_mapping=None, object_storage_method=None, extra_params=None):
         cmd = f"restore -c {self.id}"
         if restore_schema:
             cmd += " --restore-schema"
@@ -618,6 +618,8 @@ class ManagerCluster(ScyllaManagerBase):
             # --dc-mapping flag is applicable only for --restore-tables mode
             # https://manager.docs.scylladb.com/stable/sctool/restore.html#dc-mapping
             cmd += f" --dc-mapping {dc_mapping}"
+        if object_storage_method is not None:
+            cmd += " --method {} ".format(object_storage_method.value)
         if extra_params:
             cmd += f" {extra_params}"
 

--- a/sdcm/mgmt/operations.py
+++ b/sdcm/mgmt/operations.py
@@ -767,12 +767,12 @@ class ManagerTestFunctionsMixIn(
                     self.log.info(f"[Node {index}][{keyspace}.{table}] Nodetool refresh took {timer.duration}")
 
     def restore_backup_with_task(self, mgr_cluster, snapshot_tag, timeout, restore_schema=False, restore_data=False,
-                                 location_list=None, extra_params=None):
+                                 location_list=None, extra_params=None, object_storage_method=None):
         location_list = location_list if location_list else self.locations
         dc_mapping = self.get_dc_mapping() if restore_data else None
         restore_task = mgr_cluster.create_restore_task(restore_schema=restore_schema, restore_data=restore_data,
                                                        location_list=location_list, snapshot_tag=snapshot_tag,
-                                                       dc_mapping=dc_mapping, extra_params=extra_params)
+                                                       dc_mapping=dc_mapping, extra_params=extra_params, object_storage_method=object_storage_method)
         restore_task.wait_and_get_final_status(step=30, timeout=timeout)
         assert restore_task.status == TaskStatus.DONE, f"Restoration of {snapshot_tag} has failed!"
         InfoEvent(message=f'The restore task has ended successfully. '

--- a/test-cases/performance/perf-regression-latency-backup-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-backup-nemesis.yaml
@@ -12,13 +12,6 @@ n_loaders: 4
 n_monitor_nodes: 1
 region_name: us-east-1
 backup_bucket_location: 'manager-backup-tests-us-east-1'
-append_scylla_yaml:
-  auto_snapshot: false
-  object_storage_endpoints:
-    - name: s3.us-east-1.amazonaws.com
-      port: 443
-      https: true
-      aws_region: us-east-1
 aws_instance_profile_name_db: 'qa-scylla-manager-backup-instance-profile'
 user_prefix: 'manager-backup-benchmark'
 use_hdrhistogram: true


### PR DESCRIPTION
test(Manager Restore): Added object_storage_method (rclone/native)

Scylla Manager added a support for selecting the "method" parameter of restoring data from S3.
Added tests for both methods of "Native" and "rClone"
Refs: https://manager.docs.scylladb.com/master/sctool/restore.html#method

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [2tb_1t_ics](https://jenkins.scylladb.com/job/scylla-staging/job/yarongilor/job/restore-benchmark-test-1tb-2tables-9nodes/9/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
