### PR TITLE
fix(twcs): Use immediate tombstone_gc mode

### DIFF
--- a/test-cases/longevity/longevity-twcs-3h.yaml
+++ b/test-cases/longevity/longevity-twcs-3h.yaml
@@ -23,4 +23,4 @@ space_node_threshold: 64424
 
 user_prefix: 'longevity-twcs-3h'
 
-post_prepare_cql_cmds: "ALTER TABLE scylla_bench.test with gc_grace_seconds = 300;"
+post_prepare_cql_cmds: "ALTER TABLE scylla_bench.test WITH tombstone_gc = {'mode':'immediate'};"

--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -23,7 +23,7 @@ space_node_threshold: 64424
 
 user_prefix: 'longevity-twcs-48h'
 
-post_prepare_cql_cmds: "ALTER TABLE scylla_bench.test with gc_grace_seconds = 12000 and default_time_to_live = 10800 and compaction = {'class':'TimeWindowCompactionStrategy', 'compaction_window_size': 60, 'compaction_window_unit': 'MINUTES'};"
+post_prepare_cql_cmds: "ALTER TABLE scylla_bench.test and default_time_to_live = 10800 and compaction = {'class':'TimeWindowCompactionStrategy', 'compaction_window_size': 60, 'compaction_window_unit': 'MINUTES'} and WITH tombstone_gc = {'mode':'immediate'};"
 
 
 round_robin: true


### PR DESCRIPTION
While using TWCS it is recommended to use this mode. Reference: https://github.com/scylladb/scylladb/issues/25540

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- Longevities:
   - [ ] TWCS 3h
   - [ ] TWCS 48h 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

