### PR TITLE
[Manager] Update configuration and test matrix for GCE cluster tests

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1521,7 +1521,7 @@ Supported regions: us-east1, us-east4, us-west1, us-central1. Specifying just th
 
 **default:** N/A
 
-**type:** str
+**type:** str | list[str]
 
 
 ## **gce_network** / SCT_GCE_NETWORK

--- a/jenkins-pipelines/manager/ubuntu22-manager-sanity-gce.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-sanity-gce.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 managerPipeline(
     backend: 'gce',
-    test_name: 'mgmt_cli_test.ManagerBackupTests.test_backup_feature',
-    test_config: 'test-cases/manager/manager-regression-singleDC-gce.yaml',
-    gce_datacenter: 'us-east1'
+    test_name: 'mgmt_cli_test.ManagerSanityTests.test_manager_sanity',
+    test_config: 'test-cases/manager/manager-regression-multiDC-gce.yaml',
+    gce_datacenter: '''["us-east1", "us-west1"]'''
 )

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1049,7 +1049,7 @@ class SCTConfiguration(BaseModel):
     gce_project: String = SctField(
         description="gcp project name to use",
     )
-    gce_datacenter: String = SctField(
+    gce_datacenter: StringOrList = SctField(
         description="Supported regions: us-east1, us-east4, us-west1, us-central1. Specifying just the region "
         "(e.g., us-east1) means the zone will be selected automatically, or you can mention the zone "
         "explicitly (e.g., us-east1-b)",

--- a/test-cases/manager/manager-regression-multiDC-gce.yaml
+++ b/test-cases/manager/manager-regression-multiDC-gce.yaml
@@ -1,16 +1,16 @@
-test_duration: 360
+test_duration: 240
 
-stress_cmd: "cassandra-stress write cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,us-east1us_east1=2,us-west1us_west1=1)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
-stress_read_cmd: "cassandra-stress read cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,us-east1us_east1=2,us-west1us_west1=1)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
+stress_cmd: "cassandra-stress write cl=LOCAL_QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=400 -pop seq=400000000..600000000"
+stress_read_cmd: "cassandra-stress read cl=LOCAL_QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=400 -pop seq=400000000..600000000"
 
-n_db_nodes: "2 1"
+n_db_nodes: "3 3"
 n_loaders: 1
-simulated_racks: 0
+simulated_racks: 3
 
 client_encrypt: true
 
 use_preinstalled_scylla: true
 
-endpoint_snitch: 'GoogleCloudSnitch'
+endpoint_snitch: 'GossipingPropertyFileSnitch'
 user_prefix: manager-regression
 space_node_threshold: 6442

--- a/test-cases/manager/manager-regression-singleDC-gce.yaml
+++ b/test-cases/manager/manager-regression-singleDC-gce.yaml
@@ -1,0 +1,16 @@
+test_duration: 240
+
+stress_cmd: "cassandra-stress write cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=400 -pop seq=400000000..600000000"
+stress_read_cmd: "cassandra-stress read cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' -mode cql3 native -rate threads=400 -pop seq=400000000..600000000"
+
+n_db_nodes: 3
+n_loaders: 1
+simulated_racks: 3
+
+client_encrypt: true
+
+use_preinstalled_scylla: true
+
+endpoint_snitch: 'GossipingPropertyFileSnitch'
+user_prefix: manager-regression
+space_node_threshold: 6442


### PR DESCRIPTION
**Changes:**
- Updated GCE test-case yaml for multiDC test to run on cluster with sane topology 3+3 instead of 2+1.
- Introduced new test - ubuntu22-sanity-test-gce - run on multiDC cluster, whereas sct-feature-test-backup-gce switched to singleDC setup. Motivation - backup test on multiDC cluster takes too much time (up to 4h), thus it was decided to introduce sanity test on GCE, but on multiDC configuration. It allows us to keep testing GCE multiDC setup in one of Manager sanity tests and test GCE single DC in backup specific test.
- Updated gce_datacenter type to StringOrList to support both string and list types to support multiDC GCE deployments

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [ubuntu22-sanity-test-gce](https://argus.scylladb.com/tests/scylla-cluster-tests/d8ced5f9-eebf-4d62-921c-be4accba063c)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code