### PR TITLE
fix(scylla-bench): more specific regex for data validation errors

### DIFF
--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -274,7 +274,7 @@ class ScyllaBenchLogEvent(LogEvent, abstract=True):
 ScyllaBenchLogEvent.add_subevent_type("ConsistencyError", severity=Severity.ERROR, regex=r"received only")
 # Scylla-bench data validation was added by https://github.com/scylladb/scylla-bench/commit/3eb53d8ce11e5ad26062bcc662edb31dda521ccf
 ScyllaBenchLogEvent.add_subevent_type("DataValidationError", severity=Severity.CRITICAL,
-                                      regex=r"doesn't match |failed to validate data|failed to verify checksum|corrupt checksum or data|"
+                                      regex=r"doesn't match stored checksum|doesn't match ck stored in value|doesn't match pk stored in value|actual value doesn't match expected value|doesn't match size stored in value|failed to validate data|failed to verify checksum|corrupt checksum or data|"
                                             r"data corruption")
 ScyllaBenchLogEvent.add_subevent_type(
     "ParseDistributionError",


### PR DESCRIPTION
since now we have some warning coming out of scylla that has `doesn't match` with in them

so the regex need to be more specific to avoid false positives and breaking some of the tests

fix: #11939

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
