### PR TITLE
fix(sdcm/utils/common.py): Avoid permission denied on strict umask environment

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -134,6 +134,7 @@ def _remote_get_file(remoter, src, dst, user_agent=None):
     cmd = 'curl -L {} -o {}'.format(src, dst)
     if user_agent:
         cmd += ' --user-agent %s' % user_agent
+    cmd += f' && chmod 644 {dst}'
     return remoter.run(cmd, ignore_status=True)
 
 


### PR DESCRIPTION
In a strict umask environment (umask 027), the curl command executed by remote_get_file() sets the permissions of the downloaded file to 640. This causes Permission denied error on upload_sstables(), since it tries to extract downloaded tar file in scylla user, but the file does not have other-read bit on its permission.

To fix the problem, we need to set the file permission to 644 just after curl command executed.

Fixes #12120
Related https://github.com/scylladb/scylla-machine-image/pull/712

### Testing

Tested, it still fails with another error but verified Permission denied error disappear:
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/takuya/job/longevity/job/longevity-100gb-4h-test/2/
