### PR TITLE
fix(nemesis): ignore raft topology errors during restarts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,13 +285,13 @@ When writing or updating documentation in this repository, follow these standard
   ```python
   def check_cluster_health(self, nodes=None):
       """Check the health of cluster nodes.
-      
+
       Args:
           nodes: List of nodes to check. If None, checks all nodes.
-          
+
       Returns:
           bool: True if all nodes are healthy, False otherwise.
-          
+
       Raises:
           ClusterHealthError: If critical health issues are detected.
       """


### PR DESCRIPTION
Wrap node restarts with ignore_raft_topology_cmd_failing to reduce  log noise from expected coordinator failures
 (e.g. rpc::closed_error / connection is closed)in rolling-restart nemeses.
fixes: https://github.com/scylladb/scylla-cluster-tests/issues/13148

### Testing
https://jenkins.scylladb.com/job/scylla-staging/job/eugene_test_folder/job/network_errors/4/
but no barriers been executed 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
