### PR TITLE
Revert "fix(simple_query): disable elasticsearch reporting"

### DIFF
--- a/test-cases/microbenchmarking/amazon_perf_simple_query_ARM.yaml
+++ b/test-cases/microbenchmarking/amazon_perf_simple_query_ARM.yaml
@@ -15,4 +15,4 @@ instance_provision_fallback_on_demand: true
 
 email_recipients: ['scylla-perf-results@scylladb.com']
 custom_es_index: 'microbenchmarkingtest'
-store_perf_results: false
+store_perf_results: true


### PR DESCRIPTION
This reverts commit 883f0faca10fbeacc6f14e327eb3f80227a7e0a9.

seems like this is breaking the email reports, and fails the email phase of the pipeline, bring it back, and it would be disable once we have other method to generate email report for this job.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64-write/20/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
