### PR TITLE
Revert "[Backport 2025.3] fix(gce): disable scylla-doctor on GCE"

### DIFF
--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -36,9 +36,5 @@ backup_bucket_backend: 'gcs'
 
 use_preinstalled_scylla: true
 
-# Disable scylla-doctor on GCE temporarily due to v1.8 bug - https://scylladb.atlassian.net/browse/DOCTOR-12
-# Re-enable once scylla-doctor fixes the issue
-run_scylla_doctor: false
-
 # we are using monitor images, see `gce_image_monitor`
 monitor_branch: null


### PR DESCRIPTION
Reverts scylladb/scylla-cluster-tests#13563

The underlying issue in scylla-doctor was fixed in https://scylladb.atlassian.net/browse/DOCTOR-12 and released in scylla-doctor 1.9.