### PR TITLE
fix(nemesis): skip the enospc nemesis for the `2025.4` and newer versions

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1865,6 +1865,11 @@ class Nemesis(NemesisFlags):
 
     @target_all_nodes
     def disrupt_nodetool_enospc(self, sleep_time=30, all_nodes=False):
+        if ComparableScyllaVersion(self.target_node.scylla_version) > "2025.3.99":
+            raise UnsupportedNemesis(
+                "Applicalbe only for 2025.3 and lower."
+                " See https://github.com/scylladb/scylla-cluster-tests/issues/12989"
+            )
         if all_nodes:
             nodes = self.cluster.data_nodes
             InfoEvent("Enospc test on {}".format([n.name for n in nodes])).publish()


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-cluster-tests/issues/12989

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
