### PR TITLE
fix(cdc-yaml): set symetric rack configuration for cdc profile

### DIFF
--- a/data_dir/cdc_profile_multidc.yaml
+++ b/data_dir/cdc_profile_multidc.yaml
@@ -2,7 +2,7 @@ keyspace: cdc_test
 
 keyspace_definition: |
 
-  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 3, 'us-eastscylla_node_east': 2}  AND durable_writes = true;
+  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}  AND durable_writes = true;
 
 table: test_table
 
@@ -27,7 +27,6 @@ table_definition: |
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = 'Request for unit level UIs'
     AND compaction = {'class': 'SizeTieredCompactionStrategy'}
-    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND crc_check_chance = 1.0
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0

--- a/data_dir/cdc_profile_multidc_postimage.yaml
+++ b/data_dir/cdc_profile_multidc_postimage.yaml
@@ -2,7 +2,7 @@ keyspace: cdc_test
 
 keyspace_definition: |
 
-  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 2, 'us-eastscylla_node_east': 3}  AND durable_writes = true;
+  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}  AND durable_writes = true;
 
 table: test_table_postimage
 
@@ -27,7 +27,6 @@ table_definition: |
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = 'Request for unit level UIs'
     AND compaction = {'class': 'SizeTieredCompactionStrategy'}
-    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND crc_check_chance = 1.0
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0

--- a/data_dir/cdc_profile_multidc_preimage.yaml
+++ b/data_dir/cdc_profile_multidc_preimage.yaml
@@ -2,7 +2,7 @@ keyspace: cdc_test
 
 keyspace_definition: |
 
-  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 2, 'us-eastscylla_node_east': 3}  AND durable_writes = true;
+  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}  AND durable_writes = true;
 
 table: test_table_preimage
 
@@ -27,7 +27,6 @@ table_definition: |
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = 'Request for unit level UIs'
     AND compaction = {'class': 'SizeTieredCompactionStrategy'}
-    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND crc_check_chance = 1.0
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0

--- a/data_dir/cdc_profile_multidc_preimage_postimage.yaml
+++ b/data_dir/cdc_profile_multidc_preimage_postimage.yaml
@@ -2,7 +2,7 @@ keyspace: cdc_test
 
 keyspace_definition: |
 
-  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 3, 'us-eastscylla_node_east': 2}  AND durable_writes = true;
+  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}  AND durable_writes = true;
 
 table: test_table_preimage_postimage
 
@@ -27,7 +27,6 @@ table_definition: |
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = 'Request for unit level UIs'
     AND compaction = {'class': 'SizeTieredCompactionStrategy'}
-    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND crc_check_chance = 1.0
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0

--- a/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml
@@ -6,7 +6,7 @@ stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc.
               "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc_preimage_postimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=480m -mode cql3 native -rate threads=75"
              ]
 
-n_db_nodes: '4 4'
+n_db_nodes: '6 6'
 instance_type_db: 'i4i.4xlarge'
 n_loaders: '2 2'
 


### PR DESCRIPTION
CDC profiles yaml files configure different racks for different dc (asymetric configurations): eu-west-1: 3 , eu-west-2: 2

This cause error in when rf_rack_valid_keyspaces enabled: """
...  doesn't satisfy it for DC 'us-eastscylla_node_east': RF=2 vs. rack count=1 """

Set same number of rf(racks) for each dc

### Testing

- [Passed](https://argus.scylladb.com/tests/scylla-cluster-tests/d7053e51-8493-4908-8555-cefdef92ebf7)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
