### PR TITLE
set monitor image to 4.12.0 scylladb-monitor-4-12-0-2025-09-25t05-40-25z

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -7,7 +7,7 @@ instance_type_loader: 'c6i.xlarge'
 instance_type_monitor: 't3.large'
 ami_id_loader: 'resolve:ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id'
 # manual on updating monitor images see: docs/monitoring-images.md
-ami_id_monitor: 'scylladb-monitor-4-11-0-2025-07-21t09-39-20z'
+ami_id_monitor: 'scylladb-monitor-4-12-0-2025-09-25t05-40-25z'
 
 availability_zone: 'a'
 root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -5,7 +5,7 @@ gce_project: '' # empty mean default one, can be overwritten to use different on
 
 gce_image_db: '' # so we can use `scylla_version` as needed
 gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64'
-gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-11-0-2025-07-21t09-39-20z'
+gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-12-0-2025-09-25t05-40-25z'
 
 gce_image_username: 'scylla-test'
 


### PR DESCRIPTION
### Testing
- [ https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/amnon/job/byo-longevity-test/63/]

### PR pre-checks (self review)
- [v ] I added the relevant `backport` labels
- [ v] I didn't leave commented-out/debugging code

Switch to monitoring 4.12