### PR TITLE
improvement(utils): ensure scylla-qa-internal repo for xcloud backend

### DIFF
--- a/sdcm/utils/internal_modules.py
+++ b/sdcm/utils/internal_modules.py
@@ -1,11 +1,29 @@
 import sys
 from pathlib import Path
 
+from sdcm.remote import LOCALRUNNER
+from sdcm.utils.git import clone_repo
+
+scylla_qa_internal_path = Path(__file__).resolve().parents[2] / 'scylla-qa-internal'
+if not scylla_qa_internal_path.exists():
+    print("scylla-qa-internal not found, cloning...")
+    try:
+        clone_repo(
+            remoter=LOCALRUNNER,
+            repo_url="git@github.com:scylladb/scylla-qa-internal.git",
+            destination_dir_name=str(scylla_qa_internal_path),
+            clone_as_root=False,
+            branch="master")
+        print("Successfully cloned scylla-qa-internal")
+    except Exception as exc:  # noqa: BLE001
+        print(f"Failed to clone scylla-qa-internal: {exc}")
+
+
 # Add scylla-qa-internal to the Python path using pathlib
 # TODO: make this support multiple paths if needed
-scylla_qa_internal_path = str((Path(__file__).parent.parent.parent / 'scylla-qa-internal').resolve())
-if scylla_qa_internal_path not in sys.path:
-    sys.path.insert(0, scylla_qa_internal_path)
+scylla_qa_internal_path_str = str(scylla_qa_internal_path)
+if scylla_qa_internal_path_str not in sys.path:
+    sys.path.insert(0, scylla_qa_internal_path_str)
 
 # Import the internal modules
 try:


### PR DESCRIPTION
Ensure that the scylla-qa-internal repo is cloned into the local SCT checkout when tests are executed on the xcloud backend. This repo is required for establishing SSH connectivity to cloud cluster DB nodes.

Closes: https://github.com/scylladb/qa-tasks/issues/2006

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: tested locally (in CI there is a separate pipeline step that clones this repo, it is executed before the `run-test` command starts the test)
```
sct.py run-test longevity_test.LongevityTest.test_custom_time --backend xcloud 
Connected to: <socket.socket fd=4, family=2, type=1, proto=0, laddr=('127.0.0.1', 34498), raddr=('127.0.0.1', 38531)>.
Connected to pydev debugger (build 252.23892.515)
scylla-qa-internal not found, cloning...
Successfully cloned scylla-qa-internal
...
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
