### PR TITLE
fix(adaptive_timeout): correct message when exceeding SoftTimeout

### DIFF
--- a/sdcm/sct_events/system.py
+++ b/sdcm/sct_events/system.py
@@ -98,8 +98,11 @@ class TestFrameworkEvent(InformationalEvent):
 
 class SoftTimeoutEvent(TestFrameworkEvent):
 
-    def __init__(self, operation: str, duration: int | float, soft_timeout: int | float):
-        message = f"operation '{operation}' took {duration}s and soft-timeout was set to {soft_timeout}s"
+    def __init__(self, operation: str, duration: int | float, soft_timeout: int | float, still_running: bool = False):
+        if still_running:
+            message = f"operation '{operation}' exceeded soft-timeout of {soft_timeout}s and is still in progress"
+        else:
+            message = f"operation '{operation}' is finished and took {duration:.1f}s (soft timeout was set to {soft_timeout}s)"
         super().__init__(source='SoftTimeout', severity=Severity.ERROR, trace=sys._getframe().f_back, message=message)
 
 

--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -155,7 +155,8 @@ class TimeoutMonitor:
                 return
             if not self.soft_timeout_triggered and self.soft_timeout and duration > self.soft_timeout:
                 SoftTimeoutEvent(
-                    operation=self.operation, duration=duration, soft_timeout=self.soft_timeout).publish_or_dump()
+                    operation=self.operation, duration=duration, soft_timeout=self.soft_timeout, still_running=True
+                ).publish_or_dump()
                 self.soft_timeout_triggered = True
 
             time.sleep(5.0)
@@ -216,7 +217,7 @@ def adaptive_timeout(operation: Operations, node: "BaseNode",  # noqa: PLR0914, 
         soft_timeout_exceeded = soft_timeout and duration > soft_timeout
         if soft_timeout_exceeded:
             timeout_occurred = True
-        if timeout_occurred and not (tablet_sensitive_op and tablets_enabled):
+        if timeout_occurred:
             SoftTimeoutEvent(operation=operation.name, soft_timeout=soft_timeout, duration=duration).publish_or_dump()
 
         try:

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -507,7 +507,7 @@ class SctEventsTests(BaseEventsTest):
         event_data = str(event)
 
         assert event.trace
-        assert "operation 'long-one' took 0.2s and soft-timeout was set to 0.1s" in event_data
+        assert "operation 'long-one' is finished and took 0.2s (soft timeout was set to 0.1s)" in event_data
 
     def test_count_reactor_stall(self):
         count_condition_name = "test_method"


### PR DESCRIPTION
Improve the SoftTimeoutEvent message for operations with both Soft and Hard timeouts.
When the SoftTimeout is exceed, but the operation has not yet finished, 2 event will be published:
- the 1st event notifies that the Soft timeout is exceeded (including the timeout value itself)
- the 2nd event will be published when the operation completes and reports the total execution time

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/12416

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] local run of a test that includes `NodeTerminateAndReplace` nemesis. Logs entries that show the SoftTimeoutEvent being published twice (special case for operations that have both Soft and Hard timeouts):
```
❯ egrep 'SoftTimeout.*NEW_NODE' ~/sct-results/latest/sct.log
< t:2025-11-21 16:51:59,076 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > 2025-11-21 15:51:59.075: (SoftTimeoutEvent Severity.ERROR) period_type=one-time event_id=94f672f2-96d6-453f-9b92-d409f85c85fe during_nemesis=TerminateAndReplaceNode, source=SoftTimeout message=operation 'NEW_NODE' exceeded soft-timeout of 90s and is still in progress
...
< t:2025-11-21 16:53:54,430 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:ERROR > 2025-11-21 15:53:54.422: (SoftTimeoutEvent Severity.ERROR) period_type=one-time event_id=2d067dcb-f42d-40ad-b057-59b5f026c186 during_nemesis=TerminateAndReplaceNode, source=SoftTimeout message=operation 'NEW_NODE' is finished and took 205.4s (soft timeout was set to 90s)
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
