### PR TITLE
fix(xcloud): fix longevity test failure for AWS and GCE cloud providers

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -301,11 +301,11 @@ def provision_resources(backend, test_name: str, config: str):
             # 'cluster_backend' SCT config parameter to match the provider selected for cloud cluster.
             # This is only needed when provisioning resources is executed as a separate step of a test run
             if cloud_provider == "aws":
-                params.update({"cluster_backend": "aws", "xcloud_provisioning_mode": True})
+                params.update({"cluster_backend": "aws"})
                 try:
                     SCTProvisionLayout(params=params).provision()
                 finally:
-                    params.update({"cluster_backend": original_backend, "xcloud_provisioning_mode": False})
+                    params.update({"cluster_backend": original_backend})
         else:
             raise ValueError(f"backend {backend} is not supported")
     except Exception as exc:

--- a/sdcm/cluster_cloud.py
+++ b/sdcm/cluster_cloud.py
@@ -1110,7 +1110,7 @@ class ScyllaCloudCluster(cluster.BaseScyllaCluster, cluster.BaseCluster):
 
         return cluster_status, "\n" + "\n".join(diagnostic_lines)
 
-    def _wait_for_cluster_ready(self, timeout: int = 600) -> None:
+    def _wait_for_cluster_ready(self, timeout: int = 1200) -> None:
         self.log.info("Waiting for Scylla Cloud cluster to be ready")
 
         def check_cluster_status():

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -327,7 +327,9 @@ class GCECluster(cluster.BaseCluster):
         self._add_disks = add_disks
         # the full node prefix will contain unique uuid, so use this for search of existing nodes
         self._node_prefix = node_prefix.lower()
-        self._definition_builder = region_definition_builder.get_builder(params, test_config=self.test_config)
+        self._definition_builder = region_definition_builder.get_builder(
+            params, test_config=self.test_config, backend="gce"
+        )
         super().__init__(
             cluster_uuid=cluster_uuid,
             cluster_prefix=cluster_prefix,

--- a/sdcm/sct_provision/aws/layout.py
+++ b/sdcm/sct_provision/aws/layout.py
@@ -26,9 +26,7 @@ class SCTProvisionAWSLayout(SCTProvisionLayout, cluster_backend="aws"):
         return TestConfig()
 
     def provision(self):
-        use_scylla_cloud = self._params.get("cluster_backend") == "xcloud" or self._params.get(
-            "xcloud_provisioning_mode"
-        )
+        use_scylla_cloud = self._params.get("cluster_backend") == "xcloud" or self._params.get("xcloud_provider")
 
         if self.placement_group:
             self.placement_group.provision()

--- a/sdcm/sct_provision/region_definition_builder.py
+++ b/sdcm/sct_provision/region_definition_builder.py
@@ -183,7 +183,7 @@ class DefinitionBuilder(abc.ABC):
         n_monitor_nodes = self._get_node_count_for_each_region(self.params.get("n_monitor_nodes"))
 
         # skip DB node provisioning for Scylla Cloud
-        if self.params.get("cluster_backend") == "xcloud" or self.params.get("xcloud_provisioning_mode"):
+        if self.params.get("cluster_backend") == "xcloud" or self.params.get("xcloud_provider"):
             n_db_nodes = [0] * len(self.regions)
 
         for dc_idx, (region, db_nodes, loader_nodes, monitor_nodes) in enumerate(
@@ -250,9 +250,16 @@ class RegionDefinitionBuilder:
         Must be used before calling RegionDefinitionBuilder for given backend."""
         self._builder_classes[backend] = builder_class
 
-    def get_builder(self, params: SCTConfiguration, test_config: TestConfig) -> DefinitionBuilder:
+    def get_builder(self, params: SCTConfiguration, test_config: TestConfig, backend: str = None) -> DefinitionBuilder:
         """Creates RegionDefinition for each region based on SCTConfiguration.
 
-        Prior use, must register builder for given backend."""
-        backend = params.get("cluster_backend")
+        Args:
+            params: SCT configuration object.
+            test_config: Test configuration object.
+            backend: explicit backend key to select the builder.
+                Uses when the cluster class is known (e.g. GCECluster needs "gce"), but cluster_backend
+                configuration parameter may be set to something else (e.g. "xcloud").
+                When None, falls back to params.get("cluster_backend").
+        """
+        backend = backend or params.get("cluster_backend")
         return self._builder_classes[backend](params, test_config)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2460,7 +2460,7 @@ class ClusterTester(unittest.TestCase):
             self.monitors = NoMonitorSet()
             self.monitors_multitenant = [self.monitors]
 
-    def get_cluster_cloud(self, loader_info, db_info, monitor_info):  # noqa: PLR0912
+    def get_cluster_cloud(self, loader_info, db_info, monitor_info):  # noqa: PLR0912, PLR0914
         cloud_api_client = ScyllaCloudAPIClient(
             api_url=self.params.cloud_env_credentials["base_url"],
             auth_token=self.params.cloud_env_credentials["api_token"],
@@ -2570,13 +2570,26 @@ class ClusterTester(unittest.TestCase):
             if monitor_info["n_local_ssd"] is None:
                 monitor_info["n_local_ssd"] = self.params.get("gce_n_local_ssd_disk_monitor")
 
+            datacenters = gce_datacenter.split() if isinstance(gce_datacenter, str) else [gce_datacenter]
+            provisioners: List[GceProvisioner] = []
+            for datacenter in datacenters:
+                provisioners.append(
+                    provisioner_factory.create_provisioner(
+                        backend="gce",
+                        test_id=str(self.test_config.test_id()),
+                        region=datacenter,
+                        availability_zone=self.params.get("availability_zone"),
+                        network_name=self.params.get("gce_network"),
+                    )
+                )
+
             common_params = dict(
                 gce_image_username=self.params.get("gce_image_username"),
                 gce_network=self.params.get("gce_network"),
                 credentials=self.credentials,
                 user_prefix=user_prefix,
                 params=self.params,
-                gce_datacenter=gce_datacenter.split() if isinstance(gce_datacenter, str) else [gce_datacenter],
+                gce_datacenter=datacenters,
                 gce_service=get_gce_compute_instances_client(),
             )
 
@@ -2588,6 +2601,7 @@ class ClusterTester(unittest.TestCase):
                 gce_instance_type=loader_info["type"],
                 n_nodes=loader_info["n_nodes"],
                 add_disks=loader_additional_disks,
+                provisioners=provisioners,
                 **common_params,
             )
 
@@ -2602,6 +2616,7 @@ class ClusterTester(unittest.TestCase):
                     n_nodes=monitor_info["n_nodes"],
                     add_disks=monitor_additional_disks,
                     targets=dict(db_cluster=self.db_cluster, loaders=self.loaders),
+                    provisioners=provisioners,
                     **common_params,
                 )
             else:


### PR DESCRIPTION
- Replace xcloud_provisioning_mode (not a valid pydantic field) with xcloud_provider checks in provision layout and region definition builder.

This fixes regression introduced by the pydantic config migration.

- Add GCE provisioner creation in get_cluster_cloud() for loader and monitor sets, matching the pattern from get_cluster_gce().
- Add explicit backend parameter to RegionDefinitionBuilder.get_builder(), so the builder resolves correctly for cases of 'composed' backends like `xcloud` (where actual AWS/GCE cloud infra backends are used underneath).

These fix regression introduced by GCE provisioner support implementation.

Fixes: SCT-175
Fixes: QAINFRA-78
Fixes: QAINFRA-79

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [pr-provision-test on xcloud(aws)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test/256/)
- [x] :green_circle: [pr-provision-test on xcloud(gce)](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/pr-provision-test-new/247/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
