### PR TITLE
fix(adaptive_timeout): remove unneeded warnings

### DIFF
--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -59,6 +59,11 @@ def _get_soft_timeout(node_info_service: NodeLoadInfoService, timeout: int | flo
         return timeout, {}
 
 
+def _get_soft_timeout_no_node_info(node_info_service: NodeLoadInfoService, timeout: int | float = None) -> tuple[int | float, dict[str, Any]]:
+    # no timeout calculation - just return the timeout passed as argument without node load info
+    return timeout, {}
+
+
 def _get_query_timeout(node_info_service: NodeLoadInfoService, timeout: int | float = None, query: str = None) -> \
         tuple[int | float, dict[str, Any]]:
     timeout, stats = _get_soft_timeout(node_info_service=node_info_service, timeout=timeout)
@@ -101,7 +106,7 @@ class Operations(Enum):
                                  ("timeout", "service_level_for_test_step"))
     TABLET_MIGRATION = ("tablet_migration", _get_soft_timeout, ("timeout",))
     HEALTHCHECK = ("healthcheck", _get_soft_timeout, ("timeout",))
-    SSH_CONNECTIVITY = ("ssh_connectivity", _get_soft_timeout, ("timeout",))
+    SSH_CONNECTIVITY = ("ssh_connectivity", _get_soft_timeout_no_node_info, ("timeout",))
 
 
 class TestInfoServices:


### PR DESCRIPTION
the change in #12328 are causing lots of warnings while doing the inital ssh connectivity, since we are not collecting node metrics and info.

this chage is replacing the callback used, to one that doesn't assume node information is available.

Fixes: #12463

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟡  aws provision test - failure in stress command 👍🏼 
```
The option `rf_rack_valid_keyspaces` is enabled. It requires that all keyspaces are RF-rack-valid. That condition is violated: keyspace 'drop_table_during_repair_ks_0' doesn't satisfy it for DC 'eu-west-1': RF=2 vs. rack count=3
```
- [x] 🟢  aws provision test
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
