### PR TITLE
fix(localhost-java): use java 25 LTS image

### DIFF
--- a/sdcm/utils/java.py
+++ b/sdcm/utils/java.py
@@ -3,7 +3,7 @@ import os
 from sdcm import sct_abs_path
 
 
-JAVA_DOCKER_IMAGE = 'openjdk:23-slim'
+JAVA_DOCKER_IMAGE = 'eclipse-temurin:25-jre-alpine'
 
 
 class JavaContainerMixin:


### PR DESCRIPTION
Drop using java23 image (as it is deprected) and switch to java25 LTS, for localhost java containers.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/12434

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [pr-provision-test with encryption enabled](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/28/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
