### PR TITLE
fix(artifacts): handle empty AZ correctly

### DIFF
--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -242,7 +242,9 @@ def call(Map pipelineParams) {
                                                     export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
                                                     export SCT_IP_SSH_CONNECTIONS="${params.ip_ssh_connections}"
                                                     export SCT_INSTANCE_PROVISION="${params.provision_type}"
-                                                    export SCT_AVAILABILITY_ZONE="${params.availability_zone}"
+                                                    if [[ -n "${params.availability_zone ? params.availability_zone : ''}" ]] ; then
+                                                        export SCT_AVAILABILITY_ZONE="${params.availability_zone}"
+                                                    fi
 
                                                     echo "start test ......."
                                                     ./docker/env/hydra.sh run-test artifacts_test --backend ${params.backend} --logdir "`pwd`"

--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -289,7 +289,9 @@ def call(Map pipelineParams) {
                                                         export SCT_CLIENT_ENCRYPT=${params.use_client_encryption}
                                                         export SCT_USE_PREPARED_LOADERS=${params.use_prepared_loaders}
 
-                                                        export SCT_AVAILABILITY_ZONE="${params.availability_zone}"
+                                                        if [[ -n "${params.availability_zone ? params.availability_zone : ''}" ]] ; then
+                                                            export SCT_AVAILABILITY_ZONE="${params.availability_zone}"
+                                                        fi
 
                                                         if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
                                                             export SCT_GCE_DATACENTER=${params.gce_datacenter}


### PR DESCRIPTION
recent chances in #12456 remove the defaults, but artifact pipeline was still passing empty string breaking AWS backend jobs

while backporting this, we need to flush other usages like that.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2404-arm-test/12/  (with AZ)
- [x] 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2404-arm-test/13/  (empty AZ)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
