### PR TITLE
[Branch-2025.1] feature(workflows): Add build-docker-image.yaml

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -1,0 +1,100 @@
+name: Build hydra image
+
+on:
+  pull_request_target:
+    types: [labeled]
+    paths:
+      - 'Dockerfile'
+      - 'docker/env/build_n_push.sh'
+      - 'uv.lock'
+      - 'pyproject.toml'
+
+permissions:
+  actions: write
+  contents: write
+
+jobs:
+  check_org_membership:
+    runs-on: ubuntu-latest
+    outputs:
+      isTeamMember: ${{ steps.teamAffiliation.outputs.isTeamMember }}
+    steps:
+      # Skip team membership check for bots since GitHub API cannot resolve bot users
+      # This prevents GraphQL errors like "Could not resolve to a User with the login of 'Copilot'"
+      - name: Check user for team affiliation
+        uses: tspascoal/get-user-teams-membership@v3
+        if: github.event.pull_request.user.login != 'renovate[bot]' && github.event.pull_request.user.login != 'Copilot'
+        id: teamAffiliation
+        with:
+          GITHUB_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}
+          username: ${{ github.event.pull_request.user.login }}
+          team: 'dev'
+
+  build_image:
+    needs: check_org_membership
+    if: ( github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'Copilot' || needs.check_org_membership.outputs.isTeamMember == 'true' ) && contains(github.event.pull_request.labels.*.name, 'New Hydra Version')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
+
+      - name: Check if docker image is already built
+        run: |
+          git fetch origin master
+          commits_headlines=$(git log origin/master..HEAD --pretty=format:"%s")
+
+          if [[ "$commits_headlines" == *"chore(hydra): create image"* ]]; then
+              echo "Docker image already built"
+              exit 0
+          else
+              echo "Docker image not built yet"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets. GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+
+      - name: Generate a random name based on PR
+        run: |
+          docker_version=$(cut -d'-' -f1 ./docker/env/version | awk -F. '{print $1"."$2+1}')
+          sha=$(echo "${{ github.sha }}" | cut -c1-7)
+          echo "${docker_version}-PR${{ github.event.number }}-${sha}" > ./docker/env/version
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: |
+          ./docker/env/build_n_push.sh
+
+      - name: Configure Git
+        run: |
+          git config --global user.name 'scylla-sct[bot]'
+          git config --global user.email 'scylla-sct[bot]@users.noreply.github.com'
+
+      - name: Commit changes
+        run: |
+          git add -u
+          git commit -m "chore(hydra): create image $( cat ./docker/env/version )"
+
+      - name: Push changes
+        uses: ad-m/github-push-action@v1.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
Brings the branch up-to-date with master and enables that workflow also on backports. Now all 2025.x and perf-v17 do have this workflow

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] None

