### PR TITLE
feature(triggers): assign specific owner to k8s based triggers

### DIFF
--- a/jenkins-pipelines/operator/eks/weekly-trigger.xml
+++ b/jenkins-pipelines/operator/eks/weekly-trigger.xml
@@ -38,7 +38,8 @@ k8s_scylla_operator_chart_version=latest</properties>
               <properties>docker_image=scylladb/scylla-nightly
 scylla_version=latest
 k8s_scylla_operator_helm_repo=https://storage.googleapis.com/scylla-operator-charts/latest
-k8s_scylla_operator_chart_version=latest</properties>
+k8s_scylla_operator_chart_version=latest
+requested_by_user=mflendrich</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>

--- a/jenkins-pipelines/operator/functional/weekly-trigger.xml
+++ b/jenkins-pipelines/operator/functional/weekly-trigger.xml
@@ -25,6 +25,7 @@ scylla_version=latest
 k8s_scylla_operator_helm_repo=https://storage.googleapis.com/scylla-operator-charts/latest
 k8s_scylla_operator_chart_version=latest
 k8s_enable_sni=false
+requested_by_user=mflendrich
 k8s_enable_tls=false</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
@@ -42,6 +43,7 @@ scylla_version=%(release_version)s
 k8s_scylla_operator_helm_repo=https://storage.googleapis.com/scylla-operator-charts/latest
 k8s_scylla_operator_chart_version=latest
 k8s_enable_sni=false
+requested_by_user=mflendrich
 k8s_enable_tls=false</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
@@ -59,6 +61,7 @@ scylla_version=%(release_version)s
 k8s_scylla_operator_helm_repo=https://storage.googleapis.com/scylla-operator-charts/latest
 k8s_scylla_operator_chart_version=latest
 k8s_enable_sni=false
+requested_by_user=mflendrich
 k8s_enable_tls=false</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>

--- a/jenkins-pipelines/operator/gke/weekly-trigger.xml
+++ b/jenkins-pipelines/operator/gke/weekly-trigger.xml
@@ -24,7 +24,9 @@ H 02 * * 0</spec>
               <properties>docker_image=scylladb/scylla-nightly
 scylla_version=latest
 k8s_scylla_operator_helm_repo=https://storage.googleapis.com/scylla-operator-charts/latest
-k8s_scylla_operator_chart_version=latest</properties>
+k8s_scylla_operator_chart_version=latest
+requested_by_user=mflendrich
+              </properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>


### PR DESCRIPTION
so far those resources were listed on the `timer` user of jenkins which was hard to track and folloup, this change add a parameter that would set the owner directly.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
