### PR TITLE
fix(xcloud): use retries when installing vector.dev logging

### DIFF
--- a/sdcm/cluster_cloud.py
+++ b/sdcm/cluster_cloud.py
@@ -32,7 +32,7 @@ from sdcm.utils.gce_region import GceRegion
 from sdcm.test_config import TestConfig
 from sdcm.remote import RemoteCmdRunner, shell_script_cmd
 from sdcm.provision.network_configuration import ssh_connection_ip_type
-from sdcm.provision.common.utils import configure_vector_target_script
+from sdcm.provision.common.utils import configure_backoff_timeout, configure_vector_target_script, install_vector_from_local_pkg
 
 LOGGER = logging.getLogger(__name__)
 
@@ -351,8 +351,8 @@ class CloudNode(cluster.BaseNode):
             self.remoter.send_files(str(package_path), remote_path)
 
             LOGGER.debug("➡ Installing Vector")
-            ssh_cmd = f"dpkg -i {remote_path} && apt-get update && apt-get install -y vector && systemctl enable vector && systemctl start vector"
-            self.remoter.sudo(shell_script_cmd(ssh_cmd), retry=0, verbose=True)
+            ssh_cmd = configure_backoff_timeout() + install_vector_from_local_pkg(remote_path)
+            self.remoter.sudo(shell_script_cmd(ssh_cmd, quote="'"), retry=0, verbose=True)
             host, port = TestConfig().get_logging_service_host_port()
             ssh_cmd = configure_vector_target_script(host=host, port=port)
             self.remoter.sudo(shell_script_cmd(ssh_cmd, quote="'"), retry=0, verbose=True)


### PR DESCRIPTION
Installation of vector.dev on nodes in xcloud backend ocassionally fails, when refreshing package index.
This change fixes this by adding retires for commands of package index refresh and vector installation.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/12461

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: executed a few runs of xcloud backend test - [provision test on cloud build #91](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/pr-provision-test-new/91/) and builds 92-93

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
