### PR TITLE
fix(nemesis): suppress raft topology cmd errors during removenode

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -6059,11 +6059,13 @@ class NemesisRunner:
                 # For process paused with SIGSTOP signal, network sockets are still open,
                 # so already running raft barriers could stuck. To avoid that
                 # we need to block scylla ports on target node.
-                if simulate_node_unavailability == node_operations.pause_scylla_with_sigstop:
-                    with node_operations.block_scylla_ports(self.target_node, ports=[7000, 7001]):
+                with ignore_raft_topology_cmd_failing():
+                    if simulate_node_unavailability == node_operations.pause_scylla_with_sigstop:
+                        with node_operations.block_scylla_ports(self.target_node, ports=[7000, 7001]):
+                            working_node.run_nodetool(f"removenode {target_host_id}", retry=0, long_running=True)
+                    else:
                         working_node.run_nodetool(f"removenode {target_host_id}", retry=0, long_running=True)
-                else:
-                    working_node.run_nodetool(f"removenode {target_host_id}", retry=0, long_running=True)
+
                 assert node_operations.is_node_removed_from_cluster(
                     removed_node=self.target_node, verification_node=working_node
                 ), f"Node {self.target_node.name} with host id {target_host_id} was not removed. See log errors"


### PR DESCRIPTION
When removing an unavailable node (paused or port-blocked), raft topology commands may fail transiently as the target node cannot participate in raft coordination. These failures are expected and should not raise test errors. Wrap the `removenode` nodetool call in
`ignore_raft_topology_cmd_failing()` to downgrade those log events to WARNING for the duration of the operation.

This error occurred https://argus.scylladb.com/tests/scylla-cluster-tests/00366069-e7f7-49e5-b7f3-7ad4cf0447b2

should fix errors:
```
2026-02-28 07:35:59.512 <2026-02-28 07:35:58.032>: (DatabaseLogEvent Severity.ERROR) period_type=one-time event_id=f7cb0267-42db-4104-bda3-755b35f56ede: type=RUNTIME_ERROR regex=std::runtime_error line_number=127715 node=longevity-tls-1tb-7d-master-db-node-f5fbb002-eastus-2
2026-02-28T07:35:58.032 longevity-tls-1tb-7d-master-db-node-f5fbb002-eastus-2  !ERR | scylla[8189]  [shard  0: gms] raft_topology - topology change coordinator fiber got error std::runtime_error (raft topology: exec_global_command(barrier_and_drain) failed with seastar::rpc::closed_error (got error from node 7bef8f02-5e88-4e1d-b6f2-d78dd68731ec/10.0.0.8: connection is closed))
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
