### PR TITLE
fix(cluster): filterout paxos table

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4350,6 +4350,7 @@ class BaseCluster:
             filter_out_cdc_log_tables=True,
             filter_by_keyspace=keyspaces,
             filter_func=filter_func,
+            filter_out_paxos_tables=True,
         )
 
     def get_non_system_ks_cf_list(
@@ -4360,6 +4361,7 @@ class BaseCluster:
         filter_empty_tables=True,
         filter_by_keyspace: list = None,
         filter_func: Callable[..., bool] = None,
+        filter_out_paxos_tables: bool = False,
     ) -> List[str]:
         return self.get_any_ks_cf_list(
             db_node,
@@ -4370,6 +4372,7 @@ class BaseCluster:
             filter_out_cdc_log_tables=True,
             filter_by_keyspace=filter_by_keyspace,
             filter_func=filter_func,
+            filter_out_paxos_tables=filter_out_paxos_tables,
         )
 
     def get_any_ks_cf_list(
@@ -4382,6 +4385,7 @@ class BaseCluster:
         filter_out_cdc_log_tables=False,
         filter_by_keyspace: list = None,
         filter_func: Callable[..., bool] = None,
+        filter_out_paxos_tables: bool = False,
     ) -> List[str]:
         regular_column_names = ["keyspace_name", "table_name"]
         materialized_view_column_names = ["keyspace_name", "view_name"]
@@ -4414,6 +4418,8 @@ class BaseCluster:
 
             for row in current_rows:
                 table_name = f"{getattr(row, column_names[0])}.{getattr(row, column_names[1])}"
+                if filter_out_paxos_tables and getattr(row, column_names[1]).endswith("$paxos"):
+                    continue
 
                 if filter_out_system and is_system_keyspace(getattr(row, column_names[0])):
                     continue


### PR DESCRIPTION
The method `get_non_system_ks_cf_list` return all user-defined tables.
But this list contains the paxos table `table1$paxos`. Such tables could
not be altered.

Doc: [link](https://docs.scylladb.com/manual/branch-2025.4/features/lwt.html#paxos-state-tables)
```
Access to the $paxos tables is restricted. ScyllaDB does not grant 
any explicit permissions on them.
Only superusers can view these tables, 
and even they cannot execute ALTER or DROP commands
```

Add method's parameter which allow filter out such tables.

Fixes: #12672


### Testing
- [ nemesis modifying table passed](https://argus.scylladb.com/tests/scylla-cluster-tests/2d088501-03da-41b6-aa7f-f3bb3e281ffa)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
