### PR TITLE
chore(CODEOWNERS): update k8s, operator codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,6 +32,18 @@
 /sdcm/cloud_api_client.py   @dimakr
 /sdcm/cloud_api_utils.py    @dimakr
 
+# k8s
+/sdcm/cluster_k8s/          @abramche
+/sdcm/k8s_configs/          @abramche
+/sdcm/utils/k8s/            @abramche
+/defaults/k8s*.yaml         @abramche
+
+# Operator functionality
+/jenkins-pipelines/operator/                @abramche
+/test-cases/scylla-operator/                @abramche
+sdcm/fill_db_data.py                        @abramche @fruch
+upgrade_test.py                             @abramche @fruch
+
 # Stress tools
 /sdcm/stress_thread.py                      @soyacz @CodeLieutenant
 /sdcm/stress/base.py                        @soyacz @CodeLieutenant


### PR DESCRIPTION
add ownership missed in https://github.com/scylladb/scylla-cluster-tests/pull/12640

### Testing
- [x] not needed

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code