### PR TITLE
fix(perf-test): iterate over prepare_stress_cmd list in prepare_schema

### DIFF
--- a/performance_regression_gradual_grow_throughput.py
+++ b/performance_regression_gradual_grow_throughput.py
@@ -278,15 +278,15 @@ class PerformanceRegressionPredefinedStepsTest(PerformanceRegressionTest):
         self.log.info("Dataset has been populated")
 
     def prepare_schema(self, workload: Workload):
-        if workload.prepare_schema and (prepare_stress_cmd := self.params.get("prepare_stress_cmd")):
-            self.log.info("Preparing schema using command: %s", prepare_stress_cmd)
-            params = {"stress_cmd": prepare_stress_cmd, "round_robin": True, "stats_aggregate_cmds": False}
-            try:
-                stress_result = self.run_stress_thread(**params)
-                self.get_stress_results(queue=stress_result, store_results=False)
-            except Exception as exc:  # noqa: BLE001
-                self.log.error("Failed to prepare schema using command: %s. Exception: %s", prepare_stress_cmd, exc)
-                raise
+        if workload.prepare_schema and (prepare_stress_cmds := self.params.get("prepare_stress_cmd")):
+            stress_queue = []
+            for stress_cmd in prepare_stress_cmds:
+                self.log.info("Preparing schema using command: %s", stress_cmd)
+                params = {"stress_cmd": stress_cmd, "round_robin": True, "stats_aggregate_cmds": False}
+                stress_queue.append(self.run_stress_thread(**params))
+
+            for stress in stress_queue:
+                self.get_stress_results(queue=stress, store_results=False)
 
             self.log.info("Schema has been prepared")
             self.run_post_prepare_cql(workload=workload)


### PR DESCRIPTION
prepare_stress_cmd is a StringOrList config parameter, which the str_or_list_or_eval validator always converts to a list.
So far prepare_schema() was passing the list directly to run_stress_thread(), which expects a string, causing "'list' object has no attribute 'startswith'" error in test_write_gradual_increase_load test.

This change fixes the problem by always iterating over list of commands in prepare_stress_cmd SCT config attribute.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :clock1: [performance_regression_gradual_grow_throughput.PerformanceRegressionPredefinedStepsTest.test_write_gradual_increase_load test](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/perf/job/scylla-cloud-perf-regression-predefined-throughput-steps-vnodes/2/)
The test is still running, but it already passed the moment of starting prepare_stress_cmd commands, which were failing before this fix.

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
