### PR TITLE
fix(replication_strategy_utils.py): Added missing quotations to "describe keyspace" command

### DIFF
--- a/sdcm/utils/replication_strategy_utils.py
+++ b/sdcm/utils/replication_strategy_utils.py
@@ -37,7 +37,7 @@ class ReplicationStrategy:
 
     @classmethod
     def get(cls, node: "BaseNode", keyspace: str):
-        create_ks_statement = node.run_cqlsh(f"describe {keyspace}").stdout.splitlines()[1]
+        create_ks_statement = node.run_cqlsh(f"describe {cql_quote_if_needed(keyspace)}").stdout.splitlines()[1]
         return ReplicationStrategy.from_string(create_ks_statement)
 
     def apply(self, node: "BaseNode", keyspace: str):


### PR DESCRIPTION
Some identifier patterns are failing due to missing quotation. Added the missing usage of "cql_quote_if_needed".
Fixes: #13051

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [test restore](https://argus.scylladb.com/tests/scylla-cluster-tests/6b6a94c4-e0f0-4a92-b1a0-05172eedc164)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
