### PR TITLE
improvement(healthcheck): increase timeout to 60s per node

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5172,7 +5172,7 @@ class BaseScyllaCluster:
             # TODO: find how to recognize, that nemesis on the node is running
             if self.nemesis_count == 1:
                 node_for_timeout = next((n for n in self.nodes if not n.running_nemesis), self.nodes[0])
-                with adaptive_timeout(Operations.HEALTHCHECK, node=node_for_timeout, timeout=len(self.nodes) * 30):
+                with adaptive_timeout(Operations.HEALTHCHECK, node=node_for_timeout, timeout=len(self.nodes) * 60):
                     for node in self.nodes:
                         node.check_node_health()
             else:


### PR DESCRIPTION
If some of the nodes take longer than usual (i.e. driver issues), then the entire check will timeout.
Increase the timeout to be more permissive.

Most likely the cause is https://github.com/scylladb/python-driver/issues/614 as there are multiple errors like this when the healthcheck takes more than usual for a node
```
< t:2025-12-25 06:25:11,806 f:cluster.py      l:4103 c:cassandra.cluster    p:WARNING > [control connection] Error connecting to 10.4.3.116:9042: < t:2025-12-25 06:25:11,806 f:cluster.py      l:4103 c:cassandra.cluster    p:WARNING > [control connection] Error connecting to 10.4.3.116:9042:
< t:2025-12-25 06:25:11,806 f:cluster.py      l:4103 c:cassandra.cluster    p:WARNING > Traceback (most recent call last):
< t:2025-12-25 06:25:11,806 f:cluster.py      l:4103 c:cassandra.cluster    p:WARNING >   File "cassandra/cluster.py", line 3546, in cassandra.cluster.ControlConnection._connect_host_in_lbp
< t:2025-12-25 06:25:11,806 f:cluster.py      l:4103 c:cassandra.cluster    p:WARNING >   File "cassandra/cluster.py", line 3662, in cassandra.cluster.ControlConnection._try_connect
< t:2025-12-25 06:25:11,806 f:cluster.py      l:4103 c:cassandra.cluster    p:WARNING >   File "cassandra/cluster.py", line 3646, in cassandra.cluster.ControlConnection._try_connect
< t:2025-12-25 06:25:11,806 f:cluster.py      l:4103 c:cassandra.cluster    p:WARNING > cassandra.connection.ConnectionShutdown: [Errno 9] Bad file descriptor
< t:2025-12-25 06:25:11,806 f:cluster.py      l:4103 c:cassandra.cluster    p:ERROR > Control connection failed to connect, shutting down Cluster: < t:2025-12-25 06:25:11,806 f:cluster.py      l:4103 c:cassandra.cluster    p:ERROR > Control connection failed to connect, shutting down Cluster:
< t:2025-12-25 06:25:11,806 f:cluster.py      l:4103 c:cassandra.cluster    p:ERROR > Traceback (most recent call last):
< t:2025-12-25 06:25:11,806 f:cluster.py      l:4103 c:cassandra.cluster    p:ERROR >   File "cassandra/cluster.py", line 1722, in cassandra.cluster.Cluster.connect
< t:2025-12-25 06:25:11,806 f:cluster.py      l:4103 c:cassandra.cluster    p:ERROR >   File "cassandra/cluster.py", line 3520, in cassandra.cluster.ControlConnection.connect
< t:2025-12-25 06:25:11,806 f:cluster.py      l:4103 c:cassandra.cluster    p:ERROR >   File "cassandra/cluster.py", line 3581, in cassandra.cluster.ControlConnection._reconnect_internal
< t:2025-12-25 06:25:11,806 f:cluster.py      l:4103 c:cassandra.cluster    p:ERROR > cassandra.cluster.NoHostAvailable: ('Unable to connect to any servers', {'10.4.3.116:9042': ConnectionShutdown('[Errno 9] Bad file descriptor')})
```

There are multiple runs with soft timeouts for healthchek:
- https://argus.scylladb.com/tests/scylla-cluster-tests/c101d023-bbc9-4c14-9582-366d348f56b9/results
- https://argus.scylladb.com/tests/scylla-cluster-tests/7c48c527-dbef-4aee-8742-9e63ba0dd612/results
- https://argus.scylladb.com/tests/scylla-cluster-tests/0de9bf3a-8bec-48d1-bf10-41d13645e239/results

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] N/A

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
