### PR TITLE
test(manager restore) added new permanent backups

### DIFF
--- a/defaults/manager_restore_benchmark_snapshots.yaml
+++ b/defaults/manager_restore_benchmark_snapshots.yaml
@@ -1,94 +1,72 @@
 cs_read_cmd_template: "cassandra-stress read cl={cl} n={num_of_rows} -schema 'keyspace={keyspace_name} replication(strategy={replication},replication_factor={rf}) compaction(strategy={compaction})' -mode cql3 native -rate threads=500 -col 'size=FIXED({col_size}) n=FIXED({col_n})' -pop seq={sequence_start}..{sequence_end}"
 sizes:  # size of backed up dataset in GB
-  1gb_1t_ics:
-    tag: "sm_20240812100424UTC"
-    locations:
-      - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
-    exp_timeout: 1200  # 20 minutes (timeout for restore data operation)
-    scylla_version: "2024.2.0-rc1"
-    number_of_nodes: 3
-    prohibit_verification_read: false
-    dataset:
-      schema:
-        keyspace1:
-          - standard1: 1
-      num_of_rows: 1073760
-      compaction: "IncrementalCompactionStrategy"
-      cl: "ONE"
-      col_size: 1024
-      col_n: 1
-      replication: "NetworkTopologyStrategy"
-      rf: 3
-    one_one_restore_params: None
-  500gb_1t_ics:
-    tag: "sm_20240813112034UTC"
-    locations:
-      - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
-    exp_timeout: 14400  # 4 hours
-    scylla_version: "2024.2.0-rc1"
-    number_of_nodes: 3
-    prohibit_verification_read: false
-    dataset:
-      schema:
-        keyspace1:
-          - standard1: 500
-      num_of_rows: 524288000
-      compaction: "IncrementalCompactionStrategy"
-      cl: "ONE"
-      col_size: 1024
-      col_n: 1
-      replication: "NetworkTopologyStrategy"
-      rf: 3
-    one_one_restore_params: None
-  500gb_1t_ics_tablets:
-    tag: "sm_20240813114617UTC"
-    locations:
-      - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
-    exp_timeout: 14400  # 4 hours
-    scylla_version: "2024.2.0-rc1"
-    number_of_nodes: 3
-    prohibit_verification_read: false
-    dataset:
-      schema:
-        keyspace1:
-          - standard1: 500
-      num_of_rows: 524288000
-      compaction: "IncrementalCompactionStrategy"
-      cl: "ONE"
-      col_size: 1024
-      col_n: 1
-      replication: "NetworkTopologyStrategy"
-      rf: 3
-    one_one_restore_params: None
-  500gb_2t_ics:
-    tag: "sm_20240819203428UTC"
-    locations:
-      - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
-    exp_timeout: 14400  # 4 hours
-    scylla_version: "2024.2.0-rc1"
-    number_of_nodes: 3
-    prohibit_verification_read: true
-    dataset:
-      schema:
-        keyspace1:
-          - standard1: 250
-        keyspace2:
-          - standard1: 250
-      num_of_rows: 524288000
-      compaction: "IncrementalCompactionStrategy"
-      cl: "ONE"
-      col_size: 1024
-      col_n: 1
-      replication: "NetworkTopologyStrategy"
-      rf: 3
-    one_one_restore_params: None
-  1tb_1t_ics:
-    tag: "sm_20240814180009UTC"
+  2tb_1t_ics_vnodes_2024_2:
+    tag: "sm_20251223144206UTC"
     locations:
       - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
     exp_timeout: 28800  # 8 hours
-    scylla_version: "2024.2.0-rc1"
-    number_of_nodes: 3
+    scylla_version: "2024.2.13"
+    number_of_nodes: 9
+    prohibit_verification_read: false
+    dataset:
+      schema:
+        2048gb_ics_quorum_1024_1_2024_2_13:
+          - standard1: 1024
+      num_of_rows: 1073741824
+      compaction: "IncrementalCompactionStrategy"
+      cl: "QUORUM"
+      col_size: 1024
+      col_n: 1
+      replication: "NetworkTopologyStrategy"
+      rf: 3
+    one_one_restore_params: None
+  2tb_1t_ics_vnodes_2025_1:
+    tag: "sm_20251221164123UTC"
+    locations:
+      - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
+    exp_timeout: 28800  # 8 hours
+    scylla_version: "2025.1.10"
+    number_of_nodes: 9
+    prohibit_verification_read: false
+    dataset:
+      schema:
+        1024gb_ics_quorum_1024_1_2025_1_10:
+          - standard1: 1024
+      num_of_rows: 1073741824
+      compaction: "IncrementalCompactionStrategy"
+      cl: "QUORUM"
+      col_size: 1024
+      col_n: 1
+      replication: "NetworkTopologyStrategy"
+      rf: 3
+    one_one_restore_params: None
+  1tb_1t_ics_vnodes_2025_1:
+    tag: "sm_20251221160803UTC"
+    locations:
+      - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
+    exp_timeout: 28800  # 8 hours
+    scylla_version: "2025.1.10"
+    number_of_nodes: 9
+    prohibit_verification_read: false
+    dataset:
+      schema:
+        1024gb_ics_quorum_1024_1_2025_1_10:
+          - standard1: 1024
+      num_of_rows: 1073741824
+      compaction: "IncrementalCompactionStrategy"
+      cl: "QUORUM"
+      col_size: 1024
+      col_n: 1
+      replication: "NetworkTopologyStrategy"
+      rf: 3
+    one_one_restore_params: None
+  1tb_1t_ics_2025_1:
+    tag: "sm_20251217120202UTC"
+    locations:
+      - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
+    exp_timeout: 28800  # 8 hours
+    scylla_version: "2025.1.10"
+    number_of_nodes: 9
     prohibit_verification_read: false
     dataset:
       schema:
@@ -96,73 +74,47 @@ sizes:  # size of backed up dataset in GB
           - standard1: 1024
       num_of_rows: 1073741824
       compaction: "IncrementalCompactionStrategy"
-      cl: "ONE"
+      cl: "QUORUM"
       col_size: 1024
       col_n: 1
       replication: "NetworkTopologyStrategy"
       rf: 3
     one_one_restore_params: None
-  1tb_4t_twcs:
-    tag: "sm_20240821145503UTC"
+  2tb_1t_ics_2025_1:
+    tag: "sm_20251218165735UTC"
     locations:
       - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
     exp_timeout: 28800  # 8 hours
-    scylla_version: "2024.2.0-rc1"
-    number_of_nodes: 3
-    prohibit_verification_read: true
-    dataset:
-      schema:
-        keyspace1:
-          - t_10gb: 10
-          - t_90gb: 90
-          - t_300gb: 300
-          - t_600gb: 600
-      num_of_rows: 428571429
-      compaction: "TimeWindowCompactionStrategy"
-      cl:
-      col_size:
-      col_n:
-      replication: "NetworkTopologyStrategy"
-      rf: 3
-    one_one_restore_params: None
-  1tb_2t_twcs:
-    tag: "sm_20240827191125UTC"
-    locations:
-      - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
-    exp_timeout: 28800  # 8 hours
-    scylla_version: "2024.2.0-rc1"
+    scylla_version: "2025.1.10"
     number_of_nodes: 9
-    prohibit_verification_read: true
+    prohibit_verification_read: false
     dataset:
       schema:
         keyspace1:
-          - t_300gb: 300
-          - t_700gb: 700
-      num_of_rows: 428571429
-      compaction: "TimeWindowCompactionStrategy"
-      cl:
-      col_size:
-      col_n:
+          - standard1: 2048
+      num_of_rows: 2147483648
+      compaction: "IncrementalCompactionStrategy"
+      cl: "QUORUM"
+      col_size: 1024
+      col_n: 1
       replication: "NetworkTopologyStrategy"
       rf: 3
     one_one_restore_params: None
-  1.5tb_2t_ics:
-    tag: "sm_20240820180152UTC"
+  2tb_1t_twcs_2025_2:
+    tag: "sm_20251224130504UTC"
     locations:
       - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
-    exp_timeout: 43200  # 12 hours
-    scylla_version: "2024.2.0-rc1"
-    number_of_nodes: 3
-    prohibit_verification_read: true
+    exp_timeout: 28800  # 8 hours
+    scylla_version: "2025.2.5"
+    number_of_nodes: 9
+    prohibit_verification_read: false
     dataset:
       schema:
-        keyspace1:
-          - standard1: 500
-        keyspace2:
-          - standard1: 1024
-      num_of_rows: 1598029824
-      compaction: "IncrementalCompactionStrategy"
-      cl: "ONE"
+        2048gb_twcs_quorum_1024_1_2025_2_5:
+          - standard1: 2048
+      num_of_rows: 2147483648
+      compaction: "TimeWindowCompactionStrategy"
+      cl: "QUORUM"
       col_size: 1024
       col_n: 1
       replication: "NetworkTopologyStrategy"


### PR DESCRIPTION
Added new 2025.X permanent backups (like 1tb_1t_ics_2025_1) for testing manager restore
Fixes: #12964

- [x]  Some existing permanent backups have wrong schema DC name that fails the restore task and should be replaced.
    - Example failed [test](https://argus.scylladb.com/tests/scylla-cluster-tests/c23e7dd2-e234-42e0-8e98-a11ef16a5e18): `Unrecognized datacenter name 'us-east'`.
        - The incorrect schema is in s3://manager-backup-tests-permanent-snapshots-us-east-1/backup/schema/cluster/2ffdd178-9316-482a-b17a-392928149ae4/task_265385ac-6d71-4b4d-9d28-823ce6be2b81_tag_sm_20240814180009UTC_schema_with_internals.json.gz

- [x] The Manager Restore testing requires adding new permanent backups of 2025.X.
- [x] Some existing permanent backups have invalid "rc" scylla versions that should be replaced by official ones.
- [ ]  Manually delete the removed snapshots from S3.

Summary:
Updated manager restore benchmark snapshots to use new permanent backups: 
- Added 1–2TB ICS/TWCS datasets for 2024.2, 2025.1 and 2025.2, including vnodes-based 1TB/2TB ICS and 2TB TWCS snapshots.
- Replaced older 1GB/500GB/1TB/1.5TB ICS (2024 rc) and TWCS tablet/vnodes snapshots with the new 1TB and 2TB QUORUM-based datasets for recent Scylla versions and 9-node clusters.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [test 1TB tablets 9 nodes rClone 2025.1 restore](https://argus.scylladb.com/tests/scylla-cluster-tests/d94439ae-4f15-4270-a672-3efdef1b0a6e)
- [test 1TB tablets 9 nodes Native 2025.1 restore](https://argus.scylladb.com/tests/scylla-cluster-tests/f43e42a9-255c-4e5b-a1e6-641a27f4e091)
- [test 2TB vnodes 9 nodes 2024.2 Native restore](https://argus.scylladb.com/tests/scylla-cluster-tests/8fa6632a-875f-461b-929a-b07bc34d33a9)

The new backups were created via the [helper pipeline job](https://argus.scylladb.com/tests/scylla-cluster-tests/44c49441-1c2f-4fc8-bf37-a7714085289a)
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
