### PR TITLE
fix(latte): fix `schema_scale.rn` rune script

### DIFF
--- a/data_dir/latte/schema_scale.rn
+++ b/data_dir/latte/schema_scale.rn
@@ -28,7 +28,7 @@ const GAUSS_STDDEV = latte::param!("gauss_stddev", 0);
 // NOTE: 'table_group_size', 'table_shift_count' and 'table_shift_interval_s' work together.
 // When we have a big amount of tables
 // we want to have a smooth workload all over them with adequate cache hit/miss ratio.
-// So, we achive it by making the load walk over a group/subset of tables ('table_group_size')
+// So, we achieve it by making the load walk over a group/subset of tables ('table_group_size')
 // for some time ('table_shift_interval_s') then we shift the table window by the
 // 'table_shift_count' tables which effectively make the queries use a changed subset of tables
 // for queries. And it is done in a loop based on the 'table_shift_interval_s'.
@@ -83,7 +83,7 @@ pub async fn prepare(db) {
     assert!(ROW_COUNT_PER_TABLE > 0, "'row_count_per_table' cannot be less than '1'");
     assert!(TEXT_COL_SIZE > 0, "'text_col_size' cannot be less than '1'");
     assert!(BLOB_COL_SIZE > 0, "'blob_col_size' cannot be less than '1'");
-    assert!(TABLE_GROUP_SIZE > 0, "'table_group_workload_size' cannot be less than '1'");
+    assert!(TABLE_GROUP_SIZE > 0, "'table_group_size' cannot be less than '1'");
     assert!(TABLE_SHIFT_COUNT >= 0, "'table_shift_count' cannot be less than '0'");
     assert!(TABLE_SHIFT_INTERVAL_S >= 0, "'table_shift_interval_s' cannot be less than '0'");
     if (TABLE_SHIFT_COUNT == 0 && TABLE_SHIFT_INTERVAL_S != 0) || (TABLE_SHIFT_COUNT != 0 && TABLE_SHIFT_INTERVAL_S == 0) {
@@ -217,10 +217,10 @@ async fn prepare_gauss_distribution(db) {
         db.data.gauss_enabled = false;
         println!("debug: Gauss/normal distribution is disabled");
     } else {
-        Err(format!(
+        panic!(
             "'gauss_mean' and 'gauss_stddev' both must be either '0' (disabled) " +
             "or in range of '{min}..{max}' (0..row_count_per_table)",
-            min=0, max=ROW_COUNT_PER_TABLE))
+            min=0, max=ROW_COUNT_PER_TABLE)
     }
 }
 
@@ -228,7 +228,9 @@ async fn prepare_gauss_distribution(db) {
 async fn get_idx(db, i) {
     if db.data.gauss_enabled {
         let current_idx = normal(i, db.data.gauss_mean, db.data.gauss_stddev) as i64;
-        if current_idx > ROW_COUNT_PER_TABLE {
+        if current_idx < 0 {
+            current_idx = 0;
+        } else if current_idx >= ROW_COUNT_PER_TABLE {
             current_idx = ROW_COUNT_PER_TABLE - 1;
         }
         return current_idx;
@@ -270,8 +272,7 @@ pub async fn write(db, i) {
     let t_index = db.data.ks_table_mapping[ks_table_mapping_i][1];
     // NOTE: each table getting queries after a table shift will get non-zero first row index.
     //       It is ok because we care about the step increment value and not starting index.
-    let row_i = (i / TABLE_GROUP_SIZE) % ROW_COUNT_PER_TABLE;
-    let idx = get_idx(db, row_i).await;
+    let idx = get_idx(db, (i / TABLE_GROUP_SIZE)).await;
 
     let pk = uuid(idx);
     let data = gen_data(idx, ks_index, t_index).await;
@@ -286,8 +287,7 @@ pub async fn read(db, i) {
     let t_index = db.data.ks_table_mapping[ks_table_mapping_i][1];
     // NOTE: each table getting queries after a table shift will get non-zero first row index.
     //       It is ok because we care about the step increment value and not starting index.
-    let row_i = (i / TABLE_GROUP_SIZE) % ROW_COUNT_PER_TABLE;
-    let idx = get_idx(db, row_i).await;
+    let idx = get_idx(db, (i / TABLE_GROUP_SIZE)).await;
 
     let pk = uuid(idx);
     if !DATA_VALIDATION {


### PR DESCRIPTION
Cosmetic changes:
- Fix typo in the word `achieve`.
- Fix one of the assertion messages to provide proper param name.
- Make latte command fail sooner than later if we set inconsistent values
  for the `gauss_mean` and the `gauss_stddev` params. 
  Before it would try to run stress and fail at some step
  and now it will fail right away if values are inconsistent for the normal distribution.

Significant changes:
- Handle negative values from `normal()` distribution by clamping to 0
  Without it data validation may fail trying to read nonexistent rows.
  Probability grows with the number of unique seeds to the `normal` fn.
- Provide values for the normal distribution not limited by the number of table rows.

Details for the significant changes:
```
  We populate data using only non-negative row indexes.
  But in the main mixed stress we use normal distribution
  with `mean=100_000` and `stddev=20_000`.
  It means that running a test with `9_000_000_000` operations
  having the `table_group_size=100`
  we must get some negative values out of the `normal` distribution.
  And it should have made the data validation fail by not finding rows
  which are absent.
  But test worked.
  And the reason for working test was capping the input values
  to the `normal` fn by the number of rows in each table.
  It may be called a significant simplification
  where we get a huge chance to not hit any of the negative values
  just because we repeated the 200_000 seed values all the time.
  So, now it is fixed, our distribution is more unique and handles
  boundary cases correctly.
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [scylla-staging/valerii/vp-longevity-5000-tables-latte#23](https://argus.scylladb.com/tests/scylla-cluster-tests/ed7b7497-1713-40b2-afcc-f26f4d51e03d)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
