### PR TITLE
feature(c-s): c-s v4 on master and correct driver version reporting

### DIFF
--- a/defaults/docker_images/cassandra-stress/values_cassandra-stress.yaml
+++ b/defaults/docker_images/cassandra-stress/values_cassandra-stress.yaml
@@ -1,2 +1,2 @@
 cassandra-stress:
-  image: scylladb/cassandra-stress:3.20.0
+  image: scylladb/cassandra-stress:3.20.1

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -402,7 +402,10 @@ class CassandraStressThread(DockerBasedStressThread):
         try:
             prefix, *_ = stress_cmd.split("cassandra-stress", maxsplit=1)
             reporter = CassandraStressVersionReporter(
-                cmd_runner, prefix, loader.parent_cluster.test_config.argus_client()
+                runner=cmd_runner,
+                command_prefix=prefix,
+                argus_client=loader.parent_cluster.test_config.argus_client(),
+                is_driver_4x=self.is_driver_4x,
             )
             reporter.report()
         except Exception:  # noqa: BLE001

--- a/unit_tests/test_tooling_cassandra_stress_java_driver_reporter.py
+++ b/unit_tests/test_tooling_cassandra_stress_java_driver_reporter.py
@@ -1,0 +1,36 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Pytest tests for CassandraStressJavaDriverVersionReporter."""
+
+from sdcm.reporting.tooling_reporter import CassandraStressJavaDriverVersionReporter
+
+
+def test_driver_version_is_set_in_constructor():
+    reporter = CassandraStressJavaDriverVersionReporter(
+        driver_version="4.19.0.1", runner=None, command_prefix=None, argus_client=None
+    )
+
+    assert reporter.version == "4.19.0.1"
+    assert reporter.TOOL_NAME == "java-driver"
+
+
+def test_collect_version_info_is_noop():
+    reporter = CassandraStressJavaDriverVersionReporter(
+        driver_version="3.11.5.11", runner=None, command_prefix=None, argus_client=None
+    )
+
+    reporter._collect_version_info()
+
+    # Version should remain unchanged
+    assert reporter.version == "3.11.5.11"

--- a/unit_tests/test_tooling_cassandra_stress_reporter_parsing.py
+++ b/unit_tests/test_tooling_cassandra_stress_reporter_parsing.py
@@ -1,0 +1,118 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Pytest tests for CassandraStressVersionReporter parsing and behavior."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdcm.reporting.tooling_reporter import CassandraStressVersionReporter
+
+
+@pytest.fixture
+def make_runner():
+    """Factory fixture to create a mocked runner with provided stdout."""
+
+    def _make(stdout: str) -> MagicMock:
+        mock_runner = MagicMock()
+        mock_output = MagicMock()
+        mock_output.stdout = stdout
+        mock_runner.run.return_value = mock_output
+        return mock_runner
+
+    return _make
+
+
+@pytest.mark.parametrize(
+    "is_driver_4x,expected_additional",
+    [
+        (True, "java-driver-4x: 4.19.0.1"),
+        (False, "java-driver: 3.11.5.11"),
+    ],
+)
+def test_parsing_reports_driver_based_on_flag(make_runner, is_driver_4x, expected_additional):
+    stdout = "Version: 3.20.1\nscylla-java-driver: 3.11.5.11\nscylla-java-driver-4x: 4.19.0.1\n"
+    runner = make_runner(stdout)
+    reporter = CassandraStressVersionReporter(
+        runner=runner, command_prefix="", argus_client=None, is_driver_4x=is_driver_4x
+    )
+
+    reporter._collect_version_info()
+
+    assert reporter.version == "3.20.1"
+    assert reporter.additional_data == expected_additional
+    runner.run.assert_called_once_with(" cassandra-stress version")
+
+
+def test_parsing_no_driver_info(make_runner):
+    runner = make_runner("Version: 3.12.0-SNAPSHOT\n")
+    reporter = CassandraStressVersionReporter(runner=runner, command_prefix="", argus_client=None, is_driver_4x=False)
+
+    reporter._collect_version_info()
+
+    assert reporter.version == "3.12.0-SNAPSHOT"
+    assert reporter.additional_data is None
+
+
+def test_parsing_malformed_output(make_runner):
+    stdout = "Some random text\nNo colon here\nVersion: 3.12.0-SNAPSHOT\nAnother line without proper format\n"
+    runner = make_runner(stdout)
+    reporter = CassandraStressVersionReporter(runner=runner, command_prefix="", argus_client=None, is_driver_4x=False)
+
+    reporter._collect_version_info()
+
+    assert reporter.version == "3.12.0-SNAPSHOT"
+    assert reporter.additional_data is None
+
+
+def test_parsing_missing_version_reports_fallback(make_runner):
+    runner = make_runner("scylla-java-driver: 3.11.5.11\n")
+    reporter = CassandraStressVersionReporter(runner=runner, command_prefix="", argus_client=None, is_driver_4x=False)
+
+    reporter._collect_version_info()
+
+    assert reporter.version == "#FAILED_CHECK_LOGS"
+    assert reporter.additional_data == "java-driver: 3.11.5.11"
+
+
+def test_command_prefix_is_used_in_command(make_runner):
+    stdout = "Version: 3.20.1\nscylla-java-driver: 3.11.5.11\nscylla-java-driver-4x: 4.19.0.1\n"
+    runner = make_runner(stdout)
+    reporter = CassandraStressVersionReporter(
+        runner=runner,
+        command_prefix="docker exec my-container",
+        argus_client=None,
+        is_driver_4x=True,
+    )
+
+    reporter._collect_version_info()
+
+    runner.run.assert_called_once_with("docker exec my-container cassandra-stress version")
+
+
+@patch("sdcm.reporting.tooling_reporter.CassandraStressJavaDriverVersionReporter")
+def test_calls_java_driver_reporter_for_v4(mock_driver_reporter_class, make_runner):
+    stdout = "Version: 3.20.1\nscylla-java-driver: 3.11.5.11\nscylla-java-driver-4x: 4.19.0.1\n"
+    runner = make_runner(stdout)
+    mock_instance = MagicMock()
+    mock_driver_reporter_class.return_value = mock_instance
+
+    reporter = CassandraStressVersionReporter(runner=runner, command_prefix="", argus_client=None, is_driver_4x=True)
+
+    reporter._collect_version_info()
+
+    mock_driver_reporter_class.assert_called_once_with(
+        driver_version="4.19.0.1", command_prefix=None, runner=None, argus_client=None
+    )
+    mock_instance.report.assert_called_once()


### PR DESCRIPTION
This PR upgrades to the latest c-s version with a patch to Java v4 driver (the timeout issue when creating keyspaces). Also supports correctly the Java V4 driver to Argus when the driver is selected.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- 🟢  https://argus.scylladb.com/tests/scylla-cluster-tests/ee3a9339-e8bc-4e67-b35b-8e6dbab19069 (Regular 4 hour run) -> 4x driver
- 🟢 https://argus.scylladb.com/tests/scylla-cluster-tests/89d26d65-8a1d-4559-84b4-c2682a87ac8b (The same run, where the bug for creating Keyspaces was found -> it started, means bug is fixed) -> 4x driver
- 🟢  https://argus.scylladb.com/tests/scylla-cluster-tests/87de76d2-fafe-4c8f-a5a8-788550b58b7f -> 3x driver

[Reporting Driver V3](https://argus.scylladb.com/tests/scylla-cluster-tests/87de76d2-fafe-4c8f-a5a8-788550b58b7f/details)

<img width="1106" height="460" alt="Screenshot 2026-01-22 at 13 00 12" src="https://github.com/user-attachments/assets/50b59a0c-1204-4b45-8461-82d93ad70c9e" />


[Reporting Driver V4](https://argus.scylladb.com/tests/scylla-cluster-tests/89d26d65-8a1d-4559-84b4-c2682a87ac8b)
<img width="1106" height="471" alt="Screenshot 2026-01-22 at 13 00 25" src="https://github.com/user-attachments/assets/44d8f584-625d-4280-b420-b1ffd538b76b" />


Note: Double Cassandra Stress reporting comes from SCT and Argus just propagates it, First one is from Actual SCT Tool running, and the other is from Nemesis that started C-S

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
