### PR TITLE
Revert ".github/workflows: Migrate workflows to Blacksmith runners"

### DIFF
--- a/.github/workflows/add-label-when-promoted.yaml
+++ b/.github/workflows/add-label-when-promoted.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   check-commit:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       issues: write

--- a/.github/workflows/auto_assign.yaml
+++ b/.github/workflows/auto_assign.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   assignAuthor:
     name: Assign author to PR/issue
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Assign author to PR/issue
         if: github.actor != 'scylladbbot'

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   check_org_membership:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       isTeamMember: ${{ steps.teamAffiliation.outputs.isTeamMember }}
     steps:
@@ -33,7 +33,7 @@ jobs:
   build_image:
     needs: check_org_membership
     if: ( github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'Copilot' || needs.check_org_membership.outputs.isTeamMember == 'true' ) && contains(github.event.pull_request.labels.*.name, 'New Hydra Version')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/cache-issues.yaml
+++ b/.github/workflows/cache-issues.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   collect_n_upload:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     # run only on main repository, won't work on forks
     if: github.repository == 'scylladb/scylla-cluster-tests'
     steps:

--- a/.github/workflows/check-generated-code-updates.yaml
+++ b/.github/workflows/check-generated-code-updates.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check_org_membership:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       isTeamMember: ${{ steps.teamAffiliation.outputs.isTeamMember }}
     steps:
@@ -24,7 +24,7 @@ jobs:
           team: ${{ secrets.SCT_ACTION_GITHUB_TEAM }}
 
   run_validations:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: check_org_membership
     if: github.event.pull_request.user.login == 'Copilot' || github.event.pull_request.user.login == 'renovate[bot]' || needs.check_org_membership.outputs.isTeamMember == 'true'
     env:

--- a/.github/workflows/pr-require-backport-label.yaml
+++ b/.github/workflows/pr-require-backport-label.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   label:
     if: github.event.pull_request.draft == false
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   stale:
 
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write


### PR DESCRIPTION
seems like it's not needed for OSS repos

Reverts scylladb/scylla-cluster-tests#12339