### PR TITLE
ci(latte): bump latte version to `0.40.1-scylladb`

### DIFF
--- a/defaults/docker_images/latte/values_latte.yaml
+++ b/defaults/docker_images/latte/values_latte.yaml
@@ -1,2 +1,2 @@
 latte:
-  image: scylladb/latte:0.40.0-scylladb
+  image: scylladb/latte:0.40.1-scylladb


### PR DESCRIPTION
[This version](https://github.com/scylladb/latte/releases/tag/0.40.1-scylladb) includes following bug fixes for the data validation feature:
- Fix parsing of Decimal and Varint CQL data types
- Allow setting of null values to any CQL data type

And following improvement:
- Add possibility to generate a 32bit float value in rune scripts

Ready to use rune script using the data validation feature is here:
- https://github.com/scylladb/latte/blob/main/workloads/data_validation.rn

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
