### PR TITLE
fix(nemesis pipelines): generete missing configurations and pipelines

### DIFF
--- a/configurations/nemesis/KillMVBuildingCoordinator.yaml
+++ b/configurations/nemesis/KillMVBuildingCoordinator.yaml
@@ -1,0 +1,2 @@
+nemesis_class_name: 'KillMVBuildingCoordinator'
+user_prefix: 'longevity-5gb-1h-KillMVBuildingCoordinator'

--- a/configurations/nemesis/ManagerNativeBackup.yaml
+++ b/configurations/nemesis/ManagerNativeBackup.yaml
@@ -1,0 +1,2 @@
+nemesis_class_name: 'ManagerNativeBackup'
+user_prefix: 'longevity-5gb-1h-ManagerNativeBackup'

--- a/configurations/nemesis/ManagerRcloneBackup.yaml
+++ b/configurations/nemesis/ManagerRcloneBackup.yaml
@@ -1,0 +1,2 @@
+nemesis_class_name: 'ManagerRcloneBackup'
+user_prefix: 'longevity-5gb-1h-ManagerRcloneBackup'

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-KillMVBuildingCoordinator-aws.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-KillMVBuildingCoordinator-aws.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "aws",
+    region: "eu-west-1",
+    test_name: "longevity_test.LongevityTest.test_custom_time",
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/KillMVBuildingCoordinator.yaml']"
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-KillMVBuildingCoordinator-azure.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-KillMVBuildingCoordinator-azure.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "azure",
+    region: "eastus",
+    test_name: "longevity_test.LongevityTest.test_custom_time",
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/KillMVBuildingCoordinator.yaml']"
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-KillMVBuildingCoordinator-docker.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-KillMVBuildingCoordinator-docker.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "docker",
+    region: "eu-west-1",
+    test_name: "longevity_test.LongevityTest.test_custom_time",
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/KillMVBuildingCoordinator.yaml', 'configurations/nemesis/additional_configs/docker_backend.yaml']"
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-KillMVBuildingCoordinator-gce.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-KillMVBuildingCoordinator-gce.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "gce",
+    region: "us-east1",
+    test_name: "longevity_test.LongevityTest.test_custom_time",
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/KillMVBuildingCoordinator.yaml']"
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ManagerNativeBackup-aws.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ManagerNativeBackup-aws.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "aws",
+    region: "eu-west-1",
+    test_name: "longevity_test.LongevityTest.test_custom_time",
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/ManagerNativeBackup.yaml']"
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ManagerNativeBackup-azure.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ManagerNativeBackup-azure.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "azure",
+    region: "eastus",
+    test_name: "longevity_test.LongevityTest.test_custom_time",
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/ManagerNativeBackup.yaml']"
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ManagerNativeBackup-docker.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ManagerNativeBackup-docker.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "docker",
+    region: "eu-west-1",
+    test_name: "longevity_test.LongevityTest.test_custom_time",
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/ManagerNativeBackup.yaml', 'configurations/nemesis/additional_configs/docker_backend.yaml']"
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ManagerNativeBackup-gce.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ManagerNativeBackup-gce.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "gce",
+    region: "us-east1",
+    test_name: "longevity_test.LongevityTest.test_custom_time",
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/ManagerNativeBackup.yaml']"
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ManagerRcloneBackup-aws.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ManagerRcloneBackup-aws.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "aws",
+    region: "eu-west-1",
+    test_name: "longevity_test.LongevityTest.test_custom_time",
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/ManagerRcloneBackup.yaml']"
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ManagerRcloneBackup-azure.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ManagerRcloneBackup-azure.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "azure",
+    region: "eastus",
+    test_name: "longevity_test.LongevityTest.test_custom_time",
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/ManagerRcloneBackup.yaml']"
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ManagerRcloneBackup-docker.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ManagerRcloneBackup-docker.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "docker",
+    region: "eu-west-1",
+    test_name: "longevity_test.LongevityTest.test_custom_time",
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/ManagerRcloneBackup.yaml', 'configurations/nemesis/additional_configs/docker_backend.yaml']"
+)

--- a/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ManagerRcloneBackup-gce.jenkinsfile
+++ b/jenkins-pipelines/oss/nemesis/longevity-5gb-1h-ManagerRcloneBackup-gce.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: "gce",
+    region: "us-east1",
+    test_name: "longevity_test.LongevityTest.test_custom_time",
+    test_config: "['configurations/nemesis/longevity-5gb-1h-nemesis.yaml', 'configurations/nemesis/ManagerRcloneBackup.yaml']"
+)


### PR DESCRIPTION
These were missed, possibly by not running pre-commit when they were added.

Generated by running `pre-commit run --all-files`

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
