### PR TITLE
Potential fix for code scanning alert no. 7: Improper Access Control

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -2,7 +2,7 @@ name: Build hydra image
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [labeled]
     paths:
       - 'Dockerfile'
       - 'docker/env/build_n_push.sh'
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
 
       - name: Check if docker image is already built


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-cluster-tests/security/code-scanning/7](https://github.com/scylladb/scylla-cluster-tests/security/code-scanning/7)

To fix the problem, the workflow should be hardened so that after the approval label is set, the code in the PR branch cannot be altered without requiring re-approval. This is commonly done by:
1. Triggering the workflow only on the `labeled` event (not on `synchronize`, `opened`, etc.), so only label application starts the build.
2. Using an immutable reference (`pull_request.head.sha`) when checking out PR code, to guarantee the exact commit that was approved is built.

**Steps to fix:**
- In the workflow YAML (`.github/workflows/build-docker-image.yaml`):
  1. Change the trigger to only run on `pull_request_target` `types: [labeled]` so it fires only when a label is added, not on every PR push/update.
  2. In all `actions/checkout` steps, for the `ref:` parameter, use `${{ github.event.pull_request.head.sha }}` instead of `${{ github.head_ref }}`.
- No code changes are needed in build scripts, only in workflow YAML triggers and checkout refs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
