### PR TITLE
fix(gemini-test): start nemesis after hardcoded 5 minutes instead of test_duration percentage

### DIFF
--- a/gemini_test.py
+++ b/gemini_test.py
@@ -17,6 +17,8 @@ import time
 
 from sdcm.tester import ClusterTester
 
+NEMESIS_START_DELAY_SEC = 5 * 60
+
 
 class GeminiTest(ClusterTester):
     """
@@ -47,10 +49,9 @@ class GeminiTest(ClusterTester):
         self.log.debug("Start gemini benchmark")
         gemini_thread = self.run_gemini(cmd=cmd)
         self.gemini_results["cmd"] = gemini_thread.gemini_commands
-        # sleep before run nemesis test_duration * .25
-        sleep_before_start = float(self.params.get("test_duration")) * 60 * 0.1
-        self.log.info("Sleep interval {}".format(sleep_before_start))
-        time.sleep(sleep_before_start)
+        # Allow gemini to populate initial data before starting nemesis
+        self.log.info("Sleeping %s sec before starting nemesis", NEMESIS_START_DELAY_SEC)
+        time.sleep(NEMESIS_START_DELAY_SEC)
 
         self.db_cluster.start_nemesis()
 

--- a/test-cases/cdc/cdc-15m-replication-gemini.yaml
+++ b/test-cases/cdc/cdc-15m-replication-gemini.yaml
@@ -23,7 +23,6 @@ extra_network_interface: true
 
 gemini_cmd: |
   --duration 15m
-  --warmup 0s
   --concurrency 5
   --mode write
   --cql-features basic

--- a/test-cases/cdc/cdc-15m-replication-postimage.yaml
+++ b/test-cases/cdc/cdc-15m-replication-postimage.yaml
@@ -24,7 +24,6 @@ extra_network_interface: true
 # to test pre/post-images with concurrent writes happening to a single row.
 gemini_cmd: |
   --duration 15m
-  --warmup 0s
   --concurrency 1
   --mode write
   --cql-features basic

--- a/test-cases/cdc/cdc-15m-replication-preimage.yaml
+++ b/test-cases/cdc/cdc-15m-replication-preimage.yaml
@@ -25,7 +25,6 @@ extra_network_interface: true
 # to test pre/post-images with concurrent writes happening to a single row.
 gemini_cmd: |
   --duration 15m
-  --warmup 0s
   --concurrency 1
   --mode write
   --cql-features basic

--- a/test-cases/cdc/cdc-replication-longevity.yaml
+++ b/test-cases/cdc/cdc-replication-longevity.yaml
@@ -19,7 +19,6 @@ extra_network_interface: True
 
 gemini_cmd: |
   --duration 30m
-  --warmup 0s
   --concurrency 4
   --mode write
   --cql-features basic

--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -13,7 +13,6 @@ nemesis_seed: '041'
 
 gemini_cmd: |
   --duration 8h
-  --warmup 2h
   --concurrency 50
   --mode mixed
   --io-worker-pool 2048

--- a/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
@@ -12,7 +12,6 @@ nemesis_selector: "not enospc"
 
 gemini_cmd: |
   --duration 3h
-  --warmup 30m
   --concurrency 50
   --mode write
 

--- a/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
@@ -12,7 +12,6 @@ nemesis_selector: "not disruptive and not enospc"
 
 gemini_cmd: |
   --duration 3h
-  --warmup 30m
   --concurrency 50
   --mode write
 

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -12,7 +12,6 @@ nemesis_seed: '032'
 
 gemini_cmd: |
   --duration 3h
-  --warmup 30m
   --concurrency 50
   --mode mixed
 

--- a/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
@@ -11,7 +11,6 @@ nemesis_selector: "not disruptive"
 
 gemini_cmd: |
   --duration 3h
-  --warmup 30m
   --concurrency 50
   --mode mixed
 

--- a/test-cases/gemini/gemini-8h-large-num-columns.yaml
+++ b/test-cases/gemini/gemini-8h-large-num-columns.yaml
@@ -13,7 +13,6 @@ nemesis_seed: '023'
 
 gemini_cmd: |
   --duration 7h
-  --warmup 1h
   --concurrency 10
   --mode mixed
   --max-partition-keys 12

--- a/test-cases/gemini/gemini-basic-3h-ics.yaml
+++ b/test-cases/gemini/gemini-basic-3h-ics.yaml
@@ -9,7 +9,6 @@ ami_db_scylla_user: 'centos'
 
 gemini_cmd: |
   --duration 3h
-  --warmup 30m
   --concurrency 50
   --mode mixed
 

--- a/test-cases/gemini/gemini-basic-3h.yaml
+++ b/test-cases/gemini/gemini-basic-3h.yaml
@@ -8,7 +8,6 @@ user_prefix: 'gemini-basic-3h'
 
 gemini_cmd: |
   --duration 3h
-  --warmup 5m
   --concurrency 50
   --mode mixed
   --io-worker-pool 2048

--- a/unit_tests/test_data/test_scylla_yaml_builders/multi_network_interfaces/cdc-replication-longevity.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/multi_network_interfaces/cdc-replication-longevity.yaml
@@ -17,7 +17,6 @@ nemesis_class_name: 'CategoricalMonkey'
 
 gemini_cmd: |
   --duration 30m
-  --warmup 0s
   --concurrency 4
   --mode write
   --cql-features basic


### PR DESCRIPTION
The pre-nemesis sleep was computed as 10% of test_duration.
With large values (e.g. test_duration of 48 hours) this becomes way too much.
The solution: remove warmup parameter and set a hardcoded 5 minutes delay before starting nemesis.
The equivalent issue to be fixed on gemini tool side is:
https://scylladb.atlassian.net/browse/QATOOLS-190: "Replace warmup parameter with hardcoded 5 minutes duration".
We agreed the warmup parameter can be removed and the inner gemini variable can be set hard-coded to 5 minutes. So gemini will always execute a 5 minutes warmup internally,  then start the full command load. This is since in new gemini versions there are no concerns of running nemesis or advanced load commands right from the start.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [test no warmup](https://jenkins.scylladb.com/job/scylla-staging/job/yarongilor/job/gemini-longrun/2/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
