### PR TITLE
fix(cluster.py): init remoter only if node has ssh_login_info defined

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -453,14 +453,14 @@ class BaseNode(AutoSshContainerMixin):
         if self.ssh_login_info:
             self.ssh_login_info["hostname"] = self.external_address
 
-        self.remoter = RemoteCmdRunnerBase.create_remoter(**self.ssh_login_info)
+            self.remoter = RemoteCmdRunnerBase.create_remoter(**self.ssh_login_info)
 
-        # Start task threads after ssh is up, otherwise the dense ssh attempts from task
-        # threads will make SCT builder to be blocked by sshguard of gce instance.
-        self.wait_ssh_up(verbose=True)
-        self.wait_for_cloud_init()
+            # Start task threads after ssh is up, otherwise the dense ssh attempts from task
+            # threads will make SCT builder to be blocked by sshguard of gce instance.
+            self.wait_ssh_up(verbose=True)
+            self.wait_for_cloud_init()
 
-        self._reconfigure_agent(self.remoter)
+            self._reconfigure_agent(self.remoter)
 
         self._init_remoter(self.ssh_login_info)
         if not self.test_config.REUSE_CLUSTER:

--- a/unit_tests/dummy_remote.py
+++ b/unit_tests/dummy_remote.py
@@ -90,6 +90,30 @@ class LocalNode(BaseNode):
     def ssl_conf_dir(self):
         return Path(get_data_dir_path("ssl_conf"))
 
+    def _init_remoter(self, ssh_login_info):
+        pass
+
+    def wait_ssh_up(self, verbose=True, timeout=500):
+        pass
+
+    def set_hostname(self):
+        pass
+
+    def configure_remote_logging(self):
+        pass
+
+    def do_default_installations(self):
+        pass
+
+    def start_task_threads(self):
+        pass
+
+    def _init_port_mapping(self):
+        pass
+
+    def set_keep_alive(self):
+        pass
+
 
 class LocalLoaderSetDummy(BaseCluster):
     def __init__(self, nodes=None, params=None):

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -43,7 +43,8 @@ from sdcm.utils.common import (
 from sdcm.utils.distro import Distro
 from sdcm.utils.nemesis_utils.indexes import get_column_names
 from sdcm.utils.version_utils import ComparableScyllaVersion
-from unit_tests.dummy_remote import DummyRemote
+from sdcm.remote import LocalCmdRunner
+from unit_tests.dummy_remote import DummyRemote, LocalNode
 from unit_tests.lib.events_utils import EventsUtilsMixin
 from unit_tests.test_utils_common import DummyNode
 
@@ -1289,3 +1290,15 @@ class TestNodetool(unittest.TestCase):
         min_token, max_token = keyspace_min_max_tokens(node=node, keyspace="")
         assert min_token == -9193109213506951143
         assert max_token == 9202125676696964746
+
+
+def test_base_node_init_with_none_ssh_login_info():
+    """Verify that node initialization does not crash when ssh_login_info is not defined."""
+    node = LocalNode(
+        name="test_local_node",
+        parent_cluster=DummyDbCluster(nodes=[]),
+    )
+
+    node.init()
+
+    assert isinstance(node.remoter, LocalCmdRunner), f"Expected LocalCmdRunner, got {type(node.remoter)}"


### PR DESCRIPTION
Recent change d78bcc5dd introduced unconditional remoter initialization in BaseNode init sequence. However, this cannot be executed for all nodes - LocalNode objects (e.g. LocalK8SHostNode) do not have ssh_login_info defined (as they do not use SSH).

This change fixes the problem by performing SSH-related operations of BaseNode init sequence only for nodes that have ssh_login_info defined.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/13050

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: aws provision test
- [x] :green_circle: [pr-provision-test with sct-agent enabled](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/129/)
- [x] :yellow_circle: [operator test ](https://argus.scylladb.com/tests/scylla-cluster-tests/c8ed89a0-0eef-4e06-a575-8b14e571fb06). The test failed on node init on 29.12.2025 weekly run, but is passing that place with the fix. The other failure in this run is not related to the issue being fixed - it was happening regularly in this test in the past.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
