### PR TITLE
fix(nemesis): Remove 5-Minute Sleep Delay After Node Termination

### DIFF
--- a/configurations/performance/latency-decorator-error-thresholds-nemesis-ent-tablets.yaml
+++ b/configurations/performance/latency-decorator-error-thresholds-nemesis-ent-tablets.yaml
@@ -3,7 +3,7 @@ latency_decorator_error_thresholds:
     _mgmt_repair_cli:
       duration:
         fixed_limit: 7200
-    _terminate_and_wait:
+    terminate_node:
       duration:
         fixed_limit: null
     add_new_nodes:
@@ -22,7 +22,7 @@ latency_decorator_error_thresholds:
     _mgmt_repair_cli:
       duration:
         fixed_limit: 3200
-    _terminate_and_wait:
+    terminate_node:
       duration:
         fixed_limit: null
     add_new_nodes:
@@ -41,7 +41,7 @@ latency_decorator_error_thresholds:
     _mgmt_repair_cli:
       duration:
         fixed_limit: 4200
-    _terminate_and_wait:
+    terminate_node:
       duration:
         fixed_limit: null
     add_new_nodes:

--- a/configurations/performance/latency-decorator-error-thresholds-nemesis-ent-vnodes.yaml
+++ b/configurations/performance/latency-decorator-error-thresholds-nemesis-ent-vnodes.yaml
@@ -3,7 +3,7 @@ latency_decorator_error_thresholds:
     _mgmt_repair_cli:
       duration:
         fixed_limit: 7200
-    _terminate_and_wait:
+    terminate_node:
       duration:
         fixed_limit: null
     add_new_nodes:
@@ -20,7 +20,7 @@ latency_decorator_error_thresholds:
     _mgmt_repair_cli:
       duration:
         fixed_limit: 2000
-    _terminate_and_wait:
+    terminate_node:
       duration:
         fixed_limit: null
     add_new_nodes:
@@ -37,7 +37,7 @@ latency_decorator_error_thresholds:
     _mgmt_repair_cli:
       duration:
         fixed_limit: 2500
-    _terminate_and_wait:
+    terminate_node:
       duration:
         fixed_limit: null
     add_new_nodes:

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1295,10 +1295,9 @@ class Nemesis(NemesisFlags):
             new_seed_node.set_seed_flag(True)
             self.cluster.update_seed_provider()
 
-    @latency_calculator_decorator(legend="Terminate node and wait before adding new node")
-    def _terminate_and_wait(self, target_node, sleep_time=300):
+    @latency_calculator_decorator(legend="Terminate node before adding new node")
+    def terminate_node(self, target_node):
         self._terminate_cluster_node(target_node)
-        time.sleep(sleep_time)  # Sleeping for 5 mins to let the cluster live with a missing node for a while
 
     @latency_calculator_decorator(legend="Replace a node in cluster with new one")
     def replace_node(self, old_node_ip: str, host_id: str, rack: int = 0, is_zero_node: bool = False) -> BaseNode:
@@ -1541,7 +1540,8 @@ class Nemesis(NemesisFlags):
         host_id = self.target_node.host_id
         is_old_node_seed = self.target_node.is_seed
         InfoEvent(message='StartEvent - Terminate node and wait 5 minutes').publish()
-        self._terminate_and_wait(target_node=self.target_node)
+        self.terminate_node(target_node=self.target_node)
+        time.sleep(300)  # Sleeping for 5 mins to let the cluster live with a missing node for a while
         assert get_node_state(old_node_ip) == "DN", "Removed node state should be DN"
         InfoEvent(message='FinishEvent - target_node was terminated').publish()
         new_node = self.replace_node(old_node_ip, host_id, rack=self.target_node.rack,


### PR DESCRIPTION
The node termination workflow includes a hardcoded 5-minute wait immediately after the termination command is issued. This appears to be a legacy safety buffer intended to allow the backend to fully deregister the node.

Also since we are now waiting for the termination state, it should be safe to remove this sleep.

This static wait creates unnecessary latency in the teardown process and slows down CI/CD pipelines/autoscaling events.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/12708

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/4f93c81b-813b-4076-b27d-1dda6c8f1905
<img width="762" height="134" alt="image" src="https://github.com/user-attachments/assets/f2c9352f-b348-48b8-8a19-1eadaa5501da" />


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
