### PR TITLE
feat: add Cassandra Docker cluster support

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,107 @@
+# Provision test labels — used by Jenkinsfile to gate provision test stages.
+# Apply these labels to a PR to trigger the corresponding provision test.
+#
+# This file serves as documentation and can be used with label-sync tools
+# such as github-label-sync or EndBug/label-sync GitHub Action.
+
+# Run provision tests on ALL backends
+- name: test-provision
+  description: Run provision tests on all backends
+  color: "0e8a16"
+
+# Docker
+- name: test-provision-docker
+  description: Run provision test on Docker (Scylla)
+  color: "0e8a16"
+
+- name: test-provision-cassandra-docker
+  description: Run provision test on Docker (Cassandra)
+  color: "0e8a16"
+
+# AWS
+- name: test-provision-aws
+  description: Run provision test on AWS
+  color: "0e8a16"
+
+- name: test-provision-aws-reuse
+  description: Run provision test on AWS with cluster reuse
+  color: "0e8a16"
+
+# GCE
+- name: test-provision-gce
+  description: Run provision test on GCE
+  color: "0e8a16"
+
+- name: test-provision-gce-reuse
+  description: Run provision test on GCE with cluster reuse
+  color: "0e8a16"
+
+# Azure
+- name: test-provision-azure
+  description: Run provision test on Azure
+  color: "0e8a16"
+
+- name: test-provision-azure-reuse
+  description: Run provision test on Azure with cluster reuse
+  color: "0e8a16"
+
+# OCI
+- name: test-provision-oci
+  description: Run provision test on OCI
+  color: "0e8a16"
+
+- name: test-provision-oci-reuse
+  description: Run provision test on OCI with cluster reuse
+  color: "0e8a16"
+
+# Kubernetes
+- name: test-provision-k8s-local-kind-aws
+  description: Run provision test on K8s (KinD on AWS)
+  color: "0e8a16"
+
+- name: test-provision-k8s-local-kind-aws-reuse
+  description: Run provision test on K8s (KinD on AWS) with cluster reuse
+  color: "0e8a16"
+
+- name: test-provision-k8s-eks
+  description: Run provision test on K8s (EKS)
+  color: "0e8a16"
+
+- name: test-provision-k8s-eks-reuse
+  description: Run provision test on K8s (EKS) with cluster reuse
+  color: "0e8a16"
+
+# ScyllaDB Cloud (xcloud)
+- name: test-provision-xcloud-aws
+  description: Run provision test on ScyllaDB Cloud (AWS)
+  color: "0e8a16"
+
+- name: test-provision-xcloud-aws-reuse
+  description: Run provision test on ScyllaDB Cloud (AWS) with cluster reuse
+  color: "0e8a16"
+
+- name: test-provision-xcloud-gce
+  description: Run provision test on ScyllaDB Cloud (GCE)
+  color: "0e8a16"
+
+- name: test-provision-xcloud-gce-reuse
+  description: Run provision test on ScyllaDB Cloud (GCE) with cluster reuse
+  color: "0e8a16"
+
+# Vector Store
+- name: test-provision-vs-docker
+  description: Run provision test for Vector Store on Docker
+  color: "0e8a16"
+
+- name: test-provision-vs-aws
+  description: Run provision test for Vector Store on AWS
+  color: "0e8a16"
+
+- name: test-provision-vs-aws-reuse
+  description: Run provision test for Vector Store on AWS with cluster reuse
+  color: "0e8a16"
+
+# Other CI labels referenced in Jenkinsfile
+- name: test-integration
+  description: Run the integration tests suite
+  color: "0e8a16"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@
 // trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
-def target_backends = ['aws', 'gce', 'oci', 'docker', 'k8s-local-kind-aws', 'k8s-eks', 'azure', 'xcloud-aws', 'xcloud-gce', 'vs-docker', 'vs-aws']
-def sct_runner_backends = ['aws', 'gce', 'oci', 'docker', 'k8s-local-kind-aws', 'k8s-eks', 'azure', 'xcloud-aws', 'xcloud-gce', 'vs-docker', 'vs-aws']
+def target_backends = ['aws', 'gce', 'oci', 'docker', 'cassandra-docker', 'k8s-local-kind-aws', 'k8s-eks', 'azure', 'xcloud-aws', 'xcloud-gce', 'vs-docker', 'vs-aws']
+def sct_runner_backends = ['aws', 'gce', 'oci', 'docker', 'cassandra-docker', 'k8s-local-kind-aws', 'k8s-eks', 'azure', 'xcloud-aws', 'xcloud-gce', 'vs-docker', 'vs-aws']
 
 def createRunConfiguration(String backend) {
 	def scylla_version = params.scylla_version ?: getLatestScyllaRelease('scylla')
@@ -37,6 +37,11 @@ def createRunConfiguration(String backend) {
         configuration.scylla_version = ''
         // TODO: unset the image when 'scylla_version' gets specified
         configuration.oci_image_db = 'ocid1.image.oc1.iad.aaaaaaaawlq4rpsf5j3blmia6vxuu3d7tdv5ir5x3izs4ogxmdyibskhpoxq'
+    } else if (backend == 'cassandra-docker') {
+        configuration.backend = 'docker'
+        configuration.test_config = "test-cases/cassandra-docker-provision-test.yaml"
+        configuration.scylla_version = ''
+        configuration.availability_zone = 'a'
     } else if (backend.contains('docker')) {
         // use latest version of nightly image for docker backend, until we get rid off rebuilding docker image for SCT
         configuration.scylla_version = 'latest'
@@ -301,7 +306,7 @@ pipeline {
                 expression {
                     def labels = [
                         "test-provision",
-                        "test-provision-docker",
+                        "test-provision-docker", "test-provision-cassandra-docker",
                         "test-provision-aws", "test-provision-aws-reuse",
                         "test-provision-gce", "test-provision-gce-reuse",
                         "test-provision-azure", "test-provision-azure-reuse",

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -345,6 +345,9 @@ vector_store_scylla_port: 9042
 vector_store_threads: 0  # 0 = defaults to number of cores on a node
 vector_store_docker_image: 'scylladb/vector-store'
 vector_store_version: ''
+docker_image_cassandra: 'cassandra'
+cassandra_version: '4.1'
+cassandra_num_tokens: 16
 download_from_s3: []
 # The object-storage method options in Scylla-Manager are: native/rclone/auto.
 # An empty value here, means Scylla-Manager will use its default value.

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -346,7 +346,7 @@ vector_store_threads: 0  # 0 = defaults to number of cores on a node
 vector_store_docker_image: 'scylladb/vector-store'
 vector_store_version: ''
 docker_image_cassandra: 'cassandra'
-cassandra_version: '4.1'
+cassandra_version: '5'
 cassandra_num_tokens: 16
 download_from_s3: []
 # The object-storage method options in Scylla-Manager are: native/rclone/auto.

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -2714,7 +2714,7 @@ Cassandra docker image repo, i.e. 'cassandra'. Used when db_type is 'cassandra'.
 
 Cassandra version / docker image tag, i.e. '4.1' or '5.0'
 
-**default:** 4.1
+**default:** 5
 
 **type:** str
 * appendable

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -2700,6 +2700,35 @@ Vector Store version / docker image tag
 * appendable
 
 
+## **docker_image_cassandra** / SCT_DOCKER_IMAGE_CASSANDRA
+
+Cassandra docker image repo, i.e. 'cassandra'. Used when db_type is 'cassandra'.
+
+**default:** cassandra
+
+**type:** str
+* appendable
+
+
+## **cassandra_version** / SCT_CASSANDRA_VERSION
+
+Cassandra version / docker image tag, i.e. '4.1' or '5.0'
+
+**default:** 4.1
+
+**type:** str
+* appendable
+
+
+## **cassandra_num_tokens** / SCT_CASSANDRA_NUM_TOKENS
+
+num_tokens value to configure in cassandra.yaml.
+
+**default:** 16
+
+**type:** int
+
+
 ## **s3_baremetal_config** / SCT_S3_BAREMETAL_CONFIG
 
 Configuration for S3 in baremetal setups. This includes details such as endpoint URL, access key, secret key, and bucket name.

--- a/docs/plans/assets/progress-roadmap.svg
+++ b/docs/plans/assets/progress-roadmap.svg
@@ -4,9 +4,9 @@
 <text x="420" y="84" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#8899AA">26 plans across 8 domains</text>
 <rect x="30" y="120" width="780" height="50" rx="6" fill="#1B2A4A" stroke="#2A3F5F" stroke-width="1"/>
 <circle cx="50" cy="148" r="5" fill="#607D8B"/>
-<text x="60" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Draft: 15</text>
+<text x="60" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Draft: 14</text>
 <circle cx="180" cy="148" r="5" fill="#FFC107"/>
-<text x="190" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">In Progress: 3</text>
+<text x="190" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">In Progress: 4</text>
 <circle cx="310" cy="148" r="5" fill="#2196F3"/>
 <text x="320" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Approved: 0</text>
 <circle cx="440" cy="148" r="5" fill="#F44336"/>
@@ -16,12 +16,12 @@
 <circle cx="700" cy="148" r="5" fill="#9E9E9E"/>
 <text x="710" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Pending PR: 8</text>
 <rect x="40" y="175" width="760" height="20" rx="10" fill="#1B2A4A" stroke="#2A3F5F" stroke-width="1"/>
-<rect x="40" y="175" width="87.6923076923077" height="20" rx="10" fill="#FFC107"/>
-<text x="83.84615384615384" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">3</text>
-<rect x="127.6923076923077" y="175" width="438.4615384615384" height="20" rx="0" fill="#607D8B"/>
-<text x="346.9230769230769" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">15</text>
-<rect x="566.1538461538461" y="175" width="233.84615384615387" height="20" rx="0" fill="#9E9E9E"/>
-<text x="683.076923076923" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">8</text>
+<rect x="40" y="175" width="116.92307692307693" height="20" rx="10" fill="#FFC107"/>
+<text x="98.46153846153847" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">4</text>
+<rect x="156.92307692307693" y="175" width="409.2307692307692" height="20" rx="0" fill="#607D8B"/>
+<text x="361.53846153846155" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">14</text>
+<rect x="566.1538461538462" y="175" width="233.84615384615387" height="20" rx="0" fill="#9E9E9E"/>
+<text x="683.0769230769231" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">8</text>
 <rect x="30" y="220" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
 <text x="42" y="241" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">cluster</text>
 <text x="398" y="241" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">6 plans</text>
@@ -31,9 +31,9 @@
 <circle cx="44" cy="294" r="4" fill="#607D8B"/>
 <text x="56" y="298" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">GCE Provisioning</text>
 <text x="398" y="298" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
-<circle cx="44" cy="322" r="4" fill="#607D8B"/>
+<circle cx="44" cy="322" r="4" fill="#FFC107"/>
 <text x="56" y="326" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Cassandra Cluster Support</text>
-<text x="398" y="326" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<text x="398" y="326" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#FFC107">In Progress</text>
 <circle cx="44" cy="350" r="4" fill="#9E9E9E"/>
 <text x="56" y="354" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Amazon EMR Spark Migrator</text>
 <text x="398" y="354" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>

--- a/docs/plans/infrastructure/cassandra-cluster-support.md
+++ b/docs/plans/infrastructure/cassandra-cluster-support.md
@@ -1,8 +1,8 @@
 ---
-status: draft
+status: in-progress
 domain: cluster
 created: 2026-03-08
-last_updated: 2026-03-19
+last_updated: 2026-03-22
 owner: fruch
 ---
 # Cassandra Cluster Support in SCT
@@ -578,10 +578,13 @@ stress_cmd: '...'
 **Note on sequencing:** Phases 1 and 2 should land in the same PR or immediately sequential PRs. If Phase 1 is merged and Phase 2 is delayed, the codebase will have a non-mixin `CassandraDockerCluster` as permanent state, which creates technical debt.
 
 **Definition of Done:**
-- [ ] `CassandraDockerCluster` starts a Cassandra container, waits for CQL, and is reachable on port 9042
+- [x] `CassandraDockerCluster` starts a Cassandra container, waits for CQL, and is reachable on port 9042
+  - PR [#14164](https://github.com/scylladb/scylla-cluster-tests/pull/14164): `CassandraDockerNode`, `CassandraDockerCluster`, `CassandraYamlAttrProxy`
+  - Tested with Cassandra 4.1 and 5.0 (longevity_test.LongevityTest.test_custom_time)
+  - Overrides: `remote_scylla_yaml` → `cassandra.yaml`, `nodetool` path, `raft` → `NoRaft`, `wait_native_transport` → CQL port check
 - [ ] Gemini test runs with `--backend docker` using Cassandra oracle (`db_type: mixed_cassandra`)
 - [ ] Gemini successfully compares Scylla (test) vs Cassandra (oracle) reads with no unexpected errors
-- [ ] Unit test verifying Docker env var mapping (`_cassandra_env_vars()`) for single-node and multi-node clusters
+- [x] Unit test verifying Docker env var mapping (`_cassandra_env_vars()`) for single-node and multi-node clusters
 - [ ] Integration test verifying `CassandraDockerCluster` starts and CQL port is reachable
 
 ---

--- a/docs/plans/progress.json
+++ b/docs/plans/progress.json
@@ -163,10 +163,10 @@
       "title": "Cassandra Cluster Support",
       "file": "infrastructure/cassandra-cluster-support.md",
       "domain": "cluster",
-      "status": "draft",
-      "created": "2026-03-08",
-      "phases_total": null,
-      "phases_done": 0
+      "status": "in_progress",
+      "pr": 14164,
+      "phases_total": 5,
+      "phases_done": 1
     },
     {
       "id": "amazon-emr-spark-migrator",

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -636,6 +636,12 @@ class CassandraYamlAttrProxy:
         except KeyError:
             return None
 
+    def __setattr__(self, name, value):
+        if name == "_data":
+            super().__setattr__(name, value)
+        else:
+            self._data[name] = value
+
     def model_dump(self, **_kwargs):
         return dict(self._data)
 
@@ -660,7 +666,7 @@ class CassandraDockerCluster(cluster.BaseScyllaCluster, DockerCluster):
             node_key_file=node_key_file,
             cluster_prefix=cluster_prefix,
             node_prefix=node_prefix,
-            node_type="scylla-db",
+            node_type="scylla-db",  # TODO: change to "cassandra-db" once node_type is decoupled from Scylla-specific logic
             n_nodes=n_nodes,
             params=params,
         )
@@ -735,6 +741,12 @@ class CassandraDockerCluster(cluster.BaseScyllaCluster, DockerCluster):
         pass
 
     def validate_seeds_on_all_nodes(self):
+        pass
+
+    def update_db_binary(self, node_list=None, start_service=True):
+        pass
+
+    def update_db_packages(self, node_list=None, start_service=True):
         pass
 
     def wait_for_nodes_up_and_normal(self, nodes=None, verification_node=None, iterations=60, sleep_time=3, timeout=0):

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -11,15 +11,19 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
+import contextlib
 import os
 import re
 import logging
 import shutil
-from typing import Optional, Union, Dict
+import tempfile
+from typing import ContextManager, Optional, Union, Dict
 from functools import cached_property
 
+import yaml
 
-from sdcm import cluster
+from sdcm import cluster, wait
+from sdcm.exceptions import NodeNotReady
 from sdcm.provision.helpers.certificate import (
     CA_CERT_FILE,
     JKS_TRUSTSTORE_FILE,
@@ -29,6 +33,7 @@ from sdcm.provision.helpers.certificate import (
 )
 from sdcm.remote import LOCALRUNNER
 from sdcm.remote.docker_cmd_runner import DockerCmdRunner
+from sdcm.remote.remote_file import remote_file, dict_to_yaml_file, yaml_file_to_dict
 from sdcm.reporting.tooling_reporter import VectorStoreVersionReporter
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.filters import DbEventsFilter
@@ -36,6 +41,7 @@ from sdcm.utils.docker_utils import get_docker_bridge_gateway, Container, Contai
 from sdcm.utils.health_checker import check_nodes_status
 from sdcm.nemesis.utils.node_allocator import mark_new_nodes_as_running_nemesis
 from sdcm.utils.net import get_my_public_ip
+from sdcm.utils.raft import NoRaft
 from sdcm.utils.vector_store_utils import VectorStoreClusterMixin, VectorStoreNodeMixin
 
 DEFAULT_SCYLLA_DB_IMAGE = "scylladb/scylla-nightly"
@@ -262,7 +268,11 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):
 
     def install_sudo(self, user: str = "scylla", verbose=False):
         """Install and configure passwordless sudo"""
-        pkg_mgr = "microdnf" if self.distro.is_rhel_like else "apt"
+        if self.distro.is_rhel_like:
+            pkg_mgr = "microdnf"
+        else:
+            pkg_mgr = "apt"
+            self.remoter.run("apt update", verbose=verbose, ignore_status=True, user="root")
         self.remoter.run(f"{pkg_mgr} install -y sudo", verbose=verbose, ignore_status=True, user="root")
 
         self.remoter.run("mkdir -p /etc/sudoers.d", user="root", ignore_status=True, verbose=verbose)
@@ -515,6 +525,229 @@ class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):
                 self.log.warning("Failed destroy vector store cluster: %s", e)
 
         super().destroy()
+
+
+DEFAULT_CASSANDRA_IMAGE = "cassandra"
+
+
+CASSANDRA_YAML_PATH = "/etc/cassandra/cassandra.yaml"
+
+
+class CassandraDockerNode(DockerNode):
+    """A Cassandra node running in a Docker container."""
+
+    @cached_property
+    def cql_address(self):
+        return self.ip_address
+
+    def _gen_nodetool_cmd(self, sub_cmd, args, options):
+        credentials = self.parent_cluster.get_db_auth()
+        if credentials:
+            options += "-u {} -pw '{}' ".format(*credentials)
+        return f"nodetool {options} {sub_cmd} {args}"
+
+    @contextlib.contextmanager
+    def remote_scylla_yaml(self) -> ContextManager[dict]:
+        """Read/write cassandra.yaml as a plain dict.
+
+        Provides the same context-manager interface as the Scylla version
+        so that callers like ``report_scylla_yaml_to_argus`` keep working.
+        Changes made to the yielded dict are written back on exit.
+        """
+        with remote_file(
+            remoter=self.remoter,
+            remote_path=CASSANDRA_YAML_PATH,
+            serializer=dict_to_yaml_file,
+            deserializer=yaml_file_to_dict,
+            sudo=True,
+        ) as cassandra_yaml:
+            yield CassandraYamlAttrProxy(cassandra_yaml)
+
+    def extract_seeds_from_scylla_yaml(self):
+        """Extract seed IPs from cassandra.yaml."""
+        yaml_dst_path = os.path.join(tempfile.mkdtemp(prefix="sct"), "cassandra.yaml")
+        wait.wait_for(
+            func=self.remoter.receive_files,
+            step=10,
+            text="Waiting for copying cassandra.yaml",
+            timeout=300,
+            throw_exc=True,
+            src=CASSANDRA_YAML_PATH,
+            dst=yaml_dst_path,
+        )
+        with open(yaml_dst_path, encoding="utf-8") as yaml_stream:
+            conf_dict = yaml.safe_load(yaml_stream)
+
+        try:
+            node_seeds = conf_dict["seed_provider"][0]["parameters"][0].get("seeds")
+        except (KeyError, IndexError, TypeError) as details:
+            self.log.debug("Loaded YAML data structure: %s", conf_dict)
+            raise ValueError("Exception determining seed node ips from cassandra.yaml") from details
+
+        if node_seeds:
+            return [s.strip() for s in node_seeds.split(",")]
+        return []
+
+    @property
+    def is_server_encrypt(self):
+        result = self.remoter.run(f"grep '^server_encryption_options:' {CASSANDRA_YAML_PATH}", ignore_status=True)
+        return "server_encryption_options" in result.stdout.lower()
+
+    @cached_property
+    def raft(self):
+        return NoRaft(self)
+
+    def wait_native_transport(self):
+        """Cassandra has no Scylla REST API; check CQL port instead."""
+        if not self.db_up():
+            raise NodeNotReady(f"Node {self.name} CQL port not ready")
+
+    def config_setup(self, append_scylla_args="", debug_install=False, **_):
+        pass
+
+    def node_container_run_args(self, seed_ip):
+        env_vars = self.parent_cluster.cassandra_env_vars(self, seed_ip)
+        return dict(
+            name=self.name,
+            image=self.node_container_image_tag,
+            environment=env_vars,
+            network=self.parent_cluster.params.get("docker_network"),
+            nano_cpus=10**9,
+        )
+
+    def db_up(self):
+        return self.is_port_used(port=self.CQL_PORT, service_name="cassandra")
+
+
+class CassandraYamlAttrProxy:
+    """Wraps a plain dict so attribute access works like on ScyllaYaml.
+
+    ``report_scylla_yaml_to_argus`` calls ``scylla_yml.model_dump()``
+    and accesses attributes like ``broadcast_rpc_address``.  This proxy
+    makes a raw cassandra.yaml dict behave similarly.
+    """
+
+    def __init__(self, data: dict):
+        self._data = data
+
+    def __getattr__(self, name):
+        try:
+            return self._data[name]
+        except KeyError:
+            return None
+
+    def model_dump(self, **_kwargs):
+        return dict(self._data)
+
+
+class CassandraDockerCluster(cluster.BaseScyllaCluster, DockerCluster):
+    """Cassandra cluster on Docker backend for development and CI."""
+
+    def __init__(
+        self,
+        docker_image: str = DEFAULT_CASSANDRA_IMAGE,
+        docker_image_tag: str = "",
+        node_key_file: Optional[str] = None,
+        user_prefix: Optional[str] = None,
+        n_nodes: Union[list, str] = 1,
+        params: dict = None,
+    ) -> None:
+        cluster_prefix = cluster.prepend_user_prefix(user_prefix, "cs-cluster")
+        node_prefix = cluster.prepend_user_prefix(user_prefix, "cs-node")
+        super().__init__(
+            docker_image=docker_image,
+            docker_image_tag=docker_image_tag,
+            node_key_file=node_key_file,
+            cluster_prefix=cluster_prefix,
+            node_prefix=node_prefix,
+            node_type="scylla-db",
+            n_nodes=n_nodes,
+            params=params,
+        )
+
+        self.vector_store_cluster = None
+
+    def get_node_ips_param(self, *args, **kwargs):
+        """
+        Resolve ambiguity between BaseScyllaCluster and DockerCluster implementations.
+
+        Delegate explicitly to DockerCluster so CassandraDockerCluster uses
+        the Docker-specific behavior for node IP parameters.
+        """
+        return DockerCluster.get_node_ips_param(self, *args, **kwargs)
+
+    def _create_node(self, node_index, container=None):
+        node = CassandraDockerNode(
+            parent_cluster=self,
+            container=container,
+            ssh_login_info=dict(hostname=None, user=self.node_container_user, key_file=self.node_container_key_file),
+            base_logdir=self.logdir,
+            node_prefix=self.node_prefix,
+            node_index=node_index,
+        )
+
+        if container is None:
+            ContainerManager.run_container(
+                node, "node", seed_ip=self.nodes[0].public_ip_address if node_index else None
+            )
+            ContainerManager.wait_for_status(node, "node", status="running")
+
+        node.init()
+
+        return node
+
+    def cassandra_env_vars(self, node, seed_ip) -> dict:
+        """Compute Docker env vars for the Cassandra container.
+
+        Args:
+            node: The node being configured.
+            seed_ip: IP address of the seed node, or None for the first node.
+
+        Returns:
+            Dict of environment variables for the Cassandra Docker container.
+        """
+        seeds = seed_ip or ""
+        num_tokens = self.params.get("cassandra_num_tokens") or 16
+        return {
+            "CASSANDRA_CLUSTER_NAME": self.name,
+            "CASSANDRA_SEEDS": seeds,
+            "CASSANDRA_ENDPOINT_SNITCH": "SimpleSnitch",
+            "CASSANDRA_NUM_TOKENS": str(num_tokens),
+            # TODO: make heap settings configurable via sct_config params (like cassandra_num_tokens)
+            "MAX_HEAP_SIZE": "512M",
+            "HEAP_NEWSIZE": "64M",
+        }
+
+    @cached_property
+    def parallel_startup(self):
+        return False
+
+    def node_setup(self, node, verbose=False, timeout=3600):
+        pass
+
+    def node_startup(self, node, verbose=False, timeout=3600):
+        pass
+
+    def get_scylla_args(self):
+        return ""
+
+    def update_seed_provider(self):
+        pass
+
+    def validate_seeds_on_all_nodes(self):
+        pass
+
+    def wait_for_nodes_up_and_normal(self, nodes=None, verification_node=None, iterations=60, sleep_time=3, timeout=0):
+        # TODO: implement using nodetool status or move to a shared Cassandra mixin
+        # that handles the Cassandra-specific status checking (UN state).
+        # For now, wait_for_init uses wait_db_up() which checks CQL connectivity.
+        pass
+
+    @cluster.wait_for_init_wrap
+    def wait_for_init(self, node_list=None, verbose=False, timeout=None, check_node_health=True):
+        node_list = node_list if node_list else self.nodes
+        for node in node_list:
+            node.wait_db_up(timeout=timeout or 300)
 
 
 class VectorStoreSetDocker(VectorStoreClusterMixin, DockerCluster):

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1484,6 +1484,15 @@ class SCTConfiguration(BaseModel):
     vector_store_version: String = SctField(
         description="Vector Store version / docker image tag",
     )
+    docker_image_cassandra: String = SctField(
+        description="Cassandra docker image repo, i.e. 'cassandra'. Used when db_type is 'cassandra'.",
+    )
+    cassandra_version: String = SctField(
+        description="Cassandra version / docker image tag, i.e. '4.1' or '5.0'",
+    )
+    cassandra_num_tokens: int = SctField(
+        description="num_tokens value to configure in cassandra.yaml.",
+    )
     # baremetal config options
     s3_baremetal_config: String = SctField(
         description="Configuration for S3 in baremetal setups. This includes details such as endpoint URL, access key, secret key, and bucket name.",
@@ -3629,7 +3638,10 @@ class SCTConfiguration(BaseModel):
         elif backend == "oci":
             options_must_exist += ["oci_image_db"]
         elif backend == "docker":
-            options_must_exist += ["docker_image"]
+            if self.get("db_type") == "cassandra":
+                options_must_exist += ["docker_image_cassandra"]
+            else:
+                options_must_exist += ["docker_image"]
         elif backend == "baremetal":
             options_must_exist += ["db_nodes_public_ip"]
         elif "k8s" in backend or backend == "xcloud":
@@ -4128,7 +4140,9 @@ class SCTConfiguration(BaseModel):
 
     def _validate_docker_backend_parameters(self):
         if self.get("use_mgmt"):
-            raise ValueError("Scylla Manager is not supported for docker backend")
+            raise ValueError(
+                "Scylla Manager is not supported for docker backend. Set 'use_mgmt: false' in your test config."
+            )
 
     def _verify_rackaware_configuration(self):
         if not self.get("rack_aware_loader"):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2063,13 +2063,23 @@ class ClusterTester(unittest.TestCase):
         )
         common_params = dict(user_prefix=self.params.get("user_prefix"), params=self.params)
 
-        self.db_cluster = cluster_docker.ScyllaDockerCluster(
-            n_nodes=[
-                self.params.get("n_db_nodes"),
-            ],
-            **container_node_params,
-            **common_params,
-        )
+        db_type = self.params.get("db_type")
+        if db_type == "cassandra":
+            self.db_cluster = cluster_docker.CassandraDockerCluster(
+                docker_image=self.params.get("docker_image_cassandra"),
+                docker_image_tag=self.params.get("cassandra_version"),
+                node_key_file=self.credentials[0].key_file,
+                n_nodes=[self.params.get("n_db_nodes")],
+                **common_params,
+            )
+        else:
+            self.db_cluster = cluster_docker.ScyllaDockerCluster(
+                n_nodes=[
+                    self.params.get("n_db_nodes"),
+                ],
+                **container_node_params,
+                **common_params,
+            )
 
         if self.params.get("n_vector_store_nodes") > 0:
             self.db_cluster.vector_store_cluster = cluster_docker.VectorStoreSetDocker(
@@ -2081,6 +2091,10 @@ class ClusterTester(unittest.TestCase):
                 node_key_file=self.credentials[0].key_file,
             )
 
+        # TODO: for Docker backend, loaders are Scylla containers used only as a Docker host
+        # to launch stress tool containers (RemoteDocker) via docker-in-docker.
+        # This is wasteful — stress containers could run directly on the host via LOCALRUNNER.
+        # See docs/plans/infrastructure/cassandra-cluster-support.md for refactor notes.
         self.loaders = cluster_docker.LoaderSetDocker(
             n_nodes=self.params.get("n_loaders"), **container_node_params, **common_params
         )

--- a/test-cases/cassandra-docker-provision-test.yaml
+++ b/test-cases/cassandra-docker-provision-test.yaml
@@ -7,7 +7,7 @@ docker_image_cassandra: 'cassandra'
 cassandra_version: '5.0'
 
 # Loaders still use a Scylla image (has cassandra-stress built in)
-scylla_version: '2025.3.0'
+scylla_version: '2026.1.0'
 
 user_prefix: 'cassandra-docker-test'
 use_mgmt: false

--- a/test-cases/cassandra-docker-provision-test.yaml
+++ b/test-cases/cassandra-docker-provision-test.yaml
@@ -1,0 +1,18 @@
+test_duration: 5
+n_db_nodes: 1
+n_loaders: 1
+
+db_type: cassandra
+docker_image_cassandra: 'cassandra'
+cassandra_version: '5.0'
+
+# Loaders still use a Scylla image (has cassandra-stress built in)
+scylla_version: '2025.3.0'
+
+user_prefix: 'cassandra-docker-test'
+use_mgmt: false
+
+# Cassandra does not expose the Scylla REST API (port 10000) used by CommitLogCheckThread
+run_commit_log_check_thread: false
+
+stress_cmd: ["cassandra-stress write cl=ONE duration=1m -schema 'replication(strategy=SimpleStrategy,replication_factor=1)' -mode cql3 native -rate threads=10 -pop seq=1..10000 -log interval=5"]

--- a/unit_tests/test_cassandra_docker_cluster.py
+++ b/unit_tests/test_cassandra_docker_cluster.py
@@ -1,0 +1,79 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdcm.cluster_docker import CassandraDockerCluster
+
+
+@pytest.fixture
+def mock_params():
+    params = MagicMock()
+    params.get.side_effect = lambda key, default=None: {
+        "cassandra_num_tokens": 16,
+        "docker_network": "test-network",
+        "user_prefix": "test",
+    }.get(key, default)
+    return params
+
+
+class TestCassandraEnvVars:
+    @patch.object(CassandraDockerCluster, "__init__", lambda self, **kw: None)
+    def test_single_node_env_vars(self, mock_params):
+        cluster = CassandraDockerCluster()
+        cluster.params = mock_params
+        cluster.name = "test-cs-cluster"
+
+        node = MagicMock()
+        env = cluster.cassandra_env_vars(node, seed_ip=None)
+
+        assert env["CASSANDRA_CLUSTER_NAME"] == cluster.name
+        assert env["CASSANDRA_SEEDS"] == ""
+        assert env["CASSANDRA_ENDPOINT_SNITCH"] == "SimpleSnitch"
+        assert env["CASSANDRA_NUM_TOKENS"] == "16"
+        assert env["MAX_HEAP_SIZE"] == "512M"
+        assert env["HEAP_NEWSIZE"] == "64M"
+
+    @patch.object(CassandraDockerCluster, "__init__", lambda self, **kw: None)
+    def test_second_node_gets_seed_ip(self, mock_params):
+        cluster = CassandraDockerCluster()
+        cluster.params = mock_params
+        cluster.name = "test-cs-cluster"
+
+        node = MagicMock()
+        env = cluster.cassandra_env_vars(node, seed_ip="172.17.0.2")
+
+        assert env["CASSANDRA_SEEDS"] == "172.17.0.2"
+
+    @patch.object(CassandraDockerCluster, "__init__", lambda self, **kw: None)
+    def test_custom_num_tokens(self, mock_params):
+        mock_params.get.side_effect = lambda key, default=None: {
+            "cassandra_num_tokens": 256,
+            "docker_network": "test-network",
+            "user_prefix": "test",
+        }.get(key, default)
+
+        cluster = CassandraDockerCluster()
+        cluster.params = mock_params
+        cluster.name = "test-cs-cluster"
+
+        node = MagicMock()
+        env = cluster.cassandra_env_vars(node, seed_ip=None)
+
+        assert env["CASSANDRA_NUM_TOKENS"] == "256"
+
+    @patch.object(CassandraDockerCluster, "__init__", lambda self, **kw: None)
+    def test_num_tokens_defaults_to_16_when_none(self, mock_params):
+        mock_params.get.side_effect = lambda key, default=None: {
+            "cassandra_num_tokens": None,
+            "docker_network": "test-network",
+            "user_prefix": "test",
+        }.get(key, default)
+
+        cluster = CassandraDockerCluster()
+        cluster.params = mock_params
+        cluster.name = "test-cs-cluster"
+
+        node = MagicMock()
+        env = cluster.cassandra_env_vars(node, seed_ip=None)
+
+        assert env["CASSANDRA_NUM_TOKENS"] == "16"

--- a/unit_tests/test_cassandra_docker_cluster.py
+++ b/unit_tests/test_cassandra_docker_cluster.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from sdcm.cluster_docker import CassandraDockerCluster
+from sdcm.cluster_docker import CassandraDockerCluster, CassandraYamlAttrProxy
 
 
 @pytest.fixture
@@ -16,64 +16,98 @@ def mock_params():
     return params
 
 
-class TestCassandraEnvVars:
-    @patch.object(CassandraDockerCluster, "__init__", lambda self, **kw: None)
-    def test_single_node_env_vars(self, mock_params):
-        cluster = CassandraDockerCluster()
-        cluster.params = mock_params
-        cluster.name = "test-cs-cluster"
+@pytest.fixture(autouse=True)
+def _patch_cluster_init():
+    with patch.object(CassandraDockerCluster, "__init__", lambda self, **kw: None):
+        yield
 
-        node = MagicMock()
-        env = cluster.cassandra_env_vars(node, seed_ip=None)
 
-        assert env["CASSANDRA_CLUSTER_NAME"] == cluster.name
-        assert env["CASSANDRA_SEEDS"] == ""
-        assert env["CASSANDRA_ENDPOINT_SNITCH"] == "SimpleSnitch"
-        assert env["CASSANDRA_NUM_TOKENS"] == "16"
-        assert env["MAX_HEAP_SIZE"] == "512M"
-        assert env["HEAP_NEWSIZE"] == "64M"
+@pytest.fixture
+def cassandra_cluster(mock_params):
+    cluster = CassandraDockerCluster()
+    cluster.params = mock_params
+    cluster.name = "test-cs-cluster"
+    return cluster
 
-    @patch.object(CassandraDockerCluster, "__init__", lambda self, **kw: None)
-    def test_second_node_gets_seed_ip(self, mock_params):
-        cluster = CassandraDockerCluster()
-        cluster.params = mock_params
-        cluster.name = "test-cs-cluster"
 
-        node = MagicMock()
-        env = cluster.cassandra_env_vars(node, seed_ip="172.17.0.2")
+def test_single_node_env_vars(cassandra_cluster):
+    node = MagicMock()
+    env = cassandra_cluster.cassandra_env_vars(node, seed_ip=None)
 
-        assert env["CASSANDRA_SEEDS"] == "172.17.0.2"
+    assert env["CASSANDRA_CLUSTER_NAME"] == cassandra_cluster.name
+    assert env["CASSANDRA_SEEDS"] == ""
+    assert env["CASSANDRA_ENDPOINT_SNITCH"] == "SimpleSnitch"
+    assert env["CASSANDRA_NUM_TOKENS"] == "16"
+    assert env["MAX_HEAP_SIZE"] == "512M"
+    assert env["HEAP_NEWSIZE"] == "64M"
 
-    @patch.object(CassandraDockerCluster, "__init__", lambda self, **kw: None)
-    def test_custom_num_tokens(self, mock_params):
-        mock_params.get.side_effect = lambda key, default=None: {
-            "cassandra_num_tokens": 256,
-            "docker_network": "test-network",
-            "user_prefix": "test",
-        }.get(key, default)
 
-        cluster = CassandraDockerCluster()
-        cluster.params = mock_params
-        cluster.name = "test-cs-cluster"
+def test_second_node_gets_seed_ip(cassandra_cluster):
+    node = MagicMock()
+    env = cassandra_cluster.cassandra_env_vars(node, seed_ip="172.17.0.2")
 
-        node = MagicMock()
-        env = cluster.cassandra_env_vars(node, seed_ip=None)
+    assert env["CASSANDRA_SEEDS"] == "172.17.0.2"
 
-        assert env["CASSANDRA_NUM_TOKENS"] == "256"
 
-    @patch.object(CassandraDockerCluster, "__init__", lambda self, **kw: None)
-    def test_num_tokens_defaults_to_16_when_none(self, mock_params):
-        mock_params.get.side_effect = lambda key, default=None: {
-            "cassandra_num_tokens": None,
-            "docker_network": "test-network",
-            "user_prefix": "test",
-        }.get(key, default)
+def test_custom_num_tokens(mock_params):
+    mock_params.get.side_effect = lambda key, default=None: {
+        "cassandra_num_tokens": 256,
+        "docker_network": "test-network",
+        "user_prefix": "test",
+    }.get(key, default)
 
-        cluster = CassandraDockerCluster()
-        cluster.params = mock_params
-        cluster.name = "test-cs-cluster"
+    cluster = CassandraDockerCluster()
+    cluster.params = mock_params
+    cluster.name = "test-cs-cluster"
 
-        node = MagicMock()
-        env = cluster.cassandra_env_vars(node, seed_ip=None)
+    node = MagicMock()
+    env = cluster.cassandra_env_vars(node, seed_ip=None)
 
-        assert env["CASSANDRA_NUM_TOKENS"] == "16"
+    assert env["CASSANDRA_NUM_TOKENS"] == "256"
+
+
+def test_num_tokens_defaults_to_16_when_none(mock_params):
+    mock_params.get.side_effect = lambda key, default=None: {
+        "cassandra_num_tokens": None,
+        "docker_network": "test-network",
+        "user_prefix": "test",
+    }.get(key, default)
+
+    cluster = CassandraDockerCluster()
+    cluster.params = mock_params
+    cluster.name = "test-cs-cluster"
+
+    node = MagicMock()
+    env = cluster.cassandra_env_vars(node, seed_ip=None)
+
+    assert env["CASSANDRA_NUM_TOKENS"] == "16"
+
+
+def test_yaml_attr_proxy_getattr():
+    data = {"broadcast_rpc_address": "10.0.0.1", "cluster_name": "test"}
+    proxy = CassandraYamlAttrProxy(data)
+
+    assert proxy.broadcast_rpc_address == "10.0.0.1"
+    assert proxy.cluster_name == "test"
+    assert proxy.nonexistent_key is None
+
+
+def test_yaml_attr_proxy_setattr():
+    data = {"cluster_name": "test"}
+    proxy = CassandraYamlAttrProxy(data)
+
+    proxy.broadcast_rpc_address = "10.0.0.2"
+    assert proxy.broadcast_rpc_address == "10.0.0.2"
+    assert data["broadcast_rpc_address"] == "10.0.0.2"
+
+    proxy.cluster_name = "updated"
+    assert data["cluster_name"] == "updated"
+
+
+def test_yaml_attr_proxy_model_dump():
+    data = {"key1": "val1", "key2": "val2"}
+    proxy = CassandraYamlAttrProxy(data)
+
+    dumped = proxy.model_dump()
+    assert dumped == {"key1": "val1", "key2": "val2"}
+    assert dumped is not data


### PR DESCRIPTION
## Summary

- Add `CassandraDockerNode`, `CassandraDockerCluster`, and `CassandraYamlAttrProxy` classes to run Cassandra as the DB backend in Docker mode
- Override all Scylla-specific code paths (parallel_startup, raft, nodetool, scylla.yaml → cassandra.yaml, seed validation, native transport check)
- Add `docker_image_cassandra`, `cassandra_version`, `cassandra_num_tokens` config parameters
- Route `_create_docker_cluster` to Cassandra cluster when `db_type: cassandra`

## Tested

Verified end-to-end with both Cassandra 4.1 and 5.0:
```
uv run sct.py run-test longevity_test.LongevityTest.test_custom_time \
  --backend docker --config test-cases/cassandra-docker-provision-test.yaml
```
Both versions pass (1 passed, 22 warnings).

## Test plan

- [x] Unit tests for `CassandraDockerCluster.cassandra_env_vars` pass
- [x] End-to-end Docker test with Cassandra 4.1 passes
- [x] End-to-end Docker test with Cassandra 5.0 passes
- [ ] Verify existing Scylla Docker tests still pass (no regression)
- [x] Run `uv run sct.py pre-commit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)