### PR TITLE
feature(c-s): Enable c-s java 4x driver support

### DIFF
--- a/configurations/c-s-driver-version-4.yaml
+++ b/configurations/c-s-driver-version-4.yaml
@@ -1,0 +1,1 @@
+c_s_driver_version: '4'

--- a/defaults/docker_images/cassandra-stress/values_cassandra-stress.yaml
+++ b/defaults/docker_images/cassandra-stress/values_cassandra-stress.yaml
@@ -1,2 +1,2 @@
 cassandra-stress:
-  image: scylladb/cassandra-stress:3.19.0
+  image: scylladb/cassandra-stress:3.20.0

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -349,3 +349,5 @@ agent:
   binary_url: ""
   max_concurrent_jobs: 10
   log_level: "info"
+
+c_s_driver_version: '3'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -3892,3 +3892,12 @@ Whether or not to send email using argus instead of SCT.
 **default:** N/A
 
 **type:** bool
+
+
+## **c_s_driver_version** / SCT_C_S_DRIVER_VERSION
+
+cassandra-stress driver version to use: 3|4|random
+
+**default:** 3
+
+**type:** str (appendable)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -16,6 +16,7 @@ Handling Scylla-cluster-test configuration loading
 """
 
 import os
+import random
 import re
 import ast
 import json
@@ -2746,6 +2747,13 @@ class SCTConfiguration(dict):
             type=bool,
             help="Whether or not to send email using argus instead of SCT.",
         ),
+        dict(
+            name="c_s_driver_version",
+            env="SCT_C_S_DRIVER_VERSION",
+            type=str,
+            choices=("3", "4", "random"),
+            help="cassandra-stress driver version to use: 3|4|random",
+        ),
     ]
 
     required_params = [
@@ -3422,6 +3430,10 @@ class SCTConfiguration(dict):
                         f"perf_gradual_threads for {workload} should be a single-element, integer or list, "
                         f"or a list with the same length as perf_gradual_throttle_steps for {workload}"
                     )
+
+        if self.get("c_s_driver_version") == "random":
+            self["c_s_driver_version"] = random.choice(["4", "3"])
+            self.log.debug("Using random cassandra-stress driver version: %s", self["c_s_driver_version"])
 
     def load_docker_images_defaults(self):
         docker_images_dir = pathlib.Path(sct_abs_path("defaults/docker_images"))

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -107,6 +107,13 @@ class CassandraStressThread(DockerBasedStressThread):
         self.compaction_strategy = compaction_strategy
         self.set_hdr_tags(stress_cmd)
 
+    @property
+    def is_driver_4x(self) -> bool:
+        driver_version = self.params.get("c_s_driver_version")
+        if driver_version == "4":
+            return True
+        return False
+
     def set_stress_operation(self, stress_cmd):
         if " mixed " in stress_cmd:
             self.stress_operation = "mixed"
@@ -172,7 +179,7 @@ class CassandraStressThread(DockerBasedStressThread):
     def adjust_cmd_node_option(self, stress_cmd, loader, cmd_runner):
         if self.node_list and "-node" not in stress_cmd:
             stress_cmd += " -node "
-            if self.loader_set.test_config.MULTI_REGION:
+            if self.loader_set.test_config.MULTI_REGION or self.is_driver_4x:
                 # The datacenter name can be received from "nodetool status" output. It's possible for DB nodes only,
                 # not for loader nodes. So call next function for DB nodes
                 datacenter_name_per_region = self.loader_set.get_datacenter_name_per_region(db_nodes=self.node_list)
@@ -208,6 +215,15 @@ class CassandraStressThread(DockerBasedStressThread):
         stress_cmd = self.adjust_cmd_node_option(stress_cmd, loader, cmd_runner)
         return stress_cmd
 
+    def set_driver_version_in_cmd(self, stress_cmd: str) -> str:
+        if not self.is_driver_4x:
+            return stress_cmd
+
+        if " native " in stress_cmd:
+            return stress_cmd.replace(" native ", " 4x ", 1)
+
+        return stress_cmd.replace("-mode", "-mode 4x", 1)
+
     def create_stress_cmd(self, cmd_runner, keyspace_idx, loader):
         stress_cmd = self.stress_cmd
 
@@ -224,6 +240,7 @@ class CassandraStressThread(DockerBasedStressThread):
 
         stress_cmd = self.adjust_cmd_keyspace_name(stress_cmd, keyspace_idx)
         stress_cmd = self.adjust_cmd_compaction_strategy(stress_cmd)
+        stress_cmd = self.set_driver_version_in_cmd(stress_cmd)
 
         credentials = self.loader_set.get_db_auth()
         if credentials and "user=" not in stress_cmd:


### PR DESCRIPTION
Updated cassandra-stress to the latest (3.20.0) version that supports java 4.x driver.
Java 4.x driver is turned on when `-mode` includes `4x` param.
For that, new `c_s_driver` param were added. It supports '3x', '4x'
(when driver 4.x should be used) and 'random' (default) when upon test
startup one value is set and used along the entire test.
closes: https://github.com/scylladb/cassandra-stress/issues/101

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] - [longevity 4x](https://argus.scylladb.com/tests/scylla-cluster-tests/0e540003-8769-4817-8a7c-d7a01c2d4849) 
- [ ] - [upgrade test 4x](https://argus.scylladb.com/tests/scylla-cluster-tests/c2ff41e6-b308-42df-b79e-671eac8fac79)
- [ ] - [upgrade test 3x](https://argus.scylladb.com/tests/scylla-cluster-tests/1889cecb-df79-4f3f-9f40-1d1a0ca1afdb)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
