### PR TITLE
feature(sct-agent): add TLS support for sct-agent communication

### DIFF
--- a/configurations/enable_agent.yaml
+++ b/configurations/enable_agent.yaml
@@ -4,3 +4,4 @@ agent:
   binary_url: "https://github.com/scylladb/sct-agent/releases/latest/download/sct-agent"
   max_concurrent_jobs: 10
   log_level: "info"
+  tls: true

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -354,5 +354,6 @@ agent:
   binary_url: ""
   max_concurrent_jobs: 10
   log_level: "info"
+  tls: false
 
 c_s_driver_version: '3'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -466,9 +466,9 @@ When define true, will install scylla management
 
 ## **agent** / SCT_AGENT
 
-Configuration for SCT agent - a lightweight service for remote command execution.                 When enabled, replaces SSH-based command execution with RESTful API calls for DB nodes.<br>Configuration options:<br>- enabled: bool - enable agent (required)<br>- port: int - agent HTTP API port (default: 16000)<br>- binary_url: str - URL to download agent binary<br>- max_concurrent_jobs: int - max concurrent jobs per agent (default: 10)<br>- log_level: str - logging level (default: info)
+Configuration for SCT agent - a lightweight service for remote command execution.                 When enabled, replaces SSH-based command execution with RESTful API calls for DB nodes.<br>Configuration options:<br>- enabled: bool - enable agent (required)<br>- port: int - agent HTTP API port (default: 16000)<br>- binary_url: str - URL to download agent binary<br>- max_concurrent_jobs: int - max concurrent jobs per agent (default: 10)<br>- log_level: str - logging level (default: info)<br>- tls: bool - enable TLS for agent communication (default: false)
 
-**default:** {'enabled': False, 'port': 16000, 'binary_url': '', 'max_concurrent_jobs': 10, 'log_level': 'info'}
+**default:** {'enabled': False, 'port': 16000, 'binary_url': '', 'max_concurrent_jobs': 10, 'log_level': 'info', 'tls': False}
 
 **type:** dict | str
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -193,7 +193,7 @@ from sdcm.utils.scylla_args import ScyllaArgParser
 from sdcm.utils.file import File
 from sdcm.utils import cdc
 from sdcm.utils.raft import get_raft_mode
-from sdcm.utils.sct_agent_installer import reconfigure_agent_script
+from sdcm.utils.sct_agent_installer import reconfigure_agent_script, DEFAULT_AGENT_CERTS_DIR
 from sdcm.coredump import CoredumpExportSystemdThread
 from sdcm.keystore import KeyStore
 from sdcm.paths import (
@@ -563,8 +563,45 @@ class BaseNode(AutoSshContainerMixin):
         except Exception:
             self.log.error("Error saving resource state to Argus", exc_info=True)
 
+    def _setup_agent_tls_certs(self, ssh_remoter):
+        """Generate and push TLS certificates for the SCT agent."""
+        if not CA_CERT_FILE.exists():
+            raise FileNotFoundError(f"CA certificate not found: {CA_CERT_FILE}")
+
+        certs_dir = DEFAULT_AGENT_CERTS_DIR
+        local_cert_dir = Path(get_data_dir_path("ssl_conf")) / "agent" / self.ip_address
+        local_cert_dir.mkdir(parents=True, exist_ok=True)
+
+        cert_file = local_cert_dir / "server.crt"
+        key_file = local_cert_dir / "server.key"
+
+        create_certificate(
+            cert_file=cert_file,
+            key_file=key_file,
+            cname=self.name,
+            ca_cert_file=CA_CERT_FILE,
+            ca_key_file=CA_KEY_FILE,
+            ip_addresses=list({addr for addr in [self.ip_address, self.public_ip_address] if addr}),
+            dns_names=list({name for name in [self.public_dns_name, self.private_dns_name] if name}),
+        )
+
+        ssh_remoter.run(f"sudo mkdir -p {certs_dir}", verbose=False)
+        ssh_remoter.send_files(src=str(cert_file), dst="/tmp/agent_server.crt")
+        ssh_remoter.send_files(src=str(key_file), dst="/tmp/agent_server.key")
+        ssh_remoter.run("chmod 600 /tmp/agent_server.key", verbose=False)
+        ssh_remoter.run(
+            f"sudo mv /tmp/agent_server.crt {certs_dir}/server.crt && "
+            f"sudo mv /tmp/agent_server.key {certs_dir}/server.key && "
+            f"sudo chmod 600 {certs_dir}/server.key && "
+            f"sudo chmod 644 {certs_dir}/server.crt",
+            verbose=False,
+        )
+
+        self.log.info("Agent TLS certificates installed on %s", self.name)
+        return f"{certs_dir}/server.crt", f"{certs_dir}/server.key"
+
     def _reconfigure_agent(self, ssh_remoter):
-        """Reconfigure SCT agent with current API key"""
+        """Reconfigure SCT agent with current API key and optionally enable TLS"""
         agent_config = self.parent_cluster.params.get("agent")
         agent_enabled = agent_config.get("enabled", False) and self.parent_cluster.node_type in (
             "scylla-db",
@@ -576,16 +613,21 @@ class BaseNode(AutoSshContainerMixin):
         if not (agent_enabled and agent_api_key):
             return
 
-        result = ssh_remoter.run("systemctl is-active sct-agent.service", ignore_status=True, verbose=False)
-        if result.exited != 0:
+        if ssh_remoter.run("systemctl is-active sct-agent.service", ignore_status=True, verbose=False).exited != 0:
             return
 
-        self.log.info("Reconfiguring SCT agent on node %s with the current API key", self.name)
+        agent_tls = agent_config.get("tls")
+        tls_cert_file, tls_key_file = self._setup_agent_tls_certs(ssh_remoter) if agent_tls else ("", "")
+
+        self.log.info("Reconfiguring SCT agent on node %s (tls=%s)", self.name, agent_tls)
         script = reconfigure_agent_script(
             api_keys=[agent_api_key],
             port=agent_config.get("port"),
             max_concurrent_jobs=agent_config.get("max_concurrent_jobs"),
             log_level=agent_config.get("log_level"),
+            tls=agent_tls,
+            tls_cert_file=tls_cert_file,
+            tls_key_file=tls_key_file,
         )
 
         ssh_remoter.run(f"sudo bash -cxe {shlex.quote(script)}", verbose=True)
@@ -605,14 +647,22 @@ class BaseNode(AutoSshContainerMixin):
                 if self.test_config.IP_SSH_CONNECTIONS == "public"
                 else self.private_ip_address
             )
-            agent_port = agent_config.get("port")
+            agent_tls = agent_config.get("tls")
+
             self.remoter = AgentCmdRunner(
                 hostname=agent_hostname,
                 api_key=agent_api_key,
-                port=agent_port,
+                port=agent_config.get("port"),
                 user=ssh_login_info.get("user", "root") if ssh_login_info else "root",
+                tls=agent_tls,
+                ca_cert=str(CA_CERT_FILE) if agent_tls else None,
             )
-            self.log.info("Using SCT agent for command execution at %s:%s", agent_hostname, agent_port)
+            self.log.info(
+                "Using SCT agent for command execution at %s:%s (tls=%s)",
+                agent_hostname,
+                agent_config.get("port"),
+                agent_tls,
+            )
         else:
             if agent_enabled:
                 self.log.info("SCT agent is enabled but API key is not available, falling back to SSH")

--- a/sdcm/provision/helpers/certificate.py
+++ b/sdcm/provision/helpers/certificate.py
@@ -87,7 +87,7 @@ def install_client_certificate(remoter, node_identifier, force=False):
         cp /tmp/ssl_conf/client/cqlshrc ~/.cassandra/
         sed -i '/ssl = true/a hostname = {node_identifier}' ~/.cassandra/cqlshrc
         sudo mkdir -p /root/.cassandra
-        sudo cp ~/.cassandra/cqlshrc /root/.cassandra
+        [ "$HOME" = "/root" ] || sudo cp ~/.cassandra/cqlshrc /root/.cassandra
         sudo mkdir -p /etc/scylla/
         sudo rm -rf {SCYLLA_SSL_CONF_DIR}
         sudo mv -f /tmp/ssl_conf/ /etc/scylla/

--- a/sdcm/remote/agent_cmd_runner.py
+++ b/sdcm/remote/agent_cmd_runner.py
@@ -50,7 +50,14 @@ class AgentCmdRunner(CommandRunner, RetryMixin):
     default_run_retry = 3
 
     def __init__(
-        self, hostname: str, api_key: str, port: int = 16000, user: str = "root", password: Optional[str] = None
+        self,
+        hostname: str,
+        api_key: str,
+        port: int = 16000,
+        user: str = "root",
+        password: Optional[str] = None,
+        tls: bool = False,
+        ca_cert: Optional[str] = None,
     ):
         """
         Initialize agent command runner.
@@ -60,16 +67,20 @@ class AgentCmdRunner(CommandRunner, RetryMixin):
         :param port: agent HTTP API port
         :param user: not used for agent (added for interface compatibility)
         :param password: not used for agent (added for interface compatibility)
+        :param tls: enable TLS for agent communication
+        :param ca_cert: path to CA certificate file for TLS verification
         """
         super().__init__(hostname=hostname, user=user, password=password)
         self.port = port
         self.api_key = api_key
+        self.tls = tls
+        self.ca_cert = ca_cert
         self._agent_client = None
         self._streaming_jobs: Dict[str, Dict] = {}
         self._streaming_lock = threading.Lock()
 
     def _create_connection(self) -> AgentClient:
-        return AgentClient(self.hostname, self.api_key, self.port, 30)
+        return AgentClient(self.hostname, self.api_key, self.port, 30, tls=self.tls, ca_cert=self.ca_cert)
 
     @property
     def agent_client(self) -> AgentClient:
@@ -386,12 +397,13 @@ class AgentCmdRunner(CommandRunner, RetryMixin):
         return True
 
     def ssh_debug_cmd(self) -> str:
-        """Return debug command for interface compatibiliy (for agent, show API endpoint)"""
-        return f"curl -H 'Authorization: Bearer {self.api_key}' http://{self.hostname}:{self.port}/health"
+        """Return debug command for interface compatibility (for agent, show API endpoint)"""
+        scheme = "https" if self.tls else "http"
+        return f"curl -H 'Authorization: Bearer {self.api_key}' {scheme}://{self.hostname}:{self.port}/health"
 
     def stop(self):
         """Close agent client connection"""
         self._agent_client = None
 
     def __repr__(self) -> str:
-        return f"AgentCmdRunner(hostname={self.hostname}, port={self.port})"
+        return f"AgentCmdRunner(hostname={self.hostname}, port={self.port}, tls={self.tls})"

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -666,7 +666,8 @@ class SCTConfiguration(BaseModel):
             - port: int - agent HTTP API port (default: 16000)
             - binary_url: str - URL to download agent binary
             - max_concurrent_jobs: int - max concurrent jobs per agent (default: 10)
-            - log_level: str - logging level (default: info)""",
+            - log_level: str - logging level (default: info)
+            - tls: bool - enable TLS for agent communication (default: false)""",
     )
     manager_prometheus_port: int = SctField(
         description="Port to be used by the manager to contact Prometheus",

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1268,13 +1268,17 @@ class ClusterTester(unittest.TestCase):
         self.connections = []
         make_threads_be_daemonic_by_default()
 
-        if not self.params.get("cluster_backend").startswith("k8s") and any(
-            [self.params.get("client_encrypt"), self.params.get("server_encrypt")]
-        ):
+        needs_ca = any(
+            [
+                self.params.get("client_encrypt"),
+                self.params.get("server_encrypt"),
+                self.params.get("agent").get("tls"),
+            ]
+        )
+        if not self.params.get("cluster_backend").startswith("k8s") and needs_ca:
             create_ca(self.localhost)
             if self.params.get("client_encrypt"):
-                cqlshrc_file = get_data_dir_path("ssl_conf", "client", "cqlshrc")
-                update_cqlshrc(cqlshrc_file)
+                update_cqlshrc(get_data_dir_path("ssl_conf", "client", "cqlshrc"))
 
         # download rpms for update_db_packages
         if self.params.get("update_db_packages"):

--- a/sdcm/utils/agent_client.py
+++ b/sdcm/utils/agent_client.py
@@ -97,23 +97,36 @@ class AgentTimeoutError(AgentClientError):
 class AgentClient:
     """HTTP client for SCT agent API"""
 
-    def __init__(self, hostname: str, api_key: str, port: int = 16000, timeout: int = 30):
+    def __init__(
+        self,
+        hostname: str,
+        api_key: str,
+        port: int = 16000,
+        timeout: int = 30,
+        tls: bool = False,
+        ca_cert: Optional[str] = None,
+    ):
         self.hostname = hostname
         self.port = port
         self.api_key = api_key
-        self.base_url = f"http://{hostname}:{port}"
+        self.tls = tls
         self.timeout = timeout
+        self.base_url = f"{'https' if tls else 'http'}://{hostname}:{port}"
 
         self.session = requests.Session()
-        retry_strategy = Retry(
-            total=3,
-            backoff_factor=1,
-            status_forcelist=[429, 500, 502, 503, 504],
-            allowed_methods=["GET", "POST", "DELETE"],
+        adapter = HTTPAdapter(
+            max_retries=Retry(
+                total=3,
+                backoff_factor=1,
+                status_forcelist=[429, 500, 502, 503, 504],
+                allowed_methods=["GET", "POST", "DELETE"],
+            )
         )
-        adapter = HTTPAdapter(max_retries=retry_strategy)
         self.session.mount("http://", adapter)
         self.session.mount("https://", adapter)
+
+        if tls and ca_cert:
+            self.session.verify = ca_cert
 
         self.session.headers.update(
             {
@@ -250,4 +263,4 @@ class AgentClient:
             raise
 
     def __repr__(self) -> str:
-        return f"AgentClient(hostname={self.hostname}, port={self.port})"
+        return f"AgentClient(hostname={self.hostname}, port={self.port}, tls={self.tls})"

--- a/sdcm/utils/sct_agent_installer.py
+++ b/sdcm/utils/sct_agent_installer.py
@@ -16,6 +16,8 @@ import os
 import secrets
 from textwrap import dedent
 
+import yaml
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -26,10 +28,26 @@ DEFAULT_AGENT_SERVICE_PATH = "/etc/systemd/system/sct-agent.service"
 DEFAULT_AGENT_LOG_PATH = "/var/log/sct-agent.log"
 DEFAULT_AGENT_LOGROTATE_PATH = "/etc/logrotate.d/sct-agent"
 AGENT_API_KEY_FILENAME = "agent_api_key.secret"
+DEFAULT_AGENT_CERTS_DIR = "/etc/sct-agent/certs"
+
+
+def _agent_health_check_cmd(port: int, tls: bool) -> tuple[str, str]:
+    """Return (curl_flags, health_url) for agent health check scripts.
+
+    Uses -k to skip cert verification since health checks run on localhost.
+    """
+    scheme = "https" if tls else "http"
+    return ("-kf" if tls else "-f"), f"{scheme}://localhost:{port}/health"
 
 
 def get_agent_config_yaml(
-    api_keys: list[str], port: int = DEFAULT_AGENT_PORT, max_concurrent_jobs: int = 10, log_level: str = "info"
+    api_keys: list[str],
+    port: int = DEFAULT_AGENT_PORT,
+    max_concurrent_jobs: int = 10,
+    log_level: str = "info",
+    tls: bool = False,
+    tls_cert_file: str = "",
+    tls_key_file: str = "",
 ) -> str:
     """
     Generate agent configuration YAML.
@@ -37,27 +55,38 @@ def get_agent_config_yaml(
     :param api_keys: list of API keys for authentication
     :param port: agent HTTP server port
     :param max_concurrent_jobs: maximum number of concurrent jobs
-    :param log_level: logging level.
+    :param log_level: logging level
+    :param tls: enable TLS
+    :param tls_cert_file: path to TLS certificate file on the node
+    :param tls_key_file: path to TLS key file on the node
 
     :return: YAML configuration as string
     """
-    api_keys = "\n    ".join(f'- "{key}"' for key in api_keys)
-    return dedent(f"""
-        server:
-          host: "0.0.0.0"
-          port: {port}
+    config = {
+        "server": {
+            "host": "0.0.0.0",
+            "port": port,
+        },
+        "security": {
+            "api_keys": api_keys,
+        },
+        "executor": {
+            "max_concurrent_jobs": max_concurrent_jobs,
+            "default_timeout_seconds": 300,
+        },
+        "logging": {
+            "level": log_level,
+        },
+    }
 
-        security:
-          api_keys:
-            {api_keys}
+    if tls:
+        config["security"]["tls"] = {
+            "enabled": True,
+            "cert_file": tls_cert_file,
+            "key_file": tls_key_file,
+        }
 
-        executor:
-          max_concurrent_jobs: {max_concurrent_jobs}
-          default_timeout_seconds: 300
-
-        logging:
-          level: "{log_level}"
-    """)
+    return yaml.dump(config, default_flow_style=False, sort_keys=False)
 
 
 def get_agent_systemd_service(
@@ -144,6 +173,11 @@ def install_agent_script(
     :param log_level: logging level.
 
     :return: bash installation script
+
+    Note: TLS is not configured during initial install - certs require the node IP address for SANs,
+    which is not known at cloud-init time. So the agent starts on plain HTTP and TLS is enabled
+    later in the provisioning process by running the reconfigure_agent_script, when certs are
+    normally generated and agent is restarted with TLS after the node is fully provisioned.
     """
     config_yaml = get_agent_config_yaml(api_keys, port, max_concurrent_jobs, log_level).replace("$", "\\$")
     service_content = get_agent_systemd_service(binary_path, config_path, log_file_path).replace("$", "\\$")
@@ -197,13 +231,14 @@ fi
 """
 
 
-def wait_for_agent_script(port: int = DEFAULT_AGENT_PORT, timeout: int = 60) -> str:
+def wait_for_agent_script(port: int = DEFAULT_AGENT_PORT, timeout: int = 60, tls: bool = False) -> str:
     """Generate script to wait for SCT agent to be ready"""
+    curl_flags, health_url = _agent_health_check_cmd(port, tls)
     return dedent(f"""
         #!/bin/bash
         echo "Waiting for SCT agent to be ready..."
         for i in $(seq 1 {timeout}); do
-            if curl -fs http://localhost:{port}/health >/dev/null 2>&1; then
+            if curl {curl_flags}s {health_url} >/dev/null 2>&1; then
                 echo "SCT agent is ready!"
                 exit 0
             fi
@@ -214,8 +249,9 @@ def wait_for_agent_script(port: int = DEFAULT_AGENT_PORT, timeout: int = 60) -> 
     """).strip()
 
 
-def check_agent_status_script(port: int = DEFAULT_AGENT_PORT) -> str:
+def check_agent_status_script(port: int = DEFAULT_AGENT_PORT, tls: bool = False) -> str:
     """Generate script to check SCT agent status"""
+    curl_flags, health_url = _agent_health_check_cmd(port, tls)
     return dedent(f"""
         #!/bin/bash
         echo "=== SCT agent Status ==="
@@ -234,12 +270,8 @@ def check_agent_status_script(port: int = DEFAULT_AGENT_PORT) -> str:
         fi
 
         echo "=== Health Check ==="
-        if curl -f http://localhost:{port}/health 2>/dev/null; then
-            echo ""
-            echo "Health: OK"
-        else
-            echo "Health: FAILED"
-        fi
+        curl {curl_flags} {health_url} 2>/dev/null && echo -e "\\nHealth: OK" || echo "Health: FAILED"
+
 
         echo "=== Recent Logs ==="
         if [ -f /tmp/sct-agent.log ]; then
@@ -285,6 +317,9 @@ def reconfigure_agent_script(
     config_path: str = DEFAULT_AGENT_CONFIG_PATH,
     max_concurrent_jobs: int = 10,
     log_level: str = "info",
+    tls: bool = False,
+    tls_cert_file: str = "",
+    tls_key_file: str = "",
 ) -> str:
     """
     Generate bash script to reconfigure running SCT agent with a new API key(s).
@@ -292,9 +327,19 @@ def reconfigure_agent_script(
     This script updates the agent configuration file and restarts the service,
     allowing the test to use a new API key with already-provisioned instances.
     """
-    config_yaml = get_agent_config_yaml(api_keys, port, max_concurrent_jobs, log_level).replace("$", "\\$")
+    config_yaml = get_agent_config_yaml(
+        api_keys,
+        port,
+        max_concurrent_jobs,
+        log_level,
+        tls=tls,
+        tls_cert_file=tls_cert_file,
+        tls_key_file=tls_key_file,
+    )
 
-    return f"""echo "Reconfiguring SCT agent with new API key..."
+    curl_flags, health_url = _agent_health_check_cmd(port, tls)
+
+    return f"""echo "Reconfiguring SCT agent..."
 
 [ -f {config_path} ] && cp {config_path} {config_path}.backup
 
@@ -306,15 +351,12 @@ chmod 600 {config_path}
 systemctl restart sct-agent.service
 
 for i in {{1..30}}; do
-    if curl -f http://localhost:{port}/health >/dev/null 2>&1; then
-        echo "SCT agent is ready with new API key!"
-        break
-    fi
+    curl {curl_flags} {health_url} >/dev/null 2>&1 && echo "SCT agent is ready!" && break
     echo "Waiting for agent... ($i/30)"
     sleep 2
 done
 
-if ! curl -f http://localhost:{port}/health >/dev/null 2>&1; then
+if ! curl {curl_flags} {health_url} >/dev/null 2>&1; then
     echo "Warning: Agent may not have restarted successfully"
     systemctl status sct-agent.service || true
 fi

--- a/unit_tests/test_agent_client_tls.py
+++ b/unit_tests/test_agent_client_tls.py
@@ -1,0 +1,64 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+import pytest
+
+from sdcm.utils.agent_client import AgentClient
+from sdcm.remote.agent_cmd_runner import AgentCmdRunner
+
+
+@pytest.mark.parametrize(
+    "tls,expected_url",
+    [
+        pytest.param(True, "https://192.168.1.10:16000", id="tls_enabled"),
+        pytest.param(False, "http://192.168.1.10:16000", id="tls_disabled"),
+    ],
+)
+def test_base_url_scheme(tls, expected_url):
+    client = AgentClient("192.168.1.10", "test-key", port=16000, tls=tls)
+    assert client.base_url == expected_url
+
+
+@pytest.mark.parametrize(
+    "ca_cert,expected_verify",
+    [
+        pytest.param("/path/to/ca.pem", "/path/to/ca.pem", id="ca_cert_provided"),
+        pytest.param(None, True, id="ca_cert_not_provided"),
+    ],
+)
+def test_session_verify_with_tls(ca_cert, expected_verify):
+    client = AgentClient("192.168.1.10", "test-key", port=16000, tls=True, ca_cert=ca_cert)
+    assert client.session.verify == expected_verify
+
+
+@pytest.mark.parametrize(
+    "tls,expected_scheme",
+    [
+        pytest.param(True, "https://", id="tls_enabled"),
+        pytest.param(False, "http://", id="tls_disabled"),
+    ],
+)
+def test_runner_tls_propagation(tls, expected_scheme):
+    runner = AgentCmdRunner(
+        hostname="192.168.1.10",
+        api_key="test-key",
+        port=16000,
+        tls=tls,
+        ca_cert="/path/to/ca.pem" if tls else None,
+    )
+    client = runner._create_connection()
+    assert client.tls is tls
+    assert client.base_url.startswith(expected_scheme)
+    assert expected_scheme in runner.ssh_debug_cmd()
+    if tls:
+        assert client.session.verify == "/path/to/ca.pem"

--- a/unit_tests/test_sct_agent_installer.py
+++ b/unit_tests/test_sct_agent_installer.py
@@ -1,0 +1,56 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+import pytest
+import yaml
+
+from sdcm.utils.sct_agent_installer import (
+    get_agent_config_yaml,
+    reconfigure_agent_script,
+)
+
+TLS_KWARGS = {
+    "tls": True,
+    "tls_cert_file": "/etc/sct-agent/certs/server.crt",
+    "tls_key_file": "/etc/sct-agent/certs/server.key",
+}
+
+
+def test_config_yaml_with_tls_enabled():
+    parsed = yaml.safe_load(get_agent_config_yaml(api_keys=["test-key"], **TLS_KWARGS))
+    assert parsed["security"]["tls"] == {
+        "enabled": True,
+        "cert_file": "/etc/sct-agent/certs/server.crt",
+        "key_file": "/etc/sct-agent/certs/server.key",
+    }
+
+
+def test_config_yaml_without_tls():
+    parsed = yaml.safe_load(get_agent_config_yaml(api_keys=["test-key"]))
+    assert "tls" not in parsed.get("security", {})
+
+
+@pytest.mark.parametrize(
+    "tls,expected_scheme,expected_curl",
+    [
+        pytest.param(True, "https://localhost", "curl -kf", id="tls_enabled"),
+        pytest.param(False, "http://localhost", "curl -f", id="tls_disabled"),
+    ],
+)
+def test_reconfigure_script_check_scheme(tls, expected_scheme, expected_curl):
+    script = reconfigure_agent_script(
+        api_keys=["test-key"],
+        **(TLS_KWARGS if tls else {}),
+    )
+    assert expected_scheme in script
+    assert expected_curl in script


### PR DESCRIPTION
The change adds logic that allows to generate per-node TLS certificates (using the existing CA infrastructure) and push them to cluster nodes, to be used for communication with sct-agent.
The mode is enabled by default with possibility to disable it to switch back to plain HTTP.

Refs: SCT-77

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [pr-provision-test with enabled agent with TLS](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/238/)
- [x] :green_circle: [pr-provision-test with enabled agent with no TLS (plain HTTP is used)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/239/)
- [x] :green_circle: [pr-provision-test with enabled agent with TLS and client and server encryption enabled for DB nodes communication](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/237/)

regression checks:
- [x] :green_circle: [pr-provision-test with no agent and client and server encryption enabled for DB nodes communication](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/241/)
- [x] :green_circle: [regular pr-provision-test with](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/240/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
