### PR TITLE
fix(pipelines): fix backup performance pipelines

### DIFF
--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-manager-native-backup-nemesis.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-manager-native-backup-nemesis.jenkinsfile
@@ -6,6 +6,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
+    aws_region: "us-east-1",
     test_name: "performance_regression_manager_backup_test.PerformanceRegressionManagerBackupTest.test_manager_backup",
-    test_config: """["test-cases/performance/perf-regression-latency-backup-nemesis.yaml", "configurations/kms-ear.yaml", "configurations/performance/latency-decorator-error-thresholds-nemesis-ent-tablets.yaml", "configurations/manager/manager_native_backup_nemesis.yaml"]""",
+    test_config: """["test-cases/performance/perf-regression-latency-backup-nemesis.yaml", "configurations/kms-ear.yaml", "configurations/performance/latency-decorator-error-thresholds-nemesis-ent-tablets.yaml", "configurations/manager/manager_native_backup_nemesis.yaml", "configurations/manager/2TB_backup_dataset.yaml"]""",
+    sub_tests: [],
 )

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-manager-rclone-backup-nemesis.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-manager-rclone-backup-nemesis.jenkinsfile
@@ -6,6 +6,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
+    aws_region: "us-east-1",
     test_name: "performance_regression_manager_backup_test.PerformanceRegressionManagerBackupTest.test_manager_backup",
-    test_config: """["test-cases/performance/perf-regression-latency-backup-nemesis.yaml", "configurations/kms-ear.yaml", "configurations/performance/latency-decorator-error-thresholds-backup-nemesis-ent.yaml", "configurations/manager/manager_rclone_backup_nemesis.yaml"]""",
+    test_config: """["test-cases/performance/perf-regression-latency-backup-nemesis.yaml", "configurations/kms-ear.yaml", "configurations/performance/latency-decorator-error-thresholds-nemesis-ent-tablets.yaml", "configurations/manager/manager_rclone_backup_nemesis.yaml", "configurations/manager/2TB_backup_dataset.yaml"]""",
+    sub_tests: [],
 )


### PR DESCRIPTION
- the pipeline was missing a workload, added `configurations/manager/2TB_backup_dataset.yaml`
- one of the config files was wrong in the rclone pipeline, `configurations/performance/latency-decorator-error-thresholds-backup-nemesis-ent.yaml`, the correct name is `configurations/performance/latency-decorator-error-thresholds-nemesis-ent-tablets.yaml` as in the native pipeline
- set aws_region to us-east-1, because that's where the buckets are configured

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
