### PR TITLE
feature(sct-agent): add weekly longevity test with agent enabled

### DIFF
--- a/configurations/enable_agent.yaml
+++ b/configurations/enable_agent.yaml
@@ -1,0 +1,6 @@
+agent:
+  enabled: true
+  port: 16000
+  binary_url: "https://github.com/scylladb/sct-agent/releases/latest/download/sct-agent"
+  max_concurrent_jobs: 10
+  log_level: "info"

--- a/jenkins-pipelines/master-triggers/sct_triggers/sct-agent-weekly-trigger.xml
+++ b/jenkins-pipelines/master-triggers/sct_triggers/sct-agent-weekly-trigger.xml
@@ -1,0 +1,43 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?><project>
+  <actions/>
+  <description>Triggers longevity test with sct-agent enabled, every Saturday at 10:00 UTC.
+
+  Validates sct-agent readiness by running a standard longevity workload with agent-based
+  command execution instead of SSH.
+  </description>
+  <scm class="hudson.scm.NullSCM"/>
+  <disabled>false</disabled>
+  <triggers>
+    <hudson.triggers.TimerTrigger>
+      <spec>00 07 * * 6</spec>
+    </hudson.triggers.TimerTrigger>
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers>
+    <hudson.plugins.parameterizedtrigger.BuildTrigger>
+      <configs>
+        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>scylla_version=master:latest
+provision_type=on_demand
+stress_duration=720
+post_behavior_db_nodes=destroy
+post_behavior_loader_nodes=destroy
+post_behavior_monitor_nodes=destroy
+email_recipients=qa@scylladb.com
+requested_by_user=dimakr</properties>
+              <textParamValueOnNewLine>false</textParamValueOnNewLine>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>../longevity/longevity-10gb-3h-agent-test</projects>
+          <condition>SUCCESS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <triggerFromChildProjects>false</triggerFromChildProjects>
+        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+      </configs>
+    </hudson.plugins.parameterizedtrigger.BuildTrigger>
+  </publishers>
+  <buildWrappers/>
+</project>

--- a/jenkins-pipelines/oss/longevity/longevity-10gb-3h-agent.jenkinsfile
+++ b/jenkins-pipelines/oss/longevity/longevity-10gb-3h-agent.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'gce',
+    region: 'us-east1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-10gb-3h.yaml", "configurations/enable_agent.yaml"]'''
+)


### PR DESCRIPTION
Add a trigger for weekly execution of longevity test with sct-agent to be used instead of SSH for commands execution.
`longevity-10gb-3h` configuration was selected as basis, but parameterized to run for 12h.

Closes: SCT-79

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [proposed longevity-10gb-3h-gce-test config wirh agent enabled](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-10gb-3h-gce-test/6/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
