### PR TITLE
fix(pipelines): do not deploy chaos mesh in upgrade tests

### DIFF
--- a/test-cases/scylla-operator/kubernetes-operator-upgrade.yaml
+++ b/test-cases/scylla-operator/kubernetes-operator-upgrade.yaml
@@ -19,3 +19,4 @@ k8s_scylla_operator_upgrade_docker_image: ''  # default value from the Helm char
 
 use_mgmt: false
 user_prefix: 'kubernetes-operator-upgrade'
+k8s_use_chaos_mesh: false

--- a/test-cases/scylla-operator/kubernetes-platform-upgrade.yaml
+++ b/test-cases/scylla-operator/kubernetes-platform-upgrade.yaml
@@ -33,6 +33,7 @@ k8s_scylla_operator_docker_image: ''  # default value from the Helm chart will b
 
 use_mgmt: false
 user_prefix: 'kubernetes-platform-upgrade'
+k8s_use_chaos_mesh: false
 
 # NOTE: it must be 1 version lower than available in cloud platforms
 eks_cluster_version: '1.26'

--- a/test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml
+++ b/test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml
@@ -12,6 +12,7 @@ n_loaders: 1
 use_mgmt: false
 
 user_prefix: 'kubernetes-scylla-upgrade'
+k8s_use_chaos_mesh: false
 
 # Following configurations does not currently work on kubernetes, due to the lack of ssl certificate support.
 # could be enabled after https://github.com/scylladb/scylla-cluster-tests/issues/2744


### PR DESCRIPTION
it is unused in these tests' logic

### Testing
- [x] unnecessary, the tests do not work fully yet

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code