### PR TITLE
improvement(vector_logging): filter logs on client side (v2)

### DIFF
--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -49,6 +49,20 @@ def configure_syslogng_target_script(hostname: str = "") -> str:
 
 
 def configure_vector_target_script(host: str, port: int) -> str:
+    """Prepare vector configuration script with client-side log filtering.
+
+    Configures vector to filter verbose logs before sending them to SCT, reducing memory pressure
+    on database nodes and network resources usage.
+
+    Filter Pipeline:
+        journald > filter_audit > filter_system_services > filter_verbose_scylla > filter_suppress_warnings > sct-runner
+
+    Filters:
+        - filter_audit: remove audit logs
+        - filter_system_services: remove unnecessary system services logs
+        - filter_verbose_scylla: remove compaction/repair/streaming scylla logs
+        - filter_suppress_warnings: remove Severity.SUPPRESS events
+    """
     return dedent("""
         echo "
         sources:
@@ -64,11 +78,47 @@ def configure_vector_target_script(host: str, port: int) -> str:
                 type: filter
                 condition: |
                     !starts_with(to_string(.SYSLOG_IDENTIFIER) ?? \\"default\\", \\"AUDIT\\")
+
+            filter_system_services:
+                inputs:
+                    - filter_audit
+                type: filter
+                condition: |
+                    identifier = to_string(.SYSLOG_IDENTIFIER) ?? \\"\\"
+                    identifier != \\"sshd\\" &&
+                    identifier != \\"systemd\\" &&
+                    identifier != \\"systemd-logind\\" &&
+                    identifier != \\"sudo\\" &&
+                    identifier != \\"dhclient\\"
+
+            filter_verbose_scylla:
+                inputs:
+                    - filter_system_services
+                type: filter
+                condition: |
+                    message = to_string(.message) ?? \\"\\"
+                    !contains(message, \\"] compaction - [Compact\\") &&
+                    !contains(message, \\"] table - Done with off-strategy compaction\\") &&
+                    !contains(message, \\"] table - Starting off-strategy compaction\\") &&
+                    !contains(message, \\"] repair - Repair\\") &&
+                    !contains(message, \\"repair id [id=\\") &&
+                    !contains(message, \\"] stream_session - [Stream\\") &&
+                    !contains(message, \\"] sstable - Rebuilding bloom filter\\") &&
+                    !contains(message, \\"] storage_proxy - Exception when communicating with\\")
+
+            filter_suppress_warnings:
+                inputs:
+                    - filter_verbose_scylla
+                type: filter
+                condition: |
+                    message = to_string(.message) ?? \\"\\"
+                    !(match(message, to_regex!(\\"^WARNING.*[shard.*]\\")) || match(message, to_regex!(\\"^!.*WARNING.*[shard.*]\\")))
+
         sinks:
             sct-runner:
                 type: vector
                 inputs:
-                    - filter_audit
+                    - filter_suppress_warnings
                 address: {host}:{port}
                 healthcheck: false
             prometheus:


### PR DESCRIPTION
Configure vector logging to filter out unnecessary logs on the client side. This includes logs that were previously filtered out on SCT runner side in DbLogReader thread:
- compaction/repair/streaming logs from scylla
- logs from certain system services
- logs which resulted in publishing events, with SUPPRESS severity level (i.e. the events which were eventually ignored)

Filtering logs on the client side helps reduce memory pressure on both, the SCT runner instance and DB nodes. Vector will no longer read and buffer in memory certain messages from journald, on the client side; and SCT runner will not be busy processing them at all. Additionally, this reduces network bandwidth usage as logs_to_be_dropped will no longer be sent from DB nodes to SCT.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [longevity-5gb-1h-nemesis](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/76/)
- [x] :green_circle: [centos9-artifacts-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-debian12-test/7/) 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
