### PR TITLE
fix(actions_log): log only after filter stage

### DIFF
--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -35,12 +35,10 @@ import dateutil.parser
 from sdcm import sct_abs_path
 from sdcm.sct_events import Severity, SctEventProtocol
 from sdcm.sct_events.events_processes import EventsProcessesRegistry
-from sdcm.utils.action_logger import get_action_logger
 
 DEFAULT_SEVERITIES = sct_abs_path("defaults/severities.yaml")
 FILTER_EVENT_DECAY_TIME = 600.0
 LOGGER = logging.getLogger(__name__)
-ACTION_LOGGER = get_action_logger("event")
 
 
 class SctEventTypesRegistry(Dict[str, Type["SctEvent"]]):
@@ -247,15 +245,6 @@ class SctEvent:
                 LOGGER.warning("[SCT internal warning] %s is not ready to be published", self)
             return
         get_events_main_device(_registry=self._events_processes_registry).publish_event(self)
-        if self.severity.value > Severity.WARNING.value:
-            event_type = self.base
-            if self.type:
-                event_type += f".{self.type}"
-            if self.subtype:
-                event_type += f".{self.subtype}"
-            ACTION_LOGGER.error(
-                f"{event_type} {self.severity.name} Event (id={self.event_id}) on node: {getattr(self, 'node', None)}"
-            )
         self._ready_to_publish = False
 
     def publish_or_dump(self, default_logger: Optional[logging.Logger] = None, warn_not_ready: bool = True) -> None:


### PR DESCRIPTION
There's an issue with publishing filtered error events to actions.log.

This commit fixes by logging events after filtering in events main device.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/12089

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [artifact test](https://argus.scylladb.com/tests/scylla-cluster-tests/02730fd5-6c84-4cc2-9a93-59e54643051e)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
