### PR TITLE
.github/workflows/check-generated-code-updates.yaml: Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-generated-code-updates.yaml
+++ b/.github/workflows/check-generated-code-updates.yaml
@@ -1,5 +1,8 @@
 name: Check generated code is up-to-date
 
+permissions:
+  contents: read
+
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-cluster-tests/security/code-scanning/14](https://github.com/scylladb/scylla-cluster-tests/security/code-scanning/14)

In general, the workflow should explicitly set a `permissions` block so that the `GITHUB_TOKEN` is limited to the least privilege needed. Since the jobs here only need to read repository contents (checkout and validations) and don’t obviously require write access to any resource, we can set `contents: read` at the workflow level. This will apply to all jobs unless a job overrides it, and it directly addresses the CodeQL complaint.

Best fix with minimal functional change:

- Add a top-level `permissions:` section near the top of `.github/workflows/check-generated-code-updates.yaml`, alongside `name:` and `on:`.
- Set `contents: read`, which is sufficient for `actions/checkout` and typical validation steps that only read code.
- Do not alter any existing jobs, steps, secrets usage, or logic.

Concretely, in `.github/workflows/check-generated-code-updates.yaml`, between line 2 (blank) and line 3 (`on:`), insert:

```yaml
permissions:
  contents: read
```

No imports or additional definitions are required; this is purely a YAML configuration change inside the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
