### PR TITLE
fix(pipeline): switch extra_environment_variables type to text

### DIFF
--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -115,7 +115,7 @@ def call(Map pipelineParams) {
             string(defaultValue: 'next',
                    description: 'Default branch to be used for scylla and other repositories. Default is "next".',
                    name: 'byo_default_branch')
-            string(defaultValue: "${pipelineParams.get('extra_environment_variables', '')}",
+            text(defaultValue: "${pipelineParams.get('extra_environment_variables', '')}",
                    description: 'Extra environment variables to inject (format: KEY1=VAL1\nKEY2=VAL2)',
                    name: 'extra_environment_variables')
         }


### PR DESCRIPTION
Because `extra_environment_variables` is `string` type we can't provide multiple overrides - it requires line break which is not supported by `string`.

Switched to `text` like in other pipelines and to fix this issue.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
