### PR TITLE
fix(k8s, kubectl): remove deprecated version flag

### DIFF
--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -264,7 +264,7 @@ class MinimalClusterBase(KubernetesCluster, metaclass=abc.ABCMeta):
         # Example of kubectl command output:
         #   $ kubectl version --client --short
         #   Client Version: v1.18.5
-        return LOCALRUNNER.run("kubectl version --client --short").stdout.rsplit(None, 1)[-1][1:]
+        return LOCALRUNNER.run("kubectl version --client").stdout.rsplit(None, 1)[-1][1:]
 
     def docker_pull(self, image):
         self.log.info("Pull `%s' to docker environment", image)

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -1453,7 +1453,7 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             f"Got unexpected K8S data plane version(s): {data_plane_versions}"
         )
 
-        control_plane_versions = self.k8s_cluster.kubectl("version --short").stdout.splitlines()
+        control_plane_versions = self.k8s_cluster.kubectl("version").stdout.splitlines()
         # Output example:
         # Client Version: v1.20.4
         # Server Version: v1.19.13-gke.700


### PR DESCRIPTION
fixes #13149

`--short` [is the default already](https://github.com/kubernetes/kubernetes/issues/122455)

### Testing
- [x] causes https://argus.scylladb.com/tests/scylla-cluster-tests/7e735ef0-4487-4ac4-b399-efa88a94a953/events to fail and possibly other tests, rerunning

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
