### PR TITLE
fix(vector-search): stop using RC of 2025.4 Scylla in Vector Search Cloud tests

### DIFF
--- a/jenkins-pipelines/vector-search/vector-search-in-cloud-aws.jenkinsfile
+++ b/jenkins-pipelines/vector-search/vector-search-in-cloud-aws.jenkinsfile
@@ -8,7 +8,7 @@ longevityPipeline(
     xcloud_provider: 'aws',
     xcloud_env: 'staging',
     region: 'us-east-1',
-    scylla_version: '2025.4.0~rc0-0.20251001.6969918d3151',
+    scylla_version: 'release:latest',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/vector-search/vector-search-sanity.yaml'
 )

--- a/jenkins-pipelines/vector-search/vector-search-in-cloud-gce.jenkinsfile
+++ b/jenkins-pipelines/vector-search/vector-search-in-cloud-gce.jenkinsfile
@@ -8,7 +8,7 @@ longevityPipeline(
     xcloud_provider: 'gce',
     xcloud_env: 'staging',
     gce_datacenter: 'us-east1',
-    scylla_version: '2025.4.0~rc0-0.20251001.6969918d3151',
+    scylla_version: 'release:latest',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/vector-search/vector-search-sanity.yaml'
 )

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -4272,9 +4272,6 @@ class SCTConfiguration(dict):
 
         # validate if selected Scylla version is supported
         supported_versions = [v["version"] for v in cloud_api_client.get_scylla_versions()["scyllaVersions"]]
-        # TODO: for now, Scylla Cloud uses 2025.4.0-RC7 for Vector Search clusters
-        # TODO: must be removed after Scylla 2025.4 is generally available in Scylla Cloud
-        supported_versions.append("2025.4.0~rc7-0.20251215.344f64870303")
         if (selected_version := self.get("scylla_version")) not in supported_versions:
             raise ValueError(
                 f"Selected Scylla version '{selected_version}' is not supported by cloud backend.\n"


### PR DESCRIPTION
Scylla Cloud officially supports 2025.4.0 Scylla version now on all environments. 
Vector Search tests should use GA version from now on.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [sirenada-stg-vector-search-average-recall-aws](https://jenkins.scylladb.com/view/siren/job/siren-tests/job/Staging/job/Vector_Search/job/sirenada-stg-vector-search-average-recall-aws/4)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code