### PR TITLE
fix(groovy): remove redundant 'fi'

### DIFF
--- a/vars/createTestJobPipeline.groovy
+++ b/vars/createTestJobPipeline.groovy
@@ -80,7 +80,6 @@ def call() {
                                                         ./docker/env/hydra.sh create-qa-tools-jobs --triggers --sct_branch ${params.sct_branch} --sct_repo ${params.sct_repo}
                                                     echo "all jobs have been created"
                                                 fi
-                                                fi
 
                                                 if [[ "${params.sct_branch}" == "branch-perf-v17" ]] ; then
                                                     echo "start create perf for ${params.sct_branch}  ......."


### PR DESCRIPTION
Redundant 'fi' was not removed in https://github.com/scylladb/scylla-cluster-tests/pull/12153. It will break the job

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
