### PR TITLE
fix(nemesis): Fix ModifyTable nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -263,9 +263,9 @@ class NemesisBaseClass(NemesisFlags, ABC):
 
     exclusive: bool = False  # True, if the nemesis is exclusive, i.e. it should not run in parallel with other nemeses
 
-    def __init__(self, runner):
+    def __init__(self, runner: "NemesisRunner"):
         super().__init__()
-        self.runner = runner
+        self.runner: "NemesisRunner" = runner
 
     @abstractmethod
     def disrupt(self):


### PR DESCRIPTION
* They were only half updated in rebase of #10935 :/
   * Thanks to @cezarmoise for noticing 
* Add runner to all disrupt calls
* Add typing to runner variable
   * Helps with IDE hints
 

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [longevity with modify_table selector](https://argus.scylladb.com/tests/scylla-cluster-tests/8ec83188-3885-4229-945d-feba3be1f376/nemesis)
    - Spot terminated but ran most of the nemesis

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code