### PR TITLE
fix(cloud): resolve local cloud creds file

### DIFF
--- a/sdcm/utils/cloud_api_utils.py
+++ b/sdcm/utils/cloud_api_utils.py
@@ -21,7 +21,7 @@ LOGGER = logging.getLogger(__name__)
 
 def get_cloud_rest_credentials_from_file(file_path: str) -> dict:
     """Retrieve Scylla Cloud REST credentials from a file"""
-    path = Path(file_path).expanduser()
+    path = Path(file_path).expanduser().resolve()
     if not path.exists():
         raise ValueError(f"Scylla Cloud REST credentials file not found: {file_path}")
 


### PR DESCRIPTION
Resolve relative paths of local cloud credentials file.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] some stdout output of local execution of a provision test, to be able to use local creds file:
```
❯ SCT_XCLOUD_CREDENTIALS_PATH=../scylla_cloud_sct_api_creds_lab.json SCT_XCLOUD_PROVIDER=aws SCT_REGION_NAME=eu-west-1 SCT_CONFIG_FILES='["test-cases/PR-provision-test.yaml","configurations/network_config/test_communication_public.yaml"]' SCT_ENABLE_ARGUS=false SCT_SCYLLA_VERSION=2025.3.1 ./sct.py run-test longevity_test.LongevityTest.test_custom_time --backend xcloud
logged in as arn:aws:sts::797456418907:assumed-role/DeveloperAccessRole/dmytro.kruglov@scylladb.com
New directory created: /home/dmitriy/sct-results/20251011-001218-692040
Symlink `/home/dmitriy/sct-results/latest' updated to `/home/dmitriy/sct-results/20251011-001218-692040'
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.13.7, pytest-8.3.4, pluggy-1.6.0 -- /home/dmitriy/venvs/sct3.13/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.13.7', 'Platform': 'Linux-6.8.0-85-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '8.3.4', 'pluggy': '1.6.0'}, 'Plugins': {'json-report': '1.5.0', 'subtests': '0.14.2', 'anyio': '4.9.0', 'metadata': '3.1.1', 'xdist': '3.8.0', 'random-order': '1.0.4', 'typeguard': '4.3.0'}}
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /home/dmitriy/Work/Scylla/sct_fix_cloud_env_creds_file_path
configfile: pyproject.toml
plugins: json-report-1.5.0, subtests-0.14.2, anyio-4.9.0, metadata-3.1.1, xdist-3.8.0, random-order-1.0.4, typeguard-4.3.0
collecting ... collected 1 item

longevity_test.py::LongevityTest::test_custom_time < t:2025-10-11 00:12:23,201 f:base.py         l:362  c:sdcm.sct_events.base p:INFO  > The run can be interrupted by following critical events:
< t:2025-10-11 00:12:23,201 f:base.py         l:362  c:sdcm.sct_events.base p:INFO  >   * ClusterHealthValidatorEvent.NodeStatus
< t:2025-10-11 00:12:23,201 f:base.py         l:362  c:sdcm.sct_events.base p:INFO  >   * ClusterHealthValidatorEvent.ScyllaCloudClusterServerDiagnostic
< t:2025-10-11 00:12:23,201 f:base.py         l:362  c:sdcm.sct_events.base p:INFO  >   * DataValidatorEvent.UpdatedRowsValidator
< t:2025-10-11 00:12:23,201 f:base.py         l:362  c:sdcm.sct_events.base p:INFO  >   * DatabaseLogEvent.CORRUPTED_SSTABLE
< t:2025-10-11 00:12:23,201 f:base.py         l:362  c:sdcm.sct_events.base p:INFO  >   * CassandraHarryEvent.failure
< t:2025-10-11 00:12:23,201 f:base.py         l:362  c:sdcm.sct_events.base p:INFO  >   * YcsbStressEvent.failure
< t:2025-10-11 00:12:23,201 f:base.py         l:362  c:sdcm.sct_events.base p:INFO  >   * NdBenchStressEvent.failure
< t:2025-10-11 00:12:23,201 f:base.py         l:362  c:sdcm.sct_events.base p:INFO  >   * NdBenchErrorEvent.BuildFailed
< t:2025-10-11 00:12:23,201 f:base.py         l:362  c:sdcm.sct_events.base p:INFO  >   * NdBenchErrorEvent.Failure
< t:2025-10-11 00:12:23,201 f:base.py         l:362  c:sdcm.sct_events.base p:INFO  >   * CDCReaderStressEvent.failure
< t:2025-10-11 00:12:23,201 f:base.py         l:362  c:sdcm.sct_events.base p:INFO  >   * NoSQLBenchStressEvent
< t:2025-10-11 00:12:23,201 f:base.py         l:362  c:sdcm.sct_events.base p:INFO  >   * NoSQLBenchStressLogEvents.ProgressIndicatorStoppedEvent
< t:2025-10-11 00:12:23,201 f:base.py         l:362  c:sdcm.sct_events.base p:INFO  >   * CassandraStressLogEvent.OperationOnKey
< t:2025-10-11 00:12:23,201 f:base.py         l:362  c:sdcm.sct_events.base p:INFO  >   * CqlStressCassandraStressLogEvent.ReadValidationError
< t:2025-10-11 00:12:23,201 f:base.py         l:362  c:sdcm.sct_events.base p:INFO  >   * ScyllaBenchLogEvent.DataValidationError
< t:2025-10-11 00:12:23,201 f:base.py         l:362  c:sdcm.sct_events.base p:INFO  >   * ScyllaBenchLogEvent.ParseDistributionError
< t:2025-10-11 00:12:23,201 f:base.py         l:362  c:sdcm.sct_events.base p:INFO  >   * GeminiStressLogEvent.GeminiEven
...
< t:2025-10-11 00:30:01,869 f:tester.py       l:3320 c:LongevityTest        p:INFO  > Test ID: a5a14c1f-8ac2-474d-bd32-3db211c00678
PASSED< t:2025-10-11 00:30:01,871 f:tester.py       l:3396 c:LongevityTest        p:INFO  > ================================= TEST RESULTS =================================
< t:2025-10-11 00:30:01,871 f:tester.py       l:3396 c:LongevityTest        p:INFO  > ================================================================================
< t:2025-10-11 00:30:01,871 f:tester.py       l:3396 c:LongevityTest        p:INFO  > SUCCESS :)
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
