### PR TITLE
[2024.1] fix(cluster.py): upgrade openssl and openssh together to prevent sshd crash

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4558,6 +4558,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             node.remoter.sudo('systemctl disable iptables', ignore_status=True)
             node.remoter.sudo('systemctl stop firewalld', ignore_status=True)
             node.remoter.sudo('systemctl disable firewalld', ignore_status=True)
+            # upgrade openssl and openssh together to avoid sshd crash due to version mismatch
+            node.remoter.sudo('yum update -y openssl openssh-server openssh-clients', ignore_status=True)
 
         if self.params.get('logs_transport') == 'ssh':
             node.install_package('python3')


### PR DESCRIPTION
On RHEL-like distros yum install can upgrade openssl-libs as a dependency without upgrading openssh. This causes sshd to crash with "OpenSSL version mismatch" error because sshd was compiled against the old openssl version.

Explicitly upgrading openssl and openssh together early in node_setup (before any other package installations that could trigger a partial openssl-only upgrade) allows to work around the problem.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [artifacts-oel9-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-oel9-test-20241/4/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
