### PR TITLE
feat(version_utils): Use staging backtrace

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -4767,7 +4767,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
             "shard_awareness_driver": self.is_shard_awareness_driver,
             "rack_aware_policy": self.is_rack_aware_policy,
             "restore_monitor_job_base_link": restore_monitor_job_base_link,
-            "relocatable_pkg": get_relocatable_pkg_url(scylla_version),
+            "relocatable_pkg": get_relocatable_pkg_url(scylla_version) or "",
         }
 
     def get_test_results(self, source, severity=None):

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -31,7 +31,6 @@ from botocore import UNSIGNED
 from botocore.client import Config
 from sdcm.utils.repo_parser import Parser
 
-from sdcm.remote import LOCALRUNNER
 from sdcm.utils.aws_utils import DEFAULT_AWS_REGION
 from sdcm.utils.parallel_object import ParallelObject
 from sdcm.sct_events.system import ScyllaRepoEvent
@@ -908,16 +907,21 @@ class scylla_versions:
         return inner
 
 
-def get_relocatable_pkg_url(scylla_version: str) -> str:
-    relocatable_pkg = ""
+def get_relocatable_pkg_url(scylla_version: str) -> str | None:
+    relocatable_pkg = None
     if scylla_version and "build-id" in scylla_version:
         try:
             scylla_build_id = scylla_version.split("build-id")[-1].split()[0]
-            get_pkgs_cmd = (
-                f'curl -s -X POST http://backtrace.scylladb.com/index.html -d "build_id={scylla_build_id}&backtrace="'
+            response = requests.get(
+                "https://api.backtrace.scylladb.com/api/search/build_id",
+                params={"build_id": scylla_build_id},
+                timeout=10,
             )
-            res = LOCALRUNNER.run(get_pkgs_cmd)
-            relocatable_pkg = re.findall(rf"{scylla_build_id}.+(http:[/\w.:-]*\.tar\.gz)", res.stdout)[0]
+            assert response.status_code == 200
+            result = response.json()["build_data"]["reloc_url"]
+            if not result.startswith("http"):
+                result = f"https://{result}"
+            return result
         except Exception as exc:  # noqa: BLE001
             LOGGER.warning("Couldn't get relocatable_pkg link due to: %s", exc)
     return relocatable_pkg

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -14,6 +14,7 @@ from sdcm.utils.version_utils import (
     get_branch_version_for_multiple_repositories,
     get_branched_repo,
     get_git_tag_from_helm_chart_version,
+    get_relocatable_pkg_url,
     get_scylla_urls_from_repository,
     get_specific_tag_of_docker_image,
     is_enterprise,
@@ -796,6 +797,27 @@ def test_get_branched_repo(scylla_version, distro, expected_repo):
 )
 def test_verify_docker_repo_implicit_resolution_for_scylla_versions(version, expected_repo):
     assert get_scylla_docker_repo_from_version(version) == expected_repo
+
+
+@pytest.mark.need_network
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "scylla_version, expected_result",
+    [
+        pytest.param(
+            "2025.1.10 with build-id 6facdbdabc830d767b848ff2f47b418350f96a72",
+            "https://downloads.scylladb.com/unstable/scylla/branch-2025.1/relocatable/2025-11-21T14:15:54Z/scylla-unified-2025.1.10-0.20251121.cb1f72dc8134.aarch64.tar.gz",
+            id="valid build-id for 2025.1.10",
+        ),
+        pytest.param("6.2.0", None, id="version without build-id"),
+        pytest.param("", None, id="empty version string"),
+        pytest.param("6.2.0 with build-id 000", None, id="invalid_build-id"),
+    ],
+)
+def test_get_relocatable_pkg_url(scylla_version, expected_result):
+    """Test get_relocatable_pkg_url with a valid build-id from staging backtrace service."""
+    result = get_relocatable_pkg_url(scylla_version)
+    assert result == expected_result
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* Part of switching effort to a new backtrace service. Staging has REST API and as such is incompatible with how old one returned values (POST + regex on returned HTML).
  * Simplified code
* Updated method to return `str | None `
  * Makes more sense to me 
* Added new tests for the integration
  * Uses actual website, requests are light so it shouldnt matter

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Unit tests
   - Tests use real service, thats why they are marked as integration 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
