### PR TITLE
fix(sct_config.py): use oracle scylla version in exception

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2171,7 +2171,7 @@ class SCTConfiguration(dict):
                             ami = get_scylla_ami_versions(version=oracle_scylla_version,
                                                           region_name=region, arch=aws_arch)[0]
                     except Exception as ex:  # noqa: BLE001
-                        raise ValueError(f"AMIs for oracle_scylla_version='{scylla_version}' not found in {region} "
+                        raise ValueError(f"AMIs for oracle_scylla_version='{oracle_scylla_version}' not found in {region} "
                                          f"arch={aws_arch}") from ex
 
                     self.log.debug("Found AMI %s for oracle_scylla_version='%s' in %s",


### PR DESCRIPTION
During SCT config initialization, if oracle scylla version AMI is not found in AWS, the process is interrupted, but the error message uses wrong config parameter to inform about problematic version.

This change fixes the error message to use the correct config parameter.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] `lint_test_cases` check, if failed, now properly shows the oracle scylla version:
```
13:56:59  Traceback (most recent call last):
13:56:59    File "/tmp/jenkins/workspace/an_scylla-cluster-tests_PR-12778/./sct.py", line 1086, in _run_yaml_test
13:56:59      config = SCTConfiguration()
13:56:59    File "/tmp/jenkins/workspace/an_scylla-cluster-tests_PR-12778/sdcm/sct_config.py", line 2174, in __init__
13:56:59      raise ValueError(f"AMIs for oracle_scylla_version='{oracle_scylla_version}' not found in {region} "
13:56:59                       f"arch={aws_arch}") from ex
13:56:59  ValueError: AMIs for oracle_scylla_version='2022.1.14' not found in eu-west-1 arch=x86_64
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
