### PR TITLE
fix(gemini_thread.py): Lower "max-errors-to-store" value

### DIFF
--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -104,7 +104,7 @@ class GeminiStressThread(DockerBasedStressThread):
             "min-clustering-keys": 2,
             "partition-key-distribution": "uniform",  # Distribution for hitting the partition
             "partition-count": 5_000_000,
-            "max-errors-to-store": 1000,  # Number of error to make gemini fail, after N error, gemini will stop immediately with error
+            "max-errors-to-store": 30,  # Number of error to make gemini fail, after N error, gemini will stop immediately with error
         }
 
         self.gemini_oracle_statements_file = f"gemini_oracle_statements_{self.unique_id}.log"


### PR DESCRIPTION
The default value of "max-errors-to-store" parameter is currently set to 1000. This is too high and too much. There's no point keeping more that few tens of errors. No point for gemini to keep running in this state. Setting this parameter a lower value of 30.
Refs: https://github.com/scylladb/gemini/issues/607

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
