### PR TITLE
fix(provision-tests): add default AZ for docker backend

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,7 @@ def createRunConfiguration(String backend) {
         configuration.scylla_version = 'latest'
         configuration.docker_image = 'scylladb/scylla-nightly'
         configuration.test_config = "test-cases/PR-provision-test-docker.yaml"
+        configuration.availability_zone = 'a'
     } else if (backend in ['k8s-local-kind-aws', 'k8s-eks']) {
         configuration.test_config = "test-cases/scylla-operator/functional.yaml"
         configuration.test_name = "functional_tests/scylla_operator"


### PR DESCRIPTION
This is a follow up of the change performed in
https://github.com/scylladb/scylla-cluster-tests/commit/dc1df6c01e01a8bfc21ee6b61022d2edff2fbbdf. Docker backend uses AWS infrastructure when tests are executed in Jenkins. This requires the availability zone to be set.

Refs: https://github.com/scylladb/scylla-cluster-tests/pull/13034

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] integration tests run. Without this change the CI integration tests set was failing to start like in https://jenkins.scylladb.com/job/sct-github-PRs-scan/job/scylla-cluster-tests/job/PR-13102/9/pipeline-overview/

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
