### PR TITLE
.github/workflows/test-hydra-macos.yaml: Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-hydra-macos.yaml
+++ b/.github/workflows/test-hydra-macos.yaml
@@ -7,6 +7,8 @@ on:
 jobs:
   test:
     if: contains(github.event.pull_request.labels.*.name, 'test-macos')
+    permissions:
+      contents: read
     runs-on: macos-15-intel
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.QA_USER_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-cluster-tests/security/code-scanning/6](https://github.com/scylladb/scylla-cluster-tests/security/code-scanning/6)

In general, fix this issue by explicitly declaring a `permissions:` block to scope down the `GITHUB_TOKEN` to only what the workflow needs. For this workflow, the steps only require reading repository contents (for `actions/checkout`) and do not interact with issues, PRs, or other mutable GitHub resources, so `contents: read` is an appropriate minimal permission.

The best fix, without changing functionality, is to add a `permissions:` block under the `test` job in `.github/workflows/test-hydra-macos.yaml`. This will apply only to this job and avoids assumptions about other workflows. Insert:

```yaml
permissions:
  contents: read
```

at the same indentation level as `runs-on:` (i.e., directly under `test:` and below the `if:` line). No imports or additional methods are needed because this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
