### PR TITLE
fix(nemesis): suppress raft topology errors in network block nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3940,16 +3940,17 @@ class NemesisRunner:
     def _disrupt_network_block_k8s(self, list_of_timeout_options):
         duration = f"{random.choice(list_of_timeout_options)}s"
         experiment = NetworkPacketLossExperiment(self.target_node, duration, probability=100)
-        with DbNodeLogger(
-            self.cluster.nodes,
-            "block network traffic",
-            target_node=self.target_node,
-            additional_info=f"for {duration}sec",
-        ):
-            experiment.start()
-        experiment.wait_until_finished()
-        time.sleep(15)
-        self.cluster.wait_all_nodes_un()
+        with ignore_raft_topology_cmd_failing():
+            with DbNodeLogger(
+                self.cluster.nodes,
+                "block network traffic",
+                target_node=self.target_node,
+                additional_info=f"for {duration}sec",
+            ):
+                experiment.start()
+            experiment.wait_until_finished()
+            time.sleep(15)
+            self.cluster.wait_all_nodes_un()
 
     def disrupt_network_block(self):
         list_of_timeout_options = [10, 60, 120, 300, 500]
@@ -3978,7 +3979,7 @@ class NemesisRunner:
         wait_time = random.choice(list_of_timeout_options)
         self.log.debug("BlockNetwork: [%s] for %dsec", selected_option, wait_time)
         self.actions_log.info(f"Network block start on {self.target_node.name} node, wait_time: {wait_time}")
-        with context_manager:
+        with context_manager, ignore_raft_topology_cmd_failing():
             self.target_node.traffic_control(None)
             try:
                 with DbNodeLogger(


### PR DESCRIPTION
Wrapped network blocking operations in disrupt_network_block and _disrupt_network_block_k8s with ignore_raft_topology_cmd_failing() context manager to suppress expected raft topology connection closed errors during network disruption. This fixes DatabaseLogEvent ERROR: raft_topology - topology change coordinator fiber got error with connection is closed exceptions that occur when network connectivity is blocked during nemesis execution.

The network block nemesis intentionally disrupts network connectivity, which causes Raft consensus protocol to report connection failures. These errors are expected and correct behavior when a node is network- isolated, so they should be suppressed during the nemesis operation.

Fixes the error of:
```
2026-02-11 11:11:41.300 <2026-02-11 11:11:40.247>: (DatabaseLogEvent Severity.ERROR) period_type=one-time event_id=4f80e089-50e6-4f08-bf84-9f65307ea1da: type=RUNTIME_ERROR regex=std::runtime_error line_number=18953 node=longevity-200gb-48h-network-2026-1-db-node-76155e7b-1
2026-02-11T11:11:40.247 longevity-200gb-48h-network-2026-1-db-node-76155e7b-1  !ERR | scylla[6512]  [shard 0: gms] raft_topology - topology change coordinator fiber got error std::runtime_error (raft topology: exec_global_command(barrier) failed with seastar::rpc::closed_error (got error from node cbbe2fe6-1044-4894-919b-a13720bc3619/10.4.12.221: connection is closed))
```
in https://argus.scylladb.com/tests/scylla-cluster-tests/76155e7b-de05-4cdb-b819-c8e1b0bd5f64
### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [network-block-nemesis](https://argus.scylladb.com/tests/scylla-cluster-tests/54f3b13b-1982-462c-ac2c-b4f98ccfa533)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
