### PR TITLE
fix(fibs_builders): update sct runners

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -356,6 +356,7 @@ class SctRunner(ABC):
                 instance_type=self.IMAGE_BUILDER_INSTANCE_TYPE,
                 base_image=self.BASE_IMAGE,
                 tags={
+                    "RunByUser": "qa",
                     "keep": "1",
                     "keep_action": "terminate",
                     "Version": self.VERSION,

--- a/sdcm/utils/aws_builder.py
+++ b/sdcm/utils/aws_builder.py
@@ -286,7 +286,7 @@ class AwsCiBuilder(AwsBuilder):
 class AwsFipsCiBuilder(AwsBuilder):
     NUM_CPUS = 2
     NUM_EXECUTORS = 1
-    VERSION = 'v3-fibs'
+    VERSION = 'v4-fibs'
 
     @cached_property
     def name(self):

--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -45,7 +45,7 @@ def call(String backend, String region=null, String datacenter=null, String loca
                           'gce': "${gcp_project}-builders-us-east1-template-v5",
                           'aws': 'aws-sct-builders-eu-west-1-v3-asg',
                           'azure-eastus': 'aws-sct-builders-us-east-1-v3-asg',
-                          'aws-fips': 'aws-sct-builders-us-east-1-v3-fibs-CI-FIPS',
+                          'aws-fips': 'aws-sct-builders-us-east-1-v4-fibs-CI-FIPS',
                           ]
 
     def cloud_provider = getCloudProviderFromBackend(backend)


### PR DESCRIPTION
seem like for quite some time we didn't rebuild those builders and the tests seems to get stuck on them.

rebuilding those to latest ubuntu fips image, to see how it's wokring

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟡 https://argus.scylladb.com/tests/scylla-cluster-tests/911a87f7-0874-4b5d-b069-7463d5c73991 (master image that is getting stuck)
- [x] 🟡  https://argus.scylladb.com/tests/scylla-cluster-tests/e4e4c85a-aaa2-4a87-9917-80508955d111 (known working image)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
