### PR TITLE
improvement(pipelines): fix sub_tests not being declared in the pipeline

### DIFF
--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -72,7 +72,7 @@ def call(Map pipelineParams) {
             string(defaultValue: "false",
                    description: 'Stop test if perf hardware test values exceed the set limits',
                    name: 'stop_on_hw_perf_failure')
-            string(defaultValue: "${groovy.json.JsonOutput.toJson(pipelineParams.get('sub_tests'))}",
+            string(defaultValue: "${groovy.json.JsonOutput.toJson(pipelineParams.get('sub_tests', ''))}",
                    description: 'subtests in format ["sub_test1", "sub_test2"] or empty',
                    name: 'sub_tests')
 

--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -50,7 +50,7 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('post_behavior_k8s_cluster', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_k8s_cluster')
-            string(defaultValue: "${groovy.json.JsonOutput.toJson(pipelineParams.get('sub_tests'))}",
+            string(defaultValue: "${groovy.json.JsonOutput.toJson(pipelineParams.get('sub_tests', ''))}",
                    description: 'subtests in format ["sub_test1", "sub_test2"] or empty',
                    name: 'sub_tests')
 


### PR DESCRIPTION
If when the pipeline is created, sub_tests is not given, then the default value will be `null`, which breaks this code
```python
if (params.sub_tests) {
    sub_tests = new JsonSlurper().parseText(params.sub_tests)
} else {
    sub_tests = [pipelineParams.test_name]
}
```
because it is actually first interpreted as a string, then parsed into the null value.
Then it never creates any tasks
```python
for (t in sub_tests) {
    ...
    tasks["sub_test=${sub_test}"] = {
        ...
    }
``` 

Example:
[This pipeline](https://jenkins.scylladb.com/job/scylla-enterprise/job/perf-regression/job/scylla-enterprise-perf-manager-native-backup-nemesis/)
Declared without `sub_tests`
```groovy
#!groovy

// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)


perfRegressionParallelPipeline(
    backend: "aws",
    test_name: "performance_regression_manager_backup_test.PerformanceRegressionManagerBackupTest.test_manager_backup",
    test_config: """["test-cases/performance/perf-regression-latency-backup-nemesis.yaml", "configurations/kms-ear.yaml", "configurations/performance/latency-decorator-error-thresholds-nemesis-ent-tablets.yaml", "configurations/manager/manager_native_backup_nemesis.yaml"]""",
)
```


<img width="1639" height="807" alt="image" src="https://github.com/user-attachments/assets/c209c3f0-3351-4ef4-8624-8cc89f70dda2" />

Ends without running any tests
<img width="698" height="133" alt="image" src="https://github.com/user-attachments/assets/8db3d458-03ac-4991-b1bc-033bf5fb7ad9" />

Normal looks like this:
<img width="1339" height="148" alt="image" src="https://github.com/user-attachments/assets/bdea3175-c49b-45e3-b8d7-b7d27676569c" />




### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
