### PR TITLE
fix(cluster.py): upgrade ssh packages together to prevent sshd crash

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3595,6 +3595,13 @@ class BaseNode(AutoSshContainerMixin):
         self.remoter.sudo("systemctl stop firewalld", ignore_status=True)
         self.remoter.sudo("systemctl disable firewalld", ignore_status=True)
 
+    def upgrade_ssh_packages(self) -> None:
+        """
+        Upgrade `openssl` and `openssh` together on RHEL-like distros to avoid
+        potential `sshd` crashes caused by version mismatches between the packages.
+        """
+        self.remoter.sudo("yum update -y openssl openssh-server openssh-clients", ignore_status=True, retry=3)
+
     def log_message(self, message: str, level: str = "info") -> None:
         try:
             self.remoter.run(
@@ -5529,6 +5536,7 @@ class BaseScyllaCluster:
 
         if node.distro.is_rhel_like:
             node.disable_firewall()
+            node.upgrade_ssh_packages()
 
         if self.params.get("logs_transport") == "ssh":
             node.install_package("python3")
@@ -6374,6 +6382,7 @@ class BaseMonitorSet:
 
         if node.distro.is_rhel_like:
             node.disable_firewall()
+            node.upgrade_ssh_packages()
 
         node.disable_daily_triggered_services()
         # update repo cache and system after system is up


### PR DESCRIPTION
On RHEL-like distros yum install can upgrade openssl-libs as a dependency without upgrading openssh. This causes sshd to crash with "OpenSSL version mismatch" error because sshd was compiled against the old openssl version.

Explicitly upgrading openssl and openssh together early in node_setup (before any other package installations that could trigger a partial openssl-only upgrade) allows to work around the problem.

This fix was initially prepared and merged into branch-2024.1, as the issue appeared during 2024.1.22 RC testing, and was believed only that version specific. But now it is reproduced for 2025.1, so cherry-picking the fix to apply it to other branches.

Refs: https://github.com/scylladb/scylla-cluster-tests/pull/13376

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [artifacts-oel9-test on 2025.1](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-oel9-test-20241/6/)
- [x] :green_circle: [artifacts-oel9-test on master](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-oel9-test-20241/7/)
- [x] :green_circle: [artifacts-debian12-test on master - regression check](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-oel9-test-20241/9/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
