### PR TITLE
improvement(cloud_monitor): enhance get_owner for EC2 instances

### DIFF
--- a/sdcm/utils/cloud_monitor/resources/instances.py
+++ b/sdcm/utils/cloud_monitor/resources/instances.py
@@ -59,7 +59,7 @@ class AWSInstance(CloudInstance):
 
     def get_owner(self):
         # try to get the owner using tags
-        if owner := self._tags.get("RunByUser", self._tags.get("Owner")):
+        if owner := self._tags.get("RunByUser", self._tags.get("Owner", self._tags.get("owner"))):
             return owner
         # get the owner from the Cloud Trail
         if owner := self.get_owner_from_cloud_trail():


### PR DESCRIPTION
Currently, get_owner tries to determine an owner of an EC2 instance by reading "RunByUser" tag, and if that one is missing, "Owner" tag. It turns out that instead of using either of these two, some people also use "owner" tag (all lowercase). This PR adds a fallback for this third option when the other two are not present.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [X] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
