### PR TITLE
feature(platform-migration): add test for x86 to ARM cluster migration

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1234,6 +1234,16 @@ AWS image type of the oracle node
 * appendable
 
 
+## **instance_type_db_target** / SCT_INSTANCE_TYPE_DB_TARGET
+
+Target AWS instance type for platform migration (e.g., i8g.2xlarge for ARM)
+
+**default:** N/A
+
+**type:** str
+* appendable
+
+
 ## **instance_type_runner** / SCT_INSTANCE_TYPE_RUNNER
 
 instance type of the sct-runner node
@@ -3014,6 +3024,26 @@ cassandra-stress commands. You can specify everything but the -node parameter, w
 
 **type:** str | list[str]
 * supports k8s multitenancy - see [multitenancy docs](k8s-multitenancy.md)
+
+
+## **stress_before_migration** / SCT_STRESS_BEFORE_MIGRATION
+
+Stress command to write data for post-migration validation
+
+**default:** N/A
+
+**type:** str
+* appendable
+
+
+## **verify_stress_after_migration** / SCT_VERIFY_STRESS_AFTER_MIGRATION
+
+Stress command to verify data after migration
+
+**default:** N/A
+
+**type:** str
+* appendable
 
 
 ## **stress_cmd_no_mv** / SCT_STRESS_CMD_NO_MV

--- a/platform_migration_test.py
+++ b/platform_migration_test.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+from collections import defaultdict
+
+from longevity_test import LongevityTest
+from sdcm.sct_events.system import InfoEvent
+from sdcm.cluster import MAX_TIME_WAIT_FOR_DECOMMISSION, MAX_TIME_WAIT_FOR_NEW_NODE_UP
+from sdcm.utils.adaptive_timeouts import Operations, adaptive_timeout
+from sdcm.utils.aws_utils import get_arch_from_instance_type
+from sdcm.utils.cluster_tools import group_nodes_by_dc_idx
+from sdcm.utils.features import is_tablets_feature_enabled
+from sdcm.utils.parallel_object import ParallelObject
+from sdcm.utils.replication_strategy_utils import DataCenterTopologyRfControl
+
+
+class PlatformMigrationTest(LongevityTest):
+    """
+    Tests for platform migration using add-and-replace node cycling.
+
+    Migrates cluster from source platform (e.g., x86) to target platform (e.g., ARM)
+    while maintaining continuous workload.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.source_instance_type = self.params.get("instance_type_db")
+        self.target_instance_type = self.params.get("instance_type_db_target")
+        self.target_images = self.params.target_db_image_ids
+
+        if not self.target_instance_type:
+            raise ValueError("instance_type_db_target is required for platform migration test")
+
+        region = self.params.region_names[0]
+        source_arch = get_arch_from_instance_type(self.source_instance_type, region)
+        target_arch = get_arch_from_instance_type(self.target_instance_type, region)
+        self.log.info(
+            "Platform migration test: %s (%s) -> %s (%s)",
+            self.source_instance_type,
+            source_arch,
+            self.target_instance_type,
+            target_arch,
+        )
+
+    def _get_target_image_for_dc(self, dc_idx: int) -> str:
+        """Get target image for specific DC index"""
+        if not self.target_images:
+            return None
+        if len(self.target_images) == 1:
+            return self.target_images[0]
+        if dc_idx >= len(self.target_images):
+            return self.target_images[0]
+        return self.target_images[dc_idx]
+
+    def get_nodes_by_instance_type(self, instance_type: str) -> list:
+        """Get all nodes with specific instance type."""
+        return [n for n in self.db_cluster.nodes if n._instance_type == instance_type]
+
+    def add_nodes_parallel(self) -> list:
+        """Add all target nodes simultaneously across all DCs"""
+        source_nodes = self.get_nodes_by_instance_type(self.source_instance_type)
+        if not source_nodes:
+            raise ValueError(f"No nodes found with source instance type: {self.source_instance_type}")
+
+        nodes_by_dc = group_nodes_by_dc_idx(source_nodes)
+        all_added = []
+        for dc_idx, dc_nodes in nodes_by_dc.items():
+            image_id = self._get_target_image_for_dc(dc_idx)
+            # group by rack to preserve rack topology
+            nodes_by_rack = defaultdict(list)
+            for node in dc_nodes:
+                nodes_by_rack[node.rack].append(node)
+            for rack, rack_nodes in sorted(nodes_by_rack.items()):
+                self.log.info(
+                    "Adding %d target platform nodes to DC %s rack %s (image: %s)",
+                    len(rack_nodes),
+                    dc_idx,
+                    rack,
+                    image_id,
+                )
+                all_added.extend(
+                    self.db_cluster.add_nodes(
+                        count=len(rack_nodes),
+                        dc_idx=dc_idx,
+                        rack=rack,
+                        enable_auto_bootstrap=True,
+                        instance_type=self.target_instance_type,
+                        image_id=image_id,
+                    )
+                )
+
+        self.log.info("Waiting for %d new nodes to initialize...", len(all_added))
+        self._initialize_and_start_nodes(all_added)
+        self.monitors.reconfigure_scylla_monitoring()
+
+        self.log.info("Added %d target platform nodes: %s", len(all_added), [n.name for n in all_added])
+        return all_added
+
+    def migrate_nodes_batch_by_rack(self) -> list:
+        """Migrate rack-by-rack: add new nodes for rack, decommission old ones, next rack"""
+        source_nodes = self.get_nodes_by_instance_type(self.source_instance_type)
+        if not source_nodes:
+            raise ValueError(f"No nodes found with source instance type: {self.source_instance_type}")
+
+        nodes_by_rack = defaultdict(list)
+        for node in source_nodes:
+            nodes_by_rack[node.rack].append(node)
+
+        all_new_nodes = []
+        for rack, rack_nodes in sorted(nodes_by_rack.items()):
+            self.log.info("Migrating rack %s (%d nodes)", rack, len(rack_nodes))
+
+            # add target nodes for the rack
+            dc_idx = rack_nodes[0].dc_idx
+            image_id = self._get_target_image_for_dc(dc_idx)
+            added = self.db_cluster.add_nodes(
+                count=len(rack_nodes),
+                dc_idx=dc_idx,
+                rack=rack,
+                enable_auto_bootstrap=True,
+                instance_type=self.target_instance_type,
+                image_id=image_id,
+            )
+
+            self._initialize_and_start_nodes(added)
+            all_new_nodes.extend(added)
+
+            self.update_seeds_for_migration(all_new_nodes)
+            self.log.info("Decommissioning %d source nodes from rack %s", len(rack_nodes), rack)
+            self._decommission_nodes(rack_nodes)
+
+        self.monitors.reconfigure_scylla_monitoring()
+        self.log.info("Batch migration complete: %d new nodes", len(all_new_nodes))
+        return all_new_nodes
+
+    def _initialize_and_start_nodes(self, nodes: list) -> None:
+        """Initialize and start the given nodes"""
+        with adaptive_timeout(
+            Operations.NEW_NODE, node=self.db_cluster.data_nodes[0], timeout=MAX_TIME_WAIT_FOR_NEW_NODE_UP
+        ):
+            self.db_cluster.wait_for_init(
+                node_list=nodes, timeout=MAX_TIME_WAIT_FOR_NEW_NODE_UP, check_node_health=False
+            )
+        for node in nodes:
+            node.wait_node_fully_start()
+        self.db_cluster.wait_for_nodes_up_and_normal(nodes=nodes)
+
+    def _run_nodetool_decommission(self, node) -> None:
+        """Run nodetool decommission on a single node without verify/terminate."""
+        if not node._is_zero_token_node and is_tablets_feature_enabled(node):
+            DataCenterTopologyRfControl(target_node=node).decrease_keyspaces_rf()
+        with adaptive_timeout(operation=Operations.DECOMMISSION, node=node):
+            node.run_nodetool("decommission", long_running=True, retry=0)
+        self.log.info("Nodetool decommission completed on %s", node.name)
+
+    def _verify_and_terminate_nodes(self, nodes: list) -> None:
+        """Verify decommission and terminate nodes sequentially"""
+        live_candidates = [n for n in self.db_cluster.data_nodes if n not in nodes]
+        verification_node = live_candidates[0] if live_candidates else None
+
+        for node in nodes:
+            if verification_node:
+                status = self.db_cluster.get_nodetool_status(verification_node)
+                node_ips = {ip for dc_ips in status.values() for ip in dc_ips}
+                if node.ip_address in node_ips:
+                    raise Exception(
+                        f"Decommissioned node {node.name} ({node.ip_address}) still in cluster. Status: {status}"
+                    )
+            self.log.info("Decommission %s PASS", node.name)
+            self.db_cluster.terminate_node(node)
+        self.monitors.reconfigure_scylla_monitoring()
+
+    def _decommission_nodes(self, nodes: list) -> None:
+        """Decommission a list of nodes"""
+        for node in nodes:
+            if node.is_seed:
+                node.set_seed_flag(False)
+                self.db_cluster.update_seed_provider()
+                self.log.debug("Removed seed flag from %s", node.name)
+
+        num_workers = None if (self.db_cluster.parallel_node_operations and nodes[0].raft.is_enabled) else 1
+        self.log.info(
+            "Decommissioning %d nodes (%s): %s",
+            len(nodes),
+            "parallel" if num_workers is None else "sequential",
+            [n.name for n in nodes],
+        )
+
+        ParallelObject(objects=nodes, timeout=MAX_TIME_WAIT_FOR_DECOMMISSION, num_workers=num_workers).run(
+            self._run_nodetool_decommission, ignore_exceptions=False, unpack_objects=True
+        )
+
+        self._verify_and_terminate_nodes(nodes)
+        self.db_cluster.wait_all_nodes_un()
+
+    def _decommission_parallel_across_dcs(self) -> None:
+        """Decommission one node per DC in parallel"""
+        source_nodes = self.get_nodes_by_instance_type(self.source_instance_type)
+        if not source_nodes:
+            self.log.info("No source platform nodes to decommission")
+            return
+
+        nodes_by_dc = group_nodes_by_dc_idx(source_nodes)
+        dc_iter = {dc: iter(nodes) for dc, nodes in nodes_by_dc.items()}
+
+        batch_num = 0
+        while dc_iter:
+            batch_num += 1
+            batch = []
+            empty_dcs = []
+            for dc_idx, node_iter in dc_iter.items():
+                try:
+                    node = next(node_iter)
+                    if node.is_seed:
+                        node.set_seed_flag(False)
+                        self.db_cluster.update_seed_provider()
+                    batch.append(node)
+                except StopIteration:
+                    empty_dcs.append(dc_idx)
+
+            for dc in empty_dcs:
+                del dc_iter[dc]
+
+            if batch:
+                self.log.info(
+                    "Decommission batch %d: %s (parallel across %d DCs)", batch_num, [n.name for n in batch], len(batch)
+                )
+
+                ParallelObject(
+                    objects=batch,
+                    timeout=MAX_TIME_WAIT_FOR_DECOMMISSION,
+                    num_workers=len(batch),
+                ).run(self._run_nodetool_decommission, ignore_exceptions=False, unpack_objects=True)
+
+                self._verify_and_terminate_nodes(batch)
+                self.db_cluster.wait_all_nodes_un()
+
+        self.monitors.reconfigure_scylla_monitoring()
+
+    def update_seeds_for_migration(self, new_nodes: list) -> None:
+        """Ensure at least one new node is a seed before decommissioning old seeds"""
+        source_seeds = [
+            n for n in self.db_cluster.seed_nodes if getattr(n, "_instance_type", None) == self.source_instance_type
+        ]
+        self.log.info(
+            "Current seeds: %s, source platform seeds: %s",
+            [n.name for n in self.db_cluster.seed_nodes],
+            [n.name for n in source_seeds],
+        )
+
+        if source_seeds and not any(n.is_seed for n in new_nodes):
+            new_seed = new_nodes[0]
+            new_seed.set_seed_flag(True)
+            self.log.debug("Set %s as new seed node", new_seed.name)
+            self.db_cluster.update_seed_provider()
+            self.log.info("Updated seed provider on all nodes")
+
+    def verify_migration_complete(self) -> None:
+        """Assert all nodes are on target platform and node count is correct"""
+        self.log.info("Verifying migration completion...")
+
+        # check that all nodes are of the target instance type
+        for node in self.db_cluster.nodes:
+            if node._instance_type != self.target_instance_type:
+                raise AssertionError(
+                    f"Node {node.name} has instance type {node._instance_type}, expected {self.target_instance_type}"
+                )
+
+        n_db_nodes = self.params.get("n_db_nodes")
+        if isinstance(n_db_nodes, str) and " " in n_db_nodes:
+            expected_count = sum(int(x) for x in n_db_nodes.split())
+        else:
+            expected_count = int(n_db_nodes)
+
+        actual_count = len(self.db_cluster.nodes)
+        if actual_count != expected_count:
+            raise AssertionError(f"Expected {expected_count} nodes after migration, got {actual_count}")
+
+        self.log.info("Migration verification passed: %d nodes on %s", actual_count, self.target_instance_type)
+
+    def run_stress_before_migration(self) -> None:
+        if stress_cmd := self.params.get("stress_before_migration"):
+            self.verify_stress_thread(self.run_stress_thread(stress_cmd=stress_cmd))
+
+    def run_verify_stress_after_migration(self) -> None:
+        if stress_cmd := self.params.get("verify_stress_after_migration"):
+            self.verify_stress_thread(self.run_stress_thread(stress_cmd=stress_cmd))
+
+    def test_migrate_platform(self):
+        """
+        Single-DC platform migration test.
+
+        Flow:
+        1. Initial cluster health checks
+        2. Prepare data (cassandra-stress + scylla-bench validation dataset)
+        3. Start continuous stress workload
+        4. Add all target platform nodes in parallel
+        5. Update seed configuration
+        6. Decommission source nodes sequentially
+        7. Verify data integrity and stress results
+        """
+        InfoEvent(message="Initial cluster health checks").publish()
+        self.db_cluster.wait_all_nodes_un()
+        self.db_cluster.wait_for_schema_agreement()
+        self.log.info("Initial cluster: %d nodes on %s", len(self.db_cluster.nodes), self.source_instance_type)
+
+        InfoEvent(message="Preparing data").publish()
+        self.run_prepare_write_cmd()
+        self.run_stress_before_migration()
+
+        InfoEvent(message="Starting continuous stress workload").publish()
+        stress_queue = []
+        if self.params.get("stress_cmd"):
+            self._run_all_stress_cmds(
+                stress_queue,
+                {"stress_cmd": self.params.get("stress_cmd"), "round_robin": self.params.get("round_robin")},
+            )
+            self.log.info("Started continuous stress workload")
+        else:
+            self.log.warning("No stress_cmd configured, running migration without workload")
+
+        InfoEvent(message="Adding target platform nodes (parallel)").publish()
+        new_nodes = self.add_nodes_parallel()
+
+        InfoEvent(message="Updating seed configuration").publish()
+        self.update_seeds_for_migration(new_nodes)
+
+        InfoEvent(message="Decommissioning source platform nodes").publish()
+        self._decommission_nodes(self.get_nodes_by_instance_type(self.source_instance_type))
+        self.monitors.reconfigure_scylla_monitoring()
+
+        InfoEvent(message="Verifying migration").publish()
+        self.kill_stress_thread()
+        for stress in stress_queue:
+            self.verify_stress_thread(stress)
+        if stress_queue:
+            self.log.info("Stress workload completed successfully")
+        self.run_verify_stress_after_migration()
+        self.verify_migration_complete()
+
+    def test_migrate_platform_multi_dc(self):
+        """
+        Multi-DC platform migration test with parallel operations across DCs.
+
+        Flow:
+        1. Initial cluster health checks
+        2. Prepare data
+        3. Start continuous stress workload
+        4. Add all target nodes simultaneously across all DCs
+        5. Update seed configuration
+        6. Decommission source nodes in parallel across DCs (one per DC at a time)
+        7. Verify data integrity and stress results
+        """
+        InfoEvent(message="Initial cluster health checks").publish()
+        self.db_cluster.wait_all_nodes_un()
+        self.db_cluster.wait_for_schema_agreement()
+        self.log.info("Initial cluster: %d nodes on %s", len(self.db_cluster.nodes), self.source_instance_type)
+
+        InfoEvent(message="Preparing data").publish()
+        self.run_prepare_write_cmd()
+        self.run_stress_before_migration()
+
+        InfoEvent(message="Starting continuous stress workload").publish()
+        stress_queue = []
+        if self.params.get("stress_cmd"):
+            self._run_all_stress_cmds(
+                stress_queue,
+                {"stress_cmd": self.params.get("stress_cmd"), "round_robin": self.params.get("round_robin")},
+            )
+            self.log.info("Started continuous stress workload")
+        else:
+            self.log.warning("No stress_cmd configured, running migration without workload")
+
+        InfoEvent(message="Adding target platform nodes (all DCs in parallel)").publish()
+        new_nodes = self.add_nodes_parallel()
+
+        InfoEvent(message="Updating seed configuration").publish()
+        self.update_seeds_for_migration(new_nodes)
+
+        InfoEvent(message="Decommissioning source nodes (parallel across DCs)").publish()
+        self._decommission_parallel_across_dcs()
+
+        InfoEvent(message="Verifying migration").publish()
+        self.kill_stress_thread()
+        for stress in stress_queue:
+            self.verify_stress_thread(stress)
+        if stress_queue:
+            self.log.info("Stress workload completed successfully")
+        self.run_verify_stress_after_migration()
+        self.verify_migration_complete()
+
+    def test_migrate_platform_batched(self):
+        """
+        Batched platform migration test - migrate rack by rack.
+
+        Flow:
+        1. Initial cluster health checks
+        2. Prepare data
+        3. Start continuous stress workload
+        4. For each rack:
+           a. Add target nodes for rack
+           b. Update seeds
+           c. Decommission source nodes from rack
+        5. Verify data integrity and stress results
+        """
+        InfoEvent(message="Initial cluster health checks").publish()
+        self.db_cluster.wait_all_nodes_un()
+        self.db_cluster.wait_for_schema_agreement()
+        self.log.info("Initial cluster: %d nodes on %s", len(self.db_cluster.nodes), self.source_instance_type)
+
+        InfoEvent(message="Preparing data").publish()
+        self.run_prepare_write_cmd()
+        self.run_stress_before_migration()
+
+        InfoEvent(message="Starting continuous stress workload").publish()
+        stress_queue = []
+        if self.params.get("stress_cmd"):
+            self._run_all_stress_cmds(
+                stress_queue,
+                {"stress_cmd": self.params.get("stress_cmd"), "round_robin": self.params.get("round_robin")},
+            )
+            self.log.info("Started continuous stress workload")
+        else:
+            self.log.warning("No stress_cmd configured, running migration without workload")
+
+        InfoEvent(message="Starting batch-by-rack migration").publish()
+        self.migrate_nodes_batch_by_rack()  # handles add + decommission per rack
+
+        InfoEvent(message="Verifying migration").publish()
+        self.kill_stress_thread()
+        for stress in stress_queue:
+            self.verify_stress_thread(stress)
+        if stress_queue:
+            self.log.info("Stress workload completed successfully")
+        self.run_verify_stress_after_migration()
+        self.verify_migration_complete()

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3970,12 +3970,15 @@ class BaseCluster:
     def wait_for_init(self):
         raise NotImplementedError("Derived class must implement 'wait_for_init' method!")
 
-    def add_nodes(self, count, ec2_user_data="", dc_idx=0, rack=0, enable_auto_bootstrap=False, instance_type=None):
+    def add_nodes(
+        self, count, ec2_user_data="", dc_idx=0, rack=0, enable_auto_bootstrap=False, instance_type=None, image_id=None
+    ):
         """
         :param count: number of nodes to add
         :param ec2_user_data:
         :param dc_idx: datacenter index, used as an index for self.datacenter list
         :param instance_type: type of instance to use, can override what's defined in configuration
+        :param image_id: image ID to use, can override what's defined in configuration
         :return: list of Nodes
         """
         raise NotImplementedError("Derived class must implement 'add_nodes' method!")
@@ -5995,8 +5998,9 @@ class BaseScyllaCluster:
 
         target_node_ip = node.ip_address
         node_allocator = self.test_config.tester_obj().nemesis_allocator
+        verification_candidates = [n for n in self.data_nodes if n != node]
         with node_allocator.run_nemesis(
-            nemesis_label="verify decommission", node_list=self.data_nodes
+            nemesis_label="verify decommission", node_list=verification_candidates
         ) as verification_node:
             node_ip_list = get_node_ip_list(verification_node)
             missing_host_ids = verification_node.raft.search_inconsistent_host_ids()

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -955,6 +955,10 @@ class SCTConfiguration(BaseModel):
     instance_type_db_oracle: String = SctField(
         description="AWS image type of the oracle node",
     )
+    instance_type_db_target: String = SctField(
+        description="Target AWS instance type for platform migration (e.g., i8g.2xlarge for ARM)",
+    )
+    target_db_image_ids: Annotated[list[str], IgnoredType] = Field(default=[], exclude=True)
     instance_type_runner: String = SctField(
         description="instance type of the sct-runner node",
     )
@@ -1584,6 +1588,12 @@ class SCTConfiguration(BaseModel):
     )
     prepare_write_cmd: MultitenantValue(StringOrList) = SctField(
         description="cassandra-stress commands. You can specify everything but the -node parameter, which is going to be provided by the test suite infrastructure. Multiple commands can be passed as a list",
+    )
+    stress_before_migration: String = SctField(
+        description="Stress command to write data for post-migration validation",
+    )
+    verify_stress_after_migration: String = SctField(
+        description="Stress command to verify data after migration",
     )
     stress_cmd_no_mv: StringOrList = SctField(
         description="cassandra-stress commands. You can specify everything but the -node parameter, which is going to be provided by the test suite infrastructure. Multiple commands can be passed as a list",
@@ -2590,6 +2600,39 @@ class SCTConfiguration(BaseModel):
                 raise ValueError(
                     "'scylla_version' can't used together with 'ami_id_db_scylla', 'gce_image_db' or with 'scylla_repo'"
                 )
+
+            # auto-discover target image for platform migration
+            self.target_db_image_ids = []
+            if self.get("instance_type_db_target"):
+                if self.get("cluster_backend") == "aws":
+                    target_ami_list = []
+                    for region in region_names:
+                        target_arch = get_arch_from_instance_type(
+                            self.get("instance_type_db_target"), region_name=region
+                        )
+                        try:
+                            ami = (
+                                get_branched_ami(scylla_version=scylla_version, region_name=region, arch=target_arch)[0]
+                                if ":" in scylla_version
+                                else get_scylla_ami_versions(
+                                    version=scylla_version, region_name=region, arch=target_arch
+                                )[0]
+                            )
+                        except Exception as ex:  # noqa: BLE001
+                            raise ValueError(
+                                f"Target AMI for scylla_version='{scylla_version}' not found in {region} "
+                                f"arch={target_arch} (for instance_type_db_target)"
+                            ) from ex
+                        self.log.debug(
+                            "Found target AMI %s(%s) for scylla_version='%s' arch=%s in %s",
+                            ami.name,
+                            ami.image_id,
+                            scylla_version,
+                            target_arch,
+                            region,
+                        )
+                        target_ami_list.append(ami)
+                    self.target_db_image_ids = [ami.image_id for ami in target_ami_list]
 
         # 6.1) handle oracle_scylla_version if exists
         if (oracle_scylla_version := self.get("oracle_scylla_version")) and self.get("db_type") == "mixed_scylla":

--- a/test-cases/platform-migration/x86-to-arm-batched.yaml
+++ b/test-cases/platform-migration/x86-to-arm-batched.yaml
@@ -1,0 +1,4 @@
+n_db_nodes: 6
+simulated_racks: 3
+
+user_prefix: 'platform-migration-batched'

--- a/test-cases/platform-migration/x86-to-arm-multi-dc.yaml
+++ b/test-cases/platform-migration/x86-to-arm-multi-dc.yaml
@@ -1,0 +1,23 @@
+test_duration: 480
+n_db_nodes: '3 3'
+region_name: 'eu-west-1 us-east-1'
+n_loaders: '1 1'
+
+prepare_write_cmd: [
+  "cassandra-stress write cl=LOCAL_ONE n=450000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=300 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..450000000",
+  "cassandra-stress write cl=LOCAL_ONE n=450000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=300 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=450000001..900000000"
+]
+
+stress_before_migration: "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=800 -clustering-row-count=5555 -clustering-row-size=uniform:100..1024 -concurrency=5 -connection-count=5 -consistency-level=local_quorum -rows-per-request=10 -timeout=30s -validate-data"
+
+stress_cmd: [
+  "cassandra-stress mixed 'ratio(write=1,read=9)' cl=LOCAL_QUORUM duration=420m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..900000000 -errors retries=50",
+  "cassandra-stress mixed 'ratio(write=1,read=9)' cl=LOCAL_QUORUM duration=420m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..900000000 -errors retries=50"
+]
+
+rack_aware_loader: true
+region_aware_loader: true
+
+verify_stress_after_migration: "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=800 -clustering-row-count=5555 -clustering-row-size=uniform:100..1024 -concurrency=20 -connection-count=20 -consistency-level=local_quorum -rows-per-request=100 -timeout=30s -validate-data"
+
+user_prefix: 'platform-migration-multidc'

--- a/test-cases/platform-migration/x86-to-arm-single-dc-10-perc.yaml
+++ b/test-cases/platform-migration/x86-to-arm-single-dc-10-perc.yaml
@@ -1,0 +1,13 @@
+test_duration: 240
+
+prepare_write_cmd: [
+  "cassandra-stress write cl=ONE n=180000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=300 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..180000000",
+  "cassandra-stress write cl=ONE n=180000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=300 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=180000001..360000000"
+]
+
+stress_cmd: [
+  "cassandra-stress mixed 'ratio(write=1,read=9)' cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..360000000",
+  "cassandra-stress mixed 'ratio(write=1,read=9)' cl=QUORUM duration=180m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..360000000"
+]
+
+user_prefix: 'platform-migration-10perc'

--- a/test-cases/platform-migration/x86-to-arm-single-dc-50-perc.yaml
+++ b/test-cases/platform-migration/x86-to-arm-single-dc-50-perc.yaml
@@ -1,0 +1,30 @@
+test_duration: 480
+
+instance_type_db: 'i7i.2xlarge'
+instance_type_db_target: 'i8g.2xlarge'
+n_db_nodes: 6
+n_loaders: 2
+instance_type_loader: 'c7i.4xlarge'
+n_monitor_nodes: 1
+
+prepare_write_cmd: [
+  "cassandra-stress write cl=ONE n=900000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=300 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..900000000",
+  "cassandra-stress write cl=ONE n=900000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=300 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=900000001..1800000000"
+]
+
+stress_before_migration: "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=800 -clustering-row-count=5555 -clustering-row-size=uniform:100..1024 -concurrency=5 -connection-count=5 -consistency-level=quorum -rows-per-request=10 -timeout=30s -validate-data"
+
+stress_cmd: [
+  "cassandra-stress mixed 'ratio(write=1,read=9)' cl=QUORUM duration=420m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1800000000",
+  "cassandra-stress mixed 'ratio(write=1,read=9)' cl=QUORUM duration=420m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode connectionsPerHost=8 cql3 native -rate threads=50 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1800000000"
+]
+
+verify_stress_after_migration: "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=800 -clustering-row-count=5555 -clustering-row-size=uniform:100..1024 -concurrency=20 -connection-count=20 -consistency-level=one -rows-per-request=100 -timeout=30s -validate-data"
+
+append_scylla_yaml:
+  stream_throughput_outbound_megabits_per_sec: 800
+
+round_robin: true
+nemesis_class_name: 'NoOpMonkey'
+user_prefix: 'platform-migration'
+use_preinstalled_scylla: true

--- a/test-cases/platform-migration/x86-to-arm-single-dc-vnodes.yaml
+++ b/test-cases/platform-migration/x86-to-arm-single-dc-vnodes.yaml
@@ -1,0 +1,6 @@
+append_scylla_yaml:
+  enable_tablets: false
+  tablets_mode_for_new_keyspaces: 'disabled'
+  stream_throughput_outbound_megabits_per_sec: 800
+
+user_prefix: 'platform-migration-vnodes'

--- a/utils/lint_test_cases.sh
+++ b/utils/lint_test_cases.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 OUT=0
-SCT_AMI_ID_DB_SCYLLA=ami-1234 ./sct.py lint-yamls -i '.yaml' -e 'azure,multi-dc,multiDC,multidc,multiple-dc,3dcs,5dcs,rolling,docker,artifacts,private-repo,ics/long,scylla-operator,gce,custom-d3,jepsen,repair-based-operations,add-new-dc,baremetal'
+SCT_AMI_ID_DB_SCYLLA=ami-1234 ./sct.py lint-yamls -i '.yaml' -e 'azure,multi-dc,multiDC,multidc,multiple-dc,3dcs,5dcs,rolling,docker,artifacts,private-repo,ics/long,scylla-operator,gce,custom-d3,jepsen,repair-based-operations,add-new-dc,baremetal,x86-to-arm'
 OUT=$(($OUT + $?))
 
 SCT_AZURE_IMAGE_DB=image SCT_AZURE_REGION_NAME="eastus" ./sct.py lint-yamls --backend azure -i azure


### PR DESCRIPTION
Add platform migration test using add-and-replace node cycling approach. The test adds target platform nodes, then decommissions source nodes while running continuous stress workload. Data integrity is validated after migration is finished.

The following migration scenarios are covered:
  - sequential node-by-node migration
  - rack-aware batched migration (add new nodes per rack, decommission one node per rack at a time) - similar to sequential node-by-node migration with the difference that new nodes are not added all at once, but in batches per rack, to avoid doubling the cluster size at once
  - parallel decommission across DCs (one node of each DC at a time)

Test following test config and its overlays are added:
- single dc platform migration with 50% utilization - default config
- single dc with 10% utilization - overlay
- single dc for nodes - overlay
- batched-per-rack migration - batch specific scenario overlay
- multidc migration - multidc specific scenario overlay (2 DCs, 3 nodes each)

Refs: QAINFRA-42

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [single dc test config](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/177/)
- [x] :green_circle: [single dc batch per rack test config](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/206/)
- [x] :green_circle: [multidc test config](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/225/)
- [x] :green_circle: [single dc 10% utilization test config](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/215/)
- [x] :green_circle: [single dc vnodes 10% utilization test config](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/216/)
- [x] check during local run of the test that platform is changing on the cluster nodes:
```
>>> for n in self.db_cluster.nodes:
    n.remoter.run('uname -m').stdout
'x86_64\n'
'x86_64\n'
'x86_64\n'
...

for n in self.db_cluster.nodes:
    n.remoter.run('uname -m').stdout 
'aarch64\n'
'aarch64\n'
'aarch64\n'
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
