### PR TITLE
 [Branch-2025.3] Bring test-hydra-macos on par with master

### DIFF
--- a/.github/workflows/test-hydra-macos.yaml
+++ b/.github/workflows/test-hydra-macos.yaml
@@ -15,6 +15,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v5
     - name: Setup Docker
-      uses: douglascamata/setup-docker-macos-action@v1.0.1
+      uses: douglascamata/setup-docker-macos-action@v1.0.2
     - name: Run Hydra
       run: bash -x ./docker/env/hydra.sh list-images


### PR DESCRIPTION
* Fixes failures due to https://github.com/lima-vm/lima/issues/2325
* Runs them on only when labelled
