### PR TITLE
fix(pipeline): remove default availability zone

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1844,8 +1844,6 @@ def create_runner_image(cloud_provider, region, availability_zone):
 def create_runner_instance(cloud_provider, region, availability_zone, instance_type, root_disk_size_gb,
                            test_id, test_name, duration, restore_monitor=False, restored_test_id="", address_pool=None):
 
-    if cloud_provider == "aws":
-        assert len(availability_zone) == 1, f"Invalid AZ: {availability_zone}, availability-zone is one-letter a-z."
     add_file_logger()
     sct_runner_ip_path = Path("sct_runner_ip")
     sct_runner_ip_path.unlink(missing_ok=True)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2655,7 +2655,6 @@ class SCTConfiguration(dict):
             self._validate_docker_backend_parameters()
         if backend == 'xcloud':
             self._validate_cloud_backend_parameters()
-
         self._verify_data_volume_configuration(backend)
 
         if self.get('n_db_nodes'):

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -467,6 +467,11 @@ class AwsSctRunner(SctRunner):
     LONGTERM_TEST_INSTANCE_TYPE = "m7i-flex.xlarge"  # 4 vcpus, 16G
 
     def __init__(self, region_name: str, availability_zone: str, params: SCTConfiguration | None = None):
+        availability_zone = availability_zone or params.get("availability_zone")
+        assert availability_zone, "Availability zone is required for AWS"
+        availability_zone = availability_zone.split(',')[0]  # in case multiple AZs are given, take the first one
+        assert len(availability_zone) == 1, f"Invalid AZ: {availability_zone}, availability-zone is one-letter a-z."
+
         super().__init__(region_name=region_name, availability_zone=availability_zone, params=params)
         if region_name.endswith(tuple(string.ascii_lowercase)):
             region_name = region_name[:-1]
@@ -795,6 +800,10 @@ class GceSctRunner(SctRunner):
 
     def __init__(self, region_name: str, availability_zone: str,  params: SCTConfiguration | None = None):
         availability_zone = availability_zone or params.get("availability_zone") or random_zone(region_name)
+        assert availability_zone, "Availability zone is required for GCE"
+        availability_zone = availability_zone.split(',')[0]  # in case multiple AZs are given, take the first one
+        assert len(availability_zone) == 1, f"Invalid AZ: {availability_zone}, availability-zone is one-letter a-z."
+
         super().__init__(region_name=region_name, availability_zone=availability_zone, params=params)
         self.gce_region = region_name
         self.gce_source_region = self.SOURCE_IMAGE_REGION

--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -24,7 +24,7 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('region', 'us-east1')}",
                description: 'Region value',
                name: 'region')
-            string(defaultValue: "a",
+            string(defaultValue: "",
                description: 'Availability zone',
                name: 'availability_zone')
 
@@ -172,6 +172,9 @@ def call(Map pipelineParams) {
 
                                 export SCT_CONFIG_FILES=${params.test_config}
                                 export SCT_COLLECT_LOGS=false
+                                if [[ -n "${params.availability_zone ? params.availability_zone : ''}" ]] ; then
+                                    export SCT_AVAILABILITY_ZONE="${params.availability_zone}"
+                                fi
 
                                 if [[ -n "${params.requested_by_user ? params.requested_by_user : ''}" ]] ; then
                                     export BUILD_USER_REQUESTED_BY=${params.requested_by_user}

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -71,7 +71,7 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('azure_region_name', 'eastus')}",
                    description: 'Azure location',
                    name: 'azure_region_name')
-            string(defaultValue: "a",
+            string(defaultValue: "",
                description: 'Availability zone',
                name: 'availability_zone')
 

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -38,7 +38,7 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
                    description: 'GCE datacenter',
                    name: 'gce_datacenter')
-            string(defaultValue: "a",
+            string(defaultValue: "",
                description: 'Availability zone',
                name: 'availability_zone')
             separator(name: 'SCYLLA_DB', sectionHeader: 'ScyllaDB Configuration Selection')


### PR DESCRIPTION
There are 3 more pipelines have a default availability zone.
Remove it

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [rolling upgrade on GCE with wrong AZ](https://argus.scylladb.com/tests/scylla-cluster-tests/d4093c3e-87f4-4574-a48f-8a75c0fe790c)
```
18:46:56  < t:2025-12-04 16:46:56,425 f:tester.py       l:212  c:sdcm.tester          p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/sct_config.py", line 2587, in _validate_gce_availability_zones
18:46:56  < t:2025-12-04 16:46:56,425 f:tester.py       l:212  c:sdcm.tester          p:ERROR >     raise ValueError(f"GCE availability zone '{availability_zone}' is not valid for region '{region}'. "
18:46:56  < t:2025-12-04 16:46:56,425 f:tester.py       l:212  c:sdcm.tester          p:ERROR >                      f"Supported zones: {', '.join(SUPPORTED_REGIONS[region])}")
18:46:56  < t:2025-12-04 16:46:56,425 f:tester.py       l:212  c:sdcm.tester          p:ERROR > ValueError: GCE availability zone 'a' is not valid for region 'us-east1'. Supported zones: c, d
```

- [x]  [rolling upgrade on GCE without AZ](https://argus.scylladb.com/tests/scylla-cluster-tests/39c568b8-95b1-44c7-8dfe-f960ac3b0496)
```
GCE zones used: ['us-east1-c']
```

- [x] [rolling upgrade on GCE with correct AZ="c"](https://argus.scylladb.com/tests/scylla-cluster-tests/d42535ae-ca25-4fc0-bab4-25b675ba4aa3)
- [x] [longevity-10gb-3h-gce, AZ empty](https://argus.scylladb.com/tests/scylla-cluster-tests/0e1cf8c6-ce7b-4a3e-9a24-ac3fbba7ae5b)
- [x] [artifacts-gce-image, AZ empty](https://argus.scylladb.com/tests/scylla-cluster-tests/c1f17fc1-bca4-47bd-a2be-6e8ebb867511)
- [x] [artifacts-gce-image, multi AZ including wrong](https://argus.scylladb.com/tests/scylla-cluster-tests/01455e20-23ca-4914-8032-2c83d9e5ee55)
- [x] [artifacts-gce-image with correct AZ](https://argus.scylladb.com/tests/scylla-cluster-tests/c734fc13-1a42-4e20-b27f-a78c1ca91c9d)

- [x] [rolling upgrade on AWS without AZ](https://argus.scylladb.com/tests/scylla-cluster-tests/ebcd4a11-0aa6-42c3-b166-4aa1ed1f8511)
- [x] [longevity on AWS without AZ](https://argus.scylladb.com/tests/scylla-cluster-tests/5d587e94-56ba-447a-bb4e-747747ebc2a5)
- [x] [longevity on AWS with AZ](https://argus.scylladb.com/tests/scylla-cluster-tests/d113b1a4-009e-4e86-99b6-db7d959ca739)
- [x] [performance test without AZ](https://argus.scylladb.com/tests/scylla-cluster-tests/9576f393-93c7-452c-b862-713873544ce9)
- [x] [azure longevity, AZ ampty](https://argus.scylladb.com/tests/scylla-cluster-tests/47cd0804-3353-45bc-8ebf-5d1694b0c441)
- [x] [artifact-ami, AWS, AZ empty](https://argus.scylladb.com/tests/scylla-cluster-tests/391bad27-eb74-43e1-ac6b-b576b2f185ae)
- [x] [perf-simple-query-weekly-microbenchmark_arm64](https://argus.scylladb.com/tests/scylla-cluster-tests/083a5a4e-f1f9-43b1-875f-48d5f2c8defd)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
