### PR TITLE
fix(cloud-init): handle missing cloud-init on provisioned instances

### DIFF
--- a/sdcm/provision/helpers/cloud_init.py
+++ b/sdcm/provision/helpers/cloud_init.py
@@ -33,6 +33,10 @@ def wait_cloud_init_completes(remoter: RemoteCmdRunnerBase, instance: VmInstance
     LOGGER.info("Waiting for cloud-init to complete on node %s...", instance.name)
     errors_found = False
     remoter.is_up(60 * 5)
+    # Check if cloud-init is installed before trying to use it
+    if not remoter.sudo("bash -c 'command -v cloud-init'", ignore_status=True).ok:
+        LOGGER.info("cloud-init is not installed on node %s, skipping cloud-init check.", instance.name)
+        return
     # examples: 24.1.3-0ubuntu3.3, 19.3-46.amzn2.0.2
     cloud_init_version = Version(remoter.run("cloud-init --version 2>&1").stdout.split()[1].split("-")[0])
     # cloud-init supports json output from version 23.4, see:

--- a/unit_tests/provisioner/test_provision_sct_resources.py
+++ b/unit_tests/provisioner/test_provision_sct_resources.py
@@ -20,6 +20,7 @@ from sdcm.test_config import TestConfig
 def test_can_provision_instances_according_to_sct_configuration(params, test_config, azure_service, fake_remoter):
     """Integration test for provisioning sct resources according to SCT configuration."""
     fake_remoter.result_map = {
+        r"sudo bash -c 'command -v cloud-init'": Result(stdout="/usr/bin/cloud-init", exited=0),
         r"sudo cloud-init status --wait": Result(stdout="..... \n status: done", stderr="nic", exited=0),
         r"cloud-init --version 2>&1": Result(stdout="/bin/ 19.2-amzn", stderr="", exited=0),
         r"ls /var/lib/sct/cloud-init": Result(stdout="done", exited=0),
@@ -69,6 +70,7 @@ def test_can_provision_instances_according_to_sct_configuration(params, test_con
 
 def test_fallback_on_demand_when_spot_fails(fallback_on_demand, params, test_config, azure_service, fake_remoter):
     fake_remoter.result_map = {
+        r"sudo bash -c 'command -v cloud-init'": Result(stdout="/usr/bin/cloud-init", exited=0),
         r"sudo cloud-init status --wait": Result(stdout="..... \n status: done", stderr="nic", exited=0),
         r"cloud-init --version 2>&1": Result(stdout="/bin/ 19.2-amzn", stderr="", exited=0),
         r"ls /var/lib/sct/cloud-init": Result(stdout="done", exited=0),


### PR DESCRIPTION
The wait_cloud_init_completes function assumed cloud-init was always installed on provisioned VMs. When cloud-init is not present, the command 'cloud-init --version' fails with exit code 127, causing an UnexpectedExit exception that is not caught by the @retrying decorator (which only catches CloudInitError). This crashed the test setup phase.

The GCE node class (cluster_gce.py) already had a guard checking for cloud-init availability before calling wait_cloud_init_completes, but the call path through sct_provision/instances_provider.py did not.

Moved the cloud-init availability check into wait_cloud_init_completes itself so all callers are protected. If cloud-init is not installed, the function logs an informational message and returns early

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [rocky8-test](https://argus.scylladb.com/tests/scylla-cluster-tests/f62672ab-5525-4d68-beea-0e6519445972)
- [x] [artifacts-ami-test](https://argus.scylladb.com/tests/scylla-cluster-tests/3cbb6e35-1085-48f6-bee7-463811c8379f)
- [x] [artifacts-azure-image-test](https://argus.scylladb.com/tests/scylla-cluster-tests/8905b1a4-4efb-4486-9c31-a978af49fbf4)
- [x] [artifacts-centos9-test](https://argus.scylladb.com/tests/scylla-cluster-tests/207ebddc-2d54-4685-bea7-6deaee221d99)
- [x] [artifacts-debian12-test](https://argus.scylladb.com/tests/scylla-cluster-tests/cd400bd3-0846-4492-92f2-46bd39690d2b)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
