### PR TITLE
fix(aws): add Name tag to all newly created instances

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3413,6 +3413,7 @@ class BaseCluster:
         key = self.node_type if "db" not in self.node_type else "db"
         action = self.params.get(f"post_behavior_{key}_nodes")
         return {**self.test_config.common_tags(),
+                "Name": self.name,
                 "NodeType": str(self.node_type),
                 "keep_action": "terminate" if action == "destroy" else "", }
 


### PR DESCRIPTION
seems like we were missing some code path, and the Name wasn't created for those, adding some name so we can create instances

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] locally
- [x] CI PR provision test

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
