### PR TITLE
fix(pipeline): pass billing_project parameter to performance tests

### DIFF
--- a/vars/perfRegressionParallelPipelinebyRegion.groovy
+++ b/vars/perfRegressionParallelPipelinebyRegion.groovy
@@ -21,7 +21,7 @@ def call(Map pipelineParams) {
             string(defaultValue: '',
                    description: 'Actual user requesting job start, for automated job builds (e.g. through Argus)',
                    name: 'requested_by_user')
-            string(defaultValue: "${pipelineParams.get('billing_project', '')}",
+            string(defaultValue: "",
                    description: 'Billing project for the test run',
                    name: 'billing_project')
         }
@@ -303,6 +303,7 @@ def call(Map pipelineParams) {
                                             string(name: 'sub_tests', value: groovy.json.JsonOutput.toJson(sub_tests)),
                                             string(name: 'region', value: region),
                                             string(name: 'requested_by_user', value: params.requested_by_user)
+                                            string(name: 'billing_project', value: params.billing_project)
                                         ]
                                     }
                                 }


### PR DESCRIPTION
The recently added  parameter caused the performance test trigger to fail with:
```
java.lang.NullPointerException: Cannot invoke method get() on null object
```

This occurred because  returns null when the parameter is not set.

As a temporary workaround to restore the trigger functionality:
1. Set a default empty value for the  parameter.
2. Pass the  parameter from the trigger to the performance pipeline.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
