### PR TITLE
fix(nemesis): increase timeout for altering RF during decommission

### DIFF
--- a/sdcm/utils/replication_strategy_utils.py
+++ b/sdcm/utils/replication_strategy_utils.py
@@ -43,7 +43,7 @@ class ReplicationStrategy:
     def apply(self, node: "BaseNode", keyspace: str):
         cql = f"ALTER KEYSPACE {cql_quote_if_needed(keyspace)} WITH replication = {self}"
         with node.parent_cluster.cql_connection_patient(node, connect_timeout=300) as session:
-            session.execute(cql, timeout=300)
+            session.execute(cql, timeout=600)
 
         node.parent_cluster.wait_for_schema_agreement()
 


### PR DESCRIPTION
timeout increased to avoid "'Client request timeout. See Session.execute[_async](timeout)'}" errors for altering RF
request during decommission

related: https://github.com/scylladb/scylladb/issues/23946

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
