### PR TITLE
fix(sct-events): ignore compaction gate_closed noise during decommission

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -98,6 +98,7 @@ from sdcm.sct_events.group_common_events import (
     decorate_with_context_if_issues_open,
     ignore_take_snapshot_failing,
     ignore_ipv6_failure_to_assign,
+    ignore_compaction_stopped_exceptions,
 )
 from sdcm.sct_events.health import DataValidatorEvent
 from sdcm.sct_events.loaders import CassandraStressLogEvent, ScyllaBenchEvent
@@ -4502,6 +4503,7 @@ class Nemesis(NemesisFlags):
             with (
                 ignore_stream_mutation_fragments_errors(),
                 ignore_raft_topology_cmd_failing(),
+                ignore_compaction_stopped_exceptions(),
                 self.node_allocator.run_nemesis(nemesis_label="DecommissionStreamingErr") as verification_node,
                 FailedDecommissionOperationMonitoring(
                     target_node=self.target_node, verification_node=verification_node, timeout=full_operations_timeout

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -323,7 +323,11 @@ def ignore_scrub_invalid_errors():
 def ignore_compaction_stopped_exceptions():
     with ExitStack() as stack:
         stack.enter_context(
-            DbEventsFilter(db_event=DatabaseLogEvent.DATABASE_ERROR, line="was stopped due to: user request")
+            EventsSeverityChangerFilter(
+                new_severity=Severity.WARNING,
+                event_class=DatabaseLogEvent,
+                regex=r".*system_keyspace - update compaction history failed: seastar::gate_closed_exception.*",
+            )
         )
         yield
 


### PR DESCRIPTION
Workaround for https://github.com/scylladb/scylladb/issues/28017

Workaround that is already present in dtest: https://github.com/scylladb/scylla-dtest/blob/9f8a4e03ec6b2926e0361d36135d50079f4ac138/dtest_setup.py#L656

Decommission can emit a system_keyspace compaction history update failure due to seastar::gate_closed_exception, which is expected shutdown noise. Add a severity downgrade filter so the event does not fail runs.

Removed an unused compaction stop filter to keep the common event group minimal.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
