### PR TITLE
.github/workflows/cache-issues.yaml: Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cache-issues.yaml
+++ b/.github/workflows/cache-issues.yaml
@@ -1,4 +1,5 @@
 name: Cache issues status
+permissions: {}
 on:
   schedule:
     - cron: '0 */2 * * *'


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-cluster-tests/security/code-scanning/13](https://github.com/scylladb/scylla-cluster-tests/security/code-scanning/13)

In general, to fix this class of issue you explicitly declare a `permissions:` block in the workflow or job definition, granting only the minimal scopes required. If the job does not need `GITHUB_TOKEN` at all (because it uses other tokens/secrets), you can set `permissions: {}` or `permissions: none` at the workflow or job level to disable it.

For this specific workflow in `.github/workflows/cache-issues.yaml`, the job uses `GH_TOKEN` (a PAT) for GitHub operations and AWS credentials for S3 uploads. There is no use of `GITHUB_TOKEN`, so the best fix is to add a top‑level `permissions: {}` block right after the `name:` line. This will apply to all jobs in the workflow and ensure `GITHUB_TOKEN` has no permissions, without changing existing functionality.

Concretely, edit `.github/workflows/cache-issues.yaml`:
- After line 1 (`name: Cache issues status`), insert a new line `permissions: {}` (or an equivalent multiline `permissions:` block with no scopes).  
No new methods, imports, or definitions are required; this is a pure YAML workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
