### PR TITLE
improvement(treewide): Check for jump-statement-in-finally

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ lint.select = [
     "YTT",
     "F541",
     "PIE",
-    "B006",
+    "B006", "B012",
     "PLW", # mainly for PLW0211
 ]
 lint.ignore = ["E501", "PLR2004"]

--- a/sdcm/scan_operation_thread.py
+++ b/sdcm/scan_operation_thread.py
@@ -176,7 +176,7 @@ class FullscanOperationBase:
                     # success is True if there were no exceptions
                     self.current_operation_stat.success = not bool(self.current_operation_stat.exceptions)
                     self.update_stats(self.current_operation_stat)
-                    return self.current_operation_stat
+                return self.current_operation_stat
 
     def update_stats(self, new_stat):
         self.fullscan_stats.stats.append(new_stat)

--- a/sdcm/sla/sla_tests.py
+++ b/sdcm/sla/sla_tests.py
@@ -270,7 +270,7 @@ class SlaTests(Steps):
                 self.clean_auth(entities_list_of_dict=read_roles)
                 if new_sl:
                     new_sl.drop()
-                return error_events
+            return error_events
 
     def test_increase_shares_during_load(self, tester, prometheus_stats, num_of_partitions,
                                          cassandra_stress_column_definition=None):
@@ -322,7 +322,7 @@ class SlaTests(Steps):
             finally:
                 self.verify_stress_threads(tester=tester, stress_queue=stress_queue)
                 self.clean_auth(entities_list_of_dict=read_roles)
-                return error_events
+            return error_events
 
     def test_decrease_shares_during_load(self, tester, prometheus_stats, num_of_partitions,
                                          cassandra_stress_column_definition=None):
@@ -375,7 +375,7 @@ class SlaTests(Steps):
             finally:
                 self.verify_stress_threads(tester=tester, stress_queue=stress_queue)
                 self.clean_auth(entities_list_of_dict=read_roles)
-                return error_events
+            return error_events
 
     def test_replace_service_level_using_detach_during_load(self, tester, prometheus_stats, num_of_partitions,
                                                             cassandra_stress_column_definition=None):
@@ -449,7 +449,7 @@ class SlaTests(Steps):
                 self.clean_auth(entities_list_of_dict=read_roles)
                 if new_sl:
                     new_sl.drop()
-                return error_events
+            return error_events
 
     def test_replace_service_level_using_drop_during_load(self, tester, prometheus_stats, num_of_partitions,
                                                           cassandra_stress_column_definition=None):
@@ -524,7 +524,7 @@ class SlaTests(Steps):
                 self.clean_auth(entities_list_of_dict=read_roles)
                 if new_sl:
                     new_sl.drop()
-                return error_events
+            return error_events
 
     def test_maximum_allowed_sls_with_max_shares_during_load(self, tester, prometheus_stats, num_of_partitions,
                                                              cassandra_stress_column_definition=None,
@@ -568,4 +568,4 @@ class SlaTests(Steps):
             finally:
                 self.verify_stress_threads(tester=tester, stress_queue=stress_queue)
                 self.clean_auth(entities_list_of_dict=read_roles)
-                return error_events
+            return error_events


### PR DESCRIPTION
* In python 3.14, this is not Syntax warning (SyntaxWarning: 'return' in a 'finally' block)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] Integration test
   - I do think it affects the functionality, the code should be equal
