### PR TITLE
fix(chore): add AWS principals as EKSClusterAdmins to all EKS SCT clusters

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -13,6 +13,9 @@ eks_cluster_version: '1.32'
 eks_role_arn: 'arn:aws:iam::797456418907:role/eksServicePolicy'
 eks_service_ipv4_cidr: '172.20.0.0/16'
 eks_nodegroup_role_arn: 'arn:aws:iam::797456418907:role/helm-test-worker-nodes-NodeInstanceRole-6ACHDYEKNN3I'
+eks_admin_arn:
+  - 'arn:aws:iam::797456418907:role/DeveloperAccessRole'
+  - 'arn:aws:iam::797456418907:role/DevOpsAccessRole'
 # NOTE: https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
 eks_vpc_cni_version: 'v1.19.2-eksbuild.5'
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1743,6 +1743,15 @@ Supported: eastus
 **type:** str (appendable)
 
 
+## **eks_admin_arn** / SCT_EKS_ADMIN_ARN
+
+
+
+**default:** N/A
+
+**type:** str_or_list_or_eval (appendable)
+
+
 ## **eks_cluster_version** / SCT_EKS_CLUSTER_VERSION
 
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -960,6 +960,9 @@ class SCTConfiguration(dict):
         dict(name="eks_role_arn", env="SCT_EKS_ROLE_ARN", type=str,
              help=""),
 
+        dict(name="eks_admin_arn", env="SCT_EKS_ADMIN_ARN", type=str_or_list_or_eval,
+             help=""),
+
         dict(name="eks_cluster_version", env="SCT_EKS_CLUSTER_VERSION", type=str,
              help=""),
 
@@ -1951,7 +1954,7 @@ class SCTConfiguration(dict):
                     'scylla_version', 'scylla_mgmt_agent_version', 'k8s_scylla_operator_docker_image',
                     'k8s_scylla_cluster_name', 'k8s_loader_cluster_name',
                     'mgmt_docker_image', 'eks_service_ipv4_cidr', 'eks_vpc_cni_version', 'eks_role_arn',
-                    'eks_cluster_version', 'eks_nodegroup_role_arn'],
+                    'eks_admin_arn', 'eks_cluster_version', 'eks_nodegroup_role_arn'],
 
         'xcloud': ['user_prefix', 'xcloud_provider', 'scylla_version'],
     }


### PR DESCRIPTION
This change allows live monitoring SCT EKS clusters directly during the test execution - makes debugging much happier since you do not need to wait for the test to end and generate must-gather.

@fruch this accounts your [suggestion](https://github.com/scylladb/scylla-cluster-tests/commit/614417bee54c0480e32cdc388688241082c06a2b#r171491045) to move the principals to configuration

### Testing
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abramche/job/operator/job/upgrade/job/upgrade-major-scylla-podips-k8s-eks-test/7/

```
$ aws eks list-access-entries --cluster-name kuberne-scylla-upgrade-operato-343da0cd --region eu-north-1
{
    "accessEntries": [
        "arn:aws:iam::797456418907:role/DevOpsAccessRole",
        "arn:aws:iam::797456418907:role/DeveloperAccessRole",
        ...
    ]
}

~
$ kubectl get statefulset -n scylla
NAME                            READY   AGE
sct-cluster-eu-north-1-rack-1   3/3     82m
```

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
