### PR TITLE
feat: Add Python driver to the cache-issues workflow

### DIFF
--- a/.github/workflows/cache-issues.yaml
+++ b/.github/workflows/cache-issues.yaml
@@ -13,7 +13,7 @@ jobs:
       - run: |
           mkdir -p issues
           mkdir -p issues/pull-requests
-          for repo in scylladb scylla-enterprise scylla-manager scylla-operator scylla-cluster-tests scylla-dtest qa-tasks scylla-tools-java siren scylla-drivers ; do
+          for repo in scylladb scylla-enterprise scylla-manager scylla-operator scylla-cluster-tests scylla-dtest qa-tasks scylla-tools-java siren scylla-drivers python-driver ; do
             gh issue list --state all --json number,state,labels,title --limit 30000 --template '{{range .}}{{.number}},{{.state}},{{range .labels}}{{.name}}|{{end}},{{.title}}{{println ""}}{{end}}' --repo scylladb/$repo > issues/scylladb_$repo.csv
             gh pr list --state all --json number,state,labels,title --limit 30000 --template '{{range .}}{{.number}},{{.state}},{{range .labels}}{{.name}}|{{end}},{{.title}}{{println ""}}{{end}}' --repo scylladb/$repo > issues/pull-requests/scylladb_$repo.csv
           done


### PR DESCRIPTION
We want to reference python driver issues in dtest (ref: https://github.com/scylladb/scylla-dtest/pull/6416, https://github.com/scylladb/scylladb/issues/16709)
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] locally

