### PR TITLE
feature(baremetal): enhance cluster management and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ SCT_CLUSTER_BACKEND= hydra clean-resources --test-id `cat ~/sct-results/latest/t
 * `gce` - most of the artifacts and rolling upgrades run on top of this backend
 * `azure` -
 * `docker` - should be used for local development
-* `baremetal` - can be used to run with already setup cluster
+* `baremetal` - **experimental** — can be used to run with an already-provisioned cluster
 * `xcloud` - ScyllaDB Cloud managed clusters
 
 * `k8s-eks` -

--- a/defaults/baremetal_config.yaml
+++ b/defaults/baremetal_config.yaml
@@ -1,1 +1,1 @@
-user_credentials_path: '~/.ssh/scylla-test'
+user_credentials_path: '~/.ssh/scylla_test_id_ed25519'

--- a/sdcm/cluster_baremetal.py
+++ b/sdcm/cluster_baremetal.py
@@ -1,3 +1,9 @@
+"""Baremetal backend for SCT (experimental).
+
+Provides cluster management for pre-provisioned physical machines.
+This backend is experimental and not regularly tested in CI.
+"""
+
 import logging
 from typing import Optional, TypedDict
 

--- a/sdcm/cluster_baremetal.py
+++ b/sdcm/cluster_baremetal.py
@@ -45,7 +45,10 @@ class PhysicalMachineNode(cluster.BaseNode):
         base_logdir=None,
         node_prefix=None,
         after_config=None,
+        dc_idx=0,
+        node_index=0,
     ):
+        self.node_index = node_index
         ssh_login_info = {
             "hostname": None,
             "user": getattr(parent_cluster, "ssh_username", credentials.name),
@@ -60,12 +63,12 @@ class PhysicalMachineNode(cluster.BaseNode):
             ssh_login_info=ssh_login_info,
             node_prefix=node_prefix,
             after_config=after_config,
+            dc_idx=dc_idx,
         )
 
     def init(self):
         super().init()
         self.set_hostname()
-        self.run_startup_script()
 
     def wait_for_cloud_init(self):
         pass
@@ -95,10 +98,13 @@ class PhysicalMachineNode(cluster.BaseNode):
     def _get_private_ip_address(self) -> Optional[str]:
         return self._private_ip
 
+    def _set_keep_duration(self, duration_in_hours: int) -> None:
+        self.log.warning(
+            "_set_keep_duration is not implemented for PhysicalMachineNode, since there's no tagging for baremetal nodes."
+        )
+
     def set_hostname(self):
-        # disabling for now, since doesn't working with Fabric from within docker, and not needed for scylla-cloud,
-        # since not using hostname anywhere
-        # self.remoter.run('sudo hostnamectl set-hostname {}'.format(self.name))
+        # disabling since for baremetal we aren't going to fuss with their names, they are preconfigured
         pass
 
     def reboot(self, hard=True, verify_ssh=True):
@@ -129,7 +135,7 @@ class PhysicalMachineCluster(cluster.BaseCluster):
     def ssh_username(self) -> str:
         return self._ssh_username
 
-    def _create_node(self, name, public_ip, private_ip, after_config=None):
+    def _create_node(self, name, public_ip, private_ip, dc_idx, node_index=0, after_config=None):
         node = PhysicalMachineNode(
             name,
             parent_cluster=self,
@@ -138,9 +144,14 @@ class PhysicalMachineCluster(cluster.BaseCluster):
             credentials=self.credentials[0],
             base_logdir=self.logdir,
             node_prefix=self.node_prefix,
+            dc_idx=dc_idx,
+            node_index=node_index,
         )
         node.init()
         return node
+
+    def _reuse_cluster_setup(self, node):
+        node.run_startup_script()  # Reconfigure syslog-ng.
 
     def add_nodes(
         self,
@@ -152,15 +163,24 @@ class PhysicalMachineCluster(cluster.BaseCluster):
         instance_type=None,
         after_config=None,
     ):
-        assert instance_type is None, "baremetal can provision diffrent types"
+        assert instance_type is None, "baremetal can't provision different types"
         for node_index in range(count):
             node_name = "%s-%s" % (self.node_prefix, node_index)
             self.nodes.append(
-                self._create_node(node_name, self._node_public_ips[node_index], self._node_private_ips[node_index])
+                self._create_node(
+                    node_name,
+                    self._node_public_ips[node_index],
+                    self._node_private_ips[node_index],
+                    dc_idx=dc_idx,
+                    node_index=node_index,
+                )
             )
 
 
 class ScyllaPhysicalCluster(cluster.BaseScyllaCluster, PhysicalMachineCluster):
+    def _reuse_cluster_setup(self, node):
+        PhysicalMachineCluster._reuse_cluster_setup(self, node)
+
     def __init__(self, **kwargs):
         user_prefix = kwargs.pop("user_prefix")
         if username := kwargs.pop("ssh_username", None):

--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -19,6 +19,7 @@ import configparser
 from typing import BinaryIO
 from concurrent.futures.thread import ThreadPoolExecutor
 from collections import namedtuple
+from pathlib import Path
 
 import boto3
 import paramiko
@@ -198,6 +199,9 @@ class KeyStore:
         return self.get_json("argus_rest_credentials.json")
 
     def get_baremetal_config(self, config_name: str):
+        local_config_path = Path(f"{config_name}.json")
+        if local_config_path.exists():
+            return json.load(local_config_path.open("r", encoding="utf-8"))
         return self.get_json(f"{config_name}.json")
 
     def get_cloud_rest_credentials(self, environment: str = "lab"):

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -72,6 +72,7 @@ from sdcm.utils.gce_utils import gce_public_addresses, gce_private_addresses
 from sdcm.localhost import LocalHost
 from sdcm.cloud_api_client import ScyllaCloudAPIClient
 from sdcm.utils.aws_ssm_runner import SSMCommandRunner
+from sdcm.keystore import KeyStore
 from sdcm.remote.libssh2_client.exceptions import Failure as Libssh2_Failure
 
 LOGGER = logging.getLogger(__name__)
@@ -1971,6 +1972,73 @@ class Collector:
         except Exception as exc:  # noqa: BLE001
             LOGGER.warning("Failed to add Manager node for log collection: %s", exc)
 
+    def get_baremetal_instances_by_testid(self):
+        """Get baremetal instances from the baremetal config file.
+
+        Baremetal nodes are statically configured via a JSON config file
+        retrieved from S3 via KeyStore. This method reads the config and
+        creates CollectingNode instances for db_nodes, loader_nodes, and monitor_nodes.
+        """
+        s3_baremetal_config = self.params.get("s3_baremetal_config")
+        if not s3_baremetal_config:
+            LOGGER.warning("No s3_baremetal_config parameter found, cannot collect baremetal logs")
+            return
+
+        try:
+            baremetal_info = KeyStore().get_baremetal_config(s3_baremetal_config)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error("Failed to get baremetal config from KeyStore: %s", exc)
+            return
+
+        user_credentials_path = self.params.get("user_credentials_path")
+        ip_type = ssh_connection_ip_type(self.params)
+
+        node_types = {
+            "db_nodes": ("db_cluster", "scylla-db"),
+            "loader_nodes": ("loader_set", "loader"),
+            "monitor_nodes": ("monitor_set", "monitor"),
+        }
+
+        for config_key, (attr, node_tag) in node_types.items():
+            node_config = baremetal_info.get(config_key, {})
+            ssh_username = node_config.get("username", "root")
+            node_list = node_config.get("node_list", [])
+
+            for idx, node_info in enumerate(node_list):
+                public_ip = node_info.get("public_ip")
+                private_ip = node_info.get("private_ip")
+                hostname = public_ip if ip_type == "public" else private_ip
+
+                if not hostname:
+                    LOGGER.warning("No %s IP found for baremetal node %s-%d, skipping", ip_type, config_key, idx)
+                    continue
+
+                node_name = f"{node_tag}-node-{self.test_id[:8]}-{idx}"
+                ssh_login_info = {
+                    "hostname": hostname,
+                    "user": ssh_username,
+                    "key_file": user_credentials_path,
+                }
+
+                collecting_node = CollectingNode(
+                    name=node_name,
+                    ssh_login_info=ssh_login_info,
+                    instance=None,
+                    global_ip=public_ip or private_ip,
+                    tags={
+                        **self.tags,
+                        "NodeType": node_tag,
+                    },
+                )
+                getattr(self, attr).append(collecting_node)
+
+        LOGGER.info(
+            "Baremetal log collection: found %d db nodes, %d loader nodes, %d monitor nodes",
+            len(self.db_cluster),
+            len(self.loader_set),
+            len(self.monitor_set),
+        )
+
     def get_running_cluster_sets(self, backend):
         if backend in ("aws", "aws-siren", "k8s-eks"):
             self.get_aws_instances_by_testid()
@@ -1980,6 +2048,8 @@ class Collector:
             self.get_docker_instances_by_testid()
         elif backend == "xcloud":
             self.get_xcloud_instances_by_testid()
+        elif backend == "baremetal":
+            self.get_baremetal_instances_by_testid()
         else:
             self.create_collecting_nodes()
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2366,7 +2366,7 @@ class SCTConfiguration(BaseModel):
             "oci_region_name",
         ],
         "docker": ["user_credentials_path", "scylla_version"],
-        "baremetal": ["s3_baremetal_config", "db_nodes_private_ip", "db_nodes_public_ip", "user_credentials_path"],
+        "baremetal": ["s3_baremetal_config", "user_credentials_path"],
         "aws-siren": [
             "user_prefix",
             "instance_type_loader",
@@ -3871,8 +3871,6 @@ class SCTConfiguration(BaseModel):
                 options_must_exist += ["docker_image_cassandra"]
             else:
                 options_must_exist += ["docker_image"]
-        elif backend == "baremetal":
-            options_must_exist += ["db_nodes_public_ip"]
         elif "k8s" in backend or backend == "xcloud":
             options_must_exist += ["scylla_version"]
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2174,6 +2174,7 @@ class ClusterTester(unittest.TestCase):
             credentials=self.credentials,
             ssh_username=baremetal_info["db_nodes"]["username"],
             params=self.params,
+            region_names=["dummy_region"],
         )
         self.db_cluster = cluster_baremetal.ScyllaPhysicalCluster(**params)
 


### PR DESCRIPTION
Revive the baremetal backend after years of disuse. Fixes cluster management,
configuration, and adds log collection support.

### Changes

- Add `dc_idx`/`node_index` to `PhysicalMachineNode` init; explicit MRO override for `_reuse_cluster_setup`
- Call `run_startup_script` only during cluster reuse (syslog-ng/vector reconfiguration)
- Warn on unsupported `_set_keep_duration` for baremetal nodes
- Support local baremetal config file overrides in `keystore.py`
- Drop `db_nodes_private_ip`/`db_nodes_public_ip` from mandatory options
- Add `get_baremetal_instances_by_testid` for log collection with unit tests

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] since we don't have quick way to test bare metal (no CI / nor jenkins jobs), test those changes few months back with OCI pref tests

### PR pre-checks (self review)
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
