### PR TITLE
fix(logging): adjust event filter to reduce rpc "aborting on shard" errors

### DIFF
--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -185,7 +185,7 @@ def enable_default_filters(sct_config: SCTConfiguration):
     EventsSeverityChangerFilter(
         new_severity=Severity.WARNING,
         event_class=DatabaseLogEvent.ABORTING_ON_SHARD,
-        regex=r".*Parent connection [\d]+ is aborting on shard",
+        regex=r".*\brpc\b.*aborting on shard \d+",
     ).publish()
 
     # As written in https://github.com/scylladb/scylladb/issues/20950#issuecomment-2411387784


### PR DESCRIPTION
For avoiding SCT error events
Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/13189
### Testing
Local regexp testing

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
