### PR TITLE
improvement(upgrade): allow to skip truncate checks in upgrade tests

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -141,6 +141,7 @@ disable_raft: true
 enable_tablets_on_upgrade: false
 enable_views_with_tablets_on_upgrade: false
 upgrade_node_system: true
+enable_truncate_checks_on_node_upgrade: true
 
 stress_cdclog_reader_cmd: "cdc-stressor -stream-query-round-duration 30s"
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -3147,6 +3147,15 @@ Whether to upgrade sstables as part of upgrade_node or not
 **type:** boolean
 
 
+## **enable_truncate_checks_on_node_upgrade** / SCT_ENABLE_TRUNCATE_CHECKS_ON_NODE_UPGRADE
+
+Enables or disables truncate checks on each node upgrade and rollback
+
+**default:** True
+
+**type:** boolean
+
+
 ## **stress_before_upgrade** / SCT_STRESS_BEFORE_UPGRADE
 
 Stress command to be run before upgrade (preapre stage)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1596,6 +1596,10 @@ class SCTConfiguration(dict):
              type=boolean,
              help="Whether to upgrade sstables as part of upgrade_node or not"),
 
+        dict(name="enable_truncate_checks_on_node_upgrade", env="SCT_ENABLE_TRUNCATE_CHECKS_ON_NODE_UPGRADE",
+             type=boolean,
+             help="Enables or disables truncate checks on each node upgrade and rollback"),
+
         dict(name="stress_before_upgrade", env="SCT_STRESS_BEFORE_UPGRADE",
              type=str,
              help="Stress command to be run before upgrade (preapre stage)"),

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -72,28 +72,31 @@ NUMBER_OF_ROWS_FOR_TRUNCATE_TEST = 10
 def truncate_entries(func):
     @wraps(func)
     def inner(self, *args, **kwargs):
-        node = args[0]
-        with self.db_cluster.cql_connection_patient(node, keyspace='truncate_ks', connect_timeout=600) as session:
-            self.actions_log.info("Start truncate simple tables")
-            session.default_timeout = 60.0 * 5
-            session.default_consistency_level = ConsistencyLevel.QUORUM
-            try:
-                self.cql_truncate_simple_tables(session=session, rows=NUMBER_OF_ROWS_FOR_TRUNCATE_TEST)
-                self.actions_log.info("Finish truncate simple tables")
-            except cassandra.DriverException as details:
-                InfoEvent(message=f"Failed truncate simple tables. Error: {str(details)}. Traceback: {traceback.format_exc()}",
-                          severity=Severity.ERROR).publish()
-            self.validate_truncated_entries_for_table(session=session, system_truncated=True)
+        if self.do_truncates:
+            node = args[0]
+            with self.db_cluster.cql_connection_patient(node, keyspace='truncate_ks', connect_timeout=600) as session:
+                self.actions_log.info("Start truncate simple tables")
+                session.default_timeout = 60.0 * 5
+                session.default_consistency_level = ConsistencyLevel.QUORUM
+                try:
+                    self.cql_truncate_simple_tables(session=session, rows=NUMBER_OF_ROWS_FOR_TRUNCATE_TEST)
+                    self.actions_log.info("Finish truncate simple tables")
+                except cassandra.DriverException as details:
+                    InfoEvent(message=f"Failed truncate simple tables. Error: {str(details)}. Traceback: {traceback.format_exc()}",
+                              severity=Severity.ERROR).publish()
+                self.validate_truncated_entries_for_table(session=session, system_truncated=True)
 
         func_result = func(self, *args, **kwargs)
 
-        # re-new connection
-        with self.db_cluster.cql_connection_patient(node, keyspace='truncate_ks', connect_timeout=600) as session:
-            session.default_timeout = 60.0 * 5
-            session.default_consistency_level = ConsistencyLevel.QUORUM
-            self.validate_truncated_entries_for_table(session=session, system_truncated=True)
-            self.read_data_from_truncated_tables(session=session)
-            self.cql_insert_data_to_simple_tables(session=session, rows=NUMBER_OF_ROWS_FOR_TRUNCATE_TEST)
+        if self.do_truncates:
+            # re-new connection
+            with self.db_cluster.cql_connection_patient(node, keyspace='truncate_ks', connect_timeout=600) as session:
+                session.default_timeout = 60.0 * 5
+                session.default_consistency_level = ConsistencyLevel.QUORUM
+                self.validate_truncated_entries_for_table(session=session, system_truncated=True)
+                self.read_data_from_truncated_tables(session=session)
+                self.cql_insert_data_to_simple_tables(session=session, rows=NUMBER_OF_ROWS_FOR_TRUNCATE_TEST)
+
         return func_result
     return inner
 
@@ -141,7 +144,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
 
     def setUp(self):
         super().setUp()
-
+        self.do_truncates = self.params.get("enable_truncate_checks_on_node_upgrade") or False
         self.stacks = {}
         for node in self.db_cluster.nodes:
             self.configure_event_filtering(node)
@@ -623,8 +626,9 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             metric_query='sct_cassandra_stress_write_gauge{type="ops", keyspace="keyspace_entire_test"}'
                          'or sct_cql_stress_cassandra_stress_write_gauge{type="ops", keyspace="keyspace_entire_test"}', n=10)
 
-        # Prepare keyspace and tables for truncate test
-        self.fill_db_data_for_truncate_test(insert_rows=NUMBER_OF_ROWS_FOR_TRUNCATE_TEST)
+        if self.do_truncates:
+            # Prepare keyspace and tables for truncate test
+            self.fill_db_data_for_truncate_test(insert_rows=NUMBER_OF_ROWS_FOR_TRUNCATE_TEST)
 
         # generate random order to upgrade
         nodes_num = len(self.db_cluster.nodes)
@@ -952,8 +956,9 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         """
         self.upgrade_os(self.db_cluster.nodes)
 
-        # Prepare keyspace and tables for truncate test
-        self.fill_db_data_for_truncate_test(insert_rows=NUMBER_OF_ROWS_FOR_TRUNCATE_TEST)
+        if self.do_truncates:
+            # Prepare keyspace and tables for truncate test
+            self.fill_db_data_for_truncate_test(insert_rows=NUMBER_OF_ROWS_FOR_TRUNCATE_TEST)
 
         self._add_sla_credentials_to_stress_commands(workloads_with_sla=['stress_during_entire_upgrade',
                                                                          'stress_after_cluster_upgrade'])
@@ -1011,8 +1016,9 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         self.upgrade_os(self.db_cluster.nodes)
 
         InfoEvent(message="Step1 - Populate DB data").publish()
-        # Prepare keyspace and tables for truncate test
-        self.fill_db_data_for_truncate_test(insert_rows=NUMBER_OF_ROWS_FOR_TRUNCATE_TEST)
+        if self.do_truncates:
+            # Prepare keyspace and tables for truncate test
+            self.fill_db_data_for_truncate_test(insert_rows=NUMBER_OF_ROWS_FOR_TRUNCATE_TEST)
         self.run_prepare_write_cmd()
 
         InfoEvent(message="Step2 - Run 'read' command before upgrade").publish()


### PR DESCRIPTION
Those checks may be done on cheap upgrade setups.
And those checks may timeout on huge expensive setups.
Also, it will take additional time on expensive setups.

So, add possibility to skip truncate checks for such cases.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-rolling-upgrade-custom-d2-w1-latency-regression-v2#7](https://argus.scylladb.com/tests/scylla-cluster-tests/f146079b-90c6-445f-963b-433bb17bc13c)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
