### PR TITLE
feature(xcloud): job for running thoughtput and latency test

### DIFF
--- a/configurations/performance/xcloud/overrides.yaml
+++ b/configurations/performance/xcloud/overrides.yaml
@@ -1,0 +1,5 @@
+# this file contains overrides specific for xcloud so we can run performance tests
+
+# not point of using those since scylla-cloud is creating the cluster and we can't control those
+use_placement_group: false
+use_capacity_reservation: false

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-master/perf-regression/scylla-cloud-perf-regression-predefined-throughput-steps-vnodes.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-master/perf-regression/scylla-cloud-perf-regression-predefined-throughput-steps-vnodes.jenkinsfile
@@ -1,0 +1,14 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: 'xcloud',
+    xcloud_provider: 'aws',
+    xcloud_env: 'staging',
+    region: 'us-east-1',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-vnodes.yaml", "configurations/performance/xcloud/overrides.yaml"]''',
+    sub_tests: ["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_write_gradual_increase_load", "test_read_disk_only_gradual_increase_load"],
+)

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-master/perf-regression/scylla-cloud-predefined-throughput-steps-sanity-vnodes.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-master/perf-regression/scylla-cloud-predefined-throughput-steps-sanity-vnodes.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: 'xcloud',
+    xcloud_provider: 'aws',
+    xcloud_env: 'staging',
+    region: 'us-east-1',
+    test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
+    // those removed "configurations/disable_kms.yaml", "configurations/tablets_disabled.yaml", "configurations/disable_speculative_retry.yaml"
+    // since we can't yet change scylla.yaml on xcloud directly from SCT
+    test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_reduced_steps_number.yaml" , "configurations/performance/latency-decorator-error-thresholds-steps-ent-vnodes.yaml", "configurations/performance/xcloud/overrides.yaml"]''',
+    sub_tests: ["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_write_gradual_increase_load", "test_read_disk_only_gradual_increase_load"],
+)

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -22,6 +22,12 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('backend', 'aws')}",
                description: 'aws|gce',
                name: 'backend')
+            string(defaultValue: "${pipelineParams.get('xcloud_provider', 'aws')}",
+                   description: 'Cloud provider for Scylla Cloud backend (only used when backend=xcloud). Supported providers: aws, gce',
+                   name: 'xcloud_provider')
+            string(defaultValue: "${pipelineParams.get('xcloud_env', 'lab')}",
+                   description: 'Scylla Cloud environment (only used when backend=xcloud). Supported environments: lab',
+                   name: 'xcloud_env')
             string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
                description: 'us-east-1|eu-west-1',
                name: 'region')


### PR DESCRIPTION
this introduced initial job, that we can try out and see if it can run on example of performance test

Ref: https://github.com/scylladb/qa-tasks/issues/1987

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :yellow_circle: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/scylla-cloud-perf-regression-predefined-throughput-steps-vnodes/19/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
