### PR TITLE
ci(longevity): migrating large partition GCE run to new instance

### DIFF
--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -45,7 +45,7 @@ n_loaders: 5 # Each loader will have 1 scylla-bench process at every step of the
 round_robin: true
 
 instance_type_db: 'i3en.2xlarge'
-gce_instance_type_db: 'n2-highmem-16'
+gce_instance_type_db: 'z3-highmem-8-highlssd'
 gce_instance_type_loader: 'e2-standard-16'
 gce_n_local_ssd_disk_db: 16
 instance_type_loader: 'c5n.4xlarge'


### PR DESCRIPTION
Changing instance for large partiton GCE run from n2-highmem instance
 type to the new z3-highmem-8-highlssd instance type to standardize
 infrastructure across all tests.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
