### PR TITLE
improvement(scylla_yaml): additional superuser config seeding

### DIFF
--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -211,6 +211,10 @@ class ScyllaYaml(BaseModel):
     request_scheduler_options: RequestSchedulerOptions = None  # None
     thrift_framed_transport_size_in_mb: int = None  # 15
     thrift_max_message_length_in_mb: int = None  # 16
+
+    auth_superuser_name: str = "cassandra"
+    auth_superuser_salted_password: str = "$6$x7IFjiX5VCpvNiFk$2IfjTvSyGL7zerpV.wbY7mJjaRCrJ/68dtT3UpT.sSmNYz1bPjtn3mH.kJKFvaZ2T4SbVeBijjmwGjcb83LlV/"  # "cassandra"
+
     authenticator: (
         Literal[
             "org.apache.cassandra.auth.PasswordAuthenticator",

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -172,6 +172,8 @@ class ScyllaYamlTest(unittest.TestCase):
                 "audit_categories": None,
                 "audit_keyspaces": None,
                 "audit_tables": None,
+                "auth_superuser_name": "cassandra",
+                "auth_superuser_salted_password": "$6$x7IFjiX5VCpvNiFk$2IfjTvSyGL7zerpV.wbY7mJjaRCrJ/68dtT3UpT.sSmNYz1bPjtn3mH.kJKFvaZ2T4SbVeBijjmwGjcb83LlV/",
                 "authenticator": None,
                 "authenticator_password": None,
                 "authenticator_user": None,


### PR DESCRIPTION
ScyllaDB repository will have default `cassandra:cassandra` superuser creation removed. The other ways to initialize an initial superuser are:
- Over the maintenance socket (to be introduced)
- Using config seeding `auth_superuser_name` and `auth_superuser_salted_password` fields

To prepare for the removal of default superuser creation, we will switch scylla-cluster-tests to use config seeding for `cassandra:cassandra`, minimizing the changes needed.

This patch adds `auth_superuser_name` as `cassandra` and `auth_superuser_salted_password` as a salted hash of `cassandra` password to the scylla config.

Refs scylladb/scylla-enterprise#5657

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
