### PR TITLE
fix(integration-tests): fix vector-store integration tests

### DIFF
--- a/docker/scylla-sct/entry.sh
+++ b/docker/scylla-sct/entry.sh
@@ -16,7 +16,10 @@ authorizer: 'CassandraAuthorizer'
 EOM
 fi
 
+# vector indexes require tablets
+if [[ "${VECTOR_SEARCH_TEST:-}" != "true" ]]; then
 sed -e '/enable_tablets:.*/s/true/false/g' -i /etc/scylla/scylla.yaml
 sed -e '/tablets_mode_for_new_keyspaces:.*/s/enabled/disabled/g' -i /etc/scylla/scylla.yaml
+fi
 
 /docker-entrypoint.py $*

--- a/sdcm/utils/vector_store_client.py
+++ b/sdcm/utils/vector_store_client.py
@@ -63,9 +63,13 @@ class VectorStoreClient:
         payload = {"embedding": embedding, "limit": limit}
         return self.request("POST", f"/api/v1/indexes/{keyspace}/{index}/ann", json=payload).json()
 
+    def get_index_status(self, keyspace: str, index: str) -> dict:
+        """Get status and vector count for a specific index"""
+        return self.request("GET", f"/api/v1/indexes/{keyspace}/{index}/status").json()
+
     def get_index_count(self, keyspace: str, index: str) -> int:
         """Get number of embeddings in a vector index"""
-        return self.request("GET", f"/api/v1/indexes/{keyspace}/{index}/count").json()
+        return self.get_index_status(keyspace, index)["count"]
 
     def wait_for_ready(self, timeout: int = 300, check_interval: int = 5) -> bool:
         """Wait for Vector Store to become ready (to have status SERVING or INDEXING_VECTORS)"""

--- a/unit_tests/test_vector_store.py
+++ b/unit_tests/test_vector_store.py
@@ -26,7 +26,7 @@ pytestmark = [
     pytest.mark.usefixtures("events"),
     pytest.mark.integration,
     pytest.mark.docker_scylla_args(
-        scylla_docker_image="scylladb/scylla-nightly:2025.4.0-dev-0.20250811.e14c5e3890de",
+        scylla_docker_image="scylladb/scylla:2025.4.3",
         vs_docker_image="scylladb/vector-store:latest",
     ),
     pytest.mark.xdist_group("docker_heavy"),


### PR DESCRIPTION
Fix vector-store service integration tests:
- at some point there were breaking changes in the index count API (was removed actually). The info provided by the removed API was moved to /status endpoint. Updated VS client in SCT to use the status API
- hot reload support was introduced for vector-store URI parameters in scylla config. Switched restarting scylla container to hot realoding the config
- updated Scylla image in vector-store tests to 2025.4.3, as `vector_primary_uri` scylla config parameter was changed `vector_store_primary_uri` in recent Scylla releases
- tablets is hard requirement for VS now, so added a check to ensure they are enabled in VS integration tests

Fixes: SCT-65

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] integration tests

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
