### PR TITLE
fix(aws-provision): properly print count of nodes in provisioning phase

### DIFF
--- a/sdcm/provision/aws/provisioner.py
+++ b/sdcm/provision/aws/provisioner.py
@@ -120,11 +120,13 @@ class AWSInstanceProvisioner(InstanceProvisionerBase):
             instance_parameters_dict['Placement'] = {
                 'HostId': host_id
             }
-        LOGGER.info("[%s] Creating {count} on-demand instances using AMI id '%s' with following parameters:\n%s",
-                    provision_parameters.region_name,
-                    instance_parameters.ImageId,
-                    instance_parameters_dict
-                    )
+        LOGGER.info(
+            "[%s] Creating %d on-demand instances using AMI id '%s' with following parameters:\n%s",
+            provision_parameters.region_name,
+            count,
+            instance_parameters.ImageId,
+            instance_parameters_dict,
+        )
         instances = ec2_services[provision_parameters.region_name].create_instances(
             **instance_parameters_dict, MinCount=count, MaxCount=count)
         LOGGER.info("Created instances: %s.", instances)


### PR DESCRIPTION
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-rolling-upgrade-custom-d2-w1-latency-regression-v2#7](https://argus.scylladb.com/tests/scylla-cluster-tests/f146079b-90c6-445f-963b-433bb17bc13c)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
