### PR TITLE
fix(gemini): pin the image to the amd64 image

### DIFF
--- a/defaults/docker_images/gemini/values_gemini.yaml
+++ b/defaults/docker_images/gemini/values_gemini.yaml
@@ -1,2 +1,2 @@
 gemini:
-  image: scylladb/gemini:2.1.5
+  image: scylladb/gemini:2.1.5-amd64


### PR DESCRIPTION
since the last docker update we are failing to pull image from the manifest with the following error:

```
Error response from daemon: no matching manifest for linux/amd64 in the
manifest list entries: no match for platform in manifest: not found
```

we assume it's cause this manifest have a v3 variant, so this change is pinning stright to the amd64 image, skipping the manifest.

for now it's safe since we don't run any of the gemini tests with ARM based loaders

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] integration tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
