### PR TITLE
fix(performance): sending email failed

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -4024,9 +4024,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
 
         json_file_path = os.path.join(self.logdir, "email_data.json")
 
-        if email_data is not None:
+        if email_data:
             email_data['grafana_screenshots'] = grafana_screenshots
-            email_data["reporter"] = self.email_reporter.__class__.__name__
+            if self.email_reporter is not None:
+                email_data["reporter"] = self.email_reporter.__class__.__name__
             self.log.debug('Save email data to file %s', json_file_path)
             self.log.debug('Email data: %s', email_data)
             save_email_data_to_file(email_data, json_file_path)


### PR DESCRIPTION
Performance regression tests were failing to send results email with the error:
```
Building email reporter for class: NoneType
```
Unconditionally set email_data['reporter'] causing 'NoneType' for tests without specific reporters

Fixes scylladb/scylla-cluster-tests#12233

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/35dd4ff9-c1bd-48a0-97ed-50d401680e1a.
The email has been sent
[[aws][i4i.4xlarge] Performance Regression Compare Results ( unknown size) - test_read_gradual_increase_load - 2026.1.0~dev.20251017.01bcafbe2460 - 2025-10-21 08_09_13.eml](https://github.com/user-attachments/files/23019661/aws.i4i.4xlarge.Performance.Regression.Compare.Results.unknown.size.-.test_read_gradual_increase_load.-.2026.1.0.dev.20251017.01bcafbe2460.-.2025-10-21.08_09_13.eml)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
