### PR TITLE
.github/workflows/auto_assign.yaml: Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto_assign.yaml
+++ b/.github/workflows/auto_assign.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
   assignAuthor:
     name: Assign author to PR/issue
+    permissions:
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Assign author to PR/issue


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-cluster-tests/security/code-scanning/25](https://github.com/scylladb/scylla-cluster-tests/security/code-scanning/25)

The best way to fix the problem is to explicitly define the minimal set of permissions required by the workflow for the `assignAuthor` job. Since the job assigns authors to pull requests and issues, it requires write access to both `issues` and `pull-requests`. To ensure least privilege, all other permissions should be set to `none` (the default if not specified), or omitted, but at minimum, the two needed should be set. This should be done by adding a `permissions` block under the `assignAuthor` job in the `.github/workflows/auto_assign.yaml` file (after line 9). No other lines need to be modified, and no imports or external dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
