### PR TITLE
fix(hydra): don't use usernames to identify running in CI

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -150,7 +150,7 @@ if [[ -n "${CREATE_RUNNER_INSTANCE}" ]]; then
 fi
 
 # if running on Build server
-if [[ ${USER} == "jenkins" || ${USER} == "runner" ]]; then
+if [[ -n "$JENKINS_URL" || -n "$BUILD_TAG" || -n "$GITHUB_ACTIONS" ]]; then
     echo "Running on Build Server..."
     HOST_NAME=`hostname`
 else
@@ -168,7 +168,7 @@ else
   die "Please make sure you install either podman or docker on this machine to run hydra"
 fi
 
-if [[ ${USER} == "jenkins" || ${USER} == "runner" || -z "`$tool images ${DOCKER_REGISTRY}/${DOCKER_REPO}:${VERSION} -q`" ]]; then
+if [[  -n "$JENKINS_URL" || -n "$BUILD_TAG" || -n "$GITHUB_ACTIONS" || -z "`$tool images ${DOCKER_REGISTRY}/${DOCKER_REPO}:${VERSION} -q`" ]]; then
     echo "Pull version $VERSION from Docker Hub..."
     $tool pull ${DOCKER_REGISTRY}/${DOCKER_REPO}:${VERSION}
 else

--- a/unit_tests/test_hydra_sh.py
+++ b/unit_tests/test_hydra_sh.py
@@ -98,8 +98,8 @@ class LongevityPipelineTest:
     @staticmethod
     def docker_run_prefix(runner: bool):
         if runner:
-            return "docker -H ssh://ubuntu@1.1.1.1 run --rm -it --privileged -h ip-1.1.1.1.*"
-        return "docker run --rm -it --privileged .*"
+            return "docker -H ssh://ubuntu@1.1.1.1 run --rm --privileged -h ip-1.1.1.1.*"
+        return "docker run --rm --privileged .*"
 
     def sct_path(self, runner: bool):
         if runner:
@@ -236,6 +236,7 @@ class LongevityPipelineTest:
             "SCT_TEST_ID": self.test_id,
             "HOME": self.test_home_dir,
             "USER": "root",
+            "BUILD_TAG": "1234",
             "SCT_CLUSTER_BACKEND": self.backend,
             "SCT_CONFIG_FILES": '["/jenkins/slave/workspace/siren-tests/longevity-tests/cloud-longevity-small-data-'
             'set-1h-gcp/siren-tests/sct_plugin/configurations/scylla_cloud_nemesis_small_set.yaml"]',


### PR DESCRIPTION
switching to use env vars which are more common,
username can be diffrent between builders

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
