### PR TITLE
fix(mgmt_cli_test.py): report restored data size to Argus

### DIFF
--- a/sdcm/argus_results.py
+++ b/sdcm/argus_results.py
@@ -128,6 +128,7 @@ class ManagerRestoreBenchmarkResult(StaticGenericResultTable):
             ColumnMetadata(name="l&s bandwidth", unit="MiB/s/shard", type=ResultType.FLOAT, higher_is_better=True),
             ColumnMetadata(name="repair time", unit="s", type=ResultType.DURATION, higher_is_better=False),
             ColumnMetadata(name="total", unit="s", type=ResultType.DURATION, higher_is_better=False),
+            ColumnMetadata(name="size", unit="GB", type=ResultType.INTEGER, higher_is_better=False),
         ]
         ValidationRules = {
             "restore time": ValidationRule(best_pct=10),

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -22,6 +22,53 @@ LOGGER = logging.getLogger(__name__)
 # │ 10.12.4.125 │     100% │ 422.434GiB │ 422.434GiB │           0B │     0B │
 # │ 10.12.4.25  │     100% │ 422.413GiB │ 422.413GiB │           0B │     0B │
 BACKUP_SIZE_REGEX = re.compile(r".+100% │ (.*?) │ ", re.MULTILINE)
+SIZE_PATTERN = re.compile(r"^([\d.]+)\s*([KMGTPE]?i?B)$", re.IGNORECASE)
+
+
+def parse_size_to_bytes(size_str: str) -> int:
+    """Parse a human-readable size string into bytes.
+
+    Supports units: B, KB, KiB, MB, MiB, GB, GiB, TB, TiB, PB, PiB.
+    Handles optional spaces and case-insensitive units.
+    """
+    if not size_str:
+        raise ValueError("Empty size string")
+    s = size_str.strip()
+    # Normalize: remove spaces in unit like 'GiB'
+    match = SIZE_PATTERN.match(s)
+    if not match:
+        raise ValueError(f"Unrecognized size format: {size_str}")
+
+    value = float(match.group(1))
+    unit = match.group(2).upper()
+
+    # Define multipliers
+    powers_2 = {
+        "B": 1,
+        "KIB": 1024,
+        "MIB": 1024**2,
+        "GIB": 1024**3,
+        "TIB": 1024**4,
+        "PIB": 1024**5,
+        "EIB": 1024**6,
+    }
+    powers_10 = {
+        "KB": 1000,
+        "MB": 1000**2,
+        "GB": 1000**3,
+        "TB": 1000**4,
+        "PB": 1000**5,
+        "EB": 1000**6,
+    }
+
+    if unit in powers_2:
+        bytes_ = int(value * powers_2[unit])
+    elif unit in powers_10:
+        bytes_ = int(value * powers_10[unit])
+    else:
+        # Fallback: treat unknown as bytes
+        bytes_ = int(value)
+    return bytes_
 
 
 def get_persistent_snapshots():  # Snapshot sizes (dict keys) are in GB
@@ -207,3 +254,49 @@ class ObjectStorageUploadMode(str, Enum):
     AUTO = "auto"
     RCLONE = "rclone"
     NATIVE = "native"
+
+
+def parse_bandwidth_value(bandwidth_str: str) -> float | None:
+    """Parse bandwidth value from Manager output string.
+
+    Args:
+        bandwidth_str: String containing bandwidth value (e.g., "22.313MiB/s/shard")
+
+    Returns:
+        Float value of bandwidth in MiB/s/shard, or None if parsing fails
+    """
+    bandwidth_match = re.search(r"(\d+\.\d+)", bandwidth_str)
+    if bandwidth_match:
+        return float(bandwidth_match.group(1))
+    else:
+        LOGGER.warning(f"Bandwidth value is non-numeric: {bandwidth_str.strip()}. Returning None.")
+        return None
+
+
+def calculate_restore_metrics(
+    total_seconds: int,
+    repair_seconds: int,
+    download_bw: float | None = None,
+    load_and_stream_bw: float | None = None,
+) -> dict[str, int | float]:
+    """Calculate restore metrics for Argus reporting.
+
+    Args:
+        total_seconds: Total restore time in seconds
+        repair_seconds: Post-restore repair time in seconds
+        download_bw: Download bandwidth in MiB/s/shard (optional)
+        load_and_stream_bw: Load&stream bandwidth in MiB/s/shard (optional)
+
+    Returns:
+        Dictionary containing restore metrics (restore time, repair time, total, and bandwidth values)
+    """
+    results = {
+        "restore time": (total_seconds - repair_seconds),
+        "repair time": repair_seconds,
+        "total": total_seconds,
+    }
+    if download_bw:
+        results["download bandwidth"] = download_bw
+    if load_and_stream_bw:
+        results["l&s bandwidth"] = load_and_stream_bw
+    return results


### PR DESCRIPTION
Currently the restored backup snapshot size is not reported and causes confusion for the reported results.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [restore test](https://argus.scylladb.com/tests/scylla-cluster-tests/30bf56c2-6988-4876-b39a-d1b5a694b834)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
