### PR TITLE
improvement(performance): error threshold for read_disk_only test

### DIFF
--- a/configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml
+++ b/configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml
@@ -48,31 +48,26 @@ latency_decorator_error_thresholds:
 
 
   read_disk_only:
-    "150000":
+    "80000":
       P90 read:
         fixed_limit: null
       P99 read:
-        fixed_limit: 1
+        fixed_limit: null
+    "165000":
+      P90 read:
+        fixed_limit: null
+      P99 read:
+        fixed_limit: null
+    "250000":
+      P90 read:
+        fixed_limit: null
+      P99 read:
+        fixed_limit: null
     "300000":
       P90 read:
         fixed_limit: null
       P99 read:
-        fixed_limit: 1
-    "450000":
-      P90 read:
         fixed_limit: null
-      P99 read:
-        fixed_limit: 3
-    "600000":
-      P90 read:
-        fixed_limit: null
-      P99 read:
-        fixed_limit: 40
-    "700000":
-      P90 read:
-        fixed_limit: null
-      P99 read:
-        fixed_limit: 50
     unthrottled:
       P90 read:
         fixed_limit: null
@@ -81,7 +76,7 @@ latency_decorator_error_thresholds:
       Throughput read:
         # Fixed throughput limit in operations per second (ops/sec).
         # This value was determined based on performance testing: 10% below the avg. of 5 best results in the last 3 months.
-        fixed_limit: 827911
+        fixed_limit: null
 
   mixed:
     "50000":

--- a/configurations/performance/latency-decorator-error-thresholds-steps-ent-vnodes.yaml
+++ b/configurations/performance/latency-decorator-error-thresholds-steps-ent-vnodes.yaml
@@ -48,31 +48,26 @@ latency_decorator_error_thresholds:
 
 
   read_disk_only:
-    "150000":
-      P90 read:
-        fixed_limit: null
-      P99 read:
-        fixed_limit: 1
-    "300000":
-      P90 read:
-        fixed_limit: null
-      P99 read:
-        fixed_limit: 1
-    "450000":
+    "80000":
       P90 read:
         fixed_limit: null
       P99 read:
         fixed_limit: 5
-    "600000":
+    "165000":
       P90 read:
         fixed_limit: null
       P99 read:
-        fixed_limit: 40
-    "700000":
+        fixed_limit: 5
+    "250000":
       P90 read:
         fixed_limit: null
       P99 read:
         fixed_limit: 50
+    "300000":
+      P90 read:
+        fixed_limit: null
+      P99 read:
+        fixed_limit: null
     unthrottled:
       P90 read:
         fixed_limit: null
@@ -81,7 +76,7 @@ latency_decorator_error_thresholds:
       Throughput read:
         # Fixed throughput limit in operations per second (ops/sec).
         # This value was determined based on performance testing: 10% below the avg. of 5 best results in the last 3 months.
-        fixed_limit: 862336
+        fixed_limit: 300000
 
   mixed:
     "50000":

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-tablets.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/scylla-enterprise-perf-regression-predefined-throughput-steps-tablets.jenkinsfile
@@ -9,5 +9,5 @@ perfRegressionParallelPipeline(
     provision_type: 'on_demand',
     test_name: "performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest",
     test_config: '''["test-cases/performance/perf-regression-predefined-throughput-steps.yaml", "configurations/performance/cassandra_stress_gradual_load_steps_enterprise.yaml", "configurations/disable_kms.yaml", "configurations/disable_speculative_retry.yaml", "configurations/performance/latency-decorator-error-thresholds-steps-ent-tablets.yaml"]''',
-    sub_tests: ["test_read_gradual_increase_load", "test_mixed_gradual_increase_load"],
+    sub_tests: ["test_read_gradual_increase_load", "test_mixed_gradual_increase_load", "test_read_disk_only_gradual_increase_load"],
 )


### PR DESCRIPTION
Define latency error threshold for read_disk_only throughput tests

Ref: https://github.com/scylladb/qa-tasks/issues/2016

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
