### PR TITLE
fix(config): Set valid number of nodes and az for test

### DIFF
--- a/jenkins-pipelines/oss/longevity/longevity-multi-dc-rack-aware-with-znode-dc.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-multi-dc-rack-aware-with-znode-dc.jenkinsfile
@@ -6,6 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'aws',
     region: '''["eu-west-1", "eu-west-2", "eu-north-1"]''',
+    availability_zone: "a,b,c",
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-multi-dc-rack-aware-with-znode-in-diff_dc.yaml"]''',
 )

--- a/test-cases/longevity/longevity-multi-dc-rack-aware-with-znode-in-diff_dc.yaml
+++ b/test-cases/longevity/longevity-multi-dc-rack-aware-with-znode-in-diff_dc.yaml
@@ -6,9 +6,10 @@ prepare_write_cmd:  ["cassandra-stress write cl=LOCAL_QUORUM n=20971520 -schema 
 stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3,eu-northscylla_node_north=0) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5 -errors retries=50",
              "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3,eu-northscylla_node_north=0) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5 -errors retries=50",
              ]
-n_db_nodes: '4 4 0'
+n_db_nodes: '6 6 0'
 n_loaders: '1 1'
 n_db_zero_token_nodes: '0 1 1'
+availability_zone: 'a,b,c'
 
 rack_aware_loader: true
 region_aware_loader: true


### PR DESCRIPTION
Fix test configuration to run with rf_rack_valid_keyespaces=enabled parameter.

### Testing

- [Passed](https://argus.scylladb.com/tests/scylla-cluster-tests/e21cb33a-ca9a-4ad5-a924-240feef3dd52)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
