### PR TITLE
VS in Cloud tests updates for preGA release

### DIFF
--- a/data_dir/latte/vector_search/vector_search_recall.rn
+++ b/data_dir/latte/vector_search/vector_search_recall.rn
@@ -5,7 +5,6 @@ const KEYSPACE = latte::param!("keyspace", "vdb_bench");
 const TABLE = latte::param!("table", "vdb_bench_collection");
 const INDEX = latte::param!("index", "vdb_bench_collection_vector_idx");
 const REPLICATION_FACTOR = latte::param!("replication_factor", 3);
-const TABLETS_ENABLED = latte::param!("tablets_enabled", false);
 
 const ANN_LIMIT = latte::param!("ann_limit", 10);
 const MIN_RECALL_THRESHOLD = latte::param!("min_recall_threshold", 0.9);
@@ -32,7 +31,7 @@ const P_STMT = #{
 
 pub async fn schema(db) {
     db.execute(`CREATE KEYSPACE IF NOT EXISTS ${KEYSPACE} WITH REPLICATION = {
-        'class': 'NetworkTopologyStrategy', 'replication_factor': '${REPLICATION_FACTOR}'} AND durable_writes = true AND tablets = {'enabled': ${TABLETS_ENABLED}}`).await?;
+        'class': 'NetworkTopologyStrategy', 'replication_factor': '${REPLICATION_FACTOR}'} AND durable_writes = true`).await?;
 
     db.execute(`CREATE TABLE IF NOT EXISTS ${KEYSPACE}.${TABLE} (
         id int,

--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -23,7 +23,7 @@ ami_id_db_oracle: ''
 
 ami_id_vector_store: ''
 ami_vector_store_user: 'ubuntu'
-instance_type_vector_store: 't4g.small'
+instance_type_vector_store: 't4g.medium'
 
 use_preinstalled_scylla: true
 

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -23,7 +23,7 @@ gce_root_disk_type_db: 'pd-ssd'
 root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 4
 
-instance_type_vector_store: 'e2-small'
+instance_type_vector_store: 'e2-medium'
 
 gce_pd_standard_disk_size_db: 0
 gce_pd_ssd_disk_size_db: 0

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -3190,9 +3190,9 @@ class SCTConfiguration(dict):
         supported_versions = [
             v['version'] for v in cloud_api_client.get_scylla_versions()['scyllaVersions']
         ]
-        # TODO: the version is not listed in Scylla Cloud API but is used in Prod exclusively for Vector Search beta
+        # TODO: the version is not listed in Scylla Cloud API but is used in Prod exclusively for Vector Search preGA
         # TODO: must be removed after Scylla 2025.4 is generally available in Scylla Cloud
-        supported_versions.append("2025.4.0~rc0-0.20251001.6969918d3151")
+        supported_versions.append("2025.4.0~rc6-0.20251208.f64b5d375e99")
         if (selected_version := self.get('scylla_version')) not in supported_versions:
             raise ValueError(f"Selected Scylla version '{selected_version}' is not supported by cloud backend.\n"
                              f"Currently supported versions: {', '.join(supported_versions)}")


### PR DESCRIPTION
**Changes:**
- Do not disable tablets in latte script for VS
Starting from Vector Search 1.0.0 and Scylla 2025.4 VS works with tablet keyspaces only.
Removed the TABLETS_ENABLED constant from latte script. Thus, latte will create a keyspace with tablets enabled (what is a default behavior).

- Add `2025.4.0~rc6` to the list of supported by Cloud
The previous `2025.4.0~rc0` removed from the list since rc6 replaces it

- Update instance types for VS configurations
Starting from VS preGA the minimal available instance types will be:
-- t4g.medium for AWS provider
-- e2-medium for GCP provider

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [average-recall-aws](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/vector-search-pre-ga-testing/job/sirenada-stg-vector-search-average-recall-aws/6/)
- [x] [average-recall-gcp](https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/vector-search-pre-ga-testing/job/sirenada-stg-vector-search-average-recall-gcp/7/)
