### PR TITLE
fix(hdr analyze): HDR histogram summary as interval

### DIFF
--- a/sdcm/utils/hdrhistogram.py
+++ b/sdcm/utils/hdrhistogram.py
@@ -188,7 +188,7 @@ class _HdrRangeHistogramBuilder:
                         f"Submitted future for tags {self.hdr_tags} and interval {interval_num} out of {len(start_intervals)}")
                     interval_num += 1
                 results = {}
-                for e, future in enumerate(futures):
+                for e, future in enumerate(concurrent.futures.as_completed(futures, timeout=120)):
                     res = future.result(timeout=FUTURE_RESULT_TIMEOUT)  # Will raise TimeoutError after 60 seconds
                     LOGGER.debug(
                         f"Got result for {e} future for tag {self.hdr_tags[e % len(self.hdr_tags)]} and interval {e // len(self.hdr_tags)}")


### PR DESCRIPTION
The HDR histogram summary with interval build is intermittently freezing, which occasionally leads to test timeouts.
This commit aims to address and fix the issue.

Issue: https://github.com/scylladb/scylla-cluster-tests/issues/10262

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
