### PR TITLE
fix(xcloud): clean runner instances from pipelines

### DIFF
--- a/jenkins-pipelines/qa/hydra-clean-test-resources.jenkinsfile
+++ b/jenkins-pipelines/qa/hydra-clean-test-resources.jenkinsfile
@@ -20,6 +20,12 @@ pipeline {
         string(defaultValue: 'aws',
                description: 'resources backend',
                name: 'backend')
+        string(defaultValue: '',
+               description: 'Cloud provider for xcloud backend (aws, gce). Required when backend=xcloud.',
+               name: 'xcloud_provider')
+        string(defaultValue: '',
+               description: 'Scylla Cloud environment (lab, staging, prod). Required when backend=xcloud.',
+               name: 'xcloud_env')
     }
     options {
         timestamps()
@@ -41,6 +47,12 @@ pipeline {
                             export SCT_REGION_NAME=
                             export SCT_GCE_DATACENTER=
                             export SCT_AZURE_REGION_NAME=
+
+                            if [[ "${params.backend}" == "xcloud" ]] ; then
+                                export SCT_XCLOUD_PROVIDER="${params.xcloud_provider}"
+                                export SCT_XCLOUD_ENV="${params.xcloud_env}"
+                            fi
+
                             ./docker/env/hydra.sh clean-resources --backend ${params.backend} --test-id ${params.test_id}
                         """
                    }

--- a/vars/cleanSctRunners.groovy
+++ b/vars/cleanSctRunners.groovy
@@ -4,6 +4,11 @@ import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 
 def call(Map params, RunWrapper currentBuild){
     def cloud_provider = getCloudProviderFromBackend(params.backend)
+
+    if ( params.backend.equals("xcloud") ) {
+        cloud_provider = params.xcloud_provider
+    }
+
     def test_status = currentBuild.currentResult
 
     sh """#!/bin/bash


### PR DESCRIPTION
This changes  addresses missed items in cleanup pipelines:
- resolving xcloud backend to underlying cloud provider in `cleanSctRunners.groovy`, so SCT runner is properly cleaned up during `Clean SCT runner` step of longevity pipeline
- Add xcloud backend related parameters to `hydra-clean-test-resources` pipeline so Argus-triggered cleanup can be executed for Scylla Cloud tests

Fixes: SCT-80

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [Clean SCT runners step clears xcloud runners](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/197/pipeline-overview/?selected-node=326) 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
