### PR TITLE
fix(xcloud): add cluster name builder

### DIFF
--- a/sdcm/utils/cloud_api_utils.py
+++ b/sdcm/utils/cloud_api_utils.py
@@ -21,6 +21,7 @@ LOGGER = logging.getLogger(__name__)
 
 CLOUD_KEEP_ALIVE_HOURS = 360  # 15 days
 CLOUD_KEEP_BUFFER_MINUTES = 125
+MAX_CLUSTER_NAME_LENGTH = 63  # Siren limit for cluster name length
 
 MIN_SCYLLA_VERSION_FOR_VS = "2025.4.0"
 # Node instance type limitations for Vector Search Beta on Scylla Cloud
@@ -49,6 +50,20 @@ def compute_cluster_exp_hours(test_duration_minutes: int, keep_alive: bool = Fal
     if keep_alive:
         return CLOUD_KEEP_ALIVE_HOURS
     return int(Decimal((test_duration_minutes + CLOUD_KEEP_BUFFER_MINUTES) / 60).quantize(Decimal("1"), ROUND_UP))
+
+
+def build_cloud_cluster_name(username: str, test_name: str, short_test_id: str, keep_hours: int) -> str:
+    """Build ScyllaDB Cloud cluster name in format: TESTNAME-USERNAME-SHORTID-keep-Xh"""
+    sanitized_username = username.replace('.', '_')
+    cluster_name = f"{sanitized_username}-{short_test_id}-keep-{keep_hours:03d}h"
+
+    prefix_len = MAX_CLUSTER_NAME_LENGTH - len(cluster_name) - 1
+    if prefix_len >= 5:
+        test_name = test_name[:prefix_len]
+        cluster_name = f"{test_name}-{cluster_name}"
+
+    LOGGER.debug("Generated cloud cluster name: '%s'", cluster_name)
+    return cluster_name
 
 
 def get_cloud_rest_credentials_from_file(file_path: str) -> dict:


### PR DESCRIPTION
Scylla Cloud cluster has limitation of cluster name length. This change adjusts the name of the cluster to be created, if it is longer than this limit, to preserve the short test_id 'tag' in it.

Closes; https://github.com/scylladb/qa-tasks/issues/2017

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [pr-provision-test - regression check](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/pr-provision-test-new/104/)
- [x] example of generated name:
```
❯ python -m utils.cloud_cleanup.xcloud.clean_xcloud --dry-run
Found credentials in shared credentials file: ~/.aws/credentials
DRY RUN MODE - No clusters will be deleted

Cleaning Scylla Cloud clusters for 'lab' environment
--------------------------------------------------------------------------------
Initialized Scylla Cloud API client for https://api-v2.ext.lab.scylla.cloud
Found 1 cluster(s) in environment 'lab'
Cluster PR-provision-test-dmytro_kruglov-058a2658-keep-004h (ID: 1646) created at 2025-12-09T22:04:38Z: KEEPING - Age 1.2h < keep 4h (expires in 2.8h)
Environment 'lab' cleanup summary: deleted 0, kept 1

❯ ./sct.py list-resources -b xcloud --get-all
logged in as arn:aws:sts::797456418907:assumed-role/DeveloperAccessRole/dmytro.kruglov@scylladb.com
New directory created: /home/dmitriy/sct-results/20251210-001628-695160-list-resources
Checking ScyllaDB Cloud (lab)...
Initialized Scylla Cloud API client for https://api-v2.ext.lab.scylla.cloud
+-------------------------------------------------------------------------------------------------------------------------------------+
|                                                    ScyllaDB Cloud clusters (lab)                                                    |
+-----------------------------------------------------+-------------+--------+----------+----------+-----------+----------------------+
| Name                                                | Environment | Status | Provider | TestId   | RunByUser | CreatedAt            |
+-----------------------------------------------------+-------------+--------+----------+----------+-----------+----------------------+
| PR-provision-test-dmytro_kruglov-058a2658-keep-004h | lab         | ACTIVE | AWS      | 058a2658 | N/A       | 2025-12-09T22:04:38Z |
+-----------------------------------------------------+-------------+--------+----------+----------+-----------+----------------------+
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
