### PR TITLE
fix(memesis): improve race condition in disrupt_abort_repair

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -3530,11 +3530,24 @@ class NemesisRunner:
                     DbNodeLogger(self.cluster.nodes, "abort repair streaming", target_node=self.target_node),
                     self.action_log_scope(f"Abort repair streaming on {self.target_node.name} node"),
                 ):
+                    # force_terminate_repair only aborts running repair tasks
+                    # it is possible that it will be called just after a task has ended and just before the next task starts
+                    zero_jobs_log = self.target_node.follow_system_log(
+                        r"repair - Started to abort repair jobs=\{\}, nr_jobs=0"
+                    )
+
                     self.target_node.remoter.run(
                         "curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json'"
                         " http://127.0.0.1:10000/storage_service/force_terminate_repair"
                     )
-                thread.result(timeout=120)
+
+                try:
+                    thread.result(timeout=120)
+                except TimeoutError:
+                    if list(zero_jobs_log):
+                        raise UnsupportedNemesis("No repair jobs running when terminate was called")
+                    else:
+                        raise
                 time.sleep(10)  # to make sure all failed logs/events, are ignored correctly
 
         self.log.debug("Execute a complete repair for target node")


### PR DESCRIPTION
Calling `force_terminate_repair` will only affect running tasks, but it is possible that the call can happen between tasks, in which case nothing will terminate, and the repair thread will timeout.

Add checks for the case where no tasks were running, so the nemesis does not fail

closes: #11126

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/c9b398e2-e0da-4763-b902-4242aae69dbd
  Nemesis ran 17 times without issue , but the race condition never occured.
  
```
Sep 22 14:01:22.119534 longevity-5gb-1h-AbortRepairMonkey--db-node-c9b398e2-3 scylla[5852]:  [shard 0:strm] repair - Started to abort repair jobs={520d3582-8396-4dcc-b426-a2b90d5d836a}, nr_jobs=1
Sep 22 14:13:12.205992 longevity-5gb-1h-AbortRepairMonkey--db-node-c9b398e2-3 scylla[5852]:  [shard 0:strm] repair - Started to abort repair jobs={64ec12aa-24fe-404d-be6c-15677982eca0}, nr_jobs=1
Sep 22 14:21:34.564593 longevity-5gb-1h-AbortRepairMonkey--db-node-c9b398e2-3 scylla[5852]:  [shard 0:strm] repair - Started to abort repair jobs={ff7ca3d6-faa3-4eb7-a305-445336e3b5f1}, nr_jobs=1
Sep 22 14:30:03.482686 longevity-5gb-1h-AbortRepairMonkey--db-node-c9b398e2-3 scylla[5852]:  [shard 0:strm] repair - Started to abort repair jobs={7c22f6b6-bc8f-4285-9932-d69083f3e0dd}, nr_jobs=1
Sep 22 14:47:20.896786 longevity-5gb-1h-AbortRepairMonkey--db-node-c9b398e2-3 scylla[5852]:  [shard 0:strm] repair - Started to abort repair jobs={b5c08bee-06fe-4cea-94bb-d6ba202c0e86}, nr_jobs=1
Sep 22 15:04:02.843332 longevity-5gb-1h-AbortRepairMonkey--db-node-c9b398e2-3 scylla[5852]:  [shard 0:strm] repair - Started to abort repair jobs={fcfef1c0-8a00-4849-a58c-4717bf2146a6}, nr_jobs=1

Sep 22 14:17:21.150361 longevity-5gb-1h-AbortRepairMonkey--db-node-c9b398e2-2 scylla[5864]:  [shard 0:strm] repair - Started to abort repair jobs={6ecbf2de-ac50-4db8-b8e2-3c57bdae1c45}, nr_jobs=1
Sep 22 14:25:43.620345 longevity-5gb-1h-AbortRepairMonkey--db-node-c9b398e2-2 scylla[5864]:  [shard 0:strm] repair - Started to abort repair jobs={3b27b045-734f-479f-97d2-6920aaa4c8af}, nr_jobs=1
Sep 22 14:38:43.826375 longevity-5gb-1h-AbortRepairMonkey--db-node-c9b398e2-2 scylla[5864]:  [shard 0:strm] repair - Started to abort repair jobs={fd80cffa-0c25-4d74-97e8-f28881d27eec}, nr_jobs=1
Sep 22 14:43:10.362351 longevity-5gb-1h-AbortRepairMonkey--db-node-c9b398e2-2 scylla[5864]:  [shard 0:strm] repair - Started to abort repair jobs={66abe3e6-cf6d-4f69-9dc8-e0a94908a81c}, nr_jobs=1
Sep 22 14:55:44.576578 longevity-5gb-1h-AbortRepairMonkey--db-node-c9b398e2-2 scylla[5864]:  [shard 0:strm] repair - Started to abort repair jobs={d97ae63e-f2b6-4065-9773-09e3449e4450}, nr_jobs=1
Sep 22 14:59:53.321833 longevity-5gb-1h-AbortRepairMonkey--db-node-c9b398e2-2 scylla[5864]:  [shard 0:strm] repair - Started to abort repair jobs={ab4d9024-92a4-43cd-930b-ac6cffc0ee48}, nr_jobs=1

Sep 22 14:05:11.341922 longevity-5gb-1h-AbortRepairMonkey--db-node-c9b398e2-1 scylla[5891]:  [shard 0:strm] repair - Started to abort repair jobs={bb9f1241-5d26-4664-9ca4-e3f97989935d}, nr_jobs=1
Sep 22 14:08:59.185265 longevity-5gb-1h-AbortRepairMonkey--db-node-c9b398e2-1 scylla[5891]:  [shard 0:strm] repair - Started to abort repair jobs={c9fe6034-fa2f-4bd9-a505-f19b8252c206}, nr_jobs=1
Sep 22 14:34:19.322404 longevity-5gb-1h-AbortRepairMonkey--db-node-c9b398e2-1 scylla[5891]:  [shard 0:strm] repair - Started to abort repair jobs={3c55c3c2-8964-41c1-b99a-7fdc6a446366}, nr_jobs=1
Sep 22 14:51:34.469862 longevity-5gb-1h-AbortRepairMonkey--db-node-c9b398e2-1 scylla[5891]:  [shard 0:strm] repair - Started to abort repair jobs={b8937f56-ad87-4f5a-b27b-d31ab22bb36b}, nr_jobs=1
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
