### PR TITLE
fix(nemesis): disrupt_create_index timeout increased x2

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5207,7 +5207,8 @@ class Nemesis(NemesisFlags):
                 raise UnsupportedNemesis(
                     "Tried to create already existing index. See log for details")
             try:
-                with adaptive_timeout(operation=Operations.CREATE_INDEX, node=self.target_node, timeout=14400) as timeout:
+                # timeout changed from 14400 to 28800 to avoid softimeout errors
+                with adaptive_timeout(operation=Operations.CREATE_INDEX, node=self.target_node, timeout=28800) as timeout:
                     with self.action_log_scope("Wait for index to be built"):
                         wait_for_index_to_be_built(self.target_node, ks, index_name, timeout=timeout * 2)
                 verify_query_by_index_works(session, ks, cf, column)


### PR DESCRIPTION
timeout been increased to avoid timeout events during testing
fixes: https://github.com/scylladb/scylla-cluster-tests/issues/6935

### Testing


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
