### PR TITLE
Update major k8s dependencies used in EKS, GKE tests

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -9,15 +9,15 @@ availability_zone: 'a,b'
 instance_provision: 'on_demand'
 instance_type_db: 'i4i.4xlarge'
 
-eks_cluster_version: '1.27'
+eks_cluster_version: '1.32'
 eks_role_arn: 'arn:aws:iam::797456418907:role/eksServicePolicy'
 eks_service_ipv4_cidr: '172.20.0.0/16'
 eks_nodegroup_role_arn: 'arn:aws:iam::797456418907:role/helm-test-worker-nodes-NodeInstanceRole-6ACHDYEKNN3I'
 # NOTE: https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
-eks_vpc_cni_version: 'v1.15.3-eksbuild.1'
+eks_vpc_cni_version: 'v1.19.2-eksbuild.5'
 
-scylla_version: '5.2.11'
-k8s_cert_manager_version: '1.8.0'
+scylla_version: '6.2.3'
+k8s_cert_manager_version: '1.19.1'
 
 k8s_deploy_monitoring: false
 k8s_enable_performance_tuning: true

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -3,7 +3,7 @@ gce_datacenter: 'us-east1'
 availability_zone: 'c'
 gce_network: 'qa-vpc'
 
-gke_cluster_version: '1.27'
+gke_cluster_version: '1.31'
 gke_k8s_release_channel: ''
 
 gce_instance_type_db: 'n2-standard-8'
@@ -18,14 +18,14 @@ k8s_n_auxiliary_nodes: 2
 
 k8s_instance_type_auxiliary: 'n2-standard-2'
 
-scylla_version: '5.2.11'
+scylla_version: '6.2.3'
 
 # NOTE: If 'k8s_scylla_operator_docker_image' not set then the one from helm chart will be used.
 # To test nightly builds define it like this: 'scylladb/scylla-operator:nightly'
 k8s_scylla_operator_docker_image: ''
 k8s_scylla_operator_helm_repo: 'https://storage.googleapis.com/scylla-operator-charts/latest'
 k8s_scylla_operator_chart_version: 'latest'
-k8s_cert_manager_version: '1.8.0'
+k8s_cert_manager_version: '1.19.1'
 k8s_deploy_monitoring: false
 k8s_enable_performance_tuning: true
 

--- a/defaults/k8s_local_kind_config.yaml
+++ b/defaults/k8s_local_kind_config.yaml
@@ -4,14 +4,14 @@ mini_k8s_version: '0.20.0'
 n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
 
-scylla_version: '5.2.11'
+scylla_version: '6.2.3'
 
 # NOTE: If 'k8s_scylla_operator_docker_image' not set then the one from helm chart will be used.
 # To test nightly builds define it like this: 'scylladb/scylla-operator:nightly'
 k8s_scylla_operator_docker_image: ''
 k8s_scylla_operator_helm_repo: 'https://storage.googleapis.com/scylla-operator-charts/latest'
 k8s_scylla_operator_chart_version: 'latest'
-k8s_cert_manager_version: '1.8.0'
+k8s_cert_manager_version: '1.19.1'
 
 k8s_scylla_cluster_name: 'sct-cluster'
 k8s_scylla_disk_gi: 10


### PR DESCRIPTION
Current component versions are terribly out of touch with reality. Cert-manager 1.8.0 is unsupported for two years and does not support even the lowest actual Operator k8s version (1.31). This PR addresses the dependency update.

### Testing
All of the included changes were tested before and during the Operator 1.19 release:
https://jenkins.scylladb.com/view/scylla-operator/job/scylla-operator/job/operator-1.19/job/upgrade/

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code