### PR TITLE
feature(sct-agent): sct-agent MVP integration

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -336,3 +336,11 @@ download_from_s3: []
 # The object-storage method options in Scylla-Manager are: native/rclone/auto.
 # An empty value here, means Scylla-Manager will use its default value.
 manager_backup_restore_method: ''
+
+# SCT agent defaults
+agent:
+  enabled: false
+  port: 16000
+  binary_url: ""
+  max_concurrent_jobs: 10
+  log_level: "info"

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -546,6 +546,15 @@ When define true, will install scylla management
 **type:** boolean
 
 
+## **agent** / SCT_AGENT
+
+Configuration for SCT agent - a lightweight service for remote command execution.                 When enabled, replaces SSH-based command execution with RESTful API calls for DB nodes.<br>Configuration options:<br>- enabled: bool - enable agent (required)<br>- port: int - agent HTTP API port (default: 16000)<br>- binary_url: str - URL to download agent binary<br>- max_concurrent_jobs: int - max concurrent jobs per agent (default: 10)<br>- log_level: str - logging level (default: info)
+
+**default:** {'enabled': False, 'port': 16000, 'binary_url': '', 'max_concurrent_jobs': 10, 'log_level': 'info'}
+
+**type:** dict_or_str
+
+
 ## **parallel_node_operations** / SCT_PARALLEL_NODE_OPERATIONS
 
 When defined true, will run node operations in parallel. Supported operations: startup

--- a/sct.py
+++ b/sct.py
@@ -290,6 +290,11 @@ def provision_resources(backend, test_name: str, config: str):
     else:
         click.echo("No need provision logging service")
 
+    agent_config = params.get("agent")
+    if agent_config.get("enabled") and agent_config.get("binary_url"):
+        click.echo("Generate SCT agent API key")
+        test_config.generate_and_save_agent_api_key()
+
     click.echo(f"Provision {backend} cloud resources")
     try:
         if backend == "aws":

--- a/sdcm/provision/common/configuration_script.py
+++ b/sdcm/provision/common/configuration_script.py
@@ -33,6 +33,7 @@ from sdcm.provision.common.utils import (
     install_docker_service,
 )
 from sdcm.provision.user_data import CLOUD_INIT_SCRIPTS_PATH
+from sdcm.utils.sct_agent_installer import install_agent_script
 
 SYSLOGNG_SSH_TUNNEL_LOCAL_PORT = 5000
 SYSLOGNG_LOG_THROTTLE_PER_SECOND = 10000
@@ -45,7 +46,9 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
     hostname: str = ""
     log_file: str = ""
     test_config: Any | None = None
+    params: Any | None = None
     install_docker: bool = False
+    install_agent: bool = False
 
     def to_string(self) -> str:
         script = self._start_script()
@@ -142,5 +145,21 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
 
         if self.install_docker:
             script += install_docker_service()
+
+        if self.install_agent and self.test_config:
+            params = self.params if self.params else self.test_config.tester_obj().params
+            agent_config = params.get("agent")
+            if agent_config.get("enabled"):
+                api_key = self.test_config.agent_api_key()
+                if not api_key:
+                    raise ValueError("Agent API key not available. Ensure it is generated before provisioning.")
+
+                script += install_agent_script(
+                    agent_binary_url=agent_config["binary_url"],
+                    api_keys=[api_key],
+                    port=agent_config["port"],
+                    max_concurrent_jobs=agent_config["max_concurrent_jobs"],
+                    log_level=agent_config.get("log_level"),
+                )
 
         return script

--- a/sdcm/provision/security.py
+++ b/sdcm/provision/security.py
@@ -34,3 +34,4 @@ class ScyllaOpenPorts(Enum):
     MANAGER_AGENT_PROMETHEUS = 5090  # Scylla Manager Agent Prometheus API
     MANAGER_DEBUG = 5112  # Scylla Manager pprof Debug
     VECTOR = 15000  # Vector log transport
+    SCT_AGENT = 16000  # SCT agent HTTP API

--- a/sdcm/remote/agent_cmd_runner.py
+++ b/sdcm/remote/agent_cmd_runner.py
@@ -1,0 +1,397 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+import base64
+import io
+import logging
+import os
+import tarfile
+import threading
+import time
+from typing import Optional, List, Dict
+from invoke.runners import Result
+from invoke.watchers import StreamWatcher
+
+from sdcm.remote.base import CommandRunner, RetryableNetworkException, RetryMixin
+from sdcm.utils.agent_client import (
+    AgentClient,
+    AgentClientError,
+    AgentConnectionError,
+    AgentTimeoutError,
+    AgentAPIError,
+)
+from sdcm.utils.decorators import retrying
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AgentCmdRunner(CommandRunner, RetryMixin):
+    """
+    Command runner that executes commands via SCT agent REST API.
+
+    Example of usage:
+        runner = AgentCmdRunner(hostname="192.168.1.10", api_key="secret", port=16000)
+        result = runner.run("echo hello")
+        print(result.stdout)  # "hello\\n"
+    """
+
+    exception_retryable = (AgentConnectionError, AgentTimeoutError)
+    default_run_retry = 3
+
+    def __init__(
+        self, hostname: str, api_key: str, port: int = 16000, user: str = "root", password: Optional[str] = None
+    ):
+        """
+        Initialize agent command runner.
+
+        :param hostname: remote host name or IP address
+        :param api_key: API key for agent authentication
+        :param port: agent HTTP API port
+        :param user: not used for agent (added for interface compatibility)
+        :param password: not used for agent (added for interface compatibility)
+        """
+        super().__init__(hostname=hostname, user=user, password=password)
+        self.port = port
+        self.api_key = api_key
+        self._agent_client = None
+        self._streaming_jobs: Dict[str, Dict] = {}
+        self._streaming_lock = threading.Lock()
+
+    def _create_connection(self) -> AgentClient:
+        return AgentClient(self.hostname, self.api_key, self.port, 30)
+
+    @property
+    def agent_client(self) -> AgentClient:
+        if not self._agent_client:
+            self._agent_client = self._create_connection()
+        return self._agent_client
+
+    def is_up(self, timeout: Optional[float] = None) -> bool:
+        try:
+            return self.agent_client.is_healthy()
+        except (AgentClientError, AgentConnectionError, AgentTimeoutError) as exc:
+            self.log.debug("Agent health check failed: %s", exc)
+            return False
+
+    def _run_on_retryable_exception(self, exc: Exception, new_session: bool, suppress_errors: bool = False) -> bool:
+        if not suppress_errors:
+            self.log.error(exc, exc_info=exc)
+        if isinstance(exc, self.exception_retryable):
+            raise RetryableNetworkException(str(exc), original=exc)
+        return True
+
+    def _handle_streaming_job(
+        self, job, cmd: str, watcher_list: List[StreamWatcher], verbose: bool, ignore_status: bool, start_time: float
+    ) -> Result:
+        """Handle a streaming command that runs indefinitely until cancelled"""
+        with self._streaming_lock:
+            self._streaming_jobs[job.job_id] = {"cmd": cmd, "job": job}
+
+        if verbose:
+            self.log.debug("Streaming job %s started for command: %s", job.job_id, cmd)
+
+        poll_interval = 2.0
+        last_stdout_len = last_stderr_len = 0
+        current_job = job
+
+        try:
+            while True:
+                time.sleep(poll_interval)
+
+                try:
+                    current_job = self.agent_client.get_job(job.job_id)
+                except AgentAPIError as exc:
+                    if exc.status_code == 404:
+                        self.log.debug("Streaming job %s no longer exists (cancelled)", job.job_id)
+                        break
+                    raise
+
+                for stream_name, last_len in [("stdout", last_stdout_len), ("stderr", last_stderr_len)]:
+                    stream_data = getattr(current_job, stream_name, "")
+                    if stream_data and len(stream_data) > last_len:
+                        new_data = stream_data[last_len:]
+                        if watcher_list:
+                            for watcher in watcher_list:
+                                if hasattr(watcher, "submit_line"):
+                                    for line in new_data.splitlines(True):
+                                        watcher.submit_line(line)
+                        if stream_name == "stdout":
+                            last_stdout_len = len(stream_data)
+                        else:
+                            last_stderr_len = len(stream_data)
+
+                if current_job.status in ("completed", "failed", "cancelled"):
+                    if verbose:
+                        self.log.debug("Streaming job %s finished with status: %s", job.job_id, current_job.status)
+                    break
+
+        except AgentClientError as exc:
+            self.log.warning("Streaming job %s encountered error: %s", job.job_id, exc)
+        finally:
+            with self._streaming_lock:
+                self._streaming_jobs.pop(job.job_id, None)
+
+        result = Result(
+            stdout=current_job.stdout or "",
+            stderr=current_job.stderr or "",
+            exited=current_job.exit_code if current_job.exit_code is not None else 0,
+            command=cmd,
+        )
+        result.duration = time.perf_counter() - start_time
+        result.exit_status = result.exited
+
+        return result
+
+    def cancel_streaming_command(self, cmd_pattern: str) -> bool:
+        """Cancel streaming command (like 'journalctl -f' that run indefinitely) matching the given pattern"""
+        cancelled_any = False
+        with self._streaming_lock:
+            jobs_to_cancel = [job_id for job_id, info in self._streaming_jobs.items() if cmd_pattern in info["cmd"]]
+
+        for job_id in jobs_to_cancel:
+            try:
+                self.agent_client.cancel_job(job_id)
+                cancelled_any = True
+                self.log.debug("Cancelled streaming job %s matching pattern '%s'", job_id, cmd_pattern)
+            except AgentAPIError as exc:
+                if exc.status_code == 404:
+                    self.log.debug("Streaming job %s already finished", job_id)
+                else:
+                    self.log.warning("Failed to cancel streaming job %s: %s", job_id, exc)
+
+        return cancelled_any
+
+    def run(
+        self,
+        cmd: str,
+        timeout: Optional[float] = None,
+        ignore_status: bool = False,
+        verbose: bool = True,
+        new_session: bool = False,
+        log_file: Optional[str] = None,
+        retry: int = 1,
+        watchers: Optional[List[StreamWatcher]] = None,
+        change_context: bool = False,
+        timestamp_logs: bool = False,
+    ) -> Result:
+        """
+        Execute command on remote agent.
+
+        :param cmd: command to execute
+        :param timeout: command timeout in seconds
+        :param ignore_status: if True, don't raise exception on non-zero exit
+        :param verbose: if True, log command output
+        :param new_session: not used for agent (added for interface compatibility)
+        :param log_file: file to write output to (optional)
+        :param retry: number of retries on failure
+        :param watchers: stream watchers
+        :param change_context: not used for agent (added for interface compatibility)
+        :param timestamp_logs: not used for agent (added for interface compatibility)
+
+        :return: result object with stdout, stderr, exit code
+        """
+        watcher_list = self._setup_watchers(verbose, log_file, watchers or [], timestamp_logs)
+
+        @retrying(**self._get_retry_params(retry))
+        def _run():
+            start_time = time.perf_counter()
+            try:
+                if verbose:
+                    self.log.debug("Executing command on %s: %s", self.hostname, cmd)
+
+                job = self.agent_client.execute_command(
+                    command="/bin/bash", args=["-c", cmd], timeout=int(timeout) if timeout else None
+                )
+
+                # detect streaming commands
+                is_streaming = log_file is not None
+                if is_streaming:
+                    return self._handle_streaming_job(job, cmd, watcher_list, verbose, ignore_status, start_time)
+
+                completed_job = self.agent_client.wait_for_job(
+                    job.job_id, timeout=int(timeout or 600), poll_interval=0.5
+                )
+
+                result = Result(
+                    stdout=completed_job.stdout,
+                    stderr=completed_job.stderr,
+                    exited=completed_job.exit_code if completed_job.exit_code is not None else 1,
+                    command=cmd,
+                )
+                result.duration = time.perf_counter() - start_time
+                result.exit_status = result.exited
+
+                if watcher_list:
+                    for watcher in watcher_list:
+                        if hasattr(watcher, "submit_line"):
+                            for line in (completed_job.stdout or "").splitlines(True):
+                                watcher.submit_line(line)
+                            for line in (completed_job.stderr or "").splitlines(True):
+                                watcher.submit_line(line)
+
+                return result
+
+            except self.exception_retryable as exc:
+                if self._run_on_retryable_exception(exc, new_session):
+                    raise
+            except AgentClientError as exc:
+                self.log.error("Agent API error: %s", exc)
+                if not ignore_status:
+                    raise
+                result = Result(
+                    stdout="",
+                    stderr=str(exc),
+                    exited=1,
+                    command=cmd,
+                )
+                result.duration = time.perf_counter() - start_time
+                result.exit_status = result.exited
+                return result
+            return None
+
+        result = _run()
+        self._print_command_results(result, verbose, ignore_status)
+        if result.exited != 0 and not ignore_status:
+            raise Exception(f"Command '{cmd}' failed with exit code {result.exited}")
+        return result
+
+    def receive_exit_status(self):
+        pass
+
+    def _write_large_content(self, content: str, remote_path: str, sudo_prefix: str, verbose: bool) -> None:
+        """Write large content to remote file in chunks to avoid command length limitations"""
+        chunk_size = 65536
+        chunks = [content[i : i + chunk_size] for i in range(0, len(content), chunk_size)]
+
+        if chunks:
+            self.run(
+                f"{sudo_prefix}cat > {remote_path} <<'EOF'\n{chunks[0]}\nEOF",
+                verbose=verbose,
+                ignore_status=False,
+                timeout=300,
+            )
+
+        for chunk in chunks[1:]:
+            self.run(
+                f"{sudo_prefix}cat >> {remote_path} <<'EOF'\n{chunk}\nEOF",
+                verbose=verbose,
+                ignore_status=False,
+                timeout=300,
+            )
+
+    def send_files(
+        self,
+        src: str,
+        dst: str,
+        delete_dst: bool = False,
+        preserve_symlinks: bool = False,
+        verbose: bool = False,
+        sudo: bool = False,
+    ) -> bool:
+        """
+        Upload file or directory from local path to remote host using command execution.
+
+        This is a temp implementation until proper file transfer API is implemented in post MVP stages.
+
+        :param src: local file or directory path
+        :param dst: remote destination path
+        :param delete_dst: not used for agent yet (added for interface compatibility)
+        :param preserve_symlinks: not used for agent yet (added for interface compatibility)
+        :param verbose: enable verbose output
+        :param sudo: use sudo to write the file
+
+        :return: indication if operation was successful
+        """
+        src = os.path.expanduser(src)
+        sudo_prefix = "sudo " if sudo else ""
+        if os.path.isdir(src):
+            with tarfile.open(fileobj=(tar_buffer := io.BytesIO()), mode="w:gz") as tar:
+                tar.add(src, arcname=os.path.basename(src))
+            encoded = base64.b64encode(tar_buffer.getvalue()).decode("ascii")
+
+            self.run(f"{sudo_prefix}mkdir -p {dst}", verbose=verbose, ignore_status=False)
+            tmp_file = f"/tmp/sct_agent_transfer_{os.getpid()}"
+            self._write_large_content(encoded, tmp_file, sudo_prefix, verbose)
+            self.run(
+                f"cd {dst} && {sudo_prefix}base64 -d < {tmp_file} | {sudo_prefix}tar xzf - && {sudo_prefix}rm -f {tmp_file}",
+                verbose=verbose,
+                ignore_status=False,
+                timeout=600,
+            )
+        else:
+            with open(src, "rb") as f:
+                encoded = base64.b64encode(f.read()).decode("ascii")
+
+            is_dir = self.run(f"test -d {dst}", verbose=verbose, ignore_status=True)
+            dst_path = os.path.join(dst, os.path.basename(src)) if is_dir.exited == 0 else dst
+
+            self.run(f"{sudo_prefix}mkdir -p $(dirname {dst_path})", verbose=verbose, ignore_status=False)
+            tmp_file = f"/tmp/sct_agent_transfer_{os.getpid()}"
+            self._write_large_content(encoded, tmp_file, sudo_prefix, verbose)
+            self.run(
+                f"{sudo_prefix}base64 -d < {tmp_file} > {dst_path} && {sudo_prefix}rm -f {tmp_file}",
+                verbose=verbose,
+                ignore_status=False,
+                timeout=600,
+            )
+
+        return True
+
+    def receive_files(
+        self,
+        src: str,
+        dst: str,
+        delete_dst: bool = False,
+        preserve_perm: bool = True,
+        preserve_symlinks: bool = False,
+        timeout: float = 300,
+        sudo: bool = False,
+    ) -> bool:
+        """
+        Download file from remote host to local path using command execution.
+
+        This is a temp implementation until proper file transfer API is implemented in post MVP stages.
+
+        :param src: remote file path
+        :param dst: local destination path
+        :param delete_dst: not used for agent yet (added for interface compatibility)
+        :param preserve_perm: not used for agent yet (added for interface compatibility)
+        :param preserve_symlinks: not used for agent yet (added for interface compatibility)
+        :param timeout: command timeout
+        :param sudo: Use sudo to read the file
+
+        :return: indication if operation was successful
+        """
+        sudo_prefix = "sudo " if sudo else ""
+        result = self.run(f"{sudo_prefix}cat {src}", timeout=timeout, ignore_status=False, verbose=False)
+
+        if os.path.isdir(dst):
+            dst = os.path.join(dst, os.path.basename(src))
+
+        os.makedirs(os.path.dirname(dst) or ".", exist_ok=True)
+        with open(dst, "w") as f:
+            f.write(result.stdout)
+
+        return True
+
+    def ssh_debug_cmd(self) -> str:
+        """Return debug command for interface compatibiliy (for agent, show API endpoint)"""
+        return f"curl -H 'Authorization: Bearer {self.api_key}' http://{self.hostname}:{self.port}/health"
+
+    def stop(self):
+        """Close agent client connection"""
+        self._agent_client = None
+
+    def __repr__(self) -> str:
+        return f"AgentCmdRunner(hostname={self.hostname}, port={self.port})"

--- a/sdcm/remote/base.py
+++ b/sdcm/remote/base.py
@@ -48,6 +48,27 @@ class RetryableNetworkException(Exception):
         super().__init__(*args)
 
 
+class RetryMixin:
+    """Mixin class that provides retry logic for command runners"""
+
+    exception_retryable = (RetryableNetworkException,)
+    default_run_retry = 3
+
+    def _get_retry_params(self, retry: int = 1) -> dict:
+        if retry == 0:
+            # won't retry on any case
+            allowed_exceptions = tuple()
+            retry = 1
+        elif retry == 1:
+            # only retry 3 times on network exception
+            allowed_exceptions = (RetryableNetworkException,)
+            retry = self.default_run_retry
+        else:
+            # retry times that user wants on any exception
+            allowed_exceptions = (Exception,)
+        return {"n": retry, "sleep_time": 5, "allowed_exceptions": allowed_exceptions}
+
+
 class CommandRunner(metaclass=ABCMeta):
     _connection = None
 

--- a/sdcm/remote/remote_base.py
+++ b/sdcm/remote/remote_base.py
@@ -27,11 +27,11 @@ from invoke.runners import Result
 
 from sdcm.utils.decorators import retrying
 
-from .base import RetryableNetworkException, CommandRunner
+from .base import RetryableNetworkException, CommandRunner, RetryMixin
 from .local_cmd_runner import LocalCmdRunner
 
 
-class RemoteCmdRunnerBase(CommandRunner):
+class RemoteCmdRunnerBase(CommandRunner, RetryMixin):
     port: int = 22
     connect_timeout: int = 60
     key_file: Optional[str] = None
@@ -693,20 +693,6 @@ class RemoteCmdRunnerBase(CommandRunner):
         if hasattr(exc, "result"):
             self._print_command_results(exc.result, verbose, ignore_status)
         return True
-
-    def _get_retry_params(self, retry: int = 1) -> dict:
-        if retry == 0:
-            # Won't retry on any case
-            allowed_exceptions = tuple()
-            retry = 1
-        elif retry == 1:
-            # Only retry 3 times on network exception
-            allowed_exceptions = (RetryableNetworkException,)
-            retry = self.default_run_retry
-        else:
-            # Retry times that user wants on any exception
-            allowed_exceptions = (Exception,)
-        return {"n": retry, "sleep_time": 5, "allowed_exceptions": allowed_exceptions}
 
     def run(
         self,

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -644,6 +644,18 @@ class SCTConfiguration(dict):
             name="use_mgmt", env="SCT_USE_MGMT", type=boolean, help="When define true, will install scylla management"
         ),
         dict(
+            name="agent",
+            env="SCT_AGENT",
+            type=dict_or_str,
+            help="""Configuration for SCT agent - a lightweight service for remote command execution.                 When enabled, replaces SSH-based command execution with RESTful API calls for DB nodes.
+                 Configuration options:
+                 - enabled: bool - enable agent (required)
+                 - port: int - agent HTTP API port (default: 16000)
+                 - binary_url: str - URL to download agent binary
+                 - max_concurrent_jobs: int - max concurrent jobs per agent (default: 10)
+                 - log_level: str - logging level (default: info)""",
+        ),
+        dict(
             name="parallel_node_operations",
             env="SCT_PARALLEL_NODE_OPERATIONS",
             type=boolean,

--- a/sdcm/sct_provision/aws/cluster.py
+++ b/sdcm/sct_provision/aws/cluster.py
@@ -257,12 +257,14 @@ class DBCluster(ClusterBase):
 
     @property
     def _user_data(self) -> str:
+        agent_config = self.params.get("agent")
         return ScyllaUserDataBuilder(
             params=self.params,
             cluster_name=self.cluster_name,
             user_data_format_version=self.params.get("user_data_format_version"),
             syslog_host_port=self._test_config.get_logging_service_host_port(),
             test_config=self._test_config,
+            install_agent=bool(agent_config.get("enabled") and agent_config.get("binary_url")),
         ).to_string()
 
     def _zero_token_instance_parameters(self, region_id: int, availability_zone: int = 0) -> AWSInstanceParams:
@@ -393,12 +395,14 @@ class LoaderCluster(ClusterBase):
 
     @property
     def _user_data(self) -> str:
+        agent_config = self.params.get("agent")
         return AWSInstanceUserDataBuilder(
             params=self.params,
             syslog_host_port=self._test_config.get_logging_service_host_port(),
             aws_additional_interface=network_interfaces_count(self.params) > 1,
             test_config=self._test_config,
             install_docker=True,
+            install_agent=bool(agent_config.get("enabled") and agent_config.get("binary_url")),
         ).to_string()
 
 
@@ -414,10 +418,12 @@ class MonitoringCluster(ClusterBase):
 
     @property
     def _user_data(self) -> str:
+        agent_config = self.params.get("agent")
         return AWSInstanceUserDataBuilder(
             params=self.params,
             syslog_host_port=self._test_config.get_logging_service_host_port(),
             test_config=self._test_config,
+            install_agent=bool(agent_config.get("enabled") and agent_config.get("binary_url")),
         ).to_string()
 
 

--- a/sdcm/sct_provision/aws/user_data.py
+++ b/sdcm/sct_provision/aws/user_data.py
@@ -30,6 +30,7 @@ class ScyllaUserDataBuilder(ScyllaUserDataBuilderBase):
     syslog_host_port: tuple[str, int] | None = Field(default=None, exclude=True)
     test_config: Any = Field(exclude=True)
     install_docker: bool = Field(default=False, exclude=True)
+    install_agent: bool = Field(default=False, exclude=True)
 
     @computed_field
     @property
@@ -73,7 +74,9 @@ class ScyllaUserDataBuilder(ScyllaUserDataBuilderBase):
             syslog_host_port=self.syslog_host_port,
             logs_transport=self.params.get("logs_transport"),
             test_config=self.test_config,
+            params=self.params,
             install_docker=self.install_docker,
+            install_agent=self.install_agent,
         ).to_string()
         LOGGER.debug("post_boot_script: %s", post_boot_script)
         return base64.b64encode(post_boot_script.encode("utf-8")).decode("ascii")
@@ -133,6 +136,7 @@ class AWSInstanceUserDataBuilder(UserDataBuilderBase):
     test_config: Any = Field(exclude=True)
     aws_additional_interface: bool = False
     install_docker: bool = False
+    install_agent: bool = False
 
     def to_string(self) -> str:
         post_boot_script = AWSConfigurationScriptBuilder(
@@ -142,6 +146,8 @@ class AWSInstanceUserDataBuilder(UserDataBuilderBase):
             logs_transport=self.params.get("logs_transport"),
             syslog_host_port=self.syslog_host_port,
             test_config=self.test_config,
+            params=self.params,
             install_docker=self.install_docker,
+            install_agent=self.install_agent,
         ).to_string()
         return post_boot_script

--- a/sdcm/sct_provision/region_definition_builder.py
+++ b/sdcm/sct_provision/region_definition_builder.py
@@ -30,6 +30,7 @@ from sdcm.sct_provision.user_data_objects.syslog_ng import SyslogNgUserDataObjec
 from sdcm.sct_provision.user_data_objects.vector_dev import VectorDevUserDataObject
 from sdcm.sct_provision.user_data_objects.walinuxagent import EnableWaLinuxAgent
 from sdcm.sct_provision.user_data_objects.docker_service import DockerUserDataObject
+from sdcm.sct_provision.user_data_objects.sct_agent import SctAgentUserDataObject
 from sdcm.test_config import TestConfig
 
 
@@ -174,6 +175,7 @@ class DefinitionBuilder(abc.ABC):
             EnableWaLinuxAgent,
             ScyllaUserDataObject,
             DockerUserDataObject,
+            SctAgentUserDataObject,
         ]
         user_data_objects = [
             klass(test_config=self.test_config, params=self.params, instance_name=instance_name, node_type=node_type)

--- a/sdcm/sct_provision/user_data_objects/sct_agent.py
+++ b/sdcm/sct_provision/user_data_objects/sct_agent.py
@@ -1,0 +1,62 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+import logging
+from dataclasses import dataclass
+
+from sdcm.sct_provision.user_data_objects import SctUserDataObject
+from sdcm.test_config import TestConfig
+from sdcm.utils.sct_agent_installer import install_agent_script
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SctAgentUserDataObject(SctUserDataObject):
+    @property
+    def is_applicable(self) -> bool:
+        agent_config = self.params.get("agent")
+        return (
+            agent_config.get("enabled")
+            and self.node_type in ("scylla-db", "loader", "monitor")
+            and agent_config.get("binary_url")
+        )
+
+    @property
+    def packages_to_install(self) -> set[str]:
+        return {"curl", "systemd"}
+
+    @property
+    def script_to_run(self) -> str:
+        """
+        Generate installation script for cloud-init.
+
+        The script performs:
+            - downloads agent binary from URL
+            - creates configuration file with generated API key
+            - sets up systemd service
+            - starts agent and verifies it's running
+        """
+        agent_config = self.params.get("agent")
+        api_key = TestConfig.agent_api_key()
+        if not api_key:
+            raise ValueError("Agent API key not available. Ensure it is generated before provisioning.")
+
+        return install_agent_script(
+            agent_binary_url=agent_config["binary_url"],
+            api_keys=[api_key],
+            port=agent_config["port"],
+            max_concurrent_jobs=agent_config["max_concurrent_jobs"],
+            log_level=agent_config.get("log_level"),
+        )

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -22,6 +22,7 @@ from sdcm.utils.docker_utils import ContainerManager
 from sdcm.utils.get_username import get_username
 from sdcm.utils.ldap import LdapServerNotReady
 from sdcm.utils.metaclasses import Singleton
+from sdcm.utils.sct_agent_installer import generate_agent_api_key, save_agent_api_key, load_agent_api_key
 
 
 LOGGER = logging.getLogger(__name__)
@@ -58,6 +59,7 @@ class TestConfig(metaclass=Singleton):
     _latency_results_file_path = None
     _tester_obj = None
     _argus_client: ArgusSCTClient | MagicMock = MagicMock()
+    _agent_api_key = None
 
     backup_azure_blob_credentials = {}
 
@@ -247,6 +249,19 @@ class TestConfig(metaclass=Singleton):
         cls.VECTOR_ADDRESS = (address, port)
 
     @classmethod
+    def ensure_agent_api_key(cls):
+        """Ensure SCT agent API key is available"""
+        agent_config = cls._tester_obj.params.get("agent") if cls._tester_obj else {}
+        if not (agent_config.get("enabled") and agent_config.get("binary_url")):
+            return
+
+        if cls.agent_api_key():
+            return
+
+        cls.generate_and_save_agent_api_key()
+        LOGGER.info("Generated new SCT agent API key for test %s", cls.test_id())
+
+    @classmethod
     def configure_xcloud_connectivity(cls, node, params):
         if node.xcloud_connect_supported(params):
             ContainerManager.run_container(node, "xcloud_connect", params=params)
@@ -257,10 +272,15 @@ class TestConfig(metaclass=Singleton):
         host_port = cls.get_logging_service_host_port()
         if not host_port or not host_port[0]:
             host_port = None
+
+        agent_config = cls._tester_obj.params.get("agent")
+        install_agent = bool(agent_config.get("enabled", False) and agent_config.get("binary_url"))
+
         return ConfigurationScriptBuilder(
             syslog_host_port=host_port,
             logs_transport=cls._tester_obj.params.get("logs_transport") if cls._tester_obj else "syslog-ng",
             test_config=cls(),
+            install_agent=install_agent,
         ).to_string()
 
     @classmethod
@@ -315,3 +335,31 @@ class TestConfig(metaclass=Singleton):
             message="Argus is disabled by configuration",
             severity=Severity.WARNING,
         ).publish_or_dump()
+
+    @classmethod
+    def agent_api_key(cls) -> str | None:
+        return cls._agent_api_key
+
+    @classmethod
+    def set_agent_api_key(cls, api_key: str) -> None:
+        if not api_key:
+            raise ValueError("Agent API key cannot be empty")
+        cls._agent_api_key = api_key
+
+    @classmethod
+    def generate_and_save_agent_api_key(cls) -> str:
+        """Generate a new SCT agent API key and save it to SCT test results directory"""
+        api_key = generate_agent_api_key()
+        save_agent_api_key(cls.logdir(), api_key)
+        cls.set_agent_api_key(api_key)
+        LOGGER.info("New SCT agent API key has been generated and set for test %s", cls.test_id())
+        return api_key
+
+    @classmethod
+    def load_agent_api_key_from_logdir(cls, logdir: str | None = None) -> str | None:
+        """Load SCT agent API key from SCT test results directory"""
+        api_key = load_agent_api_key(logdir or cls.logdir())
+        if api_key:
+            cls.set_agent_api_key(api_key)
+        LOGGER.info("Existing SCT agent API key has been loaded and set for test %s", cls.test_id())
+        return api_key

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1193,6 +1193,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         if self.params.get("cluster_backend") == "xcloud":
             self.test_config.configure_xcloud_connectivity(self.localhost, self.params)
 
+        self.test_config.ensure_agent_api_key()
+
         self.alternator: alternator.api.Alternator = alternator.api.Alternator(sct_params=self.params)
         self.alternator = alternator.api.Alternator(sct_params=self.params)
 

--- a/sdcm/utils/agent_client.py
+++ b/sdcm/utils/agent_client.py
@@ -1,0 +1,253 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+import logging
+import time
+from typing import Optional, Dict, List, Any
+from dataclasses import dataclass
+from datetime import datetime
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class AgentJob:
+    """Command execution job of the SCT agent"""
+
+    job_id: str
+    command: str
+    args: List[str]
+    status: str
+    created_at: datetime
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    exit_code: Optional[int] = None
+    stdout: str = ""
+    stderr: str = ""
+    error: str = ""
+    duration_ms: int = 0
+    working_dir: str = ""
+    env: Dict[str, str] = None
+    timeout: int = 0
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AgentJob":
+        return cls(
+            job_id=data.get("job_id", ""),
+            command=data.get("command", ""),
+            args=data.get("args", []),
+            status=data.get("status", ""),
+            created_at=cls._parse_datetime(data.get("created_at")),
+            started_at=cls._parse_datetime(data.get("started_at")),
+            completed_at=cls._parse_datetime(data.get("completed_at")),
+            exit_code=data.get("exit_code"),
+            stdout=data.get("stdout", ""),
+            stderr=data.get("stderr", ""),
+            error=data.get("error", ""),
+            duration_ms=data.get("duration_ms", 0),
+            working_dir=data.get("working_dir", ""),
+            env=data.get("env", {}),
+            timeout=data.get("timeout", 0),
+        )
+
+    @staticmethod
+    def _parse_datetime(dt_str: Optional[str]) -> Optional[datetime]:
+        """Parse datetime string from API response"""
+        if not dt_str:
+            return None
+        try:
+            return datetime.fromisoformat(dt_str.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            return None
+
+
+class AgentClientError(Exception):
+    pass
+
+
+class AgentConnectionError(AgentClientError):
+    pass
+
+
+class AgentAPIError(AgentClientError):
+    def __init__(self, message: str, status_code: Optional[int] = None, response_data: Optional[Dict] = None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_data = response_data or {}
+
+
+class AgentTimeoutError(AgentClientError):
+    pass
+
+
+class AgentClient:
+    """HTTP client for SCT agent API"""
+
+    def __init__(self, hostname: str, api_key: str, port: int = 16000, timeout: int = 30):
+        self.hostname = hostname
+        self.port = port
+        self.api_key = api_key
+        self.base_url = f"http://{hostname}:{port}"
+        self.timeout = timeout
+
+        self.session = requests.Session()
+        retry_strategy = Retry(
+            total=3,
+            backoff_factor=1,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=["GET", "POST", "DELETE"],
+        )
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+        self.session.mount("http://", adapter)
+        self.session.mount("https://", adapter)
+
+        self.session.headers.update(
+            {
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+                "User-Agent": "SCT-Agent-Client/1.0",
+            }
+        )
+
+    def _make_request(self, method: str, url: str, operation_name: str, **kwargs) -> requests.Response:
+        """
+        Make an HTTP request with error handling
+
+        :param method: HTTP method
+        :param url: request URL
+        :param operation_name: name of operation for error messages
+        :param kwargs: arguments to pass to requests (json, params, etc.)
+
+        :return: response object
+        """
+        try:
+            response = self.session.request(method, url, timeout=self.timeout, **kwargs)
+            response.raise_for_status()
+            return response
+        except requests.exceptions.ConnectionError as exc:
+            raise AgentConnectionError(f"Cannot connect to agent at {self.base_url}: {exc}") from exc
+        except requests.exceptions.Timeout as exc:
+            raise AgentTimeoutError(f"{operation_name.capitalize()} timed out after {self.timeout}s") from exc
+        except requests.exceptions.HTTPError as exc:
+            error_data = exc.response.json() if exc.response.content else {}
+            raise AgentAPIError(
+                f"{operation_name.capitalize()} failed: {error_data.get('message', str(exc))}",
+                status_code=exc.response.status_code,
+                response_data=error_data,
+            ) from exc
+
+    def health_check(self) -> Dict[str, Any]:
+        """Request agent health status"""
+        response = self._make_request("GET", f"{self.base_url}/health", "health check")
+        return response.json()
+
+    def is_healthy(self) -> bool:
+        """Check if agent is healthy and responding"""
+        try:
+            return self.health_check().get("status") == "healthy"
+        except (AgentConnectionError, AgentAPIError, AgentTimeoutError):
+            return False
+
+    def execute_command(
+        self,
+        command: str,
+        args: Optional[List[str]] = None,
+        working_dir: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
+        timeout: Optional[int] = None,
+        tags: Optional[Dict[str, str]] = None,
+    ) -> AgentJob:
+        """
+        Execute a command on the agent asynchronously.
+
+        :param command: command to execute
+        :param args: command arguments
+        :param working_dir: working directory for command execution
+        :param env: environment variables
+        :param timeout: command timeout in seconds
+        :param tags: custom tags for job tracking
+
+        :return: AgentJob object with initial job status
+        """
+        payload = {
+            "command": command,
+            "args": args or [],
+            **({"working_dir": working_dir} if working_dir else {}),
+            **({"env": env} if env else {}),
+            **({"timeout": timeout} if timeout else {}),
+            **({"tags": tags} if tags else {}),
+        }
+
+        response = self._make_request("POST", f"{self.base_url}/api/v1/commands", "command execution", json=payload)
+        data = response.json()
+
+        return AgentJob(
+            job_id=data["job_id"],
+            command=command,
+            args=args or [],
+            status=data["status"],
+            created_at=AgentJob._parse_datetime(data["created_at"]) or datetime.now(),
+        )
+
+    def get_job(self, job_id: str) -> AgentJob:
+        """Get job status and results"""
+        try:
+            response = self._make_request("GET", f"{self.base_url}/api/v1/commands/{job_id}", "get job")
+            return AgentJob.from_dict(response.json())
+        except AgentAPIError as exc:
+            if exc.status_code == 404:
+                raise AgentAPIError(f"Job {job_id} not found", status_code=404) from exc
+            raise
+
+    def wait_for_job(self, job_id: str, timeout: int = 300, poll_interval: float = 1.0) -> AgentJob:
+        """Wait for job to complete and return results"""
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            job = self.get_job(job_id)
+            if job.status in ("completed", "failed", "cancelled"):
+                return job
+            time.sleep(poll_interval)
+
+        raise AgentTimeoutError(f"Job {job_id} did not complete within {timeout} seconds")
+
+    def list_jobs(self, status: Optional[str] = None, limit: int = 100, offset: int = 0) -> List[AgentJob]:
+        """
+        List jobs with optional filtering.
+
+        :param status: filter by status (queued, running, completed, failed, cancelled)
+        :param limit: max number of jobs to return
+        :param offset: offset for pagination
+
+        :return: list of AgentJob objects
+        """
+        params = {"limit": limit, "offset": offset, **({"status": status} if status else {})}
+        response = self._make_request("GET", f"{self.base_url}/api/v1/commands", "list jobs", params=params)
+        data = response.json()
+        return [AgentJob.from_dict(job_data) for job_data in data.get("commands", [])]
+
+    def cancel_job(self, job_id: str) -> bool:
+        """Cancel a running job"""
+        try:
+            self._make_request("DELETE", f"{self.base_url}/api/v1/commands/{job_id}", "cancel job")
+            return True
+        except AgentAPIError as exc:
+            if exc.status_code == 404:
+                raise AgentAPIError(f"Job {job_id} not found", status_code=404) from exc
+            raise
+
+    def __repr__(self) -> str:
+        return f"AgentClient(hostname={self.hostname}, port={self.port})"

--- a/sdcm/utils/aws_region.py
+++ b/sdcm/utils/aws_region.py
@@ -619,6 +619,13 @@ class AwsRegion:
                         "IpRanges": [{"CidrIp": "0.0.0.0/0", "Description": "Allow Vector Store REST API for ALL"}],
                         "Ipv6Ranges": [{"CidrIpv6": "::/0", "Description": "Allow Vector Store REST API for ALL"}],
                     },
+                    {
+                        "FromPort": 16000,
+                        "ToPort": 16000,
+                        "IpProtocol": "tcp",
+                        "IpRanges": [{"CidrIp": "0.0.0.0/0", "Description": "Allow SCT agent REST API for ALL"}],
+                        "Ipv6Ranges": [{"CidrIpv6": "::/0", "Description": "Allow SCT agent REST API for ALL"}],
+                    },
                 ]
             )
         return security_group

--- a/sdcm/utils/sct_agent_installer.py
+++ b/sdcm/utils/sct_agent_installer.py
@@ -1,0 +1,321 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+import logging
+import os
+import secrets
+from textwrap import dedent
+
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_AGENT_PORT = 16000
+DEFAULT_AGENT_BINARY_PATH = "/usr/local/bin/sct-agent"
+DEFAULT_AGENT_CONFIG_PATH = "/etc/sct-agent/config.yaml"
+DEFAULT_AGENT_SERVICE_PATH = "/etc/systemd/system/sct-agent.service"
+DEFAULT_AGENT_LOG_PATH = "/var/log/sct-agent.log"
+DEFAULT_AGENT_LOGROTATE_PATH = "/etc/logrotate.d/sct-agent"
+AGENT_API_KEY_FILENAME = "agent_api_key.secret"
+
+
+def get_agent_config_yaml(
+    api_keys: list[str], port: int = DEFAULT_AGENT_PORT, max_concurrent_jobs: int = 10, log_level: str = "info"
+) -> str:
+    """
+    Generate agent configuration YAML.
+
+    :param api_keys: list of API keys for authentication
+    :param port: agent HTTP server port
+    :param max_concurrent_jobs: maximum number of concurrent jobs
+    :param log_level: logging level.
+
+    :return: YAML configuration as string
+    """
+    api_keys = "\n    ".join(f'- "{key}"' for key in api_keys)
+    return dedent(f"""
+        server:
+          host: "0.0.0.0"
+          port: {port}
+
+        security:
+          api_keys:
+            {api_keys}
+
+        executor:
+          max_concurrent_jobs: {max_concurrent_jobs}
+          default_timeout_seconds: 300
+
+        logging:
+          level: "{log_level}"
+    """)
+
+
+def get_agent_systemd_service(
+    binary_path: str = DEFAULT_AGENT_BINARY_PATH,
+    config_path: str = DEFAULT_AGENT_CONFIG_PATH,
+    log_file_path: str = DEFAULT_AGENT_LOG_PATH,
+) -> str:
+    """
+    Generate systemd service unit file for SCT agent.
+
+    :param binary_path: path to agent binary on a node
+    :param config_path: path to agent configuration file on a node
+    :param log_file_path: path to log file (logs to file instead of journald to avoid memory pressure)
+
+    :return: systemd unit file content as a string with the following sections:
+        - [Unit]: service description and dependencies
+        - [Service]: execution configuration
+        - [Install]: installation target
+    """
+    return dedent(f"""
+        [Unit]
+        Description=SCT agent - Command execution agent for Scylla Cluster Tests
+        After=network-online.target
+        Wants=network-online.target
+
+        [Service]
+        ExecStart={binary_path} --config {config_path} --log-file {log_file_path}
+        Restart=always
+        RestartSec=10
+        User=root
+        StandardOutput=null
+        StandardError=null
+        LimitNOFILE=65536
+
+        CPUAffinity=0
+        Nice=-10
+        MemoryHigh=512M
+        MemoryMax=768M
+
+        [Install]
+        WantedBy=multi-user.target
+    """)
+
+
+def get_agent_logrotate_config(log_file_path: str = DEFAULT_AGENT_LOG_PATH) -> str:
+    """Generate logrotate configuration for SCT agent log file"""
+    return dedent(f"""
+        {log_file_path} {{
+            daily
+            rotate 7
+            compress
+            delaycompress
+            missingok
+            notifempty
+            create 0644 root root
+        }}
+    """)
+
+
+def install_agent_script(
+    agent_binary_url: str,
+    api_keys: list[str],
+    port: int = DEFAULT_AGENT_PORT,
+    binary_path: str = DEFAULT_AGENT_BINARY_PATH,
+    config_path: str = DEFAULT_AGENT_CONFIG_PATH,
+    service_path: str = DEFAULT_AGENT_SERVICE_PATH,
+    log_file_path: str = DEFAULT_AGENT_LOG_PATH,
+    logrotate_path: str = DEFAULT_AGENT_LOGROTATE_PATH,
+    max_concurrent_jobs: int = 10,
+    log_level: str = "info",
+) -> str:
+    """
+    Generate bash script to install and configure SCT agent.
+
+    :param agent_binary_url: URL to download agent binary from
+    :param api_keys: list of API keys for authentication
+    :param port: agent HTTP server port
+    :param binary_path: installation path for agent binary
+    :param config_path: path for agent configuration file
+    :param service_path: path for systemd service unit file
+    :param log_file_path: path for agent log file
+    :param logrotate_path: path for logrotate configuration file
+    :param max_concurrent_jobs: maximum concurrent jobs
+    :param log_level: logging level.
+
+    :return: bash installation script
+    """
+    config_yaml = get_agent_config_yaml(api_keys, port, max_concurrent_jobs, log_level).replace("$", "\\$")
+    service_content = get_agent_systemd_service(binary_path, config_path, log_file_path).replace("$", "\\$")
+    logrotate_content = get_agent_logrotate_config(log_file_path).replace("$", "\\$")
+
+    return f"""echo "Installing SCT agent..."
+
+echo "Downloading agent binary from {agent_binary_url}..."
+curl -fsSL -o {binary_path} {agent_binary_url}
+chmod +x {binary_path}
+
+if ! {binary_path} --version >/dev/null 2>&1; then
+    echo "Warning: Agent binary may not be valid, continuing anyway..."
+fi
+
+mkdir -p $(dirname {config_path})
+
+cat > {config_path} <<'EOF'
+{config_yaml}
+EOF
+
+chmod 600 {config_path}
+
+cat > {service_path} <<'EOF'
+{service_content}
+EOF
+
+cat > {logrotate_path} <<'EOF'
+{logrotate_content}
+EOF
+
+systemctl daemon-reload
+systemctl enable sct-agent.service
+
+systemctl start sct-agent.service
+
+echo "Waiting for agent to be ready..."
+for i in {{1..30}}; do
+    if curl -f http://localhost:{port}/health >/dev/null 2>&1; then
+        echo "SCT agent is ready!"
+        break
+    fi
+    echo "Waiting for agent... ($i/30)"
+    sleep 2
+done
+
+if ! curl -f http://localhost:{port}/health >/dev/null 2>&1; then
+    echo "Warning: Agent may not have started successfully"
+    systemctl status sct-agent.service || true
+fi
+"""
+
+
+def wait_for_agent_script(port: int = DEFAULT_AGENT_PORT, timeout: int = 60) -> str:
+    """Generate script to wait for SCT agent to be ready"""
+    return dedent(f"""
+        #!/bin/bash
+        echo "Waiting for SCT agent to be ready..."
+        for i in $(seq 1 {timeout}); do
+            if curl -fs http://localhost:{port}/health >/dev/null 2>&1; then
+                echo "SCT agent is ready!"
+                exit 0
+            fi
+            sleep 1
+        done
+        echo "ERROR: SCT agent did not become ready within {timeout} seconds"
+        exit 1
+    """).strip()
+
+
+def check_agent_status_script(port: int = DEFAULT_AGENT_PORT) -> str:
+    """Generate script to check SCT agent status"""
+    return dedent(f"""
+        #!/bin/bash
+        echo "=== SCT agent Status ==="
+        echo "Port: {port}"
+
+        if pgrep -f sct-agent >/dev/null; then
+            echo "Process: RUNNING"
+            ps aux | grep "[s]ct-agent"
+        else
+            echo "Process: NOT RUNNING"
+        fi
+
+        if command -v systemctl >/dev/null 2>&1; then
+            echo "=== Systemd Service Status ==="
+            systemctl status sct-agent.service --no-pager || true
+        fi
+
+        echo "=== Health Check ==="
+        if curl -f http://localhost:{port}/health 2>/dev/null; then
+            echo ""
+            echo "Health: OK"
+        else
+            echo "Health: FAILED"
+        fi
+
+        echo "=== Recent Logs ==="
+        if [ -f /tmp/sct-agent.log ]; then
+            tail -20 /tmp/sct-agent.log
+        elif command -v journalctl >/dev/null 2>&1; then
+            journalctl -u sct-agent.service -n 20 --no-pager || true
+        else
+            echo "No logs available"
+        fi
+    """).strip()
+
+
+def generate_agent_api_key() -> str:
+    """Generate an API key for SCT agent authentication"""
+    return secrets.token_urlsafe(32)
+
+
+def save_agent_api_key(logdir: str, api_key: str) -> None:
+    """Save the agent API key to a local file with restricted permissions"""
+    key_path = os.path.join(logdir, AGENT_API_KEY_FILENAME)
+    os.makedirs(logdir, exist_ok=True)
+    with open(key_path, "w", encoding="utf-8") as f:
+        f.write(api_key)
+
+    os.chmod(key_path, 0o600)
+
+
+def load_agent_api_key(logdir: str) -> str | None:
+    """Load the agent API key from a local file"""
+    key_path = os.path.join(logdir, AGENT_API_KEY_FILENAME)
+    if not os.path.exists(key_path):
+        return None
+
+    with open(key_path, "r", encoding="utf-8") as f:
+        api_key = f.read().strip()
+
+    return api_key
+
+
+def reconfigure_agent_script(
+    api_keys: list[str],
+    port: int = DEFAULT_AGENT_PORT,
+    config_path: str = DEFAULT_AGENT_CONFIG_PATH,
+    max_concurrent_jobs: int = 10,
+    log_level: str = "info",
+) -> str:
+    """
+    Generate bash script to reconfigure running SCT agent with a new API key(s).
+
+    This script updates the agent configuration file and restarts the service,
+    allowing the test to use a new API key with already-provisioned instances.
+    """
+    config_yaml = get_agent_config_yaml(api_keys, port, max_concurrent_jobs, log_level).replace("$", "\\$")
+
+    return f"""echo "Reconfiguring SCT agent with new API key..."
+
+[ -f {config_path} ] && cp {config_path} {config_path}.backup
+
+cat > {config_path} <<'EOF'
+{config_yaml}
+EOF
+
+chmod 600 {config_path}
+systemctl restart sct-agent.service
+
+for i in {{1..30}}; do
+    if curl -f http://localhost:{port}/health >/dev/null 2>&1; then
+        echo "SCT agent is ready with new API key!"
+        break
+    fi
+    echo "Waiting for agent... ($i/30)"
+    sleep 2
+done
+
+if ! curl -f http://localhost:{port}/health >/dev/null 2>&1; then
+    echo "Warning: Agent may not have restarted successfully"
+    systemctl status sct-agent.service || true
+fi
+"""

--- a/test-cases/agent-test-aws.yaml
+++ b/test-cases/agent-test-aws.yaml
@@ -1,0 +1,21 @@
+# Sanity test for sct-agent: verifies basic agent functionality with a minimal cluster configuration
+# and no nemesis disruptions. Used to validate agent communication and command execution.
+test_duration: 10
+prepare_write_cmd: "cassandra-stress write cl=QUORUM n=100000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=10"
+
+n_db_nodes: 3
+n_loaders: 1
+
+instance_type_db: 'i4i.large'
+
+agent:
+  enabled: true
+  port: 16000
+  binary_url: "https://dimakr.s3.eu-north-1.amazonaws.com/sct-agent"
+  max_concurrent_jobs: 10
+  log_level: "info"
+
+user_prefix: agent-test
+nemesis_class_name: NoOpMonkey
+
+use_preinstalled_scylla: true

--- a/unit_tests/lib/fake_resources.py
+++ b/unit_tests/lib/fake_resources.py
@@ -33,6 +33,7 @@ def prepare_fake_region(test_id: str, region: str, n_db_nodes: int = 3, n_loader
         "root_disk_size_monitor": 15,
         "fake_region_name": ["eastus"],
         "cluster_backend": "fake",
+        "agent": {"enabled": False, "port": 16000, "binary_url": "", "max_concurrent_jobs": 10, "log_level": "info"},
     }
     test_config = TestConfig()
     test_config.set_test_id_only(test_id)

--- a/unit_tests/test_agent_api_key.py
+++ b/unit_tests/test_agent_api_key.py
@@ -1,0 +1,57 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from sdcm.utils.sct_agent_installer import (
+    generate_agent_api_key,
+    save_agent_api_key,
+    load_agent_api_key,
+    AGENT_API_KEY_FILENAME,
+)
+
+
+class TestAgentAPIKey(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_generate_agent_api_key(self):
+        api_key = generate_agent_api_key()
+        self.assertTrue(api_key, "API should be generated and not empty")
+
+        api_key2 = generate_agent_api_key()
+        self.assertNotEqual(api_key, api_key2, "Generated keys should be unique")
+
+    def test_save_and_load_agent_api_key(self):
+        api_key = "test-api-key-12345"
+        save_agent_api_key(self.test_dir, api_key)
+
+        key_path = Path(self.test_dir) / AGENT_API_KEY_FILENAME
+        self.assertTrue(os.path.exists(key_path), "API key file should exist")
+        file_stat = os.stat(key_path)
+        file_mode = file_stat.st_mode & 0o777
+        self.assertEqual(file_mode, 0o600, f"File should have 600 permissions, got {oct(file_mode)}")
+
+        loaded_key = load_agent_api_key(self.test_dir)
+        self.assertEqual(api_key, loaded_key, "Loaded key should match saved key")
+
+    def test_load_nonexistent_api_key(self):
+        nonexistent_dir = os.path.join(self.test_dir, "nonexistent")
+        self.assertIsNone(load_agent_api_key(nonexistent_dir), "Loading from nonexistent directory should return None")


### PR DESCRIPTION
Integrate sct-agent MVP into SCT, as an alternative to using SSH for command execution on DB nodes.

Refs: https://github.com/scylladb/qa-tasks/issues/1858

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested locally with a new `test-cases/agent-test-aws.yaml` test configuration, that was added to serve as a sanity test for sct-agent - it is essentially the `pr-provision-test`-like configuration, but with sct-agent enabled, hence the commands on DB nodes are executed via the agent, not SSH.

The status of the running agent on a DB node (the agent is registered as systemd service):
```
scyllaadm@agent-test-dmitriy-db-node-cfa6fbca-2:~$ sudo systemctl status sct-agent
● sct-agent.service - SCT Agent - Command execution agent for Scylla Cluster Tests
     Loaded: loaded (/etc/systemd/system/sct-agent.service; enabled; preset: enabled)
     Active: active (running) since Mon 2025-10-20 21:46:39 UTC; 16min ago
   Main PID: 4314 (sct-agent)
      Tasks: 10 (limit: 18771)
     Memory: 238.7M (peak: 506.2M)
        CPU: 12.609s
     CGroup: /system.slice/sct-agent.service
             ├─4314 /usr/local/bin/sct-agent --config /etc/sct-agent/config.yaml
             ├─6360 dirmngr --homedir /tmp --daemon
             └─6363 gpg-agent --homedir /tmp --use-standard-socket --daemon

Oct 20 21:58:31 agent-test-dmitriy-db-node-cfa6fbca-2 sudo[7197]:     root : PWD=/ ; USER=root ; COMMAND=/usr/bin/grep ^SCYLLA_ARGS= /etc/default/scylla-server
Oct 20 21:58:31 agent-test-dmitriy-db-node-cfa6fbca-2 sudo[7197]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
Oct 20 21:58:31 agent-test-dmitriy-db-node-cfa6fbca-2 sudo[7197]: pam_unix(sudo:session): session closed for user root
Oct 20 21:58:31 agent-test-dmitriy-db-node-cfa6fbca-2 sct-agent[4314]: 2025/10/20 21:58:31 sct-agent[6ba45b84]: Command completed successfully: exit_code=0 duration=8ms cmd=/bin/bash -c sudo grep "^SCYLLA_ARGS=" /etc/default/scylla-server
Oct 20 21:58:31 agent-test-dmitriy-db-node-cfa6fbca-2 sct-agent[4314]: [2025-10-20 21:58:31] GET /api/v1/commands/6ba45b84-7c56-4f02-a30b-54a83322693f 200 41.095µs 46.243.158.145
Oct 20 21:58:31 agent-test-dmitriy-db-node-cfa6fbca-2 sct-agent[4314]: [2025-10-20 21:58:31] POST /api/v1/commands 200 585.193µs 46.243.158.145
Oct 20 21:58:31 agent-test-dmitriy-db-node-cfa6fbca-2 sct-agent[4314]: 2025/10/20 21:58:31 sct-agent[1d412446]: PWD=/ ; COMMAND=/bin/bash -c cat /etc/scylla.d/cpuset.conf
Oct 20 21:58:31 agent-test-dmitriy-db-node-cfa6fbca-2 sct-agent[4314]: 2025/10/20 21:58:31 sct-agent[1d412446]: Command completed successfully: exit_code=0 duration=2ms cmd=/bin/bash -c cat /etc/scylla.d/cpuset.conf
Oct 20 21:58:31 agent-test-dmitriy-db-node-cfa6fbca-2 sct-agent[4314]: [2025-10-20 21:58:31] GET /api/v1/commands/1d412446-cb56-4d01-90f1-b69e7d9034dc 200 35.189µs 46.243.158.145
Oct 20 21:58:32 agent-test-dmitriy-db-node-cfa6fbca-2 sct-agent[4314]: [2025-10-20 21:58:32] GET /health 200 147.001µs 46.243.158.145
``` 

Some logs of the agent service:
```
scyllaadm@agent-test-dmitriy-db-node-cfa6fbca-2:~$ journalctl -u sct-agent | grep -i 'command completed' -A5 -B5
...
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sct-agent[4314]: 2025/10/20 21:52:23 sct-agent[ac5e6753]: PWD=/ ; COMMAND=/bin/bash -c sudo systemctl stop scylla-server.service
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sudo[6333]:     root : PWD=/ ; USER=root ; COMMAND=/usr/bin/systemctl stop scylla-server.service
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sudo[6333]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sudo[6333]: pam_unix(sudo:session): session closed for user root
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sct-agent[4314]: 2025/10/20 21:52:23 sct-agent[ac5e6753]: Command completed successfully: exit_code=0 duration=16ms cmd=/bin/bash -c sudo systemctl stop scylla-server.service
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sct-agent[4314]: [2025-10-20 21:52:23] GET /api/v1/commands/ac5e6753-1430-4890-90fb-f2a87404cb90 200 34.252µs 46.243.158.145
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sct-agent[4314]: [2025-10-20 21:52:23] POST /api/v1/commands 200 557.768µs 46.243.158.145
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sct-agent[4314]: 2025/10/20 21:52:23 sct-agent[56f7425a]: PWD=/ ; COMMAND=/bin/bash -c sudo rm -rf /var/lib/scylla/data/*
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sudo[6335]:     root : PWD=/ ; USER=root ; COMMAND=/usr/bin/rm -rf /var/lib/scylla/data/*
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sudo[6335]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sudo[6335]: pam_unix(sudo:session): session closed for user root
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sct-agent[4314]: 2025/10/20 21:52:23 sct-agent[56f7425a]: Command completed successfully: exit_code=0 duration=9ms cmd=/bin/bash -c sudo rm -rf /var/lib/scylla/data/*
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sct-agent[4314]: [2025-10-20 21:52:23] GET /api/v1/commands/56f7425a-6169-47c0-83e4-3c19b6ddeb5f 200 33.039µs 46.243.158.145
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sct-agent[4314]: [2025-10-20 21:52:23] POST /api/v1/commands 200 547.074µs 46.243.158.145
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sct-agent[4314]: 2025/10/20 21:52:23 sct-agent[a20e695c]: PWD=/ ; COMMAND=/bin/bash -c sudo find /var/lib/scylla/commitlog -type f -delete
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sudo[6337]:     root : PWD=/ ; USER=root ; COMMAND=/usr/bin/find /var/lib/scylla/commitlog -type f -delete
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sudo[6337]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sudo[6337]: pam_unix(sudo:session): session closed for user root
Oct 20 21:52:23 agent-test-dmitriy-db-node-cfa6fbca-2 sct-agent[4314]: 2025/10/20 21:52:23 sct-agent[a20e695c]: Command completed successfully: exit_code=0 duration=10ms cmd=/bin/bash -c sudo find /var/lib/scylla/commitlog -type f -delete
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
