### PR TITLE
improvement(xcloud): add support for Manager node operations

### DIFF
--- a/sdcm/cluster_cloud.py
+++ b/sdcm/cluster_cloud.py
@@ -401,6 +401,50 @@ class CloudVSNode(CloudNode):
         )
 
 
+class CloudManagerNode(CloudNode):
+    """A Scylla Manager node running on Scylla Cloud"""
+
+    def __init__(
+        self,
+        parent_cluster: cluster.BaseScyllaCluster,
+        node_prefix: str = 'manager',
+        node_index: int = 1,
+        base_logdir: str | None = None,
+        dc_idx: int = 0,
+        rack: int = 0
+    ):
+        # minimal cloud_instance_data for manager node (most of the node details will be fetched via SDM)
+        cloud_instance_data = {
+            'id': None,
+            'privateIp': None,
+            'publicIp': None,
+            'status': 'ACTIVE',
+            'instanceType': 'CloudManaged'}
+
+        super().__init__(
+            cloud_instance_data=cloud_instance_data,
+            parent_cluster=parent_cluster,
+            node_prefix=node_prefix,
+            node_index=node_index,
+            base_logdir=base_logdir,
+            dc_idx=dc_idx,
+            rack=rack)
+
+    def _init_remoter(self, ssh_login_info=None):
+        localhost = TestConfig().tester_obj().localhost
+        if localhost.xcloud_connect_supported(self.parent_cluster.params):
+            sdm_env = self.parent_cluster.params.cloud_env_credentials.get("sdm_environment")
+            ssh_login_info = localhost.xcloud_connect_get_manager_ssh_address(
+                cluster_id=self._cluster_id, sdm_environment=sdm_env)
+            self.remoter = RemoteCmdRunner(**ssh_login_info)
+        else:
+            self.log.warning("XCloud connectivity is not supported, Manager node SSH remoter is not initialized")
+
+    @property
+    def node_type(self) -> str:
+        return "manager"
+
+
 class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
     """Scylla DB cluster running on Scylla Cloud"""
 
@@ -438,6 +482,7 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
         self._pending_node_configs = []
         self._deploy_vs_nodes = int(params.get('n_vector_store_nodes')) > 0
         self.vs_nodes = []
+        self.manager_node = None
 
         cluster_prefix = cluster.prepend_user_prefix(user_prefix, 'db-cluster')
         node_prefix = cluster.prepend_user_prefix(user_prefix, 'db-node')
@@ -551,10 +596,14 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
         nodes = self._init_nodes_from_cluster(count, dc_idx, rack)
         vs_nodes = self._init_vs_nodes_from_cluster() if self._deploy_vs_nodes else []
 
+        self._init_manager_node()
+
         self._cluster_created = True
         self.log.info(
-            "Successfully created cluster %s with %s DB nodes%s",
-            self.name, len(nodes), " and {} VS nodes".format(len(vs_nodes)) if vs_nodes else "")
+            "Successfully created cluster %s with %s DB nodes%s%s",
+            self.name, len(nodes),
+            " and {} VS nodes".format(len(vs_nodes)) if vs_nodes else "",
+            " and Manager node" if self.manager_node else "")
 
         return nodes
 
@@ -613,6 +662,20 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
             nodes_data=self.vs_nodes_data, node_class=CloudVSNode, node_prefix='vs-node', dc_idx=0, rack=0)
         self.vs_nodes.extend(created_nodes)
         return created_nodes
+
+    def _init_manager_node(self) -> None:
+        localhost = TestConfig().tester_obj().localhost
+        if not localhost.xcloud_connect_supported(self.params):
+            self.log.debug("XCloud connectivity not supported, skipping Manager node initialization")
+            return
+
+        self.log.info("Initializing Manager node for cluster %s", self._cluster_id)
+
+        self._wait_for_manager_node_ready()
+        self.manager_node = CloudManagerNode(parent_cluster=self)
+        self.manager_node._init_remoter()
+        self.manager_node.wait_ssh_up()
+        self.log.info("Manager node SSH connection established")
 
     def _prepare_cluster_config(self, node_count: int, instance_type: str) -> dict[str, Any]:
         instance_type_name = instance_type or self.params.cloud_provider_params.get('instance_type_db')
@@ -717,6 +780,37 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
             throw_exc=True)
         self.log.info("Vector Search nodes are ready")
 
+    def _wait_for_manager_node_ready(self, timeout: int = 600) -> None:
+        self.log.info("Waiting for Manager node installation to complete")
+        cluster_requests = self._api_client.get_cluster_requests(
+            account_id=self._account_id, cluster_id=self._cluster_id)
+        mgr_request = next((req for req in cluster_requests if req.get('requestType') == 'INSTALL_MANAGER'), None)
+        if not mgr_request:
+            self.log.warning("No INSTALL_MANAGER request found for cluster %s", self._cluster_id)
+            return
+
+        mgr_request_id = mgr_request.get('id')
+        self.log.info("Found INSTALL_MANAGER request (ID: %s), waiting for completion", mgr_request_id)
+
+        def is_manager_ready():
+            details = self._api_client.get_cluster_request_details(
+                account_id=self._account_id, request_id=mgr_request_id)
+            status = details.get('status', '').upper()
+            self.log.debug("Manager installation status: %s (%s%%)", status, details.get('progressPercent', 0))
+
+            if status == 'FAILED':
+                raise ScyllaCloudError(f"Manager installation failed: {details}")
+
+            return status == 'COMPLETED'
+
+        wait.wait_for(
+            func=is_manager_ready,
+            step=15,
+            text="Waiting for Manager node installation to complete",
+            timeout=timeout,
+            throw_exc=True)
+        self.log.info("Manager node installation completed")
+
     def get_promproxy_config(self):
         """Retrieve Prometheus proxy configuration for Scylla Cloud cluster"""
         return self._api_client.get_cluster_promproxy_config(
@@ -770,11 +864,12 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
         # validate VS nodes config parameters
         vs_nodes = (self._api_client.get_vector_search_nodes(
             account_id=self._account_id, cluster_id=self._cluster_id, dc_id=self.dc_id).get('availabilityZones') or [])
-        vs_nodes_per_az = [
-            n for n in vs_nodes[0].get('nodes', []) if n.get('status') not in ('DELETED', 'PENDING_DELETE')]
-        if vs_nodes_per_az and len(vs_nodes_per_az) != int(self.params.get('n_vector_store_nodes')):
-            raise ScyllaCloudError("Vector Search node count mismatch. "
-                                   "Update 'n_vector_store_nodes' in test config or provision a new cluster.")
+        if vs_nodes:
+            vs_nodes_per_az = [
+                n for n in vs_nodes[0].get('nodes', []) if n.get('status') not in ('DELETED', 'PENDING_DELETE')]
+            if vs_nodes_per_az and len(vs_nodes_per_az) != int(self.params.get('n_vector_store_nodes')):
+                raise ScyllaCloudError("Vector Search node count mismatch. "
+                                       "Update 'n_vector_store_nodes' in test config or provision a new cluster.")
 
         self._get_cluster_credentials()
         if self.vpc_peering_enabled:
@@ -784,9 +879,13 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
         if vs_nodes:
             self.vs_nodes.extend(self._init_nodes_from_data(self.vs_nodes_data, CloudVSNode, node_prefix='vs-node'))
 
+        self._init_manager_node()
+
         self._cluster_created = True
-        self.log.info("Successfully reused cluster '%s' with %s DB nodes%s",
-                      self.name, len(db_nodes), f" and {len(vs_nodes)} VS nodes" if vs_nodes else "")
+        self.log.info("Successfully reused cluster '%s' with %s DB nodes%s%s",
+                      self.name, len(db_nodes),
+                      f" and {len(vs_nodes)} VS nodes" if vs_nodes else "",
+                      " and Manager node" if self.manager_node else "")
 
     @staticmethod
     def _wait_for_preinstalled_scylla(node):
@@ -1029,3 +1128,7 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
     @cached_property
     def gcp_peering_name(self) -> str:
         return f"sct-to-scylla-cloud-{self.vpc_peering_details.get('projectId')}-{self.vpc_peering_id}"
+
+    @property
+    def scylla_manager_node(self) -> cluster.BaseNode:
+        return self.manager_node

--- a/sdcm/utils/internal_modules.py
+++ b/sdcm/utils/internal_modules.py
@@ -38,4 +38,7 @@ except ImportError:
         def xcloud_connect_get_ssh_address(self, node):
             raise NotImplementedError(not_supported_message)
 
+        def xcloud_connect_get_manager_ssh_address(self, cluster_id, sdm_environment):
+            raise NotImplementedError(not_supported_message)
+
 __all__ = ["XCloudConnectivityContainerMixin"]


### PR DESCRIPTION
Add SSH connectivity for Manager node of a cloud cluster.

The change implements CloudManagerNode node class, which instance can be used for instantiating ScyllaManagerTool (hence the existing APIs for sctool can be used for interacting with cloud cluster Manager node).

Closes: https://github.com/scylladb/qa-tasks/issues/1977

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [regression check for staging env where xcloud SSH connectivity is configured](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/57/) 
- [x] [regression check for lab env where xcloud SSH connectivity is not configured](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/56/) 
- [x] tested locally - deployed a basic cloud cluster and checked that manager node is accessible from SCT:
```
>>> print(self._manager_node.remoter.run('sctool -h').stdout)

Scylla Manager 3.7.0-0.20251028.7a658f7d2.
Documentation is available online at https://manager.docs.scylladb.com/.
Usage:
  sctool [command]
Available Commands:
  backup      Schedule a backup (ad-hoc or scheduled)
  cluster     Add or delete clusters
  completion  Generate shell completion
  help        Help about any command
  info        Show task parameters and history
  progress    Show the task progress
  repair      Schedule a repair (ad-hoc or scheduled)
  restore     Run an ad-hoc restore of schema or tables
  resume      Undo suspend
  start       Start executing a task
  status      Show status of clusters
  stop        Stop executing a task
  suspend     Stop execution of all tasks
  tasks       Show active tasks and their last run status
  version     Show version information
Flags:
      --api-cert-file path   File path to HTTPS client certificate used to access the Scylla Manager server when client certificate validation is enabled (envvar SCYLLA_MANAGER_API_CERT_FILE).
                             
      --api-key-file path    File path to HTTPS client key associated with --api-cert-file flag (envvar SCYLLA_MANAGER_API_KEY_FILE).
                             
      --api-url URL          Base URL of Scylla Manager server (envvar SCYLLA_MANAGER_API_URL).
                             If running sctool on the same machine as server, it's generated based on '/etc/scylla-manager/scylla-manager.yaml' file.
                              (default "http://127.0.0.1:5080/api/v1")
  -h, --help                 help for sctool
Use "sctool [command] --help" for more information about a command.


>>> from sdcm.mgmt.cli import ScyllaManagerToolNonRedhat
>>> mgmt_tool = ScyllaManagerToolNonRedhat(self._manager_node)
< t:2025-11-22 16:01:49,097 f:cli.py          l:1017 c:sdcm.mgmt.cli        p:INFO  > Initiating Scylla-Manager, version: [['Client version: 3.7.0-0.20251028.7a658f7d2'], ['Server version: 3.7.0-0.20251028.7a658f7d2']]
< t:2025-11-22 16:01:51,819 f:cluster.py      l:650  c:sdcm.cluster_cloud   p:INFO  > Detected Linux distribution: UBUNTU24
>>> mgmt_tool.sctool.version
[['Client version: 3.7.0-0.20251028.7a658f7d2'], ['Server version: 3.7.0-0.20251028.7a658f7d2']]
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
