### PR TITLE
fix(fips_asg): install rng-tools

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -225,7 +225,7 @@ class SctRunner(ABC):
 
             apt-get -qq clean
             apt-get -qq update
-            apt-get -qq install --no-install-recommends python3-pip htop screen tree systemd-coredump
+            apt-get -qq install --no-install-recommends python3-pip htop screen tree systemd-coredump rng-tools
             pip3 install awscli
 
             # disable unattended-upgrades
@@ -1393,5 +1393,5 @@ def clean_sct_runners(test_status: str,
 
 
 class AwsFipsSctRunner(AwsSctRunner):
-    VERSION = f"{SctRunner.VERSION}-fips"
+    VERSION = f"{SctRunner.VERSION}-v1-fips"
     BASE_IMAGE = 'resolve:ssm:/aws/service/marketplace/prod-k6fgbnayirmrc/latest'


### PR DESCRIPTION
Since we moved to UBI9 we are having issues with using microdnf when the host is FIPS enabled

this change is preinstalling rng-tools that provides software-generated entropy, and prevents the `getrandom()` call from hanging.

Fixes: scylladb/scylladb#26575

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-docker-fips-test/27/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
