### PR TITLE
feature(triggers): add owner to all weekly triggers

### DIFF
--- a/jenkins-pipelines/master-triggers/sct_triggers/tier1-custom-time-trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/tier1-custom-time-trigger.xml
@@ -25,7 +25,8 @@ availability_zone=c
 provision_type=on_demand
 post_behavior_db_nodes=destroy
 post_behavior_monitor_nodes=destroy
-stress_duration=1440</properties>
+stress_duration=1440
+requested_by_user=timtimb0t</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
@@ -40,7 +41,8 @@ stress_duration=1440</properties>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
               <properties>scylla_repo=http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list
 post_behavior_db_nodes=destroy
-post_behavior_monitor_nodes=destroy</properties>
+post_behavior_monitor_nodes=destroy
+requested_by_user=timtimb0t</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>

--- a/jenkins-pipelines/master-triggers/sct_triggers/weekly-master-images-rolling-upgrades-trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/weekly-master-images-rolling-upgrades-trigger.xml
@@ -52,7 +52,8 @@ UPDATE 02/02/2023: Removed rolling-upgrade-multi-dc-ami-test and rolling-upgrade
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
               <properties>new_scylla_repo=http://downloads.scylladb.com/unstable/scylla/master/rpm/centos/latest/scylla.repo
 provision_type=on_demand
-gce_project=gcp-sct-project-1</properties>
+gce_project=gcp-sct-project-1
+requested_by_user=fruch</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
@@ -66,7 +67,8 @@ gce_project=gcp-sct-project-1</properties>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
               <properties>new_scylla_repo=http://downloads.scylladb.com.s3.amazonaws.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list
 provision_type=on_demand
-gce_project=gcp-sct-project-1</properties>
+gce_project=gcp-sct-project-1
+requested_by_user=fruch</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>

--- a/vars/perfRegressionParallelPipelinebyRegion.groovy
+++ b/vars/perfRegressionParallelPipelinebyRegion.groovy
@@ -17,13 +17,16 @@ def call(Map pipelineParams) {
             string(name: 'new_scylla_repo', defaultValue: 'https://downloads.scylladb.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list', description: 'New Scylla repo')
             booleanParam(name: 'use_job_throttling', defaultValue: true, description: 'if true, use job throttling to limit the number of concurrent builds')
             string(name: 'labels_selector', defaultValue: '', description: 'This parameter is used for trigger with Scylla master version only. It points how to trigger the test: daily, weekly ot once in 3 weeks. Expected values: master-3weeks OR master-weekly OR master-daily')
+            string(defaultValue: '',
+                   description: 'Actual user requesting job start, for automated job builds (e.g. through Argus)',
+                   name: 'requested_by_user')
         }
         triggers {
             parameterizedCron (
                 '''
-                    0 8 * * * %scylla_version=master:latest;labels_selector=alternator-daily
-                    00 6 * * 0 %scylla_version=master:latest;labels_selector=master-weekly
-                    0 23 */21 * * %scylla_version=master:latest;labels_selector=master-3weeks
+                    0 8 * * * %scylla_version=master:latest;labels_selector=alternator-daily;requested_by_user=radoslawcybulski
+                    00 6 * * 0 %scylla_version=master:latest;labels_selector=master-weekly;requested_by_user=juliayakovlev
+                    0 23 */21 * * %scylla_version=master:latest;labels_selector=master-3weeks;requested_by_user=juliayakovlev
                 '''
             )
         }
@@ -250,7 +253,8 @@ def call(Map pipelineParams) {
                                             string(name: 'new_scylla_repo', value: rolling_upgrade_test ? params.new_scylla_repo : null),
                                             booleanParam(name: 'use_job_throttling', value: params.use_job_throttling),
                                             string(name: 'sub_tests', value: groovy.json.JsonOutput.toJson(sub_tests)),
-                                            string(name: 'region', value: region)
+                                            string(name: 'region', value: region),
+                                            string(name: 'requested_by_user', value: params.requested_by_user)
                                         ]
                                     }
                                 }


### PR DESCRIPTION
since we want the resources of those test to be tagged base on actual users, and not `timer` anymore, we are adding those into all of the triggers for the weekly runs

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
