### PR TITLE
fix(hydra): remove debugging code

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -149,8 +149,6 @@ if [[ -n "${CREATE_RUNNER_INSTANCE}" ]]; then
     echo
 fi
 
-echo `whoami`
-
 # if running on Build server
 if [[ ${USER} == "jenkins" || ${USER} == "runner" ]]; then
     echo "Running on Build Server..."
@@ -334,7 +332,7 @@ if [[ -n "$RUNNER_IP" ]]; then
     echo "Syncing ${SCT_DIR} to the SCT runner instance..."
     if [ -z "$HYDRA_DRY_RUN" ]; then
         ssh-keygen -R "$RUNNER_IP" || true
-        rsync -ar -e 'ssh -o StrictHostKeyChecking=no' --exclude='.venv*'  --delete ${SCT_DIR} ubuntu@${RUNNER_IP}:/home/ubuntu/
+        rsync -ar -e 'ssh -o StrictHostKeyChecking=no' --delete ${SCT_DIR} ubuntu@${RUNNER_IP}:/home/ubuntu/
     else
         echo "ssh-keygen -R \"$RUNNER_IP\" || true"
         echo "rsync -ar -e 'ssh -o StrictHostKeyChecking=no' --delete ${SCT_DIR} ubuntu@${RUNNER_IP}:/home/ubuntu/"
@@ -358,7 +356,7 @@ if [[ -n "$RUNNER_IP" ]]; then
 
     SCT_DIR="/home/ubuntu/scylla-cluster-tests"
     HOST_NAME="ip-${RUNNER_IP//./-}"
-    USER_ID=1001:1001
+    USER_ID=1000:1000
     RUNNER_CMD="ssh -o StrictHostKeyChecking=no ubuntu@${RUNNER_IP}"
     DOCKER_HOST="-H ssh://ubuntu@${RUNNER_IP}"
 fi


### PR DESCRIPTION
in PR introducing OCI, some debugging code wrongly introduced in the last cycle of fixes, the reverts those changes

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
