### PR TITLE
Update audit configuration to include 'table' 

### DIFF
--- a/configurations/audit.yaml
+++ b/configurations/audit.yaml
@@ -1,5 +1,5 @@
 append_scylla_yaml:
-  audit: 'syslog'
+  audit: 'syslog,table'
   audit_categories: 'DCL,DDL,AUTH,ADMIN'
   audit_tables: 'keyspace1.standard1,scylla_bench.test'
   audit_keyspaces: 'keyspace1,scylla_bench'


### PR DESCRIPTION
We have added two ways of auditing for cloud, now we may audit to table and to syslog, this change enables both ways of auditing to check that both ways work in the same time 

https://github.com/scylladb/scylladb/pull/26613

### Testing
https://jenkins.scylladb.com/job/scylla-staging/job/alexd/job/auth-and-audit/
https://jenkins.scylladb.com/job/scylla-staging/job/alexd/job/audit/
https://jenkins.scylladb.com/job/scylla-staging/job/alexd/job/longivity-4h-audit/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
