### PR TITLE
fix(xcloud): handle concurrent peerings cleanup for GCP cloud provider

### DIFF
--- a/sdcm/utils/gce_region.py
+++ b/sdcm/utils/gce_region.py
@@ -26,6 +26,7 @@ from google.cloud import compute_v1
 from google.cloud.compute_v1 import Firewall
 
 from sdcm.keystore import KeyStore
+from sdcm.utils.gce_utils import wait_for_extended_operation
 
 
 LOGGER = logging.getLogger(__name__)
@@ -263,8 +264,8 @@ class GceRegion:
             network=self.SCT_NETWORK_NAME,
             project=self.project,
             networks_remove_peering_request_resource=compute_v1.NetworksRemovePeeringRequest(name=peering_name))
-        self.network_client.remove_peering(request=remove_request)
-        time.sleep(3)  # wait a bit for the operation to propagate
+        operation = self.network_client.remove_peering(request=remove_request)
+        wait_for_extended_operation(operation, f"Remove peering {peering_name}", timeout=120)
 
         final_status = self.get_peering_status(peering_name)
         if final_status:


### PR DESCRIPTION
Add waiting for GCP peering cleanup operation to complete, during cloud resources cleanup.
Additionally, add retry with exponential backoff to peering cleanup procedure, for the case when there are concurrent operation on the peering. This way cleanup will wait and retry, instead of failing immediately, if the peering in question is busy with something other than cluster cleanup.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/12664

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: couple of runs for xcloud backend with VS nodes on GCP cloud provider - [run1](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/58/) and [run2](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/59/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
