### PR TITLE
fix(aws-provision): standardize TestId tag key in capacity reservations

### DIFF
--- a/sdcm/provision/aws/capacity_reservation.py
+++ b/sdcm/provision/aws/capacity_reservation.py
@@ -69,7 +69,7 @@ class SCTCapacityReservation:
         test_id = params.get("test_id")
         ec2 = boto3.client("ec2", region_name=params.region_names[0])
         reservations = ec2.describe_capacity_reservations(
-            Filters=[{"Name": "tag:test_id", "Values": [test_id]}, {"Name": "state", "Values": ["active"]}]
+            Filters=[{"Name": "tag:TestId", "Values": [test_id]}, {"Name": "state", "Values": ["active"]}]
         )
         result = {}
         availability_zone = params.get("availability_zone")
@@ -256,7 +256,7 @@ class SCTCapacityReservation:
             ec2 = boto3.client("ec2", region_name=region)
             try:
                 reservations = ec2.describe_capacity_reservations(
-                    Filters=[{"Name": "tag:test_id", "Values": [test_id]}, {"Name": "state", "Values": ["active"]}]
+                    Filters=[{"Name": "tag:TestId", "Values": [test_id]}, {"Name": "state", "Values": ["active"]}]
                 )
                 if not reservations["CapacityReservations"]:
                     LOGGER.info("There are no CRs to remove in region %s.", region)

--- a/utils/cloud_cleanup/aws/clean_aws.py
+++ b/utils/cloud_cleanup/aws/clean_aws.py
@@ -312,9 +312,9 @@ def clean_capacity_reservations(region_name):
     now = datetime.datetime.now(datetime.timezone.utc)
 
     for cr in response["CapacityReservations"]:
-        test_id = next((tag["Value"] for tag in cr.get("Tags", []) if tag["Key"] == "test_id"), "N/A")
+        test_id = next((tag["Value"] for tag in cr.get("Tags", []) if tag["Key"] == "TestId"), "N/A")
         print(
-            "found capacity reservation %s started at %s. instance type: %s, count: %s, available: %s, test_id: %s"
+            "found capacity reservation %s started at %s. instance type: %s, count: %s, available: %s, TestId: %s"
             % (
                 cr["CapacityReservationId"],
                 cr["StartDate"],


### PR DESCRIPTION
Changed the tag key from "test_id" to "TestId" in capacity reservation lookup functions to match the naming convention used consistently across the codebase for AWS resource tags. This ensures proper tracking and cleanup of capacity reservations associated with test runs.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/13252

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
