### PR TITLE
fix(latte): make latte latencies be parsed correctly

### DIFF
--- a/sdcm/loader.py
+++ b/sdcm/loader.py
@@ -226,7 +226,8 @@ class LatteExporter(StressExporter):
             return True
 
         # NOTE: all latency data lines consist of digits only.
-        if columns := line.split():
+        #       But we should trim out the [time prefix] written in square brackets.
+        if columns := line.split("]", maxsplit=1)[-1].split():
             for column in columns:
                 try:
                     float(column)
@@ -243,7 +244,7 @@ class LatteExporter(StressExporter):
 
     @staticmethod
     def split_line(line: str) -> list:
-        ret = line.split()
+        ret = line.split("]", maxsplit=1)[-1].split()
         if len(ret) != 12:
             LOGGER.error(
                 "'%s' line got splitted in the following unexpected list: %s",


### PR DESCRIPTION
Addition of a time prefix to each line of a stress log output (https://github.com/scylladb/scylla-cluster-tests/pull/11828) broke latencies reporting for latte.

So, fix it by filtering out that prefix before parsing latte results.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
