### PR TITLE
(improvement)reduce default monitor duration time to 12h.

### DIFF
--- a/jenkins-pipelines/qa/hydra-show-monitor.jenkinsfile
+++ b/jenkins-pipelines/qa/hydra-show-monitor.jenkinsfile
@@ -21,8 +21,8 @@ pipeline {
         string(defaultValue: '',
                description: 'ID of a SCT test to restore the monitoring stack',
                name: 'test_id')
-        string(defaultValue: '1440',
-               description: 'how long to keep an AWS instance with the restored monitoring stack (in minutes)',
+        string(defaultValue: '720',
+               description: 'how long to keep an AWS instance with the restored monitoring stack (in minutes, default is 720 minutes, which is 12 hours!)',
                name: 'duration')
         string(defaultValue: 'us-east-1',
                description: 'a region where to deploy an AWS instance',


### PR DESCRIPTION
People use it and done with it, cut the default by half to 12h. 'Use it or lose it'.

(Note: I still believe it'll be faster to create a container with the data and to give it to the user to run locally)

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
NOT TESTED.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
