### PR TITLE
SCYLLADB-631 test(scale-test-with-mv): Add new scale test with mv

### DIFF
--- a/data_dir/latte/schema_scale.rn
+++ b/data_dir/latte/schema_scale.rn
@@ -12,6 +12,8 @@ const TABLE_COUNT_PER_KEYSPACE = latte::param!("table_count_per_keyspace", 100);
 const ENABLE_TABLETS = latte::param!("enable_tablets", false);
 const MIN_PER_SHARD_TABLET_COUNT = latte::param!("min_per_shard_tablet_count", 10.0); // default in Scylla
 const CREATE_INDEX = latte::param!("create_index", false);
+const CREATE_COLLOCATED_MV = latte::param!("create_collocated_mv", false);
+const CREATE_NOTCOLLOCATED_MV = latte::param!("create_notcollocated_mv", false);
 const REPLICATION_FACTOR = latte::param!("replication_factor", 3);
 const COMPACTION_STRATEGY = latte::param!("compaction_strategy", "IncrementalCompactionStrategy");
 const SSTABLE_COMPRESSION = latte::param!("sstable_compression", "LZ4Compressor");
@@ -118,10 +120,28 @@ pub async fn prepare(db) {
             let p_stmt_select = `SELECT col_text, col_date, col_blob FROM ${ks}.${table} WHERE pk = :pk`;
             db.prepare(p_stmt_select_name, p_stmt_select).await?;
 
+            // Process 'select from collocated MV' prepared statement
+            let p_stmt_select_mv_colloc_name = "";
+            if CREATE_COLLOCATED_MV {
+                p_stmt_select_mv_colloc_name = `k${kpadding}${ks_i + 1}.${table}__select_mv_colloc`;
+                let p_stmt_select_mv_colloc = `SELECT pk, col_text FROM ${ks}.${table}_mv_colloc WHERE pk = :pk AND col_date = :col_date`;
+                db.prepare(p_stmt_select_mv_colloc_name, p_stmt_select_mv_colloc).await?;
+            }
+
+            // Process 'select from non-collocated MV' prepared statement
+            let p_stmt_select_mv_notcolloc_name = "";
+            if CREATE_NOTCOLLOCATED_MV {
+                p_stmt_select_mv_notcolloc_name = `k${kpadding}${ks_i + 1}.${table}__select_mv_notcolloc`;
+                let p_stmt_select_mv_notcolloc = `SELECT col_text, col_date, col_blob FROM ${ks}.${table}_mv_notcolloc WHERE col_blob = :col_blob AND pk = :pk`;
+                db.prepare(p_stmt_select_mv_notcolloc_name, p_stmt_select_mv_notcolloc).await?;
+            }
+
             // Keep mapping of prepared statements and keyspace.table values
             tables.push(#{
                 "INSERT": p_stmt_insert_name,
                 "SELECT": p_stmt_select_name,
+                "SELECT_MV_COLLOC": p_stmt_select_mv_colloc_name,
+                "SELECT_MV_NOTCOLLOC": p_stmt_select_mv_notcolloc_name,
                 "keyspace": ks,
                 "table": table,
             });
@@ -197,6 +217,24 @@ pub async fn create_schema(db, i) { // user fn to be run in a 'latte run -f ...'
     // Create indices
     if CREATE_INDEX {
         db.execute(`CREATE INDEX IF NOT EXISTS ${table}_index_on_col_text ON ${ks}.${table} (col_text)`).await?;
+    }
+
+    if CREATE_COLLOCATED_MV {
+        db.execute(`
+            CREATE MATERIALIZED VIEW IF NOT EXISTS ${ks}.${table}_mv_colloc AS
+                SELECT pk, col_text FROM ${ks}.${table}
+                WHERE pk IS NOT NULL AND col_date IS NOT NULL
+                PRIMARY KEY (pk, col_date)
+        `).await?;
+    }
+
+    if CREATE_NOTCOLLOCATED_MV {
+        db.execute(`
+            CREATE MATERIALIZED VIEW IF NOT EXISTS ${ks}.${table}_mv_notcolloc AS
+                SELECT * FROM ${ks}.${table}
+                WHERE pk IS NOT NULL AND col_blob IS NOT NULL
+                PRIMARY KEY (col_blob, pk)
+        `).await?;
     }
 }
 
@@ -307,6 +345,90 @@ pub async fn read(db, i) {
         let data = gen_data(idx, ks_index, t_index).await;
         for col_name in data.col_names {
             // TODO: make it be compatible with prep stmts which select non-all columns
+            let actual = rows.0.get(col_name).unwrap();
+            let expected = data.get(col_name).unwrap();
+            if actual != expected {
+                if col_name == "col_blob" {
+                    actual = format!("{a:?}", a=actual);
+                    expected = format!("{e:?}", e=expected);
+                }
+                db.signal_failure(
+                    `${row_err_info}, column '${col_name}'. ` +
+                    `Actual value is '${actual}', but expected is '${expected}'.`
+                ).await?;
+            }
+        }
+    }
+}
+
+pub async fn read_colloc_mv(db, i) {
+    assert!(CREATE_COLLOCATED_MV, "read_colloc_mv requires create_collocated_mv=true");
+    let ks_table_mapping_i = get_ks_table_mapping_i(db, i).await;
+    let ks_index = db.data.ks_table_mapping[ks_table_mapping_i][0];
+    let t_index = db.data.ks_table_mapping[ks_table_mapping_i][1];
+    // NOTE: each table getting queries after a table shift will get non-zero first row index.
+    //       It is ok because we care about the step increment value and not starting index.
+    let idx = get_idx(db, (i / TABLE_GROUP_SIZE)).await;
+
+    let pk = uuid(idx);
+    let data = gen_data(idx, ks_index, t_index).await;
+    let col_date =  data.get("col_date").unwrap();
+
+    if !DATA_VALIDATION {
+        db.execute_prepared(db.data.p_stmt[ks_index][t_index].SELECT_MV_COLLOC, [pk, col_date]).await?
+    } else {
+        let rows = db.execute_prepared_with_result(db.data.p_stmt[ks_index][t_index].SELECT_MV_COLLOC, [pk, col_date]).await?;
+        let rows_len = rows.len();
+        let row_err_info = (
+            `ks='${db.data.p_stmt[ks_index][t_index].keyspace}', ` +
+            `table='${db.data.p_stmt[ks_index][t_index].table}', pk='${pk}', col_date='${col_date}'`);
+        if rows_len != 1 {
+            // NOTE: may be false negative only if we didn't populate DB correctly.
+            db.signal_failure(
+                `Expected exactly 1 row. But got '${rows_len}'. ` + row_err_info
+            ).await?;
+        }
+
+        let actual = rows.0.get("col_text").unwrap();
+        let expected = data.get("col_text").unwrap();
+        if actual != expected {
+            db.signal_failure(
+                `${row_err_info}, column col_text. ` +
+                `Actual value is '${actual}', but expected is '${expected}'.`
+            ).await?;
+        }
+    }
+}
+
+pub async fn read_notcolloc_mv(db, i) {
+    assert!(CREATE_NOTCOLLOCATED_MV, "read_notcolloc_mv requires create_notcollocated_mv=true");
+    let ks_table_mapping_i = get_ks_table_mapping_i(db, i).await;
+    let ks_index = db.data.ks_table_mapping[ks_table_mapping_i][0];
+    let t_index = db.data.ks_table_mapping[ks_table_mapping_i][1];
+    // NOTE: each table getting queries after a table shift will get non-zero first row index.
+    //       It is ok because we care about the step increment value and not starting index.
+    let idx = get_idx(db, (i / TABLE_GROUP_SIZE)).await;
+
+    let pk = uuid(idx);
+    let data = gen_data(idx, ks_index, t_index).await;
+    let col_blob = data.get("col_blob").unwrap();
+
+    if !DATA_VALIDATION {
+        db.execute_prepared(db.data.p_stmt[ks_index][t_index].SELECT_MV_NOTCOLLOC, [col_blob, pk]).await?
+    } else {
+        let rows = db.execute_prepared_with_result(db.data.p_stmt[ks_index][t_index].SELECT_MV_NOTCOLLOC, [col_blob, pk]).await?;
+        let rows_len = rows.len();
+        let row_err_info = (
+            `ks='${db.data.p_stmt[ks_index][t_index].keyspace}', ` +
+            `table='${db.data.p_stmt[ks_index][t_index].table}', pk='${pk}', col_blob='${format!("{b:?}", b=col_blob)}'`);
+        if rows_len != 1 {
+            // NOTE: may be false negative only if we didn't populate DB correctly.
+            db.signal_failure(
+                `Expected exactly 1 row. But got '${rows_len}'. ` + row_err_info
+            ).await?;
+        }
+
+        for col_name in data.col_names {
             let actual = rows.0.get(col_name).unwrap();
             let expected = data.get(col_name).unwrap();
             if actual != expected {

--- a/jenkins-pipelines/oss/scale/scale-schema-5000-tables-with-mv-per-table.jenkinsfile
+++ b/jenkins-pipelines/oss/scale/scale-schema-5000-tables-with-mv-per-table.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/scale/longevity-5000-tables-with-mv-per-table-latte.yaml',
+)

--- a/sdcm/utils/loader_utils.py
+++ b/sdcm/utils/loader_utils.py
@@ -304,7 +304,12 @@ class LoaderUtilsMixin:
             prepare_verify_cmd = self.params.get("prepare_verify_cmd")
             if prepare_verify_cmd:
                 self._run_all_stress_cmds(
-                    verify_queue, params={"stress_cmd": prepare_verify_cmd, "keyspace_num": keyspace_num}
+                    verify_queue,
+                    params={
+                        "stress_cmd": prepare_verify_cmd,
+                        "keyspace_num": keyspace_num,
+                        "duration": self.params.get("prepare_stress_duration"),
+                    },
                 )
 
                 for stress in verify_queue:

--- a/test-cases/scale/longevity-5000-tables-with-mv-per-table-latte.yaml
+++ b/test-cases/scale/longevity-5000-tables-with-mv-per-table-latte.yaml
@@ -1,0 +1,123 @@
+test_duration: 1060 # ~3h prepare schema + 3h of prepare data+ 7h mixed/MV reads + 4h margin
+prepare_stress_duration: 360
+
+n_db_nodes: 6
+instance_type_db: 'i4i.4xlarge'
+n_loaders: 1
+instance_type_loader: 'c6i.4xlarge'
+
+user_prefix: 'schema-scale-5000t-5000mv'
+append_scylla_yaml:
+  # NOTE: per table metrics on the big count of tables has terrible performance
+  # See: https://github.com/scylladb/scylla-monitoring/issues/2429
+  # So, disable per table metrics
+  enable_node_aggregated_table_metrics: false
+
+nemesis_class_name: "SisyphusMonkey"
+nemesis_interval: 5
+# NOTE: prepare phase fails without nemesis. See https://github.com/scylladb/scylladb/issues/27566
+#       So, it is better to keep prepare phase without nemesis to cover the bug case.
+nemesis_during_prepare: false
+# NOTE: skip enospc https://github.com/scylladb/scylla-cluster-tests/issues/12989
+nemesis_selector: 'not enospc and not manager_operation'
+# NOTE: disable mgmt because we run disruptive nemesis with data validation.
+# And if we do repairs, it takes too long making data validation exceed retries.
+use_mgmt: false
+
+root_disk_size_monitor: 120
+root_disk_size_runner: 120
+
+round_robin: true
+# NOTE: use 1 latte thread with concurrency=12 to avoid the following bug:
+#       https://github.com/scylladb/scylladb/issues/27551
+prepare_write_cmd:
+  - >-
+    latte run --tag create-schema -f create_schema
+    --threads=1 --concurrency=12 --connections=1
+    --warmup=0 --retries=2 --retry-interval=10s --request-timeout 300 --sampling 1s
+    -d 5000
+    -P keyspace_count=1
+    -P table_count_per_keyspace=5000
+    -P enable_tablets=true
+    -P create_index=false
+    -P create_collocated_mv=true
+    -P create_notcollocated_mv=true
+    -P replication_factor=3
+    -P compaction_strategy="\"IncrementalCompactionStrategy\""
+    -P sstable_compression="\"LZ4Compressor\""
+    data_dir/latte/schema_scale.rn
+# use 2 connections per shard to decrease internal shard bounces : 6 nodes * 14 shards/node = 84 shards, so 168 connections in total
+prepare_verify_cmd:
+  - >-
+    latte run --tag populate-data -f write
+    --threads=14 --concurrency=128 --connections=168
+    --warmup=0 --retries=10 --retry-interval=5s,10s --request-timeout 60 --sampling 5s
+    -d 250000000
+    -P keyspace_count=1
+    -P table_count_per_keyspace=5000
+    -P row_count_per_table=50000
+    -P blob_col_size=128
+    -P text_col_size=128
+    -P gauss_mean=0
+    -P gauss_stddev=0
+    -P table_group_size=5000
+    -P table_shift_count=0
+    -P table_shift_interval_s=0
+    data_dir/latte/schema_scale.rn
+stress_cmd:
+  - >-
+    latte run --tag mixed -f write:1 -f read:5
+    --threads=10 --concurrency=16 --connections=10 --rate 40000
+    --warmup=0 --retries=10 --retry-interval=1s,30s --request-timeout 30 --sampling 5s
+    --validation-strategy=retry
+    -d 420m
+    -P keyspace_count=1
+    -P table_count_per_keyspace=5000
+    -P row_count_per_table=50000
+    -P blob_col_size=128
+    -P text_col_size=128
+    -P gauss_mean=25000
+    -P gauss_stddev=5000
+    -P table_group_size=10
+    -P table_shift_count=1
+    -P table_shift_interval_s=10
+    -P data_validation=true
+    data_dir/latte/schema_scale.rn
+  - >-
+    latte run --tag read_mv -f read_colloc_mv
+    --threads=2 --concurrency=8 --connections=2 --rate 5000
+    --warmup=0 --retries=10 --retry-interval=1s,30s --request-timeout 300 --sampling 30s
+    --validation-strategy=retry
+    -d 420m
+    -P keyspace_count=1
+    -P table_count_per_keyspace=5000
+    -P row_count_per_table=50000
+    -P blob_col_size=128
+    -P text_col_size=128
+    -P gauss_mean=25000
+    -P gauss_stddev=5000
+    -P table_group_size=10
+    -P table_shift_count=1
+    -P table_shift_interval_s=10
+    -P data_validation=true
+    -P create_collocated_mv=true
+    data_dir/latte/schema_scale.rn
+  - >-
+    latte run --tag read_notcolloc_mv -f read_notcolloc_mv
+    --threads=2 --concurrency=8 --connections=2 --rate 5000
+    --warmup=0 --retries=10 --retry-interval=1s,30s --request-timeout 300 --sampling 30s
+    --validation-strategy=retry
+    -d 420m
+    -P keyspace_count=1
+    -P table_count_per_keyspace=5000
+    -P row_count_per_table=50000
+    -P blob_col_size=128
+    -P text_col_size=128
+    -P gauss_mean=25000
+    -P gauss_stddev=5000
+    -P table_group_size=10
+    -P table_shift_count=1
+    -P table_shift_interval_s=10
+    -P data_validation=true
+    -P create_notcollocated_mv=true
+    data_dir/latte/schema_scale.rn


### PR DESCRIPTION
Added new scale test which added for each table mv as colocated or not solocated

Fixes SCYLLADB-631

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [Job 1 failed](https://argus.scylladb.com/tests/scylla-cluster-tests/c8b5bf74-d57d-456b-ad00-85acfb13cedf) - found coredump during start after drain
- [Job 2 failed](https://argus.scylladb.com/tests/scylla-cluster-tests/eedcfce8-b480-4670-ba47-f3e2eb0dd81d) - issue opened
- [job 3 passed](https://argus.scylladb.com/tests/scylla-cluster-tests/7483681f-5790-4692-a316-c76665cc91ec) - with optimized command 

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
