### PR TITLE
fix(logcollector): fix getting monitoring version

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -197,7 +197,7 @@ class BaseMonitoringEntity(BaseLogEntity):
             return None, None, None
 
         try:
-            monitor_version, scylla_version = result.stdout.strip().split(':')
+            monitor_version, scylla_version = result.stdout.strip().split(':')[:2]
         except ValueError:
             monitor_version = None
             scylla_version = None


### PR DESCRIPTION
Sometimes, the contents of the `monitor_version` file can be something like `None:master:latest`, which causes the split to fail. Since that value is only used in the archive file name, it is safe to ignore the last part.

closes: #12092

```
ubuntu@balancer-test-feature--monitor-node-72f249d1-1:~$ cat scylla-grafana-monitoring-scylla-monitoring/monitor_version
None:master
```
vs
```
ubuntu@elasticity-test-feature--monitor-node-f2335597-1:~$ cat scylla-grafana-monitoring-scylla-monitoring/monitor_version
None:master:latest
```


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] N/A

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
