### PR TITLE
fix(hdr): fix s-b missing support for counter mode

### DIFF
--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -172,11 +172,11 @@ class ScyllaBenchThread(DockerBasedStressThread):
         self.stop_test_on_failure = stop_test_on_failure
 
     def set_hdr_tags(self) -> list:
-        if self.sb_mode.lower() == "write":
+        if self.sb_mode.lower() in ("write", "counter_update"):
             return ["co-fixed"]
         elif self.sb_mode.lower() == "mixed":
             return ["co-fixed-write", "co-fixed-read"]
-        elif self.sb_mode.lower() == "read":
+        elif self.sb_mode.lower() in ("read", "counter_read", "scan"):
             return ["co-fixed"]
         else:
             raise ValueError(f"Unknown scylla-bench mode: {self.sb_mode}")

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -3000,11 +3000,11 @@ def get_hdr_tags(stress_tool: str, stress_operation: str, throttled_load: bool) 
             else:
                 raise ValueError(f"Unsupported stress_operation: {stress_operation}")
         case "scylla-bench":
-            if stress_operation.lower() == "write":
+            if stress_operation.lower() in ("write", "counter_update"):
                 return ["co-fixed"]
             elif stress_operation.lower() == "mixed":
                 return ["co-fixed-write", "co-fixed-read"]
-            elif stress_operation.lower() == "read":
+            elif stress_operation.lower() in ("read", "counter_read", "scan"):
                 return ["co-fixed"]
             else:
                 raise ValueError(f"Unknown scylla-bench mode: {stress_operation}")


### PR DESCRIPTION
Not all s-b modes are supported by hdr tags.

Added proper cases for all.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/13396

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
