### PR TITLE
fix(provision-tests): remove default AZs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,15 +13,17 @@ def createRunConfiguration(String backend) {
         backend: backend,
         test_name: 'longevity_test.LongevityTest.test_custom_time',
         test_config: 'test-cases/PR-provision-test.yaml',
-        availability_zone: 'a',
         scylla_version: scylla_version,
+        availability_zone: '',
         region: 'eu-west-1',
     ]
+    if (backend == 'aws' || backend == 'vs-aws') {
+        configuration.availability_zone = 'a'
+    }
     if (backend == 'gce') {
         configuration.gce_datacenter = "us-east1"
     } else if (backend == 'azure') {
         configuration.azure_region_name = 'eastus'
-        configuration.availability_zone = ''
     } else if (backend.contains('docker')) {
         // use latest version of nightly image for docker backend, until we get rid off rebuilding docker image for SCT
         configuration.scylla_version = 'latest'
@@ -42,6 +44,7 @@ def createRunConfiguration(String backend) {
         }
         if (backend == 'xcloud-aws') {
             configuration.xcloud_provider = 'aws'
+            configuration.availability_zone = 'a'
             configuration.test_config = '["test-cases/PR-provision-test.yaml"]'
         }
     }


### PR DESCRIPTION
a small refactor so we can use GCE provision tests default AZ=a doesn't work for them anymore

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] azure provision test - https://jenkins.scylladb.com/job/sct-github-PRs-scan/job/scylla-cluster-tests/job/PR-13034/6/pipeline-overview/?selected-node=112
- [x] gce provision test - https://jenkins.scylladb.com/job/sct-github-PRs-scan/job/scylla-cluster-tests/job/PR-13034/6/pipeline-overview/?selected-node=111

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
