### PR TITLE
fix(artifact_test): fix nonroot debian scylla-doctor

### DIFF
--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -198,6 +198,11 @@ class ScyllaDoctor:
                 collector in ["StorageConfigurationCollector", "PerftuneSystemConfigurationCollector"]):
             return True
 
+        if (self.node.distro.is_debian and self.offline_install and
+                collector in ["RAIDSetupCollector", "SysctlCollector"]):
+            # Debian does not have mdstat by default and sysctl is not found
+            return True
+
         # https://github.com/scylladb/scylladb/issues/18631
         # if self.node.distro.is_amazon2 and collector in ["CPUSetCollector", "PerftuneSystemConfigurationCollector"]:
         #    return True


### PR DESCRIPTION
In non-root debian11/12 test there's an issue with missing `mdstat` and `sysctl`.
Disabling these checks for this test.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/12184

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - [debian non root artifact test](https://argus.scylladb.com/tests/scylla-cluster-tests/c8a47210-741f-4aad-98dc-9fc32224cef8)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
