### PR TITLE
fix(nemesis): skip ban node nemesis due an issue

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -6059,6 +6059,11 @@ class Nemesis(NemesisFlags):
         if self._is_it_on_kubernetes():
             raise UnsupportedNemesis("Skip test for K8S because no supported yet")
 
+        if SkipPerIssues("scylladb/scylla-cluster-tests#12755", self.cluster.params):
+            # until https://github.com/scylladb/scylla-cluster-tests/issues/12755 test fails
+            # consisently and there's no point to run it
+            raise UnsupportedNemesis("scylladb/scylla-cluster-tests#12755")
+
         if SkipPerIssues("scylladb/scylla-drivers#95", self.cluster.params):
             # until https://github.com/scylladb/scylla-drivers/issues/95 would be solved
             # we should disable the target node switching


### PR DESCRIPTION
Because of https://github.com/scylladb/scylla-cluster-tests/issues/12755 there's no point in running this nemesis until it's fixed

refs: https://github.com/scylladb/scylla-cluster-tests/issues/12755

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
