### PR TITLE
fix(nemesis): add raft topology errors filter during node replacement

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1632,13 +1632,14 @@ class NemesisRunner:
         host_id = self.target_node.host_id
         is_old_node_seed = self.target_node.is_seed
         InfoEvent(message="StartEvent - Terminate node and wait 5 minutes").publish()
-        self.terminate_node(target_node=self.target_node)
-        time.sleep(300)  # Sleeping for 5 mins to let the cluster live with a missing node for a while
-        assert get_node_state(old_node_ip) == "DN", "Removed node state should be DN"
-        InfoEvent(message="FinishEvent - target_node was terminated").publish()
-        new_node = self.replace_node(
-            old_node_ip, host_id, rack=self.target_node.rack, is_zero_node=self.target_node._is_zero_token_node
-        )
+        with ignore_raft_topology_cmd_failing():
+            self.terminate_node(target_node=self.target_node)
+            time.sleep(300)  # Sleeping for 5 mins to let the cluster live with a missing node for a while
+            assert get_node_state(old_node_ip) == "DN", "Removed node state should be DN"
+            InfoEvent(message="FinishEvent - target_node was terminated").publish()
+            new_node = self.replace_node(
+                old_node_ip, host_id, rack=self.target_node.rack, is_zero_node=self.target_node._is_zero_token_node
+            )
         try:
             if new_node.get_scylla_config_param("enable_repair_based_node_ops") == "false":
                 InfoEvent(message="StartEvent - Run repair on new node").publish()


### PR DESCRIPTION
keep raft_topology log filter active for full terminate+replace workflow
 to avoid raft topology errors noise

Fixes: SCT-46

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)


[SCT-46]: https://scylladb.atlassian.net/browse/SCT-46?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ