### PR TITLE
improvement(sanity): enable client encryption in sanity longevity test

### DIFF
--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -18,5 +18,7 @@ nemesis_interval: 2
 user_prefix: 'longevity-10gb-3h'
 space_node_threshold: 64424
 
+client_encrypt: true
+
 gce_n_local_ssd_disk_db: 2
 run_db_node_benchmarks: false


### PR DESCRIPTION
Enable client_encrypt in longevity-10gb-3h.yaml to use client encryption in sanity longevities.

The AWS sanity uses `longevity-100gb-4h` config where the encryption was already enabled.

Closes: SCT-142

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [longevity-10gb-3h-azure-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-10gb-3h-azure-test/34/)
- [x] :green_circle: [longevity-10gb-3h-gce-test](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/longevity-10gb-3h-gce-test/15/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
