### PR TITLE
fix(get_scylla_docker_repo_from_version): handle dev and user input

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -3036,7 +3036,7 @@ class SCTConfiguration(dict):
 
         if scylla_version := self.get("scylla_version"):
             if self.get("cluster_backend") in ["docker", "k8s-eks", "k8s-gke"]:
-                self["docker_image"] = get_scylla_docker_repo_from_version(scylla_version)
+                self["docker_image"] = get_scylla_docker_repo_from_version(scylla_version, self.get("docker_image"))
             if self.get("cluster_backend") in (
                 "docker",
                 "k8s-eks",

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -508,9 +508,21 @@ def get_systemd_version(output: str) -> int:
     return 0
 
 
-def get_scylla_docker_repo_from_version(scylla_version: str):  # noqa: PLR0911
+def get_scylla_docker_repo_from_version(scylla_version: str, docker_image: str):  # noqa: PLR0911
+    """
+    Get scylla docker repo based scylla version.
+
+    :param scylla_version: scylla version string
+    :param docker_image: docker image name
+
+    :return: scylla docker repo
+    """
+
     # scylla_version can take on a variety of formats, so try to match non-standard/non-semver first
-    if scylla_version == "latest":
+    if docker_image:
+        # user set something which is not empty, that should be honored (even if wrong)
+        return docker_image
+    elif scylla_version == "latest" or "-dev" in scylla_version:
         return "scylladb/scylla-nightly"
     elif scylla_version == "master:latest":
         return "scylladb/scylla"

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -761,27 +761,30 @@ def test_get_branched_repo(scylla_version, distro, expected_repo):
 
 
 @pytest.mark.parametrize(
-    "version, expected_repo",
+    "version, expected_repo, input_repo",
     (
-        ("6.2.2", "scylladb/scylla"),
-        ("6.2.3", "scylladb/scylla"),
-        ("6.2.4", "scylladb/scylla"),
-        ("6.2.66", "scylladb/scylla"),
-        ("2024.1.1", "scylladb/scylla-enterprise"),
-        ("2024.2.13", "scylladb/scylla-enterprise"),
-        ("2024.2.14", "scylladb/scylla-enterprise"),
-        ("enterprise:latest", "scylladb/scylla-enterprise"),
-        ("branch-2024.2:latest", "scylladb/scylla-enterprise"),
-        ("branch-2024.1:latest", "scylladb/scylla-enterprise"),
-        ("2025.1.0", "scylladb/scylla"),
-        ("2025.2.99", "scylladb/scylla"),
-        ("2025.4.0", "scylladb/scylla"),
-        ("branch-2025.1:latest", "scylladb/scylla"),
-        ("branch-2025.2:latest", "scylladb/scylla"),
-        ("branch-2025.3:latest", "scylladb/scylla"),
-        ("branch-2025.4:latest", "scylladb/scylla"),
-        ("master:latest", "scylladb/scylla"),
+        ("6.2.2", "scylladb/scylla", None),
+        ("6.2.3", "scylladb/scylla", None),
+        ("6.2.4", "scylladb/scylla", None),
+        ("6.2.66", "scylladb/scylla", None),
+        ("2024.1.1", "scylladb/scylla-enterprise", None),
+        ("2024.2.13", "scylladb/scylla-enterprise", None),
+        ("2024.2.14", "scylladb/scylla-enterprise", None),
+        ("enterprise:latest", "scylladb/scylla-enterprise", None),
+        ("branch-2024.2:latest", "scylladb/scylla-enterprise", None),
+        ("branch-2024.1:latest", "scylladb/scylla-enterprise", None),
+        ("2025.1.0", "scylladb/scylla", None),
+        ("2025.2.99", "scylladb/scylla", None),
+        ("2025.4.0", "scylladb/scylla", None),
+        ("branch-2025.1:latest", "scylladb/scylla", None),
+        ("branch-2025.2:latest", "scylladb/scylla", None),
+        ("branch-2025.3:latest", "scylladb/scylla", None),
+        ("branch-2025.4:latest", "scylladb/scylla", None),
+        ("master:latest", "scylladb/scylla", None),
+        ("2026.1.0-dev-0.20251217.55f4a2b75472", "scylladb/scylla-nightly", None),
+        ("2026.1.0-dev-0.20251217.55f4a2b75472", "scylladb/scylla-nightly", "scylladb/scylla-nightly"),
+        ("2026.1.0.20251217.55f4a2b75472", "scylladb/scylla-nightly", "scylladb/scylla-nightly"),
     ),
 )
-def test_verify_docker_repo_implicit_resolution_for_scylla_versions(version, expected_repo):
-    assert get_scylla_docker_repo_from_version(version) == expected_repo
+def test_verify_docker_repo_implicit_resolution_for_scylla_versions(version, expected_repo, input_repo):
+    assert get_scylla_docker_repo_from_version(version, input_repo) == expected_repo


### PR DESCRIPTION
Since #12953 changd the logic a bit on we automaticlly find the docker repo

two cases wasn't working, and fixed in this commit:
* handeling the dev versions, they are always coming fomr nightly repo
* respect user input, i.e. if user set specific repo, we shouldn't never override it

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] unit tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
