### PR TITLE
Revert "improvement(vector-logging): use static port for Vector service"

### DIFF
--- a/sdcm/provision/security.py
+++ b/sdcm/provision/security.py
@@ -33,5 +33,4 @@ class ScyllaOpenPorts(Enum):
     MANAGER_HTTPS = 5443  # Scylla Manager HTTPS API
     MANAGER_AGENT_PROMETHEUS = 5090  # Scylla Manager Agent Prometheus API
     MANAGER_DEBUG = 5112  # Scylla Manager pprof Debug
-    VECTOR = 15000  # Vector log transport
     SCT_AGENT = 16000  # SCT agent HTTP API

--- a/sdcm/utils/aws_region.py
+++ b/sdcm/utils/aws_region.py
@@ -557,13 +557,6 @@ class AwsRegion:
                         ],
                     },
                     {
-                        "FromPort": 15000,
-                        "ToPort": 15000,
-                        "IpProtocol": "tcp",
-                        "IpRanges": [{"CidrIp": "0.0.0.0/0", "Description": "Allow Vector log transport for ALL"}],
-                        "Ipv6Ranges": [{"CidrIpv6": "::/0", "Description": "Allow Vector log transport for ALL"}],
-                    },
-                    {
                         "IpProtocol": "-1",
                         "IpRanges": [
                             {

--- a/sdcm/utils/gce_region.py
+++ b/sdcm/utils/gce_region.py
@@ -156,13 +156,6 @@ class GceRegion:
                 network=self.network.self_link,
             ),
             Firewall(
-                name=f"{self.SCT_NETWORK_NAME}-allow-vector",
-                direction="INGRESS",
-                allowed=[compute_v1.Allowed(I_p_protocol="tcp", ports=["15000"])],
-                source_ranges=["0.0.0.0/0"],
-                network=self.network.self_link,
-            ),
-            Firewall(
                 name=f"{self.SCT_NETWORK_NAME}-deny-all",
                 direction="INGRESS",
                 denied=[compute_v1.Denied(I_p_protocol="all")],

--- a/sdcm/utils/vector_dev.py
+++ b/sdcm/utils/vector_dev.py
@@ -23,8 +23,6 @@ from sdcm.utils.docker_utils import ContainerManager
 
 VECTOR_DEV_IMAGE = "timberio/vector:0.46.1-alpine"
 VECTOR_DEV_PORT = 49153  # Non-root
-VECTOR_EXTERNAL_PORT = 15000  # Static external port for xcloud communication
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +34,7 @@ class VectorDevContainerMixin:
 
     @property
     def vector_port(self) -> Optional[int]:
-        return VECTOR_EXTERNAL_PORT
+        return ContainerManager.get_container_port(self, "vector", VECTOR_DEV_PORT)
 
     @property
     def vector_log_dir(self) -> Optional[str]:
@@ -63,7 +61,7 @@ class VectorDevContainerMixin:
             "name": f"{self.name}-vector",
             "command": " -c /etc/vector/vector.yaml",
             "auto_remove": True,
-            "ports": {f"{VECTOR_DEV_PORT}/tcp": VECTOR_EXTERNAL_PORT},
+            "ports": {f"{VECTOR_DEV_PORT}/tcp": None},
             "volumes": volumes,
             "environment": {
                 "PUID": getpwnam(username).pw_uid,


### PR DESCRIPTION
This reverts commit 141aca874cf03f8332d8609a3a46693e08535a05.

Using static port for vector.dev container was introduced to be able to stream logs from Scylla Cloud DB nodes to SCT runner in local dev environment, using remote port forwarding through SDM proxy. But this mechanism is not supported on proxy side, so we doesn't need static port.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] provision test
- [x] :green_circle: [artifacts-debian12-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts-debian12-test/9/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
