### PR TITLE
fix(nemesis): rebuild/cleanup reduce timeouts

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1924,18 +1924,18 @@ class Nemesis(NemesisFlags):
             self._mgmt_repair_cli(ignore_down_hosts=ignore_down_hosts)
 
     def repair_nodetool_rebuild(self):
-        with adaptive_timeout(Operations.REBUILD, self.target_node, timeout=HOUR_IN_SEC * 48):
+        with adaptive_timeout(Operations.REBUILD, self.target_node, timeout=60):
             self.target_node.run_nodetool('rebuild', long_running=True, retry=0)
 
     def nodetool_cleanup_on_all_nodes_parallel(self):
         # Inner disrupt function for ParallelObject
         def _nodetool_cleanup(node):
             InfoEvent('NodetoolCleanupMonkey %s' % node).publish()
-            with adaptive_timeout(Operations.CLEANUP, node, timeout=HOUR_IN_SEC * 48):
+            with adaptive_timeout(Operations.CLEANUP, node, timeout=60):
                 node.run_nodetool(sub_cmd="cleanup", long_running=True, retry=0)
 
         parallel_objects = ParallelObject(self.cluster.nodes, num_workers=min(
-            32, len(self.cluster.nodes)), timeout=HOUR_IN_SEC * 48)
+            32, len(self.cluster.nodes)), timeout=300)
         with self.action_log_scope("Cleanup all nodes in parallel"):
             parallel_objects.run(_nodetool_cleanup)
 


### PR DESCRIPTION
the timeout for the adaptive timeouts was set to 48h that is way too big, and after reviewing it on tier1 runs reduced the timeout to 5min.

Fixes: #12261

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
