### PR TITLE
feat(unit_tests): Introduce fake_events.py module

### DIFF
--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -186,6 +186,12 @@ class SctEvent:
     def formatted_source_timestamp(self) -> str:
         return self._formatted_timestamp(self.source_timestamp)
 
+    def format_event(self) -> str:
+        """Format the event as a single log line, same layout as EventsFileLogger writes to events.log."""
+        if self.source_timestamp:
+            return f"{self.formatted_event_timestamp} <{self.formatted_source_timestamp}>: {str(self).strip()}"
+        return f"{self.formatted_event_timestamp}: {str(self).strip()}"
+
     @property
     def timestamp(self) -> float:
         """

--- a/sdcm/sct_events/file_logger.py
+++ b/sdcm/sct_events/file_logger.py
@@ -97,11 +97,7 @@ class EventsFileLogger(BaseEventsProcess[Tuple[str, Any], None], multiprocessing
                 self.write_event(event=event)
 
     def write_event(self, event: SctEvent) -> None:
-        if event.source_timestamp:
-            message = f"{event.formatted_event_timestamp} <{event.formatted_source_timestamp}>: {str(event).strip()}"
-        else:
-            message = f"{event.formatted_event_timestamp}: {str(event).strip()}"
-
+        message = event.format_event()
         message_bin = message.encode("utf-8") + b"\n"
 
         if event.severity not in (Severity.DEBUG, Severity.WARNING):

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -53,7 +53,7 @@ from sdcm.utils.docker_remote import RemoteDocker
 from sdcm.utils.subtest_utils import SUBTESTS_FAILURES
 
 from unit_tests.dummy_remote import LocalNode, LocalScyllaClusterDummy
-from unit_tests.lib.events_utils import EventsUtilsMixin
+from unit_tests.lib.fake_events import make_fake_events
 from unit_tests.lib.fake_provisioner import FakeProvisioner
 from unit_tests.lib.fake_region_definition_builder import FakeDefinitionBuilder
 from unit_tests.lib.fake_remoter import FakeRemoter
@@ -106,20 +106,14 @@ def mock_remote_scylla_yaml(scylla_node):
 
 @pytest.fixture(scope="module")
 def events():
-    mixing = EventsUtilsMixin()
-    mixing.setup_events_processes(events_device=True, events_main_device=False, registry_patcher=True)
-    yield mixing
-
-    mixing.teardown_events_processes()
+    with make_fake_events() as device:
+        yield device
 
 
 @pytest.fixture(scope="function")
 def events_function_scope():
-    mixing = EventsUtilsMixin()
-    mixing.setup_events_processes(events_device=True, events_main_device=False, registry_patcher=True)
-    yield mixing
-
-    mixing.teardown_events_processes()
+    with make_fake_events() as device:
+        yield device
 
 
 @pytest.fixture(scope="session")

--- a/unit_tests/lib/events_utils.py
+++ b/unit_tests/lib/events_utils.py
@@ -25,6 +25,18 @@ from sdcm.sct_events.event_counter import get_events_counter
 
 
 class EventsUtilsMixin:
+    """Mixin that starts the **real** events infrastructure (multiprocessing, ZMQ, file I/O).
+
+    ``setup_events_processes`` launches ``EventsDevice`` plus up to six subscriber
+    processes and sleeps ~4 s for them to initialise.  This is correct for tests
+    that exercise the events subsystem itself, but far too expensive for tests
+    that merely need events to be captured so their side-effects can be asserted.
+
+    For the latter category, prefer the ``events`` / ``events_function_scope``
+    pytest fixtures (defined in ``unit_tests/conftest.py``), which inject a
+    synchronous, in-memory ``FakeEventsDevice`` with zero start-up cost.
+    """
+
     temp_dir = None
     events_processes_registry = None
     events_processes_registry_patcher = None

--- a/unit_tests/lib/fake_events.py
+++ b/unit_tests/lib/fake_events.py
@@ -1,0 +1,265 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+import json
+import time
+import threading
+import unittest.mock
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+from sdcm.sct_events import Severity
+from sdcm.sct_events.base import SctEvent, SystemEvent
+from sdcm.sct_events.events_processes import (
+    EVENTS_MAIN_DEVICE_ID,
+    EVENTS_FILE_LOGGER_ID,
+    EventsProcessesRegistry,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class EventSnapshot:
+    """Immutable snapshot of an event captured at publish time.
+
+    Events are mutable (e.g. ContinuousEvent changes period_type between
+    begin and end), so we must freeze the formatted representations at the
+    moment ``publish_event()`` is called — just like the real EventsDevice
+    writes to raw_events_log and the real EventsFileLogger writes to
+    events.log at receipt time.
+    """
+
+    formatted: str  # same format as EventsFileLogger writes to events.log
+    attrs: dict  # parsed JSON dict — same keys as EventsDevice raw_events_log
+    severity: Severity
+    save_to_files: bool
+
+
+class FakeEventsDevice:
+    """Synchronous in-memory replacement for EventsDevice + EventsFileLogger.
+
+    No processes, threads, files, ZMQ, or sleeps.  Thread-safe.
+
+    Yielded directly by the ``events`` pytest fixture.
+    """
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.snapshots: list[EventSnapshot] = []
+
+    # ---- backward-compat aliases (tests access these on the ``events`` fixture) ----
+
+    @property
+    def events_main_device(self):
+        return self
+
+    def get_events_logger(self):
+        return self
+
+    def get_events_counter(self):
+        return self
+
+    # ---- formatted events log (in-memory replacement for events.log file) ----
+
+    def get_formatted_event_lines(self) -> list[str]:
+        """Return formatted event strings identical to what EventsFileLogger writes to events.log."""
+        with self.lock:
+            return [snap.formatted for snap in self.snapshots]
+
+    # ---- properties expected by wait_for_n_events ----
+
+    @property
+    def events_counter(self) -> int:
+        with self.lock:
+            return len(self.snapshots)
+
+    def is_alive(self) -> bool:
+        return True
+
+    # ---- publish (called by SctEvent.publish via registry lookup) ----
+
+    def publish_event(self, event: SctEvent, timeout=None) -> None:
+        # The real EventsDevice.outbound_events() skips SystemEvent instances
+        # (filters, etc.) before forwarding to EventsFileLogger.  Replicate
+        # that behaviour so event counts match the real pipeline.
+        if isinstance(event, SystemEvent):
+            return
+
+        # Snapshot the event state NOW, before the caller mutates it further.
+        snap = EventSnapshot(
+            formatted=event.format_event(),
+            attrs=json.loads(event.to_json()),
+            severity=Severity(event.severity),
+            save_to_files=event.save_to_files,
+        )
+        with self.lock:
+            self.snapshots.append(snap)
+
+    # ---- reading API (same interface as EventsFileLogger) ----
+
+    def get_events_by_category(self, limit: int | None = None) -> dict[str, list[str]]:
+        """Same return type as EventsFileLogger.get_events_by_category().
+
+        Returns ``{severity_name: [formatted_event_str, ...]}`` built from
+        in-memory storage.  Only includes events with ``save_to_files=True``
+        (same filter the real file logger applies).
+
+        When *limit* is set, returns first *limit* events for CRITICAL and
+        last *limit* events for other severities (same behaviour as the real
+        file logger).
+        """
+        result: dict[str, list[str]] = {sev.name: [] for sev in Severity}
+        with self.lock:
+            for snap in self.snapshots:
+                if snap.save_to_files:
+                    result[snap.severity.name].append(snap.formatted)
+        if limit is not None:
+            for name, value in result.items():
+                if name == Severity.CRITICAL.name:
+                    result[name] = value[:limit]
+                else:
+                    result[name] = value[-limit:] if value else []
+        return result
+
+    # ---- introspection helpers ----
+
+    @property
+    def published_events(self) -> list[dict]:
+        """Return attribute dicts of all published events.
+
+        Each dict has the same keys as the JSON written to ``raw_events_log``
+        by the real ``EventsDevice`` (e.g. ``"type"``, ``"severity"``,
+        ``"line_number"``, ``"message"``, etc.).
+        """
+        with self.lock:
+            return [snap.attrs for snap in self.snapshots]
+
+    def get_event_summary(self) -> dict[str, int]:
+        """Return ``{severity_name: count}`` — same format as ``summary.log``.
+
+        The real ``summary.log`` counts ALL events forwarded by EventsDevice
+        (SystemEvent instances are already filtered out in ``publish_event``),
+        regardless of ``save_to_files``.
+        """
+        summary: dict[str, int] = {}
+        with self.lock:
+            for snap in self.snapshots:
+                name = snap.severity.name
+                summary[name] = summary.get(name, 0) + 1
+        return summary
+
+    def clear(self) -> None:
+        with self.lock:
+            self.snapshots.clear()
+
+    # ---- wait helper for async publishers (ycsb, ndbench) ----
+
+    @contextmanager
+    def wait_for_n_events(self, subscriber, count: int, timeout: float = 10):
+        """Wait for *count* new events after the wrapped block completes."""
+        start = subscriber.events_counter
+        yield
+        target = start + count
+        deadline = time.perf_counter() + timeout
+        while time.perf_counter() < deadline and subscriber.events_counter < target:
+            time.sleep(0.05)
+        assert subscriber.events_counter >= target, (
+            f"Expected {count} events in {timeout}s, got {subscriber.events_counter - start}"
+        )
+
+
+class FakeEventsMixin:
+    """Mixin that wires a ``FakeEventsDevice`` into the events registry.
+
+    Drop-in replacement for ``EventsUtilsMixin`` in tests that only need to
+    *capture* events, not exercise the real multiprocessing infrastructure.
+
+    Provides:
+    - ``cls.events``  — a ``FakeEventsDevice`` instance
+
+    Uses ``make_fake_events()`` internally to avoid duplicating the wiring
+    logic.
+
+    Works with both ``unittest.TestCase`` subclasses and plain pytest classes.
+    Pytest always calls ``setup_class``/``teardown_class`` even on TestCase
+    subclasses, so those are the primary hooks.  ``setUpClass``/``tearDownClass``
+    are provided for compatibility with the plain ``unittest`` runner (which
+    ignores ``setup_class``).  No guard flag is needed because pytest never
+    calls both.
+
+    Subclasses that override these hooks must call ``super()`` to keep the
+    events infrastructure alive.
+    """
+
+    events: FakeEventsDevice | None = None
+    _fake_events_cm = None
+
+    @classmethod
+    def _setup_fake_events(cls):
+        cls._fake_events_cm = make_fake_events()
+        cls.events = cls._fake_events_cm.__enter__()
+
+    @classmethod
+    def _teardown_fake_events(cls):
+        if cls._fake_events_cm:
+            cls._fake_events_cm.__exit__(None, None, None)
+            cls._fake_events_cm = None
+
+    # -- pytest hooks (always called by pytest, even for TestCase subclasses) --
+
+    @classmethod
+    def setup_class(cls):
+        cls._setup_fake_events()
+
+    @classmethod
+    def teardown_class(cls):
+        cls._teardown_fake_events()
+
+    # -- unittest hooks (only called by the plain unittest runner) --
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._setup_fake_events()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._teardown_fake_events()
+        super().tearDownClass()
+
+
+@contextmanager
+def make_fake_events():
+    """Create a ``FakeEventsDevice``, wire it into a fresh registry, and patch ``SctEvent``.
+
+    Yields the device.  Used by the conftest ``events`` / ``events_function_scope``
+    fixtures, by tests that override ``fixture_event_system`` (e.g. test_tester,
+    test_longevity), and internally by ``FakeEventsMixin``.
+
+    Also patches ``get_logger_event_summary`` (which normally reads summary.log
+    from disk) to compute the summary from the in-memory ``FakeEventsDevice``
+    instead.  This lets the real ``ClusterTester.get_event_summary()`` work
+    without any override.
+    """
+    device = FakeEventsDevice()
+    registry = EventsProcessesRegistry(log_dir="/dev/null")
+    registry._registry_dict[EVENTS_MAIN_DEVICE_ID] = device
+    registry._registry_dict[EVENTS_FILE_LOGGER_ID] = device
+
+    def _fake_event_summary(_registry=None):
+        target = _registry._registry_dict[EVENTS_FILE_LOGGER_ID] if _registry else device
+        return target.get_event_summary()
+
+    with (
+        unittest.mock.patch("sdcm.sct_events.base.SctEvent._events_processes_registry", registry),
+        unittest.mock.patch("sdcm.tester.get_logger_event_summary", side_effect=_fake_event_summary),
+    ):
+        yield device

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -11,7 +11,6 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
-import json
 import logging
 import os.path
 import re
@@ -30,7 +29,6 @@ from invoke import Result
 from sdcm import sct_config
 from sdcm.cluster import BaseNode, BaseCluster, BaseMonitorSet, BaseScyllaCluster
 from sdcm.db_log_reader import DbLogReader
-from sdcm.sct_events import Severity
 from sdcm.sct_events.database import SYSTEM_ERROR_EVENTS_PATTERNS
 from sdcm.sct_events.filters import DbEventsFilter
 from sdcm.sct_events.group_common_events import ignore_upgrade_schema_errors
@@ -46,7 +44,7 @@ from sdcm.utils.version_utils import ComparableScyllaVersion
 from sdcm.remote import LocalCmdRunner
 from sdcm.sct_config import SCTConfiguration
 from unit_tests.dummy_remote import DummyRemote, LocalNode
-from unit_tests.lib.events_utils import EventsUtilsMixin
+from unit_tests.lib.fake_events import FakeEventsMixin
 from unit_tests.test_utils_common import DummyNode
 
 
@@ -73,10 +71,16 @@ class DummyDbCluster(BaseCluster, BaseScyllaCluster):
         pass
 
 
-class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
+class TestBaseNode(unittest.TestCase, FakeEventsMixin):
     @classmethod
-    def setUpClass(cls):
-        cls.setup_events_processes(events_device=True, events_main_device=False, registry_patcher=True)
+    def setup_class(cls):
+        super().setup_class()
+        cls.temp_dir = tempfile.mkdtemp()
+
+    @classmethod
+    def teardown_class(cls):
+        shutil.rmtree(cls.temp_dir, ignore_errors=True)
+        super().teardown_class()
 
     @cached_property
     def node(self):
@@ -116,10 +120,6 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
         else:
             self._db_log_reader._read_and_publish_events()
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.teardown_events_processes()
-
     def setUp(self):
         self.node.system_log = os.path.join(os.path.dirname(__file__), "test_data", "system.log")
 
@@ -138,33 +138,32 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
 
         self._read_and_publish_events()
 
-        with self.get_raw_events_log().open() as events_file:
-            events = [json.loads(line) for line in events_file]
+        events = self.events.published_events
 
-            event_a, event_b = events[-2], events[-1]
-            print(event_a)
-            print(event_b)
+        event_a, event_b = events[-2], events[-1]
+        print(event_a)
+        print(event_b)
 
-            assert event_a["type"] == "REACTOR_STALLED"
-            assert event_a["line_number"] == 0
-            assert event_b["type"] == "REACTOR_STALLED"
-            assert event_b["line_number"] == 3
+        assert event_a["type"] == "REACTOR_STALLED"
+        assert event_a["line_number"] == 0
+        assert event_b["type"] == "REACTOR_STALLED"
+        assert event_b["line_number"] == 3
 
     def test_search_kernel_callstack(self):
         self.node.parent_cluster = {"params": {"print_kernel_callstack": True}}
         self.node.system_log = os.path.join(os.path.dirname(__file__), "test_data", "kernel_callstack.log")
         self._read_and_publish_events()
-        with self.get_raw_events_log().open() as events_file:
-            events = [json.loads(line) for line in events_file]
 
-            event_a, event_b = events[-2], events[-1]
-            print(event_a)
-            print(event_b)
+        events = self.events.published_events
 
-            assert event_a["type"] == "KERNEL_CALLSTACK"
-            assert event_a["line_number"] == 2
-            assert event_b["type"] == "KERNEL_CALLSTACK"
-            assert event_b["line_number"] == 5
+        event_a, event_b = events[-2], events[-1]
+        print(event_a)
+        print(event_b)
+
+        assert event_a["type"] == "KERNEL_CALLSTACK"
+        assert event_a["line_number"] == 2
+        assert event_b["type"] == "KERNEL_CALLSTACK"
+        assert event_b["line_number"] == 5
 
     def test_search_cdc_invalid_request(self):
         self.node.system_log = os.path.join(os.path.dirname(__file__), "test_data", "system_cdc_invalid_request.log")
@@ -174,10 +173,12 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
                 with ignore_upgrade_schema_errors():
                     self._read_and_publish_events()
 
-        time.sleep(0.2)
-        with self.get_events_logger().events_logs_by_severity[Severity.ERROR].open() as events_file:
-            cdc_err_events = [line for line in events_file if "cdc - Could not retrieve CDC streams" in line]
-            assert cdc_err_events != []
+        cdc_err_events = [
+            line
+            for line in self.events.get_events_by_category()["ERROR"]
+            if "cdc - Could not retrieve CDC streams" in line
+        ]
+        assert cdc_err_events != []
 
     def test_search_power_off(self):
         self.node.system_log = os.path.join(os.path.dirname(__file__), "test_data", "power_off.log")
@@ -191,79 +192,73 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
             "longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd-logind: Powering Off...",
         ).publish()
 
-        time.sleep(0.1)
-        with self.get_events_logger().events_logs_by_severity[Severity.WARNING].open() as events_file:
-            events = [line for line in events_file if "Powering Off" in line]
-            assert events
+        events = [line for line in self.events.get_events_by_category()["WARNING"] if "Powering Off" in line]
+        assert events
 
     def test_search_system_suppressed_messages(self):
         self.node.system_log = os.path.join(os.path.dirname(__file__), "test_data", "system_suppressed_messages.log")
 
         self._read_and_publish_events()
 
-        with self.get_raw_events_log().open() as events_file:
-            events = [json.loads(line) for line in events_file]
+        events = self.events.published_events
 
-            event_a = events[-1]
-            print(event_a)
+        event_a = events[-1]
+        print(event_a)
 
-            assert event_a["type"] == "SUPPRESSED_MESSAGES", "Not expected event type {}".format(event_a["type"])
-            assert event_a["line_number"] == 6, "Not expected event line number {}".format(event_a["line_number"])
+        assert event_a["type"] == "SUPPRESSED_MESSAGES", "Not expected event type {}".format(event_a["type"])
+        assert event_a["line_number"] == 6, "Not expected event line number {}".format(event_a["line_number"])
 
     def test_search_one_line_backtraces(self):
         self.node.system_log = os.path.join(os.path.dirname(__file__), "test_data", "system_one_line_backtrace.log")
 
         self._read_and_publish_events()
 
-        with self.get_raw_events_log().open() as events_file:
-            events = [json.loads(line) for line in events_file]
+        events = self.events.published_events
 
-            backtraces = [event for event in events if event["type"] == "BACKTRACE"]
-            assert len(backtraces) == 2
-            for event_backtrace in backtraces:
-                assert event_backtrace["raw_backtrace"]
+        backtraces = [event for event in events if event["type"] == "BACKTRACE"]
+        assert len(backtraces) == 2
+        for event_backtrace in backtraces:
+            assert event_backtrace["raw_backtrace"]
 
-            oversized_events = [event for event in events if event["type"] == "OVERSIZED_ALLOCATION"]
-            assert len(oversized_events) == 2
-            for event_oversized in oversized_events:
-                print(event_oversized)
-                assert event_oversized["raw_backtrace"]
+        oversized_events = [event for event in events if event["type"] == "OVERSIZED_ALLOCATION"]
+        assert len(oversized_events) == 2
+        for event_oversized in oversized_events:
+            print(event_oversized)
+            assert event_oversized["raw_backtrace"]
 
-            print(events[-1])
+        print(events[-1])
 
     def test_gate_closed_ignored_exception_is_catched(self):
         self.node.system_log = os.path.join(os.path.dirname(__file__), "test_data", "gate_closed_ignored_exception.log")
 
         self._read_and_publish_events()
 
-        with self.get_raw_events_log().open() as events_file:
-            events = [json.loads(line) for line in events_file]
+        events = self.events.published_events
 
-            event_backtrace1, event_backtrace2 = events[-2], events[-1]
-            print(event_backtrace1)
-            print(event_backtrace2)
+        event_backtrace1, event_backtrace2 = events[-2], events[-1]
+        print(event_backtrace1)
+        print(event_backtrace2)
 
-            assert event_backtrace1["type"] == "GATE_CLOSED"
-            assert event_backtrace1["line_number"] == 1
-            assert event_backtrace2["type"] == "GATE_CLOSED"
-            assert event_backtrace2["line_number"] == 3
+        assert event_backtrace1["type"] == "GATE_CLOSED"
+        assert event_backtrace1["line_number"] == 1
+        assert event_backtrace2["type"] == "GATE_CLOSED"
+        assert event_backtrace2["line_number"] == 3
 
     def test_compaction_stopped_exception_is_catched(self):
         self.node.system_log = os.path.join(os.path.dirname(__file__), "test_data", "compaction_stopped_exception.log")
 
         self._read_and_publish_events()
 
-        with self.get_raw_events_log().open() as events_file:
-            events = [json.loads(line) for line in events_file]
+        events = self.events.published_events
 
-            event_backtrace1, event_backtrace2 = events[-3], events[-2]
-            print(event_backtrace1)
-            print(event_backtrace2)
+        event_backtrace1, event_backtrace2 = events[-3], events[-2]
+        print(event_backtrace1)
+        print(event_backtrace2)
 
-            assert event_backtrace1["type"] == "COMPACTION_STOPPED"
-            assert event_backtrace1["line_number"] == 0
-            assert event_backtrace2["type"] == "COMPACTION_STOPPED"
-            assert event_backtrace2["line_number"] == 1
+        assert event_backtrace1["type"] == "COMPACTION_STOPPED"
+        assert event_backtrace1["line_number"] == 0
+        assert event_backtrace2["type"] == "COMPACTION_STOPPED"
+        assert event_backtrace2["line_number"] == 1
 
     def test_appending_to_log(self):
         logs = """
@@ -275,14 +270,13 @@ INFO  2022-07-14 09:28:35,102 [shard 1] database - Flushed non-system tables
 
         self._read_and_publish_events(logs)
 
-        with self.get_raw_events_log().open() as events_file:
-            events = [json.loads(line) for line in events_file]
-            reactor_stalls = [event for event in events if event["type"] == "REACTOR_STALLED"]
-            assert len(reactor_stalls) == 1
-            event = reactor_stalls[0]
-            assert event["type"] == "REACTOR_STALLED"
-            assert event["line_number"] == 2
-            assert "Reactor stalled for 32 ms on shard 1" in event["line"]
+        events = self.events.published_events
+        reactor_stalls = [event for event in events if event["type"] == "REACTOR_STALLED"]
+        assert len(reactor_stalls) == 1
+        event = reactor_stalls[0]
+        assert event["type"] == "REACTOR_STALLED"
+        assert event["line_number"] == 2
+        assert "Reactor stalled for 32 ms on shard 1" in event["line"]
 
 
 class VersionDummyRemote:

--- a/unit_tests/test_decode_backtrace.py
+++ b/unit_tests/test_decode_backtrace.py
@@ -12,9 +12,10 @@
 # Copyright (c) 2020 ScyllaDB
 
 import os
-import json
-from multiprocessing import Queue
+import shutil
+import tempfile
 import unittest
+from multiprocessing import Queue
 from functools import cached_property
 
 import pytest
@@ -25,7 +26,7 @@ from sdcm.sct_events.database import SYSTEM_ERROR_EVENTS_PATTERNS
 
 from unit_tests.dummy_remote import DummyRemote
 from unit_tests.test_utils_common import DummyNode
-from unit_tests.lib.events_utils import EventsUtilsMixin
+from unit_tests.lib.fake_events import FakeEventsMixin
 
 
 class DecodeDummyNode(DummyNode):
@@ -33,14 +34,16 @@ class DecodeDummyNode(DummyNode):
         return "scylla_debug_info_file"
 
 
-class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
+class TestDecodeBactraces(unittest.TestCase, FakeEventsMixin):
     @classmethod
-    def setUpClass(cls):
-        cls.setup_events_processes(events_device=True, events_main_device=False, registry_patcher=True)
+    def setup_class(cls):
+        super().setup_class()
+        cls.temp_dir = tempfile.mkdtemp()
 
     @classmethod
-    def tearDownClass(cls):
-        cls.teardown_events_processes()
+    def teardown_class(cls):
+        shutil.rmtree(cls.temp_dir, ignore_errors=True)
+        super().teardown_class()
 
     @cached_property
     def test_config(self):
@@ -114,10 +117,7 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
         self.monitor_node.stop_task_threads()
         self.monitor_node.wait_till_tasks_threads_are_stopped()
 
-        events = []
-        with self.get_raw_events_log().open() as events_file:
-            for line in events_file.readlines():
-                events.append(json.loads(line))
+        events = self.events.published_events
 
         assert any(event.get("raw_backtrace") for event in events), "should have at least one backtrace"
         for event in events:
@@ -135,10 +135,7 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
         self.monitor_node.stop_task_threads()
         self.monitor_node.wait_till_tasks_threads_are_stopped()
 
-        events = []
-        with self.get_raw_events_log().open() as events_file:
-            for line in events_file.readlines():
-                events.append(json.loads(line))
+        events = self.events.published_events
 
         assert any(event.get("raw_backtrace") for event in events), "should have at least one backtrace"
         for event in events:
@@ -161,10 +158,7 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
         self.monitor_node.stop_task_threads()
         self.monitor_node.wait_till_tasks_threads_are_stopped()
 
-        events = []
-        with self.get_raw_events_log().open() as events_file:
-            for line in events_file.readlines():
-                events.append(json.loads(line))
+        events = self.events.published_events
 
         assert any(event.get("raw_backtrace") for event in events), "should have at least one backtrace"
         for event in events:
@@ -187,10 +181,7 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
         self.monitor_node.stop_task_threads()
         self.monitor_node.wait_till_tasks_threads_are_stopped()
 
-        events = []
-        with self.get_raw_events_log().open() as events_file:
-            for line in events_file.readlines():
-                events.append(json.loads(line))
+        events = self.events.published_events
 
         assert any(event.get("raw_backtrace") for event in events), "should have at least one backtrace"
         for event in events:
@@ -311,10 +302,7 @@ def test_backtrace_decoding_configuration(
     monitor_node.wait_till_tasks_threads_are_stopped()
 
     # Validate
-    events = []
-    with open(events_function_scope.get_raw_events_log()) as events_file:
-        for line in events_file.readlines():
-            events.append(json.loads(line))
+    events = events_function_scope.published_events
 
     filtered_events = [e for e in events if event_filter(e)]
     assert len(filtered_events) > 0, "Should have at least one matching event"

--- a/unit_tests/test_longevity.py
+++ b/unit_tests/test_longevity.py
@@ -6,9 +6,10 @@ import pytest
 
 from longevity_test import LongevityTest
 from sdcm.cluster import NoMonitorSet
-from sdcm.sct_events import events_processes
+from sdcm.sct_events.base import SctEvent
 from unit_tests.test_utils_common import DummyDbCluster, DummyNode
 from unit_tests.test_cluster import DummyDbCluster
+from unit_tests.lib.fake_events import make_fake_events
 
 
 LongevityTest.__test__ = False
@@ -18,9 +19,6 @@ LongevityTest.__test__ = False
 def fixture_mock_calls():
     with unittest.mock.patch("sdcm.tester.validate_raft_on_nodes"):
         yield
-
-    # clear the events processes registry after each test, so next test would be ableto start it fresh
-    events_processes._EVENTS_PROCESSES = None
 
 
 @pytest.mark.sct_config(files="test-cases/features/elasticity/longevity-elasticity-many-small-tables.yaml")
@@ -38,6 +36,13 @@ class DummyLongevityTest(LongevityTest):
         self.timeout_thread = None
         self.k8s_clusters = []
         self.kafka_cluster = None
+
+    @pytest.fixture(autouse=True, name="event_system")
+    def fixture_event_system(self, setup_logging):
+        with make_fake_events() as device:
+            self._fake_device = device
+            self.events_processes_registry = SctEvent._events_processes_registry
+            yield
 
     def _init_params(self):
         pass

--- a/unit_tests/test_scan_operation_thread.py
+++ b/unit_tests/test_scan_operation_thread.py
@@ -7,8 +7,6 @@ test_scan_negative_operation_timed_out - getting operation_timed_out in scan exe
 test_scan_negative_exception - getting operation_timed_out in scan execution (with and without nemesis)
 """
 
-from pathlib import Path
-import os
 from threading import Event
 from importlib import reload
 from unittest.mock import MagicMock, patch
@@ -56,15 +54,12 @@ class DBCluster(DummyDbCluster):
 
 
 def get_event_log_file(events):
-    if (log_file := Path(events.temp_dir, "events_log", "events.log")).exists():
-        return log_file.read_text(encoding="utf-8").rstrip().split("\n")
-    return ""
+    return events.get_formatted_event_lines() or ""
 
 
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_event_log_file(events):
-    with open(os.path.join(events.temp_dir, "events_log", "events.log"), "r+", encoding="utf-8") as file:
-        file.truncate(0)
+    events.events_main_device.clear()
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -120,8 +115,7 @@ def test_scan_positive(mode, events, cluster):
     default_params = ThreadParams(db_cluster=cluster, ks_cf="a.b", mode=mode, **DEFAULT_PARAMS)
     with patch.object(PrometheusDBStats, "__init__", return_value=None):
         with patch.object(PrometheusDBStats, "query", return_value=[{"values": [[0, "1"], [1, "2"]]}]):
-            with events.wait_for_n_events(events.get_events_logger(), count=2, timeout=10):
-                ScanOperationThread(default_params)._run_next_operation()
+            ScanOperationThread(default_params)._run_next_operation()
             all_events = get_event_log_file(events)
             assert "Severity.NORMAL" in all_events[0] and "period_type=begin" in all_events[0]
             assert "Severity.NORMAL" in all_events[1] and "period_type=end" in all_events[1]
@@ -133,8 +127,7 @@ def test_negative_prometheus_validation_error(events, cluster):
     default_params = ThreadParams(db_cluster=cluster, ks_cf="a.b", mode="aggregate", **DEFAULT_PARAMS)
     with patch.object(PrometheusDBStats, "__init__", return_value=None):
         with patch.object(PrometheusDBStats, "query", return_value=[{"values": [[0, "1"], [1, "1"]]}]):
-            with events.wait_for_n_events(events.get_events_logger(), count=2, timeout=30):
-                ScanOperationThread(default_params)._run_next_operation()
+            ScanOperationThread(default_params)._run_next_operation()
             all_events = get_event_log_file(events)
             assert "Severity.NORMAL" in all_events[0] and "period_type=begin" in all_events[0]
             severity = "Severity.ERROR"
@@ -180,8 +173,7 @@ def test_scan_negative_execution_errors(mode, exception, events, node):
         full_scan_operation_limit=300,
         **DEFAULT_PARAMS,
     )
-    with events.wait_for_n_events(events.get_events_logger(), count=2, timeout=10):
-        ScanOperationThread(default_params)._run_next_operation()
+    ScanOperationThread(default_params)._run_next_operation()
     all_events = get_event_log_file(events)
     assert "Severity.NORMAL" in all_events[0] and "period_type=begin" in all_events[0]
     assert "Severity.WARNING" in all_events[1] and "period_type=end" in all_events[1]
@@ -213,8 +205,7 @@ def test_scan_negative_running_nemesis(mode, severity, running_nemesis, execute_
     db_cluster = DBCluster(connection, [node], {})
     node.parent_cluster = db_cluster
     default_params = ThreadParams(db_cluster=db_cluster, ks_cf="a.b", mode=mode, **DEFAULT_PARAMS)
-    with events.wait_for_n_events(events.get_events_logger(), count=2, timeout=10):
-        ScanOperationThread(default_params)._run_next_operation()
+    ScanOperationThread(default_params)._run_next_operation()
     all_events = get_event_log_file(events)
     assert "Severity.NORMAL" in all_events[0] and "period_type=begin" in all_events[0]
     assert f"Severity.{severity}" in all_events[1] and "period_type=end" in all_events[1]

--- a/unit_tests/test_tester.py
+++ b/unit_tests/test_tester.py
@@ -19,13 +19,14 @@ import logging
 import pytest
 
 from sdcm.sct_events import Severity
+from sdcm.sct_events.base import SctEvent
 from sdcm.sct_events.health import ClusterHealthValidatorEvent
 from sdcm.tester import ClusterTester, silence, TestResultEvent
 from sdcm.sct_config import SCTConfiguration
 from sdcm.sct_events.system import TestFrameworkEvent
 from sdcm.sct_events.file_logger import get_events_grouped_by_category
 from sdcm.utils.action_logger import get_action_logger
-from unit_tests.lib.events_utils import EventsUtilsMixin
+from unit_tests.lib.fake_events import make_fake_events
 
 
 class FakeSCTConfiguration(SCTConfiguration):
@@ -40,7 +41,7 @@ class FakeSCTConfiguration(SCTConfiguration):
 ClusterTester.__test__ = False
 
 
-class ClusterTesterForTests(ClusterTester, EventsUtilsMixin):
+class ClusterTesterForTests(ClusterTester):
     k8s_clusters = None
 
     def init_argus_run(self):
@@ -119,9 +120,10 @@ class ClusterTesterForTests(ClusterTester, EventsUtilsMixin):
 
     @pytest.fixture(autouse=True, name="event_system")
     def fixture_event_system(self, setup_logging):
-        self.setup_events_processes(events_device=True, events_main_device=False, registry_patcher=True)
-        yield
-        self.teardown_events_processes()
+        with make_fake_events() as device:
+            self._fake_device = device
+            self.events_processes_registry = SctEvent._events_processes_registry
+            yield
 
     @pytest.fixture(autouse=True, name="print_output")
     def fixture_print_output(self, event_system, capsys):
@@ -501,29 +503,23 @@ class TestGatherFailureStatistics:
         tester.params = FakeSCTConfiguration()
         tester.start_time = time.time()  # Required by tearDown
 
-        # Setup events before calling tearDown
-        tester.setup_events_processes(events_device=True, events_main_device=False, registry_patcher=True)
+        # Setup fake events before calling tearDown
+        with make_fake_events():
+            tester.events_processes_registry = SctEvent._events_processes_registry
 
-        # Create an error event to make test status FAILED
-        TestFrameworkEvent(
-            source="test", source_method="test", exception=Exception("Test error"), severity=Severity.ERROR
-        ).publish()
+            # Create an error event to make test status FAILED
+            TestFrameworkEvent(
+                source="test", source_method="test", exception=Exception("Test error"), severity=Severity.ERROR
+            ).publish()
 
-        # Brief sleep needed for asynchronous event processing to complete
-        # This ensures the event is registered before get_test_status() is called
-        time.sleep(0.1)
+            # Mock gather_failure_statistics to verify it's called
+            tester.gather_failure_statistics = MagicMock()
 
-        # Mock gather_failure_statistics to verify it's called
-        tester.gather_failure_statistics = MagicMock()
+            # Run tearDown
+            tester.tearDown()
 
-        # Run tearDown
-        tester.tearDown()
-
-        # Verify gather_failure_statistics was called
-        assert tester.gather_failure_statistics.called
-
-        # Cleanup
-        tester.teardown_events_processes()
+            # Verify gather_failure_statistics was called
+            assert tester.gather_failure_statistics.called
 
 
 class TestSaveSchema:

--- a/unit_tests/test_utils_issues.py
+++ b/unit_tests/test_utils_issues.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 
 from sdcm.utils.issues import SkipPerIssues, parse_issue, GitHubIssue, JiraIssue, DEFAULT_GH_USER, DEFAULT_GH_REPO
@@ -9,13 +7,9 @@ pytestmark = pytest.mark.integration
 
 def test_no_existing_issue(events, params):
     params.artifact_scylla_version = "2023.1.3"
-    with events.wait_for_n_events(events.get_events_logger(), count=1, timeout=10):
-        assert not SkipPerIssues(["ABC"], params)
+    assert not SkipPerIssues(["ABC"], params)
 
-    events_list = []
-    with events.get_raw_events_log().open() as events_file:
-        for line in events_file.readlines():
-            events_list.append(json.loads(line))
+    events_list = events.published_events
 
     assert events_list[-1]["message"] == "couldn't parse issue: ABC"
     assert events_list[-1]["severity"] == "WARNING"


### PR DESCRIPTION
Resubmit of https://github.com/scylladb/scylla-cluster-tests/pull/13966
### Overview

The existing events system (events_lib) is slow, it sets up threads and processes and has sleeps (~10sec per module). It is needlessly complex for majority of the tests. Introduce a new events module which can be used instead and is much simpler and instantaneous.

### Testing

* [x] locally
* [ ] unit tests
* [ ] integration tests

