### PR TITLE
fix(agent): close HTTP sessions during node teardown

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1603,6 +1603,8 @@ class BaseNode(AutoSshContainerMixin):
 
     def destroy(self):
         self.stop_task_threads()
+        if self.remoter:
+            self.remoter.stop()
         ContainerManager.destroy_all_containers(self)
         self._terminate_node_in_argus()
         LOGGER.info("%s destroyed", self)

--- a/sdcm/remote/agent_cmd_runner.py
+++ b/sdcm/remote/agent_cmd_runner.py
@@ -403,7 +403,12 @@ class AgentCmdRunner(CommandRunner, RetryMixin):
 
     def stop(self):
         """Close agent client connection"""
+        if self._agent_client:
+            self._agent_client.close()
         self._agent_client = None
+
+    def __del__(self):
+        self.stop()
 
     def __repr__(self) -> str:
         return f"AgentCmdRunner(hostname={self.hostname}, port={self.port}, tls={self.tls})"

--- a/sdcm/remote/base.py
+++ b/sdcm/remote/base.py
@@ -100,6 +100,12 @@ class CommandRunner(metaclass=ABCMeta):
         Return instance parameters required to rebuild instance
         """
 
+    def stop(self):
+        """
+        Release resources held by this runner.
+        No-op by default; subclasses override to close connections/sessions.
+        """
+
     def __str__(self):
         return "{} [{}@{}]".format(self.__class__.__name__, self.user, self.hostname)
 

--- a/sdcm/utils/agent_client.py
+++ b/sdcm/utils/agent_client.py
@@ -136,6 +136,10 @@ class AgentClient:
             }
         )
 
+    def close(self):
+        """Close the underlying HTTP session and its connection pools."""
+        self.session.close()
+
     def _make_request(self, method: str, url: str, operation_name: str, **kwargs) -> requests.Response:
         """
         Make an HTTP request with error handling


### PR DESCRIPTION
The change addresses the following points in SCT that leave unclosed sessions alive at the end of a test with sct-agent enabled, causing `segfaults (exit code 139) during interpreter shutdown` error (even though the test itself passed):
- AgentClient creates a requests.Session with urllib3 connection pools, but never closes it
- AgentCmdRunner.stop() sets _agent_client = None without closing the session itself
- BaseNode.destroy() never calls remoter.stop() to close session

Fixes: SCT-136

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [longevity-10gb-3h-gce-test with enabled agent](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/longevity-10gb-3h-gce-test/12/) (the issue was permanently reproduced on this on any scenario with 6+ DB nodes)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
