### PR TITLE
fix(rolling-upgrade-ami-arm): force iotune run

### DIFF
--- a/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ami-arm.jenkinsfile
+++ b/jenkins-pipelines/oss/rolling-upgrade/rolling-upgrade-ami-arm.jenkinsfile
@@ -10,5 +10,8 @@ rollingUpgradePipeline(
     use_preinstalled_scylla: true,
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: '''["test-cases/upgrades/rolling-upgrade.yaml", "configurations/arm_instance_types/i8g_2xlarge.yaml"]''' ,
-    internode_compression: 'all'
+    internode_compression: 'all',
+
+    // since i8g.2xlarge only supported out of the box from 2025.3.3 and up, we need to force it
+    extra_environment_variables: 'SCT_FORCE_RUN_IOTUNE=true'
 )

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -108,7 +108,7 @@ def call(Map pipelineParams) {
             string(defaultValue: 'next',
                    description: 'Default branch to be used for scylla and other repositories. Default is "next".',
                    name: 'byo_default_branch')
-            string(defaultValue: '',
+            string(defaultValue: "${pipelineParams.get('extra_environment_variables', '')}",
                    description: 'Extra environment variables to inject (format: KEY1=VAL1\nKEY2=VAL2)',
                    name: 'extra_environment_variables')
         }


### PR DESCRIPTION
since we start the test with version that doesn't support yet the i8g instances out of the box, we need to manauly run iotune

we should continue doing so until 2026.1 is out and becomes the LTS

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟡 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-ami-arm-test/5/ (starts as expected, fails on counter not supported, different issue)
- [x] 🟢  https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/rolling-upgrade-ami-arm-test/6/
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-master/job/rolling-upgrade/job/rolling-upgrade-ami-arm-test/203/
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
