### PR TITLE
feat(nemesis): Remove disrupt_method_wrapper

### DIFF
--- a/docs/shelved/MULTITENANTK8s.md
+++ b/docs/shelved/MULTITENANTK8s.md
@@ -1,0 +1,12 @@
+# Background
+
+Running on K8s with Multitenancy (i.e. more DB on one physical node) was supported but not used much recently.
+With no real cases running regularly, it is not needed anymore.
+
+Goal of this document is to document features that were required for making multitenancy work that were removed so if needed they can be revisited.
+
+### Exclusive nemesis
+
+Nemesis which touch VM directly in K8s environment can affect other NemesisRunners when run in parallel.
+For this reason exclusive mechanism was introduced, which is a simple locking mechanism with global lock across different NemesisRunners.
+NemesisRunners needs to acquire the lock before executing nemesis that is marked as "exclusive" (via class level varible in NemesisBaseClass)

--- a/longevity_lwt_test.py
+++ b/longevity_lwt_test.py
@@ -18,7 +18,6 @@
 
 import time
 import logging
-from unittest.mock import MagicMock
 
 from longevity_test import LongevityTest
 from sdcm.sct_events import Severity
@@ -67,8 +66,7 @@ class LWTLongevityTest(LongevityTest):
         # If we even will catch period when no nemesis are running, it may happen that the nemesis will start in the
         # middle of data validation and fail it
         if self.db_cluster.nemesis_count > 1:
-            self.data_validator = MagicMock()
-            self.data_validator.keyspace_name = None
+            self.data_validator = None
             DataValidatorEvent.DataValidator(
                 severity=Severity.NORMAL, message="Test runs with parallel nemesis. Data validator is disabled."
             ).publish()
@@ -102,18 +100,21 @@ class LWTLongevityTest(LongevityTest):
 
     def validate_data(self, during_nemesis=False):
         try:
-            node = self.db_cluster.nodes[0]
-            if not (keyspace := self.data_validator.keyspace_name):
-                DataValidatorEvent.DataValidator(
-                    severity=Severity.NORMAL, message="Failed fo get keyspace name. Data validator is disabled."
-                ).publish()
-                return
+            if self.data_validator:
+                node = self.db_cluster.nodes[0]
+                if not (keyspace := self.data_validator.keyspace_name):
+                    DataValidatorEvent.DataValidator(
+                        severity=Severity.NORMAL, message="Failed fo get keyspace name. Data validator is disabled."
+                    ).publish()
+                    return
 
-            with self.db_cluster.cql_connection_patient(node, keyspace=keyspace) as session:
-                self.data_validator.validate_range_not_expected_to_change(
-                    session=session, during_nemesis=during_nemesis
-                )
-                self.data_validator.validate_range_expected_to_change(session=session, during_nemesis=during_nemesis)
-                self.data_validator.validate_deleted_rows(session=session, during_nemesis=during_nemesis)
+                with self.db_cluster.cql_connection_patient(node, keyspace=keyspace) as session:
+                    self.data_validator.validate_range_not_expected_to_change(
+                        session=session, during_nemesis=during_nemesis
+                    )
+                    self.data_validator.validate_range_expected_to_change(
+                        session=session, during_nemesis=during_nemesis
+                    )
+                    self.data_validator.validate_deleted_rows(session=session, during_nemesis=during_nemesis)
         except Exception as err:  # noqa: BLE001
-            LOGGER.debug(f"Data validator error: {err}")
+            LOGGER.error(f"Data validator error: {err}")

--- a/longevity_lwt_test.py
+++ b/longevity_lwt_test.py
@@ -17,6 +17,7 @@
 # After the test is finished will be performed the data validation.
 
 import time
+import logging
 from unittest.mock import MagicMock
 
 from longevity_test import LongevityTest
@@ -27,12 +28,23 @@ from sdcm.utils.common import skip_optional_stage
 from sdcm.sct_events.group_common_events import ignore_mutation_write_errors
 
 
+LOGGER = logging.getLogger(__name__)
+
+
 class LWTLongevityTest(LongevityTest):
     BASE_TABLE_PARTITION_KEYS = ["domain", "published_date"]
 
     def setUp(self):
         super().setUp()
         self.data_validator = None
+
+    def pre_nemesis(self):
+        """Runs before nemesis execution"""
+        self.validate_data(during_nemesis=True)
+
+    def post_nemesis(self):
+        """Runs after each nemesis execution"""
+        self.validate_data(during_nemesis=True)
 
     def run_prepare_write_cmd(self):
         # `mutation_write_*' errors are thrown when system is overloaded and got timeout on
@@ -88,15 +100,20 @@ class LWTLongevityTest(LongevityTest):
                 self.db_cluster.stop_nemesis(timeout=300)
             self.validate_data()
 
-    def validate_data(self):
-        node = self.db_cluster.nodes[0]
-        if not (keyspace := self.data_validator.keyspace_name):
-            DataValidatorEvent.DataValidator(
-                severity=Severity.NORMAL, message="Failed fo get keyspace name. Data validator is disabled."
-            ).publish()
-            return
+    def validate_data(self, during_nemesis=False):
+        try:
+            node = self.db_cluster.nodes[0]
+            if not (keyspace := self.data_validator.keyspace_name):
+                DataValidatorEvent.DataValidator(
+                    severity=Severity.NORMAL, message="Failed fo get keyspace name. Data validator is disabled."
+                ).publish()
+                return
 
-        with self.db_cluster.cql_connection_patient(node, keyspace=keyspace) as session:
-            self.data_validator.validate_range_not_expected_to_change(session=session)
-            self.data_validator.validate_range_expected_to_change(session=session)
-            self.data_validator.validate_deleted_rows(session=session)
+            with self.db_cluster.cql_connection_patient(node, keyspace=keyspace) as session:
+                self.data_validator.validate_range_not_expected_to_change(
+                    session=session, during_nemesis=during_nemesis
+                )
+                self.data_validator.validate_range_expected_to_change(session=session, during_nemesis=during_nemesis)
+                self.data_validator.validate_deleted_rows(session=session, during_nemesis=during_nemesis)
+        except Exception as err:  # noqa: BLE001
+            LOGGER.debug(f"Data validator error: {err}")

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -97,7 +97,7 @@ from sdcm.sct_events.group_common_events import (
     ignore_raft_topology_cmd_failing,
     suppress_expected_unavailability_errors,
 )
-from sdcm.sct_events.health import DataValidatorEvent
+
 from sdcm.sct_events.loaders import CassandraStressLogEvent, ScyllaBenchEvent
 from sdcm.sct_events.nemesis import DisruptionEvent
 from sdcm.sct_events.system import InfoEvent, CoreDumpEvent
@@ -5799,67 +5799,78 @@ class NemesisRunner:
                 with self.cluster.cql_connection_patient(node=working_node, connect_timeout=600) as session:
                     drop_materialized_view(session, ks_name, view_name)
 
+    @contextlib.contextmanager
+    def argus_submit(self, nemesis_name: str, start_time: int | float, nemesis_event: DisruptionEvent):
+        argus_client = None
+        submitted = False
+        try:
+            argus_client = self.cluster.test_config.argus_client()
+            self.argus_client.submit_nemesis(
+                name=nemesis_name,
+                class_name=self.get_class_name(),
+                start_time=int(start_time),
+                target_name=self.target_node.name,
+                target_ip=self.target_node.public_ip_address,
+                target_shards=self.target_node.scylla_shards,
+            )
+            submitted = True
+        except Exception:
+            self.log.error("Error creating nemesis information in Argus", exc_info=True)
 
-def disrupt_method_wrapper(method, caller_obj: "NemesisBaseClass", is_exclusive=False):  # noqa: PLR0915
+        try:
+            yield
+        finally:
+            if submitted:
+                match nemesis_event.nemesis_status:
+                    case NemesisStatus.FAILED:
+                        message = nemesis_event.full_traceback
+                    case NemesisStatus.SKIPPED:
+                        message = nemesis_event.skip_reason
+                    case _:
+                        message = ""
+                try:
+                    argus_client.finalize_nemesis(
+                        name=nemesis_name,
+                        start_time=int(start_time),
+                        status=nemesis_event.nemesis_status,
+                        message=message,
+                    )
+                except Exception:
+                    self.log.error("Error finalizing nemesis information in Argus", exc_info=True)
+
+    @contextlib.contextmanager
+    def verify_nodes(self):
+        num_data_nodes_before = len(self.cluster.data_nodes)
+        num_zero_nodes_before = len(self.cluster.zero_nodes)
+        try:
+            yield
+        finally:
+            num_data_nodes_after = len(self.cluster.data_nodes)
+            num_zero_nodes_after = len(self.cluster.zero_nodes)
+            if num_data_nodes_before != num_data_nodes_after:
+                self.log.error(
+                    "num data nodes before %s and data nodes after %s does not match"
+                    % (num_data_nodes_before, num_data_nodes_after)
+                )
+            if self.cluster.params.get("use_zero_nodes") and num_zero_nodes_before != num_zero_nodes_after:
+                self.log.error(
+                    "num zero nodes before %s and zero nodes after %s does not match"
+                    % (num_zero_nodes_before, num_zero_nodes_after)
+                )
+
+    def log_on_all_nodes(self, msg, start_symbol=">", end_symbol="="):
+        self.log.debug("{start_symbol} {msg} {start_symbol}".format(start_symbol=start_symbol * 12, msg=msg))
+        for nodes_set in (self.cluster, self.loaders):
+            nodes_set.log_message("{end_symbol} {msg} {end_symbol}".format(end_symbol=end_symbol * 12, msg=msg))
+
+
+def disrupt_method_wrapper(method, caller_obj: "NemesisBaseClass"):  # noqa: PLR0915
     """
     Log time elapsed for method to run
 
     :param method: Remote method to wrap.
     :return: Wrapped method.
     """
-
-    def argus_create_nemesis_info(
-        nemesis: "NemesisRunner", class_name: str, method_name: str, start_time: int | float
-    ) -> bool:
-        try:
-            argus_client = nemesis.target_node.test_config.argus_client()
-            argus_client.submit_nemesis(
-                name=method_name,
-                class_name=class_name,
-                start_time=int(start_time),
-                target_name=nemesis.target_node.name,
-                target_ip=nemesis.target_node.public_ip_address,
-                target_shards=nemesis.target_node.scylla_shards,
-            )
-            return True
-        except Exception:
-            nemesis.log.error("Error creating nemesis information in Argus", exc_info=True)
-        return False
-
-    def argus_finalize_nemesis_info(
-        nemesis: "NemesisRunner", method_name: str, start_time: int, nemesis_event: DisruptionEvent
-    ):
-        if not isinstance(start_time, int):
-            start_time = int(start_time)
-        try:
-            argus_client = nemesis.cluster.test_config.argus_client()
-            if nemesis_event.severity == Severity.ERROR:
-                argus_client.finalize_nemesis(
-                    name=method_name,
-                    start_time=start_time,
-                    status=NemesisStatus.FAILED,
-                    message=nemesis_event.full_traceback,
-                )
-            elif nemesis_event.is_skipped:
-                argus_client.finalize_nemesis(
-                    name=method_name,
-                    start_time=start_time,
-                    status=NemesisStatus.SKIPPED,
-                    message=nemesis_event.skip_reason,
-                )
-            else:
-                argus_client.finalize_nemesis(
-                    name=method_name, start_time=start_time, status=NemesisStatus.SUCCEEDED, message=""
-                )
-        except Exception:
-            nemesis.log.error("Error finalizing nemesis information in Argus", exc_info=True)
-
-    def get_nemesis_status(nemesis_event: DisruptionEvent) -> str:
-        if nemesis_event.severity == Severity.ERROR:
-            return NemesisStatus.FAILED
-        if nemesis_event.is_skipped:
-            return NemesisStatus.SKIPPED
-        return NemesisStatus.SUCCEEDED
 
     def data_validation_prints(caller):
         try:
@@ -5894,23 +5905,15 @@ def disrupt_method_wrapper(method, caller_obj: "NemesisBaseClass", is_exclusive=
                 )
             else:
                 runner.cluster.check_cluster_health()
-            num_data_nodes_before = len(runner.cluster.data_nodes)
-            num_zero_nodes_before = len(runner.cluster.zero_nodes)
             start_time = time.time()
 
             current_disruption = unique_disruption_name(method_name)
             runner.set_target_node_pool_type(target_pool_type)
             runner.set_target_node(current_disruption=current_disruption)
-            start_msg = (
-                f"Started disruption {method_name} ({runner.base_disruption_name} nemesis) on the target node "
-                f"'{str(runner.target_node)}'"
+            runner.log_on_all_nodes(
+                f"Started disruption {method_name} ({runner.base_disruption_name} nemesis) on the target node '{str(runner.target_node)}'"
             )
-            runner.log.debug("{start_symbol} {msg} {start_symbol}".format(start_symbol=">" * 12, msg=start_msg))
-            for nodes_set in (runner.cluster, runner.loaders):
-                nodes_set.log_message(
-                    "{start_symbol} {msg} {start_symbol}".format(start_symbol="=" * 12, msg=start_msg)
-                )
-            class_name = runner.get_class_name()
+
             result = None
             status = True
 
@@ -5930,10 +5933,9 @@ def disrupt_method_wrapper(method, caller_obj: "NemesisBaseClass", is_exclusive=
                     nemesis_name=runner.base_disruption_name, node=runner.target_node, publish_event=True
                 ) as nemesis_event,
                 runner.actions_log.action_scope(f"Disruption {method_name} on {runner.target_node.name}"),
+                runner.argus_submit(nemesis_name=method_name, start_time=start_time, nemesis_event=nemesis_event),
+                runner.verify_nodes(),
             ):
-                nemesis_info = argus_create_nemesis_info(
-                    nemesis=runner, class_name=class_name, method_name=method_name, start_time=start_time
-                )
                 try:
                     result = method(*args, **kwargs)
                 except (UnsupportedNemesis, MethodVersionNotFound) as exp:
@@ -5983,36 +5985,10 @@ def disrupt_method_wrapper(method, caller_obj: "NemesisBaseClass", is_exclusive=
                     runner.log.info(f"log_info: {log_info}")
                     nemesis_event.duration = time_elapsed
 
-                    if nemesis_info:
-                        argus_finalize_nemesis_info(
-                            nemesis=runner,
-                            method_name=method_name,
-                            start_time=int(start_time),
-                            nemesis_event=nemesis_event,
-                        )
-
-                    end_msg = (
-                        f"Finished disruption {method_name} ({runner.base_disruption_name} nemesis) with status "
-                        f"'{get_nemesis_status(nemesis_event)}'"
+                    runner.log_on_all_nodes(
+                        f"Finished disruption {method_name} ({runner.base_disruption_name} nemesis) with status '{nemesis_event.get_argus_nemesis_status()}'"
                     )
-                    runner.log.debug("{end_symbol} {msg} {end_symbol}".format(end_symbol="<" * 12, msg=end_msg))
-                    for nodes_set in (runner.cluster, runner.loaders):
-                        nodes_set.log_message(
-                            "{end_symbol} {msg} {end_symbol}".format(end_symbol="=" * 12, msg=end_msg)
-                        )
 
-            num_data_nodes_after = len(runner.cluster.data_nodes)
-            num_zero_nodes_after = len(runner.cluster.zero_nodes)
-            if num_data_nodes_before != num_data_nodes_after:
-                runner.log.error(
-                    "num data nodes before %s and data nodes after %s does not match"
-                    % (num_data_nodes_before, num_data_nodes_after)
-                )
-            if runner.cluster.params.get("use_zero_nodes") and num_zero_nodes_before != num_zero_nodes_after:
-                runner.log.error(
-                    "num zero nodes before %s and zero nodes after %s does not match"
-                    % (num_zero_nodes_before, num_zero_nodes_after)
-                )
             # TODO: Temporary print. Will be removed later
             data_validation_prints(runner)
         finally:

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -5922,10 +5922,7 @@ def disrupt_method_wrapper(method, caller_obj: "NemesisBaseClass", is_exclusive=
                 nodes_set.log_message(
                     "{start_symbol} {msg} {start_symbol}".format(start_symbol="=" * 12, msg=start_msg)
                 )
-
             class_name = runner.get_class_name()
-            if class_name.find("Chaos") < 0:
-                runner.metrics_srv.event_start(class_name)
             result = None
             status = True
 
@@ -5990,9 +5987,7 @@ def disrupt_method_wrapper(method, caller_obj: "NemesisBaseClass", is_exclusive=
                     runner.operation_log.append(copy.deepcopy(log_info))
                     runner.log.debug("%s duration -> %s s", runner.base_disruption_name, time_elapsed)
 
-                    if class_name.find("Chaos") < 0:
-                        runner.metrics_srv.event_stop(class_name)
-                    disrupt = runner.base_disruption_name
+
                     del log_info["operation"]
 
                     runner.update_stats(disrupt, status, log_info)

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -34,10 +34,9 @@ from abc import ABC, abstractmethod
 from contextlib import ExitStack
 from datetime import timedelta
 from typing import List, Optional, Callable, Union, Iterable, TYPE_CHECKING
-from functools import wraps, partial, cached_property
+from functools import partial, cached_property
 from collections import defaultdict, Counter, namedtuple
 from concurrent.futures import ThreadPoolExecutor
-from threading import Lock
 from uuid import uuid4
 
 from cassandra import ConsistencyLevel, InvalidRequest
@@ -211,10 +210,6 @@ if TYPE_CHECKING:
     from sdcm.mgmt.cli import BackupTask
 
 LOGGER = logging.getLogger(__name__)
-# NOTE: following lock is needed in the K8S multitenant case
-NEMESIS_LOCK = Lock()
-NEMESIS_RUN_INFO = {}
-
 DISRUPT_POOL_PROPERTY_NAME = "target_pool"
 
 __all__ = ["DataValidatorEvent"]
@@ -417,8 +412,6 @@ class NemesisRunner:
             rack=rack,
             allow_only_last_node_in_rack=allow_only_last_node_in_rack,
         )
-        if current_disruption:
-            self.set_current_disruption(current_disruption)
         self.log.info("%s: target node selected by allocator - %s", disruption_name, self.target_node)
 
     @raise_event_on_failure
@@ -1109,10 +1102,6 @@ class NemesisRunner:
 
     def get_class_name(self):
         return self.__class__.__name__.replace("Monkey", "")
-
-    def set_current_disruption(self, label=None):
-        self.log.debug("Set current_disruption -> %s", label.split("-", 1)[0])
-        self.current_disruption = label
 
     def disrupt_destroy_data_then_repair(self):
         """repair at the beginning added to avoid c-s failure 'data wasn't validated'"""
@@ -1935,12 +1924,89 @@ class NemesisRunner:
     # Nemesis running code
     def execute_nemesis(self, nemesis: NemesisBaseClass):
         """Runs selected disrupt method"""
-        event_name = nemesis.__class__.__name__
-        self.metrics_srv.event_start(event_name)
-        try:
-            disrupt_method_wrapper(nemesis.disrupt, caller_obj=nemesis, is_exclusive=nemesis.exclusive)()
-        finally:
-            self.metrics_srv.event_stop(event_name)
+        assert nemesis.runner == self, "Nemesis needs to be initialized with the same runner that executes it"
+        class_name = nemesis.__class__.__name__
+        target_pool_type = getattr(nemesis, DISRUPT_POOL_PROPERTY_NAME, DISRUPT_DEFAULT_POOL)
+
+        # Skip health check if previous nemesis was skipped to avoid wasting 2+ hours on large clusters
+        last_event = self.last_nemesis_event
+        if last_event and last_event.is_skipped:
+            self.log.info(
+                "Skipping health check: previous nemesis '%s' was skipped (reason: %s)",
+                last_event.nemesis_name,
+                last_event.skip_reason,
+            )
+        else:
+            self.cluster.check_cluster_health()
+        start_time = time.time()
+
+        nemesis_event = None
+        self.current_disruption = unique_disruption_name(class_name)
+        disruption_name = self.base_disruption_name
+        raise_error = None
+        self.set_target_node_pool_type(target_pool_type)
+        self.set_target_node()
+        with (
+            DisruptionEvent(nemesis_name=disruption_name, node=self.target_node, publish_event=True) as nemesis_event,
+            self.actions_log.action_scope(f"Disruption {class_name} on {self.target_node.name}"),
+            self.argus_submit(nemesis_name=class_name, start_time=start_time, nemesis_event=nemesis_event),
+            self.verify_nodes(),
+            self.tester.run_nemesis_hooks(),
+            self.metrics_srv.event(class_name),
+        ):
+            self.log_on_all_nodes(
+                f"Started disruption {class_name} ({disruption_name} nemesis) on the target node '{str(self.target_node)}'"
+            )
+            try:
+                nemesis.disrupt()
+            except (UnsupportedNemesis, MethodVersionNotFound) as exp:
+                nemesis_event.skip(skip_reason=str(exp))
+                raise_error = exp
+            except KillNemesis as exp:
+                if self.tester.get_event_summary().get("CRITICAL", 0):
+                    nemesis_event.add_simple_error("Killed by tearDown - test fail", traceback.format_exc())
+                else:
+                    nemesis_event.skip(skip_reason="Killed by tearDown - test success")
+                raise_error = exp
+            except Exception as details:  # noqa: BLE001
+                nemesis_event.add_simple_error(str(details), traceback.format_exc())
+                self.error_list.append(str(details))
+                self.log.error("Unhandled exception in method %s", nemesis.disrupt, exc_info=True)
+            finally:
+                self.last_nemesis_event = nemesis_event
+                end_time = time.time()
+                time_elapsed = int(end_time - start_time)
+                nemesis_event.duration = time_elapsed
+
+                # Build log_info once from nemesis_event — single source of truth
+                log_info = {
+                    "start": int(start_time),
+                    "end": int(end_time),
+                    "duration": time_elapsed,
+                    "node": str(self.target_node),
+                    "subtype": str(nemesis_event.nemesis_status.value),
+                }
+                status = True
+                if nemesis_event.severity == Severity.ERROR:
+                    log_info["error"] = nemesis_event.errors[-1]
+                    log_info["full_traceback"] = nemesis_event.full_traceback
+                    status = False
+                if nemesis_event.is_skipped:
+                    log_info["skip_reason"] = nemesis_event.skip_reason
+
+                self.duration_list.append(time_elapsed)
+                self.operation_log.append({"operation": disruption_name, **log_info})
+                self.log.debug("%s duration -> %s s", disruption_name, time_elapsed)
+                self.log.info("log_info: %s", log_info)
+                self.update_stats(disruption_name, status, log_info)
+
+                self.log_on_all_nodes(
+                    f"Finished disruption {class_name} ({disruption_name} nemesis) with status '{nemesis_event.nemesis_status}'"
+                )
+                self.current_disruption = None
+        self.set_target_node_pool_type(DISRUPT_DEFAULT_POOL)
+        if raise_error:
+            raise raise_error
 
     def build_disruptions_by_selector(self, nemesis_selector: str | None = None):
         """
@@ -5807,7 +5873,7 @@ class NemesisRunner:
         submitted = False
         try:
             argus_client = self.cluster.test_config.argus_client()
-            self.argus_client.submit_nemesis(
+            argus_client.submit_nemesis(
                 name=nemesis_name,
                 class_name=self.get_class_name(),
                 start_time=int(start_time),
@@ -5864,100 +5930,6 @@ class NemesisRunner:
         self.log.debug("{start_symbol} {msg} {start_symbol}".format(start_symbol=start_symbol * 12, msg=msg))
         for nodes_set in (self.cluster, self.loaders):
             nodes_set.log_message("{end_symbol} {msg} {end_symbol}".format(end_symbol=end_symbol * 12, msg=msg))
-
-
-def disrupt_method_wrapper(method, caller_obj: "NemesisBaseClass"):  # noqa: PLR0915
-    """
-    Log time elapsed for method to run
-
-    :param method: Remote method to wrap.
-    :return: Wrapped method.
-    """
-
-    @wraps(method)
-    def wrapper(*args, **kwargs):  # noqa: PLR0912, PLR0914, PLR0915
-        method_name = method.__self__.__class__.__name__
-        target_pool_type = getattr(method.__self__, DISRUPT_POOL_PROPERTY_NAME, DISRUPT_DEFAULT_POOL)
-        runner = caller_obj.runner
-
-        # Skip health check if previous nemesis was skipped to avoid wasting 2+ hours on large clusters
-        last_event = runner.last_nemesis_event
-        if last_event and last_event.is_skipped:
-            runner.log.info(
-                "Skipping health check: previous nemesis '%s' was skipped (reason: %s)",
-                last_event.nemesis_name,
-                last_event.skip_reason,
-            )
-        else:
-            runner.cluster.check_cluster_health()
-        start_time = time.time()
-
-        result = None
-
-        with (
-            DisruptionEvent(
-                nemesis_name=runner.base_disruption_name, node=runner.target_node, publish_event=True
-            ) as nemesis_event,
-            runner.actions_log.action_scope(f"Disruption {method_name} on {runner.target_node.name}"),
-            runner.argus_submit(nemesis_name=method_name, start_time=start_time, nemesis_event=nemesis_event),
-            runner.verify_nodes(),
-            runner.tester.run_nemesis_hooks(),
-        ):
-            runner.set_target_node_pool_type(target_pool_type)
-            runner.set_target_node(current_disruption=unique_disruption_name(method_name))
-            runner.log_on_all_nodes(
-                f"Started disruption {method_name} ({runner.base_disruption_name} nemesis) on the target node '{str(runner.target_node)}'"
-            )
-            try:
-                result = method(*args, **kwargs)
-            except (UnsupportedNemesis, MethodVersionNotFound) as exp:
-                nemesis_event.skip(skip_reason=str(exp))
-                raise
-            except KillNemesis:
-                if runner.tester.get_event_summary().get("CRITICAL", 0):
-                    nemesis_event.add_simple_error("Killed by tearDown - test fail", traceback.format_exc())
-                else:
-                    nemesis_event.skip(skip_reason="Killed by tearDown - test success")
-                raise
-            except Exception as details:  # noqa: BLE001
-                nemesis_event.add_simple_error(str(details), traceback.format_exc())
-                runner.error_list.append(str(details))
-                runner.log.error("Unhandled exception in method %s", method, exc_info=True)
-            finally:
-                runner.set_target_node_pool_type(DISRUPT_DEFAULT_POOL)
-                runner.last_nemesis_event = nemesis_event
-                end_time = time.time()
-                time_elapsed = int(end_time - start_time)
-                nemesis_event.duration = time_elapsed
-
-                # Build log_info once from nemesis_event — single source of truth
-                log_info = {
-                    "start": int(start_time),
-                    "end": int(end_time),
-                    "duration": time_elapsed,
-                    "node": str(runner.target_node),
-                    "subtype": str(nemesis_event.nemesis_status.value),
-                }
-                status = True
-                if nemesis_event.severity == Severity.ERROR:
-                    log_info["error"] = nemesis_event.errors[-1]
-                    log_info["full_traceback"] = nemesis_event.full_traceback
-                    status = False
-                if nemesis_event.is_skipped:
-                    log_info["skip_reason"] = nemesis_event.skip_reason
-
-                runner.duration_list.append(time_elapsed)
-                runner.operation_log.append({"operation": runner.base_disruption_name, **log_info})
-                runner.log.debug("%s duration -> %s s", runner.base_disruption_name, time_elapsed)
-                runner.log.info("log_info: %s", log_info)
-                runner.update_stats(runner.base_disruption_name, status, log_info)
-
-                runner.log_on_all_nodes(
-                    f"Finished disruption {method_name} ({runner.base_disruption_name} nemesis) with status '{nemesis_event.nemesis_status}'"
-                )
-        return result
-
-    return wrapper
 
 
 # Auto-discovery mechanism.

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -1949,7 +1949,12 @@ class NemesisRunner:
         with (
             DisruptionEvent(nemesis_name=disruption_name, node=self.target_node, publish_event=True) as nemesis_event,
             self.actions_log.action_scope(f"Disruption {class_name} on {self.target_node.name}"),
-            self.argus_submit(nemesis_name=class_name, start_time=start_time, nemesis_event=nemesis_event),
+            self.argus_submit(
+                nemesis_name=class_name,
+                start_time=start_time,
+                nemesis_event=nemesis_event,
+                description=nemesis.__class__.__doc__,
+            ),
             self.verify_nodes(),
             self.tester.run_nemesis_hooks(),
             self.metrics_srv.event(class_name),
@@ -5868,7 +5873,9 @@ class NemesisRunner:
                     drop_materialized_view(session, ks_name, view_name)
 
     @contextlib.contextmanager
-    def argus_submit(self, nemesis_name: str, start_time: int | float, nemesis_event: DisruptionEvent):
+    def argus_submit(
+        self, nemesis_name: str, start_time: int | float, nemesis_event: DisruptionEvent, description: str | None = None
+    ):
         argus_client = None
         submitted = False
         try:
@@ -5880,6 +5887,7 @@ class NemesisRunner:
                 target_name=self.target_node.name,
                 target_ip=self.target_node.public_ip_address,
                 target_shards=self.target_node.scylla_shards,
+                description=description,
             )
             submitted = True
         except Exception:

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -17,7 +17,6 @@ Module containing logic for running disruptions on a test cluster
 """
 
 import contextlib
-import copy
 import datetime
 import importlib
 import inspect
@@ -5915,16 +5914,7 @@ def disrupt_method_wrapper(method, caller_obj: "NemesisBaseClass"):  # noqa: PLR
             )
 
             result = None
-            status = True
 
-            log_info = {
-                "operation": runner.base_disruption_name,
-                "start": int(start_time),
-                "end": 0,
-                "duration": 0,
-                "node": str(runner.target_node),
-                "subtype": "end",
-            }
             # TODO: Temporary print. Will be removed later
             data_validation_prints(runner)
 
@@ -5939,54 +5929,47 @@ def disrupt_method_wrapper(method, caller_obj: "NemesisBaseClass"):  # noqa: PLR
                 try:
                     result = method(*args, **kwargs)
                 except (UnsupportedNemesis, MethodVersionNotFound) as exp:
-                    skip_reason = str(exp)
-                    log_info.update({"subtype": "skipped", "skip_reason": skip_reason})
-                    nemesis_event.skip(skip_reason=skip_reason)
+                    nemesis_event.skip(skip_reason=str(exp))
                     raise
                 except KillNemesis:
                     if runner.tester.get_event_summary().get("CRITICAL", 0):
-                        error_sting = "Killed by tearDown - test fail"
-                        nemesis_event.add_error([error_sting])
-                        nemesis_event.full_traceback = traceback.format_exc()
-                        nemesis_event.severity = Severity.ERROR
-                        log_info.update({"error": error_sting, "full_traceback": traceback.format_exc()})
-                        status = False
+                        nemesis_event.add_simple_error("Killed by tearDown - test fail", traceback.format_exc())
                     else:
-                        skip_reason = "Killed by tearDown - test success"
-                        log_info.update({"subtype": "skipped", "skip_reason": skip_reason})
-                        nemesis_event.skip(skip_reason=skip_reason)
+                        nemesis_event.skip(skip_reason="Killed by tearDown - test success")
                     raise
                 except Exception as details:  # noqa: BLE001
-                    nemesis_event.add_error([str(details)])
-                    nemesis_event.full_traceback = traceback.format_exc()
-                    nemesis_event.severity = Severity.ERROR
+                    nemesis_event.add_simple_error(str(details), traceback.format_exc())
                     runner.error_list.append(str(details))
                     runner.log.error("Unhandled exception in method %s", method, exc_info=True)
-                    log_info.update({"error": str(details), "full_traceback": traceback.format_exc()})
-                    status = False
                 finally:
                     end_time = time.time()
                     time_elapsed = int(end_time - start_time)
-                    log_info.update(
-                        {
-                            "end": int(end_time),
-                            "duration": time_elapsed,
-                        }
-                    )
-                    runner.duration_list.append(time_elapsed)
-                    runner.operation_log.append(copy.deepcopy(log_info))
-                    runner.log.debug("%s duration -> %s s", runner.base_disruption_name, time_elapsed)
-
-
-                    del log_info["operation"]
-
-                    runner.update_stats(disrupt, status, log_info)
-
-                    runner.log.info(f"log_info: {log_info}")
                     nemesis_event.duration = time_elapsed
 
+                    # Build log_info once from nemesis_event — single source of truth
+                    log_info = {
+                        "start": int(start_time),
+                        "end": int(end_time),
+                        "duration": time_elapsed,
+                        "node": str(runner.target_node),
+                        "subtype": str(nemesis_event.nemesis_status.value),
+                    }
+                    status = True
+                    if nemesis_event.severity == Severity.ERROR:
+                        log_info["error"] = nemesis_event.errors[-1]
+                        log_info["full_traceback"] = nemesis_event.full_traceback
+                        status = False
+                    if nemesis_event.is_skipped:
+                        log_info["skip_reason"] = nemesis_event.skip_reason
+
+                    runner.duration_list.append(time_elapsed)
+                    runner.operation_log.append({"operation": runner.base_disruption_name, **log_info})
+                    runner.log.debug("%s duration -> %s s", runner.base_disruption_name, time_elapsed)
+                    runner.log.info("log_info: %s", log_info)
+                    runner.update_stats(runner.base_disruption_name, status, log_info)
+
                     runner.log_on_all_nodes(
-                        f"Finished disruption {method_name} ({runner.base_disruption_name} nemesis) with status '{nemesis_event.get_argus_nemesis_status()}'"
+                        f"Finished disruption {method_name} ({runner.base_disruption_name} nemesis) with status '{nemesis_event.nemesis_status}'"
                     )
 
             # TODO: Temporary print. Will be removed later

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -235,6 +235,9 @@ def target_all_nodes(func: Callable) -> Callable:
     return func
 
 
+DISRUPT_DEFAULT_POOL = NEMESIS_TARGET_POOLS.data_nodes
+
+
 class NemesisFlags:
     # nemesis flags:
     topology_changes: bool = False  # flag that signal that nemesis is changing cluster topology,
@@ -5874,91 +5877,84 @@ def disrupt_method_wrapper(method, caller_obj: "NemesisBaseClass"):  # noqa: PLR
     @wraps(method)
     def wrapper(*args, **kwargs):  # noqa: PLR0912, PLR0914, PLR0915
         method_name = method.__self__.__class__.__name__
-        target_pool_type = getattr(method.__self__, DISRUPT_POOL_PROPERTY_NAME, NEMESIS_TARGET_POOLS.data_nodes)
+        target_pool_type = getattr(method.__self__, DISRUPT_POOL_PROPERTY_NAME, DISRUPT_DEFAULT_POOL)
         runner = caller_obj.runner
-        nemesis_event = None  # Initialize to None to avoid UnboundLocalError in finally block
-        try:
-            # Skip health check if previous nemesis was skipped to avoid wasting 2+ hours on large clusters
-            last_event = runner.last_nemesis_event
-            if last_event and last_event.is_skipped:
-                runner.log.info(
-                    "Skipping health check: previous nemesis '%s' was skipped (reason: %s)",
-                    last_event.nemesis_name,
-                    last_event.skip_reason,
-                )
-            else:
-                runner.cluster.check_cluster_health()
-            start_time = time.time()
 
-            current_disruption = unique_disruption_name(method_name)
+        # Skip health check if previous nemesis was skipped to avoid wasting 2+ hours on large clusters
+        last_event = runner.last_nemesis_event
+        if last_event and last_event.is_skipped:
+            runner.log.info(
+                "Skipping health check: previous nemesis '%s' was skipped (reason: %s)",
+                last_event.nemesis_name,
+                last_event.skip_reason,
+            )
+        else:
+            runner.cluster.check_cluster_health()
+        start_time = time.time()
+
+        result = None
+
+        with (
+            DisruptionEvent(
+                nemesis_name=runner.base_disruption_name, node=runner.target_node, publish_event=True
+            ) as nemesis_event,
+            runner.actions_log.action_scope(f"Disruption {method_name} on {runner.target_node.name}"),
+            runner.argus_submit(nemesis_name=method_name, start_time=start_time, nemesis_event=nemesis_event),
+            runner.verify_nodes(),
+            runner.tester.run_nemesis_hooks(),
+        ):
             runner.set_target_node_pool_type(target_pool_type)
-            runner.set_target_node(current_disruption=current_disruption)
+            runner.set_target_node(current_disruption=unique_disruption_name(method_name))
             runner.log_on_all_nodes(
                 f"Started disruption {method_name} ({runner.base_disruption_name} nemesis) on the target node '{str(runner.target_node)}'"
             )
-
-            result = None
-
-            with (
-                DisruptionEvent(
-                    nemesis_name=runner.base_disruption_name, node=runner.target_node, publish_event=True
-                ) as nemesis_event,
-                runner.actions_log.action_scope(f"Disruption {method_name} on {runner.target_node.name}"),
-                runner.argus_submit(nemesis_name=method_name, start_time=start_time, nemesis_event=nemesis_event),
-                runner.verify_nodes(),
-                runner.tester.run_nemesis_hooks(),
-            ):
-                try:
-                    result = method(*args, **kwargs)
-                except (UnsupportedNemesis, MethodVersionNotFound) as exp:
-                    nemesis_event.skip(skip_reason=str(exp))
-                    raise
-                except KillNemesis:
-                    if runner.tester.get_event_summary().get("CRITICAL", 0):
-                        nemesis_event.add_simple_error("Killed by tearDown - test fail", traceback.format_exc())
-                    else:
-                        nemesis_event.skip(skip_reason="Killed by tearDown - test success")
-                    raise
-                except Exception as details:  # noqa: BLE001
-                    nemesis_event.add_simple_error(str(details), traceback.format_exc())
-                    runner.error_list.append(str(details))
-                    runner.log.error("Unhandled exception in method %s", method, exc_info=True)
-                finally:
-                    end_time = time.time()
-                    time_elapsed = int(end_time - start_time)
-                    nemesis_event.duration = time_elapsed
-
-                    # Build log_info once from nemesis_event — single source of truth
-                    log_info = {
-                        "start": int(start_time),
-                        "end": int(end_time),
-                        "duration": time_elapsed,
-                        "node": str(runner.target_node),
-                        "subtype": str(nemesis_event.nemesis_status.value),
-                    }
-                    status = True
-                    if nemesis_event.severity == Severity.ERROR:
-                        log_info["error"] = nemesis_event.errors[-1]
-                        log_info["full_traceback"] = nemesis_event.full_traceback
-                        status = False
-                    if nemesis_event.is_skipped:
-                        log_info["skip_reason"] = nemesis_event.skip_reason
-
-                    runner.duration_list.append(time_elapsed)
-                    runner.operation_log.append({"operation": runner.base_disruption_name, **log_info})
-                    runner.log.debug("%s duration -> %s s", runner.base_disruption_name, time_elapsed)
-                    runner.log.info("log_info: %s", log_info)
-                    runner.update_stats(runner.base_disruption_name, status, log_info)
-
-                    runner.log_on_all_nodes(
-                        f"Finished disruption {method_name} ({runner.base_disruption_name} nemesis) with status '{nemesis_event.nemesis_status}'"
-                    )
-        finally:
-            # Store nemesis event to track skip status for health checks
-            if nemesis_event is not None:
+            try:
+                result = method(*args, **kwargs)
+            except (UnsupportedNemesis, MethodVersionNotFound) as exp:
+                nemesis_event.skip(skip_reason=str(exp))
+                raise
+            except KillNemesis:
+                if runner.tester.get_event_summary().get("CRITICAL", 0):
+                    nemesis_event.add_simple_error("Killed by tearDown - test fail", traceback.format_exc())
+                else:
+                    nemesis_event.skip(skip_reason="Killed by tearDown - test success")
+                raise
+            except Exception as details:  # noqa: BLE001
+                nemesis_event.add_simple_error(str(details), traceback.format_exc())
+                runner.error_list.append(str(details))
+                runner.log.error("Unhandled exception in method %s", method, exc_info=True)
+            finally:
+                runner.set_target_node_pool_type(DISRUPT_DEFAULT_POOL)
                 runner.last_nemesis_event = nemesis_event
-            runner.set_target_node_pool_type(NEMESIS_TARGET_POOLS.data_nodes)
+                end_time = time.time()
+                time_elapsed = int(end_time - start_time)
+                nemesis_event.duration = time_elapsed
 
+                # Build log_info once from nemesis_event — single source of truth
+                log_info = {
+                    "start": int(start_time),
+                    "end": int(end_time),
+                    "duration": time_elapsed,
+                    "node": str(runner.target_node),
+                    "subtype": str(nemesis_event.nemesis_status.value),
+                }
+                status = True
+                if nemesis_event.severity == Severity.ERROR:
+                    log_info["error"] = nemesis_event.errors[-1]
+                    log_info["full_traceback"] = nemesis_event.full_traceback
+                    status = False
+                if nemesis_event.is_skipped:
+                    log_info["skip_reason"] = nemesis_event.skip_reason
+
+                runner.duration_list.append(time_elapsed)
+                runner.operation_log.append({"operation": runner.base_disruption_name, **log_info})
+                runner.log.debug("%s duration -> %s s", runner.base_disruption_name, time_elapsed)
+                runner.log.info("log_info: %s", log_info)
+                runner.update_stats(runner.base_disruption_name, status, log_info)
+
+                runner.log_on_all_nodes(
+                    f"Finished disruption {method_name} ({runner.base_disruption_name} nemesis) with status '{nemesis_event.nemesis_status}'"
+                )
         return result
 
     return wrapper

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -217,7 +217,7 @@ NEMESIS_RUN_INFO = {}
 
 DISRUPT_POOL_PROPERTY_NAME = "target_pool"
 
-__all__ = []
+__all__ = ["DataValidatorEvent"]
 
 
 def target_data_nodes(func: Callable) -> Callable:
@@ -5871,22 +5871,6 @@ def disrupt_method_wrapper(method, caller_obj: "NemesisBaseClass"):  # noqa: PLR
     :return: Wrapped method.
     """
 
-    def data_validation_prints(caller):
-        try:
-            if hasattr(caller.tester, "data_validator") and caller.tester.data_validator:
-                if not (keyspace := caller.tester.data_validator.keyspace_name):
-                    DataValidatorEvent.DataValidator(
-                        severity=Severity.NORMAL, message="Failed fo get keyspace name. Data validator is disabled."
-                    ).publish()
-                    return
-
-                with caller.cluster.cql_connection_patient(caller.cluster.nodes[0], keyspace=keyspace) as session:
-                    caller.tester.data_validator.validate_range_not_expected_to_change(session, during_nemesis=True)
-                    caller.tester.data_validator.validate_range_expected_to_change(session, during_nemesis=True)
-                    caller.tester.data_validator.validate_deleted_rows(session, during_nemesis=True)
-        except Exception as err:  # noqa: BLE001
-            caller.log.debug(f"Data validator error: {err}")
-
     @wraps(method)
     def wrapper(*args, **kwargs):  # noqa: PLR0912, PLR0914, PLR0915
         method_name = method.__self__.__class__.__name__
@@ -5915,9 +5899,6 @@ def disrupt_method_wrapper(method, caller_obj: "NemesisBaseClass"):  # noqa: PLR
 
             result = None
 
-            # TODO: Temporary print. Will be removed later
-            data_validation_prints(runner)
-
             with (
                 DisruptionEvent(
                     nemesis_name=runner.base_disruption_name, node=runner.target_node, publish_event=True
@@ -5925,6 +5906,7 @@ def disrupt_method_wrapper(method, caller_obj: "NemesisBaseClass"):  # noqa: PLR
                 runner.actions_log.action_scope(f"Disruption {method_name} on {runner.target_node.name}"),
                 runner.argus_submit(nemesis_name=method_name, start_time=start_time, nemesis_event=nemesis_event),
                 runner.verify_nodes(),
+                runner.tester.run_nemesis_hooks(),
             ):
                 try:
                     result = method(*args, **kwargs)
@@ -5971,9 +5953,6 @@ def disrupt_method_wrapper(method, caller_obj: "NemesisBaseClass"):  # noqa: PLR
                     runner.log_on_all_nodes(
                         f"Finished disruption {method_name} ({runner.base_disruption_name} nemesis) with status '{nemesis_event.nemesis_status}'"
                     )
-
-            # TODO: Temporary print. Will be removed later
-            data_validation_prints(runner)
         finally:
             # Store nemesis event to track skip status for health checks
             if nemesis_event is not None:

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -263,8 +263,6 @@ class NemesisBaseClass(NemesisFlags, ABC):
     additional_configs: list[str] = None  # Configs required for running nemesis, used in job generation
     additional_params: dict[str, str] = None  # Parameters required for jenkins pipelines, used in job generation
 
-    exclusive: bool = False  # True, if the nemesis is exclusive, i.e. it should not run in parallel with other nemeses
-
     def __init__(self, runner: "NemesisRunner"):
         super().__init__()
         self.runner: "NemesisRunner" = runner
@@ -5883,19 +5881,9 @@ def disrupt_method_wrapper(method, caller_obj: "NemesisBaseClass", is_exclusive=
     def wrapper(*args, **kwargs):  # noqa: PLR0912, PLR0914, PLR0915
         method_name = method.__self__.__class__.__name__
         target_pool_type = getattr(method.__self__, DISRUPT_POOL_PROPERTY_NAME, NEMESIS_TARGET_POOLS.data_nodes)
-        nemesis_run_info_key = f"{id(method)}--{method_name}"
         runner = caller_obj.runner
         nemesis_event = None  # Initialize to None to avoid UnboundLocalError in finally block
         try:
-            NEMESIS_LOCK.acquire()
-            if not is_exclusive:
-                NEMESIS_RUN_INFO[nemesis_run_info_key] = "Running"
-                NEMESIS_LOCK.release()
-            else:
-                while NEMESIS_RUN_INFO:
-                    # NOTE: exclusive nemesis will wait before the end of all other ones
-                    time.sleep(10)
-
             # Skip health check if previous nemesis was skipped to avoid wasting 2+ hours on large clusters
             last_event = runner.last_nemesis_event
             if last_event and last_event.is_skipped:
@@ -6029,22 +6017,8 @@ def disrupt_method_wrapper(method, caller_obj: "NemesisBaseClass", is_exclusive=
             data_validation_prints(runner)
         finally:
             # Store nemesis event to track skip status for health checks
-            # Only update if nemesis_event was created (i.e., we entered the with block)
             if nemesis_event is not None:
                 runner.last_nemesis_event = nemesis_event
-
-            if is_exclusive:
-                # NOTE: sleep the nemesis interval here because the next one is already
-                #       ready to start right after the lock gets released.
-                if runner.tester.params.get("k8s_tenants_num") > 1:
-                    runner.log.debug("Exclusive nemesis: Sleep for '%s' seconds", runner.interval)
-                    time.sleep(runner.interval)
-                NEMESIS_LOCK.release()
-            else:
-                # NOTE: the key may be absent if a nemesis which waits for a lock release
-                #       gets killed/aborted. So, use safe 'pop' call with the default 'None' value.
-                NEMESIS_RUN_INFO.pop(nemesis_run_info_key, None)
-
             runner.set_target_node_pool_type(NEMESIS_TARGET_POOLS.data_nodes)
 
         return result

--- a/sdcm/nemesis/monkey/__init__.py
+++ b/sdcm/nemesis/monkey/__init__.py
@@ -467,7 +467,6 @@ class NodeTerminateAndReplace(NemesisBaseClass):
 class DrainKubernetesNodeThenReplaceScyllaNode(NemesisBaseClass):
     disruptive = True
     kubernetes = True
-    exclusive = True
 
     def disrupt(self):
         self.runner.disrupt_drain_kubernetes_node_then_replace_scylla_node()
@@ -476,7 +475,6 @@ class DrainKubernetesNodeThenReplaceScyllaNode(NemesisBaseClass):
 class TerminateKubernetesHostThenReplaceScyllaNode(NemesisBaseClass):
     disruptive = True
     kubernetes = True
-    exclusive = True
 
     def disrupt(self):
         self.runner.disrupt_terminate_kubernetes_host_then_replace_scylla_node()
@@ -485,7 +483,6 @@ class TerminateKubernetesHostThenReplaceScyllaNode(NemesisBaseClass):
 class DrainKubernetesNodeThenDecommissionAndAddScyllaNode(NemesisBaseClass):
     disruptive = True
     kubernetes = True
-    exclusive = True
 
     def disrupt(self):
         self.runner.disrupt_drain_kubernetes_node_then_decommission_and_add_scylla_node()
@@ -494,7 +491,6 @@ class DrainKubernetesNodeThenDecommissionAndAddScyllaNode(NemesisBaseClass):
 class TerminateKubernetesHostThenDecommissionAndAddScyllaNode(NemesisBaseClass):
     disruptive = True
     kubernetes = True
-    exclusive = True
 
     def disrupt(self):
         self.runner.disrupt_terminate_kubernetes_host_then_decommission_and_add_scylla_node()

--- a/sdcm/prometheus.py
+++ b/sdcm/prometheus.py
@@ -10,7 +10,7 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2020 ScyllaDB
-
+import contextlib
 import time
 import logging
 import datetime
@@ -118,6 +118,14 @@ class NemesisMetrics:
             self._disrupt_gauge.labels(disrupt).dec()
         except Exception as ex:
             LOGGER.exception("Cannot stop metrics event: %s", ex)
+
+    @contextlib.contextmanager
+    def event(self, disrupt):
+        self.event_start(disrupt)
+        try:
+            yield
+        finally:
+            self.event_stop(disrupt)
 
 
 class PrometheusAlertManagerListener(threading.Thread):

--- a/sdcm/sct_events/nemesis.py
+++ b/sdcm/sct_events/nemesis.py
@@ -12,6 +12,7 @@
 # Copyright (c) 2020 ScyllaDB
 from functools import cached_property
 
+from argus.common.enums import NemesisStatus
 from sdcm.sct_events import Severity
 from sdcm.sct_events.continuous_event import ContinuousEvent
 
@@ -44,3 +45,11 @@ class DisruptionEvent(ContinuousEvent):
         if self.full_traceback:
             fmt += "\n{0.full_traceback}"
         return fmt
+
+    @property
+    def nemesis_status(self) -> NemesisStatus:
+        if self.severity == Severity.ERROR:
+            return NemesisStatus.FAILED
+        if self.is_skipped:
+            return NemesisStatus.SKIPPED
+        return NemesisStatus.SUCCEEDED

--- a/sdcm/sct_events/nemesis.py
+++ b/sdcm/sct_events/nemesis.py
@@ -53,3 +53,9 @@ class DisruptionEvent(ContinuousEvent):
         if self.is_skipped:
             return NemesisStatus.SKIPPED
         return NemesisStatus.SUCCEEDED
+
+    def add_simple_error(self, error: str, traceback: str):
+        """Allows adding single error with less lines"""
+        self.add_error([error])
+        self.full_traceback = traceback
+        self.severity = Severity.ERROR

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -10,6 +10,7 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2016 ScyllaDB
+import contextlib
 import shutil
 import configparser
 import importlib
@@ -436,6 +437,27 @@ class ClusterTester(unittest.TestCase):
             self.log.info("Submitted SCTConfiguration to Argus.")
         except ArgusClientError:
             self.log.error("Failed to submit data to Argus", exc_info=True)
+
+    def pre_nemesis(self):
+        """Runs before nemesis execution"""
+
+    def post_nemesis(self):
+        """Runs after each nemesis execution"""
+
+    @contextlib.contextmanager
+    def run_nemesis_hooks(self):
+        """Runs hooks around nemesis invocation"""
+        try:
+            self.pre_nemesis()
+        except Exception:  # noqa: BLE001
+            self.log.error("pre_nemesis hook failed", exc_info=True)
+        try:
+            yield
+        finally:
+            try:
+                self.post_nemesis()
+            except Exception:  # noqa: BLE001
+                self.log.error("post_nemesis hook failed", exc_info=True)
 
     def start_argus_heartbeat_thread(self) -> threading.Event:
         def send_argus_heartbeat(client: ArgusSCTClient, stop_signal: threading.Event):

--- a/unit_tests/nemesis/execute_nemesis/__init__.py
+++ b/unit_tests/nemesis/execute_nemesis/__init__.py
@@ -1,0 +1,71 @@
+"""Tests for execute_nemesis method of NemesisRunner, which is responsible for executing a single nemesis disruption."""
+
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+from sdcm.nemesis import NemesisRunner, UnsupportedNemesis, KillNemesis
+from sdcm.nemesis.registry import NemesisRegistry
+
+
+class TestExecuteBaseClass(ABC):
+    """
+    For tests purposes TestExecuteBaseClass is also a flag class
+    """
+
+    def __init__(self, runner):
+        self.runner = runner
+
+    @abstractmethod
+    def disrupt(self):
+        """Disrupt method"""
+
+
+class CustomTestNemesis(TestExecuteBaseClass):
+    """A simple nemesis for testing."""
+
+    def disrupt(self):
+        print("Disrupting cluster")
+
+
+class FailingTestNemesis(TestExecuteBaseClass):
+    """A nemesis that fails during disruption."""
+
+    def disrupt(self):
+        raise RuntimeError("Intentional failure")
+
+
+class SkippingTestNemesis(TestExecuteBaseClass):
+    """A nemesis that skips."""
+
+    def disrupt(self):
+        raise UnsupportedNemesis("Intentional skip")
+
+
+class KillTestNemesis(TestExecuteBaseClass):
+    """A nemesis that raises KillNemesis."""
+
+    def disrupt(self):
+        raise KillNemesis("Intentional kill")
+
+
+class TestNemesisRunner(NemesisRunner):
+    """Test subclass of NemesisRunner with simplified registry."""
+
+    __test__ = False
+
+    def __init__(self, tester_obj, termination_event, *args, nemesis_selector=None, nemesis_seed=None, **kwargs):
+        super().__init__(
+            tester_obj, termination_event, *args, nemesis_selector=nemesis_selector, nemesis_seed=nemesis_seed, **kwargs
+        )
+        self.node_allocator = MagicMock()
+        self.metrics_srv = MagicMock()
+        self.nemesis_registry = NemesisRegistry(base_class=TestExecuteBaseClass, flag_class=TestExecuteBaseClass)
+
+    def set_target_node(self):
+        self.target_node = self.tester.db_cluster.nodes[0]
+
+    @contextmanager
+    def verify_nodes(self):
+        """Mock verify_nodes context manager."""
+        yield

--- a/unit_tests/nemesis/execute_nemesis/conftest.py
+++ b/unit_tests/nemesis/execute_nemesis/conftest.py
@@ -1,0 +1,44 @@
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from unit_tests.nemesis.execute_nemesis import (
+    TestNemesisRunner,
+    CustomTestNemesis,
+    SkippingTestNemesis,
+    FailingTestNemesis,
+    KillTestNemesis,
+)
+from unit_tests.nemesis.fake_cluster import FakeTester, PARAMS
+
+
+@pytest.fixture
+def nemesis_runner(events):
+    """Create a NemesisRunner for testing with mocked external dependencies."""
+    termination_event = threading.Event()
+    tester = FakeTester(params=PARAMS)
+    tester.db_cluster.check_cluster_health = MagicMock()
+    tester.db_cluster.test_config = MagicMock()
+    runner = TestNemesisRunner(tester, termination_event, nemesis_selector="flag_a")
+    return runner
+
+
+@pytest.fixture
+def nemesis(nemesis_runner):
+    return CustomTestNemesis(runner=nemesis_runner)
+
+
+@pytest.fixture
+def skipping_nemesis(nemesis_runner):
+    return SkippingTestNemesis(runner=nemesis_runner)
+
+
+@pytest.fixture
+def failing_nemesis(nemesis_runner):
+    return FailingTestNemesis(runner=nemesis_runner)
+
+
+@pytest.fixture
+def kill_nemesis(nemesis_runner):
+    return KillTestNemesis(runner=nemesis_runner)

--- a/unit_tests/nemesis/execute_nemesis/test_argus.py
+++ b/unit_tests/nemesis/execute_nemesis/test_argus.py
@@ -1,0 +1,227 @@
+"""
+Unit tests for Argus submission in NemesisRunner.execute_nemesis
+"""
+
+from unittest.mock import MagicMock, ANY
+
+import pytest
+
+from argus.common.enums import NemesisStatus
+from sdcm.exceptions import UnsupportedNemesis
+
+
+@pytest.fixture
+def argus_mock(nemesis_runner):
+    """Helper function to set up Argus mock for a NemesisRunner."""
+    argus_mock = MagicMock()
+    nemesis_runner.cluster.test_config.argus_client = MagicMock(return_value=argus_mock)
+    return argus_mock
+
+
+def test_argus_submit_on_success(argus_mock, nemesis, nemesis_runner):
+    """Test that successful nemesis submits correct data to Argus."""
+    nemesis_runner.execute_nemesis(nemesis)
+
+    # Verify submit_nemesis was called at the start
+    argus_mock.submit_nemesis.assert_called_once_with(
+        name="CustomTestNemesis",
+        class_name="TestNemesisRunner",
+        start_time=ANY,
+        target_name="Node1",
+        target_ip="127.0.0.1",
+        target_shards=8,
+        description="A simple nemesis for testing.",
+    )
+
+    # Verify finalize_nemesis was called at the end
+    argus_mock.finalize_nemesis.assert_called_once_with(
+        name="CustomTestNemesis",
+        start_time=ANY,
+        status=NemesisStatus.SUCCEEDED,
+        message="",
+    )
+
+    # Verify start_time is the same in both submit and finalize
+    submit_start_time = argus_mock.submit_nemesis.call_args.kwargs["start_time"]
+    finalize_start_time = argus_mock.finalize_nemesis.call_args.kwargs["start_time"]
+    assert submit_start_time == finalize_start_time
+
+
+def test_argus_submit_on_failure(failing_nemesis, nemesis_runner):
+    """Test that failing nemesis submits error information to Argus."""
+    argus_mock = MagicMock()
+    nemesis_runner.cluster.test_config.argus_client.return_value = argus_mock
+
+    nemesis_runner.execute_nemesis(failing_nemesis)
+
+    # Verify submit_nemesis was called
+    argus_mock.submit_nemesis.assert_called_once_with(
+        name="FailingTestNemesis",
+        class_name="TestNemesisRunner",
+        start_time=ANY,
+        target_name="Node1",
+        target_ip="127.0.0.1",
+        target_shards=8,
+        description="A nemesis that fails during disruption.",
+    )
+
+    # Verify finalize_nemesis was called with failure status and traceback
+    finalize_args = argus_mock.finalize_nemesis.call_args
+    assert finalize_args.kwargs["name"] == "FailingTestNemesis"
+    assert finalize_args.kwargs["status"] == NemesisStatus.FAILED
+    assert "Intentional failure" in finalize_args.kwargs["message"]
+    assert "RuntimeError" in finalize_args.kwargs["message"]
+
+    # Verify start_time is the same in both submit and finalize
+    submit_start_time = argus_mock.submit_nemesis.call_args.kwargs["start_time"]
+    finalize_start_time = finalize_args.kwargs["start_time"]
+    assert submit_start_time == finalize_start_time
+
+
+def test_argus_submit_on_skip(argus_mock, skipping_nemesis, nemesis_runner):
+    """Test that skipped nemesis submits skip reason to Argus."""
+
+    with pytest.raises(UnsupportedNemesis):
+        nemesis_runner.execute_nemesis(skipping_nemesis)
+
+    # Verify submit_nemesis was called
+    argus_mock.submit_nemesis.assert_called_once_with(
+        name="SkippingTestNemesis",
+        class_name="TestNemesisRunner",
+        start_time=ANY,
+        target_name="Node1",
+        target_ip="127.0.0.1",
+        target_shards=8,
+        description="A nemesis that skips.",
+    )
+
+    argus_mock.finalize_nemesis.assert_called_once_with(
+        status=NemesisStatus.SKIPPED, message="Intentional skip", name="SkippingTestNemesis", start_time=ANY
+    )
+
+    # Verify start_time is the same in both submit and finalize
+    submit_start_time = argus_mock.submit_nemesis.call_args.kwargs["start_time"]
+    finalize_start_time = argus_mock.finalize_nemesis.call_args.kwargs["start_time"]
+    assert submit_start_time == finalize_start_time
+
+
+def test_argus_submit_handles_submit_error_gracefully(nemesis, nemesis_runner):
+    """Test that errors during Argus submit_nemesis don't break execution."""
+    argus_mock = MagicMock()
+    argus_mock.submit_nemesis.side_effect = Exception("Argus connection error")
+    nemesis_runner.cluster.test_config.argus_client.return_value = argus_mock
+
+    # Should complete successfully despite Argus error
+    nemesis_runner.execute_nemesis(nemesis)
+
+    # Verify the nemesis still completed
+    assert len(nemesis_runner.duration_list) == 1
+    assert len(nemesis_runner.operation_log) == 1
+    event = nemesis_runner.last_nemesis_event
+    assert event.nemesis_status == NemesisStatus.SUCCEEDED
+
+    argus_mock.finalize_nemesis.assert_not_called()
+
+
+def test_argus_submit_handles_finalize_error_gracefully(nemesis, nemesis_runner):
+    """Test that errors during Argus finalize_nemesis don't break execution."""
+    argus_mock = MagicMock()
+    argus_mock.finalize_nemesis.side_effect = Exception("Argus finalize error")
+    nemesis_runner.cluster.test_config.argus_client.return_value = argus_mock
+
+    # Should complete successfully despite Argus error
+    nemesis_runner.execute_nemesis(nemesis)
+
+    # Verify the nemesis still completed
+    assert len(nemesis_runner.duration_list) == 1
+    assert len(nemesis_runner.operation_log) == 1
+    event = nemesis_runner.last_nemesis_event
+    assert event.nemesis_status == NemesisStatus.SUCCEEDED
+
+    # Both submit and finalize should have been attempted
+    argus_mock.submit_nemesis.assert_called_once()
+    argus_mock.finalize_nemesis.assert_called_once()
+
+
+def test_argus_submit_no_client_available(nemesis, nemesis_runner):
+    """Test that nemesis executes successfully when Argus client is not available."""
+    nemesis_runner.cluster.test_config.argus_client.side_effect = Exception("No Argus client")
+
+    # Should complete successfully without Argus
+    nemesis_runner.execute_nemesis(nemesis)
+
+    # Verify the nemesis still completed
+    assert len(nemesis_runner.duration_list) == 1
+    assert len(nemesis_runner.operation_log) == 1
+    event = nemesis_runner.last_nemesis_event
+    assert event.nemesis_status == NemesisStatus.SUCCEEDED
+
+
+def test_argus_submit_parameters_consistency_across_calls(nemesis, nemesis_runner):
+    """Test that submit_nemesis and finalize_nemesis use consistent parameters."""
+    argus_mock = MagicMock()
+    nemesis_runner.cluster.test_config.argus_client.return_value = argus_mock
+
+    nemesis_runner.execute_nemesis(nemesis)
+
+    submit_args = argus_mock.submit_nemesis.call_args.kwargs
+    finalize_args = argus_mock.finalize_nemesis.call_args.kwargs
+
+    # Verify name is consistent between submit and finalize
+    assert submit_args["name"] == finalize_args["name"]
+    # Verify start_time is the same in both submit and finalize
+    assert submit_args["start_time"] == finalize_args["start_time"]
+
+
+def test_argus_submit_multiple_nemesis_separate_entries(nemesis, failing_nemesis, nemesis_runner):
+    """Test that multiple nemesis executions create separate Argus entries."""
+    argus_mock = MagicMock()
+    nemesis_runner.cluster.test_config.argus_client.return_value = argus_mock
+
+    # Run two nemesis operations
+    nemesis_runner.execute_nemesis(nemesis)
+    nemesis_runner.execute_nemesis(failing_nemesis)
+
+    # Verify submit_nemesis was called twice
+    assert argus_mock.submit_nemesis.call_count == 2
+
+    # Verify finalize_nemesis was called twice
+    assert argus_mock.finalize_nemesis.call_count == 2
+
+    # Verify each call had different start times (or at least recorded)
+    submit_calls = argus_mock.submit_nemesis.call_args_list
+    # Times might be the same if execution is very fast, just verify both were called
+    assert len(submit_calls) == 2
+
+    # Verify first was success, second was failure
+    finalize_calls = argus_mock.finalize_nemesis.call_args_list
+    assert finalize_calls[0].kwargs["status"] == NemesisStatus.SUCCEEDED
+    assert finalize_calls[1].kwargs["status"] == NemesisStatus.FAILED
+
+    # Verify start_time is the same between submit and finalize for each pair
+    for submit_call, finalize_call in zip(submit_calls, finalize_calls):
+        assert submit_call.kwargs["start_time"] == finalize_call.kwargs["start_time"]
+
+
+def test_argus_submit_captures_target_node_info(nemesis, nemesis_runner):
+    """Test that Argus submission captures target node information."""
+    argus_mock = MagicMock()
+    nemesis_runner.cluster.test_config.argus_client.return_value = argus_mock
+
+    nemesis_runner.execute_nemesis(nemesis)
+
+    # Verify all required fields are passed to submit_nemesis
+    argus_mock.submit_nemesis.assert_called_once_with(
+        name="CustomTestNemesis",
+        class_name="TestNemesisRunner",
+        start_time=ANY,
+        target_name="Node1",
+        target_ip="127.0.0.1",
+        target_shards=8,
+        description="A simple nemesis for testing.",
+    )
+
+    # Verify start_time is the same in both submit and finalize
+    submit_start_time = argus_mock.submit_nemesis.call_args.kwargs["start_time"]
+    finalize_start_time = argus_mock.finalize_nemesis.call_args.kwargs["start_time"]
+    assert submit_start_time == finalize_start_time

--- a/unit_tests/nemesis/execute_nemesis/test_basic.py
+++ b/unit_tests/nemesis/execute_nemesis/test_basic.py
@@ -1,0 +1,208 @@
+import pytest
+
+from argus.common.enums import NemesisStatus
+from sdcm.exceptions import KillNemesis, UnsupportedNemesis
+from sdcm.sct_events import Severity
+
+
+def test_execute_nemesis_success(nemesis, nemesis_runner, capsys):
+    """Test execute_nemesis completes successfully."""
+    nemesis_runner.execute_nemesis(nemesis)
+
+    captured = capsys.readouterr()
+    assert "Disrupting cluster" in captured.out
+    nemesis_runner.cluster.check_cluster_health.assert_called_once()
+    nemesis_runner.metrics_srv.event.assert_called_once_with("CustomTestNemesis")
+    assert len(nemesis_runner.duration_list) == 1
+    assert len(nemesis_runner.operation_log) == 1
+
+    # Verify the DisruptionEvent was recorded correctly
+    event = nemesis_runner.last_nemesis_event
+    assert event is not None
+    assert event.nemesis_name == "CustomTestNemesis"
+    assert event.duration is not None
+    assert event.duration >= 0
+    assert event.severity == Severity.NORMAL
+    assert event.nemesis_status == NemesisStatus.SUCCEEDED
+    assert event.is_skipped is False
+    assert not event.errors
+
+    # Verify operation_log entry structure
+    op = nemesis_runner.operation_log[0]
+    assert op["operation"] == "CustomTestNemesis"
+    assert op["subtype"] == NemesisStatus.SUCCEEDED.value
+    assert "start" in op
+    assert "end" in op
+    assert "duration" in op
+    assert op["end"] >= op["start"]
+    assert op["duration"] == op["end"] - op["start"]
+    assert "error" not in op
+    assert "skip_reason" not in op
+
+
+def test_execute_nemesis_failure(failing_nemesis, nemesis_runner):
+    """Test execute_nemesis handles disruption failures."""
+    nemesis_runner.execute_nemesis(failing_nemesis)
+
+    nemesis_runner.cluster.check_cluster_health.assert_called_once()
+    assert len(nemesis_runner.error_list) == 1
+    assert "Intentional failure" in nemesis_runner.error_list[0]
+
+    # Verify the DisruptionEvent captured the error
+    event = nemesis_runner.last_nemesis_event
+    assert event is not None
+    assert event.severity == Severity.ERROR
+    assert event.nemesis_status == NemesisStatus.FAILED
+    assert event.is_skipped is False
+    assert "Intentional failure" in event.errors_formatted
+    assert event.full_traceback  # traceback should be recorded
+
+    # Verify operation_log records the error
+    op = nemesis_runner.operation_log[0]
+    assert op["subtype"] == NemesisStatus.FAILED.value
+    assert "error" in op
+    assert "Intentional failure" in str(op["error"])
+
+
+def test_execute_nemesis_skip(skipping_nemesis, nemesis_runner):
+    """Test execute_nemesis handles nemesis skip."""
+
+    with pytest.raises(UnsupportedNemesis, match="Intentional skip"):
+        nemesis_runner.execute_nemesis(skipping_nemesis)
+
+    nemesis_runner.cluster.check_cluster_health.assert_called_once()
+
+    # Verify the DisruptionEvent was marked as skipped
+    event = nemesis_runner.last_nemesis_event
+    assert event is not None
+    assert event.is_skipped is True
+    assert event.skip_reason == "Intentional skip"
+    assert event.nemesis_status == NemesisStatus.SKIPPED
+    assert event.severity == Severity.NORMAL
+    assert not event.errors
+
+    # Verify operation_log records the skip
+    op = nemesis_runner.operation_log[0]
+    assert op["subtype"] == NemesisStatus.SKIPPED.value
+    assert op["skip_reason"] == "Intentional skip"
+    assert "error" not in op
+
+
+def test_execute_nemesis_with_kill_nemesis_success(kill_nemesis, nemesis_runner):
+    """Test execute_nemesis handles KillNemesis when no critical events."""
+    nemesis_runner.tester.get_event_summary = dict
+
+    with pytest.raises(KillNemesis) as excinfo:
+        nemesis_runner.execute_nemesis(kill_nemesis)
+    assert "Intentional kill" in str(excinfo.value)
+
+    # Verify the DisruptionEvent was skipped with success message
+    event = nemesis_runner.last_nemesis_event
+    assert event is not None
+    assert event.is_skipped is True
+    assert event.skip_reason == "Killed by tearDown - test success"
+    assert event.nemesis_status == NemesisStatus.SKIPPED
+    assert event.severity == Severity.NORMAL
+    assert not event.errors
+
+    # Verify operation_log records the skip
+    op = nemesis_runner.operation_log[0]
+    assert op["subtype"] == NemesisStatus.SKIPPED.value
+    assert op["skip_reason"] == "Killed by tearDown - test success"
+    assert "error" not in op
+
+
+def test_execute_nemesis_with_kill_nemesis_failure(kill_nemesis, nemesis_runner):
+    """Test execute_nemesis handles KillNemesis when critical events exist."""
+    nemesis_runner.tester.get_event_summary = lambda: {"CRITICAL": 1}
+
+    with pytest.raises(KillNemesis) as excinfo:
+        nemesis_runner.execute_nemesis(kill_nemesis)
+    assert "Intentional kill" in str(excinfo.value)
+
+    # Verify the DisruptionEvent recorded the failure
+    event = nemesis_runner.last_nemesis_event
+    assert event is not None
+    assert event.is_skipped is False
+    assert event.severity == Severity.ERROR
+    assert event.nemesis_status == NemesisStatus.FAILED
+    assert "Killed by tearDown - test fail" in event.errors_formatted
+    assert event.full_traceback  # traceback should be recorded
+
+    # Verify operation_log records the error
+    op = nemesis_runner.operation_log[0]
+    assert op["subtype"] == NemesisStatus.FAILED.value
+    assert "error" in op
+    assert "Killed by tearDown - test fail" in str(op["error"])
+
+
+def test_execute_multiple_nemesis_in_sequence(nemesis, kill_nemesis, failing_nemesis, skipping_nemesis, nemesis_runner):
+    """Test that running multiple nemesis in sequence doesn't cause interference.
+
+    Verifies that each execution gets its own independent DisruptionEvent,
+    operation_log entry, and duration record, and that a failure in one
+    does not corrupt the state for subsequent executions.
+    """
+
+    # 1. Run a successful nemesis
+    nemesis_runner.execute_nemesis(nemesis)
+
+    assert len(nemesis_runner.duration_list) == 1
+    assert len(nemesis_runner.operation_log) == 1
+    assert len(nemesis_runner.error_list) == 0
+    first_event = nemesis_runner.last_nemesis_event
+    assert first_event.nemesis_status == NemesisStatus.SUCCEEDED
+    # operation recorded for this run
+    assert nemesis_runner.operation_log[-1]["operation"] == "CustomTestNemesis"
+    assert nemesis_runner.operation_log[-1]["subtype"] == NemesisStatus.SUCCEEDED.value
+
+    # 2. Run a failing nemesis — should not corrupt previous results
+    nemesis_runner.execute_nemesis(failing_nemesis)
+
+    assert len(nemesis_runner.duration_list) == 2
+    assert len(nemesis_runner.operation_log) == 2
+    assert len(nemesis_runner.error_list) == 1
+    second_event = nemesis_runner.last_nemesis_event
+    assert second_event.nemesis_status == NemesisStatus.FAILED
+    assert second_event is not first_event  # each run gets its own event
+    # operation recorded for this run
+    assert nemesis_runner.operation_log[-1]["operation"] == "FailingTestNemesis"
+    assert nemesis_runner.operation_log[-1]["subtype"] == NemesisStatus.FAILED.value
+    assert "Intentional failure" in nemesis_runner.operation_log[-1]["error"]
+
+    # 3. Run a skipping nemesis
+    with pytest.raises(UnsupportedNemesis):
+        nemesis_runner.execute_nemesis(skipping_nemesis)
+
+    assert len(nemesis_runner.duration_list) == 3
+    assert len(nemesis_runner.operation_log) == 3
+    assert len(nemesis_runner.error_list) == 1  # unchanged from step 2
+    third_event = nemesis_runner.last_nemesis_event
+    assert third_event.nemesis_status == NemesisStatus.SKIPPED
+    assert third_event is not second_event
+    # operation recorded for this run
+    assert nemesis_runner.operation_log[-1]["operation"] == "SkippingTestNemesis"
+    assert nemesis_runner.operation_log[-1]["subtype"] == NemesisStatus.SKIPPED.value
+    assert nemesis_runner.operation_log[-1]["skip_reason"] == "Intentional skip"
+
+    # 4. Run another successful nemesis after failure and skip
+    nemesis_runner.execute_nemesis(nemesis)
+
+    assert len(nemesis_runner.duration_list) == 4
+    assert len(nemesis_runner.operation_log) == 4
+    assert len(nemesis_runner.error_list) == 1  # still only the one from step 2
+    fourth_event = nemesis_runner.last_nemesis_event
+    assert fourth_event.nemesis_status == NemesisStatus.SUCCEEDED
+    assert fourth_event is not third_event
+    # operation recorded for this run
+    assert nemesis_runner.operation_log[-1]["operation"] == "CustomTestNemesis"
+    assert nemesis_runner.operation_log[-1]["subtype"] == NemesisStatus.SUCCEEDED.value
+
+    # Verify durations are non-negative and timestamps are monotonically ordered
+    for i, op in enumerate(nemesis_runner.operation_log):
+        assert op["duration"] >= 0, f"operation_log[{i}] has negative duration"
+        assert op["end"] >= op["start"], f"operation_log[{i}] end before start"
+    for i in range(1, len(nemesis_runner.operation_log)):
+        assert nemesis_runner.operation_log[i]["start"] >= nemesis_runner.operation_log[i - 1]["start"], (
+            f"operation_log[{i}] started before operation_log[{i - 1}]"
+        )

--- a/unit_tests/nemesis/execute_nemesis/test_healthcheck.py
+++ b/unit_tests/nemesis/execute_nemesis/test_healthcheck.py
@@ -1,0 +1,21 @@
+def test_execute_nemesis_skips_health_check_when_previous_skipped(nemesis, nemesis_runner):
+    """Test health check is skipped when previous nemesis was skipped."""
+    nemesis_runner.last_nemesis_event = type(
+        "MockEvent", (), {"is_skipped": True, "nemesis_name": "PreviousNemesis", "skip_reason": "Previous skip reason"}
+    )()
+    nemesis_runner.execute_nemesis(nemesis)
+    nemesis_runner.cluster.check_cluster_health.assert_not_called()
+
+
+def test_execute_nemesis_runs_health_check_when_previous_not_skipped(nemesis, nemesis_runner):
+    """Test health check runs when previous nemesis was not skipped."""
+    nemesis_runner.last_nemesis_event = type("MockEvent", (), {"is_skipped": False})()
+    nemesis_runner.execute_nemesis(nemesis)
+    nemesis_runner.cluster.check_cluster_health.assert_called_once()
+
+
+def test_execute_nemesis_no_previous_event(nemesis, nemesis_runner):
+    """Test health check runs when there's no previous nemesis event."""
+    nemesis_runner.last_nemesis_event = None
+    nemesis_runner.execute_nemesis(nemesis)
+    nemesis_runner.cluster.check_cluster_health.assert_called_once()

--- a/unit_tests/nemesis/fake_cluster.py
+++ b/unit_tests/nemesis/fake_cluster.py
@@ -1,6 +1,8 @@
 """Mock classes"""
 
+from contextlib import contextmanager
 from dataclasses import dataclass, field
+from unittest.mock import MagicMock
 
 from sdcm.cluster import BaseScyllaCluster
 from sdcm.nemesis.utils.node_allocator import NemesisNodeAllocator
@@ -15,6 +17,10 @@ class Node:
     running_nemesis = None
     public_ip_address: str = "127.0.0.1"
     name: str = "Node1"
+    _is_zero_token_node: bool = False
+
+    def __hash__(self):
+        return hash(self.name)
 
     @property
     def scylla_shards(self):
@@ -59,6 +65,7 @@ class FakeTester:
     def __post_init__(self):
         self.db_cluster.params = self.params
         self.nemesis_allocator = NemesisNodeAllocator(self)
+        self.test_config = MagicMock()
 
     def create_stats(self):
         pass
@@ -74,3 +81,7 @@ class FakeTester:
 
     def id(self):
         return 0
+
+    @contextmanager
+    def run_nemesis_hooks(self):
+        yield


### PR DESCRIPTION
### Overview

This PR refactors and in the end get rid of `disrupt_method_wrapper` by moving it into `execute_nemesis`. Existing logic is simplified by removing features that are no longer needed (exclusive nemesis) or by refactoring calls to be move consise and elegant (I like context managers). Result is function which is now much simpler to understand, with only neccessary features and removal of another level of indirection by removing decorator. Due to spliting into multiple function it is now also easier to test and to mock individual parts, finally enabling us to write tests for actual nemesis execution

It builds on top of https://github.com/scylladb/scylla-cluster-tests/pull/13416 to not block it from being merged and to save myself a rebase later. Until the PR is merged, this PR can be reviewed commit by commit and individual changes can be discussed before being finalized after the dependency merge

This PR can be split into individual PR one commiteach if needed, but each PR has more or less isolated changes so it should be reviewable.

### Changes
* Remove ES logging
   * ES is no longer used
* Remove duplicit metric tracking
* Remove exclusive nemesis mechanism
   * Confirmed that multitenants are no longer needed
   * Wrote up design to be reconstructed later if needed
* Add hooks into ClusterTester
   * Replaces hardcoded data validation with simple, yet flexible mechanism
   * Affects only longevity_lwt_test
* Refactor code inside the method
  * Refactor log info handling
  * Merge `with` statements
  * Add DISRUPT_DEFAULT_POOL for setting the node pools

### TODO

* [x] Update tests
* [x] Write new comprehensive tests for the new structure

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
* [x] Unit tests
* [x] Integration tests
* [x] [Single nemesis](https://argus.scylladb.com/tests/scylla-cluster-tests/f3db4a3f-be49-4547-8597-a90b84fffd9f)
* [x] [Longevity](https://argus.scylladb.com/tests/scylla-cluster-tests/875a6f83-3735-4703-bd6a-90fb0fbb2049/nemesis)
    * Ran for hour already, and it executed nemesis as expected based on Argus
### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

