### PR TITLE
fix(ignore_raft_topology_cmd_failing): remove redundant drain rpc filter

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -406,12 +406,6 @@ def ignore_raft_topology_cmd_failing():
         stack.enter_context(EventsSeverityChangerFilter(
             new_severity=Severity.WARNING,
             event_class=DatabaseLogEvent,
-            regex=r".*raft_topology - drain rpc failed, proceed to fence old writes:.*connection is closed",
-            extra_time_to_expiration=30
-        ))
-        stack.enter_context(EventsSeverityChangerFilter(
-            new_severity=Severity.WARNING,
-            event_class=DatabaseLogEvent,
             regex=r".*raft_topology - drain rpc failed, proceed to fence old writes:.*failed status returned from",
             extra_time_to_expiration=30
         ))


### PR DESCRIPTION
Removed redundant raft_topology drain rpc filter that were covered by a broader EventsSeverityChangerFilter regex,
leaving only the most general matcher to avoid duplicates.

`regex=r".*raft_topology - drain rpc failed, proceed to fence old writes:.*connection is closed"`
is covered by
`regex=r".*raft_topology - drain rpc failed, proceed to fence old writes.*connection is closed"`

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Not required

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
