### PR TITLE
fix(performance): disable speculative retry for write workload in throughput test

### DIFF
--- a/configurations/performance/rust-predefined-throughput-steps-cql-stress.yaml
+++ b/configurations/performance/rust-predefined-throughput-steps-cql-stress.yaml
@@ -1,3 +1,6 @@
+# Define the commands to be used in the write-load test. The purpose of this command is to prepare the schema.
+prepare_stress_cmd: "cql-stress-cassandra-stress write cl=ALL n=1 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate 'threads=1' -col 'size=FIXED(1024) n=FIXED(1)'"
+
 prepare_write_cmd: [
 #  in goal to solve https://github.com/scylladb/scylla-cluster-tests/issues/11037 issue, the PR https://github.com/scylladb/scylla-cluster-tests/pull/11354 was raised.
 #  The PR did not solve the problem, so we use the old command for now.

--- a/test-cases/performance/perf-regression-predefined-throughput-steps.yaml
+++ b/test-cases/performance/perf-regression-predefined-throughput-steps.yaml
@@ -1,4 +1,8 @@
 test_duration: 500
+
+# Define the commands to be used in the write-load test. The purpose of this command is to prepare the schema without hardcoded ks.table definition.
+prepare_stress_cmd: "cassandra-stress write cl=ALL n=1 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate 'threads=1' -col 'size=FIXED(1024) n=FIXED(1)'"
+
 prepare_write_cmd: [
     "cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=1..162500001",
     "cassandra-stress write  cl=ALL n=162500001 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 throttle=37500/s -col 'size=FIXED(1024) n=FIXED(1)'  -pop seq=162500002..325000002",


### PR DESCRIPTION
Bug in throughput test with write workload: speculative retry was not disabled, which could affect latency and throughput measurements.
For mixed and read loads, speculative retry is disabled after schema preparation. But for write load, the keyspace was dropped and recreated at each step, preventing this. This change pre-creates the schema for the write load test and disables speculative retry, ensuring consistent test conditions and more accurate performance results.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/12287

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [read load test](https://argus.scylladb.com/tests/scylla-cluster-tests/94c1fb51-f165-4a3f-9ceb-91f523301706) - prepare schema was not run as expected
- [x] [write load test](https://argus.scylladb.com/tests/scylla-cluster-tests/0bf715ff-e799-4957-b743-079efc45ba31)

The tables have been prepared, and the post-preparation queries have been executed:
```
< t:2025-12-08 15:00:53,578 p:INFO  > Preparing schema using command: cassandra-stress write cl=ALL n=1 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate 'threads=1' -col 'size=FIXED(1024) n=FIXED(1)'
< t:2025-12-08 15:01:30,368  p:INFO  > Schema has been prepared
< t:2025-12-08 15:01:30,368  p:DEBUG > Execute post prepare queries: ALTER TABLE keyspace1.standard1 WITH speculative_retry = 'NONE'
< t:2025-12-08 15:01:31,104 p:INFO  > Run cs command with rate: 200000 Kops; threads: 400; step name: 200000
< t:2025-12-08 17:19:58,384 p:INFO  > Preparing schema using command: cassandra-stress write cl=ALL n=1 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate 'threads=1' -col 'size=FIXED(1024) n=FIXED(1)'
< t:2025-12-08 17:20:11,298  p:INFO  > Schema has been prepared
< t:2025-12-08 17:20:11,298  p:DEBUG > Execute post prepare queries: ALTER TABLE keyspace1.standard1 WITH speculative_retry = 'NONE'
< t:2025-12-08 17:20:12,637 p:INFO  > Run cs command with rate: unthrottled Kops; threads: 400; step name: unthrottled
```

The speculative_retry is NONE for table :
```
CREATE TABLE keyspace1.standard1 (
    key blob,
    "C0" blob,
    PRIMARY KEY (key)
) WITH bloom_filter_fp_chance = 0.01
    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
    AND comment = ''
    AND compaction = {'class': 'IncrementalCompactionStrategy'}
    AND compression = {}
    AND crc_check_chance = 1
    AND default_time_to_live = 0
    AND gc_grace_seconds = 864000
    AND max_index_interval = 2048
    AND memtable_flush_period_in_ms = 0
    AND min_index_interval = 128
    AND speculative_retry = 'NONE'
    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
