### PR TITLE
fix(nemesis): Fix wrong nemesis usage

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -864,7 +864,6 @@ class NemesisRunner:
         with self.action_log_scope(f"Rolling restart cluster. random order: {random_order}"):
             self.cluster.restart_scylla(random_order=random_order)
 
-    @target_all_nodes
     def disrupt_rolling_restart_cluster_random(self):
         self.disrupt_rolling_restart_cluster(random_order=True)
 
@@ -6944,16 +6943,15 @@ class MgmtRestore(NemesisBaseClass):
 
 @target_data_nodes
 class MgmtRepair(NemesisBaseClass):
+    # For Manager APIs test, use: self.disrupt_mgmt_repair_api()
+
     manager_operation = True
     disruptive = False
     kubernetes = True
     limited = True
 
     def disrupt(self):
-        self.runner.log.info("disrupt_mgmt_repair_cli Nemesis begin")
         self.runner.disrupt_mgmt_repair_cli()
-        self.runner.log.info("disrupt_mgmt_repair_cli Nemesis end")
-        # For Manager APIs test, use: self.runner.disrupt_mgmt_repair_api()
 
 
 @target_data_nodes


### PR DESCRIPTION
Nemesis execution is not intuitive and the actual execution mechanism does not execute code inside `disrupt` method in nemesis classes, it is only used for pattern matching and then the same method is executed with default arguments.
This PR fixes it and as a consequence we will now test more nemesis, so needs to carefully tested.

ManagerBackup nemesis are in COMPLEX_NEMESIS and as such are not executed by Sisyphus, so for them this PR is not critical but it improves them regardless and brings them closer to how nemesis should look like

* Simplifies manager backup nemesis logic
   * Split into two disrupt methods
   * Remove single use methods
* Fix ClusterRollingRestartRandomOrder by adding new disrupt method   

Fixes https://github.com/scylladb/scylla-cluster-tests/issues/13039

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] Nemesis runs
    * [x] [ClusterRollingRestartRandomOrder](https://argus.scylladb.com/tests/scylla-cluster-tests/a277e63e-80d7-4a28-8831-17ebf7b77c29/nemesis)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

