### PR TITLE
fix(gemini): use client timestamps

### DIFF
--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -84,7 +84,7 @@ class GeminiStressThread(DockerBasedStressThread):
             "drop-schema": "true",
             "cql-features": "normal",
             "materialized-views": "false",
-            "use-server-timestamps": "true",
+            "use-server-timestamps": "false",
             "use-lwt": "false",
             "use-counters": "false",
             "max-tables": 1,

--- a/test-cases/cdc/cdc-replication-longevity.yaml
+++ b/test-cases/cdc/cdc-replication-longevity.yaml
@@ -25,7 +25,6 @@ gemini_cmd: |
   --cql-features basic
   --max-mutation-retries 100
   --max-mutation-retries-backoff 100ms
-  --use-server-timestamps
 
 gemini_table_options:
   - "cdc = {'enabled': true, 'ttl': 0}"

--- a/unit_tests/test_data/test_scylla_yaml_builders/multi_network_interfaces/cdc-replication-longevity.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/multi_network_interfaces/cdc-replication-longevity.yaml
@@ -23,7 +23,6 @@ gemini_cmd: |
   --cql-features basic
   --max-mutation-retries 100
   --max-mutation-retries-backoff 100ms
-  --use-server-timestamps
   --test-host-selection-policy token-aware
 
 gemini_table_options:

--- a/unit_tests/test_gemini_thread.py
+++ b/unit_tests/test_gemini_thread.py
@@ -45,7 +45,7 @@ def test_01_gemini_thread(request, docker_scylla, params):
         "--max-mutation-retries-backoff=100ms",
         "--replication-strategy=\"{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}\"",
         "--table-options=\"cdc = {'enabled': true, 'ttl': 0}\"",
-        "--use-server-timestamps=true",
+        "--use-server-timestamps=false",
     ]
 
     gemini_thread = GeminiStressThread(
@@ -85,7 +85,7 @@ def test_gemini_thread_without_cluster(request, docker_scylla, params):
             "--max-mutation-retries-backoff=100ms",
             "--replication-strategy=\"{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}\"",
             "--table-options=\"cdc = {'enabled': true, 'ttl': 0}\"",
-            "--use-server-timestamps=true",
+            "--use-server-timestamps=false",
         ]
     )
 


### PR DESCRIPTION
Because Gemini runs queries against oracle and test cluster at slightly different times it might cause data discrepancy between them (especially when delete statements are involved).

Make Gemini to use client timestamps (with `USING TIMESTAMP` added to statements) so the same order is enforced.

refs: https://github.com/scylladb/scylladb/issues/25679

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - integration tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
