### PR TITLE
ci(rolling-upgrade): migrate GCE rolling upgrade tests to z3-highmem-8-highlssd

### DIFF
--- a/configurations/gce/z3-highmem-8-highlssd.yaml
+++ b/configurations/gce/z3-highmem-8-highlssd.yaml
@@ -1,0 +1,2 @@
+gce_instance_type_db: 'z3-highmem-8-highlssd'
+gce_n_local_ssd_disk_db: 0

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-debian11.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-debian11.jenkinsfile
@@ -5,10 +5,11 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
+    gce_datacenter: 'us-central1',
     base_versions: '',  // auto mode
     linux_distro: 'debian-bullseye',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-11',
 
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
-    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-artifacts.yaml", "configurations/gce/n2-highmem-48.yaml"]''',
+    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-artifacts.yaml", "configurations/gce/z3-highmem-8-highlssd.yaml"]''',
 )

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-debian13.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-debian13.jenkinsfile
@@ -5,10 +5,11 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
+    gce_datacenter: 'us-central1',
     base_versions: '',  // auto mode
     linux_distro: 'debian-trixie',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-13',
 
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
-    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-artifacts.yaml", "configurations/gce/n2-highmem-48.yaml"]''',
+    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-artifacts.yaml", "configurations/gce/z3-highmem-8-highlssd.yaml"]''',
 )

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-gce-image.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-gce-image.jenkinsfile
@@ -5,10 +5,11 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
+    gce_datacenter: 'us-central1',
     base_versions: '',  // auto mode
     linux_distro: 'ubuntu-focal',
     use_preinstalled_scylla: true,
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
-    test_config: '''["test-cases/upgrades/rolling-upgrade.yaml", "configurations/gce/n2-highmem-32.yaml"]''',
+    test_config: '''["test-cases/upgrades/rolling-upgrade.yaml", "configurations/gce/z3-highmem-8-highlssd.yaml"]''',
     internode_compression: 'all'
 )

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-rocky10.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-rocky10.jenkinsfile
@@ -5,10 +5,11 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
+    gce_datacenter: 'us-central1',
     base_versions: '',  // auto mode
     linux_distro: 'rocky-10',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/rocky-linux-cloud/global/images/family/rocky-linux-10-optimized-gcp',
     base_version_all_sts_versions: true,
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
-    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-artifacts.yaml", "configurations/gce/n2-highmem-16.yaml"]''',
+    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-artifacts.yaml", "configurations/gce/z3-highmem-8-highlssd.yaml"]''',
 )

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ubuntu2204.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ubuntu2204.jenkinsfile
@@ -5,9 +5,10 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
+    gce_datacenter: 'us-central1',
     base_versions: '',  // auto mode
     linux_distro: 'ubuntu-jammy',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts',
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
-    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-artifacts.yaml", "configurations/gce/n2-highmem-32.yaml"]''',
+    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-artifacts.yaml", "configurations/gce/z3-highmem-8-highlssd.yaml"]''',
 )

--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ubuntu2404.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ubuntu2404.jenkinsfile
@@ -5,9 +5,10 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
+    gce_datacenter: 'us-central1',
     base_versions: '',  // auto mode
     linux_distro: 'ubuntu-noble',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64',
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
-    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-artifacts.yaml", "configurations/gce/n2-highmem-64.yaml"]''',
+    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-artifacts.yaml", "configurations/gce/z3-highmem-8-highlssd.yaml"]''',
 )


### PR DESCRIPTION
Migrated all GCE rolling upgrade pipeline configurations from various n2-highmem instance types and sizes to the new z3-highmem-8-highlssd instance type to standardize infrastructure across all upgrade tests. This provides consistent performance characteristics and better cost efficiency for rolling upgrade testing on GCE platform.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-rocky10-test/10/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-gce-image-test/5/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
