### PR TITLE
improvement(performance): remove update test details in ES

### DIFF
--- a/test-cases/performance/perf-regression-alternator-basic.yaml
+++ b/test-cases/performance/perf-regression-alternator-basic.yaml
@@ -80,7 +80,7 @@ append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --
 backtrace_decoding: true
 backtrace_stall_decoding: false
 
-store_perf_results: true
+store_perf_results: false
 email_recipients: [] # TODO: Re-enable email notifications by setting to ['alternator-perf-results@scylladb.com'] once the email template issue is resolved.
 
 

--- a/test-cases/performance/perf-regression-latency-650gb-elasticity.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-elasticity.yaml
@@ -28,8 +28,8 @@ append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --
 backtrace_decoding: true
 backtrace_stall_decoding: false
 
-store_perf_results: true
-email_recipients: ["scylla-perf-results@scylladb.com"]
+store_perf_results: false
+email_recipients: [""]
 use_prepared_loaders: false
 use_hdrhistogram: true
 email_subject_postfix: 'elasticity test'

--- a/test-cases/performance/perf-regression-latency-650gb-upgrade.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-upgrade.yaml
@@ -26,8 +26,8 @@ append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --
 backtrace_decoding: true
 backtrace_stall_decoding: false
 
-store_perf_results: true
-email_recipients: ["scylla-perf-results@scylladb.com"]
+store_perf_results: false
+email_recipients: [""]
 use_prepared_loaders: false
 use_hdrhistogram: true
 use_placement_group: true

--- a/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
@@ -28,8 +28,8 @@ append_scylla_args: '--blocked-reactor-notify-ms 5 --abort-on-lsa-bad-alloc 1 --
 backtrace_decoding: true
 backtrace_stall_decoding: false
 
-store_perf_results: true
-email_recipients: ["scylla-perf-results@scylladb.com"]
+store_perf_results: false
+email_recipients: [""]
 use_prepared_loaders: false
 use_hdrhistogram: true
 use_placement_group: true

--- a/test-cases/performance/perf-regression-predefined-throughput-steps-custom-d3-w1.yaml
+++ b/test-cases/performance/perf-regression-predefined-throughput-steps-custom-d3-w1.yaml
@@ -10,9 +10,9 @@ gce_instance_type_loader: 'e2-highcpu-8'
 use_preinstalled_scylla: true
 use_prepared_loaders: false
 backtrace_decoding: false
-store_perf_results: true
+store_perf_results: false
 use_mgmt: false
-email_recipients: ['qa@scylladb.com']
+email_recipients: ['']
 user_prefix: 'perf-rgrsn-prdfnd-steps-cstm-d3w1'
 custom_es_index: 'performancestatsv2'
 use_hdrhistogram: true


### PR DESCRIPTION
Reporting results to ES caused several issues for performance tests. The email notifications will be sent by Argus soon and do not reflect the actual ES results. Therefore, it was decided to remove reporting to ES.

This commit includes the following changes:
- Stop reporting to ES for performance tests.
- Remove the email recipients for all performance tests and prevent emails from being sent.

This fix was tested while https://github.com/scylladb/scylla-cluster-tests/pull/13057

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
