### PR TITLE
fix(longevity-change-cluster-size-by-2-times.yaml): Change db instance to i8ge.2xlarge

### DIFF
--- a/jenkins-pipelines/oss/raft/longevity-double-cluster-with-schema-changes-with-raft.jenkinsfile
+++ b/jenkins-pipelines/oss/raft/longevity-double-cluster-with-schema-changes-with-raft.jenkinsfile
@@ -5,7 +5,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    region: 'eu-west-1',
+    region: 'us-east-1',
+    availability_zone: 'b',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-change-cluster-size-by-2-times.yaml", "configurations/raft/enable_raft_experimental.yaml"]''',
 

--- a/jenkins-pipelines/oss/tier2/longevity-double-cluster-with-schema-changes.jenkinsfile
+++ b/jenkins-pipelines/oss/tier2/longevity-double-cluster-with-schema-changes.jenkinsfile
@@ -5,7 +5,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    region: 'eu-west-1',
+    region: 'us-east-1',
+    availability_zone: 'b',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-change-cluster-size-by-2-times.yaml"]''',
 

--- a/jenkins-pipelines/oss/vnodes/tier2/longevity-double-cluster-with-schema-changes-vnodes.jenkinsfile
+++ b/jenkins-pipelines/oss/vnodes/tier2/longevity-double-cluster-with-schema-changes-vnodes.jenkinsfile
@@ -5,7 +5,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    region: 'eu-west-1',
+    region: 'us-east-1',
+    availability_zone: 'b',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-change-cluster-size-by-2-times.yaml", "configurations/tablets_disabled.yaml"]''',
 

--- a/test-cases/longevity/longevity-change-cluster-size-by-2-times.yaml
+++ b/test-cases/longevity/longevity-change-cluster-size-by-2-times.yaml
@@ -13,7 +13,10 @@ stress_cmd: ["cassandra-stress write cl=QUORUM duration=720m no-warmup -schema '
 n_db_nodes: 3
 n_loaders: 2
 
-instance_type_db: 'i3en.xlarge'
+# Note: the instance of i8ge is not supported on all region and not on all availability zones.
+# Example: i8ge.2xlarge is currently supported on us-east-1b,us-east-1c,us-east-1d. And not on us-east-1a.
+instance_type_db: 'i8ge.2xlarge'
+
 
 nemesis_class_name: 'GrowShrinkClusterNemesis:1 SisyphusMonkey:1'
 nemesis_selector: ["","schema_changes and not disruptive"]


### PR DESCRIPTION
The current db instance of 'i3en.xlarge' is too small, causing a cluster overload and topology operations failure.
Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/12392
Refs: https://github.com/scylladb/scylladb/issues/26769

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [i8ge.2xlarge](https://argus.scylladb.com/tests/scylla-cluster-tests/9ee4bf92-c0f0-45ed-933a-d2e0c9e59492)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
