### PR TITLE
feature(SkipPerIssues): check also dtest skip labels

### DIFF
--- a/sdcm/utils/issues.py
+++ b/sdcm/utils/issues.py
@@ -163,7 +163,7 @@ class SkipPerIssues:
             branch_version = '.'.join(self.params.scylla_version.split('.')[0:2])
             issues_labels = sum([issue.labels for issue in self.issues], [])
 
-            return any(f'sct-{branch_version}-skip' in label.name for label in issues_labels)
+            return any(f'sct-{branch_version}-skip' in label.name for label in issues_labels) or any(f'dtest/{branch_version}-skip' in label.name for label in issues_labels)
 
         return False
 


### PR DESCRIPTION
since in lots of times the label we put for dtest skip are for the same reason we want it in SCT, so we change the code to look for any of the formats, `sct-2025.1-skip` or `dtest/2025.1-skip` so the process can be a bit more smooth (at least for SCT side of things)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-ami-arm-test/4/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
