### PR TITLE
fix(nemesis): Remove has_steady_run flag

### DIFF
--- a/data_dir/nemesis.yml
+++ b/data_dir/nemesis.yml
@@ -4,7 +4,6 @@ disrupt_abort_repair:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -21,7 +20,6 @@ disrupt_add_drop_column:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -38,7 +36,6 @@ disrupt_add_remove_dc:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: true
   manager_operation: false
@@ -55,7 +52,6 @@ disrupt_add_remove_mv:
   disruptive: true
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -72,7 +68,6 @@ disrupt_bootstrap_streaming_error:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -89,7 +84,6 @@ disrupt_corrupt_then_scrub:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -106,7 +100,6 @@ disrupt_create_index:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -123,7 +116,6 @@ disrupt_decommission_streaming_err:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -140,7 +132,6 @@ disrupt_delete_10_full_partitions:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -157,7 +148,6 @@ disrupt_delete_by_rows_range:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -174,7 +164,6 @@ disrupt_delete_overlapping_row_ranges:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -191,7 +180,6 @@ disrupt_destroy_data_then_rebuild:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -208,7 +196,6 @@ disrupt_destroy_data_then_repair:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -225,7 +212,6 @@ disrupt_disable_binary_gossip_execute_major_compaction:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -242,7 +228,6 @@ disrupt_disable_enable_ldap_authorization:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: true
   manager_operation: false
@@ -259,7 +244,6 @@ disrupt_drain_kubernetes_node_then_decommission_and_add_scylla_node:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -276,7 +260,6 @@ disrupt_drain_kubernetes_node_then_replace_scylla_node:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -293,7 +276,6 @@ disrupt_enable_disable_table_encryption_aws_kms_provider_with_rotation:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -310,7 +292,6 @@ disrupt_enable_disable_table_encryption_aws_kms_provider_without_rotation:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -327,7 +308,6 @@ disrupt_end_of_quota_nemesis:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -344,7 +324,6 @@ disrupt_grow_shrink_cluster:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -361,7 +340,6 @@ disrupt_grow_shrink_new_rack:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -378,7 +356,6 @@ disrupt_grow_shrink_zero_nodes:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -395,7 +372,6 @@ disrupt_hard_reboot_node:
   disruptive: true
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -412,7 +388,6 @@ disrupt_hot_reloading_internode_certificate:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -429,7 +404,6 @@ disrupt_increase_shares_by_attach_another_sl_during_load:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -446,7 +420,6 @@ disrupt_kill_mv_building_coordinator:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -463,7 +436,6 @@ disrupt_kill_scylla:
   disruptive: true
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -480,7 +452,6 @@ disrupt_ldap_connection_toggle:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: true
   manager_operation: false
@@ -497,7 +468,6 @@ disrupt_load_and_stream:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -514,7 +484,6 @@ disrupt_major_compaction:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -531,7 +500,6 @@ disrupt_manager_backup:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: true
@@ -548,7 +516,6 @@ disrupt_maximum_allowed_sls_with_max_shares_during_load:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -565,7 +532,6 @@ disrupt_memory_stress:
   disruptive: true
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -582,7 +548,6 @@ disrupt_mgmt_backup:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: true
   manager_operation: true
@@ -599,7 +564,6 @@ disrupt_mgmt_backup_specific_keyspaces:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: true
   manager_operation: true
@@ -616,7 +580,6 @@ disrupt_mgmt_corrupt_then_repair:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: true
@@ -633,7 +596,6 @@ disrupt_mgmt_repair_cli:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: true
@@ -650,7 +612,6 @@ disrupt_mgmt_restore:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: true
@@ -667,7 +628,6 @@ disrupt_modify_table_bloom_filter_fp_chance:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -684,7 +644,6 @@ disrupt_modify_table_caching:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -701,7 +660,6 @@ disrupt_modify_table_comment:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -718,7 +676,6 @@ disrupt_modify_table_compaction:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -735,7 +692,6 @@ disrupt_modify_table_compression:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -752,7 +708,6 @@ disrupt_modify_table_crc_check_chance:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -769,7 +724,6 @@ disrupt_modify_table_dclocal_read_repair_chance:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -786,7 +740,6 @@ disrupt_modify_table_default_time_to_live:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -803,7 +756,6 @@ disrupt_modify_table_gc_grace_time:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -820,7 +772,6 @@ disrupt_modify_table_max_index_interval:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -837,7 +788,6 @@ disrupt_modify_table_memtable_flush_period_in_ms:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -854,7 +804,6 @@ disrupt_modify_table_min_index_interval:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -871,7 +820,6 @@ disrupt_modify_table_read_repair_chance:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -888,7 +836,6 @@ disrupt_modify_table_speculative_retry:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -905,7 +852,6 @@ disrupt_modify_table_twcs_window_size:
   disruptive: true
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -922,7 +868,6 @@ disrupt_multiple_hard_reboot_node:
   disruptive: true
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -939,7 +884,6 @@ disrupt_network_block:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -956,7 +900,6 @@ disrupt_network_random_interruptions:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -973,7 +916,6 @@ disrupt_network_reject_inter_node_communication:
   disruptive: true
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -990,7 +932,6 @@ disrupt_network_reject_node_exporter:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1007,7 +948,6 @@ disrupt_network_reject_thrift:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1024,7 +964,6 @@ disrupt_network_start_stop_interface:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1041,7 +980,6 @@ disrupt_no_corrupt_repair:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -1058,7 +996,6 @@ disrupt_nodetool_cleanup:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -1075,7 +1012,6 @@ disrupt_nodetool_decommission:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: true
   manager_operation: false
@@ -1092,7 +1028,6 @@ disrupt_nodetool_drain:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -1109,7 +1044,6 @@ disrupt_nodetool_enospc:
   disruptive: true
   enospc: true
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -1126,7 +1060,6 @@ disrupt_nodetool_flush_and_reshard_on_kubernetes:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -1143,7 +1076,6 @@ disrupt_nodetool_refresh:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -1160,7 +1092,6 @@ disrupt_nodetool_seed_decommission:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1177,7 +1108,6 @@ disrupt_rebuild_streaming_err:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1194,7 +1124,6 @@ disrupt_refuse_connection_with_block_scylla_ports_on_banned_node:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1211,7 +1140,6 @@ disrupt_refuse_connection_with_send_sigstop_signal_to_scylla_on_banned_node:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1228,7 +1156,6 @@ disrupt_remove_node_then_add_node:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1245,7 +1172,6 @@ disrupt_remove_service_level_while_load:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1262,7 +1188,6 @@ disrupt_repair_streaming_err:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1279,7 +1204,6 @@ disrupt_replace_scylla_node_on_kubernetes:
   disruptive: true
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -1296,7 +1220,6 @@ disrupt_replace_service_level_using_detach_during_load:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1313,7 +1236,6 @@ disrupt_replace_service_level_using_drop_during_load:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1330,7 +1252,6 @@ disrupt_resetlocalschema:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1347,7 +1268,6 @@ disrupt_restart_then_repair_node:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -1364,7 +1284,6 @@ disrupt_restart_with_resharding:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1382,7 +1301,6 @@ disrupt_rolling_config_change_internode_compression:
   enospc: false
   free_tier_set: false
   full_cluster_restart: true
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1399,7 +1317,6 @@ disrupt_rolling_restart_cluster:
   disruptive: true
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -1416,7 +1333,6 @@ disrupt_run_cdcstressor_tool:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1433,7 +1349,6 @@ disrupt_run_unique_sequence:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1450,7 +1365,6 @@ disrupt_serial_restart_elected_topology_coordinator:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1467,7 +1381,6 @@ disrupt_show_toppartitions:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -1484,7 +1397,6 @@ disrupt_sla_decrease_shares_during_load:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1501,7 +1413,6 @@ disrupt_sla_increase_shares_during_load:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1518,7 +1429,6 @@ disrupt_snapshot_operations:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -1535,7 +1445,6 @@ disrupt_soft_reboot_node:
   disruptive: true
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -1552,7 +1461,6 @@ disrupt_start_stop_cleanup_compaction:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1569,7 +1477,6 @@ disrupt_start_stop_major_compaction:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1586,7 +1493,6 @@ disrupt_start_stop_scrub_compaction:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1603,7 +1509,6 @@ disrupt_start_stop_validation_compaction:
   disruptive: false
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1620,7 +1525,6 @@ disrupt_stop_start_scylla_server:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -1637,7 +1541,6 @@ disrupt_stop_wait_start_scylla_server:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -1654,7 +1557,6 @@ disrupt_switch_between_password_authenticator_and_saslauthd_authenticator_and_ba
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1671,7 +1573,6 @@ disrupt_terminate_and_replace_node:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1688,7 +1589,6 @@ disrupt_terminate_kubernetes_host_then_decommission_and_add_scylla_node:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -1705,7 +1605,6 @@ disrupt_terminate_kubernetes_host_then_replace_scylla_node:
   disruptive: true
   enospc: false
   free_tier_set: false
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -1722,7 +1621,6 @@ disrupt_toggle_audit_syslog:
   disruptive: true
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1739,7 +1637,6 @@ disrupt_toggle_cdc_feature_properties_on_table:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: false
   limited: false
   manager_operation: false
@@ -1756,7 +1653,6 @@ disrupt_toggle_table_gc_mode:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -1773,7 +1669,6 @@ disrupt_toggle_table_ics:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -1790,7 +1685,6 @@ disrupt_truncate:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: true
   manager_operation: false
@@ -1807,7 +1701,6 @@ disrupt_truncate_large_partition:
   disruptive: false
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false
@@ -1824,7 +1717,6 @@ disrupt_validate_hh_short_downtime:
   disruptive: true
   enospc: false
   free_tier_set: true
-  has_steady_run: false
   kubernetes: true
   limited: false
   manager_operation: false

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -255,7 +255,6 @@ class NemesisFlags:
     # i.e switch off/on network interface, network issues
     kubernetes: bool = False  # flag that signal that nemesis run with k8s cluster
     limited: bool = False  # flag that signal that nemesis are belong to limited set of nemesises
-    has_steady_run: bool = False  # flag that signal that nemesis should be run with perf tests with steady run
     schema_changes: bool = False
     config_changes: bool = False
     free_tier_set: bool = False  # nemesis should be run in FreeTierNemesisSet
@@ -284,6 +283,7 @@ class Nemesis(NemesisFlags):
         self.actions_log = get_action_logger(source=nemesis_thread_name)
         self.action_log_scope = self.actions_log.action_scope
         self.target_node: BaseNode = None
+        self.has_steady_run = False
         self.disruptions_list = []
         self.termination_event = termination_event
         self.operation_log = []


### PR DESCRIPTION
It is not used as a flag, instead it is a variable
We do not use it in any filter, it is used as a sign that some other nemesis already run a stress.
IMO this is a wrong pattern in general, but this PR does not aim to refactor it, just fix the mismatch.
Found by testing #10935, where it is causing failure as NemesisBase class does not have flags anymore. Extracted into separate PR to not keep adding changes there.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] None, only variable is moved

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
   - Backporting to only recent branches 
- [x] I didn't leave commented-out/debugging code
