### PR TITLE
fix(mgmt/cli.py): Fix download_bw and load_and_stream_bw to handle non-numerical results

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -526,7 +526,13 @@ class RestoreTask(ManagerTask):
             return None
 
         download_bandwidth_match = re.search(r"(\d+\.\d+)", download_bandwidth_str)
-        return float(download_bandwidth_match.group(1))
+        if download_bandwidth_match:
+            # Numerical value found, return it as a float
+            return float(download_bandwidth_match.group(1))
+        else:
+            # Non-numeric value found (e.g., 'unknown')
+            LOGGER.warning(f"Download bandwidth is non-numeric: {download_bandwidth_str.strip()}. Returning None.")
+            return None
 
     @property
     def load_and_stream_bw(self) -> float | None:
@@ -547,7 +553,13 @@ class RestoreTask(ManagerTask):
             return None
 
         las_bandwidth_match = re.search(r"(\d+\.\d+)", las_bandwidth_str)
-        return float(las_bandwidth_match.group(1))
+        if las_bandwidth_match:
+            # Numerical value found, return it as a float
+            return float(las_bandwidth_match.group(1))
+        else:
+            # Non-numeric value found (e.g., 'unknown'). Log warning and return None.
+            LOGGER.warning(f"Load&Stream bandwidth is non-numeric: {las_bandwidth_str.strip()}. Returning None.")
+            return None
 
     @property
     def post_restore_repair_duration(self) -> datetime.timedelta:


### PR DESCRIPTION
The mgmt cli function of download_bw fails on native restore where the restore task progress reports an output of:
```
Bandwidth:
  - Download:    unknown
  - Load&stream: unknown
```
It should handle this output and return None.
Refs: https://github.com/scylladb/scylla-manager/issues/4628
[Failing Argus run](https://argus.scylladb.com/tests/scylla-cluster-tests/2a0fccd9-fee5-43ec-877d-a288d3ccc52c)
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [native restore test](https://argus.scylladb.com/tests/scylla-cluster-tests/b5b7610e-421a-45c5-983d-cab23b4fdb42)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
