### PR TITLE
improvement(cloud_monitor): add reporting of ScyllaDB Cloud resources

### DIFF
--- a/sdcm/utils/cloud_monitor/resources/xcloud.py
+++ b/sdcm/utils/cloud_monitor/resources/xcloud.py
@@ -1,0 +1,152 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+import re
+import logging
+import datetime
+from dataclasses import dataclass
+
+import pytz
+
+from sdcm.cloud_api_client import ScyllaCloudAPIClient
+from sdcm.keystore import KeyStore
+
+
+LOGGER = logging.getLogger(__name__)
+
+KEEP_HOURS_PATTERN = re.compile(r"-keep-(\d+)h$")
+SHORT_ID_PATTERN = re.compile(r"-([0-9a-f]{8})-keep-")
+
+
+@dataclass
+class XCloudCluster:
+    """ScyllaDB Cloud cluster data for reporting"""
+
+    environment: str
+    cloud_provider: str
+    cluster_name: str
+    cluster_id: int
+    status: str
+    owner: str
+    created_at: datetime.datetime
+    db_node_count: int
+    vs_node_count: int
+    keep_hours: int | None
+    hours_remaining: float | None
+
+
+class XCloudResources:
+    """Collects all xcloud clusters across environments"""
+
+    ENVIRONMENTS = ["lab", "staging", "prod"]
+
+    def __init__(self):
+        self.clusters: list[XCloudCluster] = []
+        self.collect_all_clusters()
+
+    def collect_all_clusters(self):
+        for environment in self.ENVIRONMENTS:
+            try:
+                self.clusters.extend(self.get_clusters_for_environment(environment))
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning(f"Failed to collect xcloud clusters for '{environment}': {exc}")
+
+    def get_clusters_for_environment(self, environment: str) -> list[XCloudCluster]:
+        try:
+            credentials = KeyStore().get_cloud_rest_credentials(environment)
+            api_client = ScyllaCloudAPIClient(api_url=credentials["base_url"], auth_token=credentials["api_token"])
+            account_id = api_client.get_account_details().get("accountId")
+            clusters = api_client.get_clusters(account_id=account_id, enriched=True)
+            LOGGER.info(f"Found {len(clusters)} cluster(s) in environment '{environment}'")
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning(f"Failed to initialize API client for '{environment}' environment: {exc}")
+            return []
+
+        processed = [self.process_cluster(api_client, account_id, cluster, environment) for cluster in clusters]
+        return [c for c in processed if c is not None]
+
+    def process_cluster(self, api_client, account_id, cluster, environment):
+        try:
+            cluster_id = cluster.get("id")
+            cluster_name = cluster.get("clusterName")
+            cluster_details = api_client.get_cluster_details(
+                account_id=account_id, cluster_id=cluster_id, enriched=True
+            )
+
+            created_at_str = cluster_details.get("createdAt")
+            created_at = datetime.datetime.fromisoformat(created_at_str.replace("Z", "+00:00"))
+            keep_hours, hours_remaining = self.calculate_hours_remaining(cluster_name, created_at_str)
+
+            db_node_count = len(
+                api_client.get_cluster_nodes(account_id=account_id, cluster_id=cluster_id, enriched=True)
+            )
+            vs_node_count = self.get_vs_node_count(api_client, account_id, cluster_id, cluster_name)
+
+            return XCloudCluster(
+                environment=environment,
+                cloud_provider=cluster_details.get("cloudProvider", {}).get("name"),
+                cluster_name=cluster_name,
+                cluster_id=cluster_id,
+                status=cluster_details.get("status", "Unknown"),
+                owner=self.extract_owner_from_name(cluster_name),
+                created_at=created_at,
+                db_node_count=db_node_count,
+                vs_node_count=vs_node_count,
+                keep_hours=keep_hours,
+                hours_remaining=hours_remaining,
+            )
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error(f"Failed to process cluster {cluster.get('clusterName')} in '{environment}': {exc}")
+            return None
+
+    @staticmethod
+    def get_vs_node_count(api_client, account_id, cluster_id, cluster_name):
+        """Calculate the total number of VS nodes across all datacenters."""
+        vs_node_count = 0
+        try:
+            dcs = api_client.get_cluster_dcs(account_id=account_id, cluster_id=cluster_id, enriched=True) or []
+            for dc in dcs:
+                dc_id = dc.get("id")
+                availability_zones = (
+                    api_client.get_vector_search_nodes(account_id=account_id, cluster_id=cluster_id, dc_id=dc_id).get(
+                        "availabilityZones"
+                    )
+                    or []
+                )
+                vs_node_count += sum(len(az.get("nodes", [])) for az in availability_zones)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.debug(f"Cluster {cluster_name}: could not retrieve VS node information: {exc}")
+        return vs_node_count
+
+    @staticmethod
+    def extract_owner_from_name(cluster_name: str) -> str:
+        """Extract owner username from cluster name"""
+        match = SHORT_ID_PATTERN.search(cluster_name)
+        if match:
+            parts = cluster_name[: match.start()].rsplit("-", 1)
+            if len(parts) > 1:
+                return parts[-1].replace("_", ".")
+        return "N/A"
+
+    @staticmethod
+    def calculate_hours_remaining(cluster_name: str, created_at_str: str) -> tuple[int | None, float | None]:
+        """Extract keep_hours from cluster name and calculate hours remaining to keep the cluster"""
+        match = KEEP_HOURS_PATTERN.search(cluster_name)
+        if not match:
+            return None, None
+
+        keep_hours = int(match.group(1))
+        created_at = datetime.datetime.fromisoformat(created_at_str.replace("Z", "+00:00"))
+        age_hours = (datetime.datetime.now(tz=pytz.utc) - created_at).total_seconds() / 3600.0
+
+        return keep_hours, keep_hours - age_hours

--- a/sdcm/utils/cloud_monitor/templates/base.html
+++ b/sdcm/utils/cloud_monitor/templates/base.html
@@ -41,6 +41,17 @@
 </head>
 <body>
 {{ body|safe }}
+
+{% if xcloud_summary %}
+{{ xcloud_summary|safe }}
+{% endif %}
+
+{% if xcloud_per_user %}
+{{ xcloud_per_user|safe }}
+{% endif %}
+
+<h2>For detailed report download and open attached html</h2>
+
 <a href="https://docs.google.com/document/d/1gb8-K6RmlOypezcYB7ca7TnfuxuEoON87epUxOYorZk/edit#heading=h.mhz4o9ik7vhe">Procedure of using the cloud</a>
 </body>
 </html>

--- a/sdcm/utils/cloud_monitor/templates/per_user.html
+++ b/sdcm/utils/cloud_monitor/templates/per_user.html
@@ -56,3 +56,7 @@
         {% endfor %}
     </table>
     {% endfor %}
+
+    {% if xcloud_detailed %}
+{{ xcloud_detailed|safe }}
+    {% endif %}

--- a/sdcm/utils/cloud_monitor/templates/per_user_summary.html
+++ b/sdcm/utils/cloud_monitor/templates/per_user_summary.html
@@ -67,5 +67,3 @@
         {% endfor %}
     </table>
 {% endif %}
-
-<h2>For detailed report download and open attached html</h2>

--- a/sdcm/utils/cloud_monitor/templates/xcloud_detailed.html
+++ b/sdcm/utils/cloud_monitor/templates/xcloud_detailed.html
@@ -1,0 +1,40 @@
+    <h2>Scylla Cloud Clusters</h2>
+    {% for user, clusters in results|dictsort %}
+    <h3>{{ user }}</h3>
+    <table id="results_table">
+        <tr>
+            <th>Env</th>
+            <th>Cloud Provider</th>
+            <th>Cluster Name</th>
+            <th>Cluster ID</th>
+            <th>Status</th>
+            <th>DB Nodes</th>
+            <th>VS Nodes</th>
+            <th>Created At</th>
+            <th>Hours to Keep</th>
+        </tr>
+        {% for cluster in clusters %}
+        <tr>
+            <td>{{ cluster.environment|capitalize }}</td>
+            <td>{{ cluster.cloud_provider }}</td>
+            <td>{{ cluster.cluster_name }}</td>
+            <td>{{ cluster.cluster_id }}</td>
+            <td>{{ cluster.status }}</td>
+            <td>{{ cluster.db_node_count }}</td>
+            <td>{{ cluster.vs_node_count }}</td>
+            <td>{{ cluster.created_at }}</td>
+            {% if cluster.hours_remaining is not none %}
+                {% if cluster.hours_remaining < 0 %}
+            <td><span class="red fbold">TO DELETE ({{ "%.1f"|format(-cluster.hours_remaining) }}h overdue)</span></td>
+                {% elif cluster.hours_remaining < 1 %}
+            <td><span class="orange fbold">{{ "%.1f"|format(cluster.hours_remaining) }}h</span></td>
+                {% else %}
+            <td>{{ "%.1f"|format(cluster.hours_remaining) }}h</td>
+                {% endif %}
+            {% else %}
+            <td><span class="blue">Manual</span></td>
+            {% endif %}
+        </tr>
+        {% endfor %}
+    </table>
+    {% endfor %}

--- a/sdcm/utils/cloud_monitor/templates/xcloud_per_user_summary.html
+++ b/sdcm/utils/cloud_monitor/templates/xcloud_per_user_summary.html
@@ -1,0 +1,25 @@
+    <h3>Scylla Cloud test clusters by user</h3>
+
+    <table id="results_table">
+        <tr>
+            <th rowspan="2">User</th>
+            <th colspan="3" style="text-align: center;">Clusters (Total Nodes)</th>
+        </tr>
+        <tr>
+            <th>Lab</th>
+            <th>Staging</th>
+            <th>Prod</th>
+        </tr>
+        {% for user, env_data in results|dictsort %}
+        <tr>
+            <td>{{ user }}</td>
+            {% for env in ['lab', 'staging', 'prod'] %}
+            <td>
+                {% for provider, stats in env_data.get(env, {})|dictsort %}
+                {{ provider }}: {{ stats.cluster_count }} ({{ stats.node_count }})<br>
+                {% endfor %}
+            </td>
+            {% endfor %}
+        </tr>
+        {% endfor %}
+    </table>

--- a/sdcm/utils/cloud_monitor/templates/xcloud_summary.html
+++ b/sdcm/utils/cloud_monitor/templates/xcloud_summary.html
@@ -1,0 +1,16 @@
+    <h3>Scylla Cloud test clusters summary</h3>
+
+    <table id="results_table">
+        <tr>
+            <th>Environment</th>
+            <th>AWS</th>
+            <th>GCP</th>
+        </tr>
+        {% for env in ['lab', 'staging', 'prod'] %}
+        <tr>
+            <td>{{ env|capitalize }}</td>
+            <td>{{ results.get(env, {}).get('AWS', 0) }}</td>
+            <td>{{ results.get(env, {}).get('GCP', 0) }}</td>
+        </tr>
+        {% endfor %}
+    </table>


### PR DESCRIPTION
Update cloud_monitor script to include reporting of ScyllaDB Cloud resources usage by test accounts.

Closes: https://github.com/scylladb/qa-tasks/issues/2002

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] example of `cloud-usage-report --report-type general` command execution (daily report of cloud resources usage that is sent by email):
- tables for Scylla Cloud clusters
<img width="1193" height="635" alt="Screenshot from 2025-12-13 14-32-49" src="https://github.com/user-attachments/assets/90c84b46-4bab-4a15-8aa7-c69a7f59c9a8" />

- section for Scylla Cloud clusters in the detailed report file attached to email
<img width="1245" height="459" alt="Screenshot from 2025-12-13 14-33-10" src="https://github.com/user-attachments/assets/99e1ad72-ec9f-4d7e-afe6-191cd3b52d93" />


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax