### PR TITLE
fix(kms): make KMS checks work correctly when relevant option is empty. part2

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -850,7 +850,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
             self.params['scylla_encryption_options'] = "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'KmsKeyProviderFactory', 'kms_host': 'auto'}"
             scylla_encryption_options = self.params.get('scylla_encryption_options')
 
-        if 'auto' not in (kms_host := yaml.safe_load(scylla_encryption_options or {}).get("kms_host") or ''):
+        if 'auto' not in (kms_host := (yaml.safe_load(scylla_encryption_options) or {}).get("kms_host") or ''):
             return
         # Create a KMS key alias in each of the regions used by the current test run
         aws_kms = AwsKms(region_names=self.params.region_names)
@@ -911,7 +911,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
             self.params['scylla_encryption_options'] = "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'AzureKeyProviderFactory', 'azure_host': 'scylla-azure-kms'}"
             scylla_encryption_options = self.params.get('scylla_encryption_options')
 
-        if not (azure_host := yaml.safe_load(scylla_encryption_options or {}).get("azure_host") or ''):
+        if not (azure_host := (yaml.safe_load(scylla_encryption_options) or {}).get("azure_host") or ''):
             return
 
         test_id = str(self.test_config.test_id())


### PR DESCRIPTION
Previous fix (https://github.com/scylladb/scylla-cluster-tests/pull/12186) had a typo. Fix it.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
