### PR TITLE
feature(rolling-upgrade): replace centos9 with rocky10

### DIFF
--- a/jenkins-pipelines/master-triggers/sct_triggers/weekly-master-images-rolling-upgrades-trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/weekly-master-images-rolling-upgrades-trigger.xml
@@ -57,7 +57,7 @@ requested_by_user=fruch</properties>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
-          <projects>../rolling-upgrade/rolling-upgrade-centos9-test</projects>
+          <projects>../rolling-upgrade/rolling-upgrade-rocky10-test</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-rocky10.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-rocky10.jenkinsfile
@@ -6,8 +6,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingUpgradePipeline(
     backend: 'gce',
     base_versions: '',  // auto mode
-    linux_distro: 'centos-9',
-    gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-9',
+    linux_distro: 'rocky-10',
+    gce_image_db: 'https://www.googleapis.com/compute/v1/projects/rocky-linux-cloud/global/images/family/rocky-linux-10-optimized-gcp',
     base_version_all_sts_versions: true,
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
     test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-artifacts.yaml", "configurations/gce/n2-highmem-16.yaml"]''',

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2119,7 +2119,8 @@ class BaseNode(AutoSshContainerMixin):
             version = f"-{scylla_version}" if scylla_version else ""
             self.remoter.sudo('zypper install -y {}{}'.format(self.scylla_pkg(), version))
         else:
-            self.install_package(package_name="software-properties-common")
+            if self.distro.is_debian11 or self.distro.is_debian12:
+                self.install_package(package_name="software-properties-common")
             if self.distro.is_debian11:
                 self.install_package(package_name="apt-transport-https gnupg1-curl dirmngr openjdk-11-jre")
             elif self.distro.is_debian12:

--- a/sdcm/utils/distro.py
+++ b/sdcm/utils/distro.py
@@ -36,7 +36,7 @@ KNOWN_OS = (
     ("RHEL", "rhel", ["7", "8", "9", "10"], DistroBase.RHEL),
     ("OEL", "ol", ["7", "8", "9"], DistroBase.RHEL),
     ("AMAZON", "amzn", ["2023"], DistroBase.RHEL),
-    ("ROCKY", "rocky", ["8", "9"], DistroBase.RHEL),
+    ("ROCKY", "rocky", ["8", "9", "10"], DistroBase.RHEL),
     ("DEBIAN", "debian", ["11", "12"], DistroBase.DEBIAN),
     ("UBUNTU", "ubuntu", ["20.04", "21.04", "21.10", "22.04", "24.04"], DistroBase.DEBIAN),
     ("SLES", "sles", ["15"], DistroBase.UNKNOWN),

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -759,7 +759,7 @@ def get_s3_scylla_repos_mapping(dist_type='centos', dist_version=None):
     s3_client: S3Client = boto3.client('s3', region_name=DEFAULT_AWS_REGION)
     bucket = 'downloads.scylladb.com'
 
-    if dist_type == 'centos':
+    if dist_type in ('centos', 'rocky', 'rhel'):
         response = s3_client.list_objects(Bucket=bucket, Prefix='rpm/centos/', Delimiter='/')
 
         for repo_file in response['Contents']:
@@ -799,7 +799,7 @@ def find_scylla_repo(scylla_version, dist_type='centos', dist_version=None):
     Get a repo/list of scylla, based on scylla version match
 
     :param scylla_version: branch version to look for, ex. 'branch-2019.1:latest', 'branch-3.1:l'
-    :param dist_type: one of ['centos', 'ubuntu', 'debian']
+    :param dist_type: one of ['centos', 'ubuntu', 'debian', 'rocky', 'rhel']
     :param dist_version: family name of the distro version
     :raises: ValueError if not found
 
@@ -820,13 +820,13 @@ def find_scylla_repo(scylla_version, dist_type='centos', dist_version=None):
 
 
 def get_branched_repo(scylla_version: str,
-                      dist_type: Literal["centos", "ubuntu", "debian"] = "centos",
+                      dist_type: Literal["centos", "ubuntu", "debian", "rocky"] = "centos",
                       bucket: str = "downloads.scylladb.com") -> Optional[str]:
     """
     Get a repo/list of scylla, based on scylla version match
 
     :param scylla_version: branch version to look for, ex. 'branch-2019.1:latest', 'branch-3.1:l'
-    :param dist_type: one of ['centos', 'ubuntu', 'debian']
+    :param dist_type: one of ['centos', 'ubuntu', 'debian', 'rocky', 'rhel']
     :param bucket: which bucket to download from
     :return: str url repo/list, or None if not found
     """
@@ -845,7 +845,7 @@ def get_branched_repo(scylla_version: str,
     else:
         product = "scylla"
 
-    if dist_type == "centos":
+    if dist_type in ("centos", "rocky", "rhel"):
         prefix = f"unstable/{product}/{branch}/rpm/centos/{branch_version}/"
         filename = "scylla.repo"
     elif dist_type in ("ubuntu", "debian",):

--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -112,6 +112,14 @@ def test_2025_1_release_ubuntu():
     assert {'6.2', '2024.1', '2024.2'}.issubset(set(version_list))
 
 
+def test_2025_1_release_rocky():
+    """ Test that 2025.1 release on centos is returned correct versions """
+    scylla_repo = url_base + '/branch-2025.4/rpm/centos/2025-02-23T16:19:08Z/scylla.repo'
+    linux_distro = 'rocky-10'
+    version_list = general_test(scylla_repo, linux_distro)
+    assert {'2025.3'} == set(version_list)
+
+
 def test_2025_1_release_centos():
     """ Test that 2025.1 release on centos is returned correct versions """
     scylla_repo = url_base + '/branch-2025.1/rpm/centos/2025-02-23T16:19:08Z/scylla.repo'

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -29,7 +29,10 @@ extra_supported_versions = {
 }
 # If new support distro shared repo with others, we need to assign the start support versions. eg: centos8
 start_support_versions = {'centos-8': {'scylla': '4.1', 'enterprise': '2021.1'},
-                          'centos-9': {'scylla': '5.4', 'enterprise': '2024.1'}}
+                          'centos-9': {'scylla': '5.4', 'enterprise': '2024.1'},
+                          # oss isn't really supported on rocky10, but we add it here sinc code can't get None value
+                          'rocky-10': {'scylla': None, 'enterprise': '2025.3'},
+                          }
 start_support_backend = {'azure': {'scylla': '5.2', 'enterprise': '2023.1'}}
 
 # list of version that are available, but aren't supported, and we should test upgrades from


### PR DESCRIPTION
regular update of a distro version used
since centos is about to be deprecated within GCP
switching to testing on rocky, and while are it switching
to latest version

replace centos-9 (stream) with rocky linux 10

### TODOs
- [x] remove the old pipelines (maybe leave them for debugging proposes, since they exists in releases)
- [x] replace weekly triggers
- [ ] [replace in scylla-pkg triggers](https://github.com/scylladb/scylla-pkg/pull/5552)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-rocky10-test/8/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
