### PR TITLE
improvement(azure-image): pin availability_zone for artifact test

### DIFF
--- a/jenkins-pipelines/oss/artifacts/artifacts-azure-image.jenkinsfile
+++ b/jenkins-pipelines/oss/artifacts/artifacts-azure-image.jenkinsfile
@@ -9,7 +9,7 @@ artifactsPipeline(
     test_config: 'test-cases/artifacts/azure-image.yaml',
     backend: 'azure',
     instance_provision: 'spot',
-    availability_zone: '',
+    availability_zone: 'b', // since on release we have some families which are more available on that zone
 
     timeout: [time: 145, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',


### PR DESCRIPTION
Since we are moving to support more families, those have a bit more availablity on that zone, so we switching this one job to it

Ref: scylladb/scylla-machine-image#871
Ref: scylladb/scylla-pkg#5810

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
