### PR TITLE
fix(docker_repo): improve docker repo resolution by scylla version

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -3035,7 +3035,7 @@ class SCTConfiguration(dict):
         dist_version = scylla_linux_distro.split("-")[-1]
 
         if scylla_version := self.get("scylla_version"):
-            if not self.get("docker_image"):
+            if self.get("cluster_backend") in ["docker", "k8s-eks", "k8s-gke"]:
                 self["docker_image"] = get_scylla_docker_repo_from_version(scylla_version)
             if self.get("cluster_backend") in (
                 "docker",

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -25,6 +25,7 @@ from sdcm.utils.version_utils import (
     SCYLLA_VERSION_GROUPED_RE,
     ARGUS_VERSION_RE,
     VERSION_NOT_FOUND_ERROR,
+    get_scylla_docker_repo_from_version,
 )
 
 BASE_S3_DOWNLOAD_URL = "https://s3.amazonaws.com/downloads.scylladb.com"
@@ -757,3 +758,30 @@ def test_get_branched_repo(scylla_version, distro, expected_repo):
     expected_template = "https://s3.amazonaws.com/downloads.scylladb.com/{}"
     actual_repo = get_branched_repo(scylla_version, distro)
     assert actual_repo == expected_template.format(expected_repo)
+
+
+@pytest.mark.parametrize(
+    "version, expected_repo",
+    (
+        ("6.2.2", "scylladb/scylla"),
+        ("6.2.3", "scylladb/scylla"),
+        ("6.2.4", "scylladb/scylla"),
+        ("6.2.66", "scylladb/scylla"),
+        ("2024.1.1", "scylladb/scylla-enterprise"),
+        ("2024.2.13", "scylladb/scylla-enterprise"),
+        ("2024.2.14", "scylladb/scylla-enterprise"),
+        ("enterprise:latest", "scylladb/scylla-enterprise"),
+        ("branch-2024.2:latest", "scylladb/scylla-enterprise"),
+        ("branch-2024.1:latest", "scylladb/scylla-enterprise"),
+        ("2025.1.0", "scylladb/scylla"),
+        ("2025.2.99", "scylladb/scylla"),
+        ("2025.4.0", "scylladb/scylla"),
+        ("branch-2025.1:latest", "scylladb/scylla"),
+        ("branch-2025.2:latest", "scylladb/scylla"),
+        ("branch-2025.3:latest", "scylladb/scylla"),
+        ("branch-2025.4:latest", "scylladb/scylla"),
+        ("master:latest", "scylladb/scylla"),
+    ),
+)
+def test_verify_docker_repo_implicit_resolution_for_scylla_versions(version, expected_repo):
+    assert get_scylla_docker_repo_from_version(version) == expected_repo


### PR DESCRIPTION
The problem:

1. The new fixed [upgrade](https://jenkins.scylladb.com/view/scylla-operator/job/scylla-operator/job/operator-master/job/upgrade/job/upgrade-operator-k8s-gke-test/25/consoleFull) test fails as it assumes `scylladb/scylla-enterprise` docker repo for **initial deployments** of 2025.x versions (the logic for correct repo resolution for upgrade process is already merged)
2. SCT config outright [states](https://github.com/scylladb/scylla-cluster-tests/blob/master/sdcm/sct_config.py#L1503) (and it makes sense) that the repo will be assumed based off version if omitted
3. As evident from the test failure, this assumption does not function in this case, as the lookup relies on `is_enterprise()` [function](https://github.com/scylladb/scylla-cluster-tests/blob/master/sdcm/utils/version_utils.py#L516) which is faulty logic as `2025.x` is enterprise but is not in the enterprise repo.
4. The existing lookup logic for some reason does not ALWAYS resolve the repo and instead relied on the repo existence (`if not self.get("docker_image"):`) which seems a bad assumption as this variable was silently loaded by default (and set to `scylladb/scylla-enterprise`, which was the root of the problem).

As @pehala [mentioned](https://github.com/scylladb/scylla-cluster-tests/pull/12899#discussion_r2610101585), we have a lapse of logic in naming and usage patterns of "enterprise" lookup. 

The [repo lookup function](https://github.com/scylladb/scylla-cluster-tests/blob/master/sdcm/utils/version_utils.py#L516) mixes Docker repo resolution and ScyllaDB feature sets together which ultimately leads to this problem.

Therefore, this PR aims to:
- replace the irrelevant `is_enterprise` usage in the Docker Hub repo lookup with a much more reliable version check
- account for all possible environments and always resolve docker repo (except for `docker` back end -- should it stay this way?)
- make lookup explicitly fail by throwing an exception if there is a loophole (before the PR it silently resolved to `scylladb/scylla`)
- add unit tests for EKS, GKE scenarios

### Testing
- [x] covered by existing and new unit tests
- [x] tests are passing now 

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
