### PR TITLE
Revert "[Backport 2025.2] improvement(params): refactor availability zone handling for pipelines and GCE backend"

### DIFF
--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -286,11 +286,7 @@ class GCECluster(cluster.BaseCluster):
         self._credentials = credentials
         self._gce_instance_type = gce_instance_type
         self._gce_image_username = gce_image_username
-        availability_zone = self.params.get('availability_zone')
-        self._gce_zone_names: list[str] = [
-            f'{region}-{availability_zone or random_zone(region)}' for region in gce_region_names]
-        # Keep this print out for debugging purposes: validate that zones are correctly set
-        LOGGER.debug("GCE zones used: %s", self._gce_zone_names)
+        self._gce_zone_names: list[str] = [f'{region}-{random_zone(region)}' for region in gce_region_names]
         self._gce_n_local_ssd = int(gce_n_local_ssd) if gce_n_local_ssd else 0
         self._add_disks = add_disks
         self._service_accounts = service_accounts

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -794,7 +794,7 @@ class GceSctRunner(SctRunner):
     SCT_NETWORK = "qa-vpc"
 
     def __init__(self, region_name: str, availability_zone: str,  params: SCTConfiguration | None = None):
-        availability_zone = params.get("availability_zone") or random_zone(region_name)
+        availability_zone = random_zone(region_name)
         super().__init__(region_name=region_name, availability_zone=availability_zone, params=params)
         self.gce_region = region_name
         self.gce_source_region = self.SOURCE_IMAGE_REGION

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -16,7 +16,7 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('backend', 'gce')}",
                    description: 'aws|gce|azure|docker',
                    name: 'backend')
-            string(defaultValue: "${pipelineParams.get('availability_zone', '')}",
+            string(defaultValue: "${pipelineParams.get('availability_zone', 'a')}",
                description: 'Availability zone',
                name: 'availability_zone')
             string(defaultValue: '',

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -35,7 +35,7 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('azure_region_name', 'eastus')}",
                    description: 'Azure location',
                    name: 'azure_region_name')
-            string(defaultValue: "${pipelineParams.get('availability_zone', '')}",
+            string(defaultValue: "${pipelineParams.get('availability_zone', 'a')}",
                description: 'Availability zone',
                name: 'availability_zone')
 

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -24,7 +24,7 @@ def call(Map pipelineParams) {
                description: 'us-east-1|eu-west-1',
                name: 'region')
 
-            string(defaultValue: "${pipelineParams.get('availability_zone', '')}",
+            string(defaultValue: "${pipelineParams.get('availability_zone', 'a')}",
                 description: 'Availability zone',
                 name: 'availability_zone')
 

--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -23,7 +23,7 @@ def call(Map pipelineParams) {
                description: 'us-east-1|eu-west-1',
                name: 'region')
 
-            string(defaultValue: "${pipelineParams.get('availability_zone', '')}",
+            string(defaultValue: "${pipelineParams.get('availability_zone', 'a')}",
                 description: 'Availability zone',
                 name: 'availability_zone')
 


### PR DESCRIPTION
Shouldn't been backported, and too many issue identified with this change

Reverts scylladb/scylla-cluster-tests#12794