### PR TITLE
improvement(performance): add support for user profile in HDR analysis

### DIFF
--- a/sdcm/utils/hdrhistogram.py
+++ b/sdcm/utils/hdrhistogram.py
@@ -261,7 +261,9 @@ class _HdrRangeHistogramBuilder:
             line_index = 5
             while next_hist:
                 tag = next_hist.get_tag()
-                if tag == hdr_tag:
+                # The tag in the HDR file for the stress command with the user profile is in lowercase.
+                # Modify the tag validation to perform a case-insensitive comparison.
+                if tag.lower() == hdr_tag.lower():
                     if tag_not_found:
                         LOGGER.debug(f'found histogram entry with tag {hdr_tag} in file {hdr_file}')
                     if histogram.get_start_time_stamp() == 0:


### PR DESCRIPTION
This commit introduces two changes to enable user profile support in performance testing:

Set the HDR tag according to the stress command when using a user profile. Currently, only standard operations (read and insert) are supported for user-profile-based stress commands.

The HDR tag for stress commands with a user profile is now written in lowercase. The tag validation logic has been updated to perform a case-insensitive comparison.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/877d6962-653a-4ac7-b682-93e3c0aed7c0

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
