### PR TITLE
improvement(latte): do not run redundant `latte schema` commands

### DIFF
--- a/sdcm/stress/latte_thread.py
+++ b/sdcm/stress/latte_thread.py
@@ -94,6 +94,7 @@ def get_latte_operation_type(stress_cmd):
 class LatteStressThread(DockerBasedStressThread):
 
     DOCKER_IMAGE_PARAM_NAME = "stress_image.latte"
+    SCHEMA_CMD_CALL_COUNTER = {}
 
     def set_stress_operation(self, stress_cmd):
         return get_latte_operation_type(self.stress_cmd)
@@ -102,6 +103,8 @@ class LatteStressThread(DockerBasedStressThread):
         # extract the script so we know which files to mount into the docker image
         script_name_regx = re.compile(r'([/\w-]*\.rn)')
         script_name = script_name_regx.search(self.stress_cmd).group(0)
+        if script_name not in self.SCHEMA_CMD_CALL_COUNTER:
+            self.SCHEMA_CMD_CALL_COUNTER[script_name] = 0
 
         for src_file in (Path(get_sct_root_path()) / script_name).parent.iterdir():
             cmd_runner.send_files(str(src_file), str(Path(script_name).parent / src_file.name))
@@ -156,9 +159,24 @@ class LatteStressThread(DockerBasedStressThread):
                     if v not in ('true', 'false'):
                         processed_v = r"\"%s\"" % v
                 custom_schema_params += " -P {k}={v}".format(k=k, v=processed_v)
+        first_tag_or_op = (find_latte_tags(self.stress_cmd) or [self.stress_operation])[0]
         # NOTE: use superuser creds for the 'latte schema' cmd because test users will only be created with it.
         schema_cmd = f'latte schema {script_name} {ssl_config}{auth_config}{custom_schema_params} -- {hosts}'
-        cmd_runner.run(cmd=schema_cmd, timeout=self.timeout, retry=0)
+        # NOTE: allow schema creation repetition for non-argus usages (unit and integration tests)
+        if LatteStressThread.SCHEMA_CMD_CALL_COUNTER[script_name] < 1 or not self.params.get("enable_argus"):
+            LOGGER.debug("Calling following 'latte schema' (tag: %s) cmd: %s", first_tag_or_op, schema_cmd)
+            result = cmd_runner.run(cmd=schema_cmd, timeout=self.timeout, retry=0)
+            try:
+                LOGGER.debug(
+                    "Output for 'latte schema' (tag: %s) cmd\nstdout: %s\nstderr: %s",
+                    first_tag_or_op, result.stdout, result.stderr)
+            except Exception as e:  # noqa: BLE001
+                LOGGER.error("Failed to print out the results of the `latte schema` command. e: %s", e)
+            # NOTE: it should not require any locking because practically we have multiple seconds
+            #       diff reaching this code out by different stress threads.
+            LatteStressThread.SCHEMA_CMD_CALL_COUNTER[script_name] += 1
+        else:
+            LOGGER.debug("Skip calling following 'latte schema' (tag: %s) cmd: %s", first_tag_or_op, schema_cmd)
 
         # NOTE: set '--user' and '--password' params only if not defined explicitly
         if " --user" in self.stress_cmd and " --password" in self.stress_cmd:


### PR DESCRIPTION
As of now, we run a `latte schema` command for each `latte run` command.
We have scenarios where we run dozens of `latte run` commands.
It is huge redundancy.

So, stop making redundant cmd calls.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-provision-test#37](https://argus.scylladb.com/tests/scylla-cluster-tests/7620b674-d8f3-4789-b7cd-978de27cc885)
- [scylla-staging/valerii/vp-provision-test#38](https://argus.scylladb.com/tests/scylla-cluster-tests/eb84cec4-b031-4c6c-8816-3ccfce5cac05)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
