### PR TITLE
improvement(test): improve 5000 tables latte-based scenarios

### DIFF
--- a/data_dir/latte/schema_scale.rn
+++ b/data_dir/latte/schema_scale.rn
@@ -10,6 +10,7 @@ const TABLE_COUNT_PER_KEYSPACE = latte::param!("table_count_per_keyspace", 100);
 ///// SCHEMA creation params /////
 //////////////////////////////////
 const ENABLE_TABLETS = latte::param!("enable_tablets", false);
+const MIN_PER_SHARD_TABLET_COUNT = latte::param!("min_per_shard_tablet_count", 10.0); // default in Scylla
 const CREATE_INDEX = latte::param!("create_index", false);
 const REPLICATION_FACTOR = latte::param!("replication_factor", 3);
 const COMPACTION_STRATEGY = latte::param!("compaction_strategy", "IncrementalCompactionStrategy");
@@ -167,6 +168,11 @@ pub async fn create_schema(db, i) { // user fn to be run in a 'latte run -f ...'
     let table_index = i / KEYSPACE_COUNT + 1;
     let tpadding = get_index_padding(table_index, TABLE_COUNT_PER_KEYSPACE).await;
     let table = `schema_scale_t${tpadding}${table_index}`;
+    let min_per_shard_tablet_count = if ENABLE_TABLETS {
+        `AND tablets = {'min_per_shard_tablet_count': '${MIN_PER_SHARD_TABLET_COUNT}'}`
+    } else {
+        ""
+    };
     db.execute(`
         CREATE TABLE IF NOT EXISTS ${ks}.${table} (
             pk uuid PRIMARY KEY,
@@ -174,6 +180,7 @@ pub async fn create_schema(db, i) { // user fn to be run in a 'latte run -f ...'
             col_date date,
             col_blob blob,
         ) WITH bloom_filter_fp_chance = 0.01
+            ${min_per_shard_tablet_count}
             AND comment = 'Created by latte'
             AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
             AND compaction = {'class': '${COMPACTION_STRATEGY}'}

--- a/test-cases/scale/longevity-5000-tables-latte-vnodes.yaml
+++ b/test-cases/scale/longevity-5000-tables-latte-vnodes.yaml
@@ -18,6 +18,14 @@ nemesis_interval: 5
 # NOTE: prepare phase fails without nemesis. See https://github.com/scylladb/scylladb/issues/27566
 #       So, it is better to keep prepare phase without nemesis to cover the bug case.
 nemesis_during_prepare: false
+# NOTE: skip enospc https://github.com/scylladb/scylla-cluster-tests/issues/12989
+nemesis_selector: 'not enospc and not manager_operation'
+# NOTE: disable mgmt because we run disruptive nemesis with data validation.
+# And if we do repairs, it takes too long making data validation exceed retries.
+use_mgmt: false
+
+root_disk_size_monitor: 120
+root_disk_size_runner: 120
 
 round_robin: true
 # NOTE: use 1 latte thread with concurrency=12 to avoid the following bug:
@@ -36,13 +44,11 @@ prepare_write_cmd:
     -P compaction_strategy="\"IncrementalCompactionStrategy\""
     -P sstable_compression="\"LZ4Compressor\""
     data_dir/latte/schema_scale.rn
-# TODO: increase the concurrency to be '2048' when the following bug gets fixed:
-#       https://github.com/scylladb/scylladb/issues/27566
 prepare_verify_cmd:
   - >-
     latte run --tag populate-data -f write
-    --threads=14 --concurrency=256 --connections=1
-    --warmup=0 --retries=5 --retry-interval=1s,3s --request-timeout 30 --sampling 5s
+    --threads=14 --concurrency=64 --connections=1
+    --warmup=0 --retries=10 --retry-interval=5s,10s --request-timeout 60 --sampling 5s
     -d 1000000000
     -P keyspace_count=1
     -P table_count_per_keyspace=5000
@@ -60,7 +66,7 @@ stress_cmd:
     latte run --tag mixed -f write:1 -f read:5
     --threads=14 --concurrency=32 --connections=1
     --warmup=0 --retries=5 --retry-interval=1s,3s --request-timeout 30 --sampling 5s
-    --validation-strategy=fail-fast
+    --validation-strategy=retry
     -d 36000s
     -P keyspace_count=1
     -P table_count_per_keyspace=5000

--- a/test-cases/scale/longevity-5000-tables-latte.yaml
+++ b/test-cases/scale/longevity-5000-tables-latte.yaml
@@ -2,9 +2,7 @@
 #         https://github.com/scylladb/scylladb/issues/27621
 #       And fails because of the following bug:
 #         https://github.com/scylladb/scylladb/issues/27620
-#       So, it is unknown how much time the full data population phase going to take using tablets.
-# TODO: update the 'test_duration' value according to the expected time for the data population.
-test_duration: 1080 # 5h? prepare + 10h mixed + 3h margin
+test_duration: 900 # 1h prepare + 10h mixed + 4h margin
 
 n_db_nodes: 6
 instance_type_db: 'i4i.4xlarge'
@@ -24,6 +22,14 @@ nemesis_interval: 5
 # NOTE: prepare phase fails without nemesis. See https://github.com/scylladb/scylladb/issues/27566
 #       So, it is better to keep prepare phase without nemesis to cover the bug case.
 nemesis_during_prepare: false
+# NOTE: skip enospc https://github.com/scylladb/scylla-cluster-tests/issues/12989
+nemesis_selector: 'not enospc and not manager_operation'
+# NOTE: disable mgmt because we run disruptive nemesis with data validation.
+# And if we do repairs, it takes too long making data validation exceed retries.
+use_mgmt: false
+
+root_disk_size_monitor: 120
+root_disk_size_runner: 120
 
 round_robin: true
 # NOTE: use 1 latte thread with concurrency=12 to avoid the following bug:
@@ -37,6 +43,7 @@ prepare_write_cmd:
     -P keyspace_count=1
     -P table_count_per_keyspace=5000
     -P enable_tablets=true
+    -P min_per_shard_tablet_count=1.0
     -P create_index=false
     -P replication_factor=3
     -P compaction_strategy="\"IncrementalCompactionStrategy\""
@@ -47,8 +54,8 @@ prepare_write_cmd:
 prepare_verify_cmd:
   - >-
     latte run --tag populate-data -f write
-    --threads=14 --concurrency=256 --connections=1
-    --warmup=0 --retries=5 --retry-interval=1s,3s --request-timeout 30 --sampling 5s
+    --threads=14 --concurrency=64 --connections=1
+    --warmup=0 --retries=10 --retry-interval=5s,10s --request-timeout 60 --sampling 5s
     -d 1000000000
     -P keyspace_count=1
     -P table_count_per_keyspace=5000
@@ -66,7 +73,7 @@ stress_cmd:
     latte run --tag mixed -f write:1 -f read:5
     --threads=14 --concurrency=32 --connections=1
     --warmup=0 --retries=5 --retry-interval=1s,3s --request-timeout 30 --sampling 5s
-    --validation-strategy=fail-fast
+    --validation-strategy=retry
     -d 36000s
     -P keyspace_count=1
     -P table_count_per_keyspace=5000


### PR DESCRIPTION
It is an improvement for the recently merged new test cases at [1].
With the fix [2] for Scylla DB the 5000 tables scenario becomes workable [3][4] using tablets.

So, update the test case the following way:
- Data population with the fix [2] runs with `290kop/s` in average.
  It is less than an hour, so, adjust the test duration and comments.
- Disable enospc [5] and mgmt-based nemesis.
- Make data validation strategy be 'retry' and increase number of retries to make it work during the disruptive nemesis.
- Add support of the `min_per_shard_tablet_count` DB table parameter to improve the tablets scenario performance.
- Increase the SCT runner and monitoring disk size to make it be capable of storing all the logs, especially when we enable additional logging for ScyllaDB.

[1] https://github.com/scylladb/scylla-cluster-tests/pull/12921
[2] https://github.com/scylladb/scylladb/pull/27802
[3] https://github.com/scylladb/scylladb/issues/27620
[4] https://github.com/scylladb/scylladb/issues/27621
[5] https://github.com/scylladb/scylla-cluster-tests/issues/12989

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-longevity-5000-tables-latte#19](https://argus.scylladb.com/tests/scylla-cluster-tests/076427cf-7abc-4eda-a287-a544d2651bff)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
