### PR TITLE
fix(docker backend): skip SSH operations for local monitoring node

### DIFF
--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -650,6 +650,10 @@ class DockerMonitoringNode(cluster.BaseNode):
     def wait_for_cloud_init(self):
         pass
 
+    def wait_ssh_up(self, verbose=True, timeout=500):
+        # backend does not use SSH, but LOCALRUNNER for commands execution
+        pass
+
     @staticmethod
     def is_docker() -> bool:
         return True
@@ -672,6 +676,10 @@ class DockerMonitoringNode(cluster.BaseNode):
 
     def _refresh_instance_state(self):
         return ["127.0.0.1"], ["127.0.0.1"]
+
+    def refresh_ip_address(self):
+        # IP is always localhost for local monitoring node
+        pass
 
     @cached_property
     def grafana_address(self):
@@ -722,7 +730,7 @@ class MonitorSetDocker(cluster.BaseMonitorSet, DockerCluster):
             base_logdir=self.logdir,
             node_prefix=self.node_prefix,
             node_index=node_index,
-            ssh_login_info=dict(hostname=None, user=self.node_container_user, key_file=self.node_container_key_file),
+            ssh_login_info=None,
         )
         node.init()
         return node


### PR DESCRIPTION
After commit d78bcc5dd, order of operations changed in BaseNode object init sequence. Now it creates SSH remoter and waits for SSH to be up, before executing final _init_remoter sequence.
It affected Docker backend monitoring node initialization, as it waits for SSH on a node object, which doesn't use SSH at all (is uses LOCALRUNNER)

This change fixes this by adding no-op overrides for methods that are not needed for Monitoring node on Docker backend, to skip SSH-related initialization entirely.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [pr-provision-test-docker](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/pr-provision-test/)
- [x] :green_circle: [artifacts-docker-test](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/pr-provision-test/231/) 
- [x] :green_circle: [pr-provision-test on aws (regression check)](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/pr-provision-test/234/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
