### PR TITLE
fix(azure): support arch-aware private gallery image lookup with fallback

### DIFF
--- a/sdcm/provision/azure/utils.py
+++ b/sdcm/provision/azure/utils.py
@@ -29,6 +29,28 @@ from sdcm.utils.version_utils import (
 
 LOGGER = logging.getLogger(__name__)
 
+# Regex to detect ARM architecture from Azure instance type name.
+# Azure ARM instances have a 'p' immediately after the vCPU digit(s),
+# e.g. Standard_D8ps_v5, Standard_E4ps_v5, Standard_D2pds_v5
+_AZURE_ARM_RE = re.compile(r"^Standard_[A-Z]+\d+p")
+
+
+def get_arch_from_azure_instance_type(instance_type: str) -> VmArch:
+    """Detect CPU architecture from Azure instance type name.
+
+    Azure ARM instances use a 'p' suffix after the vCPU count digit(s)
+    to denote Ampere Altra (ARM64) processors.
+
+    Examples:
+        Standard_D8ps_v5  -> ARM (has 'p' after '8')
+        Standard_L8s_v3   -> X86 (no 'p' after '8')
+        Standard_E4ps_v5  -> ARM
+        Standard_D2pds_v5 -> ARM
+    """
+    if instance_type and _AZURE_ARM_RE.match(instance_type):
+        return VmArch.ARM
+    return VmArch.X86
+
 
 def vmarch_to_azure(arch: VmArch) -> str:
     """Convert VmArch enum to Azure architecture format.
@@ -80,11 +102,25 @@ def get_scylla_images_private_galleries(
     unparsable_scylla_versions = []
 
     with suppress(AzureResourceNotFoundError):
-        gallery_image_versions = azure_service.compute.gallery_image_versions.list_by_gallery_image(
-            resource_group_name="SCYLLA-IMAGES",
-            gallery_name="scylladb_dev",
-            gallery_image_name=branch,
-        )
+        try:
+            gallery_image_versions = list(
+                azure_service.compute.gallery_image_versions.list_by_gallery_image(
+                    resource_group_name="SCYLLA-IMAGES",
+                    gallery_name="scylladb_dev",
+                    gallery_image_name=f"{branch}-{vmarch_to_azure(arch)}",
+                )
+            )
+        except AzureResourceNotFoundError:
+            gallery_image_versions = []
+
+        if not gallery_image_versions:
+            gallery_image_versions = list(
+                azure_service.compute.gallery_image_versions.list_by_gallery_image(
+                    resource_group_name="SCYLLA-IMAGES",
+                    gallery_name="scylladb_dev",
+                    gallery_image_name=branch,
+                )
+            )
         for image in gallery_image_versions:
             if image.location != region_name or image.tags.get("name", "").startswith("debug-"):
                 continue
@@ -114,8 +150,6 @@ def get_scylla_images_private_galleries(
 def get_scylla_images(
     scylla_version: str, region_name: str, arch: VmArch = VmArch.X86, azure_service: AzureService = AzureService()
 ) -> list[GalleryImageVersion]:
-    if arch != VmArch.X86:
-        LOGGER.warning("--arch option not implemented currently for Azure machine images.")
     version_bucket = scylla_version.split(":", 1)
     only_latest = False
     tags_to_search = {"arch": arch.value}

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2838,31 +2838,39 @@ class SCTConfiguration(BaseModel):
             elif not self.get("azure_image_db") and self.get("cluster_backend") == "azure":
                 scylla_azure_images = []
                 azure_region_names = self.get("azure_region_name")
+                azure_arch = azure_utils.get_arch_from_azure_instance_type(self.get("azure_instance_type_db"))
 
                 for region in azure_region_names:
                     try:
-                        # Check if this is a full version tag
                         if parse_scylla_version_tag(scylla_version):
-                            # Full version tag: use get_scylla_images for exact matching
                             azure_image = azure_utils.get_scylla_images(
-                                scylla_version=scylla_version, region_name=region
+                                scylla_version=scylla_version, region_name=region, arch=azure_arch
                             )[0]
                         elif ":" in scylla_version:
-                            # Branch version: use get_scylla_images
                             azure_image = azure_utils.get_scylla_images(
-                                scylla_version=scylla_version, region_name=region
+                                scylla_version=scylla_version, region_name=region, arch=azure_arch
                             )[0]
                         else:
-                            # Simple version: use get_released_scylla_images
+                            if azure_arch != azure_utils.VmArch.X86:
+                                raise ValueError(
+                                    f"Azure released images (community gallery) do not support "
+                                    f"arch={azure_arch.value}. Use a branch version "
+                                    f"(e.g. 'master:latest') for ARM instances."
+                                )
                             azure_image = azure_utils.get_released_scylla_images(
-                                scylla_version=scylla_version, region_name=region
+                                scylla_version=scylla_version, region_name=region, arch=azure_arch
                             )[0]
                     except Exception as ex:  # noqa: BLE001
                         raise ValueError(
                             f"Azure Image for scylla_version='{scylla_version}' not found in {region}"
+                            f" (arch={azure_arch.value})"
                         ) from ex
                     self.log.debug(
-                        "Found Azure Image %s for scylla_version='%s' in %s", azure_image.name, scylla_version, region
+                        "Found Azure Image %s for scylla_version='%s' in %s (arch=%s)",
+                        azure_image.name,
+                        scylla_version,
+                        region,
+                        azure_arch.value,
                     )
                     scylla_azure_images.append(azure_image)
                 self["azure_image_db"] = " ".join(

--- a/unit_tests/unit/provisioner/fake_azure_service.py
+++ b/unit_tests/unit/provisioner/fake_azure_service.py
@@ -775,7 +775,15 @@ class FakeImages:
 
     def list_by_resource_group(self, resource_group_name) -> List[Image]:
         with open(self.path / resource_group_name / "azure_images_list.json", encoding="utf-8") as file:
-            return [Image.deserialize(image) for image in json.load(file)]
+            return [self._make_image(image) for image in json.load(file)]
+
+    @staticmethod
+    def _make_image(data: dict) -> Image:
+        name = data.pop("name", None)
+        img = Image(**data)
+        img.name = name
+        data["name"] = name
+        return img
 
 
 class FakeGalleryImageVersions:
@@ -790,7 +798,7 @@ class FakeGalleryImageVersions:
                 self.path / resource_group_name / f"{gallery_name}_{gallery_image_name}_gallery_images_list.json",
                 encoding="utf-8",
             ) as file:
-                return [Image.deserialize(image) for image in json.load(file)]
+                return [FakeImages._make_image(image) for image in json.load(file)]
         except FileNotFoundError:
             raise ResourceNotFoundError("No gallery images found") from None
 

--- a/unit_tests/unit/provisioner/test_azure_get_scylla_images.py
+++ b/unit_tests/unit/provisioner/test_azure_get_scylla_images.py
@@ -17,7 +17,12 @@ import logging
 
 import pytest
 
-from sdcm.provision.azure.utils import get_scylla_images
+from sdcm.provision.azure.utils import (
+    get_arch_from_azure_instance_type,
+    get_scylla_images,
+    get_scylla_images_private_galleries,
+)
+from sdcm.provision.provisioner import VmArch
 from sdcm.utils.azure_utils import AzureService
 from unit_tests.unit.provisioner.fake_azure_service import FakeAzureService
 
@@ -29,8 +34,25 @@ def azure_service(test_data_dir):
 
 def test_can_get_scylla_images_based_on_branch(azure_service):
     images = get_scylla_images("master:latest", "eastus", azure_service=azure_service)
-    assert images[0].name == "2025.1208.222124"
+    assert images[0].name == "2026.0108.151759"
     assert len(images) == 1
+
+
+def test_can_get_scylla_images_based_on_branch_arm64(azure_service):
+    images = get_scylla_images("master:latest", "eastus", azure_service=azure_service, arch=VmArch.ARM)
+    assert images[0].name == "2026.0108.145545"
+    assert len(images) == 1
+
+
+def test_private_gallery_falls_back_to_old_naming(azure_service):
+    images = get_scylla_images_private_galleries("2024.2:latest", "eastus", azure_service=azure_service)
+    assert len(images) == 1
+    assert images[0].name == "2024.1201.120000"
+
+
+def test_private_gallery_fallback_returns_empty_for_nonexistent_branch(azure_service):
+    images = get_scylla_images_private_galleries("nonexistent:latest", "eastus", azure_service=azure_service)
+    assert images == []
 
 
 def test_can_get_scylla_images_based_on_scylla_version(azure_service):
@@ -51,6 +73,24 @@ def test_unparsable_scylla_versions_are_logged(azure_service, caplog):
     assert "Couldn't parse scylla version from images: ['ScyllaDB-5.-98ad.1.dev_0: ScyllaDB-5.']" in caplog.text
 
 
+@pytest.mark.parametrize(
+    "instance_type,expected_arch",
+    [
+        ("Standard_D8ps_v5", VmArch.ARM),
+        ("Standard_D4ps_v5", VmArch.ARM),
+        ("Standard_E8ps_v5", VmArch.ARM),
+        ("Standard_D2pds_v5", VmArch.ARM),
+        ("Standard_L8s_v3", VmArch.X86),
+        ("Standard_D2_v4", VmArch.X86),
+        ("Standard_F4s_v2", VmArch.X86),
+        ("", VmArch.X86),
+        (None, VmArch.X86),
+    ],
+)
+def test_get_arch_from_azure_instance_type(instance_type, expected_arch):
+    assert get_arch_from_azure_instance_type(instance_type) == expected_arch
+
+
 def generate_images_json_file(test_data_dir):
     """generates azure_images_list.json based on real Azure images for unit tests purposes."""
     resource_group = "SCYLLA-IMAGES"
@@ -62,7 +102,7 @@ def generate_images_json_file(test_data_dir):
         images_file.write(json.dumps(serialized_images, indent=2))
 
 
-def generate_gallery_images_json_file(test_data_dir, gallery_name="scylladb_dev", image_name="master"):
+def generate_gallery_images_json_file(test_data_dir, gallery_name="scylladb_dev", image_name="master-x64"):
     """generates azure_images_list.json based on real Azure images for unit tests purposes."""
     resource_group = "SCYLLA-IMAGES"
     images = AzureService().compute.gallery_image_versions.list_by_gallery_image(

--- a/unit_tests/unit/provisioner/test_data/SCYLLA-IMAGES/scylladb_dev_2024.2_gallery_images_list.json
+++ b/unit_tests/unit/provisioner/test_data/SCYLLA-IMAGES/scylladb_dev_2024.2_gallery_images_list.json
@@ -1,0 +1,48 @@
+[
+  {
+    "tags": {
+      "arch": "x86_64",
+      "branch": "2024.2",
+      "build_mode": "release",
+      "build_tag": "",
+      "creation_timestamp": "2024-12-01T10-00-00",
+      "environment": "production",
+      "name": "scylla-2024.2.5-x86_64-2024-12-01T12-00-00",
+      "operating_system": "ubuntu22.04",
+      "scylla_build_sha_id": "",
+      "scylla_machine_image_version": "2024.2.5-",
+      "scylla_python3_version": "2024.2.5-2024.2",
+      "scylla_version": "2024.2.5-0.20241201.abcdef1234",
+      "user_data_format_version": "3"
+    },
+    "location": "eastus",
+    "properties": {
+      "publishingProfile": {
+        "targetRegions": [
+          {
+            "name": "East US",
+            "regionalReplicaCount": 1,
+            "storageAccountType": "Standard_LRS"
+          }
+        ],
+        "replicaCount": 1,
+        "excludeFromLatest": false,
+        "storageAccountType": "Standard_LRS",
+        "replicationMode": "Full"
+      },
+      "storageProfile": {
+        "source": {
+          "virtualMachineId": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/scylla-images/providers/Microsoft.Compute/virtualMachines/pkrvmfallback"
+        },
+        "osDiskImage": {
+          "hostCaching": "ReadWrite",
+          "source": {}
+        }
+      },
+      "safetyProfile": {
+        "allowDeletionOfReplicatedLocations": false
+      }
+    },
+    "name": "2024.1201.120000"
+  }
+]

--- a/unit_tests/unit/provisioner/test_data/SCYLLA-IMAGES/scylladb_dev_master-Arm64_gallery_images_list.json
+++ b/unit_tests/unit/provisioner/test_data/SCYLLA-IMAGES/scylladb_dev_master-Arm64_gallery_images_list.json
@@ -1,0 +1,186 @@
+[
+  {
+    "tags": {
+      "arch": "aarch64",
+      "branch": "master",
+      "build_mode": "release",
+      "build_tag": "",
+      "creation_timestamp": "2026-01-08T12-55-39",
+      "environment": "production",
+      "name": "scylla-2026.1.0-aarch64-2026-01-08T14-55-45",
+      "operating_system": "ubuntu24.04",
+      "scylla_build_sha_id": "",
+      "scylla_machine_image_version": "2026.1.0-",
+      "scylla_python3_version": "2026.1.0-2026.1",
+      "scylla_version": "2026.1.0-0.20260108.def9876543ab",
+      "user_data_format_version": "3"
+    },
+    "location": "eastus",
+    "properties": {
+      "publishingProfile": {
+        "targetRegions": [
+          {
+            "name": "East US",
+            "regionalReplicaCount": 1,
+            "storageAccountType": "Standard_LRS"
+          }
+        ],
+        "replicaCount": 1,
+        "excludeFromLatest": false,
+        "storageAccountType": "Standard_LRS",
+        "replicationMode": "Full"
+      },
+      "storageProfile": {
+        "source": {
+          "virtualMachineId": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/scylla-images/providers/Microsoft.Compute/virtualMachines/pkrvmbm95e9btjc"
+        },
+        "osDiskImage": {
+          "hostCaching": "ReadWrite",
+          "source": {}
+        }
+      },
+      "safetyProfile": {
+        "allowDeletionOfReplicatedLocations": false
+      }
+    },
+    "name": "2026.0108.145545"
+  },
+  {
+    "tags": {
+      "arch": "aarch64",
+      "branch": "master",
+      "build_mode": "release",
+      "build_tag": "",
+      "creation_timestamp": "2026-01-08T18-52-35",
+      "environment": "debug",
+      "name": "debug-scylla-2026.1.0-aarch64-2026-01-08T20-52-44",
+      "operating_system": "ubuntu24.04",
+      "scylla_build_sha_id": "",
+      "scylla_machine_image_version": "2026.1.0-",
+      "scylla_python3_version": "2026.1.0-2026.1",
+      "scylla_version": "2026.1.0-0.20260108.def9876543ab",
+      "user_data_format_version": "3"
+    },
+    "location": "eastus",
+    "properties": {
+      "publishingProfile": {
+        "targetRegions": [
+          {
+            "name": "East US",
+            "regionalReplicaCount": 1,
+            "storageAccountType": "Standard_LRS"
+          }
+        ],
+        "replicaCount": 1,
+        "excludeFromLatest": false,
+        "storageAccountType": "Standard_LRS",
+        "replicationMode": "Full"
+      },
+      "storageProfile": {
+        "source": {
+          "virtualMachineId": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/scylla-images/providers/Microsoft.Compute/virtualMachines/pkrvmf8l7pvuh8e"
+        },
+        "osDiskImage": {
+          "hostCaching": "ReadWrite",
+          "source": {}
+        }
+      },
+      "safetyProfile": {
+        "allowDeletionOfReplicatedLocations": false
+      }
+    },
+    "name": "2026.0108.205244"
+  },
+  {
+    "tags": {
+      "arch": "aarch64",
+      "branch": "master",
+      "build_mode": "release",
+      "build_tag": "",
+      "creation_timestamp": "2026-01-10T20-48-32",
+      "environment": "debug",
+      "name": "debug-scylla-2026.1.0-aarch64-2026-01-10T22-48-42",
+      "operating_system": "ubuntu24.04",
+      "scylla_build_sha_id": "",
+      "scylla_machine_image_version": "2026.1.0-",
+      "scylla_python3_version": "2026.1.0-2026.1",
+      "scylla_version": "2026.1.0-0.20260108.def9876543ab",
+      "user_data_format_version": "3"
+    },
+    "location": "eastus",
+    "properties": {
+      "publishingProfile": {
+        "targetRegions": [
+          {
+            "name": "East US",
+            "regionalReplicaCount": 1,
+            "storageAccountType": "Standard_LRS"
+          }
+        ],
+        "replicaCount": 1,
+        "excludeFromLatest": false,
+        "storageAccountType": "Standard_LRS",
+        "replicationMode": "Full"
+      },
+      "storageProfile": {
+        "source": {
+          "virtualMachineId": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/scylla-images/providers/Microsoft.Compute/virtualMachines/pkrvmhrixmejbcm"
+        },
+        "osDiskImage": {
+          "hostCaching": "ReadWrite",
+          "source": {}
+        }
+      },
+      "safetyProfile": {
+        "allowDeletionOfReplicatedLocations": false
+      }
+    },
+    "name": "2026.0110.224842"
+  },
+  {
+    "tags": {
+      "arch": "aarch64",
+      "branch": "master",
+      "build_mode": "release",
+      "build_tag": "",
+      "creation_timestamp": "2026-01-10T21-32-33",
+      "environment": "debug",
+      "name": "debug-scylla-2026.1.0-aarch64-2026-01-10T23-32-41",
+      "operating_system": "ubuntu24.04",
+      "scylla_build_sha_id": "",
+      "scylla_machine_image_version": "2026.1.0-",
+      "scylla_python3_version": "2026.1.0-2026.1",
+      "scylla_version": "2026.1.0-0.20260108.def9876543ab",
+      "user_data_format_version": "3"
+    },
+    "location": "eastus",
+    "properties": {
+      "publishingProfile": {
+        "targetRegions": [
+          {
+            "name": "East US",
+            "regionalReplicaCount": 1,
+            "storageAccountType": "Standard_LRS"
+          }
+        ],
+        "replicaCount": 1,
+        "excludeFromLatest": false,
+        "storageAccountType": "Standard_LRS",
+        "replicationMode": "Full"
+      },
+      "storageProfile": {
+        "source": {
+          "virtualMachineId": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/scylla-images/providers/Microsoft.Compute/virtualMachines/pkrvm4ww4j9ydjp"
+        },
+        "osDiskImage": {
+          "hostCaching": "ReadWrite",
+          "source": {}
+        }
+      },
+      "safetyProfile": {
+        "allowDeletionOfReplicatedLocations": false
+      }
+    },
+    "name": "2026.0110.233241"
+  }
+]

--- a/unit_tests/unit/provisioner/test_data/SCYLLA-IMAGES/scylladb_dev_master-x64_gallery_images_list.json
+++ b/unit_tests/unit/provisioner/test_data/SCYLLA-IMAGES/scylladb_dev_master-x64_gallery_images_list.json
@@ -1,0 +1,48 @@
+[
+  {
+    "tags": {
+      "arch": "x86_64",
+      "branch": "master",
+      "build_mode": "release",
+      "build_tag": "",
+      "creation_timestamp": "2026-01-08T13-17-45",
+      "environment": "production",
+      "name": "scylla-2026.1.0-x86_64-2026-01-08T15-17-59",
+      "operating_system": "ubuntu24.04",
+      "scylla_build_sha_id": "",
+      "scylla_machine_image_version": "2026.1.0-",
+      "scylla_python3_version": "2026.1.0-2026.1",
+      "scylla_version": "2026.1.0-0.20260108.abc1234567ef",
+      "user_data_format_version": "3"
+    },
+    "location": "eastus",
+    "properties": {
+      "publishingProfile": {
+        "targetRegions": [
+          {
+            "name": "East US",
+            "regionalReplicaCount": 1,
+            "storageAccountType": "Standard_LRS"
+          }
+        ],
+        "replicaCount": 1,
+        "excludeFromLatest": false,
+        "storageAccountType": "Standard_LRS",
+        "replicationMode": "Full"
+      },
+      "storageProfile": {
+        "source": {
+          "virtualMachineId": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/scylla-images/providers/Microsoft.Compute/virtualMachines/pkrvmq8zigsxepl"
+        },
+        "osDiskImage": {
+          "hostCaching": "ReadWrite",
+          "source": {}
+        }
+      },
+      "safetyProfile": {
+        "allowDeletionOfReplicatedLocations": false
+      }
+    },
+    "name": "2026.0108.151759"
+  }
+]


### PR DESCRIPTION
Support fetching Azure ARM64 images from private galleries by using
the new arch-suffixed gallery image definitions (e.g., `master-x64`,
`master-Arm64`) introduced in scylla-machine-image PR #861.

When the arch-suffixed gallery image definition is not found (older
branches that predate the naming split), falls back to the original
branch-only naming (e.g., `master`). This ensures backward compatibility
with older branches while enabling ARM64 support on `master:latest`.

### Changes

- Use `gallery_image_name=f"{branch}-{vmarch_to_azure(arch)}"` with
  try/except fallback to `gallery_image_name=branch`
- Remove the arch-not-supported warning from `get_scylla_images()`
  (private gallery lookup now supports ARM64)
- Add unit tests for ARM64 lookup, fallback to old naming, and
  nonexistent branch handling
- Fix test data `scylla_version` format to match `SCYLLA_VERSION_GROUPED_RE`

### Alignment with scylla-machine-image

Ref: https://github.com/scylladb/scylla-machine-image/pull/861

The machine-image PR introduces `{branch}-Arm64` and `{branch}-x64` image
definition naming in Azure galleries. This PR makes SCT look up images
using that naming scheme, with a fallback for older branches that still
use the unsuffixed `{branch}` naming.

### Fetching behavior

| Scenario | Gallery name tried | Fallback |
|---|---|---|
| `master:latest` (x86) | `master-x64` | `master` (if not found) |
| `master:latest` (ARM64) | `master-Arm64` | `master` (if not found) |
| `2024.2:latest` (x86) | `2024.2-x64` | `2024.2` (old naming) |
| Full version tag | `master-x64` / `master-Arm64` | `master` |

> **Note**: Fetching ARM64 images for *releases* (community gallery) is not yet supported.

### Testing

- [x] Unit tests pass: 7 Azure image tests (including ARM64 + fallback)
- [x] Full provisioner suite: 162 tests pass
- [x] Integration test with real Azure gallery

### PR pre-checks (self review)

- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code
- [x] Unit tests cover new functionality