### PR TITLE
fix(sct config): resolve k8s enterprise feature set with correct logic

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -4073,7 +4073,10 @@ class SCTConfiguration(dict):
             tags = azure_utils.get_image_tags(images[0])
             scylla_version = tags.get("scylla_version")
             _is_enterprise = is_enterprise(scylla_version)
-        elif backend == "docker" or "k8s" in backend:
+        elif "k8s" in backend:
+            scylla_version = self.get("scylla_version")
+            _is_enterprise = is_enterprise(scylla_version)
+        elif backend == "docker":
             docker_repo = self.get("docker_image")
             scylla_version = self.get("scylla_version")
             _is_enterprise = "enterprise" in docker_repo


### PR DESCRIPTION
Part of the fix for #13070

With the existing logic (looking at you, https://github.com/scylladb/scylla-cluster-tests/issues/13093) scylla versions running on k8s backends are faultily resolved as not enterprise, which leads to incomplete feature flags.

This change only isolates k8s from docker and resolves enterprise feature set better.

### Testing
- [x] Not needed. k8s tests are not working without this anyway.

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders
