### PR TITLE
fix(latte): do not copy non-file items in `build_stress_cmd` method

### DIFF
--- a/sdcm/stress/latte_thread.py
+++ b/sdcm/stress/latte_thread.py
@@ -107,7 +107,10 @@ class LatteStressThread(DockerBasedStressThread):
             self.SCHEMA_CMD_CALL_COUNTER[script_name] = 0
 
         for src_file in (Path(get_sct_root_path()) / script_name).parent.iterdir():
-            cmd_runner.send_files(str(src_file), str(Path(script_name).parent / src_file.name))
+            if src_file.is_file():
+                remote_path = str(Path(script_name).parent / src_file.name)
+                if not cmd_runner.run(f"test -f {remote_path}", ignore_status=True, verbose=False).ok:
+                    cmd_runner.send_files(str(src_file), remote_path)
 
         ssl_config = ''
         if self.params['client_encrypt']:


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/12734

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-provision-test#56](https://argus.scylladb.com/tests/scylla-cluster-tests/88d3163b-f314-47d9-b62e-b3287970ee12)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
