### PR TITLE
fix(apt-keys): update the command to import keys

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -31,6 +31,7 @@ import traceback
 import itertools
 import json
 import shlex
+import uuid
 from decimal import Decimal, ROUND_UP
 from typing import List, Optional, Dict, Union, Set, Iterable, ContextManager, Any, IO, AnyStr, Callable, Literal
 from datetime import datetime, timezone
@@ -1902,12 +1903,7 @@ class BaseNode(AutoSshContainerMixin):
             result = self.remoter.run('cat %s' % repo_path, verbose=True)
             verify_scylla_repo_file(result.stdout, is_rhel_like=False)
             self.install_package('gnupg2')
-            self.remoter.sudo("mkdir -m 0755 -p /etc/apt/keyrings")
-            for apt_key in self.parent_cluster.params.get("scylla_apt_keys"):
-                self.remoter.sudo(f"gpg --homedir /tmp --no-default-keyring --keyring /etc/apt/keyrings/scylladb.gpg "
-                                  f"--keyserver hkp://keyserver.ubuntu.com:80 --keyserver-options timeout=10 --recv-keys {apt_key}",
-                                  retry=3)
-            self.remoter.sudo("chmod 644 /etc/apt/keyrings/scylladb.gpg")
+            self.fetch_apt_keys()
         self.update_repo_cache()
 
     def download_scylla_manager_repo(self, scylla_repo: str) -> None:
@@ -1924,12 +1920,33 @@ class BaseNode(AutoSshContainerMixin):
         self.remoter.sudo(f"chmod 644 {repo_path}")
 
         if self.distro.is_debian_like:
-            self.remoter.sudo("mkdir -m 0755 -p /etc/apt/keyrings")
-            for apt_key in self.parent_cluster.params.get("scylla_apt_keys"):
-                self.remoter.sudo(f"gpg --homedir /tmp --no-default-keyring --keyring /etc/apt/keyrings/scylladb.gpg "
-                                  f"--keyserver hkp://keyserver.ubuntu.com:80 --recv-keys {apt_key}", retry=3)
-            self.remoter.sudo("chmod 644 /etc/apt/keyrings/scylladb.gpg")
+            self.fetch_apt_keys()
             self.remoter.sudo("apt-get update", ignore_status=True)
+
+    def fetch_apt_keys(self):
+        """
+        Fetch and install GPG keys for ScyllaDB's APT repository.
+
+        Uses a temporary keyring in /tmp to fetch and export the keys, then installs them
+        into /etc/apt/keyrings/scylladb.gpg. This approach is required for compatibility
+        with Debian 13 and newer, which have changed how APT keys are managed and require
+        keys to be stored in /etc/apt/keyrings rather than the legacy /etc/apt/trusted.gpg.
+        The temporary keyring avoids polluting the system keyring and ensures the correct
+        format for APT to use.
+        """
+        self.remoter.sudo("mkdir -m 0755 -p /etc/apt/keyrings")
+        temp_keyring = f"/tmp/temp-{uuid.uuid4()}.gpg"
+        try:
+            # Import all keys into a temporary keyring
+            for apt_key in self.parent_cluster.params.get("scylla_apt_keys"):
+                self.remoter.sudo(
+                    f"gpg --homedir /tmp --no-default-keyring --keyring {temp_keyring} --keyserver hkp://keyserver.ubuntu.com:80 --keyserver-options timeout=10 --recv-keys {apt_key}", retry=3)
+            # Export all keys at once to the keyring file
+            self.remoter.sudo(shell_script_cmd(
+                f"gpg --homedir /tmp --no-default-keyring --keyring {temp_keyring} --export --armor | gpg --dearmor > /etc/apt/keyrings/scylladb.gpg"), retry=3)
+        finally:
+            # Ensure cleanup
+            self.remoter.sudo(f"rm -f {temp_keyring}", ignore_status=True)
 
     @retrying(n=30, sleep_time=15, allowed_exceptions=(UnexpectedExit, Libssh2_UnexpectedExit,))
     def install_package(self,


### PR DESCRIPTION
the current command wasn't working for debian-13, this command now working and enable us to import all of the keys we have into the same keyring

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2404-test/49/
- [x] tested locally with debian-13

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
