### PR TITLE
fix(nemesis): add support nemesis_interval per nemesis

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1047,7 +1047,7 @@ Nemesis sleep interval to use if None provided specifically in the test
 
 **default:** 5
 
-**type:** int
+**type:** int_or_list
 
 
 ## **nemesis_sequence_sleep_between_ops** / SCT_NEMESIS_SEQUENCE_SLEEP_BETWEEN_OPS

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5330,6 +5330,7 @@ class BaseScyllaCluster:
                 termination_event=self.nemesis_termination_event,
                 nemesis_selector=nem["nemesis_selector"],
                 nemesis_seed=nem["nemesis_seed"],
+                nemesis_interval=nem["nemesis_interval"],
             )
             if hdr_tags:
                 nemesis_obj.hdr_tags = hdr_tags

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -293,7 +293,7 @@ class NemesisRunner:
         self.current_disruption = None
         self.duration_list = []
         self.error_list = []
-        self.interval = 60 * self.tester.params.get("nemesis_interval")  # convert from min to sec
+        self.interval = kwargs.get("nemesis_interval", None) or self.tester.params.get("nemesis_interval")
         self.start_time = time.time()
         self.stats = {}
         self.nemesis_selector = nemesis_selector
@@ -332,6 +332,15 @@ class NemesisRunner:
         self.node_allocator: NemesisNodeAllocator = self.tester.nemesis_allocator
 
         self.log.debug("Instantiated %s nemesis with %d seed", self.__class__.__name__, self.nemesis_seed)
+
+    @property
+    def interval(self):
+        return self._interval
+
+    @interval.setter
+    def interval(self, value):
+        interval = value[0] if isinstance(value, list) else value
+        self._interval = interval * 60  # convert from min to sec
 
     def _init_num_deletions_factor(self):
         # num_deletions_factor is a numeric divisor. It's a factor by which the available-partitions-for-deletion

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -111,6 +111,22 @@ def str_or_list(value: Union[str, List[str], List[List[str]]]) -> List[str]:
     raise ValueError(f"{value} isn't a string or a list of strings.")
 
 
+def int_or_list(value: Union[int, List[int], List[List[int]]]) -> List[int]:
+    try:
+        value = ast.literal_eval(value)
+    except Exception:  # noqa: BLE001
+        pass
+    if isinstance(value, int):
+        return [value]
+    if isinstance(value, list):
+        for element in value:
+            if isinstance(element, int):
+                continue
+            raise ValueError(f"Found non-int ({type(element)}) element in the list: {value}")
+        return value
+    raise ValueError(f"{value} isn't an int or a list of ints.")
+
+
 def str_or_list_or_eval(value: Union[str, List[str]]) -> List[str]:
     """Convert an environment variable into a Python's list."""
 
@@ -1004,9 +1020,10 @@ class SCTConfiguration(dict):
         dict(
             name="nemesis_interval",
             env="SCT_NEMESIS_INTERVAL",
-            type=int,
+            type=int_or_list,
             k8s_multitenancy_supported=True,
             help="""Nemesis sleep interval to use if None provided specifically in the test""",
+            # is_k8s_multitenant_value=True,
         ),
         dict(
             name="nemesis_sequence_sleep_between_ops",
@@ -3011,6 +3028,10 @@ class SCTConfiguration(dict):
         "ca-central-1",
     ]
 
+    multitenant_list_params = [
+        "nemesis_interval",
+    ]
+
     def __init__(self):  # noqa: PLR0912, PLR0914, PLR0915
         super().__init__()
         self.scylla_version = None
@@ -3631,7 +3652,14 @@ class SCTConfiguration(dict):
     def _validate_value(self, opt):
         opt["is_k8s_multitenant_value"] = False
         try:
-            opt["type"](self.get(opt["name"]))
+            value = opt["type"](self.get(opt["name"]))
+            if (
+                isinstance(value, list)
+                and opt.get("k8s_multitenancy_supported")
+                and opt["name"] in self.multitenant_list_params
+            ):
+                opt["is_k8s_multitenant_value"] = True
+
         except Exception as ex:  # noqa: BLE001
             if not (
                 self.get("cluster_backend").startswith("k8s")

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1472,6 +1472,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         list_class_name = self.params.get("nemesis_class_name")
         nemesis_selectors = self.params.get("nemesis_selector")
         nemesis_seeds = self.params.get("nemesis_seed")
+        nemesis_intervals = self.params.get("nemesis_interval")
 
         if nemesis_selectors and isinstance(nemesis_selectors, str):
             nemesis_selectors = [nemesis_selectors]
@@ -1481,6 +1482,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
             nemesis_seeds = [nemesis_seeds]
         if nemesis_seeds and isinstance(nemesis_seeds, str):
             nemesis_seeds = [int(seed) for seed in nemesis_seeds.split()]
+        if nemesis_intervals and isinstance(nemesis_intervals, int):
+            nemesis_intervals = [nemesis_intervals]
 
         nemesis_class_names = []
         for i, klass in enumerate(list_class_name.split(" ")):
@@ -1508,6 +1511,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
                     "nemesis": getattr(nemesis, nemesis_name),
                     "nemesis_selector": nemesis_selector,
                     "nemesis_seed": int(nemesis_seeds[i % len(nemesis_seeds)]) if nemesis_seeds else None,
+                    "nemesis_interval": nemesis_intervals[i % len(nemesis_intervals)] if nemesis_intervals else None,
                 }
             )
 

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -886,6 +886,32 @@ def test_23_2_nemesis_include_selector_list(monkeypatch):
     assert conf["nemesis_selector"] == ["config_changes and topology_changes", "topology_changes", "disruptive"]
 
 
+@pytest.mark.parametrize("nemesis_interval", [5, [5, 10, 15]])
+def test_24_1_nemesis_interval_set_as_env(monkeypatch, nemesis_interval):
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "aws")
+    monkeypatch.setenv("SCT_AMI_ID_DB_SCYLLA", "ami-dummy")
+    monkeypatch.setenv("SCT_NEMESIS_INTERVAL", f"{nemesis_interval}")
+    monkeypatch.setenv(
+        "SCT_CONFIG_FILES",
+        '["unit_tests/test_configs/minimal_test_case.yaml"]',
+    )
+    conf = sct_config.SCTConfiguration()
+    if isinstance(nemesis_interval, int):
+        nemesis_interval = [nemesis_interval]
+    assert conf["nemesis_interval"] == nemesis_interval
+
+
+def test_24_2_nemesis_interval_list_int_yaml(monkeypatch):
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "aws")
+    monkeypatch.setenv("SCT_AMI_ID_DB_SCYLLA", "ami-dummy")
+    monkeypatch.setenv(
+        "SCT_CONFIG_FILES",
+        '["unit_tests/test_configs/minimal_test_case.yaml", "unit_tests/test_configs/nemesis_interval_list_int.yaml"]',
+    )
+    conf = sct_config.SCTConfiguration()
+    assert conf["nemesis_interval"] == [100, 500]
+
+
 def test_26_run_fullscan_params_validtion_positive(monkeypatch):
     monkeypatch.setenv(
         "SCT_CONFIG_FILES",

--- a/unit_tests/test_configs/nemesis_interval_list_int.yaml
+++ b/unit_tests/test_configs/nemesis_interval_list_int.yaml
@@ -1,0 +1,1 @@
+nemesis_interval: [100, 500]


### PR DESCRIPTION
the same nemesis_interval is used for parallel nemesis run. Change type for 'nemesis_interval' config parameter and add support of configuration that  each nemesis
could be configured with its own interval

Configuration could be set as

nemesis_class_name: "nemesis1 nemesis2"
nemesis_interval: 15 60
-or-
nemesis_class_name: "nemesis1"
nemesis_interval: 5

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ Passed single nemesis ](https://argus.scylladb.com/tests/scylla-cluster-tests/93734641-a766-4cca-a4b6-f0d936cf94bd)
- [ passed parallel nemesis](https://argus.scylladb.com/tests/scylla-cluster-tests/938ce064-a7ac-4f29-8905-65e3561b03ae)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
