### PR TITLE
fix(cloud-init): prevent yum list vector from hanging on CentOS

### DIFF
--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -261,7 +261,7 @@ def install_vector_service():
         for n in 2 4 6 8 10 10 10 10; do # cloud-init is running it with set +o braceexpand
             if bash -c "$(curl -L https://setup.vector.dev)"; then
                 if yum --help 2>/dev/null 1>&2; then
-                    if yum list vector >/dev/null 2>&1; then
+                    if yum -y list vector >/dev/null 2>&1; then
                         break
                     fi
                 elif apt-get --help 2>/dev/null 1>&2; then


### PR DESCRIPTION
On CentOS 9 the vector.dev repo is configured with repo_gpgcheck=1. When running `yum list vector`, DNF prompts for GPG key import confirmation. As the command redirects output to /dev/null, the prompt is hidden and DNF waits forever for user input, causing the node initialization to hang.

Adding -y flag to auto-accept the GPG key import prompt.

Refs: https://github.com/scylladb/scylla-cluster-tests/pull/13455
Closes: SCT-61

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [artifacts-centos9-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-oel9-test-20241/11/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
