### PR TITLE
fix(monitoring): consolidate prerequisite installation

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -6869,7 +6869,7 @@ class BaseMonitorSet:
         self.configure_overview_template(node)
         try:
             self.start_scylla_monitoring(node)
-        except (Failure, UnexpectedExit):
+        except (Failure, UnexpectedExit, Libssh2_UnexpectedExit):
             self.restart_scylla_monitoring()
         # The time will be used in url of Grafana monitor,
         # the data from this point to the end of test will
@@ -6964,66 +6964,108 @@ class BaseMonitorSet:
 
         node.update_repo_cache()
 
-        if node.distro.is_rhel_like:
-            node.install_epel()
-            node.install_package(package_name="unzip wget python3 python3-pip")
-            # get-docker.sh doesn't support Rocky, thus docker should be installed from repo via dnf install
-            if node.distro.is_rocky:
-                install_docker_cmd = dedent("""
-                    dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-                    dnf install -y docker-ce docker-ce-cli containerd.io
-                """)
-            elif node.distro.is_rhel9:
-                # TODO: Temporary workaround for RHEL9 installation issue https://github.com/moby/moby/issues/49169
-                # Install packages manually hardcoding the OS version ($releasever) in /etc/yum.repos.d/docker-ce.repo
-                # After issue resolution, we can return the previous approach with installation script
-                install_docker_cmd = dedent("""
-                    dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
-                    sed -i \"s/\\$releasever/9/g\" /etc/yum.repos.d/docker-ce.repo
-                    dnf install -y docker-ce docker-ce-cli containerd.io
-                """)
-            else:
-                install_docker_cmd = dedent("""
-                    curl -fsSL get.docker.com --retry 5 --retry-max-time 300 -o get-docker.sh
-                    sh get-docker.sh
-                """)
-            prereqs_script = dedent(f"""
-                python3 -m pip install --upgrade pip
-                python3 -m pip install pyyaml
-                {install_docker_cmd}
+        prereqs_script = dedent("""
+            # Function to wait for apt locks to be released
+            wait_for_apt_lock() {
+                echo "Waiting for apt locks to be released..."
+                local max_attempts=60
+                local attempt=0
+                while fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend /var/cache/apt/archives/lock >/dev/null 2>&1; do
+                    if [ $attempt -ge $max_attempts ]; then
+                        echo "Timeout waiting for apt lock after $max_attempts attempts"
+                        exit 1
+                    fi
+                    echo "Apt is locked by another process, waiting... (attempt $((attempt+1))/$max_attempts)"
+                    sleep 10
+                    attempt=$((attempt+1))
+                done
+                echo "Apt locks are free, proceeding..."
+            }
+
+            # Function to install Docker and Python basics on Debian/Ubuntu
+            install_debian_pkgs() {
+                echo "Detected Debian/Ubuntu system..."
+
+                # 1. Wait for apt lock and update existing list of packages
+                wait_for_apt_lock
+                apt-get update
+
+                # 2. Install Docker prerequisites and basic Python
+                apt-get install -y \\
+                    curl \\
+                    unzip \\
+                    python3 \\
+                    python3-pip
+            }
+
+            # Function to install Docker and Python basics on CentOS/RHEL/Fedora
+            install_centos_pkgs() {
+                echo "Detected CentOS/RHEL system..."
+
+                # 1. Install basic python
+                yum install -y python3 python3-pip curl unzip
+            }
+
+            # Function to manage Pip and install libraries
+            install_python_libs() {
+                echo "Configuring Python environment..."
+
+                # Base pip command
+                PIP_CMD="pip3 install"
+                PIP_ARGS=""
+
+                # Check if current pip supports/requires --break-system-packages
+                if pip3 install --help | grep -q "break-system-packages"; then
+                    echo "PEP 668 detected: Enabling --break-system-packages flag."
+                    PIP_ARGS="--break-system-packages"
+                fi
+
+                # Install libraries (skip pip upgrade to avoid conflicts with system pip)
+                echo "Installing pyyaml and psutil..."
+                $PIP_CMD $PIP_ARGS pyyaml psutil
+
+                if [ $? -eq 0 ]; then
+                    echo "Python libraries installed successfully."
+                else
+                    echo "Failed to install Python libraries."
+                    exit 1
+                fi
+            }
+            install_docker() {
+                local max_retries=3
+                local attempt=0
+                while [ $attempt -lt $max_retries ]; do
+                    echo "Installing Docker (attempt $((attempt+1))/$max_retries)..."
+                    curl -fsSL https://get.docker.com --retry 5 --retry-max-time 300 -o get-docker.sh && \
+                        bash get-docker.sh && return 0
+                    attempt=$((attempt+1))
+                    echo "Docker installation failed, retrying in 10 seconds..."
+                    sleep 10
+                done
+                echo "Docker installation failed after $max_retries attempts."
+                exit 1
+            }
+
+            start_docker() {
                 systemctl start docker
-            """)
-        elif node.distro.is_ubuntu:
-            node.install_package(
-                package_name="software-properties-common python3 python3-dev python3-setuptools unzip wget python3-pip"
-            )
-            pip_break_system_packages = "--break-system-packages" if node.distro.is_ubuntu24 else ""
-            prereqs_script = dedent(f"""
-                curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-                sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-                sudo {apt_cmd("update")}
-                sudo {apt_cmd("install -y docker.io")}
-                python3 -m pip install pyyaml {pip_break_system_packages}
-                python3 -m pip install -I -U psutil {pip_break_system_packages}
-                systemctl start docker
-            """)
-        elif node.distro.is_debian:
-            node.install_package(
-                package_name="apt-transport-https ca-certificates curl software-properties-common gnupg2"
-            )
-            node.remoter.sudo(
-                'bash -ce "curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -"', retry=3
-            )
-            node.remoter.sudo(
-                cmd='add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"'
-            )
-            node.remoter.sudo(cmd="apt update")
-            node.install_package("docker-ce python3 python3-setuptools wget unzip python3-pip")
-            prereqs_script = dedent("""
-                cat /etc/debian_version
-            """)
-        else:
-            raise ValueError("Unsupported Distribution type: {}".format(str(node.distro)))
+            }
+
+            # Main execution logic
+            if [ -f /etc/debian_version ]; then
+                install_debian_pkgs
+                install_docker
+                install_python_libs
+                start_docker
+            elif [ -f /etc/redhat-release ]; then
+                install_centos_pkgs
+                install_docker
+                install_python_libs
+                start_docker
+            else
+                echo "Unsupported Operating System. This script supports Debian/Ubuntu or CentOS/RHEL."
+                exit 1
+            fi
+        """)
 
         node_exporter_setup = NodeExporterSetup()
         node_exporter_setup.install(node)


### PR DESCRIPTION
Replaced distro-specific Docker installation code with a unified bash script that properly installs docker-ce, docker-ce-cli, and containerd.io from Docker's official repository.

The new script:
- Uses Docker's official GPG key with modern keyring management
- Properly detects Debian/Ubuntu vs CentOS/RHEL systems
- Dynamically handles PEP 668 --break-system-packages for pip
- Installs docker-compose-plugin as part of the installation
- Removes deprecated apt-key usage in favor of /etc/apt/keyrings

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] 🟢 provision test (failing on other issue during the test, monitoring setup works as expected)
- [x] 🟢 baremetal (test before this PR created, and proven to work on OCI setups)
- [x] 🟢 monitor with centos based install - manager test - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/manager-rocky9-installation-test/1

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
