### PR TITLE
fix(performance): make read_disk_only duration dynamic

### DIFF
--- a/configurations/performance/cassandra_stress_gradual_load_reduced_steps_number.yaml
+++ b/configurations/performance/cassandra_stress_gradual_load_reduced_steps_number.yaml
@@ -3,6 +3,6 @@
 ## The value of perf_gradual_threads[load] must be either:
 ##   - a single-element list or integer (applied to all throttle steps)
 ##   - a list with the same length as perf_gradual_throttle_steps[load] (one thread count per step).
-perf_gradual_threads: {"read": 620, "write": 400, "mixed": 1900}
+perf_gradual_threads: {"read": 620, "write": 400, "mixed": 1900, "read_disk_only": 620}
 perf_gradual_throttle_steps: {"read": ['450000', '700000', 'unthrottled'], "mixed": ['300000', '450000', 'unthrottled'], "write": ['200000', 'unthrottled'], "read_disk_only": ['250000', '300000', 'unthrottled']}  # where every value is in ops
 perf_gradual_step_duration: {"read": '20m', "write": None, "mixed": '20m', "read_disk_only": '20m'}  # duration per step; None means until completion of the stress command

--- a/test-cases/performance/perf-regression-predefined-throughput-steps.yaml
+++ b/test-cases/performance/perf-regression-predefined-throughput-steps.yaml
@@ -36,10 +36,10 @@ stress_cmd_m: [
 
 # Read the entire data set to ensure disk only reads
 stress_cmd_read_disk: [
-  "cassandra-stress read  cl=QUORUM duration=30m -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..162500001",
-  "cassandra-stress read  cl=QUORUM duration=30m -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=162500002..325000002",
-  "cassandra-stress read  cl=QUORUM duration=30m -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=325000003..487500003",
-  "cassandra-stress read  cl=QUORUM duration=30m -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=487500004..650000004"
+  "cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..162500001",
+  "cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=162500002..325000002",
+  "cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=325000003..487500003",
+  "cassandra-stress read  cl=QUORUM duration=$duration -mode connectionsPerHost=8 cql3 native -rate 'threads=$threads $throttle' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=487500004..650000004"
 ]
 
 round_robin: true


### PR DESCRIPTION
This commit includes two fixes:

1. The duration of the 'read_disk_only' command is now parameterized instead of being incorrectly hard-coded.

2. The 'perf_gradual_threads' parameter is now defined for the 'read_disk_only' subtest.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
