### PR TITLE
improvement(build-docker-image): Run regardless of paths

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -3,11 +3,6 @@ name: Build hydra image
 on:
   pull_request_target:
     types: [labeled]
-    paths:
-      - 'Dockerfile'
-      - 'docker/env/build_n_push.sh'
-      - 'uv.lock'
-      - 'pyproject.toml'
 
 permissions:
   actions: write


### PR DESCRIPTION
Filtering for paths is redundant since we filter by the label. If someone wants to regenerate hydra, he should have the ability to do so. It is a reason why the hydra was not ran in https://github.com/scylladb/scylla-cluster-tests/pull/12845

Adding backports to all used releases, some of those will have conflicts as this file might not exists there. It should be anywhere as it is critical piece of automation IMO and I will deal with confclits on those backports.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] None needed
