### PR TITLE
fix(test-cases): stop using prepared loaders

### DIFF
--- a/configurations/perf-loaders-non-shard-aware-config.yaml
+++ b/configurations/perf-loaders-non-shard-aware-config.yaml
@@ -1,5 +1,4 @@
 # manual on creating loader AMI's: see docs/new_loader_ami.md
 # AMIs from branch-perf-v8 with non-shardware driver
-use_prepared_loaders: true
 append_scylla_yaml:
   enable_shard_aware_drivers: false

--- a/configurations/perf-loaders-shard-aware-config.yaml
+++ b/configurations/perf-loaders-shard-aware-config.yaml
@@ -1,2 +1,2 @@
 # manual on creating loader AMI's: see docs/new_loader_ami.md
-use_prepared_loaders: true
+use_prepared_loaders: false

--- a/test-cases/longevity/longevity-multi-keyspaces.yaml
+++ b/test-cases/longevity/longevity-multi-keyspaces.yaml
@@ -32,6 +32,5 @@ user_prefix: 'longevity-1000-keyspaces'
 
 # TODO: remove when https://github.com/scylladb/scylla-tools-java/issues/175 resolved
 stop_test_on_stress_failure: false
-use_prepared_loaders: true
 
 use_preinstalled_scylla: true

--- a/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
@@ -29,7 +29,6 @@ backtrace_decoding: false
 
 store_perf_results: true
 email_recipients: ["scylla-perf-results@scylladb.com"]
-use_prepared_loaders: true
 use_hdrhistogram: true
 
 adaptive_timeout_store_metrics: false

--- a/test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-grow-shrink.yaml
@@ -29,7 +29,6 @@ backtrace_decoding: false
 
 store_perf_results: true
 email_recipients: ["scylla-perf-results@scylladb.com"]
-use_prepared_loaders: true
 use_hdrhistogram: true
 email_subject_postfix: 'latency during grow-shrink'
 hinted_handoff: 'enabled'

--- a/test-cases/performance/perf-regression-latency-mv-read-concurrency.yaml
+++ b/test-cases/performance/perf-regression-latency-mv-read-concurrency.yaml
@@ -24,7 +24,6 @@ append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --
 backtrace_decoding: false
 
 store_perf_results: true
-use_prepared_loaders: true
 use_hdrhistogram: true
 custom_es_index: 'mv-overloading-latency-read'
 

--- a/test-cases/performance/perf-regression.100threads.100M-keys-z3-enterprise.yaml
+++ b/test-cases/performance/perf-regression.100threads.100M-keys-z3-enterprise.yaml
@@ -12,7 +12,6 @@ stress_cmd_no_mv: "cassandra-stress read no-warmup cl=ALL n=200M -schema 'replic
 gce_network: 'qa-vpc'
 # NOTE: following is needed for the K8S case
 k8s_loader_run_type: 'static'
-use_prepared_loaders: true
 n_db_nodes: 3
 
 # Loaders

--- a/test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml
+++ b/test-cases/upgrades/customer-profile/rolling-upgrade-custom-d1.yaml
@@ -34,8 +34,6 @@ append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 
 
 use_mgmt: false
 
-use_prepared_loaders: true
-
 append_scylla_yaml:
   consistent_cluster_management: true
   force_schema_commit_log: true


### PR DESCRIPTION
There are still few test configs that have using prepared loaders enabled, even though this capability is deprecated. This change disables using prepared loaders in remaining configs.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/12464

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
