### PR TITLE
fix(perf-pipeline): update Argus email report switch name

### DIFF
--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -14,7 +14,7 @@ def call(Map pipelineParams) {
             AWS_ACCESS_KEY_ID     = credentials('qa-aws-secret-key-id')
             AWS_SECRET_ACCESS_KEY = credentials('qa-aws-secret-access-key')
             SCT_GCE_PROJECT = "${params.gce_project}"
-            SCT_ENABLE_ARGUS_REPORT = "1"
+            SCT_ENABLE_ARGUS_EMAIL_REPORT = "1"
         }
         parameters {
             // Cloud Provider Configuration


### PR DESCRIPTION
During refactoring of SCT configuration abstraction in `aa9cd75` renaming of SCT_ENABLE_ARGUS_REPORT env var was missed for perfRegressionParallelPipeline pipeline. This results now in "Unsupported environment variables were used" error when running a performance job.
This fix renames the env var to use the correct name.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
