### PR TITLE
fix(vector.dev): use dynamic port range for vector logging

### DIFF
--- a/sdcm/provision/security.py
+++ b/sdcm/provision/security.py
@@ -33,5 +33,5 @@ class ScyllaOpenPorts(Enum):
     MANAGER_HTTPS = 5443  # Scylla Manager HTTPS API
     MANAGER_AGENT_PROMETHEUS = 5090  # Scylla Manager Agent Prometheus API
     MANAGER_DEBUG = 5112  # Scylla Manager pprof Debug
-    VECTOR = 15000  # Vector log transport
+    VECTOR = "15000-15099"  # Vector log transport port range
     SCT_AGENT = 16000  # SCT agent HTTP API

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -292,7 +292,7 @@ class TestConfig(metaclass=Singleton):
 
     @classmethod
     def configure_vector(cls, node):
-        ContainerManager.run_container(node, "vector", logdir=cls.logdir())
+        node.run_vector_container(logdir=cls.logdir())
         cls._link_running_syslog_logdir(node.vector_log_dir)
         port = node.vector_port
         LOGGER.info("vector listen on port %s (config: %s)", port, node.vector_confpath)

--- a/sdcm/utils/aws_region.py
+++ b/sdcm/utils/aws_region.py
@@ -558,7 +558,7 @@ class AwsRegion:
                     },
                     {
                         "FromPort": 15000,
-                        "ToPort": 15000,
+                        "ToPort": 15099,
                         "IpProtocol": "tcp",
                         "IpRanges": [{"CidrIp": "0.0.0.0/0", "Description": "Allow Vector log transport for ALL"}],
                         "Ipv6Ranges": [{"CidrIpv6": "::/0", "Description": "Allow Vector log transport for ALL"}],

--- a/sdcm/utils/gce_region.py
+++ b/sdcm/utils/gce_region.py
@@ -158,7 +158,7 @@ class GceRegion:
             Firewall(
                 name=f"{self.SCT_NETWORK_NAME}-allow-vector",
                 direction="INGRESS",
-                allowed=[compute_v1.Allowed(I_p_protocol="tcp", ports=["15000"])],
+                allowed=[compute_v1.Allowed(I_p_protocol="tcp", ports=["15000-15099"])],
                 source_ranges=["0.0.0.0/0"],
                 network=self.network.self_link,
             ),


### PR DESCRIPTION
Replace the static vector.dev container port 15000 with a range 15000-15099. This helps to prevent conflicts when multiple tests share a Jenkins worker.

Fixes: SCT-99

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
