### PR TITLE
fix(config): Add rf_rack_valid_keyspaces config option

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -17,6 +17,8 @@ round_robin: false
 append_scylla_args: '--blocked-reactor-notify-ms 25 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'
 append_scylla_setup_args: ''
 append_scylla_node_exporter_args: ''
+append_scylla_yaml:
+  rf_rack_valid_keyspaces: true
 experimental_features: []
 
 db_nodes_shards_selection: 'default'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -964,7 +964,7 @@ More arguments to append to oracle command line
 
 More configuration to append to /etc/scylla/scylla.yaml
 
-**default:** N/A
+**default:** {'rf_rack_valid_keyspaces': True}
 
 **type:** dict_or_str
 

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -362,6 +362,7 @@ class ScyllaYaml(BaseModel):
 
     reader_concurrency_semaphore_cpu_concurrency: int = None
     object_storage_endpoints: list[dict] = None
+    rf_rack_valid_keyspaces: bool = None
 
     vector_store_uri: str = None
 

--- a/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.result.json
@@ -17,6 +17,7 @@
   ],
   "experimental_features": [],
   "prometheus_address": "0.0.0.0",
+  "rf_rack_valid_keyspaces": true,
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,
   "enable_ipv6_dns_lookup": false,

--- a/unit_tests/test_data/test_scylla_yaml_builders/functional.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/functional.result.json
@@ -17,6 +17,7 @@
   ],
   "experimental_features": [],
   "prometheus_address": "0.0.0.0",
+  "rf_rack_valid_keyspaces": true,
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,
   "enable_ipv6_dns_lookup": false,

--- a/unit_tests/test_data/test_scylla_yaml_builders/jepsen.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/jepsen.result.json
@@ -17,6 +17,7 @@
   ],
   "experimental_features": [],
   "prometheus_address": "0.0.0.0",
+  "rf_rack_valid_keyspaces": true,
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,
   "enable_ipv6_dns_lookup": false,

--- a/unit_tests/test_data/test_scylla_yaml_builders/longevity-10gb-3h.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/longevity-10gb-3h.result.json
@@ -17,6 +17,7 @@
   "broadcast_rpc_address": "__NODE_IPV6_ADDRESS__",
   "experimental_features": [],
   "prometheus_address": "__NODE_IPV6_ADDRESS__",
+  "rf_rack_valid_keyspaces": true,
   "enable_ipv6_dns_lookup": true,
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,

--- a/unit_tests/test_data/test_scylla_yaml_builders/manager-backup-1TB-gce.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/manager-backup-1TB-gce.result.json
@@ -17,6 +17,7 @@
   ],
   "experimental_features": [],
   "prometheus_address": "0.0.0.0",
+  "rf_rack_valid_keyspaces": true,
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,
   "enable_ipv6_dns_lookup": false,

--- a/unit_tests/test_data/test_scylla_yaml_builders/multi_network_interfaces/cdc-replication-longevity.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/multi_network_interfaces/cdc-replication-longevity.result.json
@@ -17,6 +17,7 @@
   "broadcast_rpc_address": "__NODE_PRIVATE_ADDRESS_2__",
   "experimental_features": [],
   "prometheus_address": "0.0.0.0",
+  "rf_rack_valid_keyspaces": true,
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,
   "enable_ipv6_dns_lookup": false,

--- a/unit_tests/test_data/test_scylla_yaml_builders/multi_network_interfaces/longevity-10gb-3h.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/multi_network_interfaces/longevity-10gb-3h.result.json
@@ -17,6 +17,7 @@
   "broadcast_rpc_address": "__NODE_PRIVATE_ADDRESS_2__",
   "experimental_features": [],
   "prometheus_address": "0.0.0.0",
+  "rf_rack_valid_keyspaces": true,
   "enable_ipv6_dns_lookup": false,
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,

--- a/unit_tests/test_data/test_scylla_yaml_builders/perf-regression.100threads.30M-keys.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/perf-regression.100threads.30M-keys.result.json
@@ -17,6 +17,7 @@
   ],
   "experimental_features": [],
   "prometheus_address": "0.0.0.0",
+  "rf_rack_valid_keyspaces": true,
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,
   "enable_ipv6_dns_lookup": false,

--- a/unit_tests/test_data/test_scylla_yaml_builders/rolling-upgrade.result.json
+++ b/unit_tests/test_data/test_scylla_yaml_builders/rolling-upgrade.result.json
@@ -25,6 +25,7 @@
   "experimental_features": [],
   "saslauthd_socket_path": "/run/saslauthd/mux",
   "prometheus_address": "0.0.0.0",
+  "rf_rack_valid_keyspaces": true,
   "alternator_enforce_authorization": false,
   "auto_bootstrap": true,
   "enable_ipv6_dns_lookup": false,

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -414,6 +414,7 @@ class ScyllaYamlTest(unittest.TestCase):
                 'reader_concurrency_semaphore_cpu_concurrency': None,
                 'vector_store_uri': None,
                 'object_storage_endpoints': None,
+                'rf_rack_valid_keyspaces': None,
             }
         )
 


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-cluster-tests/issues/12105
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x ] https://argus.scylladb.com/tests/scylla-cluster-tests/d1261c3a-ce39-4af8-b20a-6cf778cd44ca

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x ] I added the relevant `backport` labels
- [ x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
