### PR TITLE
ci(latte): bump latte version to `0.42.1-scylladb`

### DIFF
--- a/defaults/docker_images/latte/values_latte.yaml
+++ b/defaults/docker_images/latte/values_latte.yaml
@@ -1,2 +1,2 @@
 latte:
-  image: scylladb/latte:0.42.0-scylladb
+  image: scylladb/latte:0.42.1-scylladb


### PR DESCRIPTION
Main change in this new version is the fix of the performance issue.
It was observable on a large scale.

Ref: https://github.com/scylladb/scylla-rust-driver/issues/1481

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
