### PR TITLE
fix(k8s, deps): update default k8s dependencies (csi driver, manager)

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1826,7 +1826,7 @@ Define whether performance tuning must run or not.
 
 ## **k8s_local_volume_provisioner_type** / SCT_K8S_LOCAL_VOLUME_PROVISIONER_TYPE
 
-Defines the type of the K8S local volume provisioner to be deployed. It may be either 'static' or 'dynamic'. Details about 'dynamic': 'dynamic': https://github.com/scylladb/k8s-local-volume-provisioner; 'static': sdcm/k8s_configs/static-local-volume-provisioner.yaml
+Defines the type of the K8S local volume provisioner to be deployed. It may be either 'static' or 'dynamic'. Details about 'dynamic': 'dynamic': https://github.com/scylladb/local-csi-driver; 'static': sdcm/k8s_configs/static-local-volume-provisioner.yaml
 
 **default:** N/A
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -124,8 +124,8 @@ MINIO_NAMESPACE = "minio"
 SCYLLA_CONFIG_NAME = "scylla-config"
 SCYLLA_AGENT_CONFIG_NAME = "scylla-agent-config"
 
-K8S_LOCAL_VOLUME_PROVISIONER_VERSION = "0.3.0"  # without 'v' prefix
-SCYLLA_MANAGER_AGENT_VERSION_IN_SCYLLA_MANAGER = "3.2.6"
+K8S_LOCAL_VOLUME_PROVISIONER_VERSION = "0.5.0"  # without 'v' prefix
+SCYLLA_MANAGER_AGENT_VERSION_IN_SCYLLA_MANAGER = "3.7.0"
 
 # NOTE: add custom annotations to a ServiceAccount used by a ScyllaCluster
 #       It is needed to make sure that annotations survive operator upgrades
@@ -1090,7 +1090,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
             if obj["kind"] != "DaemonSet":
                 return
             for container_data in obj["spec"]["template"]["spec"]["containers"]:
-                if "scylladb/k8s-local-volume-provisioner" in container_data["image"]:
+                if "scylladb/local-csi-driver" in container_data["image"]:
                     container_data["image"] = (
                         f"{container_data['image'].split(':')[0]}:{K8S_LOCAL_VOLUME_PROVISIONER_VERSION}")
 
@@ -1115,7 +1115,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
             repo_dst_dir = os.path.join(tmp_dir_name, 'dynamic-local-volume-provisioner')
 
             download_from_github(
-                repo='scylladb/k8s-local-volume-provisioner',
+                repo='scylladb/local-csi-driver',
                 tag=f'tags/v{K8S_LOCAL_VOLUME_PROVISIONER_VERSION}',
                 dst_dir=repo_dst_dir)
 

--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -351,7 +351,7 @@ class MinimalClusterBase(KubernetesCluster, metaclass=abc.ABCMeta):
 
     @cached_property
     def dynamic_local_volume_provisioner_image(self):
-        return f"scylladb/k8s-local-volume-provisioner:{K8S_LOCAL_VOLUME_PROVISIONER_VERSION}"
+        return f"scylladb/local-csi-driver:{K8S_LOCAL_VOLUME_PROVISIONER_VERSION}"
 
     @cached_property
     def cert_manager_images(self):

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -998,7 +998,7 @@ class SCTConfiguration(dict):
              type=str, choices=("static", "dynamic"),
              help="Defines the type of the K8S local volume provisioner to be deployed. "
                   "It may be either 'static' or 'dynamic'. Details about 'dynamic': "
-                  "'dynamic': https://github.com/scylladb/k8s-local-volume-provisioner; "
+                  "'dynamic': https://github.com/scylladb/local-csi-driver; "
                   "'static': sdcm/k8s_configs/static-local-volume-provisioner.yaml"),
 
         dict(name="k8s_scylla_operator_docker_image",


### PR DESCRIPTION
current dependencies are badly outdated (the CSI driver is outdated by more than 2 years!) and are not supported

- local volume provisioner rename and migrate to new repo
- also bump its version 0.3.0 -> 0.5.0
- manager to the latest released 3.7.0 version

### Testing
- unnecessary yet for master (the upgrade test is not working in master yet)
- however this change has been working in `operator-staging` for a month, [for example](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abramche/job/operator/job/upgrade/job/upgrade-major-scylla-k8s-gke-test/13/) contains this change

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
