### PR TITLE
fix(certs): add retry logic for certificate installation

### DIFF
--- a/sdcm/provision/helpers/certificate.py
+++ b/sdcm/provision/helpers/certificate.py
@@ -31,6 +31,7 @@ from cryptography.x509.oid import NameOID
 
 from sdcm.remote import shell_script_cmd
 from sdcm.utils.common import get_data_dir_path
+from sdcm.utils.decorators import retrying
 from sdcm.utils.docker_utils import ContainerManager, DockerException
 
 if TYPE_CHECKING:
@@ -73,6 +74,7 @@ CLIENT_CERT_FILE = Path(get_data_dir_path("ssl_conf", TLSAssets.CLIENT_CERT))
 JKS_TRUSTSTORE_FILE = Path(get_data_dir_path("ssl_conf", TLSAssets.JKS_TRUSTSTORE))
 
 
+@retrying(n=3, sleep_time=10, allowed_exceptions=(Exception,), message="Retrying SSL certificate installation")
 def install_client_certificate(remoter, node_identifier):
     if remoter.run(f"ls {SCYLLA_SSL_CONF_DIR}", ignore_status=True).ok:
         return
@@ -93,6 +95,7 @@ def install_client_certificate(remoter, node_identifier):
     remoter.run('bash -cxe "%s"' % setup_script)
 
 
+@retrying(n=3, sleep_time=10, allowed_exceptions=(Exception,), message="Retrying encryption-at-rest files installation")
 def install_encryption_at_rest_files(remoter):
     if remoter.sudo("ls /etc/encrypt_conf/system_key_dir", ignore_status=True).ok:
         return


### PR DESCRIPTION
Copying SSL certificates can potentially fail due to SSH timeouts during rsync/scp, aborting the entire test.
Adding @retrying decorator makes certificates installation resilient to transient network issues.

Closes: SCT-90

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [pr-provision-test with server/client encryption enabled](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/245/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
