### PR TITLE
fix(cluster): fix getting monitoring version when scylla_version is a branch

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5655,7 +5655,9 @@ class BaseMonitorSet:
     @property
     def monitoring_version(self):
         if scylla_version := self.params.get('scylla_version'):
-            return scylla_version
+            # scylla version can be branch-version:latest, or master:latest
+            # only version is needed
+            return scylla_version.lstrip('branch-').split(':')[0]
         scylla_version = self.targets["db_cluster"].nodes[0].scylla_version
         self.log.debug("Using %s ScyllaDB version to derive monitoring version", scylla_version)
         if scylla_version and "dev" not in scylla_version:


### PR DESCRIPTION
If `scylla_version` is given as a branch, e.g. `master:latest` or `branch-2025.3:latest` the version should be extracted from that string.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] `master-latest` [before](https://jenkins.scylladb.com/job/scylla-staging/job/cezar/job/cezar-custom-longevity/111/)
![unnamed](https://github.com/user-attachments/assets/bf784efa-8901-47cb-9e4e-11ac3ffd1fe6)
- [x] `master-latest` [after](https://jenkins.scylladb.com/job/scylla-staging/job/cezar/job/cezar-custom-longevity/115/)
![Screenshot 2025-10-08 145242](https://github.com/user-attachments/assets/8e3f128a-96ab-4be7-b76a-a32c77bd3ef6)
- [x] `branch-2025.3:latest` [before](https://jenkins.scylladb.com/job/scylla-staging/job/cezar/job/cezar-custom-longevity/112/)
![Screenshot 2025-10-08 142834](https://github.com/user-attachments/assets/b4405d0d-34eb-4bb3-bebc-7ddd92b071ff)
- [x] `branch-2025.3:latest` [after](https://jenkins.scylladb.com/job/scylla-staging/job/cezar/job/cezar-custom-longevity/116/)
![Screenshot 2025-10-08 145224](https://github.com/user-attachments/assets/d2e520c1-f32c-44e5-abc8-1ed60fa5e5cb)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
