### PR TITLE
fix(pipelines): replace aws_region with region

### DIFF
--- a/jenkins-pipelines/drivers/java-driver/perf-regression-predefined-throughput-steps-vnodes.jenkinsfile
+++ b/jenkins-pipelines/drivers/java-driver/perf-regression-predefined-throughput-steps-vnodes.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
     test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_reduced_steps_number.yaml", "configurations/disable_kms.yaml", "configurations/tablets_disabled.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-vnodes.yaml"]''',
     sub_tests: ["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_write_gradual_increase_load"],

--- a/jenkins-pipelines/drivers/rust/perf-regression-predefined-throughput-steps-vnodes.jenkinsfile
+++ b/jenkins-pipelines/drivers/rust/perf-regression-predefined-throughput-steps-vnodes.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
     test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml","configurations/performance/cql_stress_gradual_load_reduced_steps_number.yaml", "configurations/performance/rust-predefined-throughput-steps-cql-stress.yaml", "configurations/disable_kms.yaml", "configurations/tablets_disabled.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-vnodes.yaml"]''',
     sub_tests: ["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_write_gradual_increase_load"],

--- a/jenkins-pipelines/operator/scale/operator-scale-many-clients-4h.jenkinsfile
+++ b/jenkins-pipelines/operator/scale/operator-scale-many-clients-4h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-eks',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-many-clients-4h.yaml',
     availability_zone: 'a,b',

--- a/jenkins-pipelines/oss/features/FIPS/longevity-100gb-4h-fips.jenkinsfile
+++ b/jenkins-pipelines/oss/features/FIPS/longevity-100gb-4h-fips.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 // This scenario can only be triggered with a scylla repo, not an ami
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/longevity-fips-and-encryptions.yaml", "configurations/local-ear.yaml"]'''
 )

--- a/jenkins-pipelines/oss/scale/scale-many-clients-4h.jenkinsfile
+++ b/jenkins-pipelines/oss/scale/scale-many-clients-4h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scale/longevity-many-clients-4h.yaml'
 )

--- a/jenkins-pipelines/oss/vnodes/enterprise_features/longevity-100gb-4h-fips-vnodes.jenkinsfile
+++ b/jenkins-pipelines/oss/vnodes/enterprise_features/longevity-100gb-4h-fips-vnodes.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 // This scenario can only be triggered with a scylla repo, not an ami
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/longevity-fips-and-encryptions.yaml", "configurations/local-ear.yaml", "configurations/tablets_disabled.yaml"]'''
 )

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-manager-native-backup-nemesis.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-manager-native-backup-nemesis.jenkinsfile
@@ -6,8 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_manager_backup_test.PerformanceRegressionManagerBackupTest.test_manager_backup",
     test_config: """["test-cases/performance/perf-regression-latency-backup-nemesis.yaml", "configurations/kms-ear.yaml", "configurations/performance/latency-decorator-error-thresholds-nemesis-ent-tablets.yaml", "configurations/manager/manager_native_backup_nemesis.yaml", "configurations/manager/2TB_backup_dataset.yaml"]""",
-    sub_tests: [],
 )

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-manager-rclone-backup-nemesis.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-manager-rclone-backup-nemesis.jenkinsfile
@@ -6,8 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_manager_backup_test.PerformanceRegressionManagerBackupTest.test_manager_backup",
     test_config: """["test-cases/performance/perf-regression-latency-backup-nemesis.yaml", "configurations/kms-ear.yaml", "configurations/performance/latency-decorator-error-thresholds-nemesis-ent-tablets.yaml", "configurations/manager/manager_rclone_backup_nemesis.yaml", "configurations/manager/2TB_backup_dataset.yaml"]""",
-    sub_tests: [],
 )

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-tablets.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-tablets.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
     test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml"]''',
     sub_tests: ["test_read_gradual_increase_load", "test_mixed_gradual_increase_load"],

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-vnodes.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-vnodes.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
     test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml", "configurations/disable_kms.yaml", "configurations/tablets_disabled.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-vnodes.yaml"]''',
     sub_tests: ["test_read_gradual_increase_load", "test_mixed_gradual_increase_load"],

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-tablets.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-tablets.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
     test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml"]''',
     sub_tests: ["test_write_gradual_increase_load"],

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-vnodes.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-vnodes.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
     test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml", "configurations/disable_kms.yaml", "configurations/tablets_disabled.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-vnodes.yaml"]''',
     sub_tests: ["test_write_gradual_increase_load"],

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-master/perf-features/compression/features-lz4-dict-compression.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-master/perf-features/compression/features-lz4-dict-compression.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
     test_config: '''[
     "test-cases/performance/perf-regression-predefined-throughput-steps.yaml",

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-master/perf-features/compression/features-zstd-dict-compression.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-master/perf-features/compression/features-zstd-dict-compression.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
     test_config: '''[
     "test-cases/performance/perf-regression-predefined-throughput-steps.yaml",

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-master/perf-regression/perf-regression-predefined-throughput-steps-sanity-vnodes.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-master/perf-regression/perf-regression-predefined-throughput-steps-sanity-vnodes.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
     test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_reduced_steps_number.yaml", "configurations/disable_kms.yaml", "configurations/tablets_disabled.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-vnodes.yaml"]''',
     sub_tests: ["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_write_gradual_increase_load"],

--- a/jenkins-pipelines/performance_staging/perf-regression-scylla-gradual-throughput-grow-gauss-lcs.jenkinsfile
+++ b/jenkins-pipelines/performance_staging/perf-regression-scylla-gradual-throughput-grow-gauss-lcs.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionGradualGrowThroughutTest",
     test_config: '''["test-cases/performance/perf-regression-gradual-throughput-grow.yaml", "configurations/cs-gauss-distribution.yaml", "test-cases/performance/cs-compaction-strategy-lcs.yaml"]''',
     sub_tests: ["test_write_gradual_increase_load","test_read_gradual_increase_load", "test_mixed_gradual_increase_load"],

--- a/jenkins-pipelines/performance_staging/perf-regression-scylla-gradual-throughput-grow-uniform.jenkinsfile
+++ b/jenkins-pipelines/performance_staging/perf-regression-scylla-gradual-throughput-grow-uniform.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionGradualGrowThroughutTest",
     test_config: '''["test-cases/performance/perf-regression-gradual-throughput-grow.yaml", "configurations/cs-uniform-distribution.yaml"]''',
     sub_tests: ["test_write_gradual_increase_load","test_read_gradual_increase_load", "test_mixed_gradual_increase_load"],

--- a/jenkins-pipelines/performance_staging/scylla-staging-perf-regression-predefined-throughput-steps-vnodes.jenkinsfile
+++ b/jenkins-pipelines/performance_staging/scylla-staging-perf-regression-predefined-throughput-steps-vnodes.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
     test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps.yaml", "configurations/disable_kms.yaml", "configurations/tablets_disabled.yaml", "configurations/disable_speculative_retry.yaml"]''',
     sub_tests: ["test_write_gradual_increase_load", "test_read_gradual_increase_load", "test_mixed_gradual_increase_load"],


### PR DESCRIPTION
`region` is the correct name for that parameter, not `aws_region`.
No errors happen currently because all params go into a map, and `aws_region` is just never used.

It has no real consequences, most tests are triggered and given a region.
But in some cases, i.e. native backup, the region must match the bucket defined in the config.


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
