### PR TITLE
fix(node_exporter): add retry to curl download

### DIFF
--- a/sdcm/node_exporter_setup.py
+++ b/sdcm/node_exporter_setup.py
@@ -14,7 +14,7 @@ class NodeExporterSetup:
             if ! id node_exporter > /dev/null 2>&1; then
                 useradd -rs /bin/false node_exporter
             fi
-            curl -L -O https://github.com/prometheus/node_exporter/releases/download/v{NODE_EXPORTER_VERSION}/node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
+            curl -L --retry 5 --retry-max-time 300 -O https://github.com/prometheus/node_exporter/releases/download/v{NODE_EXPORTER_VERSION}/node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
             tar -xzvf node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
             mv node_exporter-{NODE_EXPORTER_VERSION}.linux-amd64/node_exporter /usr/local/bin
 


### PR DESCRIPTION
The curl command should retry, otherwise it will download an HTML file in case of failure.

A failure looks like this:
https://argus.scylladb.com/tests/scylla-cluster-tests/17e234bb-1815-42d6-aa63-bb70f72d1071
```
2025-12-11 15:50:30.753: (TestFrameworkEvent Severity.ERROR) period_type=one-time event_id=55caa311-758b-49c6-9f85-a9b33e7f153d, source=LongevityBalancerTest.SetUp()
exception=[Node balancer-test-feature--loader-node-17e234bb-4 [35.153.39.19 | 10.12.1.38] (Type: c6i.2xlarge) (rack: RACK0)] NodeSetupFailed: Encountered a bad command exit code!
Command: 'sudo bash -cxe "\nif ! id node_exporter > /dev/null 2>&1; then\n    useradd -rs /bin/false node_exporter\nfi\ncurl -L -O https://github.com/prometheus/node_exporter/releases/download/v1.8.2/node_exporter-1.8.2.linux-amd64.tar.gz\ntar -xzvf node_exporter-1.8.2.linux-amd64.tar.gz\nmv node_exporter-1.8.2.linux-amd64/node_exporter /usr/local/bin\n\nif [ -e /etc/systemd/system/node_exporter.service ]; then\n    rm /etc/systemd/system/node_exporter.service\nfi\n\ncat <<EOM >> /etc/systemd/system/node_exporter.service\n[Unit]\nDescription=Node Exporter\nAfter=network.target\n\n[Service]\nUser=node_exporter\nGroup=node_exporter\nType=simple\nExecStart=/usr/local/bin/node_exporter --no-collector.interrupts --no-collector.hwmon --no-collector.bcache --no-collector.btrfs --no-collector.fibrechannel --no-collector.infiniband --no-collector.ipvs --no-collector.nfs --no-collector.nfsd --no-collector.powersupplyclass --no-collector.rapl --no-collector.tapestats --no-collector.thermal_zone --no-collector.udp_queues --no-collector.zfs\n\n[Install]\nWantedBy=multi-user.target\nEOM\n\nsystemctl daemon-reload\nsystemctl enable node_exporter.service\nsystemctl start node_exporter.service\n"'
Exit code: 2
Stdout:
Stderr:
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
100 54894    0 54894    0     0  26913      0 --:--:--  0:00:02 --:--:-- 26922
+ tar -xzvf node_exporter-1.8.2.linux-amd64.tar.gz
gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
Traceback (most recent call last):
  File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 4128, in node_setup
    cl_inst.node_setup(_node, **setup_kwargs)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 5546, in node_setup
    node_exporter_setup.install(node)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/ubuntu/scylla-cluster-tests/sdcm/node_exporter_setup.py", line 13, in install
    remoter.sudo(shell_script_cmd(f"""
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
        if ! id node_exporter > /dev/null 2>&1; then
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<27 lines>...
        systemctl start node_exporter.service
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    """))
    ^^^^^
  File "/home/ubuntu/scylla-cluster-tests/sdcm/remote/base.py", line 126, in sudo
    return self.run(cmd=cmd,
           ~~~~~~~~^^^^^^^^^
                    timeout=timeout,
                    ^^^^^^^^^^^^^^^^
    ...<5 lines>...
                    watchers=watchers,
                    ^^^^^^^^^^^^^^^^^^
                    timestamp_logs=timestamp_logs)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/scylla-cluster-tests/sdcm/remote/remote_base.py", line 695, in run
    result = _run()
  File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/decorators.py", line 79, in inner
    return func(*args, **kwargs)
  File "/home/ubuntu/scylla-cluster-tests/sdcm/remote/remote_base.py", line 686, in _run
    return self._run_execute(cmd, timeout, ignore_status, verbose, new_session, watchers)
           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/scylla-cluster-tests/sdcm/remote/remote_base.py", line 615, in _run_execute
    result = connection.run(**command_kwargs)
  File "/home/ubuntu/scylla-cluster-tests/sdcm/remote/libssh2_client/__init__.py", line 622, in run
    return self._complete_run(channel, exception, timeout_reached, timeout, result, warn, stdout, stderr)
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/scylla-cluster-tests/sdcm/remote/libssh2_client/__init__.py", line 657, in _complete_run
    raise UnexpectedExit(result)
sdcm.remote.libssh2_client.exceptions.UnexpectedExit: Encountered a bad command exit code!
Command: 'sudo bash -cxe "\nif ! id node_exporter > /dev/null 2>&1; then\n    useradd -rs /bin/false node_exporter\nfi\ncurl -L -O https://github.com/prometheus/node_exporter/releases/download/v1.8.2/node_exporter-1.8.2.linux-amd64.tar.gz\ntar -xzvf node_exporter-1.8.2.linux-amd64.tar.gz\nmv node_exporter-1.8.2.linux-amd64/node_exporter /usr/local/bin\n\nif [ -e /etc/systemd/system/node_exporter.service ]; then\n    rm /etc/systemd/system/node_exporter.service\nfi\n\ncat <<EOM >> /etc/systemd/system/node_exporter.service\n[Unit]\nDescription=Node Exporter\nAfter=network.target\n\n[Service]\nUser=node_exporter\nGroup=node_exporter\nType=simple\nExecStart=/usr/local/bin/node_exporter --no-collector.interrupts --no-collector.hwmon --no-collector.bcache --no-collector.btrfs --no-collector.fibrechannel --no-collector.infiniband --no-collector.ipvs --no-collector.nfs --no-collector.nfsd --no-collector.powersupplyclass --no-collector.rapl --no-collector.tapestats --no-collector.thermal_zone --no-collector.udp_queues --no-collector.zfs\n\n[Install]\nWantedBy=multi-user.target\nEOM\n\nsystemctl daemon-reload\nsystemctl enable node_exporter.service\nsystemctl start node_exporter.service\n"'
Exit code: 2
Stdout:
Stderr:
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
100 54894    0 54894    0     0  26913      0 --:--:--  0:00:02 --:--:-- 26922
+ tar -xzvf node_exporter-1.8.2.linux-amd64.tar.gz
gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
