### PR TITLE
fix(ignore_raft_topology_cmd_failing): add tablet drain failure downgrade

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -406,7 +406,7 @@ def ignore_raft_topology_cmd_failing():
         stack.enter_context(EventsSeverityChangerFilter(
             new_severity=Severity.WARNING,
             event_class=DatabaseLogEvent,
-            regex=r".*raft_topology - drain rpc failed, proceed to fence old writes:.*connection is closed",
+            regex=r".*raft_topology - tablets draining failed with std::runtime_error.*connection is closed",
             extra_time_to_expiration=30
         ))
         stack.enter_context(EventsSeverityChangerFilter(


### PR DESCRIPTION
This PR does two things.
1. Removes redundant filter which is already covered by broader regex
  ` .*raft_topology - drain rpc failed, proceed to fence old writes:.*connection is closed`
  is covered by
  `.*raft_topology - drain rpc failed, proceed to fence old writes.*connection is closed`

2. Adds a new filter for raft_topology - tablets draining failure

Fixes: #9490

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/jsmolar/job/longevity-5gb-1h-DecommissionStreamingErrMonkey-aws-test/4/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
