### PR TITLE
fix(docker): better fallbacks for when no `IPAddress` available

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -122,6 +122,7 @@ from sdcm.utils.version_utils import get_s3_scylla_repos_mapping
 import sdcm.provision.azure.utils as azure_utils
 from utils.build_system.create_test_release_jobs import JenkinsPipelines
 from utils.get_supported_scylla_base_versions import UpgradeBaseVersion
+from sdcm.utils.docker_utils import get_ip_address_of_container
 
 
 SUPPORTED_CLOUDS = ("aws", "gce", "azure",)
@@ -628,7 +629,7 @@ def list_resources(ctx, user, test_id, get_all, get_all_running, verbose, backen
                         docker_table.add_row([
                             container.name,
                             builder_name,
-                            container.attrs["NetworkSettings"]["Networks"]["bridge"]["IPAddress"] if get_all_running else container.status,
+                            get_ip_address_of_container(container) if get_all_running else container.status,
                             container.labels.get("TestId", "N/A"),
                             container.labels.get("RunByUser", "N/A"),
                             container.attrs.get("Created", "N/A"),

--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -30,6 +30,7 @@ import jinja2
 from sdcm.keystore import KeyStore
 from sdcm.utils.common import list_instances_gce, list_instances_aws, list_resources_docker, format_timestamp
 from sdcm.utils.gce_utils import gce_public_addresses
+from sdcm.utils.docker_utils import get_ip_address_of_container
 
 LOGGER = logging.getLogger(__name__)
 
@@ -675,7 +676,7 @@ def get_running_instances_for_email_report(test_id: str, ip_filter: str = None):
         for container in containers:
             container.reload()
             nodes.append([container.name,
-                          container.attrs["NetworkSettings"]["Networks"]["bridge"]["IPAddress"],
+                          get_ip_address_of_container(container),
                           container.status,
                           "docker container",
                           builder_name])

--- a/sdcm/utils/docker_utils.py
+++ b/sdcm/utils/docker_utils.py
@@ -46,6 +46,27 @@ def deprecation(message):
     warnings.warn(message, DeprecationWarning, stacklevel=3)
 
 
+def get_ip_address_of_container(container: Container) -> str:
+    """
+    Get the IP address of a Docker container.
+    Takes into account https://docs.docker.com/engine/deprecated/#top-level-network-properties-in-networksettings.
+
+    :param container: Docker container object
+    :return: IP address string or None if not available
+    """
+    network_settings = container.attrs.get("NetworkSettings", {})
+    ip_address = network_settings.get("IPAddress")
+    if ip_address:
+        return ip_address
+    networks = network_settings.get("Networks", {})
+    if networks:
+        # Get the IP address from the first network, if available
+        first_network = next(iter(networks.values()), None)
+        if first_network:
+            return first_network.get("IPAddress")
+    return None
+
+
 class ContainerAlreadyRegistered(DockerException):
     pass
 
@@ -312,7 +333,7 @@ class ContainerManager:
             ip_address = cls.get_container(
                 instance, name).attrs["NetworkSettings"]["Networks"][docker_network]["IPAddress"]
         else:
-            ip_address = cls.get_container(instance, name).attrs["NetworkSettings"]["Networks"]["bridge"]["IPAddress"]
+            ip_address = get_ip_address_of_container(cls.get_container(instance, name))
         if not ip_address:
             raise Retry
         return ip_address


### PR DESCRIPTION
seems like in some case we have situation that we face docker instances not in the networks we assume they would, and we should have a clear fallbacks

Fix: #12608

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-azure-image-test/60/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
