### PR TITLE
improvement(events): add RackAwarePolice event for scylla-bench load

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -95,6 +95,7 @@ SchemaDisagreementErrorEvent: ERROR
 ScyllaBenchLogEvent.ConsistencyError: ERROR
 ScyllaBenchLogEvent.DataValidationError: CRITICAL
 ScyllaBenchLogEvent.ParseDistributionError: CRITICAL
+ScyllaBenchLogEvent.RackAwarePolicy: NORMAL
 GeminiStressLogEvent.GeminiEvent: CRITICAL
 PrometheusAlertManagerEvent: CRITICAL
 ScyllaOperatorLogEvent: ERROR

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -269,6 +269,7 @@ class ScyllaBenchLogEvent(LogEvent, abstract=True):
     ConsistencyError: Type[LogEventProtocol]
     DataValidationError: Type[LogEventProtocol]
     ParseDistributionError: Type[LogEventProtocol]
+    RackAwarePolicy: Type[LogEventProtocol]
 
 
 ScyllaBenchLogEvent.add_subevent_type("ConsistencyError", severity=Severity.ERROR, regex=r"received only")
@@ -281,6 +282,8 @@ ScyllaBenchLogEvent.add_subevent_type(
     severity=Severity.CRITICAL,
     regex=r"missing parameter|unexpected parameter|unsupported"
           r"|invalid input value|distribution is invalid|distribution has invalid format")
+ScyllaBenchLogEvent.add_subevent_type("RackAwarePolicy", severity=Severity.NORMAL,
+                                      regex=r"Using provided rack name '.+' for RackAwareRoundRobinPolicy")
 
 
 SCYLLA_BENCH_ERROR_EVENTS = (
@@ -290,6 +293,11 @@ SCYLLA_BENCH_ERROR_EVENTS = (
 )
 SCYLLA_BENCH_ERROR_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
     [(re.compile(event.regex), event) for event in SCYLLA_BENCH_ERROR_EVENTS]
+
+SCYLLA_BENCH_NORMAL_EVENTS = (ScyllaBenchLogEvent.RackAwarePolicy(), )
+
+SCYLLA_BENCH_NORMAL_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
+    [(re.compile(event.regex), event) for event in SCYLLA_BENCH_NORMAL_EVENTS]
 
 CASSANDRA_HARRY_ERROR_EVENTS = (
 )


### PR DESCRIPTION
Information about running the scylla-bench load with the RackAwareRoundRobinPolicy has been added to the scylla-bench log file.
This commit introduces the following changes:

1. Detect when the load runs with RackAwareRoundRobinPolicy and publish a NORMAL ScyllaBenchLogEvent.RackAwarePolicy event.
2. Add unit tests for this event.

Task: https://github.com/scylladb/scylla-cluster-tests/issues/10899

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity-twcs-2h-rackaware](https://argus.scylladb.com/tests/scylla-cluster-tests/f37797ea-e259-4edf-a9dd-2dd53b5e8b9c)

Reported event:
```
2025-11-06 10:34:30.538: (ScyllaBenchLogEvent Severity.NORMAL) period_type=one-time event_id=406932dc-88dc-4854-96af-c98a82cf52a6: type=RackAwarePolicy regex=Using provided rack name '.+' for RackAwareRoundRobinPolicy line_number=2 node=Node longevity-twcs-3h-add-rack-loader-node-f37797ea-1 [54.247.233.117 | 10.4.1.114] (Type: c6i.xlarge) (rack: RACK0)
[2025-11-06 10:34:30.468] Using provided rack name 'RACK0' for RackAwareRoundRobinPolicy
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
