### PR TITLE
fix(get_datacenter_name_per_region): use first alive nodes to get datacenter name

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3456,12 +3456,16 @@ class BaseCluster:
     def get_datacenter_name_per_region(self, db_nodes=None):
         datacenter_name_per_region = {}
         for region, nodes in self.nodes_by_region(nodes=db_nodes).items():
-            if status := nodes[0].get_nodes_status():
+            node = next((node for node in nodes if node.db_up()), None)
+            if node is None:
+                LOGGER.error("No DB up node found in region %s to get datacenter name", region)
+                continue
+            if status := node.get_nodes_status():
                 # If `nodetool status` failed to get status for the node
-                if dc_name := status.get(nodes[0], {}).get('dc'):
+                if dc_name := status.get(node, {}).get('dc'):
                     datacenter_name_per_region[region] = dc_name
             else:
-                LOGGER.error("Failed to get nodes status from node %s", nodes[0].name)
+                LOGGER.error("Failed to get nodes status from node %s", node.name)
 
         return datacenter_name_per_region
 

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -450,12 +450,13 @@ class TestBaseMonitorSet(unittest.TestCase):
 
 class NodetoolDummyNode(BaseNode):
 
-    def __init__(self, resp, myregion=None, myname=None, myrack=None):
+    def __init__(self, resp, myregion=None, myname=None, myrack=None, db_up=True):
         self.resp = resp
         self.myregion = myregion
         self.myname = myname
         self.parent_cluster = None
         self.rack = myrack
+        self._db_up = db_up
 
     @property
     def region(self):
@@ -467,6 +468,12 @@ class NodetoolDummyNode(BaseNode):
 
     def run_nodetool(self, *args, **kwargs):
         return Result(exited=0, stderr="", stdout=self.resp)
+
+    def db_up(self):
+        """ return True if the database is up
+        Couldn't be a property, because BaseNode.db_up is a method
+        """
+        return self._db_up
 
 
 class DummyScyllaCluster(BaseScyllaCluster, BaseCluster):
@@ -554,6 +561,62 @@ class TestNodetoolStatus(unittest.TestCase):
         assert datacenter_name_per_region == {'east-us': 'eastus', 'west-us': 'westus'}
 
         datacenter_name_per_region = db_cluster.get_datacenter_name_per_region(db_nodes=[node1])
+        assert datacenter_name_per_region == {'east-us': 'eastus'}
+
+    def test_datacenter_name_per_region_when_region_doesnt_have_live_nodes(self):
+        resp = "\n".join(["Datacenter: eastus",
+                          "==================",
+                          "Status=Up/Down",
+                          "|/ State=Normal/Leaving/Joining/Moving",
+                          "--  Address   Load       Tokens       Owns    Host ID                               Rack",
+                          "UN  10.0.59.34    21.71 GB   256          ?       e5bcb094-e4de-43aa-8dc9-b1bf74b3b346  1a",
+                          "UN  10.0.198.153  ?          256          ?       fba174cd-917a-40f6-ab62-cc58efaaf301  1a",
+                          "Datacenter: westus",
+                          "==================",
+                          "Status=Up/Down",
+                          "|/ State=Normal/Leaving/Joining/Moving",
+                          "--  Address   Load       Tokens       Owns    Host ID                               Rack",
+                          "DN  10.1.59.34    21.71 GB   256          ?       e5bcb094-e4de-43aa-8dc9-b1bf74546346  2a"
+                          ]
+                         )
+        node1 = NodetoolDummyNode(resp=resp, myregion="east-us", myname="10.0.59.34")
+        node2 = NodetoolDummyNode(resp=resp, myregion="east-us", myname="10.0.198.153")
+        node3 = NodetoolDummyNode(resp=resp, myregion="west-us", myname='10.1.59.34', db_up=False)
+        db_cluster = DummyScyllaCluster([node1, node2, node3])
+        setattr(db_cluster, "params", {"use_zero_nodes": False})
+        node1.parent_cluster = node2.parent_cluster = node3.parent_cluster = db_cluster
+        datacenter_name_per_region = db_cluster.get_datacenter_name_per_region()
+        assert datacenter_name_per_region == {'east-us': 'eastus'}
+
+        datacenter_name_per_region = db_cluster.get_datacenter_name_per_region(db_nodes=[node3])
+        assert datacenter_name_per_region == {}
+
+    def test_datacenter_name_per_region_when_first_node_is_dn(self):
+        resp = "\n".join(["Datacenter: eastus",
+                          "==================",
+                          "Status=Up/Down",
+                          "|/ State=Normal/Leaving/Joining/Moving",
+                          "--  Address   Load       Tokens       Owns    Host ID                               Rack",
+                          "DN  10.0.59.34    21.71 GB   256          ?       e5bcb094-e4de-43aa-8dc9-b1bf74b3b346  1a",
+                          "UN  10.0.198.153  ?          256          ?       fba174cd-917a-40f6-ab62-cc58efaaf301  1a",
+                          "Datacenter: westus",
+                          "==================",
+                          "Status=Up/Down",
+                          "|/ State=Normal/Leaving/Joining/Moving",
+                          "--  Address   Load       Tokens       Owns    Host ID                               Rack",
+                          "UN  10.1.59.34    21.71 GB   256          ?       e5bcb094-e4de-43aa-8dc9-b1bf74546346  2a"
+                          ]
+                         )
+        node1 = NodetoolDummyNode(resp=resp, myregion="east-us", myname="10.0.59.34", db_up=False)
+        node2 = NodetoolDummyNode(resp=resp, myregion="east-us", myname="10.0.198.153")
+        node3 = NodetoolDummyNode(resp=resp, myregion="west-us", myname='10.1.59.34')
+        db_cluster = DummyScyllaCluster([node1, node2, node3])
+        setattr(db_cluster, "params", {"use_zero_nodes": False})
+        node1.parent_cluster = node2.parent_cluster = node3.parent_cluster = db_cluster
+        datacenter_name_per_region = db_cluster.get_datacenter_name_per_region()
+        assert datacenter_name_per_region == {'east-us': 'eastus', 'west-us': 'westus'}
+
+        datacenter_name_per_region = db_cluster.get_datacenter_name_per_region(db_nodes=[node1, node2])
         assert datacenter_name_per_region == {'east-us': 'eastus'}
 
     def test_get_rack_names_per_datacenter_and_rack_idx(self):


### PR DESCRIPTION
method get_datacenter_name_per_region use the nodes[0] to get datacenter name.
But it could be down by nemesis as in job example:
https://argus.scylladb.com/tests/scylla-cluster-tests/3214440e-ead0-4eea-b880-a63938368b8e
In the job nemesis RestartElectedTopologyCoordinator stops nodes[0]:
first node in list(because it was topology coordinator) and then try to
run `nodetool status` on node that is down.
```
 if status := nodes[0].get_nodes_status():
```
this cause to nemesis thread to stuck.

Fix get_datacenter_name_per_region to get first alive node
in sorted by dc nodes to get real name of datacente
### Testing
- [Failed job before fix](https://argus.scylladb.com/tests/scylla-cluster-tests/3214440e-ead0-4eea-b880-a63938368b8e) 
- [Passed job after fix](https://argus.scylladb.com/tests/scylla-cluster-tests/aef508b5-2cc9-43dc-8d84-4161cb677765)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
