### PR TITLE
improvement(disrupt_add_remove_dc): add timeout to drop keyspace

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4921,7 +4921,7 @@ class Nemesis(NemesisFlags):
                 # in case of test end/killed, leave the cleanup alone
                 if exc_type is not KillNemesis:
                     with self.cluster.cql_connection_patient(node) as session:
-                        session.execute('DROP KEYSPACE IF EXISTS keyspace_new_dc')
+                        session.execute('DROP KEYSPACE IF EXISTS keyspace_new_dc', timeout=300)
                     if node_added:
                         self.cluster.decommission(new_node)
             context_manager.push(finalizer)


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylla-enterprise/issues/4507

This change adds a timeout for the DROP KEYSPACE operation in the `disrupt_add_remove_dc` finalizer.

The keyspace was successfully dropped after executing `session.execute('DROP KEYSPACE IF EXISTS keyspace_new_dc')`.
However, the CQL command occasionally returned a timeout error, even though the keyspace was actually removed.

The exact cause of this behavior is unclear, but increasing the timeout appears to resolve the issue.
The new timeout value matches the one used in a similar context here: https://github.com/scylladb/scylla-cluster-tests/blob/4db66ea86c531303f968f72286c53bcc6bf35e2e/sdcm/nemesis.py#L5564

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
Is not needed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
