### PR TITLE
fix(xcloud): pass correct arguments to create runner stage

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2027,7 +2027,8 @@ class SCTConfiguration(dict):
         backend_config_files = [sct_abs_path('defaults/test_default.yaml')]
         if backend:
             if backend == 'xcloud':
-                backend_config_files += self.defaults_config_files[env.get('xcloud_provider', 'aws')]
+                assert 'xcloud_provider' in env, "xcloud_provider must be set for xcloud backend"
+                backend_config_files += self.defaults_config_files[env.get('xcloud_provider')]
             backend_config_files += self.defaults_config_files[str(backend)]
         self.multi_region_params = self.per_provider_multi_region_params.get(str(backend), [])
 

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -794,7 +794,7 @@ class GceSctRunner(SctRunner):
     SCT_NETWORK = "qa-vpc"
 
     def __init__(self, region_name: str, availability_zone: str,  params: SCTConfiguration | None = None):
-        availability_zone = params.get("availability_zone") or random_zone(region_name)
+        availability_zone = availability_zone or params.get("availability_zone") or random_zone(region_name)
         super().__init__(region_name=region_name, availability_zone=availability_zone, params=params)
         self.gce_region = region_name
         self.gce_source_region = self.SOURCE_IMAGE_REGION

--- a/vars/createArgusTestRun.groovy
+++ b/vars/createArgusTestRun.groovy
@@ -13,6 +13,11 @@ def call(Map params) {
 			export SCT_CLUSTER_BACKEND="${params.backend}"
 			export SCT_CONFIG_FILES=${test_config}
 
+            if [[ "${params.backend}" == "xcloud" ]] ; then
+                export SCT_XCLOUD_PROVIDER="${params.xcloud_provider}"
+                export SCT_XCLOUD_ENV="${params.xcloud_env}"
+            fi
+
 			./docker/env/hydra.sh create-argus-test-run
 
 			echo " Argus test run created."

--- a/vars/createSctRunner.groovy
+++ b/vars/createSctRunner.groovy
@@ -42,6 +42,11 @@ def call(Map params, Integer test_duration, String region) {
         export SCT_CLUSTER_BACKEND="${params.backend}"
         export SCT_CONFIG_FILES=${test_config}
 
+        if [[ "${params.backend}" == "xcloud" ]] ; then
+            export SCT_XCLOUD_PROVIDER="${params.xcloud_provider}"
+            export SCT_XCLOUD_ENV="${params.xcloud_env}"
+        fi
+
         if [[ -n "${params.requested_by_user ? params.requested_by_user : ''}" ]] ; then
             export BUILD_USER_REQUESTED_BY=${params.requested_by_user}
         fi

--- a/vars/finishArgusTestRun.groovy
+++ b/vars/finishArgusTestRun.groovy
@@ -12,7 +12,10 @@ def call(Map params, RunWrapper currentBuild) {
 
     export SCT_CLUSTER_BACKEND="${params.backend}"
     export SCT_CONFIG_FILES=${test_config}
-
+    if [[ "${params.backend}" == "xcloud" ]] ; then
+        export SCT_XCLOUD_PROVIDER="${params.xcloud_provider}"
+        export SCT_XCLOUD_ENV="${params.xcloud_env}"
+    fi
     ./docker/env/hydra.sh finish-argus-test-run --jenkins-status "${test_status}"
 
     echo " Argus test run finished."

--- a/vars/getJobTimeouts.groovy
+++ b/vars/getJobTimeouts.groovy
@@ -18,6 +18,11 @@ List<Integer> call(Map params, String region){
     if [[ -n "${params.azure_region_name ? params.azure_region_name : ''}" ]] ; then
         export SCT_AZURE_REGION_NAME=${groovy.json.JsonOutput.toJson(params.azure_region_name)}
     fi
+
+    if [[ "${params.backend}" == "xcloud" ]] ; then
+        export SCT_XCLOUD_PROVIDER="${params.xcloud_provider}"
+        export SCT_XCLOUD_ENV="${params.xcloud_env}"
+    fi
     ./docker/env/hydra.sh output-conf -b "${params.backend}"
     """
     def testData = sh(script: cmd, returnStdout: true).trim()


### PR DESCRIPTION
after we removed the default AZs, and fixed the ability to handle specific AZ in GCE, the create runner stage started failing for xcloud backend ontop GCE.

this fix is removing the default fallback to AWS configuration in case of xcloud, and introduce the correct environment variables to this stage for the configuration to be picked correctly

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] test locally
```bash
export SCT_CLUSTER_BACKEND=xcloud
export SCT_XCLOUD_PROVIDER=gce

./sct.py    create-runner-instance \
            --cloud-provider gce \
            --region  us-east1 \
            --test-id 1234-1234-1234-1234 \
            --duration 48 \
            --test-name fruch-testing
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
