### PR TITLE
fix(xcloud): fallback node data values for email report

### DIFF
--- a/sdcm/cluster_cloud.py
+++ b/sdcm/cluster_cloud.py
@@ -376,6 +376,26 @@ class CloudNode(cluster.BaseNode):
             is_enabled=True,
             is_ready=lambda: True)
 
+    @property
+    def scylla_shards(self) -> int:
+        if self.xcloud_connect_supported:
+            return super().scylla_shards
+        self.log.warning("XCloud connectivity is not supported, skip collecting scylla_shards info")
+        return 0
+
+    @property
+    def kernel_version(self):
+        if self.xcloud_connect_supported:
+            return super().kernel_version
+        self.log.warning("XCloud connectivity is not supported, skip collecting kernel version info")
+        return "N/A"
+
+    @property
+    def scylla_version_detailed(self):
+        return (super().scylla_version_detailed
+                if self.xcloud_connect_supported
+                else self.parent_cluster.params.get('scylla_version'))
+
 
 class CloudVSNode(CloudNode):
     """A Vector Search node running on Scylla Cloud"""


### PR DESCRIPTION
When collecting info for email report, DB nodes are accessed to get shards, kernel and scylla versions values.
This change ensures that we do not fail on this step, when SSH connectivity to cloud cluster DB nodes is not configured - sentinel values will be returned in this case.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [pr-provision-test on staging - SSH connectivity is available and report data is collected from nodes](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/53/)
- [x] :green_circle: [pr-provision-test on lab - SSH connectivity is not available, using fallback values in report for some data](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/52/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
