### PR TITLE
fix(nemesis): don't use target node as verification node

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2120,7 +2120,8 @@ class Nemesis(NemesisFlags):
         timeout = HOUR_IN_SEC * 3
         if not self.cluster.params.get("use_mgmt") and not self.cluster.params.get("use_cloud_manager"):
             if ignore_down_hosts:
-                nodes = self.cluster.get_nodes_up_and_normal(self.target_node)
+                with self.node_allocator.run_nemesis(nemesis_label="Repair") as verification_node:
+                    nodes = self.cluster.get_nodes_up_and_normal(verification_node)
             else:
                 nodes = self.cluster.data_nodes
 


### PR DESCRIPTION
The target node may be killed by the nemesis prior to using it as a verification node.

refs: https://github.com/scylladb/scylla-cluster-tests/pull/11683

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] before: https://argus.scylladb.com/tests/scylla-cluster-tests/ac08023f-e3cf-48e0-9354-c4d17234a547 ❌ 
- [x] after: https://argus.scylladb.com/tests/scylla-cluster-tests/df94c7aa-e8af-40e8-b34f-5562c264033d ✔️ 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
