### PR TITLE
refactor(mgmt): move run_manager_backup to dedicated backup module to avoid circular imports

### DIFF
--- a/sdcm/mgmt/backup.py
+++ b/sdcm/mgmt/backup.py
@@ -1,0 +1,28 @@
+"""Manager backup operations module.
+
+This module provides backup functionality for Scylla Manager clusters
+without circular import dependencies.
+"""
+
+from sdcm.mgmt import TaskStatus
+from sdcm.sct_events.system import InfoEvent
+
+
+def run_manager_backup(mgr_cluster, locations, method=None, timeout=7200):
+    """
+    Perform a Manager backup task and wait for its completion.
+
+    Args:
+        mgr_cluster: The ManagerCluster object.
+        locations: List of backup locations.
+        method: The upload mode (e.g., RCLONE or NATIVE).
+        timeout: Timeout for the backup task.
+
+    Returns:
+        The completed backup task.
+    """
+    InfoEvent(message=f"Starting a Manager backup (Object Storage Upload Mode: {method})").publish()
+    task = mgr_cluster.create_backup_task(location_list=locations, rate_limit_list=["0"], method=method)
+    backup_status = task.wait_and_get_final_status(timeout=timeout)
+    assert backup_status == TaskStatus.DONE, "Backup upload has failed!"
+    return task

--- a/sdcm/mgmt/operations.py
+++ b/sdcm/mgmt/operations.py
@@ -875,23 +875,3 @@ class ManagerTestFunctionsMixIn(
             repair_task.wait_for_percentage(next_percentage_block)
         repair_task.wait_and_get_final_status(step=30)
         InfoEvent(message="Repair ended").publish()
-
-
-def run_manager_backup(mgr_cluster, locations, method=None, timeout=7200):
-    """
-    Perform a Manager backup task and wait for its completion.
-
-    Args:
-        mgr_cluster: The ManagerCluster object.
-        locations: List of backup locations.
-        method: The upload mode (e.g., RCLONE or NATIVE).
-        timeout: Timeout for the backup task.
-
-    Returns:
-        The completed backup task.
-    """
-    InfoEvent(message=f"Starting a Manager backup (Object Storage Upload Mode: {method})").publish()
-    task = mgr_cluster.create_backup_task(location_list=locations, rate_limit_list=["0"], method=method)
-    backup_status = task.wait_and_get_final_status(timeout=timeout)
-    assert backup_status == TaskStatus.DONE, "Backup upload has failed!"
-    return task

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -72,7 +72,7 @@ from sdcm.db_stats import PrometheusDBStats
 from sdcm.log import SDCMAdapter
 from sdcm.logcollector import save_kallsyms_map
 from sdcm.mgmt.common import TaskStatus, ScyllaManagerError, get_persistent_snapshots, ObjectStorageUploadMode
-from sdcm.mgmt.operations import run_manager_backup
+from sdcm.mgmt.backup import run_manager_backup
 from sdcm.mgmt.argus_report import report_manager_backup_results_to_argus
 from sdcm.mgmt.helpers import get_dc_name_from_ks_statement, get_schema_create_statements_from_snapshot
 from sdcm.nemesis_publisher import NemesisElasticSearchPublisher


### PR DESCRIPTION
Extracted the `run_manager_backup` function from `sdcm/mgmt/operations.py` into a new dedicated module `sdcm/mgmt/backup.py`. This breaks the circular import dependency chain: `sdcm/tester.py` → `sdcm/nemesis.py` → `sdcm/mgmt/operations.py` → `sdcm/tester.py`.

The backup module only imports from non-tester modules (`sdcm.mgmt`, `sdcm.sct_events`), eliminating the circular dependency while maintaining the same functionality.

Updated import in `sdcm/nemesis.py` to import from the new backup module.

Changes:
- Created `sdcm/mgmt/backup.py` with `run_manager_backup` function
- Removed `run_manager_backup` from `sdcm/mgmt/operations.py`
- Updated import in `sdcm/nemesis.py`

This resolves the ImportError that prevented unit tests from loading when importing ClusterTester, which depends on nemesis which was trying to import from operations.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] unit test would be enough for this one

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
