### PR TITLE
fix(nemesis): change base_disruption_name from cached_property to property

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1131,7 +1131,7 @@ class Nemesis(NemesisFlags):
     def disrupt(self):
         raise NotImplementedError("Derived classes must implement disrupt()")
 
-    @cached_property
+    @property
     def base_disruption_name(self) -> str:
         return self.current_disruption.rsplit("-", 1)[0]
 


### PR DESCRIPTION
Fixed issue #12985 where wrong nemesis names were incorrectly appearing in DisruptionEvent logs. The root cause was that base_disruption_name used @cached_property decorator which cached the first nemesis name and never updated it when the nemesis changed, causing stale names to persist.

The fix replaces @cached_property with @property, eliminating caching entirely. This is the correct approach because the value is accessed only 5 times within a single nemesis execution and never changes during that execution.

Fixes: #12985 

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [azure-3h-test](https://argus.scylladb.com/tests/scylla-cluster-tests/8b014ac4-daea-423e-aa63-03c16eee4941)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
