### PR TITLE
fix(cloud backend): fallback for cluster RF

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -3725,7 +3725,7 @@ Cloud provider for Scylla Cloud deployment (aws, gce)
 
 ## **xcloud_replication_factor** / SCT_XCLOUD_REPLICATION_FACTOR
 
-Replication factor for Scylla Cloud cluster (default: 3)
+Replication factor for Scylla Cloud cluster
 
 **default:** N/A
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1836,7 +1836,7 @@ class SCTConfiguration(dict):
              help="Cloud provider for Scylla Cloud deployment (aws, gce)"),
 
         dict(name="xcloud_replication_factor", env="SCT_XCLOUD_REPLICATION_FACTOR", type=int,
-             help="Replication factor for Scylla Cloud cluster (default: 3)"),
+             help="Replication factor for Scylla Cloud cluster"),
 
         dict(name="xcloud_vpc_peering", env="SCT_XCLOUD_VPC_PEERING", type=dict_or_str,
              help="""Dictionary of VPC peering parameters for private connectivity between
@@ -3161,9 +3161,9 @@ class SCTConfiguration(dict):
                 f"Supported instance types: {', '.join(supported_instances)}")
 
         rf = self.get('xcloud_replication_factor')
-        n_nodes = self.get('n_db_nodes')
+        n_nodes = int(self.get('n_db_nodes'))
         if rf is None:
-            self['xcloud_replication_factor'] = n_nodes
+            self['xcloud_replication_factor'] = min(n_nodes, 3)
         elif rf > n_nodes:
             raise ValueError(f"xcloud_replication_factor ({rf}) cannot be greater than n_db_nodes ({n_nodes})")
 


### PR DESCRIPTION
During initial implementation of Scylla cloud backend for SCT the flawed assumption was made that, if `replication_factor` parameter is not explicitly specified for new cloud cluster,
we fallback to number of nodes. That led to server side failures during deployment of cluster with higher number of nodes.

This change sets valid RF fallback value for a cluster to be deployed.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [cloud cluster with 6 nodes requested and no RF explicitly specified](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/180/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
