### PR TITLE
feature(azure): support using images from private galleries

### DIFF
--- a/unit_tests/provisioner/fake_azure_service.py
+++ b/unit_tests/provisioner/fake_azure_service.py
@@ -604,12 +604,26 @@ class FakeImages:
             return [Image.deserialize(image) for image in json.load(file)]
 
 
+class FakeGalleryImageVersions:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def list_by_gallery_image(self, resource_group_name: str, gallery_name: str, gallery_image_name: str) -> List[Image]:
+        try:
+            with open(self.path / resource_group_name / f"{gallery_name}_{gallery_image_name}_gallery_images_list.json",
+                      encoding="utf-8") as file:
+                return [Image.deserialize(image) for image in json.load(file)]
+        except FileNotFoundError:
+            raise ResourceNotFoundError("No gallery images found") from None
+
+
 class Compute:
 
     def __init__(self, path) -> None:
         self.path: Path = path
         self.virtual_machines = FakeVirtualMachines(self.path)
         self.images = FakeImages(self.path)
+        self.gallery_image_versions = FakeGalleryImageVersions(self.path)
 
 
 class FakeResourceManagementClient:

--- a/unit_tests/provisioner/test_azure_get_scylla_images.py
+++ b/unit_tests/provisioner/test_azure_get_scylla_images.py
@@ -30,7 +30,7 @@ def azure_service():
 
 def test_can_get_scylla_images_based_on_branch(azure_service):
     images = get_scylla_images("master:latest", "eastus", azure_service=azure_service)
-    assert images[0].name == "ScyllaDB-2022.1.rc9-0.20220721.9c95c3a8c-1-build-11"
+    assert images[0].name == "2025.1208.222124"
     assert len(images) == 1
 
 
@@ -59,5 +59,18 @@ def generate_images_json_file():
         resource_group_name=resource_group,
     )
     with open(Path(__file__).parent / "test_data" / resource_group / "azure_images_list.json", "w", encoding="utf-8") as images_file:
+        serialized_images = [image.serialize() | {"name": image.name} for image in images]
+        images_file.write(json.dumps(serialized_images, indent=2))
+
+
+def generate_gallery_images_json_file(gallery_name="scylladb_dev", image_name="master"):
+    """generates azure_images_list.json based on real Azure images for unit tests purposes. """
+    resource_group = "SCYLLA-IMAGES"
+    images = AzureService().compute.gallery_image_versions.list_by_gallery_image(
+        resource_group_name=resource_group,
+        gallery_name=gallery_name,
+        gallery_image_name=image_name,
+    )
+    with open(Path(__file__).parent / "test_data" / resource_group / f"{gallery_name}_{image_name}_gallery_images_list.json", "w", encoding="utf-8") as images_file:
         serialized_images = [image.serialize() | {"name": image.name} for image in images]
         images_file.write(json.dumps(serialized_images, indent=2))

--- a/unit_tests/provisioner/test_data/SCYLLA-IMAGES/scylladb_dev_master_gallery_images_list.json
+++ b/unit_tests/provisioner/test_data/SCYLLA-IMAGES/scylladb_dev_master_gallery_images_list.json
@@ -1,0 +1,153 @@
+[
+  {
+    "tags": {
+      "arch": "x86_64",
+      "branch": "master",
+      "build_mode": "release",
+      "build_tag": "",
+      "creation_timestamp": "2025-12-08T19-37-41",
+      "environment": "debug",
+      "operating_system": "ubuntu24.04",
+      "scylla_build_sha_id": "",
+      "scylla_machine_image_version": "2026.1.0-",
+      "scylla_python3_version": "2026.1.0-2026.1",
+      "scylla_version": "2026.1.0-2026.1",
+      "user_data_format_version": "3"
+    },
+    "location": "eastus",
+    "properties": {
+      "publishingProfile": {
+        "targetRegions": [
+          {
+            "name": "East US",
+            "regionalReplicaCount": 1,
+            "storageAccountType": "Standard_LRS"
+          },
+          {
+            "name": "East US 2",
+            "regionalReplicaCount": 1,
+            "storageAccountType": "Standard_LRS"
+          }
+        ],
+        "replicaCount": 1,
+        "excludeFromLatest": false,
+        "storageAccountType": "Standard_LRS",
+        "replicationMode": "Full"
+      },
+      "storageProfile": {
+        "source": {
+          "virtualMachineId": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/scylla-images/providers/Microsoft.Compute/virtualMachines/pkrvm1zxtnltn4v"
+        },
+        "osDiskImage": {
+          "hostCaching": "ReadWrite",
+          "source": {}
+        }
+      },
+      "safetyProfile": {
+        "allowDeletionOfReplicatedLocations": false
+      }
+    },
+    "name": "2025.1208.213757"
+  },
+  {
+    "tags": {
+      "arch": "x86_64",
+      "branch": "master",
+      "build_mode": "release",
+      "build_tag": "",
+      "creation_timestamp": "2025-12-08T20-21-19",
+      "environment": "debug",
+      "operating_system": "ubuntu24.04",
+      "scylla_build_sha_id": "",
+      "scylla_machine_image_version": "2026.1.0-",
+      "scylla_python3_version": "2026.1.0-2026.1",
+      "scylla_version": "2026.1.0-2026.1",
+      "user_data_format_version": "3"
+    },
+    "location": "eastus",
+    "properties": {
+      "publishingProfile": {
+        "targetRegions": [
+          {
+            "name": "East US",
+            "regionalReplicaCount": 1,
+            "storageAccountType": "Standard_LRS"
+          },
+          {
+            "name": "East US 2",
+            "regionalReplicaCount": 1,
+            "storageAccountType": "Standard_LRS"
+          }
+        ],
+        "replicaCount": 1,
+        "excludeFromLatest": false,
+        "storageAccountType": "Standard_LRS",
+        "replicationMode": "Full"
+      },
+      "storageProfile": {
+        "source": {
+          "virtualMachineId": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/scylla-images/providers/Microsoft.Compute/virtualMachines/pkrvm3z04mrpgui"
+        },
+        "osDiskImage": {
+          "hostCaching": "ReadWrite",
+          "source": {}
+        }
+      },
+      "safetyProfile": {
+        "allowDeletionOfReplicatedLocations": false
+      }
+    },
+    "name": "2025.1208.222124"
+  },
+  {
+    "tags": {
+      "arch": "x86_64",
+      "branch": "master",
+      "build_mode": "release",
+      "build_tag": "",
+      "creation_timestamp": "2025-12-08T20-45-29",
+      "environment": "debug",
+      "name": "debug-scylla-2026.1.0-x86_64-2025-12-08T22-45-34",
+      "operating_system": "ubuntu24.04",
+      "scylla_build_sha_id": "",
+      "scylla_machine_image_version": "2026.1.0-",
+      "scylla_python3_version": "2026.1.0-2026.1",
+      "scylla_version": "2026.1.0-2026.1",
+      "user_data_format_version": "3"
+    },
+    "location": "eastus",
+    "properties": {
+      "publishingProfile": {
+        "targetRegions": [
+          {
+            "name": "East US",
+            "regionalReplicaCount": 1,
+            "storageAccountType": "Standard_LRS"
+          },
+          {
+            "name": "East US 2",
+            "regionalReplicaCount": 1,
+            "storageAccountType": "Standard_LRS"
+          }
+        ],
+        "replicaCount": 1,
+        "excludeFromLatest": false,
+        "storageAccountType": "Standard_LRS",
+        "replicationMode": "Full"
+      },
+      "storageProfile": {
+        "source": {
+          "virtualMachineId": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/scylla-images/providers/Microsoft.Compute/virtualMachines/pkrvmbu7izkpsno"
+        },
+        "osDiskImage": {
+          "hostCaching": "ReadWrite",
+          "source": {}
+        }
+      },
+      "safetyProfile": {
+        "allowDeletionOfReplicatedLocations": false
+      }
+    },
+    "name": "2025.1208.224534"
+  }
+]


### PR DESCRIPTION
since we are moving to using private galleries, updating the code to be able to handle them and find them correctly

since it's not gonna reach all branches the code falls back to looking in the custom images, and that should still work in older branchs.

pointing to a specific image uri would still work the same

Ref: scylladb/scylla-machine-image#843

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
