### PR TITLE
fix(cql-stress): increase max open files

### DIFF
--- a/sdcm/cql_stress_cassandra_stress_thread.py
+++ b/sdcm/cql_stress_cassandra_stress_thread.py
@@ -139,6 +139,7 @@ class CqlStressCassandraStressThread(CassandraStressThread):
         cmd_runner = cleanup_context = RemoteDocker(loader, self.docker_image_name,
                                                     command_line="-c 'tail -f /dev/null'",
                                                     extra_docker_opts=f'{cpu_options} '
+                                                    '--ulimit nofile=65536:65536 '
                                                     '--network=host '
                                                     '--security-opt seccomp=unconfined '
                                                     f'--label shell_marker={self.shell_marker}'


### PR DESCRIPTION
By default 1024 file descriptors can be opened in cql-stress docker container and may result in error:
`Too many open files (os error 24)`

Fix by increasing limits in cql-stress docker container.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] - test integration

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
