### PR TITLE
tests: centralize expected error filters for node restarts

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -88,17 +88,13 @@ from sdcm.sct_events.group_common_events import (
     ignore_alternator_client_errors,
     ignore_no_space_errors,
     ignore_scrub_invalid_errors,
-    ignore_stream_mutation_fragments_errors,
-    ignore_raft_topology_cmd_failing,
-    ignore_ycsb_connection_refused,
     decorate_with_context,
     ignore_reactor_stall_errors,
     ignore_disk_quota_exceeded_errors,
-    ignore_raft_transport_failing,
     decorate_with_context_if_issues_open,
     ignore_take_snapshot_failing,
     ignore_ipv6_failure_to_assign,
-    ignore_compaction_stopped_exceptions,
+    suppress_expected_unavailability_errors,
 )
 from sdcm.sct_events.health import DataValidatorEvent
 from sdcm.sct_events.loaders import CassandraStressLogEvent, ScyllaBenchEvent
@@ -507,7 +503,7 @@ class NemesisRunner:
         with self.action_log_scope(f"Wait for schema agreement on {self.target_node.name}"):
             self.cluster.wait_for_schema_agreement()
 
-    @decorate_with_context(ignore_raft_topology_cmd_failing)
+    @decorate_with_context(suppress_expected_unavailability_errors)
     def disrupt_stop_wait_start_scylla_server(self, sleep_time=300):
         with self.action_log_scope(f"Stop Scylla on {self.target_node.name} node"):
             self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
@@ -520,7 +516,7 @@ class NemesisRunner:
         with self.action_log_scope(f"Start Scylla on {self.target_node.name} node"):
             self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
-    @decorate_with_context(ignore_ycsb_connection_refused)
+    @decorate_with_context(suppress_expected_unavailability_errors)
     def disrupt_stop_start_scylla_server(self):
         with self.action_log_scope(f"Stop Scylla on {self.target_node.name}"):
             self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
@@ -777,7 +773,7 @@ class NemesisRunner:
             with (
                 DbNodeLogger(self.cluster.nodes, "restart node", target_node=self.target_node),
                 self.action_log_scope(f"Restart {self.target_node.name} node"),
-                ignore_raft_topology_cmd_failing(),
+                suppress_expected_unavailability_errors(),
             ):
                 self.target_node.restart()
 
@@ -825,7 +821,7 @@ class NemesisRunner:
             self.log.debug("Rebooting %s out of %s times", i + 1, num_of_reboots)
             cdc_expected_error = self.target_node.follow_system_log(patterns=cdc_expected_error_patterns)
             cdc_success_msg = self.target_node.follow_system_log(patterns=cdc_success_msg_patterns)
-            with ignore_raft_topology_cmd_failing():
+            with suppress_expected_unavailability_errors():
                 self.reboot_node(target_node=self.target_node, hard=True)
             if random.choice([True, False]):
                 self.log.info("Waiting scylla services to start after node reboot")
@@ -856,12 +852,12 @@ class NemesisRunner:
             )
 
     def disrupt_soft_reboot_node(self):
-        with ignore_raft_topology_cmd_failing():
+        with suppress_expected_unavailability_errors():
             self.reboot_node(target_node=self.target_node, hard=False)
         with self.action_log_scope(f"Wait for {self.target_node.name} node to be fully started"):
             self.target_node.wait_node_fully_start()
 
-    @decorate_with_context([ignore_ycsb_connection_refused, ignore_raft_topology_cmd_failing])
+    @decorate_with_context(suppress_expected_unavailability_errors)
     def disrupt_rolling_restart_cluster(self, random_order=False):
         with self.action_log_scope(f"Rolling restart cluster. random order: {random_order}"):
             self.cluster.restart_scylla(random_order=random_order)
@@ -906,7 +902,7 @@ class NemesisRunner:
             with self.cluster.cql_connection_patient(self.target_node) as session:
                 session.execute("DROP KEYSPACE keyspace_for_authenticator_switch")
 
-    @decorate_with_context([ignore_ycsb_connection_refused, ignore_raft_topology_cmd_failing])
+    @decorate_with_context(suppress_expected_unavailability_errors)
     def disrupt_rolling_config_change_internode_compression(self):
         def get_internode_compression_new_value_randomly(current_compression):
             self.log.debug(f"Current compression is {current_compression}")
@@ -926,7 +922,7 @@ class NemesisRunner:
             node.restart_scylla_server()
         self.actions_log.info("changed inter node compression")
 
-    @decorate_with_context(ignore_ycsb_connection_refused)
+    @decorate_with_context(suppress_expected_unavailability_errors)
     def disrupt_restart_with_resharding(self):
         # If tablets in use, skipping resharding since it is not supported.
         if is_tablets_feature_enabled(self.target_node):
@@ -1030,7 +1026,7 @@ class NemesisRunner:
 
         return sstables
 
-    @decorate_with_context([ignore_ycsb_connection_refused, ignore_raft_topology_cmd_failing])
+    @decorate_with_context(suppress_expected_unavailability_errors)
     def _destroy_data_and_restart_scylla(self, keyspaces_for_destroy: list = None, sstables_to_destroy_perc: int = 50):
         tables = self.cluster.get_non_system_ks_cf_list(
             db_node=self.target_node, filter_empty_tables=False, filter_by_keyspace=keyspaces_for_destroy
@@ -1120,7 +1116,7 @@ class NemesisRunner:
         with self.action_log_scope(f"Rebuild after destroy data on {self.target_node.name} node"):
             self.repair_nodetool_rebuild()
 
-    @decorate_with_context(ignore_ycsb_connection_refused)
+    @decorate_with_context(suppress_expected_unavailability_errors)
     def disrupt_nodetool_drain(self):
         with self.action_log_scope(f"Draining Scylla on {self.target_node.name} node"):
             result = self.target_node.run_nodetool("drain", timeout=15 * 60, coredump_on_timeout=True)
@@ -1308,7 +1304,7 @@ class NemesisRunner:
         self.actions_log.info(f"New nodes are up and normal: {nodes_names}")
         return new_nodes
 
-    @decorate_with_context([ignore_ycsb_connection_refused, ignore_raft_topology_cmd_failing])
+    @decorate_with_context(suppress_expected_unavailability_errors)
     def _terminate_cluster_node(self, node):
         with self.action_log_scope(f"Terminate {node.name} node"):
             self.cluster.terminate_node(node)
@@ -1633,7 +1629,7 @@ class NemesisRunner:
         host_id = self.target_node.host_id
         is_old_node_seed = self.target_node.is_seed
         InfoEvent(message="StartEvent - Terminate node and wait 5 minutes").publish()
-        with ignore_raft_topology_cmd_failing():
+        with suppress_expected_unavailability_errors():
             self.terminate_node(target_node=self.target_node)
             time.sleep(300)  # Sleeping for 5 mins to let the cluster live with a missing node for a while
             assert get_node_state(old_node_ip) == "DN", "Removed node state should be DN"
@@ -1668,7 +1664,7 @@ class NemesisRunner:
                 new_node.set_seed_flag(True)
                 self.cluster.update_seed_provider()
 
-    @decorate_with_context([ignore_ycsb_connection_refused, ignore_raft_topology_cmd_failing])
+    @decorate_with_context(suppress_expected_unavailability_errors)
     def disrupt_kill_scylla(self):
         self._kill_scylla_daemon()
 
@@ -3354,7 +3350,7 @@ class NemesisRunner:
                 cluster_id=chosen_snapshot_info["cluster_id"],
                 tag=chosen_snapshot_tag,
             )
-            with ignore_ycsb_connection_refused(), ignore_raft_topology_cmd_failing():
+            with suppress_expected_unavailability_errors():
                 self.cluster.restart_scylla()  # After schema restoration, you should restart the nodes
 
             # TODO: Bring it back after the implementation of https://github.com/scylladb/scylla-manager/issues/4049
@@ -3952,7 +3948,7 @@ class NemesisRunner:
     def _disrupt_network_block_k8s(self, list_of_timeout_options):
         duration = f"{random.choice(list_of_timeout_options)}s"
         experiment = NetworkPacketLossExperiment(self.target_node, duration, probability=100)
-        with ignore_raft_topology_cmd_failing():
+        with suppress_expected_unavailability_errors():
             with DbNodeLogger(
                 self.cluster.nodes,
                 "block network traffic",
@@ -3991,7 +3987,7 @@ class NemesisRunner:
         wait_time = random.choice(list_of_timeout_options)
         self.log.debug("BlockNetwork: [%s] for %dsec", selected_option, wait_time)
         self.actions_log.info(f"Network block start on {self.target_node.name} node, wait_time: {wait_time}")
-        with context_manager, ignore_raft_topology_cmd_failing():
+        with context_manager, suppress_expected_unavailability_errors():
             self.target_node.traffic_control(None)
             try:
                 with DbNodeLogger(
@@ -4052,17 +4048,7 @@ class NemesisRunner:
         else:
             host_id = remove_node_host_id
 
-        if SkipPerIssues("https://github.com/scylladb/scylladb/issues/21815", params=self.tester.params):
-            # TBD: To be removed after https://github.com/scylladb/scylladb/issues/21815 is resolved
-            ignore_stream_mutation_errors_due_to_issue = ignore_stream_mutation_fragments_errors
-        else:
-            ignore_stream_mutation_errors_due_to_issue = contextlib.nullcontext
-
-        with (
-            ignore_ycsb_connection_refused(),
-            ignore_stream_mutation_errors_due_to_issue(),
-            ignore_raft_topology_cmd_failing(),
-        ):
+        with suppress_expected_unavailability_errors():
             self.actions_log.info(f"Stop {node_to_remove.name} node and make sure is DN")
             node_to_remove.stop_scylla_server(verify_up=False, verify_down=True)
             self._terminate_cluster_node(node_to_remove)
@@ -4338,7 +4324,7 @@ class NemesisRunner:
 
     @decorate_with_context(
         [
-            ignore_ycsb_connection_refused,
+            suppress_expected_unavailability_errors,
         ]
     )
     @decorate_with_context_if_issues_open(
@@ -4480,9 +4466,7 @@ class NemesisRunner:
             ):
                 stack.enter_context(expected_start_failed_context)
             with (
-                ignore_stream_mutation_fragments_errors(),
-                ignore_raft_topology_cmd_failing(),
-                ignore_compaction_stopped_exceptions(),
+                suppress_expected_unavailability_errors(),
                 self.node_allocator.run_nemesis(nemesis_label="DecommissionStreamingErr") as verification_node,
                 FailedDecommissionOperationMonitoring(
                     target_node=self.target_node, verification_node=verification_node, timeout=full_operations_timeout
@@ -4571,7 +4555,7 @@ class NemesisRunner:
         Stop decommission in middle to trigger some streaming fails, then rebuild the data on the node.
         If the node is decommissioned unexpectedly, need to re-add a new node to cluster.
         """
-        with ignore_stream_mutation_fragments_errors(), ignore_raft_topology_cmd_failing():
+        with suppress_expected_unavailability_errors():
             self.start_and_interrupt_decommission_streaming()
 
     def disrupt_rebuild_streaming_err(self):
@@ -4584,7 +4568,7 @@ class NemesisRunner:
                 "Rebuild is not supported with tablets. Skipping nemesis (scylladb/scylladb#17575)"
             )
 
-        with ignore_stream_mutation_fragments_errors(), ignore_raft_topology_cmd_failing():
+        with suppress_expected_unavailability_errors():
             self.start_and_interrupt_rebuild_streaming()
 
     def disrupt_repair_streaming_err(self):
@@ -4595,7 +4579,7 @@ class NemesisRunner:
         """
         self.log.debug("Cluster repair starts")
         self.run_repair()
-        with ignore_raft_topology_cmd_failing():
+        with suppress_expected_unavailability_errors():
             self.start_and_interrupt_repair_streaming()
 
     def _corrupt_data_file(self):
@@ -4802,7 +4786,7 @@ class NemesisRunner:
             enable_kms_key_rotation=True, additional_scylla_encryption_options={"key_provider": "KmsKeyProviderFactory"}
         )
 
-    @decorate_with_context([ignore_ycsb_connection_refused, ignore_raft_topology_cmd_failing])
+    @decorate_with_context(suppress_expected_unavailability_errors)
     @scylla_versions(("2023.1.1-dev", None))
     def _enable_disable_table_encryption(self, enable_kms_key_rotation, additional_scylla_encryption_options=None):  # noqa: PLR0914
         if self.cluster.params.get("cluster_backend") != "aws":
@@ -5680,7 +5664,7 @@ class NemesisRunner:
                 raise UnsupportedNemesis("Non-system keyspace and table are not found. nemesis can't be run")
             ks_name, base_table_name = random.choice(ks_cfs).split(".")
             view_name = f"{base_table_name}_view"
-            with ignore_raft_topology_cmd_failing():
+            with suppress_expected_unavailability_errors():
                 self.target_node.stop_scylla()
             with self.cluster.cql_connection_patient(node=cql_query_executor_node, connect_timeout=600) as session:
                 try:
@@ -5866,11 +5850,7 @@ class NemesisRunner:
             bootstrap_node=new_node, verification_node=self.target_node, actions_log=self.actions_log
         )
 
-        with (
-            ignore_stream_mutation_fragments_errors(),
-            ignore_raft_topology_cmd_failing(),
-            ignore_raft_transport_failing(),
-        ):
+        with suppress_expected_unavailability_errors():
             bootstrapabortmanager.run_bootstrap_and_abort_with_action(
                 terminate_pattern, abort_action=new_node.stop_scylla
             )
@@ -5966,7 +5946,7 @@ class NemesisRunner:
             self.log.debug("Coordinator node: %s, %s", coordinator_node, coordinator_node.name)
             with (
                 self.action_log_scope(f"Stop Scylla coordinator {coordinator_node.name} node"),
-                ignore_raft_topology_cmd_failing(),
+                suppress_expected_unavailability_errors(),
             ):
                 self.target_node.stop_scylla()
             self.log.debug("Wait random timeout %s to new coordinator will be elected", election_wait_timeout)
@@ -6167,7 +6147,7 @@ class NemesisRunner:
             try:
                 num_of_restarts = len(self.cluster.nodes) // 2
                 self.log.debug("Number of serial restart of topology coordinator: %s", num_of_restarts)
-                with ignore_raft_topology_cmd_failing():
+                with suppress_expected_unavailability_errors():
                     for i in range(num_of_restarts):
                         self.log.debug("Kill coordinator node: %s round: %s", self.target_node.name, i + 1)
                         self._kill_scylla_daemon()

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -10,17 +10,20 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2020 ScyllaDB
+import logging
 from contextlib import contextmanager, ExitStack, ContextDecorator
 from functools import wraps
 from typing import ContextManager, Callable, Sequence
 
 from sdcm.cluster import TestConfig
 from sdcm.sct_events import Severity
+from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.filters import DbEventsFilter, EventsSeverityChangerFilter, EventsFilter
 from sdcm.sct_events.loaders import YcsbStressEvent
-from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.monitors import PrometheusAlertManagerEvent
 from sdcm.utils.issues import SkipPerIssues
+
+LOGGER = logging.getLogger(__name__)
 
 
 @contextmanager
@@ -611,6 +614,33 @@ def ignore_ipv6_failure_to_assign():
                 extra_time_to_expiration=60,
             )
         )
+        yield
+
+
+NODE_UNAVAILABLE_CONTEXTS: list[Callable[[], ContextManager]] = [
+    ignore_raft_topology_cmd_failing,
+    ignore_raft_transport_failing,
+    ignore_ycsb_connection_refused,
+    ignore_stream_mutation_fragments_errors,
+    ignore_compaction_stopped_exceptions,
+]
+
+
+@contextmanager
+def suppress_expected_unavailability_errors():
+    """Unified context manager for suppressing expected errors during node unavailability.
+
+    Activates a core set of event filters that cover the most common errors seen when
+    a Scylla node becomes temporarily unreachable (restart, shutdown, network block, etc.).
+
+    Args:
+        extra_contexts: Additional context managers (or callables returning them)
+            to activate alongside the core set. Use this for scenario-specific filters
+    """
+    LOGGER.debug("Entered the context of suppressing expected errors")
+    with ExitStack() as stack:
+        for ctx_factory in NODE_UNAVAILABLE_CONTEXTS:
+            stack.enter_context(ctx_factory())
         yield
 
 


### PR DESCRIPTION
- reduce log/event noise during node restarts by grouping expected error suppressors under suppress_expected_errors().
- keep behavior extensible via extra_contexts for special cases.

Fixes SCYLLADB-849

### Testing
https://argus.scylladb.com/tests/scylla-cluster-tests/773316ad-1fd8-4faa-b2e5-ffd320584945

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
