### PR TITLE
fix(xcloud): add keep post_behavior logic for cleanup-resources flow

### DIFF
--- a/sdcm/utils/resources_cleanup.py
+++ b/sdcm/utils/resources_cleanup.py
@@ -744,6 +744,9 @@ def clean_clusters_scylla_cloud(tags_dict: dict, config: dict, dry_run: bool = F
     """Clean up Scylla Cloud resources based on tags"""
     assert tags_dict, "tags_dict not provided (can't clean all instances)"
 
+    if "NodeType" in tags_dict and "scylla-db" not in tags_dict.get("NodeType"):
+        return
+
     if dry_run:
         LOGGER.info("DRY RUN: No actual resources will be deleted")
 


### PR DESCRIPTION
The `cleanup-resources` SCT command for xcloud backend always deletes test DB cluster.
This change adds the needed check in Scylla Cloud resources cleanup procedure, to ensure that DB cluster is kept when requested.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [Clean Resources pipeline step do nor delete DB cluster if keep post-behavior is requested](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/205/pipeline-overview/?selected-node=261)
```
16:05:25  Post behavior keep for db_nodes. Keep resources running
16:05:25  Post behavior destroy for monitor_nodes. Schedule cleanup
16:05:25  Post behavior destroy for loader_nodes. Schedule cleanup
16:05:25  Post behavior destroy for k8s_cluster. Schedule cleanup
```

The deployed `pr-provision-test-dmytro_kruglov-4e038170-keep-360h` cluster is still running:
```
❯ python -m utils.cloud_cleanup.xcloud.clean_xcloud --dry-run
...
Cleaning Scylla Cloud clusters for 'staging' environment
--------------------------------------------------------------------------------
Initialized Scylla Cloud API client for https://api.ext.siren.stg.scylla.cloud
Found 2 cluster(s) in environment 'staging'
Cluster PR-provision-test-dmytro_kruglov-f0819f11-keep-033h (ID: 32037) created at 2025-12-18T11:26:24Z: KEEPING - Age 3.8h < keep 33h (expires in 29.2h)
Cluster pr-provision-test-dmytro_kruglov-4e038170-keep-360h (ID: 32045) created at 2025-12-18T14:39:03Z: KEEPING - Age 0.6h < keep 360h (expires in 359.4h)
Environment 'staging' cleanup summary: deleted 0, kept 2

========================================
OVERALL SUMMARY:
  Total clusters checked: 2
  Clusters deleted: 0
  Clusters kept: 2
========================================
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
