### PR TITLE
fix(vector-search): update Scylla version used for VS cluster in Cloud

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -4226,9 +4226,9 @@ class SCTConfiguration(dict):
 
         # validate if selected Scylla version is supported
         supported_versions = [v["version"] for v in cloud_api_client.get_scylla_versions()["scyllaVersions"]]
-        # TODO: the version is not listed in Scylla Cloud API but is used in Prod exclusively for Vector Search preGA
+        # TODO: for now, Scylla Cloud uses 2025.4.0-RC7 for Vector Search clusters
         # TODO: must be removed after Scylla 2025.4 is generally available in Scylla Cloud
-        supported_versions.append("2025.4.0~rc6-0.20251208.f64b5d375e99")
+        supported_versions.append("2025.4.0~rc7-0.20251215.344f64870303")
         if (selected_version := self.get("scylla_version")) not in supported_versions:
             raise ValueError(
                 f"Selected Scylla version '{selected_version}' is not supported by cloud backend.\n"


### PR DESCRIPTION
Add `2025.4.0-rc7` to the list of supported by Cloud. 

VS in Cloud is officially released with this version of Scylla. 
The previous 2025.4.0-rc7 removed from the list since VS in Cloud did not make it with RC6, but with RC7

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/vector-search-pre-ga-testing/job/sirenada-stg-vector-search-average-recall-aws/7/