### PR TITLE
fix(docker-fips): correct procps package name for Ubuntu-based images

### DIFF
--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -231,6 +231,8 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):
     def do_default_installations(self):
         self.install_sudo()
         self.install_package("tar")
+        procps_package = "procps" if self.distro.is_debian_like else "procps-ng"
+        self.install_package(procps_package)
         super().do_default_installations()
 
     def install_sudo(self, user: str = 'scylla', verbose=False):
@@ -404,7 +406,6 @@ class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):
         if self.test_config.BACKTRACE_DECODING:
             node.install_scylla_debuginfo()
 
-        node.install_package("procps-ng")
         node.config_setup(append_scylla_args=self.get_scylla_args())
         node.restart_scylla(verify_up_before=True)
 


### PR DESCRIPTION
The scylla-nightly-pro FIPS image is Ubuntu-based. For docker backend clusters we are installing 'procps-ng' (RHEL package name), but on Debian/Ubuntu the package is called 'procps'.
This caused artifact-docker-fips test to fail trying to install the non-existent package.

This change fixes FIPS docker artifact test by using proper 'procps' package name, depending on the distro.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [artifacts-docker-fips](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-docker-test/25/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
