### PR TITLE
fix(reuse-cluster): ensure SSL certificates when reusing cluster

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5560,7 +5560,7 @@ class BaseScyllaCluster:
             f"sed -ie 's/^rpc_address: .*/rpc_address: {node.ip_address}/g' {node.offline_install_dir}/etc/scylla/scylla.yaml"
         )
 
-    def node_setup(self, node: BaseNode, verbose: bool = False, timeout: int = 3600):  # noqa: PLR0912, PLR0914
+    def node_setup(self, node: BaseNode, verbose: bool = False, timeout: int = 3600):  # noqa: PLR0912, PLR0914, PLR0915
         node.wait_ssh_up(verbose=verbose, timeout=timeout)
 
         if node.distro.is_rhel_like or self.params.get("cluster_backend") == "oci":
@@ -5589,6 +5589,14 @@ class BaseScyllaCluster:
 
         if self.test_config.REUSE_CLUSTER:
             self._reuse_cluster_setup(node)
+            if (self.params.get("server_encrypt") or self.params.get("client_encrypt")) and not (
+                node.ssl_conf_dir / TLSAssets.DB_CERT
+            ).exists():
+                self._generate_db_node_certs(node)
+                install_client_certificate(node.remoter, node.ip_address, force=True)
+            # warm up raft cached_property per node to avoid rapid TLS session cycling
+            # during validate_raft_on_nodes (https://github.com/scylladb/python-driver/issues/614 workaround)
+            _ = node.raft
             return
 
         node.disable_daily_triggered_services()
@@ -5636,18 +5644,7 @@ class BaseScyllaCluster:
             SnitchConfig(node=node, datacenters=datacenters).apply()
 
         if any([self.params.get("server_encrypt"), self.params.get("client_encrypt")]):
-            # Create node certificate for internode communication
-            node.create_node_certificate(
-                cert_file=node.ssl_conf_dir / TLSAssets.DB_CERT,
-                cert_key=node.ssl_conf_dir / TLSAssets.DB_KEY,
-                csr_file=node.ssl_conf_dir / TLSAssets.DB_CSR,
-            )
-            # Create client facing node certificate, for client-to-node communication
-            node.create_node_certificate(
-                node.ssl_conf_dir / TLSAssets.DB_CLIENT_FACING_CERT, node.ssl_conf_dir / TLSAssets.DB_CLIENT_FACING_KEY
-            )
-            for src in (CA_CERT_FILE, JKS_TRUSTSTORE_FILE):
-                shutil.copy(src, node.ssl_conf_dir)
+            self._generate_db_node_certs(node)
         node.config_setup(append_scylla_args=self.get_scylla_args())
 
         self._scylla_post_install(node, install_scylla, nic_devname)
@@ -5822,6 +5819,20 @@ class BaseScyllaCluster:
 
     def _reuse_cluster_setup(self, node):
         pass
+
+    def _generate_db_node_certs(self, node):
+        """Generate per-node SSL certificates for a DB node"""
+        node.create_node_certificate(
+            cert_file=node.ssl_conf_dir / TLSAssets.DB_CERT,
+            cert_key=node.ssl_conf_dir / TLSAssets.DB_KEY,
+            csr_file=node.ssl_conf_dir / TLSAssets.DB_CSR,
+        )
+        node.create_node_certificate(
+            node.ssl_conf_dir / TLSAssets.DB_CLIENT_FACING_CERT,
+            node.ssl_conf_dir / TLSAssets.DB_CLIENT_FACING_KEY,
+        )
+        for src in (CA_CERT_FILE, JKS_TRUSTSTORE_FILE):
+            shutil.copy(src, node.ssl_conf_dir)
 
     @staticmethod
     def clean_replacement_node_options(node):
@@ -6182,6 +6193,9 @@ class BaseLoaderSet:
 
         if TestConfig().REUSE_CLUSTER:
             self.kill_stress_thread()
+            if self.params.get("client_encrypt") and not (node.ssl_conf_dir / TLSAssets.CLIENT_CERT).exists():
+                self._generate_loader_certs(node)
+                install_client_certificate(node.remoter, node.ip_address, force=True)
             return
 
         node_exporter_setup = NodeExporterSetup()
@@ -6192,16 +6206,7 @@ class BaseLoaderSet:
             return
 
         if self.params.get("client_encrypt"):
-            node.create_node_certificate(
-                node.ssl_conf_dir / TLSAssets.CLIENT_CERT, node.ssl_conf_dir / TLSAssets.CLIENT_KEY
-            )
-            for src in (CA_CERT_FILE, JKS_TRUSTSTORE_FILE):
-                shutil.copy(src, node.ssl_conf_dir)
-            export_pem_cert_to_pkcs12_keystore(
-                node.ssl_conf_dir / TLSAssets.CLIENT_CERT,
-                node.ssl_conf_dir / TLSAssets.CLIENT_KEY,
-                node.ssl_conf_dir / TLSAssets.PKCS12_KEYSTORE,
-            )
+            self._generate_loader_certs(node)
 
             if self.params.get("use_prepared_loaders"):
                 node.config_client_encrypt()
@@ -6218,6 +6223,19 @@ class BaseLoaderSet:
 
         # Login to Docker Hub.
         docker_hub_login(remoter=node.remoter)
+
+    def _generate_loader_certs(self, node):
+        """Generate SSL client certificates for a loader node"""
+        node.create_node_certificate(
+            node.ssl_conf_dir / TLSAssets.CLIENT_CERT, node.ssl_conf_dir / TLSAssets.CLIENT_KEY
+        )
+        for src in (CA_CERT_FILE, JKS_TRUSTSTORE_FILE):
+            shutil.copy(src, node.ssl_conf_dir)
+        export_pem_cert_to_pkcs12_keystore(
+            node.ssl_conf_dir / TLSAssets.CLIENT_CERT,
+            node.ssl_conf_dir / TLSAssets.CLIENT_KEY,
+            node.ssl_conf_dir / TLSAssets.PKCS12_KEYSTORE,
+        )
 
     def node_startup(self, node, verbose=False, **kwargs):
         pass

--- a/sdcm/provision/helpers/certificate.py
+++ b/sdcm/provision/helpers/certificate.py
@@ -75,8 +75,8 @@ JKS_TRUSTSTORE_FILE = Path(get_data_dir_path("ssl_conf", TLSAssets.JKS_TRUSTSTOR
 
 
 @retrying(n=3, sleep_time=10, allowed_exceptions=(Exception,), message="Retrying SSL certificate installation")
-def install_client_certificate(remoter, node_identifier):
-    if remoter.run(f"ls {SCYLLA_SSL_CONF_DIR}", ignore_status=True).ok:
+def install_client_certificate(remoter, node_identifier, force=False):
+    if not force and remoter.run(f"ls {SCYLLA_SSL_CONF_DIR}", ignore_status=True).ok:
         return
     dst = "/tmp/ssl_conf"
     remoter.run(f"mkdir -p {dst}")

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3820,8 +3820,9 @@ class ClusterTester(unittest.TestCase):
         time.sleep(1)  # Sleep is needed to let events from save_email_data being processed
         self.argus_collect_gemini_results()
         self.destroy_localhost()
-        with silence(parent=self, name="Cleaning up SSL config directory"):
-            cleanup_ssl_config()
+        if not self.test_config.KEEP_ALIVE_DB_NODES:
+            with silence(parent=self, name="Cleaning up SSL config directory"):
+                cleanup_ssl_config()
 
         self.log.info("Test ID: {}".format(self.test_config.test_id()))
 


### PR DESCRIPTION
When reusing a cluster with enabled encrypted communication the SSL certificates were missing because they were deleted during teardown of the previous run.

This change adds a two-layer fix:
- skip SSL certs cleanup when cluster is kept alive (post_behavior=keep)
- if certs are missing for some reason during reuse, regenerate them with a new CA and push to all nodes - Scylla hot-reloads certs, and loaders pick up new client certs at stress tool launch time

Fixes: SCT-32

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] tested locally as cluster reuse is not yet supported in Jenkins:
- initial cluster deployment
```
...
< t:2026-03-03 21:56:06,046 f:tester.py       l:3829 c:LongevityTest        p:INFO  > Test ID: 5b0f5502-ed0e-4649-a9f3-18f2ee7bdb93
< t:2026-03-03 21:56:06,047 f:tester.py       l:3904 c:LongevityTest        p:INFO  > ================================= TEST RESULTS =================================
< t:2026-03-03 21:56:06,047 f:tester.py       l:3904 c:LongevityTest        p:INFO  > ================================================================================
< t:2026-03-03 21:56:06,047 f:tester.py       l:3904 c:LongevityTest        p:INFO  > SUCCESS :)
```
- reuse of the cluster 5b0f5502-ed0e-4649-a9f3-18f2ee7bdb93 (existing certs are reused)
```
...
< t:2026-03-03 22:06:41,566 f:sct_config.py   l:3540 c:sdcm.sct_config      p:INFO  > reuse_cluster: 5b0f5502-ed0e-4649-a9f3-18f2ee7bdb93
...
< t:2026-03-03 22:06:49,700 f:certificate.py  l:123  c:sdcm.provision.helpers.certificate p:INFO  > CA /home/dmitriy/Work/Scylla/sct_reuse_ckuster_with_encrypt/data_dir/ssl_conf/ca.pem certificate and /home/dmitriy/Work/Scylla/sct_reuse_ckuster_with_encrypt/data_dir/ssl_conf/ca.key key already exist. Skipping creation.
...
< t:2026-03-03 22:06:56,630 f:cluster_aws.py  l:447  c:sdcm.cluster         p:INFO  > Cluster PR-provision-test-dmitriy-db-cluster-5b0f5502 (AMI: ['ami-0bc3666a33c15eee5']): Found instances to be reused from test [True] = [ec2.Instance(id='i-01feea31820f1f197'), ec2.Instance(id='i-01852b727d394aa6a'), ec2.Instance(id='i-0ca98db8abdaa0be3')]
...
< t:2026-03-03 22:07:27,621 f:cluster_aws.py  l:447  c:sdcm.cluster         p:INFO  > Cluster PR-provision-test-dmitriy-loader-set-5b0f5502 (AMI: ['ami-01d0334e94e895e89']): Found instances to be reused from test [True] = [ec2.Instance(id='i-0bd50d65f6603a595')]
...
< t:2026-03-03 22:07:40,925 f:cluster_aws.py  l:447  c:sdcm.cluster         p:INFO  > Cluster PR-provision-test-dmitriy-monitor-set-5b0f5502 (AMI: ['ami-09f4bc2a7c979a302']): Found instances to be reused from test [True] = [ec2.Instance(id='i-012c4872f68bdf8e9')]
...
< t:2026-03-03 22:13:30,332 f:tester.py       l:3829 c:LongevityTest        p:INFO  > Test ID: 5b0f5502-ed0e-4649-a9f3-18f2ee7bdb93
< t:2026-03-03 22:13:30,333 f:tester.py       l:3904 c:LongevityTest        p:INFO  > ================================= TEST RESULTS =================================
< t:2026-03-03 22:13:30,333 f:tester.py       l:3904 c:LongevityTest        p:INFO  > ================================================================================
< t:2026-03-03 22:13:30,333 f:tester.py       l:3904 c:LongevityTest        p:INFO  > SUCCESS :)
```
- reuse of the cluster 5b0f5502-ed0e-4649-a9f3-18f2ee7bdb93 after certs are deleted (new certs are generated and pushed)
```
...
< t:2026-03-03 22:44:39,698 f:sct_config.py   l:3540 c:sdcm.sct_config      p:INFO  > reuse_cluster: 5b0f5502-ed0e-4649-a9f3-18f2ee7bdb93
...
< t:2026-03-03 22:46:19,839 f:db_log_reader.py l:152  c:sdcm.db_log_reader   p:DEBUG > 2026-03-03T21:46:18.645 PR-provision-test-dmitriy-db-node-5b0f5502-1  !INFO | scylla[5848]  [shard 0:sl:d] cql_server - Reloaded {"/etc/scylla/ssl_conf/client-facing.crt", "/etc/scylla/ssl_conf/client-facing.key", "/etc/scylla/ssl_conf/ca.pem"}
...
< t:2026-03-03 22:46:19,842 f:db_log_reader.py l:152  c:sdcm.db_log_reader   p:DEBUG > 2026-03-03T21:46:18.659 PR-provision-test-dmitriy-db-node-5b0f5502-2  !INFO | scylla[5786]  [shard 0:sl:d] cql_server - Reloaded {"/etc/scylla/ssl_conf/client-facing.crt", "/etc/scylla/ssl_conf/client-facing.key", "/etc/scylla/ssl_conf/ca.pem"}
...
< t:2026-03-03 22:46:19,941 f:db_log_reader.py l:152  c:sdcm.db_log_reader   p:DEBUG > 2026-03-03T21:46:18.733 PR-provision-test-dmitriy-db-node-5b0f5502-3  !INFO | scylla[5740]  [shard 0:sl:d] cql_server - Reloaded {"/etc/scylla/ssl_conf/client-facing.crt", "/etc/scylla/ssl_conf/client-facing.key", "/etc/scylla/ssl_conf/ca.pem"}

...
< t:2026-03-03 22:44:58,010 f:cluster_aws.py  l:447  c:sdcm.cluster         p:INFO  > Cluster PR-provision-test-dmitriy-db-cluster-5b0f5502 (AMI: ['ami-0bc3666a33c15eee5']): Found instances to be reused from test [True] = [ec2.Instance(id='i-01feea31820f1f197'), ec2.Instance(id='i-01852b727d394aa6a'), ec2.Instance(id='i-0ca98db8abdaa0be3')]
...
< t:2026-03-03 22:45:29,891 f:cluster_aws.py  l:447  c:sdcm.cluster         p:INFO  > Cluster PR-provision-test-dmitriy-loader-set-5b0f5502 (AMI: ['ami-01d0334e94e895e89']): Found instances to be reused from test [True] = [ec2.Instance(id='i-0bd50d65f6603a595')]
...
< t:2026-03-03 22:45:43,214 f:cluster_aws.py  l:447  c:sdcm.cluster         p:INFO  > Cluster PR-provision-test-dmitriy-monitor-set-5b0f5502 (AMI: ['ami-09f4bc2a7c979a302']): Found instances to be reused from test [True] = [ec2.Instance(id='i-012c4872f68bdf8e9')]
...
< t:2026-03-03 22:51:41,098 f:tester.py       l:3829 c:LongevityTest        p:INFO  > Test ID: 5b0f5502-ed0e-4649-a9f3-18f2ee7bdb93
< t:2026-03-03 22:51:41,099 f:tester.py       l:3904 c:LongevityTest        p:INFO  > ================================= TEST RESULTS =================================
< t:2026-03-03 22:51:41,099 f:tester.py       l:3904 c:LongevityTest        p:INFO  > ================================================================================
< t:2026-03-03 22:51:41,099 f:tester.py       l:3904 c:LongevityTest        p:INFO  > SUCCESS :)
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
