### PR TITLE
fix(scylla-bench): update log parsing for new format

### DIFF
--- a/sdcm/loader.py
+++ b/sdcm/loader.py
@@ -387,8 +387,8 @@ class ScyllaBenchStressExporter(StressExporter):
 
     def metrics_position_in_log(self) -> MetricsPosition:
         # Enumerate stress metric position in the log. Example:
-        # time  operations/s    rows/s   errors  max   99.9th   99th      95th     90th       median        mean
-        # 1.033603151s    3439    34390    0  71.434239ms   70.713343ms   62.685183ms    2.818047ms  1.867775ms 1.048575ms  2.947276ms
+        # time   ops/s  rows/s errors max    99.9th 99th   95th   90th   median mean
+        # 1.1s  191149  191149      0 343ms  154ms  3.2ms  1.6ms  1.2ms  688µs  1.1ms
 
         return MetricsPosition(ops=1, lat_mean=10, lat_med=9, lat_perc_95=7, lat_perc_99=6, lat_perc_999=5,
                                lat_max=4, errors=3)
@@ -396,22 +396,21 @@ class ScyllaBenchStressExporter(StressExporter):
     def skip_line(self, line) -> bool:
         # If line is not starts with numeric ended by "s" - skip this line.
         # Example:
-        #    Client compression:  true
-        #    1.004777157s       2891    28910     0  67.829759ms   64.290815ms    58.327039ms    4.653055ms   3.244031µs   1.376255µs
+        #    [2025-11-10 15:21:00.186] Hdr memory consumption:	 85251200 bytes
+        #    [2025-11-10 15:21:01.187]  time   ops/s  rows/s errors max    99.9th 99th   95th   90th   median mean
+        #    [2025-11-10 15:21:01.187] 15m27s   89225   89225      0 5.3ms  3.8ms  2.7ms  1.7ms  1.4ms  1.1ms  1.1ms
 
-        line_splitted = (line or '').split()
-        if not line_splitted or not line_splitted[0].endswith('s'):
-            return True  # skip the line
-
-        try:
-            _ = float(line_splitted[0][:-1])
+        line_no_date = line.split(']', maxsplit=1)[-1].strip()
+        line_splitted = (line_no_date or '').split()
+        if len(line_splitted) == 11 and line_splitted[0].endswith("s"):
             return False  # The line hold the metrics, don't skip the line
-        except ValueError:
+        else:
             return True  # skip the line
 
     @staticmethod
     def split_line(line: str) -> list:
-        return [element.strip() for element in line.split()]
+        line_no_date = line.split(']', maxsplit=1)[-1].strip()
+        return [element.strip() for element in line_no_date.split()]
 
 
 class CassandraHarryStressExporter(StressExporter):

--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -281,7 +281,7 @@ class ScyllaBenchThread(DockerBasedStressThread):
 
         with ScyllaBenchStressExporter(instance_name=cmd_runner_name,
                                        metrics=nemesis_metrics_obj(),
-                                       stress_operation=self.sb_mode,
+                                       stress_operation=str(self.sb_mode.value),
                                        stress_log_filename=log_file_name,
                                        loader_idx=loader_idx), \
                 cleanup_context, \


### PR DESCRIPTION
The scylla-bench result log format has changed:
- Each line now starts with a date and time.
- The time column format has been updated and can no longer be converted directly to a float (e.g., it may appear as 15m27s).

As a result, Scylla-bench latency metrics are currently not displayed on the dashboard.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/12452

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/3622d882-d4fe-4d82-9b3d-f4bd40ef039f

<img width="2223" height="401" alt="image" src="https://github.com/user-attachments/assets/fd767d25-3eb1-4895-9c7c-b4faef5bd247" />


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
