### PR TITLE
fix(argus): send aborted jenkins status despite current one

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1877,14 +1877,15 @@ def finish_argus_test_run(jenkins_status):
             return
         test_config.set_test_id_only(params.get('test_id'))
         test_config.init_argus_client(params)
-        status = test_config.argus_client().get_status()
-        if status in [TestStatus.PASSED, TestStatus.FAILED, TestStatus.TEST_ERROR]:
-            LOGGER.info("Argus TestRun already finished with status %s", status.value)
-            return
-        new_status = TestStatus.FAILED
         if jenkins_status == "ABORTED":
             LOGGER.info("Jenkins build status is ABORTED, setting Argus TestRun status to ABORTED")
             new_status = TestStatus.ABORTED
+        else:
+            status = test_config.argus_client().get_status()
+            if status in [TestStatus.PASSED, TestStatus.FAILED, TestStatus.TEST_ERROR]:
+                LOGGER.info("Argus TestRun already finished with status %s", status.value)
+                return
+            new_status = TestStatus.FAILED
         test_config.argus_client().set_sct_run_status(new_status)
         test_config.argus_client().finalize_sct_run()
     except ArgusClientError:


### PR DESCRIPTION
In case jenkins gets aborted, sct executed on remote runner, ends test normally and updates argus state according to events.

I've tried to catch end signal in SCT and adjust 'get_test_status' logic but couldn't make it working.

I propose simple solution based on `jenkins-status` passed to `finish-argus-test-run` where 'ABORTED' status will override whatever was already set in Argus.

fixes: https://github.com/scylladb/argus/issues/725

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [timeouted longevity test](https://argus.scylladb.com/tests/scylla-cluster-tests/e1ce1f69-ef65-4201-a8ec-a7dbfedae0f8)


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
