### PR TITLE
fix(gke): not use network_configuration

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2050,6 +2050,16 @@ class BaseScyllaPodContainer(BasePodContainer):
 
     parent_cluster: ScyllaPodCluster
 
+    def __str__(self):
+        # TODO: when new network_configuration will be supported by all backends, copy this function from sdcm.cluster_aws.AWSNode.__str__
+        #  to here
+        return 'Node %s [%s | %s%s]%s' % (
+            self.name,
+            self.public_ip_address,
+            self.private_ip_address,
+            " | %s" % self.ipv6_ip_address if self.test_config.IP_SSH_CONNECTIONS == "ipv6" else "",
+            self._dc_info_str())
+
     def actual_scylla_yaml(self) -> ContextManager[ScyllaYaml]:
         return super().remote_scylla_yaml()
 


### PR DESCRIPTION
The upgrade-scylla-k8s-gke test failed due to an error while retrieving 'broadcast_address_ip_type'. The issue originates from this commit: https://github.com/scylladb/scylla-cluster-tests/pull/11909 , which added usage of the new network configuration inside the '__str__' method in cluster.py.

This new network configuration is intended only for AWS, so it should not be applied globally. Because '__str__' is used by all backends unless specifically overridden, the AWS-specific logic is now being applied to GKE as well, causing the failure.

To fix this, the '__str__' method should be overridden for the GKE node implementation so it does not use the AWS-only network configuration.

Test failed with this error: https://argus.scylladb.com/tests/scylla-cluster-tests/e94ad114-1dd6-40ab-982d-07854008e647

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [upgrade-scylla-k8s-gke-test](https://argus.scylladb.com/tests/scylla-cluster-tests/7202422a-4d56-4723-b5e9-7b9647bc4a34) - This test failed with a different error, unrelated to the issue addressed by this commit.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
