### PR TITLE
SCYLLADB-295 feature(nemesis): add diagnostics collector and new test configs

### DIFF
--- a/docs/diagnostic_collector.md
+++ b/docs/diagnostic_collector.md
@@ -1,0 +1,202 @@
+# Diagnostic Collector
+
+This module provides a small, reusable framework for collecting and storing diagnostics data
+during any cluster operation or CQL command execution. Collection runs in a background thread,
+so the diagnostics are gathered periodically while the main code keeps doing its work.
+
+It was originally introduced to capture materialized view (MV) and secondary index (SI) build
+state, but it is intentionally generic: a collector can gather any data (system tables, metrics,
+files, etc.). Potential uses include SLA metrics and tracking tablet splits/merges during cluster
+operations.
+
+## Building Blocks
+
+- `DiagnosticCollector`: Abstract base class for collectors. Implement `collect()` / `store()`
+  (and optionally `clean()`).
+- `DiagnosticManager`: Owns a background worker thread that runs the collectors on a fixed
+  interval and keeps a `DiagnosticResult` per cycle. Performs one final collection before stopping
+  so the last interval is not lost. Exposes `is_running`/`is_healthy()`/`error` to monitor the
+  worker, and can be restarted after being stopped.
+- `collect_diagnostics(...)`: A generic context-manager helper — the recommended way to run
+  collectors. Works with any collector, so no per-collector wrapper is needed.
+- `ExceptionHandler`: Strategy-based handling of collect/store failures
+  (`ExceptionStrategy.CONTINUE` or `ExceptionStrategy.STOP`).
+- `MVDiagnosticCollector`: Built-in collector for MV/SI build diagnostics.
+
+## Recommended Usage: `collect_diagnostics`
+
+`collect_diagnostics` accepts one or more collectors and runs them in the background for the
+duration of the `with` block. This is the simplest and preferred entry point:
+
+```python
+from sdcm.utils.diagnostic_collector.manager import collect_diagnostics
+from sdcm.utils.diagnostic_collector.views import MVDiagnosticCollector
+
+# `session` is a Cassandra/Scylla session object.
+with collect_diagnostics(MVDiagnosticCollector(session)):
+    # Diagnostics are collected periodically while this block runs.
+    run_workload()
+```
+
+Multiple collectors and a custom interval are supported:
+
+```python
+with collect_diagnostics(MVDiagnosticCollector(session), MyCollector(session), interval=30.0):
+    run_workload()
+```
+
+The output directory defaults to the current test log directory (`TestConfig().logdir()`), so it
+does not need to be passed explicitly. Override it only when needed:
+
+```python
+MVDiagnosticCollector(session, dir_path="/tmp/sct-results")
+```
+
+## Advanced Usage
+
+### As a context manager
+
+When you need access to the manager object (for example, to read results afterwards), use
+`DiagnosticManager` directly:
+
+```python
+from sdcm.utils.diagnostic_collector import ExceptionHandler
+from sdcm.utils.diagnostic_collector.manager import DiagnosticManager
+from sdcm.utils.diagnostic_collector.views import MVDiagnosticCollector
+
+manager = DiagnosticManager(
+    collectors=[MVDiagnosticCollector(session, exception_handler=ExceptionHandler())],
+    interval=60.0,
+)
+
+with manager:
+    run_workload()
+
+# Access results after the manager stops.
+results = manager.get_results()
+```
+
+### With explicit start/stop
+
+```python
+from sdcm.utils.diagnostic_collector.manager import DiagnosticManager
+from sdcm.utils.diagnostic_collector.views import MVDiagnosticCollector
+
+manager = DiagnosticManager(collectors=[MVDiagnosticCollector(session)], interval=30.0)
+
+manager.start_collecting()
+try:
+    run_workload()
+finally:
+    manager.stop_collecting()
+
+results = manager.get_results()
+```
+
+### Reading collected results
+
+`DiagnosticManager` keeps an in-memory history of every collection cycle, in addition to whatever
+each collector persists in its own `store()`. The history is exposed through three methods:
+
+- `get_results()` — return a copy of the full history as a list of `DiagnosticResult` (one entry
+  per collector per cycle). Safe to call while collection is running.
+- `clear_results()` — drop the accumulated history (e.g. to start a fresh round before the next
+  workload).
+- `is_collecting` — `True` while a collection cycle is in progress.
+
+```python
+for result in manager.get_results():
+    print(result.collector_name, result.timestamp, result.collected, result.stored, result.error)
+    print(result.data)   # this cycle's snapshot — independent of every other cycle
+```
+
+Each cycle's `collect()` return value is recorded as an independent snapshot, so reading the
+history never shows data overwritten by a later cycle. `DiagnosticManager` owns its worker thread
+and creates a fresh one on each `start_collecting()`, so a stopped manager can simply be started
+again to run another round (you may also use a new `collect_diagnostics(...)` block).
+
+> **Memory note:** the in-memory history holds the full `collect()` snapshot for every cycle. It is
+> a bounded ring buffer (`max_history`, default `10_000`): once full, the oldest cycle is dropped
+> automatically so a long-running manager cannot grow memory without bound. For short-lived
+> `collect_diagnostics(...)` blocks the whole history is freed when the block exits. Pass
+> `max_history=None` for an unbounded history (and call `clear_results()` periodically yourself).
+> Each collector's on-disk `store()` output is independent of this in-memory history.
+
+## Adding a New Collector
+
+To collect a new kind of diagnostics, subclass `DiagnosticCollector` and implement the data
+collection and storage. No changes to `DiagnosticManager` or `collect_diagnostics` are required —
+just pass your new collector to `collect_diagnostics`.
+
+1. Subclass `DiagnosticCollector`.
+2. Implement `collect()` — gather and return the data for one cycle.
+3. Implement `store(result)` — persist the collected data (file, log, metric sink, ...).
+4. Optionally implement `clean()` — release resources when collection stops.
+5. Store output under `self.root_dir` (`diagnostics/`) so it gets picked up with the runner logs.
+
+> **Snapshot ownership:** `collect()` must return a **new** object each call, and `clean()` must
+> not mutate a value already returned by `collect()` (rebind internal state instead of clearing it
+> in place). The manager keeps every cycle's return value in its history, so sharing/clearing a
+> single object would corrupt previously recorded results.
+
+
+```python
+import json
+from datetime import datetime
+from pathlib import Path
+
+from sdcm.test_config import TestConfig
+from sdcm.utils.diagnostic_collector import DiagnosticCollector
+
+
+class MyCollector(DiagnosticCollector):
+    """Collect some custom diagnostics data."""
+
+    save_dir = Path("my_diagnostics")
+
+    def __init__(self, session, dir_path: str | None = None, name: str | None = None):
+        super().__init__(name)
+        self._session = session
+        self._dir = Path(dir_path or TestConfig().logdir()) / self.root_dir / self.save_dir
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._save_path = self._dir / f"{self.name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
+
+    def collect(self):
+        return list(self._session.execute("SELECT * FROM system.some_table"))
+
+    def store(self, result):
+        with open(self._save_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps({"timestamp": datetime.now().isoformat(), "data": result}, default=str) + "\n")
+
+    def clean(self):
+        # Optional: release resources here.
+        pass
+```
+
+Use it exactly like any other collector:
+
+```python
+with collect_diagnostics(MyCollector(session)):
+    run_workload()
+```
+
+## Error Handling
+
+`ExceptionHandler` decides what happens when a collector's `collect()` or `store()` raises. Each
+collector owns its own handler (dependency injection), so different collectors can use different
+policies, and a handler can be swapped at runtime via `collector.exception_handler = ...`:
+
+- `ExceptionStrategy.CONTINUE` (default): log the error and keep collecting on the next cycle.
+- `ExceptionStrategy.STOP`: stop the collection thread.
+
+Subclass `ExceptionHandler` and override `handle_exception_during_collecting` /
+`handle_exception_during_storing` to customize the behavior, then pass it to the collector via its
+`exception_handler` argument. A single handler instance may be shared across several collectors.
+
+## Notes
+
+- `DiagnosticManager` runs as a daemon thread and performs a final collection before stopping,
+  so the last interval is not lost.
+- `MVDiagnosticCollector` writes JSON lines to a timestamped log file under
+  `diagnostics/mv_si_diagnostics`.
+- Output written under `diagnostics/` is included in the SCT runner log artifacts.

--- a/docs/diagnostic_collector.md
+++ b/docs/diagnostic_collector.md
@@ -1,0 +1,224 @@
+# Diagnostic Collector
+
+This module provides a small, reusable framework for collecting and storing diagnostics data
+during any cluster operation or CQL command execution. Collection runs in a background thread,
+so the diagnostics are gathered periodically while the main code keeps doing its work.
+
+It was originally introduced to capture materialized view (MV) and secondary index (SI) build
+state, but it is intentionally generic: a collector can gather any data (system tables, metrics,
+files, etc.). Potential uses include SLA metrics and tracking tablet splits/merges during cluster
+operations.
+
+## Building Blocks
+
+- `DiagnosticCollector`: Abstract base class for collectors. Implement `collect()` / `store()`
+  (and optionally `clean()`).
+- `DiagnosticManager`: Owns a background worker thread that runs the collectors on a fixed
+  interval and keeps a `DiagnosticResult` per cycle. Performs one final collection before stopping
+  so the last interval is not lost. Exposes `is_running`/`is_healthy()`/`error` to monitor the
+  worker, and can be restarted after being stopped.
+- `collect_diagnostics(...)`: A generic context-manager helper — the recommended way to run
+  collectors. Works with any collector, so no per-collector wrapper is needed.
+- `ExceptionHandler`: Strategy-based handling of collect/store failures
+  (`ExceptionStrategy.CONTINUE` or `ExceptionStrategy.STOP`).
+- `MVDiagnosticCollector`: Built-in collector for MV/SI build diagnostics.
+
+## Recommended Usage: `collect_diagnostics`
+
+`collect_diagnostics` accepts one or more collectors and runs them in the background for the
+duration of the `with` block. This is the simplest and preferred entry point:
+
+```python
+from sdcm.utils.diagnostic_collector.manager import collect_diagnostics
+from sdcm.utils.diagnostic_collector.views import MVDiagnosticCollector
+
+# `session` is a Cassandra/Scylla session object.
+with collect_diagnostics(MVDiagnosticCollector(session)):
+    # Diagnostics are collected periodically while this block runs.
+    run_workload()
+```
+
+Multiple collectors and a custom interval are supported:
+
+```python
+with collect_diagnostics(MVDiagnosticCollector(session), MyCollector(session), interval=30.0):
+    run_workload()
+```
+
+The output directory defaults to the current test log directory (`TestConfig().logdir()`), so it
+does not need to be passed explicitly. Override it only when needed:
+
+```python
+MVDiagnosticCollector(session, dir_path="/tmp/sct-results")
+```
+
+## Advanced Usage
+
+### As a context manager
+
+When you need access to the manager object (for example, to read results afterwards), use
+`DiagnosticManager` directly:
+
+```python
+from sdcm.utils.diagnostic_collector import ExceptionHandler
+from sdcm.utils.diagnostic_collector.manager import DiagnosticManager
+from sdcm.utils.diagnostic_collector.views import MVDiagnosticCollector
+
+manager = DiagnosticManager(
+    collectors=[MVDiagnosticCollector(session, exception_handler=ExceptionHandler())],
+    interval=60.0,
+)
+
+with manager:
+    run_workload()
+
+# Access results after the manager stops.
+results = manager.get_results()
+```
+
+### With explicit start/stop
+
+```python
+from sdcm.utils.diagnostic_collector.manager import DiagnosticManager
+from sdcm.utils.diagnostic_collector.views import MVDiagnosticCollector
+
+manager = DiagnosticManager(collectors=[MVDiagnosticCollector(session)], interval=30.0)
+
+manager.start_collecting()
+try:
+    run_workload()
+finally:
+    manager.stop_collecting()
+
+results = manager.get_results()
+```
+
+### Reading collected results
+
+`DiagnosticManager` keeps an in-memory history of every collection cycle, in addition to whatever
+each collector persists in its own `store()`. The history is exposed through three methods:
+
+- `get_results()` — return a copy of the full history as a list of `DiagnosticResult` (one entry
+  per collector per cycle). Safe to call while collection is running.
+- `clear_results()` — drop the accumulated history (e.g. to start a fresh round before the next
+  workload).
+- `is_collecting` — `True` while a collection cycle is in progress.
+
+```python
+for result in manager.get_results():
+    print(result.collector_name, result.timestamp, result.collected, result.stored, result.error)
+    print(result.data)   # this cycle's snapshot — independent of every other cycle
+```
+
+Each cycle's `collect()` return value is recorded as an independent snapshot, so reading the
+history never shows data overwritten by a later cycle. `DiagnosticManager` owns its worker thread
+and creates a fresh one on each `start_collecting()`, so a stopped manager can simply be started
+again to run another round (you may also use a new `collect_diagnostics(...)` block).
+
+> **Memory note:** the in-memory history holds the full `collect()` snapshot for every cycle. It is
+> a bounded ring buffer (`max_history`, default `10_000`): once full, the oldest cycle is dropped
+> automatically so a long-running manager cannot grow memory without bound. For short-lived
+> `collect_diagnostics(...)` blocks the whole history is freed when the block exits. Pass
+> `max_history=None` for an unbounded history (and call `clear_results()` periodically yourself).
+> Each collector's on-disk `store()` output is independent of this in-memory history.
+
+## Adding a New Collector
+
+To collect a new kind of diagnostics, subclass `DiagnosticCollector` and implement the data
+collection and storage. No changes to `DiagnosticManager` or `collect_diagnostics` are required —
+just pass your new collector to `collect_diagnostics`.
+
+1. Subclass `DiagnosticCollector`.
+2. Implement `collect()` — gather and return the data for one cycle.
+3. Implement `store(result)` — persist the collected data (file, log, metric sink, ...).
+4. Optionally implement `clean()` — release resources when collection stops.
+5. Store output under `self.root_dir` (`diagnostics/`) so it gets picked up with the runner logs.
+
+> **Snapshot ownership:** `collect()` must return a **new** object each call, and `clean()` must
+> not mutate a value already returned by `collect()` (rebind internal state instead of clearing it
+> in place). The manager keeps every cycle's return value in its history, so sharing/clearing a
+> single object would corrupt previously recorded results.
+
+
+```python
+import json
+from datetime import datetime
+from pathlib import Path
+
+from sdcm.test_config import TestConfig
+from sdcm.utils.diagnostic_collector import DiagnosticCollector
+
+
+class MyCollector(DiagnosticCollector):
+    """Collect some custom diagnostics data."""
+
+    save_dir = Path("my_diagnostics")
+
+    def __init__(self, session, dir_path: str | None = None, name: str | None = None):
+        super().__init__(name)
+        self._session = session
+        self._dir = Path(dir_path or TestConfig().logdir()) / self.root_dir / self.save_dir
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._save_path = self._dir / f"{self.name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
+
+    def collect(self):
+        return list(self._session.execute("SELECT * FROM system.some_table"))
+
+    def store(self, result):
+        with open(self._save_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps({"timestamp": datetime.now().isoformat(), "data": result}, default=str) + "\n")
+
+    def clean(self):
+        # Optional: release resources here.
+        pass
+```
+
+Use it exactly like any other collector:
+
+```python
+with collect_diagnostics(MyCollector(session)):
+    run_workload()
+```
+
+## Error Handling
+
+`ExceptionHandler` decides what happens when a collector's `collect()` or `store()` raises. Each
+collector owns its own handler (dependency injection), so different collectors can use different
+policies, and a handler can be swapped at runtime via `collector.exception_handler = ...`:
+
+- `ExceptionStrategy.CONTINUE` (default): log the error and keep collecting on the next cycle.
+- `ExceptionStrategy.STOP`: stop the collection thread.
+
+Subclass `ExceptionHandler` and override `handle_exception_during_collecting` /
+`handle_exception_during_storing` to customize the behavior, then pass it to the collector via its
+`exception_handler` argument. A single handler instance may be shared across several collectors.
+
+### Reporting failures to Argus
+
+The default `ExceptionHandler` only logs, so a collector that fails for a whole run leaves no trace
+outside `sct.log`. Inside an SCT test, use `EventExceptionHandler` instead — it publishes each
+collect/store failure as a `TestFrameworkEvent`, so the failure is visible in Argus:
+
+```python
+from sdcm.utils.diagnostic_collector.handlers import EventExceptionHandler
+
+with collect_diagnostics(MVDiagnosticCollector(session, exception_handler=EventExceptionHandler())):
+    run_workload()
+```
+
+Severity defaults to `WARNING`, because diagnostics are best-effort and a transient failure while
+collecting must not fail an otherwise healthy run. Pass `severity=Severity.ERROR` for a collector
+whose data the test actually depends on, and `strategy=ExceptionStrategy.STOP` to halt collection on
+the first failure.
+
+`EventExceptionHandler` lives in its own module so that the generic layer keeps no dependency on the
+SCT event bus; it degrades to plain logging when no events device is running, so it is safe to use
+outside a running test.
+
+## Notes
+
+- `DiagnosticManager` runs as a daemon thread and performs a final collection before stopping,
+  so the last interval is not lost.
+- `MVDiagnosticCollector` writes JSON lines to a timestamped log file under
+  `diagnostics/mv_si_diagnostics`.
+- Output written under `diagnostics/` is included in the SCT runner log artifacts.

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1598,6 +1598,24 @@ class SSLConfCollector(BaseSCTLogCollector):
     cluster_log_type = "ssl-conf"
 
 
+class DiagnosticsLogCollector(BaseSCTLogCollector):
+    log_entities = [
+        DirLog(name="diagnostics/*", search_locally=True),
+    ]
+    cluster_log_type = "diagnostics"
+
+    def collect_logs(self, local_search_path: Optional[str] = None) -> list[str]:
+        # Diagnostics artifacts are optional - they are produced only when a diagnostics collector
+        # (e.g. MV/SI collector) runs during the test. Unlike other BaseSCTLogCollector subclasses,
+        # absence of these files is not a failure, so don't raise when nothing was collected.
+        for ent in self.log_entities:
+            ent.collect(None, self.local_dir, None, local_search_path=local_search_path)
+        if not os.listdir(self.local_dir):
+            LOGGER.debug("No diagnostics artifacts found - nothing to collect for %s", self.cluster_log_type)
+            return []
+        return self.create_archive_and_upload()
+
+
 class Collector:
     """Collector instance
 
@@ -1654,6 +1672,7 @@ class Collector:
             VectorStoreLogCollector: self.vector_store_set,
             SSTablesCollector: self.db_cluster,
             JepsenLogCollector: self.loader_set,
+            DiagnosticsLogCollector: self.sct_set,
         }
         if self.params.get("server_encrypt") or self.params.get("client_encrypt"):
             self.cluster_log_collectors[SSLConfCollector] = self.sct_set

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1585,6 +1585,24 @@ class SSLConfCollector(BaseSCTLogCollector):
     cluster_log_type = "ssl-conf"
 
 
+class DiagnosticsLogCollector(BaseSCTLogCollector):
+    log_entities = [
+        DirLog(name="diagnostics/*", search_locally=True),
+    ]
+    cluster_log_type = "diagnostics"
+
+    def collect_logs(self, local_search_path: Optional[str] = None) -> list[str]:
+        # Diagnostics artifacts are optional - they are produced only when a diagnostics collector
+        # (e.g. MV/SI collector) runs during the test. Unlike other BaseSCTLogCollector subclasses,
+        # absence of these files is not a failure, so don't raise when nothing was collected.
+        for ent in self.log_entities:
+            ent.collect(None, self.local_dir, None, local_search_path=local_search_path)
+        if not os.listdir(self.local_dir):
+            LOGGER.debug("No diagnostics artifacts found - nothing to collect for %s", self.cluster_log_type)
+            return []
+        return self.create_archive_and_upload()
+
+
 class Collector:
     """Collector instance
 
@@ -1641,6 +1659,7 @@ class Collector:
             VectorStoreLogCollector: self.vector_store_set,
             SSTablesCollector: self.db_cluster,
             JepsenLogCollector: self.loader_set,
+            DiagnosticsLogCollector: self.sct_set,
         }
         if self.params.get("server_encrypt") or self.params.get("client_encrypt"):
             self.cluster_log_collectors[SSLConfCollector] = self.sct_set

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -193,6 +193,8 @@ from test_lib.compaction import (
 from test_lib.cql_types import CQLTypeBuilder
 from test_lib.sla import ServiceLevel, MAX_ALLOWED_SERVICE_LEVELS
 from sdcm.utils.topology_ops import FailedDecommissionOperationMonitoring
+from sdcm.utils.diagnostic_collector.manager import collect_diagnostics
+from sdcm.utils.diagnostic_collector.views import MVDiagnosticCollector
 
 if TYPE_CHECKING:
     from sdcm.audit import AuditStore
@@ -4680,7 +4682,10 @@ class NemesisRunner:
             if ComparableScyllaVersion(self.target_node.scylla_version) <= ComparableScyllaVersion("2025.3.99"):
                 raise UnsupportedNemesis("MV/SI for tablets are not supported for Scylla 2025.3 and older versions")
 
-        with self.cluster.cql_connection_patient(self.target_node, connect_timeout=300) as session:
+        with (
+            self.cluster.cql_connection_patient(self.target_node, connect_timeout=300) as session,
+            collect_diagnostics(MVDiagnosticCollector(session)),
+        ):
             ks_cf_list = self.cluster.get_non_system_ks_cf_list(self.target_node, filter_out_mv=True)
             if not ks_cf_list:
                 raise UnsupportedNemesis("No table found to create index on")
@@ -4754,7 +4759,10 @@ class NemesisRunner:
             view_name = f"{base_table_name}_view"
             with suppress_expected_unavailability_errors():
                 self.target_node.stop_scylla()
-            with self.cluster.cql_connection_patient(node=cql_query_executor_node, connect_timeout=600) as session:
+            with (
+                self.cluster.cql_connection_patient(node=cql_query_executor_node, connect_timeout=600) as session,
+                collect_diagnostics(MVDiagnosticCollector(session)),
+            ):
                 try:
                     create_materialized_view_for_random_column(session, ks_name, base_table_name, view_name)
                 except Exception as error:
@@ -5259,23 +5267,26 @@ class NemesisRunner:
         except NemesisNodeAllocationError:
             raise UnsupportedNemesis(f"Coordinator node is busy with {coordinator_node.running_nemesis}")
 
-        with self.node_allocator.run_nemesis(
-            node_list=self.cluster.nodes, nemesis_label="Verification node for MV"
-        ) as working_node:
+        with (
+            self.node_allocator.run_nemesis(
+                node_list=self.cluster.nodes, nemesis_label="Verification node for MV"
+            ) as working_node,
+            self.cluster.cql_connection_patient(node=working_node, connect_timeout=600) as session,
+            collect_diagnostics(MVDiagnosticCollector(session)),
+        ):
             ks_name, base_table_name = self.random.choice(ks_cfs).split(".")
             view_name = f"{base_table_name}_view_{str(uuid4())[:8]}"
-            with self.cluster.cql_connection_patient(node=working_node, connect_timeout=600) as session:
-                try:
-                    create_materialized_view_for_random_column(session, ks_name, base_table_name, view_name)
-                    wait_materialized_view_building_tasks_started(session, ks_name, view_name)
-                except ViewFinishedBuildingException:
-                    drop_materialized_view(session, ks_name, view_name)
-                    raise UnsupportedNemesis(
-                        f"Skip nemesis because view {ks_name}.{view_name} has already finished building"
-                    )
-                except Exception as error:  # pylint: disable=broad-except
-                    self.log.error("Failed creating a materialized view: %s", error)
-                    raise
+            try:
+                create_materialized_view_for_random_column(session, ks_name, base_table_name, view_name)
+                wait_materialized_view_building_tasks_started(session, ks_name, view_name)
+            except ViewFinishedBuildingException:
+                drop_materialized_view(session, ks_name, view_name)
+                raise UnsupportedNemesis(
+                    f"Skip nemesis because view {ks_name}.{view_name} has already finished building"
+                )
+            except Exception as error:  # pylint: disable=broad-except
+                self.log.error("Failed creating a materialized view: %s", error)
+                raise
             try:
                 num_of_restarts = len(self.cluster.nodes) // 2
                 self.log.debug("Number of serial restart of topology coordinator: %s", num_of_restarts)
@@ -5297,14 +5308,12 @@ class NemesisRunner:
                 with adaptive_timeout(operation=Operations.CREATE_MV, node=working_node, timeout=14400) as timeout:
                     wait_for_view_to_be_built(working_node, ks_name, view_name, timeout=timeout * 2)
 
-                with self.cluster.cql_connection_patient(node=working_node, connect_timeout=600) as session:
-                    result = list(
-                        session.execute(SimpleStatement(f"SELECT * FROM {ks_name}.{view_name} limit 1", fetch_size=10))
-                    )
-                    assert len(result) >= 1, f"MV {ks_name}.{view_name} was not built"
+                result = list(
+                    session.execute(SimpleStatement(f"SELECT * FROM {ks_name}.{view_name} limit 1", fetch_size=10))
+                )
+                assert len(result) >= 1, f"MV {ks_name}.{view_name} was not built"
             finally:
-                with self.cluster.cql_connection_patient(node=working_node, connect_timeout=600) as session:
-                    drop_materialized_view(session, ks_name, view_name)
+                drop_materialized_view(session, ks_name, view_name)
 
     def disrupt_trigger_split_merge_tablets_with_alter(self):
         """

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -189,6 +189,9 @@ from test_lib.compaction import (
 )
 from test_lib.cql_types import CQLTypeBuilder
 from sdcm.utils.topology_ops import FailedDecommissionOperationMonitoring
+from sdcm.utils.diagnostic_collector.handlers import EventExceptionHandler
+from sdcm.utils.diagnostic_collector.manager import collect_diagnostics
+from sdcm.utils.diagnostic_collector.views import MVDiagnosticCollector
 
 if TYPE_CHECKING:
     from sdcm.audit import AuditStore
@@ -4543,7 +4546,10 @@ class NemesisRunner:
             if ComparableScyllaVersion(self.target_node.scylla_version) <= ComparableScyllaVersion("2025.3.99"):
                 raise UnsupportedNemesis("MV/SI for tablets are not supported for Scylla 2025.3 and older versions")
 
-        with self.cluster.cql_connection_patient(self.target_node, connect_timeout=300) as session:
+        with (
+            self.cluster.cql_connection_patient(self.target_node, connect_timeout=300) as session,
+            collect_diagnostics(MVDiagnosticCollector(session, exception_handler=EventExceptionHandler())),
+        ):
             ks_cf_list = self.cluster.get_non_system_ks_cf_list(self.target_node, filter_out_mv=True)
             if not ks_cf_list:
                 raise UnsupportedNemesis("No table found to create index on")
@@ -4617,7 +4623,10 @@ class NemesisRunner:
             view_name = f"{base_table_name}_view"
             with suppress_expected_unavailability_errors():
                 self.target_node.stop_scylla()
-            with self.cluster.cql_connection_patient(node=cql_query_executor_node, connect_timeout=600) as session:
+            with (
+                self.cluster.cql_connection_patient(node=cql_query_executor_node, connect_timeout=600) as session,
+                collect_diagnostics(MVDiagnosticCollector(session, exception_handler=EventExceptionHandler())),
+            ):
                 try:
                     create_materialized_view_for_random_column(session, ks_name, base_table_name, view_name)
                 except Exception as error:
@@ -5122,23 +5131,26 @@ class NemesisRunner:
         except NemesisNodeAllocationError:
             raise UnsupportedNemesis(f"Coordinator node is busy with {coordinator_node.running_nemesis}")
 
-        with self.node_allocator.run_nemesis(
-            node_list=self.cluster.nodes, nemesis_label="Verification node for MV"
-        ) as working_node:
+        with (
+            self.node_allocator.run_nemesis(
+                node_list=self.cluster.nodes, nemesis_label="Verification node for MV"
+            ) as working_node,
+            self.cluster.cql_connection_patient(node=working_node, connect_timeout=600) as session,
+            collect_diagnostics(MVDiagnosticCollector(session, exception_handler=EventExceptionHandler())),
+        ):
             ks_name, base_table_name = self.random.choice(ks_cfs).split(".")
             view_name = f"{base_table_name}_view_{str(uuid4())[:8]}"
-            with self.cluster.cql_connection_patient(node=working_node, connect_timeout=600) as session:
-                try:
-                    create_materialized_view_for_random_column(session, ks_name, base_table_name, view_name)
-                    wait_materialized_view_building_tasks_started(session, ks_name, view_name)
-                except ViewFinishedBuildingException:
-                    drop_materialized_view(session, ks_name, view_name)
-                    raise UnsupportedNemesis(
-                        f"Skip nemesis because view {ks_name}.{view_name} has already finished building"
-                    )
-                except Exception as error:  # pylint: disable=broad-except
-                    self.log.error("Failed creating a materialized view: %s", error)
-                    raise
+            try:
+                create_materialized_view_for_random_column(session, ks_name, base_table_name, view_name)
+                wait_materialized_view_building_tasks_started(session, ks_name, view_name)
+            except ViewFinishedBuildingException:
+                drop_materialized_view(session, ks_name, view_name)
+                raise UnsupportedNemesis(
+                    f"Skip nemesis because view {ks_name}.{view_name} has already finished building"
+                )
+            except Exception as error:  # pylint: disable=broad-except
+                self.log.error("Failed creating a materialized view: %s", error)
+                raise
             try:
                 num_of_restarts = len(self.cluster.nodes) // 2
                 self.log.debug("Number of serial restart of topology coordinator: %s", num_of_restarts)
@@ -5160,14 +5172,12 @@ class NemesisRunner:
                 with adaptive_timeout(operation=Operations.CREATE_MV, node=working_node, timeout=14400) as timeout:
                     wait_for_view_to_be_built(working_node, ks_name, view_name, timeout=timeout * 2)
 
-                with self.cluster.cql_connection_patient(node=working_node, connect_timeout=600) as session:
-                    result = list(
-                        session.execute(SimpleStatement(f"SELECT * FROM {ks_name}.{view_name} limit 1", fetch_size=10))
-                    )
-                    assert len(result) >= 1, f"MV {ks_name}.{view_name} was not built"
+                result = list(
+                    session.execute(SimpleStatement(f"SELECT * FROM {ks_name}.{view_name} limit 1", fetch_size=10))
+                )
+                assert len(result) >= 1, f"MV {ks_name}.{view_name} was not built"
             finally:
-                with self.cluster.cql_connection_patient(node=working_node, connect_timeout=600) as session:
-                    drop_materialized_view(session, ks_name, view_name)
+                drop_materialized_view(session, ks_name, view_name)
 
     def disrupt_trigger_split_merge_tablets_with_alter(self):
         """

--- a/sdcm/utils/diagnostic_collector/__init__.py
+++ b/sdcm/utils/diagnostic_collector/__init__.py
@@ -1,0 +1,79 @@
+import logging
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+from enum import StrEnum
+
+LOGGER = logging.getLogger(__name__)
+
+__all__ = [
+    "DiagnosticCollector",
+    "ExceptionHandler",
+    "ExceptionStrategy",
+    "DiagnosticException",
+]
+
+
+class ExceptionStrategy(StrEnum):
+    """Strategy for handling exceptions during diagnostics collection."""
+
+    CONTINUE = "continue"  # Continue collecting diagnostics even if an exception occurs
+    STOP = "stop"  # Stop collecting diagnostics if an exception occurs
+
+
+class DiagnosticException(Exception):
+    """Base exception for diagnostic collection errors."""
+
+
+class ExceptionHandler:
+    """Handles exceptions that occur during diagnostics operations.
+
+    A handler is a reusable strategy object: a single instance can be shared by several collectors,
+    or each collector can own its own. It is injected into a :class:`DiagnosticCollector` and can be
+    swapped at runtime (``collector.exception_handler = OtherHandler()``) to change failure policy on
+    the fly. The manager always reads the handler from the failing collector, so each collector can
+    independently decide whether to ``CONTINUE`` (skip itself) or ``STOP`` (halt the whole run).
+    """
+
+    def handle_exception_during_collecting(
+        self, collector: "DiagnosticCollector", exception: Exception
+    ) -> ExceptionStrategy:
+        """Handle exceptions that occur during diagnostics collecting stage."""
+        LOGGER.error("Exception occurred in collector '%s': %s", collector.name, exception)
+        return ExceptionStrategy.CONTINUE
+
+    def handle_exception_during_storing(
+        self, collector: "DiagnosticCollector", exception: Exception
+    ) -> ExceptionStrategy:
+        """Handle exceptions that occur during diagnostics storing stage."""
+        LOGGER.error("Exception occurred while storing diagnostics for collector '%s': %s", collector.name, exception)
+        return ExceptionStrategy.CONTINUE
+
+
+class DiagnosticCollector(ABC):
+    """Abstract base class for diagnostic collectors.
+
+    Each collector owns its own :class:`ExceptionHandler` (dependency injection), so the failure
+    policy lives next to the collector it governs and can be customized or swapped per collector,
+    including at runtime.
+    """
+
+    root_dir = Path("diagnostics")
+
+    def __init__(self, name: str | None = None, exception_handler: ExceptionHandler | None = None):
+        self.name = name or self.__class__.__name__
+        # Per-collector strategy object; defaults to the CONTINUE-everything handler. Reassign at
+        # runtime to change how this collector's collect/store failures are handled.
+        self.exception_handler = exception_handler or ExceptionHandler()
+
+    @abstractmethod
+    def collect(self) -> Any:
+        """Collect diagnostics data. Must be implemented by subclasses."""
+
+    @abstractmethod
+    def store(self, result: Any):
+        """Store the collected diagnostics data. Must be implemented by subclasses."""
+
+    def clean(self):
+        """Clean up any resources used by the collector. Optional to implement."""

--- a/sdcm/utils/diagnostic_collector/handlers.py
+++ b/sdcm/utils/diagnostic_collector/handlers.py
@@ -1,0 +1,60 @@
+import logging
+
+from sdcm.sct_events import Severity
+from sdcm.sct_events.system import TestFrameworkEvent
+from sdcm.utils.diagnostic_collector import DiagnosticCollector, ExceptionHandler, ExceptionStrategy
+
+LOGGER = logging.getLogger(__name__)
+
+__all__ = [
+    "EventExceptionHandler",
+]
+
+
+class EventExceptionHandler(ExceptionHandler):
+    """Publish collector failures as SCT events so they are visible in Argus, not only in sct.log.
+
+    The default :class:`ExceptionHandler` only logs, which means a collector that fails for a whole
+    run leaves no trace outside ``sct.log``. This handler is the opt-in alternative: pass it to a
+    collector that runs inside an SCT test and its failures become ``TestFrameworkEvent``s.
+
+    It lives here rather than in the manager so the generic diagnostics layer
+    (:mod:`sdcm.utils.diagnostic_collector` and :mod:`sdcm.utils.diagnostic_collector.manager`)
+    keeps no dependency on the SCT event bus, and so unit tests need no event device.
+
+    Severity defaults to ``WARNING``: diagnostics are best-effort, and a transient CQL failure while
+    collecting must not fail an otherwise healthy test run. Pass ``severity=Severity.ERROR`` for a
+    collector whose data the test actually depends on.
+    """
+
+    def __init__(
+        self,
+        severity: Severity = Severity.WARNING,
+        strategy: ExceptionStrategy = ExceptionStrategy.CONTINUE,
+    ):
+        self.severity = severity
+        self.strategy = strategy
+
+    def _publish(self, collector: DiagnosticCollector, exception: Exception, stage: str) -> ExceptionStrategy:
+        # publish_or_dump() falls back to plain logging when no events device is running, so the
+        # same handler works inside a test, in unit tests and in any non-SCT consumer.
+        TestFrameworkEvent(
+            source=collector.name,
+            source_method=f"diagnostics.{stage}",
+            message=f"Diagnostics collector '{collector.name}' failed during {stage}",
+            exception=exception,
+            severity=self.severity,
+        ).publish_or_dump(default_logger=LOGGER)
+        return self.strategy
+
+    def handle_exception_during_collecting(
+        self, collector: DiagnosticCollector, exception: Exception
+    ) -> ExceptionStrategy:
+        """Publish an event for a failure in the collecting stage."""
+        return self._publish(collector, exception, "collect")
+
+    def handle_exception_during_storing(
+        self, collector: DiagnosticCollector, exception: Exception
+    ) -> ExceptionStrategy:
+        """Publish an event for a failure in the storing stage."""
+        return self._publish(collector, exception, "store")

--- a/sdcm/utils/diagnostic_collector/manager.py
+++ b/sdcm/utils/diagnostic_collector/manager.py
@@ -1,0 +1,264 @@
+import contextlib
+import logging
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime
+from threading import Event, Lock, Thread
+from typing import Any, Iterator, Sequence
+
+from sdcm.utils.diagnostic_collector import DiagnosticCollector, ExceptionStrategy
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class DiagnosticResult:
+    """Container for Diagnostic results."""
+
+    collector_name: str
+    timestamp: datetime
+    data: Any
+    collected: bool
+    stored: bool
+    error: Exception | None = None
+
+
+class DiagnosticManager:
+    """Manages the collection and storage of diagnostics data from multiple collectors.
+
+    The manager owns an internal worker thread (composition) instead of subclassing ``Thread``.
+    This allows the manager to be started again after it was stopped, and lets it monitor the
+    worker's execution: liveness via :attr:`is_running` and crash detection via :attr:`error`.
+
+    Each collector carries its own :class:`ExceptionHandler`, so the manager dispatches failure
+    handling through the failing collector (``collector.exception_handler``). This lets every
+    collector use a different, runtime-swappable policy.
+
+    The in-memory history is a bounded ring buffer (:attr:`max_history`): once full, the oldest
+    cycle is dropped automatically so a long-running manager cannot grow memory without bound. Pass
+    ``max_history=None`` for an unbounded history (and manage :meth:`clear_results` yourself).
+    """
+
+    def __init__(
+        self,
+        collectors: Sequence[DiagnosticCollector],
+        interval: float = 60.0,
+        name: str = "DiagnosticManager",
+        max_history: int | None = 10_000,
+    ):
+        self._collectors = collectors
+        self._interval = interval
+        self._name = name
+        self._stop_event = Event()
+        # Bounded ring buffer: once full, the oldest cycle is dropped automatically so a
+        # long-running manager cannot grow memory without bound. Pass max_history=None for an
+        # unbounded history (legacy behavior) when the caller manages clear_results() itself.
+        self._results: deque[DiagnosticResult] = deque(maxlen=max_history)
+        self._results_lock = Lock()
+        self._is_collecting = Event()
+        self._thread: Thread | None = None
+        self._lifecycle_lock = Lock()
+        self._thread_error: BaseException | None = None
+
+    @property
+    def is_collecting(self) -> bool:
+        """True while a single collection cycle is in progress."""
+        return self._is_collecting.is_set()
+
+    @property
+    def is_running(self) -> bool:
+        """True while the background worker thread is alive."""
+        return self._thread is not None and self._thread.is_alive()
+
+    @property
+    def error(self) -> BaseException | None:
+        """The exception that crashed the worker thread, if any (else ``None``)."""
+        return self._thread_error
+
+    def is_healthy(self) -> bool:
+        """True if the worker is running and has not crashed."""
+        return self.is_running and self._thread_error is None
+
+    def _thread_main(self):
+        """Top-level body of the owned thread: run the loop and record any crash."""
+        try:
+            self._run()
+        except BaseException as e:  # noqa: BLE001  # monitor crashes, then re-expose on stop
+            self._thread_error = e
+            LOGGER.exception("Diagnostics worker thread '%s' crashed: %s", self._name, e)
+        finally:
+            self._is_collecting.clear()
+
+    def _run(self):
+        LOGGER.debug("Starting collect diagnostics data every %s seconds", self._interval)
+        while not self._stop_event.is_set():
+            LOGGER.debug("Waiting for next collection interval...")
+            if self._stop_event.wait(self._interval):
+                break
+            self._collecting_diagnostics()
+
+        # Perform final collection before stopping to avoid missing diagnostics. The stop event is
+        # already set at this point, so force the cycle to run instead of aborting at the guard.
+        LOGGER.debug("Performing final diagnostics collection before stopping.")
+        self._collecting_diagnostics(final=True)
+        LOGGER.debug("Diagnostic collection thread stopped.")
+
+    def _record_result(
+        self, collector: DiagnosticCollector, data: Any, collected: bool, stored: bool, error: Exception | None
+    ):
+        """Append a DiagnosticResult to the history in a thread-safe way."""
+        result = DiagnosticResult(
+            collector_name=collector.name,
+            timestamp=datetime.now(),
+            data=data,
+            collected=collected,
+            stored=stored,
+            error=error,
+        )
+        with self._results_lock:
+            self._results.append(result)
+
+    def _collecting_diagnostics(self, final: bool = False):
+        """Collect diagnostics data from all collectors.
+
+        Args:
+            final: When True this is the final collection performed on stop. The stop event is
+                already set by then, so the per-collector stop guard is skipped to ensure the
+                cycle actually runs.
+        """
+        self._is_collecting.set()
+        LOGGER.debug("Starting diagnostics collection from %d collectors", len(self._collectors))
+        for collector in self._collectors:
+            if not final and self._stop_event.is_set():
+                LOGGER.debug("Stopping diagnostics collection due to stop event.")
+                break
+            collected = stored = True
+            data = None
+            error = None
+            try:
+                LOGGER.debug("Collecting diagnostics from collector '%s'", collector.name)
+                data = collector.collect()
+            except Exception as e:  # noqa: BLE001
+                strategy = collector.exception_handler.handle_exception_during_collecting(collector, e)
+                # Always record the failed cycle so callers can see which collector failed and why
+                # instead of silently dropping it from get_results().
+                self._record_result(collector, data=None, collected=False, stored=False, error=e)
+                if strategy == ExceptionStrategy.STOP:
+                    LOGGER.debug("Stopping diagnostics collection due to exception during collecting.")
+                    self._stop_event.set()
+                    break
+                continue
+
+            stop_after_store = False
+            try:
+                LOGGER.debug("Storing diagnostics for collector '%s'", collector.name)
+                collector.store(data)
+            except Exception as e:  # noqa: BLE001
+                strategy = collector.exception_handler.handle_exception_during_storing(collector, e)
+                error = e
+                stored = False
+                if strategy == ExceptionStrategy.STOP:
+                    LOGGER.debug("Stopping diagnostics storing due to exception during storing.")
+                    self._stop_event.set()
+                    stop_after_store = True
+
+            self._record_result(collector, data=data, collected=collected, stored=stored, error=error)
+            if stop_after_store:
+                break
+
+        self._is_collecting.clear()
+        LOGGER.debug("Finished diagnostics collection cycle.")
+
+    def start_collecting(self):
+        """Start (or restart) the background collection thread.
+
+        A brand-new ``Thread`` is created on each start, so a manager that was previously stopped
+        can be started again without the ``RuntimeError: threads can only be started once`` that a
+        ``Thread`` subclass would raise.
+
+        The check-and-create is serialized by ``_lifecycle_lock`` so concurrent callers can never
+        spawn more than one worker thread.
+        """
+        with self._lifecycle_lock:
+            if self.is_running:
+                LOGGER.debug("Diagnostics collection already running; ignoring start request.")
+                return
+            LOGGER.debug("Starting diagnostics collection thread.")
+            self._stop_event.clear()
+            self._thread_error = None
+            self._thread = Thread(target=self._thread_main, name=self._name, daemon=True)
+            self._thread.start()
+
+    def stop_collecting(self, timeout: float | None = None):
+        """Stop the worker, run collector cleanup, and surface a crashed worker.
+
+        Serialized by ``_lifecycle_lock`` so it cannot race with a concurrent ``start_collecting()``.
+
+        Args:
+            timeout: Optional maximum number of seconds to wait for the worker thread to stop.
+                If it does not stop in time, an error is logged and collector cleanup is skipped
+                (cleaning collectors while the worker may still be running would race with it)
+                instead of blocking forever.
+
+        Raises:
+            RuntimeError: If the worker thread crashed with an unexpected exception.
+        """
+        with self._lifecycle_lock:
+            LOGGER.debug("Stopping diagnostics collection thread.")
+            self._stop_event.set()
+            if self._thread is not None and self._thread.is_alive():
+                self._thread.join(timeout=timeout)
+            self._is_collecting.clear()
+            if self._thread is not None and self._thread.is_alive():
+                LOGGER.error(
+                    "Diagnostics worker thread '%s' did not stop within %s seconds. Skipping collectors cleanup",
+                    self._name,
+                    timeout,
+                )
+            else:
+                for collector in self._collectors:
+                    try:
+                        collector.clean()
+                    except Exception as e:  # noqa: BLE001
+                        LOGGER.error("Exception occurred while cleaning collector '%s': %s", collector.name, e)
+
+            # Monitoring: re-raise an unexpected worker crash so callers are not left unaware.
+            if self._thread_error is not None:
+                raise RuntimeError("Diagnostics worker thread crashed") from self._thread_error
+
+    def get_results(self) -> list[DiagnosticResult]:
+        """Get the collected diagnostics results."""
+        with self._results_lock:
+            return list(self._results)
+
+    def clear_results(self):
+        """Clear the collected diagnostics results."""
+        with self._results_lock:
+            self._results.clear()
+
+    def __enter__(self) -> DiagnosticManager:
+        self.start_collecting()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Exit context manager and stop collecting diagnostics."""
+        self.stop_collecting()
+        if exc_type is not None:
+            LOGGER.error(
+                "Exception occurred in DiagnosticManager context: %s", exc_val, exc_info=(exc_type, exc_val, exc_tb)
+            )
+
+
+@contextlib.contextmanager
+def collect_diagnostics(*collectors: DiagnosticCollector, interval: float = 60.0) -> Iterator[DiagnosticManager]:
+    """Run the given diagnostic collectors in the background for the duration of the ``with`` block.
+
+    Generic helper that works with any ``DiagnosticCollector``, so no per-collector facade is needed.
+
+    Example:
+        with collect_diagnostics(MVDiagnosticCollector(session)):
+            ...
+    """
+    with DiagnosticManager(collectors, interval=interval) as manager:
+        yield manager

--- a/sdcm/utils/diagnostic_collector/views.py
+++ b/sdcm/utils/diagnostic_collector/views.py
@@ -1,0 +1,81 @@
+import logging
+import json
+
+
+from datetime import datetime
+from typing import Any
+from pathlib import Path
+
+from sdcm.test_config import TestConfig
+from sdcm.utils.diagnostic_collector import DiagnosticCollector, ExceptionHandler
+
+LOGGER = logging.getLogger(__name__)
+
+
+class MVDiagnosticCollector(DiagnosticCollector):
+    """Collect diagnostics data for Materialized Views and Secondary Indexes."""
+
+    queries = [
+        "SELECT count(*) FROM system.view_building_tasks",
+        "SELECT * FROM system.view_building_tasks",
+        "SELECT * from system.view_build_status_v2",
+        "SELECT * FROM system.views_builds_in_progress",
+    ]
+
+    save_dir = Path("mv_si_diagnostics")
+
+    def __init__(
+        self,
+        session,
+        dir_path: str | None = None,
+        name: str | None = None,
+        exception_handler: ExceptionHandler | None = None,
+    ):
+        super().__init__(name, exception_handler=exception_handler)
+        self._session = session
+        self._results: dict[str, Any] = {}
+        self._dir = Path(dir_path or TestConfig().logdir()) / super().root_dir / self.save_dir
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._save_path = self._dir / f"{self.name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
+
+    def collect(self) -> Any:
+        """Collect MV and SI diagnostics data."""
+        results: dict[str, Any] = {}
+        for query in self.queries:
+            result = self._execute_query(query)
+            results[query] = list(result)
+        # Keep a reference to the latest snapshot for the store() fallback, but return a fresh
+        # dict so each recorded DiagnosticResult.data is independent and not overwritten next cycle.
+        self._results = results
+        return results
+
+    def store(self, result: Any):
+        """Store MV and SI diagnostics data."""
+        # Only fall back to the last snapshot when the manager passed nothing; an empty-but-valid
+        # mapping is a legitimate result and must not silently reuse a previous snapshot.
+        if result is None:
+            result = self._results
+
+        timestamp = datetime.now().isoformat()
+        try:
+            with open(self._save_path, "a", encoding="utf-8") as f:
+                for query, data in result.items():
+                    record = {"timestamp": timestamp, "query": query, "data": data}
+                    f.write(json.dumps(record, default=str) + "\n")
+                    LOGGER.debug("Stored MV/SI diagnostics data: %s, %d rows", query, len(data) if data else 0)
+        except (OSError, IOError) as e:
+            LOGGER.error("Failed to write diagnostics to %s: %s", self._save_path, e)
+            raise
+
+    def clean(self):
+        """Clean up MV and SI collector resources."""
+        # Rebind instead of clearing in place: the last snapshot is shared with the
+        # DiagnosticResult.data handed to the manager, so mutating it would wipe recorded history.
+        self._results = {}
+
+    def _execute_query(self, query: str) -> Any:
+        try:
+            return self._session.execute(query)
+        except Exception as e:  # noqa: BLE001
+            LOGGER.error("Exception occurred while executing query '%s': %s", query, e)
+            return []  # Return empty list on error to prevent issues in collect()

--- a/sdcm/utils/diagnostic_collector/views.py
+++ b/sdcm/utils/diagnostic_collector/views.py
@@ -1,0 +1,77 @@
+import logging
+import json
+
+
+from datetime import datetime
+from typing import Any
+from pathlib import Path
+
+from sdcm.test_config import TestConfig
+from sdcm.utils.diagnostic_collector import DiagnosticCollector, ExceptionHandler
+
+LOGGER = logging.getLogger(__name__)
+
+
+class MVDiagnosticCollector(DiagnosticCollector):
+    """Collect diagnostics data for Materialized Views and Secondary Indexes."""
+
+    queries = [
+        "SELECT count(*) FROM system.view_building_tasks",
+        "SELECT * FROM system.view_building_tasks",
+        "SELECT * from system.view_build_status_v2",
+        "SELECT * FROM system.views_builds_in_progress",
+    ]
+
+    save_dir = Path("mv_si_diagnostics")
+
+    def __init__(
+        self,
+        session,
+        dir_path: str | None = None,
+        name: str | None = None,
+        exception_handler: ExceptionHandler | None = None,
+    ):
+        super().__init__(name, exception_handler=exception_handler)
+        self._session = session
+        self._results: dict[str, Any] = {}
+        self._dir = Path(dir_path or TestConfig().logdir()) / super().root_dir / self.save_dir
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._save_path = self._dir / f"{self.name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
+
+    def collect(self) -> Any:
+        """Collect MV and SI diagnostics data."""
+        results: dict[str, Any] = {}
+        for query in self.queries:
+            try:
+                results[query] = list(self._session.execute(query))
+            except Exception as e:  # noqa: BLE001
+                LOGGER.error("Exception occurred while executing query '%s': %s", query, e)
+                results[query] = []  # keep going so one failing query doesn't lose the whole cycle
+        # Keep a reference to the latest snapshot for the store() fallback, but return a fresh
+        # dict so each recorded DiagnosticResult.data is independent and not overwritten next cycle.
+        self._results = results
+        return results
+
+    def store(self, result: Any):
+        """Store MV and SI diagnostics data."""
+        # Only fall back to the last snapshot when the manager passed nothing; an empty-but-valid
+        # mapping is a legitimate result and must not silently reuse a previous snapshot.
+        if result is None:
+            result = self._results
+
+        timestamp = datetime.now().isoformat()
+        try:
+            with open(self._save_path, "a", encoding="utf-8") as f:
+                for query, data in result.items():
+                    record = {"timestamp": timestamp, "query": query, "data": data}
+                    f.write(json.dumps(record, default=str) + "\n")
+                    LOGGER.debug("Stored MV/SI diagnostics data: %s, %d rows", query, len(data) if data else 0)
+        except (OSError, IOError) as e:
+            LOGGER.error("Failed to write diagnostics to %s: %s", self._save_path, e)
+            raise
+
+    def clean(self):
+        """Clean up MV and SI collector resources."""
+        # Rebind instead of clearing in place: the last snapshot is shared with the
+        # DiagnosticResult.data handed to the manager, so mutating it would wipe recorded history.
+        self._results = {}

--- a/unit_tests/unit/diagnostic_collector/__init__.py
+++ b/unit_tests/unit/diagnostic_collector/__init__.py
@@ -1,0 +1,78 @@
+"""Shared mock classes for diagnostic_collector unit tests."""
+
+import time
+from typing import Any
+
+from sdcm.utils.diagnostic_collector import DiagnosticCollector, ExceptionHandler, ExceptionStrategy
+
+
+class MockDiagnosticCollector(DiagnosticCollector):
+    """Mock implementation of DiagnosticCollector shared across diagnostic_collector tests."""
+
+    def __init__(
+        self,
+        name: str | None = None,
+        collect_data: Any = None,
+        should_fail_collect: bool = False,
+        should_fail_store: bool = False,
+        collect_delay: float = 0,
+        exception_handler: ExceptionHandler | None = None,
+    ):
+        super().__init__(name, exception_handler=exception_handler)
+        self.collect_data = {"test": "data"} if collect_data is None else collect_data
+        self.should_fail_collect = should_fail_collect
+        self.should_fail_store = should_fail_store
+        self.collect_delay = collect_delay
+        self.collect_count = 0
+        self.store_count = 0
+        self.clean_count = 0
+        self.stored_results = []
+
+    def collect(self) -> Any:
+        """Mock collect implementation."""
+        self.collect_count += 1
+        if self.collect_delay > 0:
+            time.sleep(self.collect_delay)
+        if self.should_fail_collect:
+            raise RuntimeError(f"Collection failed for {self.name}")
+        return {"data": self.collect_data, "count": self.collect_count}
+
+    def store(self, result: Any):
+        """Mock store implementation."""
+        self.store_count += 1
+        if self.should_fail_store:
+            raise RuntimeError(f"Storage failed for {self.name}")
+        self.stored_results.append(result)
+
+    def clean(self):
+        """Mock clean implementation."""
+        self.clean_count += 1
+
+
+class MockExceptionHandler(ExceptionHandler):
+    """Mock exception handler that records exceptions and returns configured strategies."""
+
+    def __init__(
+        self,
+        collect_strategy: ExceptionStrategy = ExceptionStrategy.CONTINUE,
+        store_strategy: ExceptionStrategy = ExceptionStrategy.CONTINUE,
+    ):
+        super().__init__()
+        self.collect_strategy = collect_strategy
+        self.store_strategy = store_strategy
+        self.collect_exceptions = []
+        self.store_exceptions = []
+
+    def handle_exception_during_collecting(
+        self, collector: DiagnosticCollector, exception: Exception
+    ) -> ExceptionStrategy:
+        """Track collecting exceptions and return configured strategy."""
+        self.collect_exceptions.append((collector, exception))
+        return self.collect_strategy
+
+    def handle_exception_during_storing(
+        self, collector: DiagnosticCollector, exception: Exception
+    ) -> ExceptionStrategy:
+        """Track storing exceptions and return configured strategy."""
+        self.store_exceptions.append((collector, exception))
+        return self.store_strategy

--- a/unit_tests/unit/diagnostic_collector/__init__.py
+++ b/unit_tests/unit/diagnostic_collector/__init__.py
@@ -1,0 +1,78 @@
+"""Shared mock classes for diagnostic_collector unit tests."""
+
+import time
+from typing import Any
+
+from sdcm.utils.diagnostic_collector import DiagnosticCollector, ExceptionHandler, ExceptionStrategy
+
+
+class MockDiagnosticCollector(DiagnosticCollector):
+    """Mock implementation of DiagnosticCollector shared across diagnostic_collector tests."""
+
+    def __init__(
+        self,
+        name: str | None = None,
+        collect_data: Any = None,
+        should_fail_collect: bool = False,
+        should_fail_store: bool = False,
+        collect_delay: float = 0,
+        exception_handler: ExceptionHandler | None = None,
+    ):
+        super().__init__(name, exception_handler=exception_handler)
+        self.collect_data = {"test": "data"} if collect_data is None else collect_data
+        self.should_fail_collect = should_fail_collect
+        self.should_fail_store = should_fail_store
+        self.collect_delay = collect_delay
+        self.collect_count = 0
+        self.store_attempts = 0
+        self.clean_count = 0
+        self.stored_results = []
+
+    def collect(self) -> Any:
+        """Mock collect implementation."""
+        self.collect_count += 1
+        if self.collect_delay > 0:
+            time.sleep(self.collect_delay)
+        if self.should_fail_collect:
+            raise RuntimeError(f"Collection failed for {self.name}")
+        return {"data": self.collect_data, "count": self.collect_count}
+
+    def store(self, result: Any):
+        """Mock store implementation."""
+        self.store_attempts += 1
+        if self.should_fail_store:
+            raise RuntimeError(f"Storage failed for {self.name}")
+        self.stored_results.append(result)
+
+    def clean(self):
+        """Mock clean implementation."""
+        self.clean_count += 1
+
+
+class MockExceptionHandler(ExceptionHandler):
+    """Mock exception handler that records exceptions and returns configured strategies."""
+
+    def __init__(
+        self,
+        collect_strategy: ExceptionStrategy = ExceptionStrategy.CONTINUE,
+        store_strategy: ExceptionStrategy = ExceptionStrategy.CONTINUE,
+    ):
+        super().__init__()
+        self.collect_strategy = collect_strategy
+        self.store_strategy = store_strategy
+        self.collect_exceptions = []
+        self.store_exceptions = []
+
+    def handle_exception_during_collecting(
+        self, collector: DiagnosticCollector, exception: Exception
+    ) -> ExceptionStrategy:
+        """Track collecting exceptions and return configured strategy."""
+        self.collect_exceptions.append((collector, exception))
+        return self.collect_strategy
+
+    def handle_exception_during_storing(
+        self, collector: DiagnosticCollector, exception: Exception
+    ) -> ExceptionStrategy:
+        """Track storing exceptions and return configured strategy."""
+        self.store_exceptions.append((collector, exception))
+        return self.store_strategy

--- a/unit_tests/unit/diagnostic_collector/conftest.py
+++ b/unit_tests/unit/diagnostic_collector/conftest.py
@@ -1,0 +1,11 @@
+"""Shared fixtures for the diagnostic_collector unit tests."""
+
+import pytest
+
+from unit_tests.unit.diagnostic_collector import MockDiagnosticCollector
+
+
+@pytest.fixture
+def mock_collector():
+    """A MockDiagnosticCollector with a fixed name, so tests can assert on it."""
+    return MockDiagnosticCollector(name="TestCollector")

--- a/unit_tests/unit/diagnostic_collector/test_base.py
+++ b/unit_tests/unit/diagnostic_collector/test_base.py
@@ -1,0 +1,111 @@
+"""Unit tests for diagnostic_collector base classes and utilities."""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from sdcm.utils.diagnostic_collector import ExceptionHandler, ExceptionStrategy
+
+from unit_tests.unit.diagnostic_collector import MockDiagnosticCollector, MockExceptionHandler
+
+
+# --- Test DiagnosticCollector ---
+
+
+def test_diagnostic_collector_workflow():
+    """Test typical collector workflow: collect -> store -> clean."""
+    collector = MockDiagnosticCollector(collect_data={"workflow": "data"})
+    collector.store = MagicMock(wraps=collector.store)
+
+    # Collect
+    data = collector.collect()
+    assert data == {"data": {"workflow": "data"}, "count": 1}
+    assert collector.collect_count == 1
+
+    # Store
+    collector.store(data)
+    collector.store.assert_called_once_with(data)
+
+    # Clean
+    collector.clean()
+    assert collector.clean_count == 1
+
+
+# --- Test ExceptionHandler ---
+
+
+def test_exception_handler_handle_collecting_exception(caplog):
+    """Test exception handler handles collecting exceptions."""
+    handler = ExceptionHandler()
+    collector = MockDiagnosticCollector(name="TestCollector")
+    exception = Exception("Test exception")
+
+    with caplog.at_level(logging.ERROR):
+        strategy = handler.handle_exception_during_collecting(collector, exception)
+
+    assert strategy == ExceptionStrategy.CONTINUE
+    assert "Exception occurred in collector 'TestCollector'" in caplog.text
+    assert "Test exception" in caplog.text
+
+
+def test_exception_handler_handle_storing_exception(caplog):
+    """Test exception handler handles storing exceptions."""
+    handler = ExceptionHandler()
+    collector = MockDiagnosticCollector(name="TestCollector")
+    exception = Exception("Store failed")
+
+    with caplog.at_level(logging.ERROR):
+        strategy = handler.handle_exception_during_storing(collector, exception)
+
+    assert strategy == ExceptionStrategy.CONTINUE
+    assert "Exception occurred while storing diagnostics for collector 'TestCollector'" in caplog.text
+    assert "Store failed" in caplog.text
+
+
+def test_mock_exception_handler_tracks_collect_exceptions():
+    """Test mock exception handler tracks collecting exceptions."""
+    handler = MockExceptionHandler(collect_strategy=ExceptionStrategy.STOP)
+    collector = MockDiagnosticCollector(name="TestCollector")
+    exception = Exception("Test exception")
+
+    strategy = handler.handle_exception_during_collecting(collector, exception)
+
+    assert strategy == ExceptionStrategy.STOP
+    assert len(handler.collect_exceptions) == 1
+    assert handler.collect_exceptions[0][0] == collector
+    assert handler.collect_exceptions[0][1] == exception
+
+
+def test_mock_exception_handler_tracks_store_exceptions():
+    """Test mock exception handler tracks storing exceptions."""
+    handler = MockExceptionHandler(store_strategy=ExceptionStrategy.STOP)
+    collector = MockDiagnosticCollector(name="TestCollector")
+    exception = Exception("Store failed")
+
+    strategy = handler.handle_exception_during_storing(collector, exception)
+
+    assert strategy == ExceptionStrategy.STOP
+    assert len(handler.store_exceptions) == 1
+    assert handler.store_exceptions[0][0] == collector
+    assert handler.store_exceptions[0][1] == exception
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        ExceptionStrategy.CONTINUE,
+        ExceptionStrategy.STOP,
+    ],
+)
+def test_mock_exception_handler_strategies(strategy):
+    """Test mock exception handler returns configured strategies."""
+    handler = MockExceptionHandler(collect_strategy=strategy, store_strategy=strategy)
+    collector = MockDiagnosticCollector()
+    exception = Exception("Test")
+
+    collect_result = handler.handle_exception_during_collecting(collector, exception)
+    store_result = handler.handle_exception_during_storing(collector, exception)
+
+    assert collect_result == strategy
+    assert store_result == strategy

--- a/unit_tests/unit/diagnostic_collector/test_base.py
+++ b/unit_tests/unit/diagnostic_collector/test_base.py
@@ -1,0 +1,61 @@
+"""Unit tests for diagnostic_collector base classes and utilities."""
+
+from unittest.mock import MagicMock
+
+from sdcm.utils.diagnostic_collector import ExceptionHandler, ExceptionStrategy
+
+from unit_tests.unit.diagnostic_collector import MockDiagnosticCollector
+
+
+# --- Test DiagnosticCollector ---
+
+
+def test_diagnostic_collector_workflow():
+    """Test typical collector workflow: collect -> store -> clean."""
+    collector = MockDiagnosticCollector(collect_data={"workflow": "data"})
+    collector.store = MagicMock(wraps=collector.store)
+
+    # Collect
+    data = collector.collect()
+    assert data == {"data": {"workflow": "data"}, "count": 1}
+    assert collector.collect_count == 1
+
+    # Store
+    collector.store(data)
+    collector.store.assert_called_once_with(data)
+
+    # Clean
+    collector.clean()
+    assert collector.clean_count == 1
+
+
+# --- Test ExceptionHandler ---
+
+
+def test_exception_handler_handle_collecting_exception(mock_collector, caplog):
+    """Test exception handler handles collecting exceptions."""
+    handler = ExceptionHandler()
+    exception = Exception("Test exception")
+
+    strategy = handler.handle_exception_during_collecting(mock_collector, exception)
+
+    assert strategy == ExceptionStrategy.CONTINUE
+    assert "Exception occurred in collector 'TestCollector'" in caplog.text
+    assert "Test exception" in caplog.text
+
+
+def test_exception_handler_handle_storing_exception(mock_collector, caplog):
+    """Test exception handler handles storing exceptions."""
+    handler = ExceptionHandler()
+    exception = Exception("Store failed")
+
+    strategy = handler.handle_exception_during_storing(mock_collector, exception)
+
+    assert strategy == ExceptionStrategy.CONTINUE
+    assert "Exception occurred while storing diagnostics for collector 'TestCollector'" in caplog.text
+    assert "Store failed" in caplog.text
+
+
+# MockExceptionHandler is a test double, so it is not tested here directly: its recording and
+# strategy behaviour is exercised for real by the manager tests (test_manager.py), which would fail
+# loudly if it broke.

--- a/unit_tests/unit/diagnostic_collector/test_handlers.py
+++ b/unit_tests/unit/diagnostic_collector/test_handlers.py
@@ -1,0 +1,69 @@
+"""Unit tests for EventExceptionHandler."""
+
+from unittest.mock import patch
+
+import pytest
+
+from sdcm.sct_events import Severity
+from sdcm.utils.diagnostic_collector import ExceptionStrategy
+from sdcm.utils.diagnostic_collector.handlers import EventExceptionHandler
+
+
+@pytest.fixture
+def no_events_device():
+    """Simulate an environment without a running events device (unit tests, non-SCT consumers)."""
+    with patch("sdcm.sct_events.events_device.get_events_main_device", side_effect=RuntimeError("no device")):
+        yield
+
+
+@pytest.mark.parametrize(
+    "method, stage",
+    [
+        pytest.param("handle_exception_during_collecting", "collect", id="collect"),
+        pytest.param("handle_exception_during_storing", "store", id="store"),
+    ],
+)
+def test_event_exception_handler_publishes_event(mock_collector, events_function_scope, method, stage):
+    """Each stage publishes a real TestFrameworkEvent naming the failing collector, stage and error."""
+    handler = EventExceptionHandler()
+
+    strategy = getattr(handler, method)(mock_collector, RuntimeError("boom"))
+
+    published = events_function_scope.get_events_by_category()[Severity.WARNING.name]
+    assert len(published) == 1, f"exactly one WARNING event should be published, got {published}"
+    event = published[0]
+    assert "TestFrameworkEvent" in event, f"a TestFrameworkEvent should be published, got {event}"
+    assert f"source=TestCollector.diagnostics.{stage}()" in event, (
+        f"the event should name the failing collector and stage, got {event}"
+    )
+    assert f"Diagnostics collector 'TestCollector' failed during {stage}" in event, (
+        f"the event message should describe the failure, got {event}"
+    )
+    assert "exception=boom" in event, f"the event should carry the original exception, got {event}"
+    assert strategy == ExceptionStrategy.CONTINUE, f"Publishing must not halt the run by default, got {strategy}"
+
+
+def test_event_exception_handler_severity_and_strategy_are_configurable(mock_collector, events_function_scope):
+    """A collector whose data the test depends on can escalate severity and halt the run."""
+    handler = EventExceptionHandler(severity=Severity.ERROR, strategy=ExceptionStrategy.STOP)
+
+    strategy = handler.handle_exception_during_collecting(mock_collector, RuntimeError("boom"))
+
+    by_category = events_function_scope.get_events_by_category()
+    assert len(by_category[Severity.ERROR.name]) == 1, (
+        f"the failure should be published at the configured severity, got {by_category}"
+    )
+    assert by_category[Severity.WARNING.name] == [], "the default severity should not be used once configured"
+    assert strategy == ExceptionStrategy.STOP, f"configured strategy should be returned, got {strategy}"
+
+
+def test_event_exception_handler_falls_back_to_logging_without_events_device(mock_collector, caplog, no_events_device):
+    """Without an events device the event is dumped to the logger instead of raising."""
+    handler = EventExceptionHandler()
+
+    strategy = handler.handle_exception_during_collecting(mock_collector, RuntimeError("boom"))
+
+    assert strategy == ExceptionStrategy.CONTINUE, "fallback path must not change the strategy"
+    assert "Diagnostics collector 'TestCollector' failed during collect" in caplog.text, (
+        "the event must be dumped to the logger when no events device is available"
+    )

--- a/unit_tests/unit/diagnostic_collector/test_manager.py
+++ b/unit_tests/unit/diagnostic_collector/test_manager.py
@@ -1,0 +1,708 @@
+"""Unit tests for DiagnosticManager."""
+
+import logging
+import threading
+import time
+
+import pytest
+
+from sdcm.utils.diagnostic_collector import ExceptionStrategy
+from sdcm.utils.diagnostic_collector.manager import DiagnosticManager, DiagnosticResult, collect_diagnostics
+
+from unit_tests.unit.diagnostic_collector import MockDiagnosticCollector, MockExceptionHandler
+
+
+# --- Test DiagnosticManager Collection ---
+
+
+def test_diagnostic_manager_single_collection():
+    """Test manager collects and stores diagnostics from all collectors."""
+    collectors = [
+        MockDiagnosticCollector(name="Collector1", collect_data="data1"),
+        MockDiagnosticCollector(name="Collector2", collect_data="data2"),
+    ]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    # Trigger single collection manually
+    manager._collecting_diagnostics()
+
+    # Verify all collectors were called
+    assert collectors[0].collect_count == 1, f"Collector1 should be collected once, got {collectors[0].collect_count}"
+    assert collectors[0].store_count == 1, f"Collector1 should be stored once, got {collectors[0].store_count}"
+    assert collectors[1].collect_count == 1, f"Collector2 should be collected once, got {collectors[1].collect_count}"
+    assert collectors[1].store_count == 1, f"Collector2 should be stored once, got {collectors[1].store_count}"
+
+    # Verify results were stored
+    results = manager.get_results()
+    assert len(results) == 2, f"Expected 2 results (one per collector), got {len(results)}"
+    assert results[0].collector_name == "Collector1", (
+        f"First result should be from Collector1, got {results[0].collector_name}"
+    )
+    assert results[1].collector_name == "Collector2", (
+        f"Second result should be from Collector2, got {results[1].collector_name}"
+    )
+    assert results[0].collected is True, f"First result should be marked collected, got {results[0].collected}"
+    assert results[0].stored is True, f"First result should be marked stored, got {results[0].stored}"
+
+
+def test_diagnostic_manager_collection_with_collect_failure():
+    """Test manager handles collection failures properly."""
+    handler = MockExceptionHandler(collect_strategy=ExceptionStrategy.CONTINUE)
+    collectors = [
+        MockDiagnosticCollector(name="FailingCollector", should_fail_collect=True, exception_handler=handler),
+        MockDiagnosticCollector(name="SuccessCollector", collect_data="success"),
+    ]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    manager._collecting_diagnostics()
+
+    # First collector should fail to collect
+    assert collectors[0].collect_count == 1, (
+        f"FailingCollector should be collected once, got {collectors[0].collect_count}"
+    )
+    assert collectors[0].store_count == 0, (
+        f"FailingCollector should not be stored after collect failure, got {collectors[0].store_count}"
+    )
+
+    # Second collector should succeed
+    assert collectors[1].collect_count == 1, (
+        f"SuccessCollector should be collected once, got {collectors[1].collect_count}"
+    )
+    assert collectors[1].store_count == 1, f"SuccessCollector should be stored once, got {collectors[1].store_count}"
+
+    # Verify exception was handled
+    assert len(handler.collect_exceptions) == 1, (
+        f"Expected exactly 1 handled collect exception, got {len(handler.collect_exceptions)}"
+    )
+    assert handler.collect_exceptions[0][0].name == "FailingCollector", (
+        f"Handled exception should be from FailingCollector, got {handler.collect_exceptions[0][0].name}"
+    )
+
+    # The failed cycle must be recorded (not silently dropped) so callers can see which collector
+    # failed and why.
+    results = manager.get_results()
+    assert len(results) == 2, f"Expected 2 results (failed + succeeded collector), got {len(results)}"
+    failed_result = next(r for r in results if r.collector_name == "FailingCollector")
+    assert failed_result.collected is False, "Failed collector result should be marked not collected"
+    assert failed_result.stored is False, "Failed collector result should be marked not stored"
+    assert failed_result.error is not None, "Failed collector result should record the collect error"
+    assert failed_result.data is None, "Failed collector result should carry no data"
+
+
+def test_diagnostic_manager_collection_with_store_failure():
+    """Test manager handles storage failures properly."""
+    handler = MockExceptionHandler(store_strategy=ExceptionStrategy.CONTINUE)
+    collectors = [
+        MockDiagnosticCollector(name="StoreFailCollector", should_fail_store=True, exception_handler=handler),
+        MockDiagnosticCollector(name="SuccessCollector", collect_data="success"),
+    ]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    manager._collecting_diagnostics()
+
+    # First collector should collect but fail to store
+    assert collectors[0].collect_count == 1, (
+        f"StoreFailCollector should be collected once, got {collectors[0].collect_count}"
+    )
+    assert collectors[0].store_count == 1, (
+        f"StoreFailCollector store should be attempted once, got {collectors[0].store_count}"
+    )
+
+    # Second collector should succeed
+    assert collectors[1].collect_count == 1, (
+        f"SuccessCollector should be collected once, got {collectors[1].collect_count}"
+    )
+    assert collectors[1].store_count == 1, f"SuccessCollector should be stored once, got {collectors[1].store_count}"
+
+    # Verify exception was handled
+    assert len(handler.store_exceptions) == 1, (
+        f"Expected exactly 1 handled store exception, got {len(handler.store_exceptions)}"
+    )
+    assert handler.store_exceptions[0][0].name == "StoreFailCollector", (
+        f"Handled exception should be from StoreFailCollector, got {handler.store_exceptions[0][0].name}"
+    )
+
+    # Verify results show storage failure
+    results = manager.get_results()
+    assert len(results) == 2, f"Expected 2 results (one per collector), got {len(results)}"
+    assert results[0].collected is True, f"First result should be marked collected, got {results[0].collected}"
+    assert results[0].stored is False, (
+        f"First result should be marked not stored after store failure, got {results[0].stored}"
+    )
+    assert results[0].error is not None, "First result should record the store error, got None"
+
+
+def test_diagnostic_manager_stop_on_collect_exception():
+    """Test manager stops collection when handler returns STOP strategy."""
+    handler = MockExceptionHandler(collect_strategy=ExceptionStrategy.STOP)
+    collectors = [
+        MockDiagnosticCollector(name="Collector1", should_fail_collect=True, exception_handler=handler),
+        MockDiagnosticCollector(name="Collector2"),
+        MockDiagnosticCollector(name="Collector3"),
+    ]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    manager._collecting_diagnostics()
+
+    # First collector fails and triggers stop
+    assert collectors[0].collect_count == 1, (
+        f"Collector1 should be collected once before stop, got {collectors[0].collect_count}"
+    )
+    # Subsequent collectors should not be called
+    assert collectors[1].collect_count == 0, (
+        f"Collector2 should not be collected after STOP strategy, got {collectors[1].collect_count}"
+    )
+    assert collectors[2].collect_count == 0, (
+        f"Collector3 should not be collected after STOP strategy, got {collectors[2].collect_count}"
+    )
+
+    # Stop event should be set
+    assert manager._stop_event.is_set(), "Stop event should be set after collect handler returns STOP"
+
+
+def test_diagnostic_manager_stop_on_store_exception():
+    """Test manager stops collection when storage handler returns STOP strategy."""
+    handler = MockExceptionHandler(store_strategy=ExceptionStrategy.STOP)
+    collectors = [
+        MockDiagnosticCollector(name="Collector1", should_fail_store=True, exception_handler=handler),
+        MockDiagnosticCollector(name="Collector2"),
+    ]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    manager._collecting_diagnostics()
+
+    # First collector collects but fails to store
+    assert collectors[0].collect_count == 1, f"Collector1 should be collected once, got {collectors[0].collect_count}"
+    assert collectors[0].store_count == 1, f"Collector1 store should be attempted once, got {collectors[0].store_count}"
+    # Second collector should not be called
+    assert collectors[1].collect_count == 0, (
+        f"Collector2 should not be collected after STOP strategy, got {collectors[1].collect_count}"
+    )
+
+    # Stop event should be set
+    assert manager._stop_event.is_set(), "Stop event should be set after store handler returns STOP"
+
+
+def test_diagnostic_manager_per_collector_handlers_mixed_strategies():
+    """Per-collector handlers: two CONTINUE collectors and one STOP collector (DI, path 1).
+
+    Mirrors the 3-collector scenario: C1/C2 use CONTINUE handlers, C3 uses a STOP handler. C3's
+    failure must halt the run, while C1/C2 (ordered before C3) still complete the cycle.
+    """
+    continue_handler = MockExceptionHandler(collect_strategy=ExceptionStrategy.CONTINUE)
+    stop_handler = MockExceptionHandler(collect_strategy=ExceptionStrategy.STOP)
+    collectors = [
+        MockDiagnosticCollector(name="C1", exception_handler=continue_handler),
+        MockDiagnosticCollector(name="C2", exception_handler=continue_handler),
+        MockDiagnosticCollector(name="C3", should_fail_collect=True, exception_handler=stop_handler),
+    ]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    manager._collecting_diagnostics()
+
+    # C1 and C2 precede the failing STOP collector, so they complete this cycle.
+    assert collectors[0].collect_count == 1 and collectors[0].store_count == 1, "C1 should fully run before the STOP"
+    assert collectors[1].collect_count == 1 and collectors[1].store_count == 1, "C2 should fully run before the STOP"
+    # C3 fails and its STOP handler halts the run.
+    assert collectors[2].collect_count == 1, "C3 should be attempted once"
+    assert manager._stop_event.is_set(), "C3's STOP handler must set the stop event"
+
+    # The shared CONTINUE handler saw no failures; the STOP handler saw exactly C3's failure.
+    assert continue_handler.collect_exceptions == [], "CONTINUE handler should not have handled any failure"
+    assert len(stop_handler.collect_exceptions) == 1, "STOP handler should have handled exactly C3's failure"
+    assert stop_handler.collect_exceptions[0][0].name == "C3", "STOP handler should have handled C3"
+
+
+def test_diagnostic_manager_runtime_handler_swap():
+    """A collector's exception_handler can be swapped at runtime to change its failure policy."""
+    collector = MockDiagnosticCollector(
+        name="Swappable",
+        should_fail_collect=True,
+        exception_handler=MockExceptionHandler(collect_strategy=ExceptionStrategy.CONTINUE),
+    )
+    manager = DiagnosticManager(collectors=[collector], interval=1.0)
+
+    # First cycle: CONTINUE policy -> run is not stopped.
+    manager._collecting_diagnostics()
+    assert not manager._stop_event.is_set(), "CONTINUE handler must not stop the run"
+
+    # Swap the policy on the live collector to STOP and collect again.
+    collector.exception_handler = MockExceptionHandler(collect_strategy=ExceptionStrategy.STOP)
+    manager._collecting_diagnostics()
+    assert manager._stop_event.is_set(), "After swapping to a STOP handler, the run must stop"
+
+
+# --- Test DiagnosticManager Thread Management ---
+
+
+def test_diagnostic_manager_start_stop():
+    """Test manager can start and stop collection thread."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=0.1)
+
+    # Start collection
+    manager.start_collecting()
+    assert manager.is_running, "Manager thread should be alive after start_collecting()"
+
+    # Give it time to run at least once
+    time.sleep(0.2)
+
+    # Stop collection
+    manager.stop_collecting()
+    assert not manager.is_running, "Manager thread should not be alive after stop_collecting()"
+
+    # Verify clean was called
+    assert collectors[0].clean_count == 1, (
+        f"Collector clean() should be called once on stop, got {collectors[0].clean_count}"
+    )
+
+
+def test_diagnostic_manager_multiple_collections():
+    """Test manager performs multiple collections over time."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=0.1)
+
+    manager.start_collecting()
+    deadline = time.time() + 2.0
+    try:
+        while collectors[0].collect_count < 2 and time.time() < deadline:
+            time.sleep(0.01)
+    finally:
+        manager.stop_collecting()
+
+    # Verify multiple collections occurred (at least 2, could be 3-4 depending on timing)
+    assert collectors[0].collect_count >= 2, (
+        f"Expected at least 2 collections over the run, got {collectors[0].collect_count}"
+    )
+
+
+def test_diagnostic_manager_is_collecting_flag():
+    """Test is_collecting flag is set during collection."""
+    collectors = [MockDiagnosticCollector(name="Collector1", collect_delay=0.05)]
+    manager = DiagnosticManager(collectors=collectors, interval=0.5)
+
+    assert manager.is_collecting is False, "is_collecting should be False before start"
+
+    manager.start_collecting()
+    time.sleep(0.1)  # Wait for first collection to start
+
+    # During collection, flag might be set
+    # Note: This is timing-dependent, so we just verify it's a bool
+    collecting_status = manager.is_collecting
+    assert isinstance(collecting_status, bool), f"is_collecting should return a bool, got {type(collecting_status)}"
+
+    manager.stop_collecting()
+    assert manager.is_collecting is False, "is_collecting should be False after stop"
+
+
+def test_diagnostic_manager_final_collection_on_stop():
+    """Test manager performs final collection when stopped."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=10.0)  # Long interval
+
+    manager.start_collecting()
+    time.sleep(0.1)  # Not enough time for interval-based collection
+    initial_count = collectors[0].collect_count
+    manager.stop_collecting()
+
+    # Exactly one final collection must run on stop (regression guard: a missing/broken final
+    # collection would leave the count unchanged).
+    assert collectors[0].collect_count == initial_count + 1, (
+        f"Exactly one final collection should run on stop "
+        f"(initial={initial_count}, final={collectors[0].collect_count})"
+    )
+
+
+# --- Test DiagnosticManager Context Manager ---
+
+
+def test_diagnostic_manager_context_manager():
+    """Test manager works as context manager."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=0.1)
+
+    with manager as mgr:
+        assert mgr is manager, "Context manager should yield the manager instance itself"
+        assert manager.is_running, "Manager thread should be alive inside the context"
+        time.sleep(0.15)
+
+    # After context exit, manager should be stopped
+    assert not manager.is_running, "Manager thread should be stopped after context exit"
+    assert collectors[0].clean_count == 1, (
+        f"Collector clean() should be called once on context exit, got {collectors[0].clean_count}"
+    )
+
+
+def test_diagnostic_manager_context_manager_with_exception(caplog):
+    """Test manager handles exceptions in context manager."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=0.1)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError):
+            with manager:
+                raise ValueError("Test exception")
+
+    # Manager should still be stopped
+    assert not manager.is_running, "Manager thread should be stopped even when context body raises"
+    assert "Exception occurred in DiagnosticManager context" in caplog.text, (
+        "Expected the context exception to be logged at ERROR level"
+    )
+
+
+# --- Test collect_diagnostics Helper ---
+
+
+def test_collect_diagnostics_helper_runs_and_cleans():
+    """Test the generic collect_diagnostics helper collects in the background and cleans up on exit."""
+    collector = MockDiagnosticCollector(name="Collector1")
+
+    with collect_diagnostics(collector, interval=0.1) as manager:
+        assert manager.is_running, "collect_diagnostics() should start a live background manager"
+        time.sleep(0.15)
+
+    assert not manager.is_running, "Manager should be stopped after collect_diagnostics() context exit"
+    assert collector.collect_count >= 1, f"Collector should be collected at least once, got {collector.collect_count}"
+    assert collector.clean_count == 1, f"Collector clean() should be called once on exit, got {collector.clean_count}"
+
+
+def test_collect_diagnostics_helper_multiple_collectors():
+    """Test the helper accepts multiple collectors as varargs."""
+    collectors = [MockDiagnosticCollector(name="Collector1"), MockDiagnosticCollector(name="Collector2")]
+
+    with collect_diagnostics(*collectors, interval=0.1):
+        time.sleep(0.15)
+
+    for collector in collectors:
+        assert collector.collect_count >= 1, (
+            f"{collector.name} should be collected at least once, got {collector.collect_count}"
+        )
+        assert collector.clean_count == 1, (
+            f"{collector.name} clean() should be called once on exit, got {collector.clean_count}"
+        )
+
+
+# --- Test DiagnosticManager Results Management ---
+
+
+def test_diagnostic_manager_get_results():
+    """Test getting results from manager."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    manager._collecting_diagnostics()
+    results = manager.get_results()
+
+    assert len(results) == 1, f"Expected exactly 1 result after one collection, got {len(results)}"
+    assert isinstance(results[0], DiagnosticResult), f"Result should be a DiagnosticResult, got {type(results[0])}"
+    assert results[0].collector_name == "Collector1", (
+        f"Result should be from Collector1, got {results[0].collector_name}"
+    )
+
+
+def test_diagnostic_manager_get_results_returns_copy():
+    """Test get_results returns a copy, not the original list."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    manager._collecting_diagnostics()
+    results1 = manager.get_results()
+    results2 = manager.get_results()
+
+    # Should be equal but not the same object
+    assert results1 == results2, "Two get_results() calls should return equal contents"
+    assert results1 is not results2, "get_results() should return a new copy each call, not the same list object"
+
+
+def test_diagnostic_manager_clear_results():
+    """Test clearing results from manager."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    manager._collecting_diagnostics()
+    assert len(manager.get_results()) == 1, f"Expected 1 result before clear, got {len(manager.get_results())}"
+
+    manager.clear_results()
+    assert len(manager.get_results()) == 0, (
+        f"Expected 0 results after clear_results(), got {len(manager.get_results())}"
+    )
+
+
+def test_diagnostic_manager_accumulates_results():
+    """Test results accumulate over multiple collections."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=0.1)
+
+    manager.start_collecting()
+    time.sleep(0.25)  # Allow 2-3 collections
+    manager.stop_collecting()
+
+    results = manager.get_results()
+    # Should have multiple results (at least 2)
+    assert len(results) >= 2, f"Expected results to accumulate to at least 2, got {len(results)}"
+
+    # Each result should be for the same collector
+    for result in results:
+        assert result.collector_name == "Collector1", (
+            f"All accumulated results should be from Collector1, got {result.collector_name}"
+        )
+
+
+def test_diagnostic_manager_full_history_two_collectors_multiple_cycles():
+    """Two collectors over several cycles: manager keeps the full, ordered, independent history.
+
+    Drives the collection cycle deterministically (no timing) so the number of cycles is exact,
+    and guards against history corruption by asserting each cycle's snapshot is preserved.
+    """
+    collectors = [
+        MockDiagnosticCollector(name="Collector1", collect_data="data1"),
+        MockDiagnosticCollector(name="Collector2", collect_data="data2"),
+    ]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    cycles = 4  # within the requested 3-5 range
+    for _ in range(cycles):
+        manager._collecting_diagnostics()
+
+    # Each collector was collected and stored exactly once per cycle.
+    for collector in collectors:
+        assert collector.collect_count == cycles, (
+            f"{collector.name} should be collected {cycles} times, got {collector.collect_count}"
+        )
+        assert collector.store_count == cycles, (
+            f"{collector.name} should be stored {cycles} times, got {collector.store_count}"
+        )
+
+    results = manager.get_results()
+    # Full history: one DiagnosticResult per collector per cycle.
+    assert len(results) == cycles * len(collectors), (
+        f"Manager should keep full history of {cycles * len(collectors)} results, got {len(results)}"
+    )
+
+    # Per collector, every cycle's snapshot must be an INDEPENDENT object whose data reflects that
+    # cycle (regression guard: a shared/overwritten dict would make all counts equal the latest).
+    for name in ("Collector1", "Collector2"):
+        per_collector = [r for r in results if r.collector_name == name]
+        assert len(per_collector) == cycles, f"{name} should have {cycles} results in history, got {len(per_collector)}"
+        counts = [r.data["count"] for r in per_collector]
+        assert counts == list(range(1, cycles + 1)), (
+            f"{name} history must preserve each cycle's snapshot {list(range(1, cycles + 1))}, got {counts}"
+        )
+
+
+def test_diagnostic_manager_history_survives_stop_and_clean():
+    """Recorded history (and its data) stays intact after stop_collecting() runs collector.clean()."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    cycles = 3
+    for _ in range(cycles):
+        manager._collecting_diagnostics()
+
+    manager.stop_collecting()  # triggers clean() on every collector
+
+    assert collectors[0].clean_count == 1, f"clean() should run once on stop, got {collectors[0].clean_count}"
+    results = manager.get_results()
+    assert len(results) == cycles, f"Full history of {cycles} results should remain after stop, got {len(results)}"
+    counts = [r.data["count"] for r in results]
+    assert counts == list(range(1, cycles + 1)), (
+        f"History data must be intact and independent after clean(), got {counts}"
+    )
+
+
+def test_diagnostic_manager_clean_on_stop():
+    """Test clean is called on all collectors when manager stops."""
+    collectors = [
+        MockDiagnosticCollector(name="Collector1"),
+        MockDiagnosticCollector(name="Collector2"),
+    ]
+    manager = DiagnosticManager(collectors=collectors, interval=0.1)
+
+    manager.start_collecting()
+    time.sleep(0.15)
+    manager.stop_collecting()
+
+    # Clean should be called on all collectors
+    assert collectors[0].clean_count == 1, (
+        f"Collector1 clean() should be called once on stop, got {collectors[0].clean_count}"
+    )
+    assert collectors[1].clean_count == 1, (
+        f"Collector2 clean() should be called once on stop, got {collectors[1].clean_count}"
+    )
+
+
+def test_diagnostic_manager_clean_handles_exceptions(caplog):
+    """Test manager handles exceptions during clean gracefully."""
+
+    class FailingCleanCollector(MockDiagnosticCollector):
+        def clean(self):
+            super().clean()
+            raise RuntimeError("Clean failed")
+
+    collectors = [
+        FailingCleanCollector(name="Collector1"),
+        MockDiagnosticCollector(name="Collector2"),
+    ]
+    manager = DiagnosticManager(collectors=collectors, interval=0.1)
+
+    with caplog.at_level(logging.ERROR):
+        manager.start_collecting()
+        time.sleep(0.15)
+        manager.stop_collecting()
+
+    # Both clean methods should be called despite exception
+    assert collectors[0].clean_count == 1, (
+        f"FailingCleanCollector clean() should still be called once, got {collectors[0].clean_count}"
+    )
+    assert collectors[1].clean_count == 1, (
+        f"Collector2 clean() should be called once despite earlier failure, got {collectors[1].clean_count}"
+    )
+    assert "Exception occurred while cleaning collector 'Collector1'" in caplog.text, (
+        "Expected the clean() failure to be logged at ERROR level"
+    )
+
+
+# --- Test Edge Cases ---
+
+
+def test_diagnostic_manager_empty_collectors():
+    """Test manager handles empty collector list."""
+    manager = DiagnosticManager(collectors=[], interval=1.0)
+
+    manager._collecting_diagnostics()
+    results = manager.get_results()
+
+    assert len(results) == 0, f"Empty collector list should produce no results, got {len(results)}"
+
+
+def test_diagnostic_manager_stop_before_start():
+    """Test stopping manager before starting doesn't cause issues."""
+    collectors = [MockDiagnosticCollector()]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    # Stop without starting should not raise exception
+    manager.stop_collecting()
+    assert not manager.is_running, "Manager should not be alive when stopped before ever starting"
+
+
+def test_diagnostic_manager_double_start():
+    """Test starting manager twice doesn't create issues."""
+    collectors = [MockDiagnosticCollector()]
+    manager = DiagnosticManager(collectors=collectors, interval=0.1)
+
+    manager.start_collecting()
+    assert manager.is_running, "Manager thread should be alive after first start_collecting()"
+
+    # Second start should not crash
+    manager.start_collecting()
+    time.sleep(0.15)
+
+    manager.stop_collecting()
+    assert not manager.is_running, "Manager thread should be stopped after stop_collecting()"
+
+
+def test_diagnostic_manager_concurrent_start_creates_single_thread():
+    """Test concurrent start_collecting() calls never spawn more than one worker thread."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=0.1)
+
+    barrier = threading.Barrier(8)
+    created_threads = set()
+    created_lock = threading.Lock()
+
+    def racer():
+        barrier.wait()  # release all callers at once to maximize the race
+        manager.start_collecting()
+        if manager._thread is not None:
+            with created_lock:
+                created_threads.add(manager._thread.ident)
+
+    threads = [threading.Thread(target=racer) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    try:
+        assert manager.is_running, "Exactly one worker should be running after concurrent starts"
+        # The lifecycle lock must serialize the check-and-create, so only a single worker ident
+        # is ever observed across all racing callers.
+        assert len(created_threads) == 1, (
+            f"Concurrent start_collecting() must create a single worker thread, got {created_threads}"
+        )
+    finally:
+        manager.stop_collecting()
+    assert not manager.is_running, "Manager thread should be stopped after stop_collecting()"
+
+
+def test_diagnostic_manager_restart_after_stop():
+    """Test a stopped manager can be started again (owned thread is recreated on each start)."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=0.1)
+
+    manager.start_collecting()
+    time.sleep(0.15)
+    manager.stop_collecting()
+    assert not manager.is_running, "Manager thread should be stopped after stop_collecting()"
+    first_run_count = collectors[0].collect_count
+    assert first_run_count >= 1, "First run should have collected at least once"
+
+    # Restart must work (no RuntimeError) and resume collecting on a fresh thread.
+    manager.start_collecting()
+    assert manager.is_running, "Manager should be running again after restart"
+    time.sleep(0.15)
+    manager.stop_collecting()
+    assert not manager.is_running, "Manager thread should be stopped after second stop_collecting()"
+    assert collectors[0].collect_count > first_run_count, (
+        f"Restart should resume collecting (first={first_run_count}, after restart={collectors[0].collect_count})"
+    )
+
+
+def test_diagnostic_manager_monitors_worker_crash():
+    """Test an unexpected crash in the worker is captured and re-raised on stop."""
+
+    class ExplodingManager(DiagnosticManager):
+        def _run(self):
+            raise RuntimeError("boom in worker")
+
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = ExplodingManager(collectors=collectors, interval=0.1)
+
+    manager.start_collecting()
+    time.sleep(0.1)
+
+    # The worker crashed: not healthy, and the captured error is exposed.
+    assert manager.is_healthy() is False, "A crashed worker should not be reported as healthy"
+    assert isinstance(manager.error, RuntimeError), f"Worker error should be captured, got {manager.error!r}"
+
+    # stop_collecting() surfaces the crash to the caller instead of swallowing it.
+    with pytest.raises(RuntimeError, match="Diagnostics worker thread crashed"):
+        manager.stop_collecting()
+
+
+def test_diagnostic_manager_thread_safety():
+    """Test results can be read concurrently while collection is happening, without errors."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=0.05)
+
+    manager.start_collecting()
+
+    # Access results from main thread while the collection thread is running.
+    # We don't assert on counts here (that is timing-dependent); we only verify that
+    # concurrent reads always return a valid, non-decreasing snapshot list and never raise.
+    previous_len = 0
+    for _ in range(20):
+        results = manager.get_results()
+        assert isinstance(results, list), f"get_results() should always return a list, got {type(results)}"
+        # get_results returns a copy, so the snapshot length must never go backwards
+        assert len(results) >= previous_len, (
+            f"Concurrent get_results() snapshot length must not decrease (previous={previous_len}, current={len(results)})"
+        )
+        previous_len = len(results)
+        time.sleep(0.01)
+
+    manager.stop_collecting()
+
+    # After stopping, a final collection is guaranteed, so there must be at least one result.
+    final_results = manager.get_results()
+    assert final_results, "Expected at least one result after stop (final collection is guaranteed)"

--- a/unit_tests/unit/diagnostic_collector/test_manager.py
+++ b/unit_tests/unit/diagnostic_collector/test_manager.py
@@ -1,0 +1,627 @@
+"""Unit tests for DiagnosticManager."""
+
+import time
+
+import pytest
+
+from sdcm.utils.diagnostic_collector import ExceptionStrategy
+from sdcm.utils.diagnostic_collector.manager import DiagnosticManager, DiagnosticResult, collect_diagnostics
+
+from unit_tests.unit.diagnostic_collector import MockDiagnosticCollector, MockExceptionHandler
+
+
+# --- Test DiagnosticManager Collection ---
+
+
+def test_diagnostic_manager_single_collection():
+    """Test manager collects and stores diagnostics from all collectors."""
+    collectors = [
+        MockDiagnosticCollector(name="Collector1", collect_data="data1"),
+        MockDiagnosticCollector(name="Collector2", collect_data="data2"),
+    ]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    # Trigger single collection manually
+    manager._collecting_diagnostics()
+
+    # Verify all collectors were called
+    assert collectors[0].collect_count == 1, f"Collector1 should be collected once, got {collectors[0].collect_count}"
+    assert collectors[0].store_attempts == 1, f"Collector1 should be stored once, got {collectors[0].store_attempts}"
+    assert collectors[1].collect_count == 1, f"Collector2 should be collected once, got {collectors[1].collect_count}"
+    assert collectors[1].store_attempts == 1, f"Collector2 should be stored once, got {collectors[1].store_attempts}"
+
+    # Verify results were stored
+    results = manager.get_results()
+    assert len(results) == 2, f"Expected 2 results (one per collector), got {len(results)}"
+    assert results[0].collector_name == "Collector1", (
+        f"First result should be from Collector1, got {results[0].collector_name}"
+    )
+    assert results[1].collector_name == "Collector2", (
+        f"Second result should be from Collector2, got {results[1].collector_name}"
+    )
+    assert results[0].collected is True, f"First result should be marked collected, got {results[0].collected}"
+    assert results[0].stored is True, f"First result should be marked stored, got {results[0].stored}"
+
+
+def test_diagnostic_manager_collection_with_collect_failure():
+    """Test manager handles collection failures properly."""
+    handler = MockExceptionHandler(collect_strategy=ExceptionStrategy.CONTINUE)
+    collectors = [
+        MockDiagnosticCollector(name="FailingCollector", should_fail_collect=True, exception_handler=handler),
+        MockDiagnosticCollector(name="SuccessCollector", collect_data="success"),
+    ]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    manager._collecting_diagnostics()
+
+    # First collector should fail to collect
+    assert collectors[0].collect_count == 1, (
+        f"FailingCollector should be collected once, got {collectors[0].collect_count}"
+    )
+    assert collectors[0].store_attempts == 0, (
+        f"FailingCollector should not be stored after collect failure, got {collectors[0].store_attempts}"
+    )
+
+    # Second collector should succeed
+    assert collectors[1].collect_count == 1, (
+        f"SuccessCollector should be collected once, got {collectors[1].collect_count}"
+    )
+    assert collectors[1].store_attempts == 1, (
+        f"SuccessCollector should be stored once, got {collectors[1].store_attempts}"
+    )
+
+    # Verify exception was handled
+    assert len(handler.collect_exceptions) == 1, (
+        f"Expected exactly 1 handled collect exception, got {len(handler.collect_exceptions)}"
+    )
+    assert handler.collect_exceptions[0][0].name == "FailingCollector", (
+        f"Handled exception should be from FailingCollector, got {handler.collect_exceptions[0][0].name}"
+    )
+
+    # The failed cycle must be recorded (not silently dropped) so callers can see which collector
+    # failed and why.
+    results = manager.get_results()
+    assert len(results) == 2, f"Expected 2 results (failed + succeeded collector), got {len(results)}"
+    failed_result = next(r for r in results if r.collector_name == "FailingCollector")
+    assert failed_result.collected is False, "Failed collector result should be marked not collected"
+    assert failed_result.stored is False, "Failed collector result should be marked not stored"
+    assert failed_result.error is not None, "Failed collector result should record the collect error"
+    assert failed_result.data is None, "Failed collector result should carry no data"
+
+
+def test_diagnostic_manager_collection_with_store_failure():
+    """Test manager handles storage failures properly."""
+    handler = MockExceptionHandler(store_strategy=ExceptionStrategy.CONTINUE)
+    collectors = [
+        MockDiagnosticCollector(name="StoreFailCollector", should_fail_store=True, exception_handler=handler),
+        MockDiagnosticCollector(name="SuccessCollector", collect_data="success"),
+    ]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    manager._collecting_diagnostics()
+
+    # First collector should collect but fail to store
+    assert collectors[0].collect_count == 1, (
+        f"StoreFailCollector should be collected once, got {collectors[0].collect_count}"
+    )
+    assert collectors[0].store_attempts == 1, (
+        f"StoreFailCollector store should be attempted once, got {collectors[0].store_attempts}"
+    )
+
+    # Second collector should succeed
+    assert collectors[1].collect_count == 1, (
+        f"SuccessCollector should be collected once, got {collectors[1].collect_count}"
+    )
+    assert collectors[1].store_attempts == 1, (
+        f"SuccessCollector should be stored once, got {collectors[1].store_attempts}"
+    )
+
+    # Verify exception was handled
+    assert len(handler.store_exceptions) == 1, (
+        f"Expected exactly 1 handled store exception, got {len(handler.store_exceptions)}"
+    )
+    assert handler.store_exceptions[0][0].name == "StoreFailCollector", (
+        f"Handled exception should be from StoreFailCollector, got {handler.store_exceptions[0][0].name}"
+    )
+
+    # Verify results show storage failure
+    results = manager.get_results()
+    assert len(results) == 2, f"Expected 2 results (one per collector), got {len(results)}"
+    assert results[0].collected is True, f"First result should be marked collected, got {results[0].collected}"
+    assert results[0].stored is False, (
+        f"First result should be marked not stored after store failure, got {results[0].stored}"
+    )
+    assert results[0].error is not None, "First result should record the store error, got None"
+
+
+@pytest.mark.parametrize(
+    "fail_kwargs, expected_store_attempts",
+    [
+        # A collect failure breaks out immediately, so store is never attempted...
+        pytest.param({"should_fail_collect": True}, 0, id="collect"),
+        # ...while a store failure still records its DiagnosticResult before breaking out, which is
+        # a separate code path (the stop_after_store flag) that can regress on its own.
+        pytest.param({"should_fail_store": True}, 1, id="store"),
+    ],
+)
+def test_diagnostic_manager_stop_strategy_halts_cycle(fail_kwargs, expected_store_attempts):
+    """A STOP strategy from either stage halts the cycle and skips the remaining collectors."""
+    handler = MockExceptionHandler(collect_strategy=ExceptionStrategy.STOP, store_strategy=ExceptionStrategy.STOP)
+    collectors = [
+        MockDiagnosticCollector(name="Collector1", exception_handler=handler, **fail_kwargs),
+        MockDiagnosticCollector(name="Collector2"),
+        MockDiagnosticCollector(name="Collector3"),
+    ]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    manager._collecting_diagnostics()
+
+    assert collectors[0].collect_count == 1, (
+        f"Collector1 should be collected once before stop, got {collectors[0].collect_count}"
+    )
+    assert collectors[0].store_attempts == expected_store_attempts, (
+        f"Collector1 store attempts should be {expected_store_attempts}, got {collectors[0].store_attempts}"
+    )
+    for collector in collectors[1:]:
+        assert collector.collect_count == 0, (
+            f"{collector.name} should not be collected after STOP strategy, got {collector.collect_count}"
+        )
+
+    assert manager._stop_event.is_set(), "Stop event should be set after the handler returns STOP"
+
+
+def test_diagnostic_manager_per_collector_handlers_mixed_strategies():
+    """Per-collector handlers: two CONTINUE collectors and one STOP collector (DI, path 1).
+
+    Mirrors the 3-collector scenario: C1/C2 use CONTINUE handlers, C3 uses a STOP handler. C3's
+    failure must halt the run, while C1/C2 (ordered before C3) still complete the cycle.
+    """
+    continue_handler = MockExceptionHandler(collect_strategy=ExceptionStrategy.CONTINUE)
+    stop_handler = MockExceptionHandler(collect_strategy=ExceptionStrategy.STOP)
+    collectors = [
+        MockDiagnosticCollector(name="C1", exception_handler=continue_handler),
+        MockDiagnosticCollector(name="C2", exception_handler=continue_handler),
+        MockDiagnosticCollector(name="C3", should_fail_collect=True, exception_handler=stop_handler),
+    ]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    manager._collecting_diagnostics()
+
+    # C1 and C2 precede the failing STOP collector, so they complete this cycle.
+    assert collectors[0].collect_count == 1 and collectors[0].store_attempts == 1, "C1 should fully run before the STOP"
+    assert collectors[1].collect_count == 1 and collectors[1].store_attempts == 1, "C2 should fully run before the STOP"
+    # C3 fails and its STOP handler halts the run.
+    assert collectors[2].collect_count == 1, "C3 should be attempted once"
+    assert manager._stop_event.is_set(), "C3's STOP handler must set the stop event"
+
+    # The shared CONTINUE handler saw no failures; the STOP handler saw exactly C3's failure.
+    assert continue_handler.collect_exceptions == [], "CONTINUE handler should not have handled any failure"
+    assert len(stop_handler.collect_exceptions) == 1, "STOP handler should have handled exactly C3's failure"
+    assert stop_handler.collect_exceptions[0][0].name == "C3", "STOP handler should have handled C3"
+
+
+def test_diagnostic_manager_runtime_handler_swap():
+    """A collector's exception_handler can be swapped at runtime to change its failure policy."""
+    collector = MockDiagnosticCollector(
+        name="Swappable",
+        should_fail_collect=True,
+        exception_handler=MockExceptionHandler(collect_strategy=ExceptionStrategy.CONTINUE),
+    )
+    manager = DiagnosticManager(collectors=[collector], interval=1.0)
+
+    # First cycle: CONTINUE policy -> run is not stopped.
+    manager._collecting_diagnostics()
+    assert not manager._stop_event.is_set(), "CONTINUE handler must not stop the run"
+
+    # Swap the policy on the live collector to STOP and collect again.
+    collector.exception_handler = MockExceptionHandler(collect_strategy=ExceptionStrategy.STOP)
+    manager._collecting_diagnostics()
+    assert manager._stop_event.is_set(), "After swapping to a STOP handler, the run must stop"
+
+
+# --- Test DiagnosticManager Thread Management ---
+
+
+def test_diagnostic_manager_lifecycle_over_multiple_collections():
+    """Full lifecycle: start -> repeated collection -> stop -> clean, for every collector."""
+    collectors = [
+        MockDiagnosticCollector(name="Collector1"),
+        MockDiagnosticCollector(name="Collector2"),
+    ]
+    manager = DiagnosticManager(collectors=collectors, interval=0.1)
+
+    assert manager.is_running is False, "manager should not be running before start"
+    assert manager.is_collecting is False, "is_collecting should be False before start"
+
+    manager.start_collecting()
+    assert manager.is_running, "Manager thread should be alive after start_collecting()"
+
+    deadline = time.time() + 5.0
+    try:
+        while collectors[0].collect_count < 2 and time.time() < deadline:
+            time.sleep(0.01)
+    finally:
+        manager.stop_collecting()
+
+    assert manager.is_running is False, "Manager thread should not be alive after stop_collecting()"
+    assert manager.is_collecting is False, "is_collecting should be False after stop"
+    for collector in collectors:
+        assert collector.collect_count >= 2, (
+            f"{collector.name} should collect repeatedly, got {collector.collect_count}"
+        )
+        assert collector.clean_count == 1, (
+            f"{collector.name} clean() should be called once on stop, got {collector.clean_count}"
+        )
+
+
+def test_diagnostic_manager_final_collection_on_stop():
+    """A final collection always runs on stop, even when no interval ever elapsed."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=10.0)
+
+    # Drive the worker loop directly with the stop already requested: the interval wait returns
+    # immediately and the only cycle that can run is the forced final one. No thread, no sleep,
+    # so the exact-count assertion below cannot be perturbed by scheduling.
+    manager._stop_event.set()
+    manager._run()
+
+    # Regression guard for the final=True bypass of the per-collector stop guard: without it the
+    # final cycle aborts at the guard and the count stays at 0.
+    assert collectors[0].collect_count == 1, (
+        f"Exactly one final collection should run on stop, got {collectors[0].collect_count}"
+    )
+
+
+# --- Test DiagnosticManager Context Manager ---
+
+
+def test_diagnostic_manager_context_manager():
+    """Test manager works as context manager."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=0.1)
+
+    with manager as mgr:
+        assert mgr is manager, "Context manager should yield the manager instance itself"
+        assert manager.is_running, "Manager thread should be alive inside the context"
+        time.sleep(0.15)
+
+    # After context exit, manager should be stopped
+    assert not manager.is_running, "Manager thread should be stopped after context exit"
+    assert collectors[0].clean_count == 1, (
+        f"Collector clean() should be called once on context exit, got {collectors[0].clean_count}"
+    )
+
+
+def test_diagnostic_manager_context_manager_with_exception(caplog):
+    """Test manager handles exceptions in context manager."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=0.1)
+
+    with pytest.raises(ValueError, match="Test exception"):
+        with manager:
+            raise ValueError("Test exception")
+
+    # Manager should still be stopped
+    assert not manager.is_running, "Manager thread should be stopped even when context body raises"
+    assert "Exception occurred in DiagnosticManager context: Test exception" in caplog.text, (
+        "Expected the context exception, with its message, to be logged"
+    )
+
+
+# --- Test collect_diagnostics Helper ---
+
+
+def test_collect_diagnostics_helper_runs_and_cleans():
+    """Test the generic collect_diagnostics helper collects in the background and cleans up on exit."""
+    collector = MockDiagnosticCollector(name="Collector1")
+
+    with collect_diagnostics(collector, interval=0.1) as manager:
+        assert manager.is_running, "collect_diagnostics() should start a live background manager"
+        time.sleep(0.15)
+
+    assert not manager.is_running, "Manager should be stopped after collect_diagnostics() context exit"
+    assert collector.collect_count >= 1, f"Collector should be collected at least once, got {collector.collect_count}"
+    assert collector.clean_count == 1, f"Collector clean() should be called once on exit, got {collector.clean_count}"
+
+
+def test_collect_diagnostics_helper_cleans_up_on_exception():
+    """The helper stops the manager and cleans collectors even when the context body raises."""
+    collector = MockDiagnosticCollector(name="Collector1")
+
+    with pytest.raises(ValueError, match="boom"):
+        with collect_diagnostics(collector, interval=0.1) as manager:
+            raise ValueError("boom")
+
+    assert not manager.is_running, "helper must stop the manager when the body raises"
+    assert collector.clean_count == 1, f"helper must clean collectors when the body raises, got {collector.clean_count}"
+
+
+def test_collect_diagnostics_helper_multiple_collectors():
+    """Test the helper accepts multiple collectors as varargs."""
+    collectors = [MockDiagnosticCollector(name="Collector1"), MockDiagnosticCollector(name="Collector2")]
+
+    with collect_diagnostics(*collectors, interval=0.1):
+        time.sleep(0.15)
+
+    for collector in collectors:
+        assert collector.collect_count >= 1, (
+            f"{collector.name} should be collected at least once, got {collector.collect_count}"
+        )
+        assert collector.clean_count == 1, (
+            f"{collector.name} clean() should be called once on exit, got {collector.clean_count}"
+        )
+
+
+# --- Test DiagnosticManager Results Management ---
+
+
+def test_diagnostic_manager_get_results():
+    """Test getting results from manager."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    manager._collecting_diagnostics()
+    results = manager.get_results()
+
+    assert len(results) == 1, f"Expected exactly 1 result after one collection, got {len(results)}"
+    assert isinstance(results[0], DiagnosticResult), f"Result should be a DiagnosticResult, got {type(results[0])}"
+    assert results[0].collector_name == "Collector1", (
+        f"Result should be from Collector1, got {results[0].collector_name}"
+    )
+
+
+def test_diagnostic_manager_get_results_returns_copy():
+    """Test get_results returns a copy, not the original list."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    manager._collecting_diagnostics()
+    results1 = manager.get_results()
+    results2 = manager.get_results()
+
+    # Should be equal but not the same object
+    assert results1 == results2, "Two get_results() calls should return equal contents"
+    assert results1 is not results2, "get_results() should return a new copy each call, not the same list object"
+
+
+def test_diagnostic_manager_clear_results():
+    """Test clearing results from manager."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    manager._collecting_diagnostics()
+    assert len(manager.get_results()) == 1, f"Expected 1 result before clear, got {len(manager.get_results())}"
+
+    manager.clear_results()
+    assert len(manager.get_results()) == 0, (
+        f"Expected 0 results after clear_results(), got {len(manager.get_results())}"
+    )
+
+
+def test_diagnostic_manager_accumulates_results():
+    """Test results accumulate over multiple collections."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=0.1)
+
+    manager.start_collecting()
+    # Poll for the condition instead of assuming a fixed number of intervals fire within a sleep:
+    # a loaded CI machine can deliver fewer collections than the wall-clock budget suggests.
+    deadline = time.time() + 5.0
+    try:
+        while len(manager.get_results()) < 2 and time.time() < deadline:
+            time.sleep(0.01)
+    finally:
+        manager.stop_collecting()
+
+    results = manager.get_results()
+    assert len(results) >= 2, f"Expected results to accumulate to at least 2, got {len(results)}"
+
+    # Each result should be for the same collector
+    for result in results:
+        assert result.collector_name == "Collector1", (
+            f"All accumulated results should be from Collector1, got {result.collector_name}"
+        )
+
+
+def test_diagnostic_manager_full_history_two_collectors_multiple_cycles():
+    """Two collectors over several cycles: manager keeps the full, ordered, independent history.
+
+    Drives the collection cycle deterministically (no timing) so the number of cycles is exact,
+    and guards against history corruption by asserting each cycle's snapshot is preserved.
+    """
+    collectors = [
+        MockDiagnosticCollector(name="Collector1", collect_data="data1"),
+        MockDiagnosticCollector(name="Collector2", collect_data="data2"),
+    ]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    cycles = 4  # several cycles, enough to prove each cycle's snapshot stays independent
+    for _ in range(cycles):
+        manager._collecting_diagnostics()
+
+    # Each collector was collected and stored exactly once per cycle.
+    for collector in collectors:
+        assert collector.collect_count == cycles, (
+            f"{collector.name} should be collected {cycles} times, got {collector.collect_count}"
+        )
+        assert collector.store_attempts == cycles, (
+            f"{collector.name} should be stored {cycles} times, got {collector.store_attempts}"
+        )
+
+    results = manager.get_results()
+    # Full history: one DiagnosticResult per collector per cycle.
+    assert len(results) == cycles * len(collectors), (
+        f"Manager should keep full history of {cycles * len(collectors)} results, got {len(results)}"
+    )
+
+    # Per collector, every cycle's snapshot must be an INDEPENDENT object whose data reflects that
+    # cycle (regression guard: a shared/overwritten dict would make all counts equal the latest).
+    for name in ("Collector1", "Collector2"):
+        per_collector = [r for r in results if r.collector_name == name]
+        assert len(per_collector) == cycles, f"{name} should have {cycles} results in history, got {len(per_collector)}"
+        counts = [r.data["count"] for r in per_collector]
+        assert counts == list(range(1, cycles + 1)), (
+            f"{name} history must preserve each cycle's snapshot {list(range(1, cycles + 1))}, got {counts}"
+        )
+
+
+def test_diagnostic_manager_history_survives_stop_and_clean():
+    """Recorded history (and its data) stays intact after stop_collecting() runs collector.clean()."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    cycles = 3
+    for _ in range(cycles):
+        manager._collecting_diagnostics()
+
+    manager.stop_collecting()  # triggers clean() on every collector
+
+    assert collectors[0].clean_count == 1, f"clean() should run once on stop, got {collectors[0].clean_count}"
+    results = manager.get_results()
+    assert len(results) == cycles, f"Full history of {cycles} results should remain after stop, got {len(results)}"
+    counts = [r.data["count"] for r in results]
+    assert counts == list(range(1, cycles + 1)), (
+        f"History data must be intact and independent after clean(), got {counts}"
+    )
+
+
+def test_diagnostic_manager_clean_handles_exceptions(caplog):
+    """Test manager handles exceptions during clean gracefully."""
+
+    class FailingCleanCollector(MockDiagnosticCollector):
+        def clean(self):
+            super().clean()
+            raise RuntimeError("Clean failed")
+
+    collectors = [
+        FailingCleanCollector(name="Collector1"),
+        MockDiagnosticCollector(name="Collector2"),
+    ]
+    manager = DiagnosticManager(collectors=collectors, interval=0.1)
+
+    manager.start_collecting()
+    time.sleep(0.15)
+    manager.stop_collecting()
+
+    # Both clean methods should be called despite exception
+    assert collectors[0].clean_count == 1, (
+        f"FailingCleanCollector clean() should still be called once, got {collectors[0].clean_count}"
+    )
+    assert collectors[1].clean_count == 1, (
+        f"Collector2 clean() should be called once despite earlier failure, got {collectors[1].clean_count}"
+    )
+    assert "Exception occurred while cleaning collector 'Collector1'" in caplog.text, (
+        "Expected the clean() failure to be logged at ERROR level"
+    )
+
+
+# --- Test Edge Cases ---
+
+
+def test_diagnostic_manager_empty_collectors():
+    """Test manager handles empty collector list."""
+    manager = DiagnosticManager(collectors=[], interval=1.0)
+
+    manager._collecting_diagnostics()
+    results = manager.get_results()
+
+    assert len(results) == 0, f"Empty collector list should produce no results, got {len(results)}"
+
+
+def test_diagnostic_manager_stop_before_start():
+    """Test stopping manager before starting doesn't cause issues."""
+    collectors = [MockDiagnosticCollector()]
+    manager = DiagnosticManager(collectors=collectors, interval=1.0)
+
+    # Stop without starting should not raise exception
+    manager.stop_collecting()
+    assert not manager.is_running, "Manager should not be alive when stopped before ever starting"
+
+
+def test_diagnostic_manager_double_start():
+    """Test starting manager twice doesn't create issues."""
+    collectors = [MockDiagnosticCollector()]
+    manager = DiagnosticManager(collectors=collectors, interval=0.1)
+
+    manager.start_collecting()
+    assert manager.is_running, "Manager thread should be alive after first start_collecting()"
+
+    # Second start should not crash
+    manager.start_collecting()
+    time.sleep(0.15)
+
+    manager.stop_collecting()
+    assert not manager.is_running, "Manager thread should be stopped after stop_collecting()"
+
+
+def test_diagnostic_manager_restart_after_stop():
+    """Test a stopped manager can be started again (owned thread is recreated on each start)."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=0.1)
+
+    manager.start_collecting()
+    time.sleep(0.15)
+    manager.stop_collecting()
+    assert not manager.is_running, "Manager thread should be stopped after stop_collecting()"
+    first_run_count = collectors[0].collect_count
+    assert first_run_count >= 1, "First run should have collected at least once"
+
+    # Restart must work (no RuntimeError) and resume collecting on a fresh thread.
+    manager.start_collecting()
+    assert manager.is_running, "Manager should be running again after restart"
+    time.sleep(0.15)
+    manager.stop_collecting()
+    assert not manager.is_running, "Manager thread should be stopped after second stop_collecting()"
+    assert collectors[0].collect_count > first_run_count, (
+        f"Restart should resume collecting (first={first_run_count}, after restart={collectors[0].collect_count})"
+    )
+
+
+def test_diagnostic_manager_monitors_worker_crash():
+    """Test an unexpected crash in the worker is captured and re-raised on stop."""
+
+    class ExplodingManager(DiagnosticManager):
+        def _run(self):
+            raise RuntimeError("boom in worker")
+
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = ExplodingManager(collectors=collectors, interval=0.1)
+
+    manager.start_collecting()
+    time.sleep(0.1)
+
+    # The worker crashed: not healthy, and the captured error is exposed.
+    assert manager.is_healthy() is False, "A crashed worker should not be reported as healthy"
+    assert isinstance(manager.error, RuntimeError), f"Worker error should be captured, got {manager.error!r}"
+
+    # stop_collecting() surfaces the crash to the caller instead of swallowing it.
+    with pytest.raises(RuntimeError, match="Diagnostics worker thread crashed"):
+        manager.stop_collecting()
+
+
+def test_diagnostic_manager_thread_safety():
+    """Test results can be read concurrently while collection is happening, without errors."""
+    collectors = [MockDiagnosticCollector(name="Collector1")]
+    manager = DiagnosticManager(collectors=collectors, interval=0.05)
+
+    manager.start_collecting()
+
+    # Access results from main thread while the collection thread is running.
+    # We don't assert on counts here (that is timing-dependent); we only verify that
+    # concurrent reads always return a valid, non-decreasing snapshot list and never raise.
+    previous_len = 0
+    for _ in range(20):
+        results = manager.get_results()
+        assert isinstance(results, list), f"get_results() should always return a list, got {type(results)}"
+        # get_results returns a copy, so the snapshot length must never go backwards
+        assert len(results) >= previous_len, (
+            f"Concurrent get_results() snapshot length must not decrease (previous={previous_len}, current={len(results)})"
+        )
+        previous_len = len(results)
+        time.sleep(0.01)
+
+    manager.stop_collecting()
+
+    # After stopping, a final collection is guaranteed, so there must be at least one result.
+    final_results = manager.get_results()
+    assert final_results, "Expected at least one result after stop (final collection is guaranteed)"

--- a/unit_tests/unit/diagnostic_collector/test_views.py
+++ b/unit_tests/unit/diagnostic_collector/test_views.py
@@ -1,0 +1,150 @@
+"""Unit tests for MVDiagnosticCollector."""
+
+import json
+
+from sdcm.utils.diagnostic_collector.views import MVDiagnosticCollector
+
+
+# --- Mock session ---
+
+
+class FakeSession:
+    """Minimal stand-in for a Cassandra/Scylla session used by MVDiagnosticCollector."""
+
+    def __init__(self, rows_by_query: dict | None = None, fail_queries: set | None = None):
+        self.rows_by_query = rows_by_query or {}
+        self.fail_queries = fail_queries or set()
+        self.executed: list[str] = []
+
+    def execute(self, query: str):
+        self.executed.append(query)
+        if query in self.fail_queries:
+            raise RuntimeError(f"query failed: {query}")
+        return self.rows_by_query.get(query, [])
+
+
+# --- collect() ---
+
+
+def test_mv_collect_runs_all_queries(tmp_path):
+    """collect() runs every configured query in order."""
+    session = FakeSession()
+    collector = MVDiagnosticCollector(session, dir_path=str(tmp_path))
+
+    result = collector.collect()
+
+    assert set(result.keys()) == set(MVDiagnosticCollector.queries), (
+        f"collect() should produce a result for every query, got {set(result.keys())}"
+    )
+    assert session.executed == list(MVDiagnosticCollector.queries), (
+        f"All queries should be executed in order, got {session.executed}"
+    )
+
+
+def test_mv_collect_returns_fresh_independent_snapshot(tmp_path):
+    """Each collect() returns a NEW dict so manager history is not overwritten next cycle."""
+    session = FakeSession()
+    collector = MVDiagnosticCollector(session, dir_path=str(tmp_path))
+
+    first = collector.collect()
+    second = collector.collect()
+
+    assert first is not second, "collect() must return a new dict each cycle, not a shared one"
+
+    # Mutating the latest returned snapshot must not affect the earlier one.
+    second.clear()
+    assert first, "earlier snapshot must remain intact when a later snapshot is mutated"
+
+
+def test_mv_clean_does_not_wipe_previously_returned_snapshot(tmp_path):
+    """clean() rebinds internal state instead of clearing the shared dict in place."""
+    session = FakeSession()
+    collector = MVDiagnosticCollector(session, dir_path=str(tmp_path))
+
+    snapshot = collector.collect()
+    assert snapshot, "collect() should return a non-empty snapshot"
+
+    collector.clean()
+
+    assert snapshot, "clean() must not empty a snapshot already handed out by collect()"
+    assert collector._results == {}, "clean() should reset the collector's own state to an empty dict"
+
+
+def test_mv_execute_query_returns_empty_on_error(tmp_path):
+    """A failing query yields an empty list instead of raising, so collect() keeps going."""
+    failing_query = MVDiagnosticCollector.queries[0]
+    session = FakeSession(fail_queries={failing_query})
+    collector = MVDiagnosticCollector(session, dir_path=str(tmp_path))
+
+    result = collector.collect()
+
+    assert result[failing_query] == [], "Failed query should produce an empty list, not raise"
+    # The remaining queries still run.
+    assert len(result) == len(MVDiagnosticCollector.queries), (
+        f"All queries should be represented even when one fails, got {len(result)}"
+    )
+
+
+# --- store() ---
+
+
+def test_mv_store_writes_jsonl(tmp_path):
+    """store() appends one JSON line per query with the expected fields."""
+    rows = {MVDiagnosticCollector.queries[0]: [{"a": 1}]}
+    session = FakeSession(rows_by_query=rows)
+    collector = MVDiagnosticCollector(session, dir_path=str(tmp_path))
+
+    data = collector.collect()
+    collector.store(data)
+
+    assert collector._save_path.exists(), f"store() should create the log file at {collector._save_path}"
+    lines = collector._save_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == len(MVDiagnosticCollector.queries), (
+        f"store() should write one line per query, got {len(lines)}"
+    )
+    record = json.loads(lines[0])
+    assert set(record.keys()) == {"timestamp", "query", "data"}, (
+        f"Each record should contain timestamp/query/data, got {set(record.keys())}"
+    )
+
+
+def test_mv_store_falls_back_to_last_snapshot_when_result_empty(tmp_path):
+    """store(None) falls back to the collector's last collected snapshot."""
+    rows = {MVDiagnosticCollector.queries[0]: [{"a": 1}]}
+    session = FakeSession(rows_by_query=rows)
+    collector = MVDiagnosticCollector(session, dir_path=str(tmp_path))
+
+    collector.collect()
+    collector.store(None)  # falsy -> fallback to self._results
+
+    assert collector._save_path.exists(), "store() fallback should still write the last snapshot to disk"
+    lines = collector._save_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == len(MVDiagnosticCollector.queries), (
+        f"Fallback store should write one line per query, got {len(lines)}"
+    )
+
+
+def test_mv_store_empty_mapping_does_not_fall_back(tmp_path):
+    """store({}) writes nothing instead of silently reusing the previous snapshot."""
+    rows = {MVDiagnosticCollector.queries[0]: [{"a": 1}]}
+    session = FakeSession(rows_by_query=rows)
+    collector = MVDiagnosticCollector(session, dir_path=str(tmp_path))
+
+    collector.collect()  # populates self._results with a non-empty snapshot
+    collector.store({})  # empty-but-valid result must NOT fall back to the last snapshot
+
+    if collector._save_path.exists():
+        lines = collector._save_path.read_text(encoding="utf-8").strip().splitlines()
+        assert lines == [], "An empty result must not write the previous snapshot to disk"
+
+
+# --- output directory ---
+
+
+def test_mv_output_dir_layout(tmp_path):
+    """Output is placed under <dir_path>/diagnostics/mv_si_diagnostics so it is collected with logs."""
+    collector = MVDiagnosticCollector(FakeSession(), dir_path=str(tmp_path))
+
+    expected_dir = tmp_path / "diagnostics" / "mv_si_diagnostics"
+    assert collector._dir == expected_dir, f"Collector dir should be {expected_dir}, got {collector._dir}"
+    assert expected_dir.is_dir(), "Collector should create its output directory on init"

--- a/unit_tests/unit/diagnostic_collector/test_views.py
+++ b/unit_tests/unit/diagnostic_collector/test_views.py
@@ -1,0 +1,153 @@
+"""Unit tests for MVDiagnosticCollector."""
+
+import json
+
+import pytest
+
+from sdcm.utils.diagnostic_collector.views import MVDiagnosticCollector
+
+
+# --- Mock session ---
+
+
+class FakeSession:
+    """Minimal stand-in for a Cassandra/Scylla session used by MVDiagnosticCollector."""
+
+    def __init__(self, rows_by_query: dict | None = None, fail_queries: set | None = None):
+        self.rows_by_query = rows_by_query or {}
+        self.fail_queries = fail_queries or set()
+        self.executed: list[str] = []
+
+    def execute(self, query: str):
+        self.executed.append(query)
+        if query in self.fail_queries:
+            raise RuntimeError(f"query failed: {query}")
+        return self.rows_by_query.get(query, [])
+
+
+@pytest.fixture
+def make_collector(tmp_path):
+    """Build a collector over a FakeSession, writing under an isolated tmp_path."""
+
+    def _make(rows_by_query: dict | None = None, fail_queries: set | None = None) -> MVDiagnosticCollector:
+        session = FakeSession(rows_by_query=rows_by_query, fail_queries=fail_queries)
+        return MVDiagnosticCollector(session, dir_path=str(tmp_path))
+
+    return _make
+
+
+@pytest.fixture
+def collector(make_collector):
+    """Collector over a session where every query returns no rows."""
+    return make_collector()
+
+
+@pytest.fixture
+def collector_with_rows(make_collector):
+    """Collector over a session whose first query returns one row."""
+    return make_collector(rows_by_query={MVDiagnosticCollector.queries[0]: [{"a": 1}]})
+
+
+# --- collect() ---
+
+
+def test_mv_collect_runs_all_queries(collector):
+    """collect() runs every configured query in order."""
+    result = collector.collect()
+
+    assert set(result.keys()) == set(MVDiagnosticCollector.queries), (
+        f"collect() should produce a result for every query, got {set(result.keys())}"
+    )
+    assert collector._session.executed == list(MVDiagnosticCollector.queries), (
+        f"All queries should be executed in order, got {collector._session.executed}"
+    )
+
+
+def test_mv_collect_returns_fresh_independent_snapshot(collector):
+    """Each collect() returns a NEW dict so manager history is not overwritten next cycle."""
+    first = collector.collect()
+    second = collector.collect()
+
+    assert first is not second, "collect() must return a new dict each cycle, not a shared one"
+
+    # Mutating the latest returned snapshot must not affect the earlier one.
+    second.clear()
+    assert first, "earlier snapshot must remain intact when a later snapshot is mutated"
+
+
+def test_mv_clean_does_not_wipe_previously_returned_snapshot(collector):
+    """clean() rebinds internal state instead of clearing the shared dict in place."""
+    snapshot = collector.collect()
+    assert snapshot, "collect() should return a non-empty snapshot"
+
+    collector.clean()
+
+    assert snapshot, "clean() must not empty a snapshot already handed out by collect()"
+    assert collector._results == {}, "clean() should reset the collector's own state to an empty dict"
+
+
+def test_mv_collect_returns_empty_rows_on_query_error(make_collector):
+    """A failing query yields an empty list instead of raising, so collect() keeps going."""
+    failing_query = MVDiagnosticCollector.queries[0]
+    collector = make_collector(fail_queries={failing_query})
+
+    result = collector.collect()
+
+    assert result[failing_query] == [], "Failed query should produce an empty list, not raise"
+    # The remaining queries still run.
+    assert len(result) == len(MVDiagnosticCollector.queries), (
+        f"All queries should be represented even when one fails, got {len(result)}"
+    )
+
+
+# --- store() ---
+
+
+def test_mv_store_writes_jsonl(collector_with_rows):
+    """store() appends one JSON line per query with the expected fields."""
+    data = collector_with_rows.collect()
+    collector_with_rows.store(data)
+
+    assert collector_with_rows._save_path.exists(), (
+        f"store() should create the log file at {collector_with_rows._save_path}"
+    )
+    lines = collector_with_rows._save_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == len(MVDiagnosticCollector.queries), (
+        f"store() should write one line per query, got {len(lines)}"
+    )
+    record = json.loads(lines[0])
+    assert set(record.keys()) == {"timestamp", "query", "data"}, (
+        f"Each record should contain timestamp/query/data, got {set(record.keys())}"
+    )
+
+
+def test_mv_store_falls_back_to_last_snapshot_when_result_empty(collector_with_rows):
+    """store(None) falls back to the collector's last collected snapshot."""
+    collector_with_rows.collect()
+    collector_with_rows.store(None)  # falsy -> fallback to self._results
+
+    assert collector_with_rows._save_path.exists(), "store() fallback should still write the last snapshot to disk"
+    lines = collector_with_rows._save_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == len(MVDiagnosticCollector.queries), (
+        f"Fallback store should write one line per query, got {len(lines)}"
+    )
+
+
+def test_mv_store_empty_mapping_does_not_fall_back(collector_with_rows):
+    """store({}) writes nothing instead of silently reusing the previous snapshot."""
+    collector_with_rows.collect()  # populates self._results with a non-empty snapshot
+    collector_with_rows.store({})  # empty-but-valid result must NOT fall back to the last snapshot
+
+    if collector_with_rows._save_path.exists():
+        lines = collector_with_rows._save_path.read_text(encoding="utf-8").strip().splitlines()
+        assert lines == [], "An empty result must not write the previous snapshot to disk"
+
+
+# --- output directory ---
+
+
+def test_mv_output_dir_layout(collector, tmp_path):
+    """Output is placed under <dir_path>/diagnostics/mv_si_diagnostics so it is collected with logs."""
+    expected_dir = tmp_path / "diagnostics" / "mv_si_diagnostics"
+    assert collector._dir == expected_dir, f"Collector dir should be {expected_dir}, got {collector._dir}"
+    assert expected_dir.is_dir(), "Collector should create its output directory on init"


### PR DESCRIPTION
Introduce a new diagnostic manager and collectors feature. This tool allows collecting diagnostic information during any cluster operation or CQL command execution. It runs in a separate thread and executes a set of DiagnosticCollectors, which gather any required data.

Initially, the feature was requested to collect specific system tables when creating materialized views (MV) or secondary indexes (SI). However, its functionality extends to collecting and storing any diagnostic information, including files, metrics, and system tables.

Potential future uses include collecting metrics for service-level agreements (SLA) and tracking tablet splits and merges during cluster operations.

Fixes SCYLLADB-295

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
