### PR TITLE
fix(latte_thread): do not copy non-file items in build_stress_cmd

### DIFF
--- a/sdcm/stress/latte_thread.py
+++ b/sdcm/stress/latte_thread.py
@@ -107,7 +107,8 @@ class LatteStressThread(DockerBasedStressThread):
             self.SCHEMA_CMD_CALL_COUNTER[script_name] = 0
 
         for src_file in (Path(get_sct_root_path()) / script_name).parent.iterdir():
-            cmd_runner.send_files(str(src_file), str(Path(script_name).parent / src_file.name))
+            if src_file.is_file():  # exclude non-file items from being copied
+                cmd_runner.send_files(str(src_file), str(Path(script_name).parent / src_file.name))
 
         ssl_config = ''
         if self.params['client_encrypt']:


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-cluster-tests/issues/12734

Added a check to make sure that the `src_file` instance returned by `iterdir()` is file indeed. If it's a directory, the copy operation that happens next fails.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [vector-search-in-cloud-aws](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/vector-search-in-cloud-aws/32/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
