### PR TITLE
Increate future timeout

### DIFF
--- a/sdcm/utils/hdrhistogram.py
+++ b/sdcm/utils/hdrhistogram.py
@@ -17,7 +17,7 @@ LOGGER = logging.getLogger(__file__)
 PROCESS_LIMIT = multiprocessing.cpu_count()
 TIME_INTERVAL = 600
 PERCENTILES = [50, 90, 95, 99, 99.9, 99.99, 99.999]
-FUTURE_RESULT_TIMEOUT = 10  # seconds
+FUTURE_RESULT_TIMEOUT = 60  # seconds
 
 
 def make_hdrhistogram_summary(
@@ -189,7 +189,7 @@ class _HdrRangeHistogramBuilder:
                     interval_num += 1
                 results = {}
                 for e, future in enumerate(futures):
-                    res = future.result(timeout=FUTURE_RESULT_TIMEOUT)  # Will raise TimeoutError after 10 seconds
+                    res = future.result(timeout=FUTURE_RESULT_TIMEOUT)  # Will raise TimeoutError after 60 seconds
                     LOGGER.debug(
                         f"Got result for {e} future for tag {self.hdr_tags[e % len(self.hdr_tags)]} and interval {e // len(self.hdr_tags)}")
                     if res:


### PR DESCRIPTION
Increase future's timeout, as current is too low for alternator's performance testing.

YCSB produces mutliple files (each with it's own tag), while hdr histogram processing in sct does scan directory for all hdr files and run a different future over each file x tag combination. As a result each hdr histogram from ycsb will be processed 6 times (one for each tag).
This change is temporary.