### PR TITLE
fix(test_default.yaml): bump oracle_scylla_version to 2024.1

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -116,7 +116,7 @@ authenticator_password: ''
 
 # gemini defaults
 n_test_oracle_db_nodes: 1
-oracle_scylla_version: '2022.1.14'
+oracle_scylla_version: '2024.1'
 append_scylla_args_oracle: '--enable-cache false'
 run_gemini_in_rolling_upgrade: false
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -280,7 +280,7 @@ Format version of the user-data to use for scylla images,<br>default to what tag
 
 Version of scylla to use as oracle cluster with gemini tests, ex. '3.0.11'<br>Automatically lookup AMIs for formal versions.<br>WARNING: can't be used together with 'ami_id_db_oracle'
 
-**default:** 2022.1.14
+**default:** 2024.1
 
 **type:** str
 


### PR DESCRIPTION
oracle_scylla_version is currently set a too older version of 2022.1.14. It's also missing AMIs and fails CI.
Fixes: #12542
Refs: #12777

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [test](https://argus.scylladb.com/tests/scylla-cluster-tests/369bab03-4622-4b67-bf55-0fabc3ba6235) gemini 2.2.1with nemesis.
- [test no nemesis](https://jenkins.scylladb.com/job/scylla-staging/job/yarongilor/job/gemini-sequence-nemesis/40/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
