### PR TITLE
fix(pipelines): get values from the run instead of the pipeline

### DIFF
--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -262,7 +262,7 @@ def call(Map pipelineParams) {
                         if (params.sub_tests) {
                             sub_tests = new JsonSlurper().parseText(params.sub_tests)
                         } else {
-                            sub_tests = [pipelineParams.test_name]
+                            sub_tests = [params.test_name]
                         }
                         // select the step function to use for throttling, if not throttling, it's a no-op
                         def throttle_closure = params.use_job_throttling ? this.&throttle : { labels, closure -> closure() }
@@ -270,10 +270,10 @@ def call(Map pipelineParams) {
                         for (t in sub_tests) {
                             def perf_test
                             def sub_test = t
-                            if (sub_test == pipelineParams.test_name) {
+                            if (sub_test == params.test_name) {
                                 perf_test = sub_test
                             } else {
-                                perf_test = "${pipelineParams.test_name}.${sub_test}"
+                                perf_test = "${params.test_name}.${sub_test}"
                             }
 
                             tasks["sub_test=${sub_test}"] = {

--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -171,15 +171,15 @@ def call(Map pipelineParams) {
                         if (params.sub_tests) {
                             sub_tests = new JsonSlurper().parseText(params.sub_tests)
                         } else {
-                            sub_tests = [pipelineParams.test_name]
+                            sub_tests = [params.test_name]
                         }
                         for (t in sub_tests) {
                             def perf_test
                             def sub_test = t
-                            if (sub_test == pipelineParams.test_name) {
+                            if (sub_test == params.test_name) {
                                 perf_test = sub_test
                             } else {
-                                perf_test = "${pipelineParams.test_name}.${sub_test}"
+                                perf_test = "${params.test_name}.${sub_test}"
                             }
 
                             tasks["sub_test=${sub_test}"] = {


### PR DESCRIPTION
If the values are gotten from `pipelineParams`, then it will ignore any custom values set in Jenkins.

If someone wanted to quickly run a performance test in their staging folder, and re-used an existing pipeline, changing the test name parameter would have no effect.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
