### PR TITLE
feature(scylla_yaml): add 'rack' as valid internode_compression value

### DIFF
--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -922,7 +922,7 @@ class NemesisRunner:
     def disrupt_rolling_config_change_internode_compression(self):
         def get_internode_compression_new_value_randomly(current_compression):
             self.log.debug(f"Current compression is {current_compression}")
-            values = ["dc", "all", None]
+            values = ["dc", "all", "rack", None]
             values_to_toggle = list(filter(lambda value: value != current_compression, values))
             return random.choice(values_to_toggle)
 

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -147,7 +147,7 @@ class ScyllaYaml(BaseModel):
     cross_node_timeout: bool = None  # False
     internode_send_buff_size_in_bytes: int = None  # 0
     internode_recv_buff_size_in_bytes: int = None  # 0
-    internode_compression: Literal["none", "all", "dc"] = None  # "none"
+    internode_compression: Literal["none", "all", "dc", "rack"] = None  # "none"
     internode_compression_enable_advanced: bool = None
     rpc_dict_training_when: Literal["always", "never", "when_leader"] = None
     rpc_dict_training_min_time_seconds: int = None


### PR DESCRIPTION
## Summary

- Add `"rack"` to the `Literal["none", "all", "dc"]` type for `internode_compression` in `ScyllaYaml`
- Add `"rack"` to the nemesis rolling-config-change toggle list (`disrupt_rolling_config_change_internode_compression`)
- Add `"rack"` to the functional test values list (`test_rolling_config_change_internode_compression`)

## ScyllaDB change

Refs: scylladb/scylladb#27099 — `messaging_service: Add internode_compression=rack as option`

## Testing

- [ ] [upgrade-scylla-k8s-gke-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/upgrade-scylla-k8s-gke-test/1)