### PR TITLE
feat(nemesis): Remove unneeded skipping for kubernetes

### DIFF
--- a/data_dir/nemesis.yml
+++ b/data_dir/nemesis.yml
@@ -1061,7 +1061,7 @@ disrupt_restart_with_resharding:
   enospc: false
   free_tier_set: false
   has_steady_run: false
-  kubernetes: true
+  kubernetes: false
   limited: false
   manager_operation: false
   networking: false


### PR DESCRIPTION
Filtering is done in build_disruptions_by_selector and as such should not be needed in individual nemesis.
Mark NodeRestartWithResharding as not supporting kubernetes, since it was being skipped in `disrupt_restart_with_resharding`

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] None

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
