### PR TITLE
refactor(cluster-tools): move expand_cluster_heterogeneous to shared utility

### DIFF
--- a/longevity_balancer_test.py
+++ b/longevity_balancer_test.py
@@ -43,21 +43,6 @@ class LongevityBalancerTest(LongevityTest):
     - stress_cmd: The stress command to use for the second data population, after adding and removing nodes
     """
 
-    def expand_cluster_heterogenous(self):
-        new_nodes = self.db_cluster.add_nodes(
-            count=self.params.get("nemesis_add_node_cnt"),
-            instance_type=self.params.get("nemesis_grow_shrink_instance_type"),
-            enable_auto_bootstrap=True,
-            rack=None,
-        )
-        self.monitors.reconfigure_scylla_monitoring()
-        up_timeout = MAX_TIME_WAIT_FOR_NEW_NODE_UP
-        with adaptive_timeout(Operations.NEW_NODE, node=self.db_cluster.data_nodes[0], timeout=up_timeout):
-            self.db_cluster.wait_for_init(node_list=new_nodes, timeout=up_timeout, check_node_health=False)
-        self.db_cluster.set_seeds()
-        self.db_cluster.update_seed_provider()
-        self.db_cluster.wait_for_nodes_up_and_normal(nodes=new_nodes)
-
     def wait_for_balance(self):
         # run multiple times because `storage_service/quiesce_topology` only returns when
         # the topology operations that were ongoing when the command was issued are done
@@ -140,7 +125,7 @@ class LongevityBalancerTest(LongevityTest):
         6. Wait for the cluster to balance.
         7. Check the final balance of the cluster.
         """
-        self.expand_cluster_heterogenous()
+        self.expand_cluster_heterogeneous()
         with PeriodicDiskUsageToArgus(
             self.db_cluster, self.test_config.argus_client(), interval=600, threshold=BALANCE_THRESHOLD
         ):

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -1213,6 +1213,9 @@ class ManagerRestoreBenchmarkTests(ManagerTestFunctionsMixIn):
         The test suggests two flows - populate the cluster with data, create the backup, and then restore it or
         restore from a pre-created backup.
         """
+        # If the tested restore cluster setup requires mixed instance types, add the extra nodes with different instance types
+        if self.params.get("nemesis_grow_shrink_instance_type"):
+            self.expand_cluster_heterogeneous()
         if manager_backup_restore_method := self.params.get("manager_backup_restore_method"):
             manager_backup_restore_method = ObjectStorageUploadMode(manager_backup_restore_method)
         if reuse_snapshot_name := self.params.get("mgmt_reuse_backup_snapshot_name"):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -923,6 +923,21 @@ class ClusterTester(unittest.TestCase):
         db_cluster.set_seeds()
         db_cluster.update_seed_provider()
 
+    def expand_cluster_heterogeneous(self):
+        """Add nodes with different instance types to the cluster.
+
+        This method adds nodes using the instance type specified by 'nemesis_grow_shrink_instance_type'
+        configuration parameter. The number of nodes to add is controlled by 'nemesis_add_node_cnt'.
+        This is useful for creating heterogeneous clusters with mixed instance types.
+        """
+        from sdcm.utils.cluster_tools import expand_cluster_heterogeneous as _expand_cluster_heterogeneous  # noqa: PLC0415
+
+        return _expand_cluster_heterogeneous(
+            db_cluster=self.db_cluster,
+            monitors=self.monitors,
+            params=self.params,
+        )
+
     @property
     def rack_names_per_datacenter_and_rack_idx_map(self):
         if self.db_cluster is None:

--- a/sdcm/utils/cluster_tools.py
+++ b/sdcm/utils/cluster_tools.py
@@ -21,7 +21,8 @@ from sdcm.utils.parallel_object import ParallelObject
 
 
 if TYPE_CHECKING:
-    from sdcm.cluster import BaseCluster, BaseNode
+    from sdcm.cluster import BaseCluster, BaseNode, BaseMonitorSet
+    from sdcm.sct_config import SCTConfiguration
 
 LOGGER = logging.getLogger(__name__)
 
@@ -112,3 +113,42 @@ def clear_snapshot_nodes(cluster):
         for node in cluster.data_nodes
     ]
     ParallelObject(objects=triggers, timeout=1200).call_objects()
+
+
+def expand_cluster_heterogeneous(
+    db_cluster: BaseCluster,
+    monitors: BaseMonitorSet,
+    params: SCTConfiguration,
+) -> list[BaseNode]:
+    """Add nodes with different instance types to the cluster.
+
+    This function adds nodes using the instance type specified by 'nemesis_grow_shrink_instance_type'
+    configuration parameter. The number of nodes to add is controlled by 'nemesis_add_node_cnt'.
+    This is useful for creating heterogeneous clusters with mixed instance types.
+
+    Args:
+        db_cluster: The database cluster to expand.
+        monitors: The monitor set to reconfigure after adding nodes.
+        params: The SCT configuration parameters.
+
+    Returns:
+        List of newly added nodes.
+    """
+    # Import here to avoid circular imports
+    from sdcm.cluster import MAX_TIME_WAIT_FOR_NEW_NODE_UP  # noqa: PLC0415
+    from sdcm.utils.adaptive_timeouts import adaptive_timeout, Operations  # noqa: PLC0415
+
+    new_nodes = db_cluster.add_nodes(
+        count=params.get("nemesis_add_node_cnt"),
+        instance_type=params.get("nemesis_grow_shrink_instance_type"),
+        enable_auto_bootstrap=True,
+        rack=None,
+    )
+    monitors.reconfigure_scylla_monitoring()
+    up_timeout = MAX_TIME_WAIT_FOR_NEW_NODE_UP
+    with adaptive_timeout(Operations.NEW_NODE, node=db_cluster.data_nodes[0], timeout=up_timeout):
+        db_cluster.wait_for_init(node_list=new_nodes, timeout=up_timeout, check_node_health=False)
+    db_cluster.set_seeds()
+    db_cluster.update_seed_provider()
+    db_cluster.wait_for_nodes_up_and_normal(nodes=new_nodes)
+    return new_nodes

--- a/test-cases/features/size-based-load-balancing/size-based-load-balancing.yaml
+++ b/test-cases/features/size-based-load-balancing/size-based-load-balancing.yaml
@@ -1,6 +1,6 @@
 # Size-based load balancing test.
 # This test ensures storage utilization within each rack stays within the allowed threshold.
-# - Work with a heterogenous cluster: add 'nemesis_add_node_cnt' nodes of type 'nemesis_grow_shrink_instance_type' to the base cluster (n_db_nodes = 6).
+# - Work with a heterogeneous cluster: add 'nemesis_add_node_cnt' nodes of type 'nemesis_grow_shrink_instance_type' to the base cluster (n_db_nodes = 6).
 # - Initial data population: run the 'prepare_write_cmd' scylla-bench commands.
 #   The commands are designed to create a significant amount of data (total ~1.2TB) with a wide distribution of partition sizes, which should trigger the size-based load balancing logic.
 # - Scale-out: add one node per rack ('nemesis_add_node_cnt'/ 'simulated_racks' = 3) of type 'nemesis_grow_shrink_instance_type'.


### PR DESCRIPTION

Refactored the expand_cluster_heterogeneous method to be available as a shared utility function in sdcm/utils/cluster_tools.py. This enables both LongevityBalancerTest and ManagerRestoreBenchmarkTests to use the same functionality for creating heterogeneous clusters with mixed instance types.

Changes:
- Added expand_cluster_heterogeneous function to cluster_tools.py
- Updated ClusterTester to delegate to the shared function
- Removed duplicate implementation from LongevityBalancerTest
- Added heterogeneous cluster support to test_restore_benchmark
- Fixed typo: renamed heterogenous -> heterogeneous throughout

This refactoring reduces code duplication and allows restore benchmark tests to optionally add nodes with different instance types when the nemesis_grow_shrink_instance_type parameter is configured.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [test mixed cluster native restore](https://argus.scylladb.com/tests/scylla-cluster-tests/a3924e69-cf11-4734-be18-52b8e2d610e8)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
