### PR TITLE
parallel remove nodes draft PR

### DIFF
--- a/data_dir/nemesis.yml
+++ b/data_dir/nemesis.yml
@@ -30,6 +30,22 @@ disrupt_add_drop_column:
   supports_high_disk_utilization: true
   topology_changes: false
   zero_node_changes: false
+disrupt_add_nodes_remove_nodes:
+  config_changes: false
+  delete_rows: false
+  disruptive: true
+  enospc: false
+  free_tier_set: false
+  has_steady_run: false
+  kubernetes: false
+  limited: false
+  manager_operation: false
+  networking: false
+  schema_changes: false
+  sla: false
+  supports_high_disk_utilization: false
+  topology_changes: true
+  zero_node_changes: false
 disrupt_add_remove_dc:
   config_changes: false
   delete_rows: false
@@ -894,22 +910,6 @@ disrupt_rebuild_streaming_err:
   supports_high_disk_utilization: true
   topology_changes: false
   zero_node_changes: false
-disrupt_refuse_connection_with_block_scylla_ports_on_banned_node:
-  config_changes: false
-  delete_rows: false
-  disruptive: true
-  enospc: false
-  free_tier_set: false
-  has_steady_run: false
-  kubernetes: false
-  limited: false
-  manager_operation: false
-  networking: false
-  schema_changes: false
-  sla: false
-  supports_high_disk_utilization: true
-  topology_changes: true
-  zero_node_changes: false
 disrupt_refuse_connection_with_send_sigstop_signal_to_scylla_on_banned_node:
   config_changes: false
   delete_rows: false
@@ -939,7 +939,7 @@ disrupt_remove_node_then_add_node:
   networking: false
   schema_changes: false
   sla: false
-  supports_high_disk_utilization: false
+  supports_high_disk_utilization: true
   topology_changes: true
   zero_node_changes: false
 disrupt_remove_service_level_while_load:

--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -6,16 +6,15 @@ stress_cmd: ["scylla-bench -workload=timeseries -mode=write -replication-factor=
 # write-rate = -max-rate / -concurrency = 30000 / 150 = 200
 stress_read_cmd: [
     "scylla-bench -workload=timeseries -mode=read -partition-count=4000 -concurrency=150 -replication-factor=3 -clustering-row-count=10000 -clustering-row-size=200  -rows-per-request=1 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 200 -distribution hnormal --connection-count 100 -duration=2880m -timeout=30s -retry-number=30 -retry-interval=80ms,1s",
-    "scylla-bench -workload=timeseries -mode=read -partition-count=4000 -concurrency=150 -replication-factor=3 -clustering-row-count=10000 -clustering-row-size=200  -rows-per-request=1 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 200 -distribution uniform --connection-count 100 -duration=2880m -timeout=30s -retry-number=30 -retry-interval=80ms,1s"
     ]
 
 
 n_db_nodes: 6
-n_loaders: 3
+n_loaders: 1
 
-instance_type_db: 'i8ge.xlarge'
+instance_type_db: 'i3en.xlarge'
 
-nemesis_class_name: 'SisyphusMonkey'
+nemesis_class_name: 'IsolateNodeWithIptableRuleNemesis'
 nemesis_seed: '025'
 nemesis_interval: 15
 nemesis_during_prepare: false


### PR DESCRIPTION
Draft PR to validate the new parallel remove-nodes logic. The flow is functional, but the implementation currently relies on multiple inner helper functions and likely needs follow-up refactoring/generalization. Please focus review on correctness and failure handling (DOWN detection, removenode behavior, cleanup).

New helper methods were added; it’s not yet clear whether they should remain methods on the nemesis class, be extracted into a shared helper module, or kept as inner helper functions.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/7826

### Testing
https://jenkins.scylladb.com/job/scylla-staging/job/eugene_test_folder/job/parall_rmv_nd/17/
https://argus.scylladb.com/tests/scylla-cluster-tests/415318da-3136-4e93-80c3-02894f7bde35

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
