### PR TITLE
fix(performance): run warmup for read_disk_only test

### DIFF
--- a/performance_regression_gradual_grow_throughput.py
+++ b/performance_regression_gradual_grow_throughput.py
@@ -157,7 +157,7 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
         workload = Workload(
             workload_type=workload_type,
             cs_cmd_tmpl=self.params.get("stress_cmd_read_disk"),
-            cs_cmd_warm_up=None,
+            cs_cmd_warm_up=self.params.get("stress_cmd_cache_warmup"),
             num_threads=self.params["perf_gradual_threads"][workload_type],
             throttle_steps=self.throttle_steps(workload_type),
             preload_data=True,


### PR DESCRIPTION
Warmup for read_disk_only load is missed. It cause to high latency while first step.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
