### PR TITLE
improvement(performance): completely remove support of v15/v16 branches

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1553,7 +1553,7 @@ def create_qa_tools_jobs(username, password, sct_branch, sct_repo, triggers):
              help="Create pipeline jobs for performance")
 @click.argument('username', envvar='JENKINS_USERNAME', type=str, required=False)
 @click.argument('password', envvar='JENKINS_PASSWORD', type=str, required=False)
-@click.option('--sct_branch', default='branch-perf-v15', type=str)
+@click.option('--sct_branch', default='branch-perf-v17', type=str)
 @click.option('--sct_repo', default='git@github.com:scylladb/scylla-cluster-tests.git', type=str)
 @click.option('--triggers/--no-triggers', default=False)
 def create_performance_jobs(username, password, sct_branch, sct_repo, triggers):

--- a/vars/createTestJobPipeline.groovy
+++ b/vars/createTestJobPipeline.groovy
@@ -35,8 +35,6 @@ def call() {
                 '''
                     H 01 * * 0 %jenkins_path="scylla-master/releng-testing"
                     H 01 * * 0 %jenkins_path="scylla-master"
-                    H 01 * * 0 %sct_branch=branch-perf-v15
-                    H 01 * * 0 %sct_branch=branch-perf-v16
                     H 01 * * 0 %sct_branch=branch-perf-v17
                 '''
             )
@@ -82,17 +80,6 @@ def call() {
                                                         ./docker/env/hydra.sh create-qa-tools-jobs --triggers --sct_branch ${params.sct_branch} --sct_repo ${params.sct_repo}
                                                     echo "all jobs have been created"
                                                 fi
-
-                                                if [[ "${params.sct_branch}" == "branch-perf-v15" ]] ; then
-                                                    echo "start create perf for ${params.sct_branch}  ......."
-                                                        ./docker/env/hydra.sh create-performance-jobs --triggers --sct_branch ${params.sct_branch} --sct_repo ${params.sct_repo}
-                                                    echo "all jobs have been created"
-                                                fi
-
-                                                if [[ "${params.sct_branch}" == "branch-perf-v16" ]] ; then
-                                                    echo "start create perf for ${params.sct_branch}  ......."
-                                                        ./docker/env/hydra.sh create-performance-jobs --triggers --sct_branch ${params.sct_branch} --sct_repo ${params.sct_repo}
-                                                    echo "all jobs have been created"
                                                 fi
 
                                                 if [[ "${params.sct_branch}" == "branch-perf-v17" ]] ; then


### PR DESCRIPTION
As part of the efforts for task https://github.com/scylladb/qa-tasks/issues/1936, all relevant jobs from 'branch-perf-v15' and 'branch-perf-v16' folders were moved to 'branch-perf-v17' folder. The old folders have been removed.

This commit fully removes support for the v15 and v16 branches from the SCT code:
- the 'create-sct-test-jobs-for-branch' Jenkins job no longer includes them.
- the default branch for the 'sct.create_performance_jobs' function is now 'branch-perf-v17'.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
