### PR TITLE
fix(nemesis): skip disrupt_kill_mv_building_coordinator if mv builds too fast

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -129,7 +129,7 @@ from sdcm.utils.k8s.chaos_mesh import MemoryStressExperiment, IOFaultChaosExperi
 from sdcm.utils.ldap import SASLAUTHD_AUTHENTICATOR, LdapServerType
 from sdcm.utils.loader_utils import DEFAULT_USER, DEFAULT_USER_PASSWORD, SERVICE_LEVEL_NAME_TEMPLATE
 from sdcm.utils.nemesis_utils import NEMESIS_TARGET_POOLS, DefaultValue, unique_disruption_name
-from sdcm.utils.nemesis_utils.indexes import (get_random_column_name, create_index,
+from sdcm.utils.nemesis_utils.indexes import (ViewFinishedBuildingException, get_random_column_name, create_index,
                                               wait_for_index_to_be_built, verify_query_by_index_works,
                                               drop_index, wait_for_view_to_be_built, drop_materialized_view,
                                               is_cf_a_view, create_materialized_view_for_random_column, wait_materialized_view_building_tasks_started)
@@ -5678,6 +5678,10 @@ class Nemesis(NemesisFlags):
                 try:
                     create_materialized_view_for_random_column(session, ks_name, base_table_name, view_name)
                     wait_materialized_view_building_tasks_started(session, ks_name, view_name)
+                except ViewFinishedBuildingException:
+                    drop_materialized_view(session, ks_name, view_name)
+                    raise UnsupportedNemesis(
+                        f"Skip nemesis because view {ks_name}.{view_name} has already finished building")
                 except Exception as error:  # pylint: disable=broad-except
                     self.log.error('Failed creating a materialized view: %s', error)
                     raise

--- a/sdcm/utils/nemesis_utils/indexes.py
+++ b/sdcm/utils/nemesis_utils/indexes.py
@@ -224,6 +224,10 @@ def create_materialized_view_for_random_column(session, keyspace_name, base_tabl
                                  mv_columns=[column] + primary_key_columns)
 
 
+class ViewFinishedBuildingException(Exception):
+    """Exception raised when a materialized view has finished building."""
+
+
 def wait_materialized_view_building_tasks_started(session, ks_name, view_name, timeout=600):
     """
     Waits for materialized view building tasks to start within a specified timeout period.
@@ -243,7 +247,7 @@ def wait_materialized_view_building_tasks_started(session, ks_name, view_name, t
         AssertionError: If the specified materialized view is not found in the system schema.
         TimeoutError: If the building tasks do not start within the specified timeout period.
     """
-    LOGGER.info(f"waiting {timeout} seconds build tasks started")
+    LOGGER.info(f"waiting {timeout} seconds for view {ks_name}.{view_name} to start building")
     start_time = time.time()
     while time.time() - start_time < timeout:
         try:
@@ -254,7 +258,12 @@ def wait_materialized_view_building_tasks_started(session, ks_name, view_name, t
                 f"select * from system.view_building_tasks where key = 'view_building' and view_id = {row.id} ALLOW FILTERING;"))
             if len(result) > 0:
                 return
+            if session.execute(f"SELECT * FROM system.built_views WHERE keyspace_name='{ks_name}' AND view_name='{view_name}'"):
+                raise ViewFinishedBuildingException(f"View {ks_name}.{view_name} has already finished building.")
+        except ViewFinishedBuildingException:
+            raise
         except:
             continue
         time.sleep(15)
-    raise TimeoutError(f"Timeout error ({timeout} seconds) while waiting building tasks started")
+    raise TimeoutError(
+        f"Timeout error ({timeout} seconds) while waiting for view {ks_name}.{view_name} to start building")


### PR DESCRIPTION
In certain scenarios, usually when the table has very little data, the materialized view will have been already built by the time the check for whether is has started is done.
In that scenario, the nemesis should be skipped.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] before: https://argus.scylladb.com/tests/scylla-cluster-tests/558f8c4e-440a-4da5-bf16-9a08f9060d95/nemesis
  fails with timeout error `TimeoutError: Timeout error (600 seconds) while waiting building tasks started`
  but view as built
  ```
  Nov 23 21:31:07.268635 longevity-harry-2h-fix-harr-db-node-558f8c4e-1 scylla[5359]:  [shard 0: gms] schema_tables - Creating harry.table0_view_4ad1b213 id=b8bde800-c8b3-11f0-8e78-63abcf4fdc7e version=b8bde801-c8b3-11f0-8e78-63abcf4fdc7e
  Nov 23 21:31:07.359263 longevity-harry-2h-fix-harr-db-node-558f8c4e-1 scylla[5359]:  [shard 0: gms] view - Building view harry.table0_view_4ad1b213, starting at token minimum token
  Nov 23 21:31:07.834124 longevity-harry-2h-fix-harr-db-node-558f8c4e-1 scylla[5359]:  [shard 0:strm] view - Finished building view harry.table0_view_4ad1b213
	```
- [x] after: https://argus.scylladb.com/tests/scylla-cluster-tests/ba375516-e577-4f23-94b2-03cb5d24e384/nemesis
  skipped `Skip nemesis because view harry.table0_view_6c5dad61 has already finished building`
  and the view is dropped
  ```
  Nov 26 11:47:50.052145 longevity-harry-2h-fix-mv-t-db-node-ba375516-1 scylla[5352]:  [shard 0: gms] view - Building view harry.table0_view_3d2933c4, starting at token minimum token
  Nov 26 11:47:50.320507 longevity-harry-2h-fix-mv-t-db-node-ba375516-1 scylla[5352]:  [shard 0:strm] view - Finished building view harry.table0_view_3d2933c4
  Nov 26 11:47:50.594469 longevity-harry-2h-fix-mv-t-db-node-ba375516-1 scylla[5352]:  [shard 0: gms] schema_tables - Dropping harry.table0_view_3d2933c4 id=bbfc01d0-cabd-11f0-a392-61a4e16925f0 version=bbfc01d1-cabd-11f0-a392-61a4e16925f0
  Nov 26 11:47:50.595765 longevity-harry-2h-fix-mv-t-db-node-ba375516-1 scylla[5352]:  [shard 1: gms] database - Dropping harry.table0_view_3d2933c4 with auto-snapshot
  Nov 26 11:47:50.595816 longevity-harry-2h-fix-mv-t-db-node-ba375516-1 scylla[5352]:  [shard 0: gms] database - Truncating harry.table0_view_3d2933c4 with auto-snapshot
  ```
- [x] normal: https://argus.scylladb.com/tests/scylla-cluster-tests/0eebb9a9-d81f-400e-9f4b-d734362e2e27/nemesis
  passes as expected

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
