### PR TITLE
improvement(xcloud): add SSH connectivity support for VS nodes

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -147,6 +147,7 @@ from sdcm.logcollector import (
     PythonSCTLogCollector,
     ScyllaLogCollector,
     SirenManagerLogCollector,
+    VectorStoreLogCollector,
 )
 from sdcm.send_email import build_reporter, save_email_data_to_file
 from sdcm.utils import alternator
@@ -3929,6 +3930,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
                      "prometheus_data": "",
                      "monitoring_stack": "",
                      "siren_manager": "",
+                     "vector_store_log": "",
                      }
         storage_dir = os.path.join(self.logdir, "collected_logs")
         os.makedirs(storage_dir, exist_ok=True)
@@ -3947,9 +3949,14 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
                      "collector": MonitorLogCollector,
                      "logname": "monitoring_log", },
                     {"name": "siren_manager",
-                     "nodes": self.db_cluster and self.db_cluster.manager_instance,
+                     "nodes": (self.db_cluster and hasattr(self.db_cluster, 'manager_instance')
+                               and self.db_cluster.manager_instance),
                      "collector": SirenManagerLogCollector,
                      "logname": "monitoring_log", },
+                    {"name": "vector_store",
+                     "nodes": (self.db_cluster and hasattr(self.db_cluster, 'vs_nodes') and self.db_cluster.vs_nodes),
+                     "collector": VectorStoreLogCollector,
+                     "logname": "vector_store_log", },
                     {"name": "k8s_cluster_api",
                      "nodes": [],
                      "collector": KubernetesAPIServerLogCollector,

--- a/sdcm/utils/internal_modules.py
+++ b/sdcm/utils/internal_modules.py
@@ -38,7 +38,10 @@ except ImportError:
         def xcloud_connect_get_ssh_address(self, node):
             raise NotImplementedError(not_supported_message)
 
-        def xcloud_connect_get_manager_ssh_address(self, cluster_id, sdm_environment):
+        def xcloud_connect_get_manager_ssh_address(self, node):
+            raise NotImplementedError(not_supported_message)
+
+        def xcloud_connect_get_vs_ssh_address(self, node):
             raise NotImplementedError(not_supported_message)
 
 __all__ = ["XCloudConnectivityContainerMixin"]


### PR DESCRIPTION
Add SSH connectivity for Vector Store nodes in a cloud cluster. Additionally, enable collecting logs from Vector Store nodes.

Refs: https://github.com/scylladb/qa-tasks/issues/1991

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] checked SSH access to VS nodes at runtime:
```
>>> for node in self.vs_nodes:
...     print(node.remoter.run('systemctl status vector-store.service').stdout)
    
● vector-store.service - Vector Rust Service
     Loaded: loaded (/etc/systemd/system/vector-store.service; disabled; preset: enabled)
     Active: active (running) since Wed 2025-12-03 11:56:11 UTC; 15min ago
   Main PID: 1805 (vector-store)
      Tasks: 4 (limit: 2197)
     Memory: 13.7M (peak: 14.1M)
        CPU: 649ms
     CGroup: /system.slice/vector-store.service
             └─1805 /home/ubuntu/vector-store/vector-store
● vector-store.service - Vector Rust Service
     Loaded: loaded (/etc/systemd/system/vector-store.service; disabled; preset: enabled)
     Active: active (running) since Wed 2025-12-03 11:56:56 UTC; 14min ago
   Main PID: 1821 (vector-store)
      Tasks: 3 (limit: 2197)
     Memory: 13.6M (peak: 14.1M)
        CPU: 675ms
     CGroup: /system.slice/vector-store.service
             └─1821 /home/ubuntu/vector-store/vector-store
● vector-store.service - Vector Rust Service
     Loaded: loaded (/etc/systemd/system/vector-store.service; disabled; preset: enabled)
     Active: active (running) since Wed 2025-12-03 11:57:45 UTC; 13min ago
   Main PID: 1803 (vector-store)
      Tasks: 3 (limit: 2197)
     Memory: 13.7M (peak: 14.2M)
        CPU: 662ms
     CGroup: /system.slice/vector-store.service
             └─1803 /home/ubuntu/vector-store/vector-store
```
- [x] :green_circle: [logs of pr-provision-test with VS nodes deployed](https://argus.scylladb.com/tests/scylla-cluster-tests/0e020079-c6ef-4e01-b094-f4876fe236d1/logs)
Collected logs from VS nodes:
```
❯ ll vector-store-set-0e020079/*
vector-store-set-0e020079/176009:
total 688K
drwxr-xr-x 2 dmitriy 4,0K gru  3 22:04 .
drwxr-xr-x 5 dmitriy 4,0K gru  3 22:03 ..
-rw-rw-r-- 1 dmitriy 676K gru  3 22:03 system.log
-rw-rw-r-- 1 dmitriy  730 gru  3 22:04 vector_store.log

vector-store-set-0e020079/176010:
total 668K
drwxr-xr-x 2 dmitriy 4,0K gru  3 22:04 .
drwxr-xr-x 5 dmitriy 4,0K gru  3 22:03 ..
-rw-rw-r-- 1 dmitriy 656K gru  3 22:03 system.log
-rw-rw-r-- 1 dmitriy  743 gru  3 22:04 vector_store.log

vector-store-set-0e020079/176011:
total 652K
drwxr-xr-x 2 dmitriy 4,0K gru  3 22:04 .
drwxr-xr-x 5 dmitriy 4,0K gru  3 22:03 ..
-rw-rw-r-- 1 dmitriy 640K gru  3 22:03 system.log
-rw-rw-r-- 1 dmitriy  743 gru  3 22:04 vector_store.log
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
