### PR TITLE
fix(scylla-bench): workaround for docker pull

### DIFF
--- a/defaults/docker_images/scylla-bench/values_scylla-bench.yaml
+++ b/defaults/docker_images/scylla-bench/values_scylla-bench.yaml
@@ -1,2 +1,2 @@
 scylla-bench:
-  image: scylladb/scylla-bench:0.3.1
+  image: scylladb/scylla-bench:0.3.1-amd64


### PR DESCRIPTION
Docker pull of scylla-bench started to fail. I got it in performance test with error:

docker pull scylladb/scylla-bench:0.3.1
Error response from daemon: no matching manifest for linux/amd64 in the manifest list entries: no match for platform in manifest: not found

As workaround run it with manifest explicitly

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] test running successfully: https://argus.scylladb.com/tests/scylla-cluster-tests/a6aa688c-3acd-4b2b-9294-e3e05f48057f

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
