### PR TITLE
feature(upgrade-test): add configuration to disable Gemini during rolling upgrades

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -118,6 +118,7 @@ authenticator_password: ''
 n_test_oracle_db_nodes: 1
 oracle_scylla_version: '2022.1.14'
 append_scylla_args_oracle: '--enable-cache false'
+run_gemini_in_rolling_upgrade: false
 
 # cassandra-stress defaults
 stress_multiplier: 1

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1149,6 +1149,15 @@ table options for created table. example:<br>["cdc={'enabled': true}"]<br>["cdc=
 **type:** list
 
 
+## **run_gemini_in_rolling_upgrade** / SCT_RUN_GEMINI_IN_ROLLING_UPGRADE
+
+Enable running Gemini workload during rolling upgrade test. Default is false.
+
+**default:** N/A
+
+**type:** boolean
+
+
 ## **instance_type_loader** / SCT_INSTANCE_TYPE_LOADER
 
 AWS image type of the loader node

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -754,6 +754,8 @@ class SCTConfiguration(dict):
              help="""table options for created table. example:
                      ["cdc={'enabled': true}"]
                      ["cdc={'enabled': true}", "compaction={'class': 'IncrementalCompactionStrategy'}"] """),
+        dict(name="run_gemini_in_rolling_upgrade", env="SCT_RUN_GEMINI_IN_ROLLING_UPGRADE", type=boolean,
+             help="Enable running Gemini workload during rolling upgrade test. Default is false."),
         # AWS config options
 
         dict(name="instance_type_loader", env="SCT_INSTANCE_TYPE_LOADER", type=str,

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -45,3 +45,6 @@ gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'
 use_preinstalled_scylla: false
 
 gemini_log_cql_statements: false
+
+# Disable Gemini workload during rolling upgrade test
+run_gemini_in_rolling_upgrade: false

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -668,13 +668,17 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             metric_query='sct_cassandra_stress_write_gauge{type="ops", keyspace="keyspace1"}'
                          'or sct_cql_stress_cassandra_stress_write_gauge{type="ops", keyspace="keyspace1"}', n=5)
 
-        self.actions_log.info("Starting gemini during upgrade")
-        gemini_cmd = self.params.get("gemini_cmd")
-        if self.enable_cdc_for_tables:
-            gemini_cmd += " --table-options \"cdc={'enabled': true}\""
-        gemini_thread = self.run_gemini(gemini_cmd)
-        self.metric_has_data(
-            metric_query='sum(increase(gemini_cql_requests[1m]))', n=10)
+        gemini_thread = None
+        if self.params.get("run_gemini_in_rolling_upgrade"):
+            self.actions_log.info("Starting gemini during upgrade")
+            gemini_cmd = self.params.get("gemini_cmd")
+            if self.enable_cdc_for_tables:
+                gemini_cmd += " --table-options \"cdc={'enabled': true}\""
+            gemini_thread = self.run_gemini(gemini_cmd)
+            self.metric_has_data(
+                metric_query='sum(increase(gemini_cql_requests[1m]))', n=10)
+        else:
+            self.actions_log.info("Gemini workload is disabled for this rolling upgrade test")
 
         with ignore_upgrade_schema_errors():
 
@@ -861,8 +865,11 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
                                         'entire test, actual: %d' % (
                 error_factor, schema_load_error_num)
 
-        self.actions_log.info('Step10 - Verify that gemini did not failed during upgrade')
-        self.verify_gemini_results(queue=gemini_thread)
+        if gemini_thread:
+            self.actions_log.info('Step10 - Verify that gemini did not failed during upgrade')
+            self.verify_gemini_results(queue=gemini_thread)
+        else:
+            self.actions_log.info('Step10 - Skipping Gemini verification as Gemini was not run during this test')
 
         self.actions_log.info('all nodes were upgraded, and last workaround is verified.')
 


### PR DESCRIPTION
Added a new configuration parameter 'run_gemini_in_rolling_upgrade' to allow disabling Gemini workload execution during rolling upgrade tests. This provides flexibility to run rolling upgrades without Gemini when needed for specific test scenarios or troubleshooting. The default is set to false to prevent Gemini from running during standard rolling upgrade tests.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-ami-test/26/ (shorter in ~45m)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
