### PR TITLE
ci(perf): add `custom-d1` latency steady state test to CI trigger config

### DIFF
--- a/configurations/performance/latte-perf-regression-latency-steady-state-custom-d1-workload1.yaml
+++ b/configurations/performance/latte-perf-regression-latency-steady-state-custom-d1-workload1.yaml
@@ -1,5 +1,5 @@
 test_duration: 300
-n_db_nodes: 8
+n_db_nodes: 9
 n_loaders: 2
 stress_duration: 60
 

--- a/vars/perfRegressionParallelPipelinebyRegion.groovy
+++ b/vars/perfRegressionParallelPipelinebyRegion.groovy
@@ -28,6 +28,7 @@ def call(Map pipelineParams) {
                     0 8 * * 6 %scylla_version=master:latest;labels_selector=alternator-weekly;requested_by_user=radoslawcybulski
                     00 6 * * 0 %scylla_version=master:latest;labels_selector=master-weekly;requested_by_user=juliayakovlev
                     0 23 */21 * * %scylla_version=master:latest;labels_selector=master-3weeks;requested_by_user=juliayakovlev
+                    13 6 8-14 * 2 %scylla_version=master:latest;labels_selector=gce-custom-monthly;requested_by_user=valerii.ponomarov
                 '''
             )
         }
@@ -51,6 +52,7 @@ def call(Map pipelineParams) {
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-vnodes',
                                 region: 'us-east-1',
                                 versions: ['2024.1', '2024.2', '2025.1', '2025.2', '2025.3', '2025.4', 'master'],
+                                pre_release: [], // Example: ['rc1', 'rc3']
                                 sub_tests: ['"test_read_gradual_increase_load"', '"test_mixed_gradual_increase_load"'],
                                 labels: ['master-weekly']
                             ],
@@ -58,6 +60,7 @@ def call(Map pipelineParams) {
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-vnodes',
                                 region: 'us-east-1',
                                 versions: ['2024.1', '2024.2', '2025.1', '2025.2', '2025.3', '2025.4', 'master'],
+                                pre_release: [],
                                 sub_tests: ['"test_write_gradual_increase_load"'],
                                 labels: ['master-weekly']
                             ],
@@ -65,6 +68,7 @@ def call(Map pipelineParams) {
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade',
                                 region: 'eu-west-1',
                                 versions: ['2024.1', '2024.2', '2025.1', '2025.2', '2025.3', '2025.4', 'master'],
+                                pre_release: [],
                                 sub_tests: ['"test_latency_mixed_with_upgrade"'],
                                 labels: ['master-weekly'],
                                 rolling_upgrade_test: true
@@ -73,6 +77,7 @@ def call(Map pipelineParams) {
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis',
                                 region: 'eu-west-2',
                                 versions: ['2024.1', '2024.2', '2025.1', '2025.2', '2025.3', '2025.4',],
+                                pre_release: [],
                                 sub_tests: ['"test_latency_mixed_with_nemesis"'],
                                 labels: ['master-weekly']
                             ],
@@ -80,6 +85,7 @@ def call(Map pipelineParams) {
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis',
                                 region: 'eu-west-2',
                                 versions: ['master'],
+                                pre_release: [],
                                 sub_tests: ['"test_latency_mixed_with_nemesis"', '"test_latency_read_with_nemesis"', '"test_latency_write_with_nemesis"'],
                                 labels: ['master-weekly']
                             ],
@@ -87,6 +93,7 @@ def call(Map pipelineParams) {
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-rbno-disabled',
                                 region: 'eu-west-3',
                                 versions: ['2024.1', '2024.2', '2025.1', '2025.2', '2025.3', '2025.4', 'master'],
+                                pre_release: [],
                                 sub_tests: ['"test_latency_mixed_with_nemesis"'],
                                 labels: ['master-weekly']
                             ],
@@ -94,6 +101,7 @@ def call(Map pipelineParams) {
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64',
                                 region: 'us-east-1',
                                 versions: ['2024.1', '2024.2', '2025.1', '2025.2', '2025.3', '2025.4', 'master'],
+                                pre_release: [],
                                 sub_tests: ['microbenchmark'],
                                 labels: ['master-weekly'],
                                 microbenchmark: true
@@ -102,6 +110,7 @@ def call(Map pipelineParams) {
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64-write',
                                 region: 'us-east-1',
                                 versions: ['2024.1', '2024.2', '2025.1', '2025.2', '2025.3', '2025.4', 'master'],
+                                pre_release: [],
                                 sub_tests: ['microbenchmark'],
                                 labels: ['master-weekly'],
                                 microbenchmark: true
@@ -110,6 +119,7 @@ def call(Map pipelineParams) {
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64',
                                 region: 'us-east-1',
                                 versions: ['2024.1', '2024.2', '2025.1', '2025.2', '2025.3', '2025.4', 'master'],
+                                pre_release: [],
                                 sub_tests: ['microbenchmark'],
                                 labels: ['master-weekly'],
                                 microbenchmark: true
@@ -118,6 +128,7 @@ def call(Map pipelineParams) {
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64-write',
                                 region: 'us-east-1',
                                 versions: ['2024.1', '2024.2', '2025.1', '2025.2', '2025.3', '2025.4', 'master'],
+                                pre_release: [],
                                 sub_tests: ['microbenchmark'],
                                 labels: ['master-weekly'],
                                 microbenchmark: true
@@ -126,6 +137,7 @@ def call(Map pipelineParams) {
                                 job_name: 'scylla-master/perf-regression/perf-regression-predefined-throughput-steps-sanity-vnodes',
                                 region: '',
                                 versions: [],
+                                pre_release: [],
                                 sub_tests: [],
                                 labels: ['master-daily']
                             ],
@@ -136,11 +148,21 @@ def call(Map pipelineParams) {
                                 sub_tests: ['test_full'],
                                 labels: ['alternator-weekly']
                             ],
+                            [
+                                job_name: 'scylla-master/perf-regression/latte-perf-regression-latency-steady-state-custom-d1-workload1-vnodes',
+                                cloud_provider: 'gce',
+                                region: 'us-east1',
+                                versions: ['2025.1', '2025.2', '2025.3', '2025.4', 'master'],
+                                pre_release: ['rc1', 'rc3'],
+                                sub_tests: ['"test_latency_steady_state"'],
+                                labels: ['gce-custom-monthly']
+                            ],
                             // Tablets
                             [
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-tablets',
                                 region: 'us-east-1',
                                 versions: ['2025.1', '2025.2', '2025.3', '2025.4', 'master'],
+                                pre_release: [],
                                 sub_tests: ['"test_read_gradual_increase_load"', '"test_mixed_gradual_increase_load"'],
                                 labels: ['master-weekly']
                             ],
@@ -148,14 +170,25 @@ def call(Map pipelineParams) {
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-write-tablets',
                                 region: 'us-east-1',
                                 versions: ['2025.1', '2025.2', '2025.3', '2025.4', 'master'],
+                                pre_release: [],
                                 sub_tests: ['"test_write_gradual_increase_load"'],
                                 labels: ['master-weekly']
+                            ],
+                            [
+                                job_name: 'scylla-master/perf-regression/latte-perf-regression-latency-steady-state-custom-d1-workload1-tablets',
+                                cloud_provider: 'gce',
+                                region: 'us-east1',
+                                versions: ['2025.1', '2025.2', '2025.3', '2025.4', 'master'],
+                                pre_release: ['rc1', 'rc3'],
+                                sub_tests: ['"test_latency_steady_state"'],
+                                labels: ['gce-custom-monthly']
                             ],
                             // One in 3 weeks
                             [
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-during-rolling-upgrade-tablets',
                                 region: 'eu-west-2',
                                 versions: ['2025.1', '2025.2', '2025.3', '2025.4', 'master'],
+                                pre_release: [],
                                 sub_tests: ['"test_latency_mixed_with_upgrade"'],
                                 labels: ['master-3weeks'],
                                 rolling_upgrade_test: true
@@ -164,6 +197,7 @@ def call(Map pipelineParams) {
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-tablets',
                                 region: 'eu-west-3',
                                 versions: ['2025.1', '2025.2', '2025.3', '2025.4', ],
+                                pre_release: [],
                                 sub_tests: ['"test_latency_read_with_nemesis"', '"test_latency_mixed_with_nemesis"'],
                                 labels: ['master-3weeks']
                             ],
@@ -171,6 +205,7 @@ def call(Map pipelineParams) {
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-with-nemesis-tablets',
                                 region: 'eu-west-3',
                                 versions: ['master'],
+                                pre_release: [],
                                 sub_tests: ['"test_latency_mixed_with_nemesis"'],
                                 labels: ['master-3weeks']
                             ],
@@ -178,6 +213,7 @@ def call(Map pipelineParams) {
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-elasticity',
                                 region: 'eu-north-1',
                                 versions: ['2025.1', '2025.2', '2025.3', '2025.4', ],
+                                pre_release: [],
                                 sub_tests: ['"test_latency_mixed_with_nemesis"', '"test_latency_write_with_nemesis"'],
                                 labels: ['master-3weeks']
                             ],
@@ -185,6 +221,7 @@ def call(Map pipelineParams) {
                                 job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-latency-650gb-elasticity',
                                 region: 'eu-north-1',
                                 versions: ['master'],
+                                pre_release: [],
                                 sub_tests: ['"test_latency_mixed_with_nemesis"'],
                                 labels: ['master-3weeks']
                             ],
@@ -225,6 +262,12 @@ def call(Map pipelineParams) {
                                     if (version) {
                                         if (labels_selector && !(entry.labels.contains(labels_selector))) {
                                             println("Skipping job $job_name for labels_selector: $labels_selector")
+                                            continue
+                                        }
+                                        // NOTE: Check that Scylla version matches specified 'pre-release' parts.
+                                        //       Semver structure: <major> "." <minor> "." <patch> "-" <pre-release> "+" <build>
+                                        if (entry.pre_release && !entry.pre_release.any { pr -> version.contains("-${pr}") }) {
+                                            println("Skipping job $job_name because $version version doesn't match specified pre-releases: ${entry.pre_release}")
                                             continue
                                         }
                                         region = entry.region


### PR DESCRIPTION
Ref: https://github.com/scylladb/qa-tasks/issues/2004

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
