### PR TITLE
fix(docker): fix all deprecated references to IPAddress

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -625,7 +625,7 @@ def list_resources(ctx, user, test_id, get_all, get_all_running, verbose, backen
                         docker_table.add_row([
                             container.name,
                             builder_name,
-                            container.attrs["NetworkSettings"]["IPAddress"] if get_all_running else container.status,
+                            container.attrs["NetworkSettings"]["Networks"]["bridge"]["IPAddress"] if get_all_running else container.status,
                             container.labels.get("TestId", "N/A"),
                             container.labels.get("RunByUser", "N/A"),
                             container.attrs.get("Created", "N/A"),

--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -675,7 +675,7 @@ def get_running_instances_for_email_report(test_id: str, ip_filter: str = None):
         for container in containers:
             container.reload()
             nodes.append([container.name,
-                          container.attrs["NetworkSettings"]["IPAddress"],
+                          container.attrs["NetworkSettings"]["Networks"]["bridge"]["IPAddress"],
                           container.status,
                           "docker container",
                           builder_name])

--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -43,7 +43,7 @@ class RemoteDocker(BaseNode):
                     f" {self.docker_id}").stdout.strip()
             else:
                 self._internal_ip_address = self.node.remoter.run(
-                    f"docker inspect --format='{{{{ .NetworkSettings.IPAddress }}}}' {self.docker_id}").stdout.strip()
+                    f"docker inspect --format='{{{{ .NetworkSettings.Networks.bridge.IPAddress }}}}' {self.docker_id}").stdout.strip()
         return self._internal_ip_address
 
     @property

--- a/sdcm/utils/docker_utils.py
+++ b/sdcm/utils/docker_utils.py
@@ -312,7 +312,7 @@ class ContainerManager:
             ip_address = cls.get_container(
                 instance, name).attrs["NetworkSettings"]["Networks"][docker_network]["IPAddress"]
         else:
-            ip_address = cls.get_container(instance, name).attrs["NetworkSettings"]["IPAddress"]
+            ip_address = cls.get_container(instance, name).attrs["NetworkSettings"]["Networks"]["bridge"]["IPAddress"]
         if not ip_address:
             raise Retry
         return ip_address

--- a/unit_tests/test_utils_docker.py
+++ b/unit_tests/test_utils_docker.py
@@ -282,8 +282,8 @@ class TestContainerManager(unittest.TestCase):
 
     @patch("time.sleep", int)
     def test_get_ip_address(self):
-        no_ip_address = dict(NetworkSettings=dict(IPAddress=""))
-        ip_address = dict(NetworkSettings=dict(IPAddress="10.0.0.1"))
+        no_ip_address = dict(NetworkSettings=dict(Networks=dict(bridge=dict(IPAddress=""))))
+        ip_address = dict(NetworkSettings=dict(Networks=dict(bridge=dict(IPAddress="10.0.0.1"))))
         ip_addresses = iter((no_ip_address, no_ip_address, ip_address, "mark", ) + (no_ip_address, ) * 10)
 
         def attrs():


### PR DESCRIPTION
seems like the API for docker instance networking was changed and some parts were deprecated while we didn't noticed and now we did,

and this change replace all the places to look within bridged network

Ref: https://docs.docker.com/engine/deprecated/#top-level-network-properties-in-networksettings

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
