### PR TITLE
test(mgmt-restore): introduce a multi-DC Native Restore test

### DIFF
--- a/configurations/multi_dc_native_restore.yaml
+++ b/configurations/multi_dc_native_restore.yaml
@@ -1,0 +1,7 @@
+instance_type_db: 'i4i.4xlarge'
+endpoint_snitch: 'GossipingPropertyFileSnitch'
+n_db_nodes: '3 3'
+n_loaders: '2 2'
+simulated_racks: 0
+availability_zone: 'a,b,c'
+region_aware_loader: true

--- a/defaults/manager_restore_benchmark_snapshots.yaml
+++ b/defaults/manager_restore_benchmark_snapshots.yaml
@@ -80,6 +80,26 @@ sizes:  # size of backed up dataset in GB
       replication: "NetworkTopologyStrategy"
       rf: 3
     one_one_restore_params: None
+  2tb_1t_twcs_2025_4_multidc:
+    tag: "sm_20260224031828UTC"
+    locations:
+      - "s3:manager-backup-tests-permanent-snapshots-us-east-1"
+    exp_timeout: 86400  # 24 hours
+    scylla_version: "2025.4.3"
+    number_of_nodes: 6
+    prohibit_verification_read: false
+    dataset:
+      schema:
+        keyspace1:
+          - standard1: 2048
+      num_of_rows: 2147483648
+      compaction: "TimeWindowCompactionStrategy"
+      cl: "QUORUM"
+      col_size: 1024
+      col_n: 1
+      replication: "NetworkTopologyStrategy"
+      rf: 3
+    one_one_restore_params: None
   2tb_1t_ics_2025_1:
     tag: "sm_20251218165735UTC"
     locations:

--- a/jenkins-pipelines/manager/restore_benchmark/ubuntu22-manager-2tb-1t-6nodes-multidc.jenkinsfile
+++ b/jenkins-pipelines/manager/restore_benchmark/ubuntu22-manager-2tb-1t-6nodes-multidc.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    region: 'us-east-1',
+    provision_type: 'on_demand',
+    test_name: 'mgmt_cli_test.ManagerRestoreBenchmarkTests.test_restore_benchmark',
+    test_config: '''["test-cases/manager/manager-backup-restore-set-dataset.yaml", "configurations/object_storage.yaml", "configurations/object_storage_native_method.yaml", "configurations/network_config/all_addresses_ipv6_public.yaml", "configurations/multi_dc_native_restore.yaml"]''',
+    mgmt_reuse_backup_snapshot_name: '2tb_1t_twcs_2025_4_multidc',
+
+    extra_environment_variables: '''SCT_MGMT_SKIP_POST_RESTORE_STRESS_READ=true'''
+)


### PR DESCRIPTION
Added a 2TB multi-DC restore benchmark (2tb_1t_twcs_2025_4_multidc).
The test was previously timing out after 8 hours.
So it now sets a timeout of 24 hours.
Refs: https://scylladb.atlassian.net/browse/SCYLLADB-1108


### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [multi-dc pipeline](https://argus.scylladb.com/tests/scylla-cluster-tests/90362c79-e5e3-405e-85c9-432c6379deb3)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
