### PR TITLE
feature(mgmt-snapshots): add multi-keyspace support for snapshot preparer

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -321,6 +321,9 @@ mgmt_snapshots_preparer_params:
   threads_num: 500
   col_size: 1024
   col_n: 1
+  # Number of keyspaces to distribute the data across. The total backup size will be divided equally among them.
+  # For example, with num_keyspaces=10 and backup_size=1000 (1TB), each keyspace will contain ~100GB of data.
+  num_keyspaces: 1
   # Defined in a runtime based on backup size, number of loaders, scylla version, etc
   ks_name: ''
   num_of_rows: ''

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -2539,7 +2539,7 @@ Size of backup snapshot in Gb to be prepared for backup
 
 Custom parameters of c-s write operation used in snapshots preparer
 
-**default:** {'cs_cmd_template': "cassandra-stress {operation} cl={cl} n={num_of_rows} -schema 'keyspace={ks_name} replication(strategy={replication},replication_factor={rf}) compaction(strategy={compaction})' -mode cql3 native -rate threads={threads_num} -col 'size=FIXED({col_size}) n=FIXED({col_n})' -pop seq={sequence_start}..{sequence_end}", 'operation': 'write', 'cl': 'QUORUM', 'replication': 'NetworkTopologyStrategy', 'rf': 3, 'compaction': 'IncrementalCompactionStrategy', 'threads_num': 500, 'col_size': 1024, 'col_n': 1, 'ks_name': '', 'num_of_rows': '', 'sequence_start': '', 'sequence_end': ''}
+**default:** {'cs_cmd_template': "cassandra-stress {operation} cl={cl} n={num_of_rows} -schema 'keyspace={ks_name} replication(strategy={replication},replication_factor={rf}) compaction(strategy={compaction})' -mode cql3 native -rate threads={threads_num} -col 'size=FIXED({col_size}) n=FIXED({col_n})' -pop seq={sequence_start}..{sequence_end}", 'operation': 'write', 'cl': 'QUORUM', 'replication': 'NetworkTopologyStrategy', 'rf': 3, 'compaction': 'IncrementalCompactionStrategy', 'threads_num': 500, 'col_size': 1024, 'col_n': 1, 'num_keyspaces': 1, 'ks_name': '', 'num_of_rows': '', 'sequence_start': '', 'sequence_end': ''}
 
 **type:** dict_or_str
 

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -834,7 +834,7 @@ class ManagerHelperTests(ManagerTestFunctionsMixIn):
         backup_size = self.params.get("mgmt_prepare_snapshot_size")  # in Gb
         assert backup_size and backup_size >= 1, "Backup size must be at least 1Gb"
 
-        ks_name, cs_write_cmds = self.build_snapshot_preparer_cs_write_cmd(backup_size)
+        ks_names, cs_write_cmds = self.build_snapshot_preparer_cs_write_cmd(backup_size)
         self.run_and_verify_stress_in_threads(cs_cmds=cs_write_cmds, stop_on_failure=True)
 
         self.log.info("Run backup and wait for it to finish")
@@ -866,11 +866,13 @@ class ManagerHelperTests(ManagerTestFunctionsMixIn):
             manager_cluster_id = "N/A"
 
         self.log.info("Send snapshot details to Argus")
+        # Handle both single keyspace (string) and multiple keyspaces (list) for backward compatibility
+        ks_name_str = ",".join(ks_names) if isinstance(ks_names, list) else ks_names
         snapshot_details = {
             "tag": backup_task.get_snapshot_tag(),
             "size": backup_size,
             "locations": ",".join(location_list),
-            "ks_name": ks_name,
+            "ks_name": ks_name_str,
             "scylla_version": self.params.get_version_based_on_conf()[0],
             "cluster_id": cluster_id,
             "ear_key_id": key_id,


### PR DESCRIPTION

Extended the mgmt_snapshots_preparer_params functionality to support generating cassandra-stress commands for multiple keyspaces. This allows distributing the total backup size equally across a configurable number of keyspaces.

Changes:
- Added `num_keyspaces` parameter to mgmt_snapshots_preparer_params config (default: 1 for backward compatibility)
- Modified `_build_ks_name()` to accept optional `ks_index` parameter for multi-keyspace naming (appends `_ks{index}` suffix)
- Refactored `build_snapshot_preparer_cs_write_cmd()` to delegate to single or multi-keyspace method based on configuration
- Added `_build_multi_keyspace_cs_write_cmds()` that divides total backup size equally among keyspaces and generates commands for each
- Updated mgmt_cli_test.py caller to handle both string and list returns
- Added unit tests covering the new functionality

Example usage: For 1TB backup across 10 keyspaces (~100GB each):
  mgmt_snapshots_preparer_params:
    num_keyspaces: 10

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [create 10 keyspaces with tables of total 2TB](https://argus.scylladb.com/tests/scylla-cluster-tests/0aebb38a-d612-4466-bf2d-775abf02c7f7)
 Used `extra_environment_variables` of:
```
SCT_MGMT_SNAPSHOTS_PREPARER_PARAMS='{"num_keyspaces": 10, "threads_num": 50}'
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
