### PR TITLE
fix(s3_remote_uploader): use Keystore instance to access its methods

### DIFF
--- a/sdcm/utils/s3_remote_uploader.py
+++ b/sdcm/utils/s3_remote_uploader.py
@@ -84,7 +84,7 @@ def upload_remote_files_directly_to_s3(ssh_info: dict[str, str], files: List[str
     chan_response = SshOutAsFile(chan)
     s3 = boto3.client("s3")
     s3.upload_fileobj(chan_response, s3_bucket, s3_key, ExtraArgs=extra_args)
-    for user, canonical_id in KeyStore.get_acl_grantees().items():
+    for user, canonical_id in KeyStore().get_acl_grantees().items():
         LOGGER.info("Setting ACL for user %s", user)
         s3.put_object_acl(Bucket=s3_bucket, Key=s3_key, GrantRead=f"id={canonical_id}")
     link = f"https://{s3_bucket}.s3.amazonaws.com/{s3_key}"


### PR DESCRIPTION
Fix acessing 'Keystore.get_acl_grantees` - it is implemented as instance method, but is accessed as class method.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
