### PR TITLE
improvement(xcloud): enable prod environment for SCT tests

### DIFF
--- a/docs/xcloud-backend.md
+++ b/docs/xcloud-backend.md
@@ -114,10 +114,13 @@ xcloud_vpc_peering:
 ## Listing cloud clusters
 
 ```bash
-# list using `list-resources` hydra command
+# list all environments using `list-resources` hydra command
 hydra list-resources -b xcloud --get-all
 
-# list using cleanup script in dry-run mode
+# list specific environment only
+hydra list-resources -b xcloud --get-all --xcloud-env lab
+
+# list all environments using cleanup script in dry-run mode
 ./docker/env/hydra.sh python -m utils.cloud_cleanup.xcloud.clean_xcloud --dry-run
 ```
 
@@ -140,7 +143,7 @@ Keep duration is automatically set based on test duration and is calculated as:
 
 **Executing cleanup script manually:**
 ```bash
-# dry-run mode to see what would be deleted
+# dry-run mode to see what would be deleted (checks all environments by default)
 ./docker/env/hydra.sh python -m utils.cloud_cleanup.xcloud.clean_xcloud --dry-run
 
 # cleanup of test clusters on specific environment

--- a/sct.py
+++ b/sct.py
@@ -469,8 +469,8 @@ def clean_resources(ctx, post_behavior, user, test_id, logdir, dry_run, backend,
     "xcloud_envs",
     type=str,
     multiple=True,
-    default=["lab", "staging"],
-    help="ScyllaDB Cloud environments to check (can be specified multiple times). Defaults to lab and staging",
+    default=["lab", "staging", "prod"],
+    help="ScyllaDB Cloud environments to check (can be specified multiple times). Defaults to lab, staging, and prod",
 )
 @click.pass_context
 def list_resources(ctx, user, test_id, get_all, get_all_running, verbose, backend_type, xcloud_envs):  # noqa: PLR0912, PLR0914, PLR0915

--- a/utils/cloud_cleanup/xcloud/clean_xcloud.py
+++ b/utils/cloud_cleanup/xcloud/clean_xcloud.py
@@ -10,7 +10,7 @@ from sdcm.cloud_api_client import ScyllaCloudAPIClient
 from sdcm.keystore import KeyStore
 
 DRY_RUN = False
-ENVIRONMENTS = ["lab", "staging"]
+ENVIRONMENTS = ["lab", "staging", "prod"]
 
 KEEP_HOURS_PATTERN = re.compile(r"-keep-(\d+)h$")
 

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -32,7 +32,7 @@ def call(Map pipelineParams) {
                    name: 'xcloud_provider')
 
             string(defaultValue: "${pipelineParams.get('xcloud_env', 'lab')}",
-                   description: 'Scylla Cloud environment (only used when backend=xcloud). Supported environments: lab',
+                   description: 'Scylla Cloud environment (only used when backend=xcloud). Supported environments: lab, staging, prod',
                    name: 'xcloud_env')
 
             string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",


### PR DESCRIPTION
Added prod environment to xcloud operations (resources listing and cleanup) to support SCT testing on prod ScyllaDB Cloud environment.

Refs: https://github.com/scylladb/qa-tasks/issues/1946

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [pr-provision-test on prod env (cleanup is correctly performed as pipeline step as per post-behaviour settings)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/240/)
- [x] check during runtime to ensure that ssh commands can be executed on prod env nodes:
```
>>> nodes[0].parent_cluster.params['xcloud_env']
'prod'

>>> for i in nodes: i.remoter.run('uptime').stdout
' 08:32:40 up 14 min, 146 users,  load average: 0.07, 0.12, 0.13\n'
' 08:32:44 up 14 min, 129 users,  load average: 1.04, 1.05, 0.62\n'
' 08:32:47 up 14 min, 118 users,  load average: 0.77, 0.33, 0.19\n'
```
- [x] check that list-resources command lists the prod env as well:
```
❯ ./sct.py list-resources -b xcloud --get-all --xcloud-env prod
logged in as arn:aws:sts::797456418907:assumed-role/DeveloperAccessRole/dmytro.kruglov@scylladb.com
New directory created: /home/dmitriy/sct-results/20260108-104724-047070-list-resources
Checking ScyllaDB Cloud (prod)...
Initialized Scylla Cloud API client for https://api.cloud.scylladb.com
+-------------------------------------------------------------------------------------------------------------------------------------+
|                                                    ScyllaDB Cloud clusters (prod)                                                   |
+-----------------------------------------------------+-------------+--------+----------+----------+-----------+----------------------+
| Name                                                | Environment | Status | Provider | TestId   | RunByUser | CreatedAt            |
+-----------------------------------------------------+-------------+--------+----------+----------+-----------+----------------------+
| PR-provision-test-dmytro_kruglov-ec6863b7-keep-004h | prod        | ACTIVE | AWS      | ec6863b7 | N/A       | 2026-01-08T08:16:26Z |
+-----------------------------------------------------+-------------+--------+----------+----------+-----------+----------------------+
```
- [x] check that cloud resources reporting/cleanup script is collecting prod env resources:
```
❯ python -m utils.cloud_cleanup.xcloud.clean_xcloud --dry-run

Cleaning Scylla Cloud clusters for 'lab' environment
--------------------------------------------------------------------------------
...

Cleaning Scylla Cloud clusters for 'staging' environment
--------------------------------------------------------------------------------
...

Cleaning Scylla Cloud clusters for 'prod' environment
--------------------------------------------------------------------------------
Initialized Scylla Cloud API client for https://api.cloud.scylladb.com
Found 1 cluster(s) in environment 'prod'
Cluster PR-provision-test-dmytro_kruglov-ec6863b7-keep-004h (ID: 43826) created at 2026-01-08T08:16:26Z: KEEPING - Age 1.5h < keep 4h (expires in 2.5h)
Environment 'prod' cleanup summary: deleted 0, kept 1

========================================
OVERALL SUMMARY:
  Total clusters checked: 3
  Clusters deleted: 0
  Clusters kept: 3
========================================
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
