### PR TITLE
feature(nemesis): add xcloud backend flag for nemesis classes

### DIFF
--- a/data_dir/nemesis.yml
+++ b/data_dir/nemesis.yml
@@ -13,6 +13,7 @@ AbortRepairMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 AddDropColumnMonkey:
   config_changes: false
@@ -29,6 +30,7 @@ AddDropColumnMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 AddRemoveDcNemesis:
   config_changes: false
@@ -45,6 +47,7 @@ AddRemoveDcNemesis:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: true
+  xcloud: false
   zero_node_changes: false
 AddRemoveMvNemesis:
   config_changes: false
@@ -61,6 +64,7 @@ AddRemoveMvNemesis:
   sla: false
   supports_high_disk_utilization: false
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 AddRemoveRackNemesis:
   config_changes: true
@@ -77,6 +81,7 @@ AddRemoveRackNemesis:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 BlockNetworkMonkey:
   config_changes: false
@@ -93,6 +98,7 @@ BlockNetworkMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 BootstrapStreamingErrorNemesis:
   config_changes: false
@@ -109,6 +115,7 @@ BootstrapStreamingErrorNemesis:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: true
+  xcloud: false
   zero_node_changes: false
 CDCStressorMonkey:
   config_changes: false
@@ -125,6 +132,7 @@ CDCStressorMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 ClusterRollingRestart:
   config_changes: false
@@ -141,6 +149,7 @@ ClusterRollingRestart:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 ClusterRollingRestartRandomOrder:
   config_changes: false
@@ -157,6 +166,7 @@ ClusterRollingRestartRandomOrder:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 CorruptThenRebuildMonkey:
   config_changes: false
@@ -173,6 +183,7 @@ CorruptThenRebuildMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 CorruptThenRepairMonkey:
   config_changes: false
@@ -189,6 +200,7 @@ CorruptThenRepairMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 CorruptThenScrubMonkey:
   config_changes: false
@@ -205,6 +217,7 @@ CorruptThenScrubMonkey:
   sla: false
   supports_high_disk_utilization: false
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 CreateIndexNemesis:
   config_changes: false
@@ -221,6 +234,7 @@ CreateIndexNemesis:
   sla: false
   supports_high_disk_utilization: false
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 DecommissionMonkey:
   config_changes: false
@@ -237,6 +251,7 @@ DecommissionMonkey:
   sla: false
   supports_high_disk_utilization: false
   topology_changes: true
+  xcloud: false
   zero_node_changes: false
 DecommissionSeedNode:
   config_changes: false
@@ -253,6 +268,7 @@ DecommissionSeedNode:
   sla: false
   supports_high_disk_utilization: false
   topology_changes: true
+  xcloud: false
   zero_node_changes: false
 DecommissionStreamingErrMonkey:
   config_changes: false
@@ -269,6 +285,7 @@ DecommissionStreamingErrMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: true
+  xcloud: false
   zero_node_changes: false
 DeleteByPartitionsMonkey:
   config_changes: false
@@ -285,6 +302,7 @@ DeleteByPartitionsMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 DeleteByRowsRangeMonkey:
   config_changes: false
@@ -301,6 +319,7 @@ DeleteByRowsRangeMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 DeleteOverlappingRowRangesMonkey:
   config_changes: false
@@ -317,6 +336,7 @@ DeleteOverlappingRowRangesMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 DisableBinaryGossipExecuteMajorCompaction:
   config_changes: false
@@ -333,6 +353,7 @@ DisableBinaryGossipExecuteMajorCompaction:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 DrainKubernetesNodeThenDecommissionAndAddScyllaNode:
   config_changes: false
@@ -349,6 +370,7 @@ DrainKubernetesNodeThenDecommissionAndAddScyllaNode:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 DrainKubernetesNodeThenReplaceScyllaNode:
   config_changes: false
@@ -365,6 +387,7 @@ DrainKubernetesNodeThenReplaceScyllaNode:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 DrainerMonkey:
   config_changes: false
@@ -381,6 +404,7 @@ DrainerMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: true
+  xcloud: false
   zero_node_changes: false
 EnableDisableTableEncryptionAwsKmsProviderWithRotationMonkey:
   config_changes: false
@@ -397,6 +421,7 @@ EnableDisableTableEncryptionAwsKmsProviderWithRotationMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 EnableDisableTableEncryptionAwsKmsProviderWithoutRotationMonkey:
   config_changes: false
@@ -413,6 +438,7 @@ EnableDisableTableEncryptionAwsKmsProviderWithoutRotationMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 EndOfQuotaNemesis:
   config_changes: true
@@ -429,6 +455,7 @@ EndOfQuotaNemesis:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 EnospcAllNodesMonkey:
   config_changes: false
@@ -445,6 +472,7 @@ EnospcAllNodesMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 EnospcMonkey:
   config_changes: false
@@ -461,6 +489,7 @@ EnospcMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 GrowShrinkClusterNemesis:
   config_changes: false
@@ -477,6 +506,7 @@ GrowShrinkClusterNemesis:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: true
+  xcloud: false
   zero_node_changes: false
 GrowShrinkZeroTokenNode:
   config_changes: false
@@ -493,6 +523,7 @@ GrowShrinkZeroTokenNode:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: true
 HardRebootNodeMonkey:
   config_changes: false
@@ -509,6 +540,7 @@ HardRebootNodeMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 IsolateNodeWithIptableRuleNemesis:
   config_changes: false
@@ -525,6 +557,7 @@ IsolateNodeWithIptableRuleNemesis:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: true
+  xcloud: false
   zero_node_changes: false
 IsolateNodeWithProcessSignalNemesis:
   config_changes: false
@@ -541,6 +574,7 @@ IsolateNodeWithProcessSignalNemesis:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: true
+  xcloud: false
   zero_node_changes: false
 KillMVBuildingCoordinator:
   config_changes: false
@@ -557,6 +591,7 @@ KillMVBuildingCoordinator:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: true
+  xcloud: false
   zero_node_changes: false
 LoadAndStreamMonkey:
   config_changes: false
@@ -573,6 +608,7 @@ LoadAndStreamMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 MajorCompactionMonkey:
   config_changes: false
@@ -589,6 +625,7 @@ MajorCompactionMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 MemoryStressMonkey:
   config_changes: false
@@ -605,6 +642,7 @@ MemoryStressMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 MgmtBackup:
   config_changes: false
@@ -621,6 +659,7 @@ MgmtBackup:
   sla: false
   supports_high_disk_utilization: false
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 MgmtBackupSpecificKeyspaces:
   config_changes: false
@@ -637,6 +676,7 @@ MgmtBackupSpecificKeyspaces:
   sla: false
   supports_high_disk_utilization: false
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 MgmtCorruptThenRepair:
   config_changes: false
@@ -653,6 +693,7 @@ MgmtCorruptThenRepair:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 MgmtRepair:
   config_changes: false
@@ -669,6 +710,7 @@ MgmtRepair:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 MgmtRestore:
   config_changes: false
@@ -685,6 +727,7 @@ MgmtRestore:
   sla: false
   supports_high_disk_utilization: false
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 ModifyTableBloomFilterFpChanceMonkey:
   config_changes: false
@@ -701,6 +744,7 @@ ModifyTableBloomFilterFpChanceMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 ModifyTableCachingMonkey:
   config_changes: false
@@ -717,6 +761,7 @@ ModifyTableCachingMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 ModifyTableCommentMonkey:
   config_changes: false
@@ -733,6 +778,7 @@ ModifyTableCommentMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 ModifyTableCompactionMonkey:
   config_changes: false
@@ -749,6 +795,7 @@ ModifyTableCompactionMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 ModifyTableCompressionMonkey:
   config_changes: false
@@ -765,6 +812,7 @@ ModifyTableCompressionMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 ModifyTableCrcCheckChanceMonkey:
   config_changes: false
@@ -781,6 +829,7 @@ ModifyTableCrcCheckChanceMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 ModifyTableDclocalReadRepairChanceMonkey:
   config_changes: false
@@ -797,6 +846,7 @@ ModifyTableDclocalReadRepairChanceMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 ModifyTableDefaultTimeToLiveMonkey:
   config_changes: false
@@ -813,6 +863,7 @@ ModifyTableDefaultTimeToLiveMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 ModifyTableGcGraceTimeMonkey:
   config_changes: false
@@ -829,6 +880,7 @@ ModifyTableGcGraceTimeMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 ModifyTableMaxIndexIntervalMonkey:
   config_changes: false
@@ -845,6 +897,7 @@ ModifyTableMaxIndexIntervalMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 ModifyTableMemtableFlushPeriodInMsMonkey:
   config_changes: false
@@ -861,6 +914,7 @@ ModifyTableMemtableFlushPeriodInMsMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 ModifyTableMinIndexIntervalMonkey:
   config_changes: false
@@ -877,6 +931,7 @@ ModifyTableMinIndexIntervalMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 ModifyTableReadRepairChanceMonkey:
   config_changes: false
@@ -893,6 +948,7 @@ ModifyTableReadRepairChanceMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 ModifyTableSpeculativeRetryMonkey:
   config_changes: false
@@ -909,6 +965,7 @@ ModifyTableSpeculativeRetryMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 ModifyTableTwcsWindowSizeMonkey:
   config_changes: false
@@ -925,6 +982,7 @@ ModifyTableTwcsWindowSizeMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 MultipleHardRebootNodeMonkey:
   config_changes: false
@@ -941,6 +999,7 @@ MultipleHardRebootNodeMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 NemesisSequence:
   config_changes: false
@@ -957,6 +1016,7 @@ NemesisSequence:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 NoCorruptRepairMonkey:
   config_changes: false
@@ -973,6 +1033,7 @@ NoCorruptRepairMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 NodeRestartWithResharding:
   config_changes: true
@@ -989,6 +1050,7 @@ NodeRestartWithResharding:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: true
+  xcloud: false
   zero_node_changes: false
 NodeTerminateAndReplace:
   config_changes: false
@@ -1005,6 +1067,7 @@ NodeTerminateAndReplace:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: true
+  xcloud: false
   zero_node_changes: true
 NodeToolCleanupMonkey:
   config_changes: false
@@ -1021,6 +1084,7 @@ NodeToolCleanupMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 OperatorNodeReplace:
   config_changes: false
@@ -1037,6 +1101,7 @@ OperatorNodeReplace:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 OperatorNodetoolFlushAndReshard:
   config_changes: false
@@ -1053,6 +1118,7 @@ OperatorNodetoolFlushAndReshard:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 PauseLdapNemesis:
   config_changes: false
@@ -1069,6 +1135,7 @@ PauseLdapNemesis:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 RandomInterruptionNetworkMonkey:
   config_changes: false
@@ -1085,6 +1152,7 @@ RandomInterruptionNetworkMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 RebuildStreamingErrMonkey:
   config_changes: false
@@ -1101,6 +1169,7 @@ RebuildStreamingErrMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 RefreshBigMonkey:
   config_changes: false
@@ -1117,6 +1186,7 @@ RefreshBigMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 RefreshMonkey:
   config_changes: false
@@ -1133,6 +1203,7 @@ RefreshMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 RejectInterNodeNetworkMonkey:
   config_changes: false
@@ -1149,6 +1220,7 @@ RejectInterNodeNetworkMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 RejectNodeExporterNetworkMonkey:
   config_changes: false
@@ -1165,6 +1237,7 @@ RejectNodeExporterNetworkMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 RejectThriftNetworkMonkey:
   config_changes: false
@@ -1181,6 +1254,7 @@ RejectThriftNetworkMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 RemoveServiceLevelMonkey:
   config_changes: false
@@ -1197,6 +1271,7 @@ RemoveServiceLevelMonkey:
   sla: true
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 RepairStreamingErrMonkey:
   config_changes: false
@@ -1213,6 +1288,7 @@ RepairStreamingErrMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 ResetLocalSchemaMonkey:
   config_changes: true
@@ -1229,6 +1305,7 @@ ResetLocalSchemaMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 RestartThenRepairNodeMonkey:
   config_changes: false
@@ -1245,6 +1322,7 @@ RestartThenRepairNodeMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 RollingRestartConfigChangeInternodeCompression:
   config_changes: true
@@ -1261,6 +1339,7 @@ RollingRestartConfigChangeInternodeCompression:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 ScyllaKillMonkey:
   config_changes: false
@@ -1277,6 +1356,7 @@ ScyllaKillMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 SerialRestartOfElectedTopologyCoordinatorNemesis:
   config_changes: false
@@ -1293,6 +1373,7 @@ SerialRestartOfElectedTopologyCoordinatorNemesis:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: true
+  xcloud: false
   zero_node_changes: false
 SlaDecreaseSharesDuringLoad:
   config_changes: false
@@ -1309,6 +1390,7 @@ SlaDecreaseSharesDuringLoad:
   sla: true
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 SlaIncreaseSharesByAttachAnotherSlDuringLoad:
   config_changes: false
@@ -1325,6 +1407,7 @@ SlaIncreaseSharesByAttachAnotherSlDuringLoad:
   sla: true
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 SlaIncreaseSharesDuringLoad:
   config_changes: false
@@ -1341,6 +1424,7 @@ SlaIncreaseSharesDuringLoad:
   sla: true
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 SlaMaximumAllowedSlsWithMaxSharesDuringLoad:
   config_changes: false
@@ -1357,6 +1441,7 @@ SlaMaximumAllowedSlsWithMaxSharesDuringLoad:
   sla: true
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 SlaReplaceUsingDetachDuringLoad:
   config_changes: false
@@ -1373,6 +1458,7 @@ SlaReplaceUsingDetachDuringLoad:
   sla: true
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 SlaReplaceUsingDropDuringLoad:
   config_changes: false
@@ -1389,6 +1475,7 @@ SlaReplaceUsingDropDuringLoad:
   sla: true
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 SnapshotOperations:
   config_changes: false
@@ -1405,6 +1492,7 @@ SnapshotOperations:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 SoftRebootNodeMonkey:
   config_changes: false
@@ -1421,6 +1509,7 @@ SoftRebootNodeMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 SslHotReloadingNemesis:
   config_changes: true
@@ -1437,6 +1526,7 @@ SslHotReloadingNemesis:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 StartStopCleanupCompaction:
   config_changes: false
@@ -1453,6 +1543,7 @@ StartStopCleanupCompaction:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 StartStopMajorCompaction:
   config_changes: false
@@ -1469,6 +1560,7 @@ StartStopMajorCompaction:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 StartStopScrubCompaction:
   config_changes: false
@@ -1485,6 +1577,7 @@ StartStopScrubCompaction:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 StartStopValidationCompaction:
   config_changes: false
@@ -1501,6 +1594,7 @@ StartStopValidationCompaction:
   sla: false
   supports_high_disk_utilization: false
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 StopStartInterfacesNetworkMonkey:
   config_changes: false
@@ -1517,6 +1611,7 @@ StopStartInterfacesNetworkMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 StopStartMonkey:
   config_changes: false
@@ -1533,6 +1628,7 @@ StopStartMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 StopWaitStartMonkey:
   config_changes: false
@@ -1549,6 +1645,7 @@ StopWaitStartMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: true
 SwitchBetweenPasswordAuthAndSaslauthdAuth:
   config_changes: true
@@ -1565,6 +1662,7 @@ SwitchBetweenPasswordAuthAndSaslauthdAuth:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 TerminateAndRemoveNodeMonkey:
   config_changes: false
@@ -1581,6 +1679,7 @@ TerminateAndRemoveNodeMonkey:
   sla: false
   supports_high_disk_utilization: false
   topology_changes: true
+  xcloud: false
   zero_node_changes: false
 TerminateKubernetesHostThenDecommissionAndAddScyllaNode:
   config_changes: false
@@ -1597,6 +1696,7 @@ TerminateKubernetesHostThenDecommissionAndAddScyllaNode:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 TerminateKubernetesHostThenReplaceScyllaNode:
   config_changes: false
@@ -1613,6 +1713,7 @@ TerminateKubernetesHostThenReplaceScyllaNode:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 ToggleAuditNemesisSyslog:
   config_changes: true
@@ -1629,6 +1730,7 @@ ToggleAuditNemesisSyslog:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 ToggleCDCMonkey:
   config_changes: true
@@ -1645,6 +1747,7 @@ ToggleCDCMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 ToggleGcModeMonkey:
   config_changes: false
@@ -1661,6 +1764,7 @@ ToggleGcModeMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 ToggleLdapConfiguration:
   config_changes: false
@@ -1677,6 +1781,7 @@ ToggleLdapConfiguration:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: false
   zero_node_changes: false
 ToggleTableIcsMonkey:
   config_changes: false
@@ -1693,6 +1798,7 @@ ToggleTableIcsMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 TopPartitions:
   config_changes: false
@@ -1709,6 +1815,7 @@ TopPartitions:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 TruncateLargeParititionMonkey:
   config_changes: false
@@ -1725,6 +1832,7 @@ TruncateLargeParititionMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 TruncateMonkey:
   config_changes: false
@@ -1741,6 +1849,7 @@ TruncateMonkey:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false
 ValidateHintedHandoffShortDowntime:
   config_changes: false
@@ -1757,4 +1866,5 @@ ValidateHintedHandoffShortDowntime:
   sla: false
   supports_high_disk_utilization: true
   topology_changes: false
+  xcloud: true
   zero_node_changes: false

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -245,6 +245,7 @@ class NemesisFlags:
     networking: bool = False  # flag that signal that nemesis interact with nemesis,
     # i.e switch off/on network interface, network issues
     kubernetes: bool = False  # flag that signal that nemesis run with k8s cluster
+    xcloud: bool = False  # flag that signal that nemesis can run with xcloud backend (Scylla Cloud)
     limited: bool = False  # flag that signal that nemesis are belong to limited set of nemesises
     schema_changes: bool = False
     config_changes: bool = False
@@ -6502,6 +6503,7 @@ class AddRemoveRackNemesis(NemesisBaseClass):
 class StopWaitStartMonkey(NemesisBaseClass):
     disruptive = True
     kubernetes = True
+    xcloud = True
     limited = True
     zero_node_changes = True
 
@@ -6513,6 +6515,7 @@ class StopWaitStartMonkey(NemesisBaseClass):
 class StopStartMonkey(NemesisBaseClass):
     disruptive = True
     kubernetes = True
+    xcloud = True
     limited = True
 
     def disrupt(self):
@@ -6588,6 +6591,7 @@ class HardRebootNodeMonkey(NemesisBaseClass):
 class SoftRebootNodeMonkey(NemesisBaseClass):
     disruptive = True
     kubernetes = True
+    xcloud = True
     limited = True
     free_tier_set = True
 
@@ -6617,6 +6621,7 @@ class CorruptThenRepairMonkey(NemesisBaseClass):
 class CorruptThenRebuildMonkey(NemesisBaseClass):
     disruptive = True
     kubernetes = True
+    xcloud = True
 
     def disrupt(self):
         self.runner.disrupt_destroy_data_then_rebuild()
@@ -6650,6 +6655,7 @@ class DecommissionSeedNode(NemesisBaseClass):
 class NoCorruptRepairMonkey(NemesisBaseClass):
     disruptive = False
     kubernetes = True
+    xcloud = True
     limited = True
 
     def disrupt(self):
@@ -6659,6 +6665,7 @@ class NoCorruptRepairMonkey(NemesisBaseClass):
 class MajorCompactionMonkey(NemesisBaseClass):
     disruptive = False
     kubernetes = True
+    xcloud = True
     limited = True
 
     def disrupt(self):
@@ -6706,6 +6713,7 @@ class RemoveServiceLevelMonkey(NemesisBaseClass):
 class EnospcMonkey(NemesisBaseClass):
     disruptive = True
     kubernetes = True
+    xcloud = True
     limited = True
     enospc = True
 
@@ -6717,6 +6725,7 @@ class EnospcMonkey(NemesisBaseClass):
 class EnospcAllNodesMonkey(NemesisBaseClass):
     disruptive = True
     kubernetes = True
+    xcloud = True
     enospc = True
 
     def disrupt(self):
@@ -6727,6 +6736,7 @@ class EnospcAllNodesMonkey(NemesisBaseClass):
 class NodeToolCleanupMonkey(NemesisBaseClass):
     disruptive = False
     kubernetes = True
+    xcloud = True
     limited = True
 
     def disrupt(self):
@@ -6736,6 +6746,7 @@ class NodeToolCleanupMonkey(NemesisBaseClass):
 class TruncateMonkey(NemesisBaseClass):
     disruptive = False
     kubernetes = True
+    xcloud = True
     limited = True
     free_tier_set = True
 
@@ -6746,6 +6757,7 @@ class TruncateMonkey(NemesisBaseClass):
 class TruncateLargeParititionMonkey(NemesisBaseClass):
     disruptive = False
     kubernetes = True
+    xcloud = True
     free_tier_set = True
 
     def disrupt(self):
@@ -6755,6 +6767,7 @@ class TruncateLargeParititionMonkey(NemesisBaseClass):
 class DeleteByPartitionsMonkey(NemesisBaseClass):
     disruptive = False
     kubernetes = True
+    xcloud = True
     free_tier_set = True
     delete_rows = True
 
@@ -6765,6 +6778,7 @@ class DeleteByPartitionsMonkey(NemesisBaseClass):
 class DeleteByRowsRangeMonkey(NemesisBaseClass):
     disruptive = False
     kubernetes = True
+    xcloud = True
     free_tier_set = True
     delete_rows = True
 
@@ -6775,6 +6789,7 @@ class DeleteByRowsRangeMonkey(NemesisBaseClass):
 class DeleteOverlappingRowRangesMonkey(NemesisBaseClass):
     disruptive = False
     kubernetes = True
+    xcloud = True
     free_tier_set = True
     delete_rows = True
 
@@ -6892,6 +6907,7 @@ class AddDropColumnMonkey(NemesisBaseClass):
     disruptive = False
     networking = False
     kubernetes = True
+    xcloud = True
     limited = True
     schema_changes = True
     free_tier_set = True
@@ -6902,6 +6918,7 @@ class AddDropColumnMonkey(NemesisBaseClass):
 
 class ToggleTableIcsMonkey(NemesisBaseClass):
     kubernetes = True
+    xcloud = True
     schema_changes = True
     free_tier_set = True
 
@@ -6911,6 +6928,7 @@ class ToggleTableIcsMonkey(NemesisBaseClass):
 
 class ToggleGcModeMonkey(NemesisBaseClass):
     kubernetes = True
+    xcloud = True
     disruptive = False
     schema_changes = True
     free_tier_set = True
@@ -6946,6 +6964,7 @@ class MgmtRestore(NemesisBaseClass):
     manager_operation = True
     disruptive = True
     kubernetes = True
+    xcloud = True
     limited = True
     supports_high_disk_utilization = False  # Snapshot/Restore operations consume disk space
 
@@ -7094,6 +7113,7 @@ class OperatorNodetoolFlushAndReshard(NemesisBaseClass):
 class ScyllaKillMonkey(NemesisBaseClass):
     disruptive = True
     kubernetes = True
+    xcloud = True
     free_tier_set = True
 
     def disrupt(self):
@@ -7104,6 +7124,7 @@ class ScyllaKillMonkey(NemesisBaseClass):
 class ValidateHintedHandoffShortDowntime(NemesisBaseClass):
     disruptive = True
     kubernetes = True
+    xcloud = True
     free_tier_set = True
 
     def disrupt(self):
@@ -7114,6 +7135,7 @@ class ValidateHintedHandoffShortDowntime(NemesisBaseClass):
 class SnapshotOperations(NemesisBaseClass):
     disruptive = False
     kubernetes = True
+    xcloud = True
     limited = True
 
     def disrupt(self):
@@ -7133,6 +7155,7 @@ class NodeRestartWithResharding(NemesisBaseClass):
 class ClusterRollingRestart(NemesisBaseClass):
     disruptive = True
     kubernetes = True
+    xcloud = True
     free_tier_set = True
 
     def disrupt(self):
@@ -7153,6 +7176,7 @@ class RollingRestartConfigChangeInternodeCompression(NemesisBaseClass):
 class ClusterRollingRestartRandomOrder(NemesisBaseClass):
     disruptive = True
     kubernetes = True
+    xcloud = True
     free_tier_set = True
 
     def disrupt(self):
@@ -7171,6 +7195,7 @@ class SwitchBetweenPasswordAuthAndSaslauthdAuth(NemesisBaseClass):
 class TopPartitions(NemesisBaseClass):
     disruptive = False
     kubernetes = True
+    xcloud = True
     limited = True
 
     def disrupt(self):
@@ -7533,6 +7558,7 @@ class BootstrapStreamingErrorNemesis(NemesisBaseClass):
 class DisableBinaryGossipExecuteMajorCompaction(NemesisBaseClass):
     disruptive = True
     kubernetes = True
+    xcloud = True
 
     def disrupt(self):
         self.runner.disrupt_disable_binary_gossip_execute_major_compaction()
@@ -7606,6 +7632,7 @@ class ModifyTableTwcsWindowSizeMonkey(NemesisBaseClass):
 
 class ModifyTableCommentMonkey(NemesisBaseClass):
     kubernetes = True
+    xcloud = True
     limited = True
     schema_changes = True
     free_tier_set = True
@@ -7617,6 +7644,7 @@ class ModifyTableCommentMonkey(NemesisBaseClass):
 
 class ModifyTableGcGraceTimeMonkey(NemesisBaseClass):
     kubernetes = True
+    xcloud = True
     limited = True
     schema_changes = True
     free_tier_set = True
@@ -7628,6 +7656,7 @@ class ModifyTableGcGraceTimeMonkey(NemesisBaseClass):
 
 class ModifyTableCachingMonkey(NemesisBaseClass):
     kubernetes = True
+    xcloud = True
     limited = True
     schema_changes = True
     free_tier_set = True
@@ -7639,6 +7668,7 @@ class ModifyTableCachingMonkey(NemesisBaseClass):
 
 class ModifyTableBloomFilterFpChanceMonkey(NemesisBaseClass):
     kubernetes = True
+    xcloud = True
     limited = True
     schema_changes = True
     free_tier_set = True
@@ -7650,6 +7680,7 @@ class ModifyTableBloomFilterFpChanceMonkey(NemesisBaseClass):
 
 class ModifyTableCompactionMonkey(NemesisBaseClass):
     kubernetes = True
+    xcloud = True
     limited = True
     schema_changes = True
     free_tier_set = True
@@ -7661,6 +7692,7 @@ class ModifyTableCompactionMonkey(NemesisBaseClass):
 
 class ModifyTableCompressionMonkey(NemesisBaseClass):
     kubernetes = True
+    xcloud = True
     limited = True
     schema_changes = True
     free_tier_set = True
@@ -7672,6 +7704,7 @@ class ModifyTableCompressionMonkey(NemesisBaseClass):
 
 class ModifyTableCrcCheckChanceMonkey(NemesisBaseClass):
     kubernetes = True
+    xcloud = True
     limited = True
     schema_changes = True
     free_tier_set = True
@@ -7683,6 +7716,7 @@ class ModifyTableCrcCheckChanceMonkey(NemesisBaseClass):
 
 class ModifyTableDclocalReadRepairChanceMonkey(NemesisBaseClass):
     kubernetes = True
+    xcloud = True
     limited = True
     schema_changes = True
     free_tier_set = True
@@ -7694,6 +7728,7 @@ class ModifyTableDclocalReadRepairChanceMonkey(NemesisBaseClass):
 
 class ModifyTableDefaultTimeToLiveMonkey(NemesisBaseClass):
     kubernetes = True
+    xcloud = True
     limited = True
     schema_changes = True
     free_tier_set = True
@@ -7705,6 +7740,7 @@ class ModifyTableDefaultTimeToLiveMonkey(NemesisBaseClass):
 
 class ModifyTableMaxIndexIntervalMonkey(NemesisBaseClass):
     kubernetes = True
+    xcloud = True
     limited = True
     schema_changes = True
     free_tier_set = True
@@ -7716,6 +7752,7 @@ class ModifyTableMaxIndexIntervalMonkey(NemesisBaseClass):
 
 class ModifyTableMinIndexIntervalMonkey(NemesisBaseClass):
     kubernetes = True
+    xcloud = True
     limited = True
     schema_changes = True
     free_tier_set = True
@@ -7727,6 +7764,7 @@ class ModifyTableMinIndexIntervalMonkey(NemesisBaseClass):
 
 class ModifyTableMemtableFlushPeriodInMsMonkey(NemesisBaseClass):
     kubernetes = True
+    xcloud = True
     limited = True
     schema_changes = True
     free_tier_set = True
@@ -7738,6 +7776,7 @@ class ModifyTableMemtableFlushPeriodInMsMonkey(NemesisBaseClass):
 
 class ModifyTableReadRepairChanceMonkey(NemesisBaseClass):
     kubernetes = True
+    xcloud = True
     limited = True
     schema_changes = True
     free_tier_set = True
@@ -7749,6 +7788,7 @@ class ModifyTableReadRepairChanceMonkey(NemesisBaseClass):
 
 class ModifyTableSpeculativeRetryMonkey(NemesisBaseClass):
     kubernetes = True
+    xcloud = True
     limited = True
     schema_changes = True
     free_tier_set = True

--- a/test-cases/longevity/longevity-scylla-cloud-5gb-1h.yaml
+++ b/test-cases/longevity/longevity-scylla-cloud-5gb-1h.yaml
@@ -18,7 +18,7 @@ gce_instance_type_db: 'n2-highmem-2'
 gce_instance_type_loader: 'e2-standard-2'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: "not disruptive and schema_changes"
+nemesis_selector: "not disruptive and xcloud"
 nemesis_seed: '111'
 nemesis_interval: 5
 


### PR DESCRIPTION
Add `xcloud` flag to NemesisFlags to indicate which nemeses are compatible with the xcloud backend. Nemesis selection is filtered by this flag when running on xcloud, similar to the existing kubernetes flag.

50 nemeses are marked as xcloud-compatible (tested with simple PR-provision-test config).
There are some number of Nemeses, which are not yet supported as they perform `follow_log`-like operations. And streaming of DB nodes logs to SCT runner at runtime is to be implemented for xcloud backend.

Additionally, a few Nemeses are not supported for xcloud backend:
- some require APIs which are not implemented in Scylla Cloud public API
- few require direct infrastructure access (e.g. adding extra network interfaces), which is not applicable for managed clusters
- few Management operations related nemeses require access to DB nodes port 10001, but VPC peering public API exposes only CQL port

Closes: SCT-52

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [example of one labeled nemesis (AddDropColumnMonkey) run](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/193/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
