### PR TITLE
fix(performance): remove terminate node validation

### DIFF
--- a/configurations/performance/latency-decorator-error-thresholds-nemesis-ent-tablets.yaml
+++ b/configurations/performance/latency-decorator-error-thresholds-nemesis-ent-tablets.yaml
@@ -5,7 +5,7 @@ latency_decorator_error_thresholds:
         fixed_limit: 7200
     _terminate_and_wait:
       duration:
-        fixed_limit: 450
+        fixed_limit: null
     add_new_nodes:
       duration:
         fixed_limit: 2500
@@ -24,7 +24,7 @@ latency_decorator_error_thresholds:
         fixed_limit: 3200
     _terminate_and_wait:
       duration:
-        fixed_limit: 450
+        fixed_limit: null
     add_new_nodes:
       duration:
         fixed_limit: 3200
@@ -43,7 +43,7 @@ latency_decorator_error_thresholds:
         fixed_limit: 4200
     _terminate_and_wait:
       duration:
-        fixed_limit: 450
+        fixed_limit: null
     add_new_nodes:
       duration:
         fixed_limit: 2500

--- a/configurations/performance/latency-decorator-error-thresholds-nemesis-ent-vnodes.yaml
+++ b/configurations/performance/latency-decorator-error-thresholds-nemesis-ent-vnodes.yaml
@@ -5,7 +5,7 @@ latency_decorator_error_thresholds:
         fixed_limit: 7200
     _terminate_and_wait:
       duration:
-        fixed_limit: 450
+        fixed_limit: null
     add_new_nodes:
       duration:
         fixed_limit: 4200
@@ -22,7 +22,7 @@ latency_decorator_error_thresholds:
         fixed_limit: 2000
     _terminate_and_wait:
       duration:
-        fixed_limit: 450
+        fixed_limit: null
     add_new_nodes:
       duration:
         fixed_limit: 1800
@@ -39,7 +39,7 @@ latency_decorator_error_thresholds:
         fixed_limit: 2500
     _terminate_and_wait:
       duration:
-        fixed_limit: 450
+        fixed_limit: null
     add_new_nodes:
       duration:
         fixed_limit: 2400


### PR DESCRIPTION
Stop validating the `terminate_and_wait` step duration in the `operations-under-load` performance test. 
This delay can be caused by various factors—such as system or AWS issues—not only Scylla. 
The test should not fail based on the duration of this step.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
