### PR TITLE
fix(nemesis): Do not run rebuild nemesis on tablets

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2122,6 +2122,18 @@ class Nemesis(NemesisFlags):
         with adaptive_timeout(Operations.REBUILD, self.target_node, timeout=60):
             self.target_node.run_nodetool("rebuild", long_running=True, retry=0)
 
+    def rebuild_or_repair(self, target_node, reason=""):
+        """
+        Runs rebuild on Vnodes and repair on tablets, as rebuild is not supported for tablets
+        https://github.com/scylladb/scylladb/issues/17575
+        """
+        if is_tablets_feature_enabled(target_node):
+            with self.action_log_scope(f"Run repair (instead of rebuild) on {self.target_node.name}, reason: {reason}"):
+                self.run_repair()
+        else:
+            with self.action_log_scope(f"Run rebuild on {self.target_node.name}, reason: {reason}"):
+                self.repair_nodetool_rebuild()
+
     def nodetool_cleanup_on_all_nodes_parallel(self):
         # Inner disrupt function for ParallelObject
         def _nodetool_cleanup(node):
@@ -4512,14 +4524,9 @@ class Nemesis(NemesisFlags):
                 self.action_log_scope(f"Reboot {self.target_node.name} node during decommission streaming"),
             ):
                 ParallelObject(objects=[trigger, watcher], timeout=full_operations_timeout).call_objects()
-            if new_node := decommission_post_action():
-                new_node.wait_node_fully_start()
-                with self.action_log_scope(f"New node {new_node.name} rebuild"):
-                    new_node.run_nodetool("rebuild", long_running=True, retry=0)
-            else:
-                self.target_node.wait_node_fully_start()
-                with self.action_log_scope(f"Run rebuild on {self.target_node.name}"):
-                    self.target_node.run_nodetool(sub_cmd="rebuild", long_running=True, retry=0)
+            target_node = decommission_post_action() or self.target_node
+            target_node.wait_node_fully_start()
+            self.rebuild_or_repair(target_node, "After decomission streaming")
 
     def start_and_interrupt_repair_streaming(self):
         """
@@ -4553,9 +4560,7 @@ class Nemesis(NemesisFlags):
 
         self.target_node.wait_node_fully_start()
 
-        with adaptive_timeout(Operations.REBUILD, self.target_node, timeout=HOUR_IN_SEC * 48):
-            with self.action_log_scope(f"Rebuild data after destroy on {self.target_node.name} node"):
-                self.target_node.run_nodetool("rebuild", long_running=True, retry=0)
+        self.rebuild_or_repair(self.target_node, reason="After destroy")
 
     def start_and_interrupt_rebuild_streaming(self):
         """


### PR DESCRIPTION
* Skip rebuild nemesis, we have repair alternatives
    * `disrupt_destroy_data_then_rebuild` -> `disrupt_destroy_data_then_repair`
    * `disrupt_rebuild_streaming_err` -> `disrupt_repair_streaming_err`
* Run repair instead of rebuild for nemesis for tablets, where rebuild is done to repair data

Fixes https://github.com/scylladb/scylla-cluster-tests/issues/13269

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] Nemesis changed:
    * [ ] disrupt_decommission_streaming_err
    * [x] [disrupt_repair_streaming_err](https://argus.scylladb.com/tests/scylla-cluster-tests/648a4a59-c9b7-4d4c-a6df-0b4ca438dcea)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code