### PR TITLE
fix(gce): disable scylla-doctor on GCE

### DIFF
--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -38,5 +38,9 @@ backup_bucket_backend: 'gcs'
 
 use_preinstalled_scylla: true
 
+# Disable scylla-doctor on GCE temporarily due to v1.8 bug - https://scylladb.atlassian.net/browse/DOCTOR-12
+# Re-enable once scylla-doctor fixes the issue
+run_scylla_doctor: false
+
 # we are using monitor images, see `gce_image_monitor`
 monitor_branch: null


### PR DESCRIPTION
scylla-doctor v1.8 crashes on GCE with "'str' object has no attribute 'get'" error. This causes a cascade failure that prevents log collection and fails artifact tests. Disable using scylla-doctor until the problem is fixed there.

Closes: SCT-76

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [artifacts-ubuntu2404-test (on GCE)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-gce-image-new/6/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
