### PR TITLE
fix(wait_ssh_up): use adaptive_timeout and triple the hard timeout

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1314,7 +1314,11 @@ class BaseNode(AutoSshContainerMixin):
         text = None
         if verbose:
             text = '%s: Waiting for SSH to be up' % self.name
-        wait.wait_for(func=self.remoter.is_up, step=10, text=text, timeout=timeout, throw_exc=True)
+
+        ssh_timeout_multiplier = 3
+        with adaptive_timeout(Operations.SSH_CONNECTIVITY, node=self, timeout=timeout, node_available=False):
+            wait.wait_for(func=self.remoter.is_up, step=10 * ssh_timeout_multiplier,
+                          text=text, timeout=timeout * ssh_timeout_multiplier, throw_exc=True)
 
     def is_port_used(self, port: int, service_name: str) -> bool:
         """Wait for the port to be used for the specified timeout. Returns True if used and False otherwise."""

--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -101,6 +101,7 @@ class Operations(Enum):
                                  ("timeout", "service_level_for_test_step"))
     TABLET_MIGRATION = ("tablet_migration", _get_soft_timeout, ("timeout",))
     HEALTHCHECK = ("healthcheck", _get_soft_timeout, ("timeout",))
+    SSH_CONNECTIVITY = ("ssh_connectivity", _get_soft_timeout, ("timeout",))
 
 
 class TestInfoServices:
@@ -165,11 +166,17 @@ def adaptive_timeout(operation: Operations, node: "BaseNode",  # noqa: PLR0914, 
     Use Operation.SOFT_TIMEOUT to set timeout explicitly without calculations.
     """
     tablet_sensitive_op = operation in {Operations.DECOMMISSION, Operations.NEW_NODE}
-    tablets_enabled = is_tablets_feature_enabled(node)
+    kwargs.setdefault('node_available', True)
+
+    # in some situations we may want to skip tablet check, since it depends on ssh connectivity
+    tablets_enabled = kwargs['node_available'] and is_tablets_feature_enabled(node)
 
     _, timeout_func, required_arg_names = operation.value
     args = {arg: kwargs[arg] for arg in required_arg_names}
-    store_metrics = node.parent_cluster.params.get("adaptive_timeout_store_metrics")
+
+    # if node is known to be not available, skip metrics gathering and use default timeouts
+    store_metrics = node.parent_cluster.params.get(
+        "adaptive_timeout_store_metrics") and kwargs['node_available']
     if store_metrics:
         metrics = NodeLoadInfoServices().get(node)
     else:


### PR DESCRIPTION
so we can track the issue we are seeing with ssh connectivity to nodes we are extending the timeout we wait for them x3, in case is some slowness during cloud-init.

also we are using `adaptive_timeout` so we track the cases it's taking more then original timeout we had.

Ref: #11581

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] aws provision test
- [x] short longevity - 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/160/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
