### PR TITLE
fix(triggers): fix datacenter parameter name for gce xcloud trigger

### DIFF
--- a/jenkins-pipelines/master-triggers/sct_triggers/xcloud-weekly-provisioning-trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/xcloud-weekly-provisioning-trigger.xml
@@ -69,7 +69,7 @@ requested_by_user=dimakr</properties>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
               <properties>scylla_version=release:latest
 provision_type=on_demand
-region=us-east1
+gce_datacenter=us-east1
 xcloud_provider=gce
 post_behavior_db_nodes=destroy
 post_behavior_monitor_nodes=destroy


### PR DESCRIPTION
Use proper region/datacenter parameter name for GCE cloud provider configuration in the trigger for xcloud backend sanity test.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
