### PR TITLE
fix(manager restore): remove "method" parameter when restoring the schema

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -1161,7 +1161,6 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
             timeout=600,
             restore_schema=True,
             location_list=locations,
-            manager_backup_restore_method=manager_backup_restore_method,
         )
 
         if restore_outside_manager:


### PR DESCRIPTION
The "method" parameter is not applicable in sctool "restore" of the schema.
Fixes: #12976

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- restore native 1tb tablets [test](https://jenkins.scylladb.com/job/scylla-staging/job/yarongilor/job/restore-benchmark-test-refactor/20/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
