### PR TITLE
improvement(upgrade): send latte latency results to argus

### DIFF
--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -227,6 +227,20 @@ class IOPropertiesDeviationResultsTable(StaticGenericResultTable):
         }
 
 
+class LatteStressLatencyComparison(StaticGenericResultTable):
+    class Meta:
+        name = "Latency comparison"
+        description = "Compares identical sets of latte commands ran twice (i.e before and after upgrade)"
+        Columns = [
+            ColumnMetadata(name="before_ops", unit="", type=ResultType.INTEGER),
+            ColumnMetadata(name="before_mean", unit="ms", type=ResultType.FLOAT),
+            ColumnMetadata(name="before_p99", unit="ms", type=ResultType.FLOAT),
+            ColumnMetadata(name="after_p99", unit="ms", type=ResultType.FLOAT),
+            ColumnMetadata(name="after_mean", unit="ms", type=ResultType.FLOAT),
+            ColumnMetadata(name="after_ops", unit="", type=ResultType.INTEGER),
+        ]
+
+
 workload_to_table = {
     "mixed": LatencyCalculatorMixedResult,
     "write": LatencyCalculatorWriteResult,

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -29,6 +29,7 @@ from argus.client.sct.types import Package
 from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
 
+from sdcm import argus_results
 from sdcm import wait
 from sdcm.cluster import BaseNode
 from sdcm.utils.issues import SkipPerIssues
@@ -997,16 +998,17 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
 
         Number of 'before' and 'after' commands must match. Their latency values will be compaired.
 
-        - Write initial latte data (prepare_write_cmd?)
+        - Write initial latte data (prepare_write_cmd)
         - Wait for end of compactions
         - Read latte data generating report file (stress_before_upgrade)
+        - Write latency results from the 'stress_before_upgrade' to Argus
         - Run a read latte stress (stress_during_entire_upgrade) not waiting for it's end
         - Upgrade the DB cluster
         * self.run_raft_topology_upgrade_procedure()
         - Wait for the end of the stress command (stress_during_entire_upgrade)
         - Wait for end of compactions
         - Read latte data (stress_after_cluster_upgrade) generating report file
-        - Compare latte report files and raise SCT ERROR event if latencies are worse for more than 10%
+        - Write latency results from the 'stress_after_cluster_upgrade' to Argus
         """
         self.upgrade_os(self.db_cluster.nodes)
 
@@ -1022,6 +1024,23 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         stress_before_upgrade_results = []
         for stress_before_upgrade_thread_pool in stress_before_upgrade_thread_pools:
             stress_before_upgrade_results.append(self.get_stress_results(stress_before_upgrade_thread_pool))
+        self.log.info("Stress results before upgrade: %s", stress_before_upgrade_results)
+
+        result_table = argus_results.LatteStressLatencyComparison()
+        # NOTE: write 'before' results to Argus
+        for i in range(len(stress_before_upgrade_results)):
+            row = f"#{i + 1}"
+            result_table.add_result(
+                column="before_ops", row=row, status=argus_results.Status.UNSET,
+                value=int(stress_before_upgrade_results[i][0]["op rate"]))
+            result_table.add_result(
+                column="before_mean", row=row, status=argus_results.Status.UNSET,
+                value=float(stress_before_upgrade_results[i][0]["latency mean"]))
+            result_table.add_result(
+                column="before_p99", row=row, status=argus_results.Status.UNSET,
+                value=float(stress_before_upgrade_results[i][0]["latency 99th percentile"]))
+        argus_results.submit_results_to_argus(argus_client=self.test_config.argus_client(), result_table=result_table)
+
         stress_during_entire_upgrade_thread_pools = self._run_stress_workload(
             "stress_during_entire_upgrade", wait_for_finish=False, round_robin=True)
 
@@ -1062,10 +1081,22 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         stress_after_upgrade_results = []
         for stress_after_upgrade_thread_pool in stress_after_upgrade_thread_pools:
             stress_after_upgrade_results.append(self.get_stress_results(stress_after_upgrade_thread_pool))
+        self.log.info("Stress results after upgrade: %s", stress_after_upgrade_results)
 
-        self.log.info(
-            "Going to compare following READ stress results:\nbefore upgrade: %s\nafter upgrade: %s",
-            stress_before_upgrade_results, stress_after_upgrade_results)
+        # NOTE: write 'after' results to Argus
+        for i in range(len(stress_after_upgrade_results)):
+            row = f"#{i + 1}"
+            result_table.add_result(
+                column="after_p99", row=row, status=argus_results.Status.UNSET,
+                value=float(stress_after_upgrade_results[i][0]["latency 99th percentile"]))
+            result_table.add_result(
+                column="after_mean", row=row, status=argus_results.Status.UNSET,
+                value=float(stress_after_upgrade_results[i][0]["latency mean"]))
+            result_table.add_result(
+                column="after_ops", row=row, status=argus_results.Status.UNSET,
+                value=int(stress_after_upgrade_results[i][0]["op rate"]))
+        argus_results.submit_results_to_argus(argus_client=self.test_config.argus_client(), result_table=result_table)
+
         assert len(stress_before_upgrade_results) > 0
         for stress_before_upgrade_result in stress_before_upgrade_results:
             assert len(stress_before_upgrade_result) > 0
@@ -1080,7 +1111,6 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
                 assert 'latency 99th percentile' in stress_after_upgrade_results[i][j]
                 current_latency_after = float(stress_after_upgrade_results[i][j]['latency 99th percentile'])
                 assert current_latency_after > 0
-                assert current_latency_after / current_latency_before < 1.2
 
     def test_kubernetes_scylla_upgrade(self):
         """


### PR DESCRIPTION
The `test_cluster_upgrade_latency_regression` test
is designed to run multiple unique latte stress commands.
It has following stress phases:
- populate data
- load before upgrade
- load during upgrade
- load after upgrade

So, make it write the `before` and `after` results into Argus making it be viewable by us.
And remove the assertion of expected proportions for results
because it is almost always will fail due to existence of some parallel operations
which make some of the `after` latencies be much bigger.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-rolling-upgrade-custom-d2-w1-latency-regression-v2#7](https://argus.scylladb.com/tests/scylla-cluster-tests/f146079b-90c6-445f-963b-433bb17bc13c)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
