### PR TITLE
feature(pilelines): improve loading of extra_environment_variables

### DIFF
--- a/vars/loadEnvFromString.groovy
+++ b/vars/loadEnvFromString.groovy
@@ -1,11 +1,11 @@
 #!groovy
 
 def call(String parameter) {
-    if (parameter == null || parameter.isEmpty()) {
-        return
-    }
-    def props = readProperties text: parameter
-    props.each { key, value ->
-        env[key] = value
+    if (!parameter) return
+
+    readProperties(text: parameter).each { key, value ->
+        // Remove surrounding quotes from value if present
+        def cleanValue = (value instanceof String) ? value.replaceAll(/^(['"])(.*)\1$/, '$2') : value
+        env[key] = cleanValue
     }
 }


### PR DESCRIPTION
If the variable is of type `dict_or_str`, then it must be supplied in the following form: 
`SCT_APPEND_SCYLLA_YAML={"stream_io_throughput_mb_per_sec": 0}` 
This is unintuitive compared to how an env variable is defined in shell: 
`export SCT_APPEND_SCYLLA_YAML='{"stream_io_throughput_mb_per_sec": 0}'`
Note the extra quotes.


This change removes the extra quotes, which would otherwise cause the code that merges dicts to fail, since the value would be parsed as a str not a dict.

Example of failure: https://jenkins.scylladb.com/job/scylla-enterprise/job/perf-regression/job/scylla-enterprise-perf-manager-native-backup-nemesis/10/

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
