### PR TITLE
fix(remote_base): use full path to rsync availability check

### DIFF
--- a/sdcm/remote/remote_base.py
+++ b/sdcm/remote/remote_base.py
@@ -453,7 +453,7 @@ class RemoteCmdRunnerBase(CommandRunner, RetryMixin):
         """
         Check if rsync is available on the remote host.
         """
-        result = self.run("rsync --version", ignore_status=True)
+        result = self.run("/usr/bin/rsync --version", ignore_status=True)
         return result.ok
 
     def _encode_remote_paths(self, paths: List[str], escape=True) -> str:


### PR DESCRIPTION
Non-interactive SSH shell may have minimal PATH not including /usr/bin, causing rsync detection to fail. Use full path /usr/bin/rsync to ensure proper availability check.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/13035

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] couple runs in a row of the failed scenario: [run1](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-10gb-3h-azure-test/6/) and [run2](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-10gb-3h-azure-test/5/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
