### PR TITLE
fix(tagging): add required tags to EKS nodes if absent

### DIFF
--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -245,7 +245,7 @@ class EksNodePool(CloudK8sNodePool):
     @property
     def _node_group_cfg(self) -> dict:
         labels = {} if self.labels is None else self.labels
-        tags = {} if self.tags is None else self.tags
+        tags = {'Owner': 'SCT', 'Name': 'SCT', **(self.tags or {})}
         node_labels = labels.copy()
         node_labels['node-pool'] = self.name
         node_pool_config = {


### PR DESCRIPTION
### Testing
- cherry-picked from `operator-staging` where all AWS tests worked since the changes

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code