### PR TITLE
fix(nemesis): skip disrupt_refuse_connection nemesis when target is alone in rack

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -5997,6 +5997,9 @@ class NemesisRunner:
             self.set_target_node(rack=target_node_rack)
             self.log.info("Target node rack %s, loader rack %s", self.target_node.rack, loader_rack)
 
+    def _is_single_node_in_rack(self, node: BaseNode) -> bool:
+        return len([n for n in self.cluster.data_nodes if (n.rack == node.rack and n.dc_idx == node.dc_idx)]) == 1
+
     def _refuse_connection_from_banned_node(self, use_iptables=False):
         """Banned node could not connect with rest nodes in cluster
 
@@ -6016,6 +6019,8 @@ class NemesisRunner:
             raise UnsupportedNemesis("Raft feature: consistent-topology-changes is not enabled")
         if self._is_it_on_kubernetes():
             raise UnsupportedNemesis("Skip test for K8S because no supported yet")
+        if self._is_single_node_in_rack(self.target_node):
+            raise UnsupportedNemesis(f"Target node {self.target_node.name} is alone in its rack, cannot remove it.")
 
         if SkipPerIssues("scylladb/scylla-drivers#95", self.cluster.params):
             # until https://github.com/scylladb/scylla-drivers/issues/95 would be solved


### PR DESCRIPTION
The nemeses `disrupt_refuse_connection_with_block_scylla_ports_on_banned_node` and disrupt_refuse_connection_with_send_sigstop_signal_to_scylla_on_banned_node` need to remove the target node at some point, and if that node is the only one in the rack, that is not allowed.

Example of failure:
https://argus.scylladb.com/tests/scylla-cluster-tests/f4267f80-cf89-4611-8d74-58f0592f33f9
```
2026-03-11 00:14:39.759: (DisruptionEvent Severity.ERROR) period_type=end event_id=d15192fb-c14d-4a82-903e-d67140a1cfc2 duration=6m42s: nemesis_name=IsolateNodeWithIptableRuleNemesis target_node=Node elasticity-test-nemesis-master-db-node-f4267f80-3 [18.203.101.143 | 10.4.2.41] (Type: i8g.large) (rack: RACK2) errors=Node was not removed properly (Node status:{'state': 'DN', 'load': '381.20GB', 'tokens': '256', 'owns': '?', 'host_id': 'be4a0f28-65a5-47b0-a922-cf9a5df22211', 'rack': 'RACK2'})
Traceback (most recent call last):
  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis/__init__.py", line 6084, in _refuse_connection_from_banned_node
    working_node.run_nodetool(f"removenode {target_host_id}", retry=0, long_running=True)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 3100, in run_nodetool
    result = runner(cmd, timeout=timeout, ignore_status=ignore_status, verbose=verbose, retry=retry)
  File "/home/ubuntu/scylla-cluster-tests/sdcm/remote/remote_long_running.py", line 70, in run_long_running_cmd
    raise UnexpectedExit(result=result)
sdcm.remote.libssh2_client.exceptions.UnexpectedExit: Encountered a bad command exit code!
Command: '/usr/bin/nodetool  removenode be4a0f28-65a5-47b0-a922-cf9a5df22211 '
Exit code: 4
Stdout:
Stderr:
error executing POST request to http://localhost:10000/storage_service/remove_node with parameters {"host_id": ["be4a0f28-65a5-47b0-a922-cf9a5df22211"]}: remote replied with status code 500 Internal Server Error:
std::runtime_error (Removenode failed: node remove rejected: Cannot remove the node because its removal would make some existing keyspace RF-rack-invalid)
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis/__init__.py", line 6344, in wrapper
    result = method(*args, **kwargs)
  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis/monkey/__init__.py", line 987, in disrupt
    self.runner.disrupt_refuse_connection_with_block_scylla_ports_on_banned_node()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis/__init__.py", line 5982, in disrupt_refuse_connection_with_block_scylla_ports_on_banned_node
    self._refuse_connection_from_banned_node(use_iptables=True)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis/__init__.py", line 6034, in _refuse_connection_from_banned_node
    ExitStack() as stack,
    ~~~~~~~~~^^
  File "/usr/local/lib/python3.14/contextlib.py", line 619, in __exit__
    raise exc
  File "/usr/local/lib/python3.14/contextlib.py", line 604, in __exit__
    if cb(*exc_details):
       ~~^^^^^^^^^^^^^^
  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis/__init__.py", line 6043, in _finalizer
    self._remove_node_add_node(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^
        verification_node=working_node,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        node_to_remove=self.target_node,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        remove_node_host_id=target_host_id,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis/__init__.py", line 4126, in _remove_node_add_node
    assert removed_node_status is None, "Node was not removed properly (Node status:{})".format(removed_node_status)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Node was not removed properly (Node status:{'state': 'DN', 'load': '381.20GB', 'tokens': '256', 'owns': '?', 'host_id': 'be4a0f28-65a5-47b0-a922-cf9a5df22211', 'rack': 'RACK2'})
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
