### PR TITLE
SCT-27 improvement(tooling_reporter.py): Add vector-store version reporting

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -45,6 +45,7 @@ from sdcm.provision.network_configuration import (
 )
 from sdcm.provision.scylla_yaml import SeedProvider
 from sdcm.provision.helpers.cloud_init import wait_cloud_init_completes
+from sdcm.reporting.tooling_reporter import VectorStoreVersionReporter
 from sdcm.sct_provision.aws.cluster import PlacementGroup
 
 from sdcm.remote import LocalCmdRunner, shell_script_cmd, NETWORK_EXCEPTIONS
@@ -1352,6 +1353,12 @@ class VectorStoreAWSNode(VectorStoreNodeMixin, AWSNode):
             f"sudo chown {self.parent_cluster.params.get('ami_vector_store_user')}: /home/ubuntu/vector-store/.env",
             verbose=True,
         )
+        try:
+            VectorStoreVersionReporter(
+                self.remoter, "/opt/vector-store/vector-store", self.test_config.argus_client()
+            ).report()
+        except Exception:  # noqa: BLE001
+            LOGGER.warning("Error submitting vector store version, VS package won't show in Argus.", exc_info=True)
 
 
 class VectorStoreSetAWS(VectorStoreClusterMixin, AWSCluster):

--- a/sdcm/reporting/tooling_reporter.py
+++ b/sdcm/reporting/tooling_reporter.py
@@ -309,3 +309,15 @@ class GeminiGoCqlDriverVersionReporter(ToolReporterBase):
 
     def _collect_version_info(self) -> None:
         pass
+
+
+class VectorStoreVersionReporter(ToolReporterBase):
+    TOOL_NAME = "vector-store"
+
+    def _collect_version_info(self):
+        output = self.runner.sudo(f"{self.command_prefix} --version")
+        LOGGER.info("%s: Collected vector-store output:\n%s", self, output.stdout)
+
+        name, version, *_ = output.stdout.split(" ")
+        LOGGER.info("%s: Collected %s version:\n%s", self, name, version)
+        self.version = version


### PR DESCRIPTION
This commit adds version reporting for vector-store nodes to Argus, both
AWS and Docker backends are supported.

Fixes #11489

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [AWS](https://jenkins.scylladb.com/job/scylla-staging/job/alexey/job/vector-search-in-cloud-aws/)
- [x] [Argus](https://argus.scylladb.com/tests/scylla-cluster-tests/69f390e8-c960-46af-837b-b73e2b72822b)
- [ ] [Docker]()
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
