### PR TITLE
improvement(logcollector): collecting logs from Manager node

### DIFF
--- a/defaults/cloud_config.yaml
+++ b/defaults/cloud_config.yaml
@@ -2,10 +2,6 @@ n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
 
-use_mgmt: false
-
-use_cloud_manager: true
-
 # disable it since it need ssh access to db nodes
 # TODO: remove it once we have such access by default
 run_commit_log_check_thread: false

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1032,6 +1032,8 @@ class SirenManagerLogCollector(LogCollector):
         FileLog(name="scylla_manager.log",
                 command="sudo journalctl -u scylla-manager.service --no-tail",
                 search_locally=True),
+        CommandLog(name='scylla.yaml',
+                   command=f'cat {SCYLLA_YAML_PATH}'),
     ]
     cluster_log_type = "siren-manager-set"
     cluster_dir_prefix = "siren-manager-set"
@@ -1808,6 +1810,14 @@ class Collector:
                         self.vector_store_set, "xcloud_connect_get_vs_ssh_address")
             except Exception as exc:  # noqa: BLE001
                 LOGGER.warning("Failed to add Vector Store nodes for log collection: %s", exc)
+
+        try:
+            manager_node_data = {"id": f"manager-{cluster_id}"}
+            self._add_xcloud_node_to_collecting_set(
+                cluster_id, manager_node_data, "manager",
+                self.siren_manager_set, "xcloud_connect_get_manager_ssh_address")
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("Failed to add Manager node for log collection: %s", exc)
 
     def get_running_cluster_sets(self, backend):
         if backend in ("aws", "aws-siren", "k8s-eks"):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3949,8 +3949,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
                      "collector": MonitorLogCollector,
                      "logname": "monitoring_log", },
                     {"name": "siren_manager",
-                     "nodes": (self.db_cluster and hasattr(self.db_cluster, 'manager_instance')
-                               and self.db_cluster.manager_instance),
+                     "nodes": self.db_cluster and (
+                         [self.db_cluster.scylla_manager_node] if self.params.get('cluster_backend') == 'xcloud'
+                         else self.db_cluster.manager_instance),
                      "collector": SirenManagerLogCollector,
                      "logname": "monitoring_log", },
                     {"name": "vector_store",


### PR DESCRIPTION
Enable collecting logs from Manager node in deployments on xcloud backend.

Closes: https://github.com/scylladb/qa-tasks/issues/2005

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [pr-provision-test, collected logs](https://argus.scylladb.com/tests/scylla-cluster-tests/d5907f2c-a141-490e-9a27-717c01a46448/logs)
Collected logs from Manager node:
```
❯ ll siren-manager-set-d5907f2c/manager-30525
total 1,7M
drwxr-xr-x 2 dmitriy 4,0K gru  5 14:36 .
drwxr-xr-x 3 dmitriy 4,0K gru  5 14:35 ..
-rw-rw-r-- 1 dmitriy  77K gru  5 14:36 scylla_manager.log
-rw-rw-r-- 1 dmitriy  37K gru  5 14:36 scylla.yaml
-rw-rw-r-- 1 dmitriy 1,5M gru  5 14:35 system.log
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
