### PR TITLE
improvement(upgrade): check limited voters feature in latte upgrade test

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -1048,6 +1048,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
 
         InfoEvent(message="Step4 - Run raft topology upgrade procedure").publish()
         self.run_raft_topology_upgrade_procedure()
+        self.validate_limited_voters_feature_enabled()
 
         InfoEvent(message="Step5 - Wait for stress_during_entire_upgrade to finish").publish()
         for stress_during_entire_upgrade_thread_pool in stress_during_entire_upgrade_thread_pools:


### PR DESCRIPTION
Run `validate_limited_voters_feature_enabled` method
in the `test_cluster_upgrade_latency_regression` upgrade test.

Ref: https://github.com/scylladb/scylla-cluster-tests/pull/10853

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
