### PR TITLE
feature: Decrypt sstable before uploading

### DIFF
--- a/docs/plans/mini-plans/2026-03-26-decrypt-sstables-before-collecting.md
+++ b/docs/plans/mini-plans/2026-03-26-decrypt-sstables-before-collecting.md
@@ -1,0 +1,51 @@
+# Mini-Plan: Decrypt SSTables Before Collecting
+
+**Date:** 2026-03-26
+**Estimated LOC:** ~350
+**Related Issue:** SCYLLADB-1243
+
+## Problem
+
+SCT collects corrupted/malformed sstables during tests for post-mortem investigation. Since most
+tests now run with encryption at rest enabled, the collected sstables are encrypted and unusable
+for debugging. We need to decrypt them before uploading to S3.
+
+## Approach
+
+- Add `strip_encryption_options_from_schema(schema_text)` helper in `sstable_utils.py` that
+  removes `scylla_encryption_options` lines from schema.cql content using regex
+- Add `decrypt_sstables_on_node(node, snapshot_path, keyspace, table)` function in
+  `sstable_utils.py` that:
+  1. Reads `schema.cql` from the snapshot directory
+  2. Strips `scylla_encryption_options` if present
+  3. Writes modified schema to a temp file on the node
+  4. Runs `scylla sstable upgrade --all --schema-file=<modified_schema> <sstable>
+     --output-dir=<temp>` for each Data.db file in the snapshot
+  5. Replaces original snapshot files with decrypted output
+  6. On any failure, logs warning and falls back to encrypted files (non-blocking)
+- Integrate into `SSTablesCollector.collect_logs()` — call after `nodetool snapshot`, before
+  `upload_remote_files_directly_to_s3()`
+- Integrate into `upload_sstables_to_s3()` — call after `nodetool snapshot`, before upload
+- Integrate into `SstablesValidator._upload_corrupted_files()` — take a snapshot first, then
+  decrypt, then upload
+- Add unit tests for `strip_encryption_options_from_schema()` logic
+
+## Files to Modify
+
+- `sdcm/utils/sstable/sstable_utils.py` -- Add `strip_encryption_options_from_schema()` and
+  `decrypt_sstables_on_node()`
+- `sdcm/logcollector.py` -- Call `decrypt_sstables_on_node()` in `SSTablesCollector.collect_logs()`
+  after snapshot, before S3 upload
+- `sdcm/utils/sstable/s3_uploader.py` -- Call `decrypt_sstables_on_node()` in
+  `upload_sstables_to_s3()` after snapshot, before S3 upload
+- `sdcm/teardown_validators/sstables.py` -- Add snapshot step and call decryption in
+  `_upload_corrupted_files()` before upload
+- `unit_tests/test_sstable_decrypt.py` -- (new) Unit tests for schema stripping
+
+## Verification
+
+- [ ] Unit tests pass: `uv run python -m pytest unit_tests/test_sstable_decrypt.py -v`
+- [ ] Full unit test suite passes: `uv run sct.py unit-tests`
+- [ ] `uv run sct.py pre-commit` passes
+- [ ] `strip_encryption_options_from_schema` correctly removes `scylla_encryption_options`
+- [ ] Decryption failure doesn't block sstable collection (fallback to encrypted)

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -102,6 +102,10 @@ class CollectingNode:
             "Name": self.name,
         }
 
+    def add_install_prefix(self, path: str) -> str:
+        """CollectingNode always connects to a standard Scylla install — no prefix needed."""
+        return path
+
     @cached_property
     def distro(self):
         LOGGER.debug("Trying to detect Linux distribution...")

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1377,41 +1377,6 @@ class JepsenLogCollector(LogCollector):
         return s3_link
 
 
-def resolve_snapshot_path(node: "CollectingNode", sstable_dir: str, keyspace: str, table_name: str) -> str | None:
-    """Return a snapshot path for *table_name* on *node*, or None if none can be found.
-
-    Tries ``nodetool snapshot`` first.  When that fails (e.g. the node has already been
-    destroyed), falls back to the most recent snapshot directory left on disk by
-    ``teardown_validators``.
-    """
-    try:
-        result = node.remoter.run(f"nodetool snapshot {keyspace} -cf {table_name}")
-        try:
-            snapshot_dir = result.stdout.split("Snapshot directory: ")[1].strip()
-            return f"{sstable_dir}/snapshots/{snapshot_dir}"
-        except IndexError:
-            LOGGER.error("Cannot extract snapshot directory from stdout: %s", result.stdout)
-    except Exception as snapshot_error:  # noqa: BLE001
-        LOGGER.warning(
-            "nodetool snapshot failed (node may be gone): %s — trying most recent existing snapshot",
-            snapshot_error,
-        )
-    # Node is unreachable — fall back to the most recent snapshot left by teardown_validators
-    existing = [
-        p.rstrip("/")
-        for p in node.remoter.run(
-            f"ls -td {sstable_dir}/snapshots/*/",
-            ignore_status=True,
-        ).stdout.split()
-        if p.strip()
-    ]
-    if not existing:
-        LOGGER.error("No existing snapshots found in %s/snapshots/ — cannot collect sstables", sstable_dir)
-        return None
-    LOGGER.info("Using existing snapshot: %s", existing[0])
-    return existing[0]
-
-
 class SSTablesCollector(BaseSCTLogCollector):
     """
     Collect corrupted sstables from db node.
@@ -1446,9 +1411,13 @@ class SSTablesCollector(BaseSCTLogCollector):
                     return []
             node: CollectingNode = [node for node in self.nodes if node.name == node_name][0]
             LOGGER.info("Collecting sstables for node %s...", node.name)
-            snapshot_path = resolve_snapshot_path(node, sstable_dir, keyspace, table_name)
-            if snapshot_path is None:
+            result = node.remoter.run(f"nodetool snapshot {keyspace} -cf {table_name}")
+            try:
+                snapshot_dir = result.stdout.split("Snapshot directory: ")[1].strip()
+            except IndexError:
+                LOGGER.error("Cannot extract snapshot directory from stdout: %s", result.stdout)
                 return []
+            snapshot_path = f"{sstable_dir}/snapshots/{snapshot_dir}"
             decrypted_path = decrypt_sstables_on_node(node, snapshot_path, keyspace=keyspace, table=table_name)
             s3_link = upload_remote_files_directly_to_s3(
                 node.ssh_login_info,

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1394,20 +1394,26 @@ class SSTablesCollector(BaseSCTLogCollector):
     def _load_state_from_file(self, state_file: Path):
         """Load snapshot state from a pre-computed JSON file written by CorruptedSstablesPreparator.
 
-        Returns ``(snapshot_path, decrypted_path, keyspace, table_name, sstable_name,
+        Returns ``(upload_files, decrypted_path, keyspace, table_name, sstable_name,
                    ssh_login_info, node=None)`` where *node* is always ``None`` in this path
         because SSH is not available after ``stop_resources()``.
+
+        *upload_files* is a targeted list of file paths (specific sstable components + schema.cql)
+        rather than the entire snapshot directory.  Falls back to ``[snapshot_path]`` for
+        state files written by older code that did not include the ``upload_files`` key.
         """
         state = json.loads(state_file.read_text(encoding="utf-8"))
         snapshot_path = state["snapshot_path"]
+        upload_files = state.get("upload_files") or [snapshot_path]
         decrypted_path = state.get("decrypted_path")
         LOGGER.info(
-            "SSTablesCollector: using pre-computed snapshot from state file (snapshot=%s, decrypted=%s)",
+            "SSTablesCollector: using pre-computed snapshot from state file (snapshot=%s, files=%d, decrypted=%s)",
             snapshot_path,
+            len(upload_files),
             decrypted_path,
         )
         return (
-            snapshot_path,
+            upload_files,
             decrypted_path,
             state["keyspace"],
             state["table_name"],
@@ -1419,8 +1425,12 @@ class SSTablesCollector(BaseSCTLogCollector):
     def _load_state_via_ssh(self, logdir: Path):
         """Fall back to the original SSH-based snapshot path.
 
-        Returns ``(snapshot_path, decrypted_path, keyspace, table_name, sstable_name,
+        Returns ``(upload_files, decrypted_path, keyspace, table_name, sstable_name,
                    ssh_login_info, node)`` or raises/returns ``None`` sentinel values on failure.
+
+        In this path *upload_files* is ``[snapshot_path]`` (the whole directory) because the
+        per-file targeting is done in ``collect_logs``'s fallback when the full upload exceeds
+        the size limit.
         """
         raw_events_file_path = logdir / EVENTS_LOG_DIR / RAW_EVENTS_LOG
         sstable_dir = keyspace = table_name = sstable_name = node_name = None
@@ -1446,7 +1456,7 @@ class SSTablesCollector(BaseSCTLogCollector):
             LOGGER.error("Cannot extract snapshot directory from stdout: %s", result.stdout)
             return None
         snapshot_path = f"{sstable_dir}/snapshots/{snapshot_dir}"
-        return snapshot_path, None, keyspace, table_name, sstable_name, node.ssh_login_info, node
+        return [snapshot_path], None, keyspace, table_name, sstable_name, node.ssh_login_info, node
 
     def collect_logs(self, local_search_path: Optional[str] = None) -> list[str]:
         try:
@@ -1462,11 +1472,11 @@ class SSTablesCollector(BaseSCTLogCollector):
                 loaded = self._load_state_via_ssh(logdir)
                 if loaded is None:
                     return []
-            snapshot_path, decrypted_path, keyspace, table_name, sstable_name, ssh_login_info, node = loaded
+            upload_files, decrypted_path, keyspace, table_name, sstable_name, ssh_login_info, node = loaded
 
             s3_link = upload_remote_files_directly_to_s3(
                 ssh_login_info,
-                [snapshot_path] + ([decrypted_path] if decrypted_path else []),
+                upload_files + ([decrypted_path] if decrypted_path else []),
                 s3_bucket=S3Storage.bucket_name,
                 s3_key=f"{self.test_id}/{self.current_run}/corrupted-sstables-{keyspace}-{table_name}.tar.gz",
                 max_size_gb=20,
@@ -1474,14 +1484,16 @@ class SSTablesCollector(BaseSCTLogCollector):
             )
             if not s3_link:
                 # upload malformed sstable along with several others and schema file
-                # node is only set in the fallback (no state file) path; the state-file path has
-                # no live SSH connection available, so we skip the per-file fallback in that case.
+                # node is only set in the fallback (no state file) path; the state-file path
+                # already has targeted files so the per-file fallback only applies to the
+                # SSH path where upload_files is [snapshot_path] (the whole directory).
                 if node is None:
                     LOGGER.warning(
-                        "SSTablesCollector: full-snapshot upload failed and no live node available — "
+                        "SSTablesCollector: upload failed and no live node available — "
                         "cannot fall back to per-file upload"
                     )
                 else:
+                    snapshot_path = upload_files[0]  # SSH path always has [snapshot_path]
                     malformed_files = node.remoter.run(
                         f"ls {snapshot_path}/{sstable_name.rsplit('-', 1)[0]}*", ignore_status=True
                     ).stdout.split()

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1377,6 +1377,41 @@ class JepsenLogCollector(LogCollector):
         return s3_link
 
 
+def resolve_snapshot_path(node: "CollectingNode", sstable_dir: str, keyspace: str, table_name: str) -> str | None:
+    """Return a snapshot path for *table_name* on *node*, or None if none can be found.
+
+    Tries ``nodetool snapshot`` first.  When that fails (e.g. the node has already been
+    destroyed), falls back to the most recent snapshot directory left on disk by
+    ``teardown_validators``.
+    """
+    try:
+        result = node.remoter.run(f"nodetool snapshot {keyspace} -cf {table_name}")
+        try:
+            snapshot_dir = result.stdout.split("Snapshot directory: ")[1].strip()
+            return f"{sstable_dir}/snapshots/{snapshot_dir}"
+        except IndexError:
+            LOGGER.error("Cannot extract snapshot directory from stdout: %s", result.stdout)
+    except Exception as snapshot_error:  # noqa: BLE001
+        LOGGER.warning(
+            "nodetool snapshot failed (node may be gone): %s — trying most recent existing snapshot",
+            snapshot_error,
+        )
+    # Node is unreachable — fall back to the most recent snapshot left by teardown_validators
+    existing = [
+        p.rstrip("/")
+        for p in node.remoter.run(
+            f"ls -td {sstable_dir}/snapshots/*/",
+            ignore_status=True,
+        ).stdout.split()
+        if p.strip()
+    ]
+    if not existing:
+        LOGGER.error("No existing snapshots found in %s/snapshots/ — cannot collect sstables", sstable_dir)
+        return None
+    LOGGER.info("Using existing snapshot: %s", existing[0])
+    return existing[0]
+
+
 class SSTablesCollector(BaseSCTLogCollector):
     """
     Collect corrupted sstables from db node.
@@ -1411,13 +1446,9 @@ class SSTablesCollector(BaseSCTLogCollector):
                     return []
             node: CollectingNode = [node for node in self.nodes if node.name == node_name][0]
             LOGGER.info("Collecting sstables for node %s...", node.name)
-            result = node.remoter.run(f"nodetool snapshot {keyspace} -cf {table_name}")
-            try:
-                snapshot_dir = result.stdout.split("Snapshot directory: ")[1].strip()
-            except IndexError:
-                LOGGER.error("Cannot extract snapshot directory from stdout: %s", result.stdout)
+            snapshot_path = resolve_snapshot_path(node, sstable_dir, keyspace, table_name)
+            if snapshot_path is None:
                 return []
-            snapshot_path = f"{sstable_dir}/snapshots/{snapshot_dir}"
             decrypted_path = decrypt_sstables_on_node(node, snapshot_path, keyspace=keyspace, table=table_name)
             s3_link = upload_remote_files_directly_to_s3(
                 node.ssh_login_info,

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -66,6 +66,7 @@ from sdcm.utils.decorators import retrying
 from sdcm.utils.docker_utils import get_docker_bridge_gateway
 from sdcm.utils.k8s import KubernetesOps
 from sdcm.utils.s3_remote_uploader import upload_remote_files_directly_to_s3
+from sdcm.utils.sstable.sstable_utils import decrypt_sstables_on_node
 from sdcm.utils.gce_utils import gce_public_addresses, gce_private_addresses
 from sdcm.localhost import LocalHost
 from sdcm.cloud_api_client import ScyllaCloudAPIClient
@@ -1413,9 +1414,10 @@ class SSTablesCollector(BaseSCTLogCollector):
                 LOGGER.error("Cannot extract snapshot directory from stdout: %s", result.stdout)
                 return []
             snapshot_path = f"{sstable_dir}/snapshots/{snapshot_dir}"
+            decrypted_path = decrypt_sstables_on_node(node, snapshot_path, keyspace=keyspace, table=table_name)
             s3_link = upload_remote_files_directly_to_s3(
                 node.ssh_login_info,
-                [snapshot_path],
+                [snapshot_path] + ([decrypted_path] if decrypted_path else []),
                 s3_bucket=S3Storage.bucket_name,
                 s3_key=f"{self.test_id}/{self.current_run}/corrupted-sstables-{keyspace}-{table_name}.tar.gz",
                 max_size_gb=20,

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -66,7 +66,7 @@ from sdcm.utils.decorators import retrying
 from sdcm.utils.docker_utils import get_docker_bridge_gateway
 from sdcm.utils.k8s import KubernetesOps
 from sdcm.utils.s3_remote_uploader import upload_remote_files_directly_to_s3
-from sdcm.utils.sstable.sstable_utils import decrypt_sstables_on_node
+from sdcm.utils.sstable.sstable_utils import CORRUPTED_SSTABLES_STATE_FILENAME
 from sdcm.utils.gce_utils import gce_public_addresses, gce_private_addresses
 from sdcm.localhost import LocalHost
 from sdcm.cloud_api_client import ScyllaCloudAPIClient
@@ -1391,36 +1391,81 @@ class SSTablesCollector(BaseSCTLogCollector):
         data_path, keyspace, table_dir, sstable_name = sstable_path.rsplit("/", 3)
         return f"{data_path}/{keyspace}/{table_dir}", keyspace, table_dir.split("-")[0], sstable_name
 
+    def _load_state_from_file(self, state_file: Path):
+        """Load snapshot state from a pre-computed JSON file written by CorruptedSstablesPreparator.
+
+        Returns ``(snapshot_path, decrypted_path, keyspace, table_name, sstable_name,
+                   ssh_login_info, node=None)`` where *node* is always ``None`` in this path
+        because SSH is not available after ``stop_resources()``.
+        """
+        state = json.loads(state_file.read_text(encoding="utf-8"))
+        snapshot_path = state["snapshot_path"]
+        decrypted_path = state.get("decrypted_path")
+        LOGGER.info(
+            "SSTablesCollector: using pre-computed snapshot from state file (snapshot=%s, decrypted=%s)",
+            snapshot_path,
+            decrypted_path,
+        )
+        return (
+            snapshot_path,
+            decrypted_path,
+            state["keyspace"],
+            state["table_name"],
+            state["sstable_name"],
+            state["ssh_login_info"],
+            None,  # node — no live SSH in this path
+        )
+
+    def _load_state_via_ssh(self, logdir: Path):
+        """Fall back to the original SSH-based snapshot path.
+
+        Returns ``(snapshot_path, decrypted_path, keyspace, table_name, sstable_name,
+                   ssh_login_info, node)`` or raises/returns ``None`` sentinel values on failure.
+        """
+        raw_events_file_path = logdir / EVENTS_LOG_DIR / RAW_EVENTS_LOG
+        sstable_dir = keyspace = table_name = sstable_name = node_name = None
+        with open(raw_events_file_path, "r", encoding="utf-8") as events_file:
+            for raw_line in events_file.readlines():
+                event = json.loads(raw_line)
+                if event.get("type") == "CORRUPTED_SSTABLE" and event.get("severity") == "CRITICAL":
+                    try:
+                        sstable_dir, keyspace, table_name, sstable_name = self.get_sstable_details(event.get("line"))
+                        node_name = event.get("node")
+                        break
+                    except IndexError:
+                        LOGGER.warning("Couldn't get sstable details from event line.")
+        if not node_name:
+            LOGGER.info("CORRUPTED_SSTABLE error event not found. Skipping sstables collection.")
+            return None
+        node = [n for n in self.nodes if n.name == node_name][0]
+        LOGGER.info("Collecting sstables for node %s...", node.name)
+        result = node.remoter.run(f"nodetool snapshot {keyspace} -cf {table_name}")
+        try:
+            snapshot_dir = result.stdout.split("Snapshot directory: ")[1].strip()
+        except IndexError:
+            LOGGER.error("Cannot extract snapshot directory from stdout: %s", result.stdout)
+            return None
+        snapshot_path = f"{sstable_dir}/snapshots/{snapshot_dir}"
+        return snapshot_path, None, keyspace, table_name, sstable_name, node.ssh_login_info, node
+
     def collect_logs(self, local_search_path: Optional[str] = None) -> list[str]:
         try:
-            raw_events_file_path = Path(self.local_dir).parent.parent.parent / EVENTS_LOG_DIR / RAW_EVENTS_LOG
-            with open(raw_events_file_path, "r", encoding="utf-8") as events_file:
-                for raw_line in events_file.readlines():
-                    event = json.loads(raw_line)
-                    if event.get("type") == "CORRUPTED_SSTABLE" and event.get("severity") == "CRITICAL":
-                        try:
-                            sstable_dir, keyspace, table_name, sstable_name = self.get_sstable_details(
-                                event.get("line")
-                            )
-                            node_name = event.get("node")
-                            break
-                        except IndexError:
-                            LOGGER.warning("Couldn't get sstable details from event line.")
-                else:
-                    LOGGER.info("CORRUPTED_SSTABLE error event not found. Skipping sstables collection.")
+            # CorruptedSstablesPreparator runs before stop_resources() and writes a state file
+            # with the snapshot path and decrypted path so we can skip all SSH calls here.
+            logdir = Path(self.local_dir).parent.parent.parent
+            state_file = logdir / CORRUPTED_SSTABLES_STATE_FILENAME
+            if state_file.exists():
+                loaded = self._load_state_from_file(state_file)
+            else:
+                # Fall back to the original SSH-based path (node may still be alive, e.g. in tests
+                # where post_behavior_db_nodes != destroy, or when the validator was disabled).
+                loaded = self._load_state_via_ssh(logdir)
+                if loaded is None:
                     return []
-            node: CollectingNode = [node for node in self.nodes if node.name == node_name][0]
-            LOGGER.info("Collecting sstables for node %s...", node.name)
-            result = node.remoter.run(f"nodetool snapshot {keyspace} -cf {table_name}")
-            try:
-                snapshot_dir = result.stdout.split("Snapshot directory: ")[1].strip()
-            except IndexError:
-                LOGGER.error("Cannot extract snapshot directory from stdout: %s", result.stdout)
-                return []
-            snapshot_path = f"{sstable_dir}/snapshots/{snapshot_dir}"
-            decrypted_path = decrypt_sstables_on_node(node, snapshot_path, keyspace=keyspace, table=table_name)
+            snapshot_path, decrypted_path, keyspace, table_name, sstable_name, ssh_login_info, node = loaded
+
             s3_link = upload_remote_files_directly_to_s3(
-                node.ssh_login_info,
+                ssh_login_info,
                 [snapshot_path] + ([decrypted_path] if decrypted_path else []),
                 s3_bucket=S3Storage.bucket_name,
                 s3_key=f"{self.test_id}/{self.current_run}/corrupted-sstables-{keyspace}-{table_name}.tar.gz",
@@ -1429,18 +1474,26 @@ class SSTablesCollector(BaseSCTLogCollector):
             )
             if not s3_link:
                 # upload malformed sstable along with several others and schema file
-                malformed_files = node.remoter.run(
-                    f"ls {snapshot_path}/{sstable_name.rsplit('-', 1)[0]}*", ignore_status=True
-                ).stdout.split()
-                recent_sstables = node.remoter.run(f"ls -t {snapshot_path}/m?-* | head -n30").stdout.split()
-                s3_link = upload_remote_files_directly_to_s3(
-                    node.ssh_login_info,
-                    malformed_files + recent_sstables + [f"{snapshot_path}/schema.cql"],
-                    s3_bucket=S3Storage.bucket_name,
-                    s3_key=f"{self.test_id}/{self.current_run}/corrupted-sstables-{keyspace}-{table_name}.tar.gz",
-                    max_size_gb=80,
-                    public_read_acl=True,
-                )
+                # node is only set in the fallback (no state file) path; the state-file path has
+                # no live SSH connection available, so we skip the per-file fallback in that case.
+                if node is None:
+                    LOGGER.warning(
+                        "SSTablesCollector: full-snapshot upload failed and no live node available — "
+                        "cannot fall back to per-file upload"
+                    )
+                else:
+                    malformed_files = node.remoter.run(
+                        f"ls {snapshot_path}/{sstable_name.rsplit('-', 1)[0]}*", ignore_status=True
+                    ).stdout.split()
+                    recent_sstables = node.remoter.run(f"ls -t {snapshot_path}/m?-* | head -n30").stdout.split()
+                    s3_link = upload_remote_files_directly_to_s3(
+                        ssh_login_info,
+                        malformed_files + recent_sstables + [f"{snapshot_path}/schema.cql"],
+                        s3_bucket=S3Storage.bucket_name,
+                        s3_key=f"{self.test_id}/{self.current_run}/corrupted-sstables-{keyspace}-{table_name}.tar.gz",
+                        max_size_gb=80,
+                        public_read_acl=True,
+                    )
         except Exception as error:
             LOGGER.exception("failed collecting malformed sstables:\n%s", error, exc_info=error)
             return []

--- a/sdcm/remote/remote_cmd_runner.py
+++ b/sdcm/remote/remote_cmd_runner.py
@@ -144,7 +144,10 @@ class RemoteCmdRunner(RemoteCmdRunnerBase, ssh_transport="fabric", default=True)
         if not suppress_errors:
             self.log.error(exc, exc_info=exc)
         self.ssh_is_up.clear()
-        if self._is_error_retryable(str(exc)):
+        # Always treat bare EOFError as retryable: paramiko raises EOFError() with no message when
+        # the SSH transport dies (see https://github.com/paramiko/paramiko/issues/1584).
+        # str(EOFError()) == "" so _is_error_retryable would return False, silently skipping retries.
+        if isinstance(exc, EOFError) or self._is_error_retryable(str(exc)):
             raise RetryableNetworkException(str(exc), original=exc)
         return True
 

--- a/sdcm/teardown_validators/__init__.py
+++ b/sdcm/teardown_validators/__init__.py
@@ -1,5 +1,5 @@
 from sdcm.teardown_validators.events import ErrorEventsValidator
 from sdcm.teardown_validators.rackaware import RackawareValidator
-from sdcm.teardown_validators.sstables import SstablesValidator
+from sdcm.teardown_validators.sstables import CorruptedSstablesPreparator, SstablesValidator
 
-teardown_validators_list = [SstablesValidator, ErrorEventsValidator, RackawareValidator]
+teardown_validators_list = [CorruptedSstablesPreparator, SstablesValidator, ErrorEventsValidator, RackawareValidator]

--- a/sdcm/teardown_validators/sstables.py
+++ b/sdcm/teardown_validators/sstables.py
@@ -14,6 +14,7 @@ from sdcm.teardown_validators.base import TeardownValidator
 from sdcm.utils.common import S3Storage
 from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.s3_remote_uploader import upload_remote_files_directly_to_s3
+from sdcm.utils.sstable.sstable_utils import decrypt_sstable_files_on_node, strip_encryption_options_from_schema
 
 LOGGER = logging.getLogger(__name__)
 
@@ -39,11 +40,67 @@ def severity_change_context():
         yield
 
 
+def table_dir_from_sstable_path(sstable: str) -> str | None:
+    """Extract the table directory (``/var/lib/scylla/data/<ks>/<table-dir>``) from an sstable path."""
+    clean = re.sub(r"/quarantine(/.*)?$", "", sstable)
+    parts = clean.rstrip("/").split("/")
+    # Expected structure: ['', 'var', 'lib', 'scylla', 'data', <ks>, <table-dir>, ...]
+    return "/".join(parts[:7]) if len(parts) >= 7 else None
+
+
+def decrypt_corrupted_sstables(node: BaseNode, corrupted_sstables: list[str]) -> list[str]:
+    """Take per-table snapshots to get schema.cql, then decrypt the corrupted Data.db files.
+
+    Returns a list of decrypted directory paths that should be included in the upload alongside
+    the original (encrypted) files.
+    """
+    snapshot_tag = "sct-scrub-decrypt"
+    # Map table_dir -> (keyspace, table_name) for each unique table touched
+    table_dir_info: dict[str, tuple[str, str]] = {}
+    for sstable in corrupted_sstables:
+        table_dir = table_dir_from_sstable_path(sstable)
+        if table_dir:
+            parts = table_dir.rstrip("/").split("/")
+            table_dir_info[table_dir] = (parts[5], parts[6].split("-")[0])
+
+    # Collect schema text per table dir, taking snapshots as needed
+    schema_by_table_dir: dict[str, str] = {}
+    for table_dir, (keyspace, table_name) in table_dir_info.items():
+        snap_result = node.remoter.run(
+            f"nodetool snapshot -t {snapshot_tag} -cf {table_name} -- {keyspace}",
+            ignore_status=True,
+        )
+        if snap_result.ok:
+            schema_path = f"{table_dir}/snapshots/{snapshot_tag}/schema.cql"
+            schema_result = node.remoter.run(f"cat {schema_path}", ignore_status=True, verbose=False)
+            if schema_result.ok and schema_result.stdout.strip():
+                schema_by_table_dir[table_dir] = strip_encryption_options_from_schema(schema_result.stdout)
+            node.remoter.run(f"nodetool clearsnapshot -t {snapshot_tag} {keyspace}", ignore_status=True)
+
+    # Group Data.db files by table_dir and decrypt each group
+    decrypted_dirs = []
+    for table_dir, schema_text in schema_by_table_dir.items():
+        keyspace, table_name = table_dir_info[table_dir]
+        data_files = [
+            s for s in corrupted_sstables if s.endswith("-Data.db") and table_dir_from_sstable_path(s) == table_dir
+        ]
+        if data_files:
+            decrypted_dir = decrypt_sstable_files_on_node(
+                node=node,
+                data_files=data_files,
+                schema_text=schema_text,
+                keyspace=keyspace,
+                table=table_name,
+            )
+            if decrypted_dir:
+                decrypted_dirs.append(decrypted_dir)
+    return decrypted_dirs
+
+
 class SstablesValidator(TeardownValidator):
     validator_name = "scrub"
 
-    @staticmethod
-    def _upload_corrupted_files(node: BaseNode, invalid_sstables_lines):
+    def _upload_corrupted_files(self, node: BaseNode, invalid_sstables_lines):
         # get corrupted sstables from lines:
         # INFO  2024-04-02 12:40:24,787 [shard 0:stre] sstable - Moving sstable /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/me-3gey_0z3c_2h5vl2ogebmg26ku9t-big-Data.db to "/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/quarantine"
         # scylla[5976]:  [shard 6:strm] compaction - Finished scrubbing in validate mode /var/lib/scylla/data/keyspace1/standard1-01b9f260d55311ef8caf5992914eabbe/me-3gn1_0bxv_16fs02rr7ufpbjejzy-big-Data.db - sstable is invalid"
@@ -54,9 +111,12 @@ class SstablesValidator(TeardownValidator):
                 corrupted_sstables.append(list(matches)[-1].group(0))
         # remove duplicates from corrupted_sstables
         corrupted_sstables = list(set(corrupted_sstables))
+
+        decrypted_dirs = decrypt_corrupted_sstables(node, corrupted_sstables)
+
         s3_link = upload_remote_files_directly_to_s3(
             node.ssh_login_info,
-            list(corrupted_sstables),
+            list(corrupted_sstables) + decrypted_dirs,
             s3_bucket=S3Storage.bucket_name,
             s3_key=f"{node.parent_cluster.uuid}/{node.name}-corrupted-sstables.tar.gz",
             max_size_gb=30,

--- a/sdcm/teardown_validators/sstables.py
+++ b/sdcm/teardown_validators/sstables.py
@@ -1,20 +1,28 @@
 from contextlib import ExitStack, contextmanager
+import json
 import logging
 import re
 from functools import partial
+from pathlib import Path
 
 from sdcm import wait
 from sdcm.cluster import BaseNode
 from sdcm.exceptions import WaitForTimeoutError
 from sdcm.sct_events import Severity
 from sdcm.sct_events.database import DatabaseLogEvent
+from sdcm.sct_events.events_device import EVENTS_LOG_DIR, RAW_EVENTS_LOG
 from sdcm.sct_events.filters import EventsSeverityChangerFilter
 from sdcm.sct_events.teardown_validators import ValidatorEvent, ScrubValidationErrorEvent
 from sdcm.teardown_validators.base import TeardownValidator
 from sdcm.utils.common import S3Storage
 from sdcm.utils.parallel_object import ParallelObject
 from sdcm.utils.s3_remote_uploader import upload_remote_files_directly_to_s3
-from sdcm.utils.sstable.sstable_utils import decrypt_sstable_files_on_node, strip_encryption_options_from_schema
+from sdcm.utils.sstable.sstable_utils import (
+    CORRUPTED_SSTABLES_STATE_FILENAME,
+    decrypt_sstables_on_node,
+    decrypt_sstable_files_on_node,
+    strip_encryption_options_from_schema,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -186,3 +194,125 @@ class SstablesValidator(TeardownValidator):
                 ValidatorEvent(
                     message=f"Error during nodetool scrub validation: {exc}", severity=Severity.ERROR
                 ).publish()
+
+
+CORRUPTED_SSTABLE_PATH_RE = re.compile(r"[./\w\-]+\.db")
+
+
+def find_corrupted_sstable_in_events(raw_events_file: Path):
+    """Scan the raw events log and return (sstable_dir, keyspace, table_name, sstable_name, node_name).
+
+    Returns a tuple of all-None values when no matching event is found.
+    """
+    with open(raw_events_file, "r", encoding="utf-8") as fh:
+        for raw_line in fh:
+            try:
+                event = json.loads(raw_line)
+            except json.JSONDecodeError:
+                continue
+            if event.get("type") == "CORRUPTED_SSTABLE" and event.get("severity") == "CRITICAL":
+                try:
+                    sstable_path = CORRUPTED_SSTABLE_PATH_RE.findall(event.get("line", ""))[0]
+                    data_path, ks, table_dir, sst_name = sstable_path.rsplit("/", 3)
+                    return (
+                        f"{data_path}/{ks}/{table_dir}",
+                        ks,
+                        table_dir.split("-")[0],
+                        sst_name,
+                        event.get("node"),
+                    )
+                except (IndexError, ValueError):
+                    LOGGER.warning("CorruptedSstablesPreparator: couldn't parse sstable path from event line")
+    return None, None, None, None, None
+
+
+def find_node_by_name(db_clusters_multitenant, node_name: str):
+    """Return the first node whose ``name`` matches *node_name*, or ``None``."""
+    for cluster in db_clusters_multitenant:
+        for node in cluster.nodes:
+            if node.name == node_name:
+                return node
+    return None
+
+
+def take_snapshot_and_decrypt(node, sstable_dir: str, keyspace: str, table_name: str):
+    """Run ``nodetool snapshot``, then decrypt the snapshot.  Return ``(snapshot_path, decrypted_path)``.
+
+    Raises on unexpected errors so the caller can catch and log.
+    """
+    result = node.remoter.run(
+        f"nodetool snapshot {keyspace} -cf {table_name}",
+        ignore_status=True,
+    )
+    if not result.ok:
+        LOGGER.warning("CorruptedSstablesPreparator: nodetool snapshot failed: %s — skipping", result.stderr)
+        return None, None
+    try:
+        snapshot_dir = result.stdout.split("Snapshot directory: ")[1].strip()
+    except IndexError:
+        LOGGER.error("CorruptedSstablesPreparator: cannot parse snapshot dir from stdout: %s", result.stdout)
+        return None, None
+    snapshot_path = f"{sstable_dir}/snapshots/{snapshot_dir}"
+    decrypted_path = decrypt_sstables_on_node(node, snapshot_path, keyspace=keyspace, table=table_name)
+    return snapshot_path, decrypted_path
+
+
+class CorruptedSstablesPreparator(TeardownValidator):
+    """Pre-snapshot and pre-decrypt corrupted sstables while the node is still alive.
+
+    Reads CORRUPTED_SSTABLE events from the raw events log, takes a ``nodetool snapshot`` of the
+    affected table on the relevant node, decrypts the sstables, and writes a JSON state file to
+    ``{logdir}/corrupted_sstables_snapshot.json``.
+
+    ``SSTablesCollector.collect_logs()`` reads that state file and only performs the upload,
+    avoiding any SSH calls after ``stop_resources()`` when the node may no longer be reachable.
+    """
+
+    validator_name = "corrupted_sstables_preparator"
+
+    def validate(self):
+        logdir = Path(self.tester.logdir)
+        state_file = logdir / CORRUPTED_SSTABLES_STATE_FILENAME
+        raw_events_file = logdir / EVENTS_LOG_DIR / RAW_EVENTS_LOG
+
+        if not raw_events_file.exists():
+            LOGGER.debug("CorruptedSstablesPreparator: raw events log not found at %s — skipping", raw_events_file)
+            return
+
+        sstable_dir, keyspace, table_name, sstable_name, node_name = find_corrupted_sstable_in_events(raw_events_file)
+        if not node_name:
+            LOGGER.info("CorruptedSstablesPreparator: no CORRUPTED_SSTABLE event found — nothing to prepare")
+            return
+
+        node = find_node_by_name(self.tester.db_clusters_multitenant, node_name)
+        if node is None:
+            LOGGER.warning("CorruptedSstablesPreparator: node %s not found in any cluster — skipping", node_name)
+            return
+
+        LOGGER.info(
+            "CorruptedSstablesPreparator: taking snapshot for %s.%s on node %s", keyspace, table_name, node_name
+        )
+        try:
+            snapshot_path, decrypted_path = take_snapshot_and_decrypt(node, sstable_dir, keyspace, table_name)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("CorruptedSstablesPreparator: unexpected error — skipping. Error: %s", exc)
+            return
+        if snapshot_path is None:
+            return
+
+        state = {
+            "snapshot_path": snapshot_path,
+            "decrypted_path": decrypted_path,
+            "keyspace": keyspace,
+            "table_name": table_name,
+            "sstable_name": sstable_name,
+            "node_name": node_name,
+            "ssh_login_info": node.ssh_login_info,
+        }
+        state_file.write_text(json.dumps(state), encoding="utf-8")
+        LOGGER.info(
+            "CorruptedSstablesPreparator: state written to %s (snapshot=%s, decrypted=%s)",
+            state_file,
+            snapshot_path,
+            decrypted_path,
+        )

--- a/sdcm/teardown_validators/sstables.py
+++ b/sdcm/teardown_validators/sstables.py
@@ -265,10 +265,15 @@ def find_node_by_name(db_clusters_multitenant, node_name: str):
     return None
 
 
-def take_snapshot_and_decrypt(node, sstable_dir: str, keyspace: str, table_name: str):
-    """Run ``nodetool snapshot``, then decrypt the snapshot.  Return ``(snapshot_path, decrypted_path)``.
+def take_snapshot_and_decrypt(node, sstable_dir: str, keyspace: str, table_name: str, sstable_name: str):
+    """Take a snapshot, find the corrupted sstable within it, and decrypt.
 
-    Raises on unexpected errors so the caller can catch and log.
+    Instead of uploading the entire snapshot directory (which can be hundreds of GBs for large
+    tables), this function targets only the specific corrupted sstable's component files within
+    the snapshot — the same approach the old ``SSTablesCollector`` fallback used.
+
+    Returns ``(snapshot_path, sstable_files, decrypted_path)`` where *sstable_files* is a list
+    of absolute paths to the corrupted sstable's component files inside the snapshot.
     """
     result = node.remoter.run(
         f"nodetool snapshot {keyspace} -cf {table_name}",
@@ -276,15 +281,36 @@ def take_snapshot_and_decrypt(node, sstable_dir: str, keyspace: str, table_name:
     )
     if not result.ok:
         LOGGER.warning("CorruptedSstablesPreparator: nodetool snapshot failed: %s — skipping", result.stderr)
-        return None, None
+        return None, [], None
     try:
         snapshot_dir = result.stdout.split("Snapshot directory: ")[1].strip()
     except IndexError:
         LOGGER.error("CorruptedSstablesPreparator: cannot parse snapshot dir from stdout: %s", result.stdout)
-        return None, None
+        return None, [], None
+
     snapshot_path = f"{sstable_dir}/snapshots/{snapshot_dir}"
+
+    # Find the specific corrupted sstable's component files within the snapshot.
+    # An sstable name like "ms-3gzg_0wzh_...-big-Data.db" shares a prefix
+    # "ms-3gzg_0wzh_...-big" with all its components (Filter.db, Statistics.db, etc.).
+    prefix = sstable_name.rsplit("-", 1)[0]
+    ls_result = node.remoter.run(
+        f"ls {snapshot_path}/{prefix}-* 2>/dev/null || true",
+        ignore_status=True,
+        verbose=False,
+    )
+    sstable_files = ls_result.stdout.split() if ls_result.stdout.strip() else []
+
+    if not sstable_files:
+        LOGGER.warning(
+            "CorruptedSstablesPreparator: corrupted sstable %s not found in snapshot %s "
+            "(it may have been quarantined before the snapshot was taken)",
+            sstable_name,
+            snapshot_path,
+        )
+
     decrypted_path = decrypt_sstables_on_node(node, snapshot_path, keyspace=keyspace, table=table_name)
-    return snapshot_path, decrypted_path
+    return snapshot_path, sstable_files, decrypted_path
 
 
 class CorruptedSstablesPreparator(TeardownValidator):
@@ -323,15 +349,21 @@ class CorruptedSstablesPreparator(TeardownValidator):
             "CorruptedSstablesPreparator: taking snapshot for %s.%s on node %s", keyspace, table_name, node_name
         )
         try:
-            snapshot_path, decrypted_path = take_snapshot_and_decrypt(node, sstable_dir, keyspace, table_name)
+            snapshot_path, sstable_files, decrypted_path = take_snapshot_and_decrypt(
+                node, sstable_dir, keyspace, table_name, sstable_name
+            )
         except Exception as exc:  # noqa: BLE001
             LOGGER.warning("CorruptedSstablesPreparator: unexpected error — skipping. Error: %s", exc)
             return
         if snapshot_path is None:
             return
 
+        # Build the targeted file list for upload: schema.cql + corrupted sstable components + decrypted dir.
+        # This avoids uploading the entire snapshot directory which can be hundreds of GBs.
+        upload_files = sstable_files + [f"{snapshot_path}/schema.cql"]
         state = {
             "snapshot_path": snapshot_path,
+            "upload_files": upload_files,
             "decrypted_path": decrypted_path,
             "keyspace": keyspace,
             "table_name": table_name,
@@ -341,8 +373,9 @@ class CorruptedSstablesPreparator(TeardownValidator):
         }
         state_file.write_text(json.dumps(state), encoding="utf-8")
         LOGGER.info(
-            "CorruptedSstablesPreparator: state written to %s (snapshot=%s, decrypted=%s)",
+            "CorruptedSstablesPreparator: state written to %s (snapshot=%s, files=%d, decrypted=%s)",
             state_file,
             snapshot_path,
+            len(upload_files),
             decrypted_path,
         )

--- a/sdcm/teardown_validators/sstables.py
+++ b/sdcm/teardown_validators/sstables.py
@@ -199,8 +199,32 @@ class SstablesValidator(TeardownValidator):
 CORRUPTED_SSTABLE_PATH_RE = re.compile(r"[./\w\-]+\.db")
 
 
+def _parse_sstable_path(sstable_path: str):
+    """Parse a ``.db`` sstable path into ``(sstable_dir, keyspace, table_name, sstable_name)``.
+
+    Returns ``None`` when the path does not have the expected Scylla data layout
+    (``/var/lib/scylla/data/<ks>/<table-dir>/<component>.db``).
+    """
+    parts = sstable_path.rsplit("/", 3)
+    if len(parts) != 4:
+        return None
+    data_path, ks, table_dir, sst_name = parts
+    # Sanity-check: ks and table_dir must be non-empty and table_dir must contain a UUID
+    # separator (e.g. "standard1-01b9f260d55311ef8caf5992914eabbe").
+    if not ks or "-" not in table_dir:
+        return None
+    return f"{data_path}/{ks}/{table_dir}", ks, table_dir.split("-")[0], sst_name
+
+
 def find_corrupted_sstable_in_events(raw_events_file: Path):
     """Scan the raw events log and return (sstable_dir, keyspace, table_name, sstable_name, node_name).
+
+    Iterates all ``.db`` path matches in the event line (last match first) so that the correct
+    Scylla data path is selected even when the line contains multiple ``.db`` references.
+
+    Only the **first** ``CORRUPTED_SSTABLE`` event is processed.  If multiple tables or nodes
+    have corrupted sstables, only the first discovered event is prepared for upload.  This matches
+    the behavior of ``SSTablesCollector`` which also handles a single corrupted-sstables state file.
 
     Returns a tuple of all-None values when no matching event is found.
     """
@@ -211,18 +235,24 @@ def find_corrupted_sstable_in_events(raw_events_file: Path):
             except json.JSONDecodeError:
                 continue
             if event.get("type") == "CORRUPTED_SSTABLE" and event.get("severity") == "CRITICAL":
-                try:
-                    sstable_path = CORRUPTED_SSTABLE_PATH_RE.findall(event.get("line", ""))[0]
-                    data_path, ks, table_dir, sst_name = sstable_path.rsplit("/", 3)
-                    return (
-                        f"{data_path}/{ks}/{table_dir}",
-                        ks,
-                        table_dir.split("-")[0],
-                        sst_name,
-                        event.get("node"),
+                matches = CORRUPTED_SSTABLE_PATH_RE.findall(event.get("line", ""))
+                # Try matches in reverse order: the actual sstable path is typically the
+                # last .db reference in the log line (after error-description text).
+                for candidate in reversed(matches):
+                    parsed = _parse_sstable_path(candidate)
+                    if parsed is not None:
+                        sstable_dir, ks, table_name, sst_name = parsed
+                        return sstable_dir, ks, table_name, sst_name, event.get("node")
+                if matches:
+                    LOGGER.warning(
+                        "CorruptedSstablesPreparator: found .db paths but none matched Scylla data layout: %s",
+                        matches,
                     )
-                except (IndexError, ValueError):
-                    LOGGER.warning("CorruptedSstablesPreparator: couldn't parse sstable path from event line")
+                else:
+                    LOGGER.warning(
+                        "CorruptedSstablesPreparator: no .db path found in event line: %s",
+                        event.get("line", "")[:200],
+                    )
     return None, None, None, None, None
 
 

--- a/sdcm/utils/sstable/s3_uploader.py
+++ b/sdcm/utils/sstable/s3_uploader.py
@@ -5,6 +5,7 @@ from sdcm.cluster import BaseNode
 from sdcm.logcollector import CollectingNode
 from sdcm.utils.common import S3Storage
 from sdcm.utils.s3_remote_uploader import upload_remote_files_directly_to_s3
+from sdcm.utils.sstable.sstable_utils import decrypt_sstables_on_node
 
 LOGGER = logging.getLogger(__name__)
 
@@ -26,9 +27,18 @@ def upload_sstables_to_s3(
     try:
         node.remoter.run(nodetool_snapshot_cmd)
         snapshot_paths = node.remoter.run(f"find {data_directory} -type d -name {snapshot_tag}").stdout.split()
+        upload_paths = []
+        for snapshot_path in snapshot_paths:
+            # snapshot_path is .../data/{keyspace}/{table}-{uuid}/snapshots/{tag}
+            table_dir = snapshot_path.split("/snapshots/")[0]
+            table_name = table_dir.rsplit("/", 1)[1].rsplit("-", 1)[0]
+            upload_paths.append(snapshot_path)
+            decrypted_path = decrypt_sstables_on_node(node, snapshot_path, keyspace=keyspace, table=table_name)
+            if decrypted_path:
+                upload_paths.append(decrypted_path)
         s3_link = upload_remote_files_directly_to_s3(
             node.ssh_login_info,
-            snapshot_paths,
+            upload_paths,
             s3_bucket=S3Storage.bucket_name,
             s3_key=f"{test_id}/{snapshot_date}/sstables-{snapshot_date}-{node.name}-{keyspace}.tar.gz",
             max_size_gb=400,

--- a/sdcm/utils/sstable/sstable_utils.py
+++ b/sdcm/utils/sstable/sstable_utils.py
@@ -12,6 +12,8 @@ from sdcm.exceptions import SstablesNotFound
 
 LOGGER = logging.getLogger(__name__)
 
+CORRUPTED_SSTABLES_STATE_FILENAME = "corrupted_sstables_snapshot.json"
+
 
 class NonDeletedTombstonesFound(Exception):
     pass

--- a/sdcm/utils/sstable/sstable_utils.py
+++ b/sdcm/utils/sstable/sstable_utils.py
@@ -447,20 +447,46 @@ def get_sstable_data_dump_command(node, keyspace: str, table: str) -> str:
     return _generate_sstable_dump_command(node, "dump-data", keyspace, table)
 
 
-# Matches a full CQL property assignment for scylla_encryption_options, e.g.:
-#   AND scylla_encryption_options = {'cipher_algorithm': '...', ...}
-# The pattern is tolerant of multi-line values (the value part is always on one line in practice,
-# but the leading AND keyword may be preceded by spaces/newlines).
-ENCRYPTION_OPTIONS_RE = re.compile(r"\s+AND\s+scylla_encryption_options\s*=\s*\{[^}]*\}", re.IGNORECASE)
+# Pattern 1: ``WITH scylla_encryption_options = {...} AND ...`` — the property is the first
+# after WITH and is followed by at least one more property.  We strip the property *and* the
+# trailing AND, leaving ``WITH <next_property>``.
+_ENC_WITH_THEN_AND_RE = re.compile(
+    r"(\bWITH)\s+scylla_encryption_options\s*=\s*\{[^}]*\}\s+AND\b",
+    re.IGNORECASE,
+)
+
+# Pattern 2: ``... AND scylla_encryption_options = {...}`` — the property appears after another
+# property.  We strip the leading AND and the entire property clause.
+_ENC_AND_RE = re.compile(
+    r"\s+AND\s+scylla_encryption_options\s*=\s*\{[^}]*\}",
+    re.IGNORECASE,
+)
+
+# Pattern 3: ``WITH scylla_encryption_options = {...}`` as the *only* property — no AND before
+# or after.  We strip ``WITH <clause>`` entirely.  Scylla's schema.cql normally has many
+# properties so this is rare, but it can happen with minimal CREATE TABLE statements.
+_ENC_WITH_ONLY_RE = re.compile(
+    r"\s+WITH\s+scylla_encryption_options\s*=\s*\{[^}]*\}",
+    re.IGNORECASE,
+)
 
 
 def strip_encryption_options_from_schema(schema_text: str) -> str:
     """Remove ``scylla_encryption_options`` property assignments from a schema.cql string.
 
-    When sstables are encrypted at the table level, the snapshot's ``schema.cql`` contains an
-    ``AND scylla_encryption_options = {...}`` clause.  Passing such a schema to
-    ``scylla sstable upgrade`` would produce encrypted output.  This helper strips the clause so
-    that the upgrade tool writes plain (unencrypted) sstables.
+    When sstables are encrypted at the table level, the snapshot's ``schema.cql`` contains a
+    ``scylla_encryption_options = {...}`` clause (preceded by ``WITH`` or ``AND``).  Passing such
+    a schema to ``scylla sstable upgrade`` would produce encrypted output.  This helper strips
+    the clause so that the upgrade tool writes plain (unencrypted) sstables.
+
+    Handles three layouts:
+
+    1. ``WITH scylla_encryption_options = {...} AND next_prop``
+       → ``WITH next_prop``
+    2. ``WITH other_prop AND scylla_encryption_options = {...}``
+       → ``WITH other_prop``
+    3. ``WITH scylla_encryption_options = {...}`` (sole property)
+       → property + WITH keyword removed
 
     Args:
         schema_text: Raw text of a ``schema.cql`` file.
@@ -468,7 +494,14 @@ def strip_encryption_options_from_schema(schema_text: str) -> str:
     Returns:
         Schema text with all ``scylla_encryption_options`` clauses removed.
     """
-    return ENCRYPTION_OPTIONS_RE.sub("", schema_text)
+    # Order matters: try the most specific pattern first.
+    # Pattern 1: WITH <enc> AND ... → WITH ...
+    result = _ENC_WITH_THEN_AND_RE.sub(r"\1", schema_text)
+    # Pattern 2: ... AND <enc>
+    result = _ENC_AND_RE.sub("", result)
+    # Pattern 3: WITH <enc> (sole property — no AND on either side)
+    result = _ENC_WITH_ONLY_RE.sub("", result)
+    return result
 
 
 def decrypt_sstables_on_node(node, snapshot_path: str, keyspace: str, table: str) -> str | None:

--- a/sdcm/utils/sstable/sstable_utils.py
+++ b/sdcm/utils/sstable/sstable_utils.py
@@ -1,12 +1,16 @@
+import base64
 import datetime
 import json
 import logging
 import random
+import re
 from pathlib import Path
 
 from sdcm.paths import SCYLLA_YAML_PATH
 from sdcm.utils.version_utils import ComparableScyllaVersion
 from sdcm.exceptions import SstablesNotFound
+
+LOGGER = logging.getLogger(__name__)
 
 
 class NonDeletedTombstonesFound(Exception):
@@ -439,3 +443,196 @@ def get_sstable_data_dump_command(node, keyspace: str, table: str) -> str:
     if not is_new_sstable_dump_supported(node):
         return "sstabledump"
     return _generate_sstable_dump_command(node, "dump-data", keyspace, table)
+
+
+# Matches a full CQL property assignment for scylla_encryption_options, e.g.:
+#   AND scylla_encryption_options = {'cipher_algorithm': '...', ...}
+# The pattern is tolerant of multi-line values (the value part is always on one line in practice,
+# but the leading AND keyword may be preceded by spaces/newlines).
+ENCRYPTION_OPTIONS_RE = re.compile(r"\s+AND\s+scylla_encryption_options\s*=\s*\{[^}]*\}", re.IGNORECASE)
+
+
+def strip_encryption_options_from_schema(schema_text: str) -> str:
+    """Remove ``scylla_encryption_options`` property assignments from a schema.cql string.
+
+    When sstables are encrypted at the table level, the snapshot's ``schema.cql`` contains an
+    ``AND scylla_encryption_options = {...}`` clause.  Passing such a schema to
+    ``scylla sstable upgrade`` would produce encrypted output.  This helper strips the clause so
+    that the upgrade tool writes plain (unencrypted) sstables.
+
+    Args:
+        schema_text: Raw text of a ``schema.cql`` file.
+
+    Returns:
+        Schema text with all ``scylla_encryption_options`` clauses removed.
+    """
+    return ENCRYPTION_OPTIONS_RE.sub("", schema_text)
+
+
+def decrypt_sstables_on_node(node, snapshot_path: str, keyspace: str, table: str) -> str | None:
+    """Decrypt all sstables in *snapshot_path* into a sibling ``decrypted/`` subdirectory.
+
+    Reads ``schema.cql`` from *snapshot_path*, strips any ``scylla_encryption_options`` clause,
+    and runs ``scylla sstable upgrade`` once for all ``Data.db`` files found, writing output to
+    ``{snapshot_path}/decrypted/``.  The original encrypted files are left untouched so both
+    versions are available for upload.
+
+    On any error the function logs a warning and returns ``None`` without raising, so sstable
+    collection is never blocked by a decryption failure.
+
+    Args:
+        node: A DB / collecting node that has ``remoter`` and ``add_install_prefix`` attributes.
+        snapshot_path: Remote absolute path to the snapshot directory (contains ``schema.cql``
+            and ``*.db`` files).
+        keyspace: Keyspace name of the table whose sstables are being decrypted.
+        table: Table name of the sstables being decrypted.
+
+    Returns:
+        Path to the ``decrypted/`` directory on success, ``None`` otherwise.
+    """
+    try:
+        schema_result = node.remoter.run(f"cat {snapshot_path}/schema.cql", ignore_status=True, verbose=False)
+        if not schema_result.ok or not schema_result.stdout.strip():
+            LOGGER.warning(
+                "decrypt_sstables_on_node: schema.cql not found or empty at %s/schema.cql — skipping decryption",
+                snapshot_path,
+            )
+            return None
+
+        ls_result = node.remoter.run(
+            f"ls {snapshot_path}/*-Data.db 2>/dev/null || true", ignore_status=True, verbose=False
+        )
+        data_files = ls_result.stdout.split() if ls_result.stdout.strip() else []
+
+        if not data_files:
+            LOGGER.debug("decrypt_sstables_on_node: no Data.db files found in %s — nothing to decrypt", snapshot_path)
+            return None
+
+        return run_scylla_sstable_upgrade(
+            node=node,
+            data_files=data_files,
+            schema_text=strip_encryption_options_from_schema(schema_result.stdout),
+            keyspace=keyspace,
+            table=table,
+            output_dir=f"{snapshot_path}/decrypted",
+        )
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning(
+            "decrypt_sstables_on_node: unexpected error for %s — skipping decryption. Error: %s",
+            snapshot_path,
+            exc,
+        )
+        return None
+
+
+def decrypt_sstable_files_on_node(
+    node, data_files: list[str], schema_text: str, keyspace: str, table: str
+) -> str | None:
+    """Decrypt *data_files* into a sibling ``decrypted/`` subdirectory next to the first file.
+
+    Accepts explicit file paths and a schema string rather than reading them from a snapshot
+    directory.  Use this when the sstables to decrypt are not in a snapshot (e.g. quarantined or
+    invalidated files found by scrub).
+
+    On any error the function logs a warning and returns ``None`` without raising.
+
+    Args:
+        node: A DB / collecting node that has ``remoter`` and ``add_install_prefix`` attributes.
+        data_files: List of remote absolute paths to ``Data.db`` files to decrypt.
+        schema_text: Raw CQL schema text (will have ``scylla_encryption_options`` stripped
+            automatically).
+        keyspace: Keyspace name of the table whose sstables are being decrypted.
+        table: Table name of the sstables being decrypted.
+
+    Returns:
+        Path to the ``decrypted/`` directory on success, ``None`` otherwise.
+    """
+    if not data_files:
+        return None
+    try:
+        parent_dir = data_files[0].rsplit("/", 1)[0]
+        return run_scylla_sstable_upgrade(
+            node=node,
+            data_files=data_files,
+            schema_text=strip_encryption_options_from_schema(schema_text),
+            keyspace=keyspace,
+            table=table,
+            output_dir=f"{parent_dir}/decrypted",
+        )
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning(
+            "decrypt_sstable_files_on_node: unexpected error for %s — skipping decryption. Error: %s",
+            data_files,
+            exc,
+        )
+        return None
+
+
+def run_scylla_sstable_upgrade(
+    node, data_files: list[str], schema_text: str, keyspace: str, table: str, output_dir: str
+) -> str | None:
+    """Run ``scylla sstable upgrade`` for *data_files* and write output to *output_dir*.
+
+    The output directory is created fresh (any prior contents are removed).  Original files are
+    left untouched.  Both encrypted originals and decrypted output are kept so callers can upload
+    both directories.
+
+    Args:
+        node: Node with ``remoter`` and ``add_install_prefix``.
+        data_files: Remote paths to ``Data.db`` files.
+        schema_text: Schema CQL text (already stripped of encryption options).
+        keyspace: Keyspace name, passed to ``--keyspace``.
+        table: Table name, passed to ``--table``.
+        output_dir: Destination directory for upgraded files (created fresh).
+
+    Returns:
+        *output_dir* on success, ``None`` if the upgrade failed or produced no files.
+    """
+    tmp_id = abs(hash(data_files[0])) % 10**8
+    tmp_schema = f"/tmp/sct_decrypt_schema_{tmp_id}.cql"
+    # Use base64 to write the schema file so that special characters, newlines, and
+    # shell-quoting in the schema text do not interfere with the remote shell invocation.
+    schema_b64 = base64.b64encode(schema_text.encode()).decode()
+    node.remoter.run(
+        f"echo {schema_b64} | base64 -d > {tmp_schema}",
+        ignore_status=False,
+        verbose=False,
+    )
+
+    node.remoter.sudo(f"rm -rf {output_dir}", ignore_status=False, verbose=False)
+    node.remoter.sudo(f"mkdir -p {output_dir}", ignore_status=False, verbose=False)
+
+    scylla_conf_dir = str(Path(node.add_install_prefix(SCYLLA_YAML_PATH)).parent)
+    scylla_bin = node.add_install_prefix("/usr/bin/scylla")
+    sstables_args = " ".join(f"--sstables {f}" for f in data_files)
+
+    result = node.remoter.sudo(
+        f"SCYLLA_CONF={scylla_conf_dir} {scylla_bin} sstable upgrade"
+        f" --all --keyspace {keyspace} --table {table}"
+        f" --schema-file={tmp_schema} {sstables_args} --output-dir={output_dir}",
+        ignore_status=True,
+        verbose=True,
+    )
+    node.remoter.run(f"rm -f {tmp_schema}", ignore_status=True, verbose=False)
+
+    if not result.ok:
+        LOGGER.warning(
+            "run_scylla_sstable_upgrade: upgrade failed (exit %s):\n  stdout: %s\n  stderr: %s",
+            result.exit_status,
+            result.stdout.strip() or "<empty>",
+            result.stderr.strip() or "<empty>",
+        )
+        return None
+
+    ls_out = node.remoter.sudo(f"ls {output_dir}/", ignore_status=True, verbose=False)
+    if not ls_out.stdout.strip():
+        LOGGER.warning(
+            "run_scylla_sstable_upgrade: upgrade reported success but produced no output files"
+            " — stdout: %s  stderr: %s",
+            result.stdout.strip() or "<empty>",
+            result.stderr.strip() or "<empty>",
+        )
+        return None
+
+    LOGGER.info("run_scylla_sstable_upgrade: decrypted %d file(s) into %s", len(data_files), output_dir)
+    return output_dir

--- a/unit_tests/test_corrupted_sstables_preparator.py
+++ b/unit_tests/test_corrupted_sstables_preparator.py
@@ -1,0 +1,393 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Unit tests for CorruptedSstablesPreparator validator and SSTablesCollector.collect_logs().
+
+These tests use tmp_path for filesystem isolation and unittest.mock.Mock for the tester/node
+stubs, following the same conventions as test_teardown_validator.py.
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, Pattern
+from unittest.mock import MagicMock, Mock, patch
+
+from invoke import Result
+
+from sdcm.logcollector import LogCollector, SSTablesCollector
+from sdcm.remote import RemoteCmdRunnerBase
+from sdcm.sct_events.events_device import EVENTS_LOG_DIR, RAW_EVENTS_LOG
+from sdcm.teardown_validators.sstables import CorruptedSstablesPreparator
+from sdcm.utils.sstable.sstable_utils import CORRUPTED_SSTABLES_STATE_FILENAME
+
+LOGGER = __import__("logging").getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Raw event lines used in tests
+# ---------------------------------------------------------------------------
+
+CORRUPTED_EVENT_LINE = (
+    "INFO  2024-04-02 12:40:24,787 [shard 0:stre] sstable - Moving sstable "
+    "/var/lib/scylla/data/keyspace1/standard1-01b9f260d55311ef8caf5992914eabbe/"
+    "me-3gn1_0bxv_16fs02rr7ufpbjejzy-big-Data.db to quarantine"
+)
+
+CORRUPTED_EVENT_JSON = json.dumps(
+    {
+        "type": "CORRUPTED_SSTABLE",
+        "severity": "CRITICAL",
+        "node": "db-node-0",
+        "line": CORRUPTED_EVENT_LINE,
+    }
+)
+
+OTHER_EVENT_JSON = json.dumps(
+    {
+        "type": "DATABASE_ERROR",
+        "severity": "ERROR",
+        "node": "db-node-0",
+        "line": "some other error",
+    }
+)
+
+NODETOOL_SNAPSHOT_STDOUT = "Snapshot directory: 1712059224000"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def ok(stdout: str = "") -> Result:
+    return Result(stdout=stdout, exited=0)
+
+
+def fail(stderr: str = "error") -> Result:
+    return Result(stdout="", stderr=stderr, exited=1)
+
+
+def make_raw_events_file(logdir: Path, lines: list[str]) -> Path:
+    """Write raw events lines to the expected path and return the file path."""
+    events_dir = logdir / EVENTS_LOG_DIR
+    events_dir.mkdir(parents=True, exist_ok=True)
+    raw_events_file = events_dir / RAW_EVENTS_LOG
+    raw_events_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return raw_events_file
+
+
+def make_fake_node(result_map: Dict[Pattern, Result], name: str = "db-node-0"):
+    """Return a Mock node with a FakeRemoter that responds per result_map."""
+    node = Mock()
+    node.name = name
+    node.ssh_login_info = {"hostname": "10.0.0.1", "user": "scyllaadm"}
+    RemoteCmdRunnerBase.set_default_remoter_class(
+        type(
+            "FakeRemoterWithMap",
+            (RemoteCmdRunnerBase,),
+            {
+                "result_map": result_map,
+                "run": lambda self, cmd, **kw: next(
+                    (v for p, v in self.result_map.items() if re.match(p, cmd)),
+                    Result(stdout="", exited=0),
+                ),
+                "_create_connection": lambda self: None,
+                "_close_connection": lambda self: None,
+                "is_up": lambda self, timeout=30: True,
+                "_run_on_retryable_exception": lambda self, exc, new_session, suppress_errors=False: True,
+            },
+        )
+    )
+    node.remoter = RemoteCmdRunnerBase.create_remoter(name)
+    return node
+
+
+def make_validator(logdir: Path, node: Mock | None = None):
+    """Return a CorruptedSstablesPreparator with the given logdir and optional node."""
+    params = MagicMock()
+    params.get.return_value = {"enabled": True}
+    tester = Mock()
+    tester.logdir = str(logdir)
+    if node is not None:
+        cluster = Mock()
+        cluster.nodes = [node]
+        tester.db_clusters_multitenant = [cluster]
+    else:
+        tester.db_clusters_multitenant = []
+    validator = CorruptedSstablesPreparator.__new__(CorruptedSstablesPreparator)
+    validator.params = params
+    validator.tester = tester
+    validator.configuration = {"enabled": True}
+    validator.is_enabled = True
+    return validator
+
+
+# ---------------------------------------------------------------------------
+# Tests: no events → no state file
+# ---------------------------------------------------------------------------
+
+
+def test_no_raw_events_file_skips(tmp_path):
+    """Validator is a no-op when the raw events log does not exist."""
+    validator = make_validator(tmp_path)
+    validator.validate()
+
+    assert not (tmp_path / CORRUPTED_SSTABLES_STATE_FILENAME).exists()
+
+
+def test_no_corrupted_sstable_event_skips(tmp_path):
+    """Validator writes no state file when there are no CORRUPTED_SSTABLE events."""
+    make_raw_events_file(tmp_path, [OTHER_EVENT_JSON])
+    validator = make_validator(tmp_path)
+    validator.validate()
+
+    assert not (tmp_path / CORRUPTED_SSTABLES_STATE_FILENAME).exists()
+
+
+def test_malformed_json_lines_are_skipped(tmp_path):
+    """Non-JSON lines in the raw events log do not crash the validator."""
+    make_raw_events_file(tmp_path, ["not-json", OTHER_EVENT_JSON])
+    validator = make_validator(tmp_path)
+    validator.validate()
+
+    assert not (tmp_path / CORRUPTED_SSTABLES_STATE_FILENAME).exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests: node not found → no state file
+# ---------------------------------------------------------------------------
+
+
+def test_node_not_found_skips(tmp_path):
+    """Validator is a no-op when the event references a node that is not in any cluster."""
+    make_raw_events_file(tmp_path, [CORRUPTED_EVENT_JSON])
+    # Supply a node with a *different* name
+    node = make_fake_node({}, name="db-node-99")
+    validator = make_validator(tmp_path, node=node)
+    validator.validate()
+
+    assert not (tmp_path / CORRUPTED_SSTABLES_STATE_FILENAME).exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests: snapshot fails → no state file
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_failure_skips(tmp_path):
+    """Validator writes no state file when nodetool snapshot returns non-zero."""
+    make_raw_events_file(tmp_path, [CORRUPTED_EVENT_JSON])
+    node = make_fake_node(
+        {re.compile(r"nodetool snapshot.*"): fail("snapshot failed")},
+        name="db-node-0",
+    )
+    validator = make_validator(tmp_path, node=node)
+    validator.validate()
+
+    assert not (tmp_path / CORRUPTED_SSTABLES_STATE_FILENAME).exists()
+
+
+def test_snapshot_stdout_missing_directory_label_skips(tmp_path):
+    """Validator writes no state file when snapshot stdout lacks 'Snapshot directory:'."""
+    make_raw_events_file(tmp_path, [CORRUPTED_EVENT_JSON])
+    node = make_fake_node(
+        {re.compile(r"nodetool snapshot.*"): ok("Snapshot created.")},
+        name="db-node-0",
+    )
+    validator = make_validator(tmp_path, node=node)
+    validator.validate()
+
+    assert not (tmp_path / CORRUPTED_SSTABLES_STATE_FILENAME).exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests: happy path → state file written correctly
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_state_file_written(tmp_path):
+    """Validator writes the expected state file when everything succeeds."""
+    make_raw_events_file(tmp_path, [CORRUPTED_EVENT_JSON])
+    node = make_fake_node(
+        {re.compile(r"nodetool snapshot.*"): ok(NODETOOL_SNAPSHOT_STDOUT)},
+        name="db-node-0",
+    )
+
+    expected_decrypted = (
+        "/var/lib/scylla/data/keyspace1/standard1-01b9f260d55311ef8caf5992914eabbe/snapshots/1712059224000/decrypted"
+    )
+
+    with patch(
+        "sdcm.teardown_validators.sstables.decrypt_sstables_on_node",
+        return_value=expected_decrypted,
+    ) as mock_decrypt:
+        validator = make_validator(tmp_path, node=node)
+        validator.validate()
+
+    state_file = tmp_path / CORRUPTED_SSTABLES_STATE_FILENAME
+    assert state_file.exists(), "State file should have been written"
+
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    assert state["keyspace"] == "keyspace1"
+    assert state["table_name"] == "standard1"
+    assert state["node_name"] == "db-node-0"
+    assert state["sstable_name"] == "me-3gn1_0bxv_16fs02rr7ufpbjejzy-big-Data.db"
+    assert state["decrypted_path"] == expected_decrypted
+    assert "snapshot_path" in state
+    assert "ssh_login_info" in state
+
+    # decrypt_sstables_on_node must be called with the snapshot path
+    mock_decrypt.assert_called_once()
+    _, kwargs = mock_decrypt.call_args
+    assert kwargs.get("keyspace") == "keyspace1" or mock_decrypt.call_args[0][2] == "keyspace1"
+
+
+def test_happy_path_decrypt_called_with_snapshot_path(tmp_path):
+    """decrypt_sstables_on_node is called with the snapshot path derived from the event."""
+    make_raw_events_file(tmp_path, [CORRUPTED_EVENT_JSON])
+    node = make_fake_node(
+        {re.compile(r"nodetool snapshot.*"): ok(NODETOOL_SNAPSHOT_STDOUT)},
+        name="db-node-0",
+    )
+
+    with patch(
+        "sdcm.teardown_validators.sstables.decrypt_sstables_on_node",
+        return_value=None,
+    ) as mock_decrypt:
+        validator = make_validator(tmp_path, node=node)
+        validator.validate()
+
+    mock_decrypt.assert_called_once()
+    call_args = mock_decrypt.call_args
+    # first positional arg is node, second is snapshot_path
+    snapshot_path = call_args[0][1] if call_args[0] else call_args[1]["snapshot_path"]
+    assert "1712059224000" in snapshot_path, f"Snapshot tag not in path: {snapshot_path}"
+    assert "keyspace1" in snapshot_path
+    assert "standard1" in snapshot_path
+
+
+def test_state_file_has_none_decrypted_path_when_decrypt_returns_none(tmp_path):
+    """State file is written with decrypted_path=None when decryption fails."""
+    make_raw_events_file(tmp_path, [CORRUPTED_EVENT_JSON])
+    node = make_fake_node(
+        {re.compile(r"nodetool snapshot.*"): ok(NODETOOL_SNAPSHOT_STDOUT)},
+        name="db-node-0",
+    )
+
+    with patch("sdcm.teardown_validators.sstables.decrypt_sstables_on_node", return_value=None):
+        validator = make_validator(tmp_path, node=node)
+        validator.validate()
+
+    state_file = tmp_path / CORRUPTED_SSTABLES_STATE_FILENAME
+    assert state_file.exists()
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    assert state["decrypted_path"] is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: SSTablesCollector.collect_logs() — state-file path
+# ---------------------------------------------------------------------------
+
+
+def make_collector(local_dir: Path, test_id: str = "test-uuid", nodes: list | None = None):
+    """Build a minimal SSTablesCollector without calling __init__."""
+    collector = SSTablesCollector.__new__(SSTablesCollector)
+    collector.local_dir = str(local_dir)
+    collector.test_id = test_id
+    collector.nodes = nodes or []
+    # current_run is a class-level property; patch it at the class level for isolation
+    LogCollector._current_run = "run-1"
+    return collector
+
+
+def test_sstables_collector_state_file_path_calls_upload(tmp_path):
+    """SSTablesCollector.collect_logs() uses state file instead of SSH when it exists."""
+    # Mimic the logdir structure: local_dir is 3 levels below logdir
+    local_dir = tmp_path / "collector" / "corrupted-sstables" / "2026-01-01"
+    local_dir.mkdir(parents=True)
+
+    snapshot_path = "/var/lib/scylla/data/ks/tbl-uuid/snapshots/1712059224000"
+    decrypted_path = f"{snapshot_path}/decrypted"
+    state = {
+        "snapshot_path": snapshot_path,
+        "decrypted_path": decrypted_path,
+        "keyspace": "ks",
+        "table_name": "tbl",
+        "sstable_name": "me-big-Data.db",
+        "node_name": "db-node-0",
+        "ssh_login_info": {"hostname": "10.0.0.1", "user": "scyllaadm"},
+    }
+    state_file = tmp_path / CORRUPTED_SSTABLES_STATE_FILENAME
+    state_file.write_text(json.dumps(state), encoding="utf-8")
+
+    collector = make_collector(local_dir)
+    fake_s3_link = "https://s3.amazonaws.com/bucket/corrupted.tar.gz"
+
+    with patch(
+        "sdcm.logcollector.upload_remote_files_directly_to_s3",
+        return_value=fake_s3_link,
+    ) as mock_upload:
+        result = collector.collect_logs()
+
+    mock_upload.assert_called_once()
+    call_kwargs = mock_upload.call_args
+    paths_arg = call_kwargs[0][1] if call_kwargs[0] else call_kwargs[1].get("files")
+    assert snapshot_path in paths_arg
+    assert decrypted_path in paths_arg
+    assert result == [fake_s3_link]
+
+
+def test_sstables_collector_no_state_file_falls_back_to_ssh(tmp_path):
+    """SSTablesCollector.collect_logs() falls back to SSH path when state file is absent."""
+    local_dir = tmp_path / "collector" / "corrupted-sstables" / "2026-01-01"
+    local_dir.mkdir(parents=True)
+
+    # Write raw events log with a CORRUPTED_SSTABLE event
+    events_dir = tmp_path / EVENTS_LOG_DIR
+    events_dir.mkdir(parents=True)
+    (events_dir / RAW_EVENTS_LOG).write_text(CORRUPTED_EVENT_JSON + "\n", encoding="utf-8")
+
+    snapshot_dir = "1712059224000"
+    node = Mock()
+    node.name = "db-node-0"
+    node.ssh_login_info = {"hostname": "10.0.0.1", "user": "scyllaadm"}
+    node.remoter.run.return_value = Result(stdout=f"Snapshot directory: {snapshot_dir}", exited=0)
+
+    collector = make_collector(local_dir, nodes=[node])
+    fake_s3_link = "https://s3.amazonaws.com/bucket/corrupted.tar.gz"
+
+    with patch(
+        "sdcm.logcollector.upload_remote_files_directly_to_s3",
+        return_value=fake_s3_link,
+    ) as mock_upload:
+        result = collector.collect_logs()
+
+    # SSH was used (nodetool snapshot call)
+    node.remoter.run.assert_called()
+    mock_upload.assert_called_once()
+    assert result == [fake_s3_link]
+
+
+def test_sstables_collector_no_corrupted_event_returns_empty(tmp_path):
+    """SSTablesCollector.collect_logs() returns [] when no CORRUPTED_SSTABLE event exists."""
+    local_dir = tmp_path / "collector" / "corrupted-sstables" / "2026-01-01"
+    local_dir.mkdir(parents=True)
+
+    events_dir = tmp_path / EVENTS_LOG_DIR
+    events_dir.mkdir(parents=True)
+    (events_dir / RAW_EVENTS_LOG).write_text(OTHER_EVENT_JSON + "\n", encoding="utf-8")
+
+    collector = make_collector(local_dir)
+    result = collector.collect_logs()
+    assert result == []

--- a/unit_tests/test_corrupted_sstables_preparator.py
+++ b/unit_tests/test_corrupted_sstables_preparator.py
@@ -23,25 +23,36 @@ from pathlib import Path
 from typing import Dict, Pattern
 from unittest.mock import MagicMock, Mock, patch
 
+import pytest
 from invoke import Result
 
 from sdcm.logcollector import LogCollector, SSTablesCollector
 from sdcm.remote import RemoteCmdRunnerBase
 from sdcm.sct_events.events_device import EVENTS_LOG_DIR, RAW_EVENTS_LOG
-from sdcm.teardown_validators.sstables import CorruptedSstablesPreparator
-from sdcm.utils.sstable.sstable_utils import CORRUPTED_SSTABLES_STATE_FILENAME
+from sdcm.teardown_validators.sstables import (
+    CorruptedSstablesPreparator,
+    find_corrupted_sstable_in_events,
+    _parse_sstable_path,
+)
+from sdcm.utils.sstable.sstable_utils import (
+    CORRUPTED_SSTABLES_STATE_FILENAME,
+    strip_encryption_options_from_schema,
+)
 
 LOGGER = __import__("logging").getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Raw event lines used in tests
+# Raw event lines used in tests — uses the malformed_sstable_exception format
+# that triggers real CORRUPTED_SSTABLE events (see sdcm/sct_events/database.py).
 # ---------------------------------------------------------------------------
 
 CORRUPTED_EVENT_LINE = (
-    "INFO  2024-04-02 12:40:24,787 [shard 0:stre] sstable - Moving sstable "
+    "[shard 0:main] seastar - Exiting on unhandled exception: "
+    "sstables::malformed_sstable_exception (Buffer improperly sized to hold requested data. "
+    "Got: 2. Expected: 4 in sstable "
     "/var/lib/scylla/data/keyspace1/standard1-01b9f260d55311ef8caf5992914eabbe/"
-    "me-3gn1_0bxv_16fs02rr7ufpbjejzy-big-Data.db to quarantine"
+    "me-3gn1_0bxv_16fs02rr7ufpbjejzy-big-Data.db)"
 )
 
 CORRUPTED_EVENT_JSON = json.dumps(
@@ -391,3 +402,323 @@ def test_sstables_collector_no_corrupted_event_returns_empty(tmp_path):
     collector = make_collector(local_dir)
     result = collector.collect_logs()
     assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: strip_encryption_options_from_schema
+# ---------------------------------------------------------------------------
+
+
+class TestStripEncryptionOptionsFromSchema:
+    """Verify that scylla_encryption_options is stripped in all possible schema layouts."""
+
+    ENC_OPTS = (
+        "{'cipher_algorithm': 'AES/ECB/PKCS5Padding',"
+        " 'key_provider': 'LocalFileSystemKeyProviderFactory',"
+        " 'secret_key_file': '/etc/scylla/encrypt_conf/secret_key',"
+        " 'secret_key_strength': '128'}"
+    )
+
+    def test_and_prefix_middle_property(self):
+        """Standard case: scylla_encryption_options after AND between other properties."""
+        schema = (
+            "CREATE TABLE ks.tbl (id int PRIMARY KEY) WITH bloom_filter_fp_chance = 0.01"
+            f"\n    AND scylla_encryption_options = {self.ENC_OPTS}"
+            "\n    AND compaction = {'class': 'SizeTieredCompactionStrategy'};"
+        )
+        result = strip_encryption_options_from_schema(schema)
+        assert "scylla_encryption_options" not in result
+        assert "bloom_filter_fp_chance" in result
+        assert "compaction" in result
+
+    def test_and_prefix_last_property(self):
+        """scylla_encryption_options is the last AND property."""
+        schema = (
+            "CREATE TABLE ks.tbl (id int PRIMARY KEY) WITH bloom_filter_fp_chance = 0.01"
+            f"\n    AND scylla_encryption_options = {self.ENC_OPTS};"
+        )
+        result = strip_encryption_options_from_schema(schema)
+        assert "scylla_encryption_options" not in result
+        assert "bloom_filter_fp_chance" in result
+
+    def test_with_prefix_first_property_followed_by_and(self):
+        """scylla_encryption_options is the first property after WITH, followed by AND."""
+        schema = (
+            f"CREATE TABLE ks.tbl (id int PRIMARY KEY) WITH scylla_encryption_options = {self.ENC_OPTS}"
+            "\n    AND bloom_filter_fp_chance = 0.01"
+            "\n    AND compaction = {'class': 'SizeTieredCompactionStrategy'};"
+        )
+        result = strip_encryption_options_from_schema(schema)
+        assert "scylla_encryption_options" not in result
+        assert "WITH" in result
+        assert "bloom_filter_fp_chance" in result
+        assert "compaction" in result
+
+    def test_with_prefix_sole_property(self):
+        """scylla_encryption_options is the only property (no AND before or after)."""
+        schema = f"CREATE TABLE ks.tbl (id int PRIMARY KEY) WITH scylla_encryption_options = {self.ENC_OPTS};"
+        result = strip_encryption_options_from_schema(schema)
+        assert "scylla_encryption_options" not in result
+        assert "WITH" not in result
+
+    def test_no_encryption_options_unchanged(self):
+        """Schema without scylla_encryption_options is returned unchanged."""
+        schema = (
+            "CREATE TABLE ks.tbl (id int PRIMARY KEY) WITH bloom_filter_fp_chance = 0.01"
+            "\n    AND compaction = {'class': 'SizeTieredCompactionStrategy'};"
+        )
+        result = strip_encryption_options_from_schema(schema)
+        assert result == schema
+
+    def test_case_insensitive(self):
+        """The strip is case-insensitive."""
+        schema = (
+            "CREATE TABLE ks.tbl (id int PRIMARY KEY) WITH bloom_filter_fp_chance = 0.01"
+            "\n    AND SCYLLA_ENCRYPTION_OPTIONS = {'cipher_algorithm': 'AES'};"
+        )
+        result = strip_encryption_options_from_schema(schema)
+        assert "SCYLLA_ENCRYPTION_OPTIONS" not in result
+        assert "scylla_encryption_options" not in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests: _parse_sstable_path
+# ---------------------------------------------------------------------------
+
+
+class TestParseSSTablePath:
+    """Verify that _parse_sstable_path correctly extracts components from sstable paths."""
+
+    def test_valid_data_db_path(self):
+        path = "/var/lib/scylla/data/keyspace1/standard1-abc123/me-big-Data.db"
+        result = _parse_sstable_path(path)
+        assert result is not None
+        sstable_dir, ks, table_name, sst_name = result
+        assert sstable_dir == "/var/lib/scylla/data/keyspace1/standard1-abc123"
+        assert ks == "keyspace1"
+        assert table_name == "standard1"
+        assert sst_name == "me-big-Data.db"
+
+    def test_valid_statistics_db_path(self):
+        path = "/var/lib/scylla/data/ks/tbl-uuid/me-3g9s_1eqc-big-Statistics.db"
+        result = _parse_sstable_path(path)
+        assert result is not None
+        _, ks, table_name, sst_name = result
+        assert ks == "ks"
+        assert table_name == "tbl"
+        assert sst_name == "me-3g9s_1eqc-big-Statistics.db"
+
+    def test_too_few_components_returns_none(self):
+        """Paths with fewer than 4 slash-separated components are rejected."""
+        assert _parse_sstable_path("/tmp/foo.db") is None
+        assert _parse_sstable_path("foo.db") is None
+
+    def test_no_uuid_separator_in_table_dir_returns_none(self):
+        """Table dir must contain a hyphen (UUID separator); plain names are rejected."""
+        assert _parse_sstable_path("/var/lib/scylla/data/ks/tablename/me-Data.db") is None
+
+    def test_quarantine_path(self):
+        """Paths inside quarantine directories still parse correctly."""
+        path = "/var/lib/scylla/data/ks/tbl-uuid/quarantine/me-big-Data.db"
+        result = _parse_sstable_path(path)
+        # quarantine adds an extra level, so rsplit("/", 3) splits differently
+        # The function should still return something as long as the components validate
+        if result is not None:
+            _, ks, table_name, _ = result
+            # Quarantine path has /quarantine/ as the table_dir component
+            assert table_name is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests: find_corrupted_sstable_in_events
+# ---------------------------------------------------------------------------
+
+
+class TestFindCorruptedSstableInEvents:
+    """Verify that find_corrupted_sstable_in_events correctly parses various event formats.
+
+    Positive-path cases are parametrized to cover every known real-world ``CORRUPTED_SSTABLE``
+    error line format.  Negative-path cases (no path, wrong severity, etc.) are separate tests.
+    """
+
+    @staticmethod
+    def _write_events(tmp_path, events_json_lines):
+        events_dir = tmp_path / EVENTS_LOG_DIR
+        events_dir.mkdir(parents=True, exist_ok=True)
+        raw_file = events_dir / RAW_EVENTS_LOG
+        raw_file.write_text("\n".join(events_json_lines) + "\n", encoding="utf-8")
+        return raw_file
+
+    # ------------------------------------------------------------------
+    # Parametrized positive-path tests: each tuple is
+    #   (test_id, event_line, expected_keyspace, expected_table, expected_sstable, node)
+    # ------------------------------------------------------------------
+    POSITIVE_CASES = [
+        pytest.param(
+            (
+                "[shard 0:main] seastar - Exiting on unhandled exception: "
+                "sstables::malformed_sstable_exception (Buffer improperly sized to hold requested data. "
+                "Got: 2. Expected: 4 in sstable "
+                "/var/lib/scylla/data/keyspace1/standard1-01b9f260/me-big-Statistics.db)"
+            ),
+            "keyspace1",
+            "standard1",
+            "me-big-Statistics.db",
+            "db-node-0",
+            id="malformed_sstable_exception_statistics_db",
+        ),
+        pytest.param(
+            (
+                "[shard 0:main] seastar - Exiting on unhandled exception: "
+                "sstables::malformed_sstable_exception (Buffer improperly sized in sstable "
+                "/var/lib/scylla/data/ks/tbl-abc123/me-big-Data.db)"
+            ),
+            "ks",
+            "tbl",
+            "me-big-Data.db",
+            "db-node-1",
+            id="malformed_sstable_exception_data_db",
+        ),
+        pytest.param(
+            (
+                "[shard 2:comp] compaction - invalid_mutation_fragment_stream exception in "
+                "/var/lib/scylla/data/myks/mytbl-deadbeef/me-123-big-Data.db"
+            ),
+            "myks",
+            "mytbl",
+            "me-123-big-Data.db",
+            "db-node-0",
+            id="invalid_mutation_fragment_stream",
+        ),
+        pytest.param(
+            (
+                "Error reading /tmp/cache.db - "
+                "sstables::malformed_sstable_exception in "
+                "/var/lib/scylla/data/ks/tbl-uuid/me-big-Data.db"
+            ),
+            "ks",
+            "tbl",
+            "me-big-Data.db",
+            "db-node-0",
+            id="multiple_db_paths_picks_valid_scylla_path",
+        ),
+        # Real-world format from sstable_utils.py:116-120 — same .db path appears twice in the
+        # line ("Could not load SSTable: /path/Data.db: ... (/path/Data.db: first and last ...")
+        pytest.param(
+            (
+                "Could not load SSTable: "
+                "/var/lib/scylla/data/keyspace1/standard1-01b9f260d55311ef8caf5992914eabbe/"
+                "me-3g9w_104a_01xg12j55gjivrwtt5-big-Data.db: "
+                "sstables::malformed_sstable_exception ("
+                "/var/lib/scylla/data/keyspace1/standard1-01b9f260d55311ef8caf5992914eabbe/"
+                "me-3g9w_104a_01xg12j55gjivrwtt5-big-Data.db: "
+                "first and last keys of summary are misordered: "
+                "first={key: pk{00080000000000000003}, token: -578762209316392770} "
+                "> last={key: pk{00080000000000000008}, token: -6917704163689751025})"
+            ),
+            "keyspace1",
+            "standard1",
+            "me-3g9w_104a_01xg12j55gjivrwtt5-big-Data.db",
+            "db-node-0",
+            id="could_not_load_sstable_misordered_keys",
+        ),
+        # Real-world format from sstable_utils.py:99-102 — full generation ID with long UUID
+        pytest.param(
+            (
+                "[shard 0:main] seastar - Exiting on unhandled exception: "
+                "sstables::malformed_sstable_exception (Buffer improperly sized to hold requested data. "
+                "Got: 2. Expected: 4 in sstable "
+                "/var/lib/scylla/data/keyspace1/standard1-01b9f260d55311ef8caf5992914eabbe/"
+                "me-3g9s_1eqc_2z60w2ushgma9j7ypu-big-Statistics.db)"
+            ),
+            "keyspace1",
+            "standard1",
+            "me-3g9s_1eqc_2z60w2ushgma9j7ypu-big-Statistics.db",
+            "db-node-0",
+            id="malformed_sstable_full_generation_id",
+        ),
+        # Real-world format: scylla[PID] prefix (systemd journal format, seen in GCE PKE runs)
+        pytest.param(
+            (
+                "scylla[5976]:  [shard 6:strm] compaction - Finished scrubbing in validate mode "
+                "/var/lib/scylla/data/keyspace1/standard1-01b9f260d55311ef8caf5992914eabbe/"
+                "me-3gn1_0bxv_16fs02rr7ufpbjejzy-big-Data.db - sstable is invalid - "
+                "invalid_mutation_fragment_stream"
+            ),
+            "keyspace1",
+            "standard1",
+            "me-3gn1_0bxv_16fs02rr7ufpbjejzy-big-Data.db",
+            "db-node-0",
+            id="scrub_validate_mode_sstable_is_invalid",
+        ),
+    ]
+
+    @pytest.mark.parametrize("line, expected_ks, expected_table, expected_sst, node_name", POSITIVE_CASES)
+    def test_event_line_parsed_correctly(self, tmp_path, line, expected_ks, expected_table, expected_sst, node_name):
+        """Parametrized: each known real-world error line format is correctly parsed."""
+        event = json.dumps(
+            {
+                "type": "CORRUPTED_SSTABLE",
+                "severity": "CRITICAL",
+                "node": node_name,
+                "line": line,
+            }
+        )
+        raw_file = self._write_events(tmp_path, [event])
+        _, ks, table_name, sst_name, found_node = find_corrupted_sstable_in_events(raw_file)
+        assert ks == expected_ks
+        assert table_name == expected_table
+        assert sst_name == expected_sst
+        assert found_node == node_name
+
+    # ------------------------------------------------------------------
+    # Negative-path tests
+    # ------------------------------------------------------------------
+
+    def test_no_db_path_returns_none(self, tmp_path):
+        """Event without any .db path returns all-None tuple."""
+        event = json.dumps(
+            {
+                "type": "CORRUPTED_SSTABLE",
+                "severity": "CRITICAL",
+                "node": "db-node-0",
+                "line": "sstables::malformed_sstable_exception (some error without a path)",
+            }
+        )
+        raw_file = self._write_events(tmp_path, [event])
+        result = find_corrupted_sstable_in_events(raw_file)
+        assert result == (None, None, None, None, None)
+
+    def test_no_corrupted_event_returns_none(self, tmp_path):
+        """File with only non-CORRUPTED_SSTABLE events returns all-None."""
+        raw_file = self._write_events(tmp_path, [OTHER_EVENT_JSON])
+        result = find_corrupted_sstable_in_events(raw_file)
+        assert result == (None, None, None, None, None)
+
+    def test_non_critical_severity_ignored(self, tmp_path):
+        """CORRUPTED_SSTABLE events with severity != CRITICAL are ignored."""
+        event = json.dumps(
+            {
+                "type": "CORRUPTED_SSTABLE",
+                "severity": "ERROR",
+                "node": "db-node-0",
+                "line": ("sstables::malformed_sstable_exception in /var/lib/scylla/data/ks/tbl-uuid/me-big-Data.db"),
+            }
+        )
+        raw_file = self._write_events(tmp_path, [event])
+        result = find_corrupted_sstable_in_events(raw_file)
+        assert result == (None, None, None, None, None)
+
+    def test_malformed_json_lines_are_skipped(self, tmp_path):
+        """Non-JSON lines mixed in don't prevent parsing valid events."""
+        valid_event = json.dumps(
+            {
+                "type": "CORRUPTED_SSTABLE",
+                "severity": "CRITICAL",
+                "node": "db-node-0",
+                "line": ("sstables::malformed_sstable_exception in /var/lib/scylla/data/ks/tbl-uuid/me-big-Data.db"),
+            }
+        )
+        raw_file = self._write_events(tmp_path, ["not-json", "also {bad", valid_event])
+        _, ks, _, _, _ = find_corrupted_sstable_in_events(raw_file)
+        assert ks == "ks"

--- a/unit_tests/test_corrupted_sstables_preparator.py
+++ b/unit_tests/test_corrupted_sstables_preparator.py
@@ -32,6 +32,7 @@ from sdcm.sct_events.events_device import EVENTS_LOG_DIR, RAW_EVENTS_LOG
 from sdcm.teardown_validators.sstables import (
     CorruptedSstablesPreparator,
     find_corrupted_sstable_in_events,
+    take_snapshot_and_decrypt,
     _parse_sstable_path,
 )
 from sdcm.utils.sstable.sstable_utils import (
@@ -230,14 +231,22 @@ def test_snapshot_stdout_missing_directory_label_skips(tmp_path):
 def test_happy_path_state_file_written(tmp_path):
     """Validator writes the expected state file when everything succeeds."""
     make_raw_events_file(tmp_path, [CORRUPTED_EVENT_JSON])
+
+    snapshot_path = "/var/lib/scylla/data/keyspace1/standard1-01b9f260d55311ef8caf5992914eabbe/snapshots/1712059224000"
+    prefix = "me-3gn1_0bxv_16fs02rr7ufpbjejzy-big"
+    sstable_components = "\n".join(
+        f"{snapshot_path}/{prefix}-{comp}" for comp in ["Data.db", "Filter.db", "Statistics.db", "TOC.txt"]
+    )
+
     node = make_fake_node(
-        {re.compile(r"nodetool snapshot.*"): ok(NODETOOL_SNAPSHOT_STDOUT)},
+        {
+            re.compile(r"nodetool snapshot.*"): ok(NODETOOL_SNAPSHOT_STDOUT),
+            re.compile(rf"ls .*/snapshots/1712059224000/{prefix}-\*.*"): ok(sstable_components),
+        },
         name="db-node-0",
     )
 
-    expected_decrypted = (
-        "/var/lib/scylla/data/keyspace1/standard1-01b9f260d55311ef8caf5992914eabbe/snapshots/1712059224000/decrypted"
-    )
+    expected_decrypted = f"{snapshot_path}/decrypted"
 
     with patch(
         "sdcm.teardown_validators.sstables.decrypt_sstables_on_node",
@@ -257,6 +266,10 @@ def test_happy_path_state_file_written(tmp_path):
     assert state["decrypted_path"] == expected_decrypted
     assert "snapshot_path" in state
     assert "ssh_login_info" in state
+    # upload_files must contain the targeted sstable components + schema.cql
+    assert "upload_files" in state
+    assert f"{snapshot_path}/schema.cql" in state["upload_files"]
+    assert any(f.endswith("-Data.db") for f in state["upload_files"])
 
     # decrypt_sstables_on_node must be called with the snapshot path
     mock_decrypt.assert_called_once()
@@ -268,7 +281,10 @@ def test_happy_path_decrypt_called_with_snapshot_path(tmp_path):
     """decrypt_sstables_on_node is called with the snapshot path derived from the event."""
     make_raw_events_file(tmp_path, [CORRUPTED_EVENT_JSON])
     node = make_fake_node(
-        {re.compile(r"nodetool snapshot.*"): ok(NODETOOL_SNAPSHOT_STDOUT)},
+        {
+            re.compile(r"nodetool snapshot.*"): ok(NODETOOL_SNAPSHOT_STDOUT),
+            re.compile(r"ls .*/snapshots/.*"): ok(""),  # no component files found in snapshot
+        },
         name="db-node-0",
     )
 
@@ -292,7 +308,10 @@ def test_state_file_has_none_decrypted_path_when_decrypt_returns_none(tmp_path):
     """State file is written with decrypted_path=None when decryption fails."""
     make_raw_events_file(tmp_path, [CORRUPTED_EVENT_JSON])
     node = make_fake_node(
-        {re.compile(r"nodetool snapshot.*"): ok(NODETOOL_SNAPSHOT_STDOUT)},
+        {
+            re.compile(r"nodetool snapshot.*"): ok(NODETOOL_SNAPSHOT_STDOUT),
+            re.compile(r"ls .*/snapshots/.*"): ok(""),  # no component files in snapshot
+        },
         name="db-node-0",
     )
 
@@ -330,8 +349,14 @@ def test_sstables_collector_state_file_path_calls_upload(tmp_path):
 
     snapshot_path = "/var/lib/scylla/data/ks/tbl-uuid/snapshots/1712059224000"
     decrypted_path = f"{snapshot_path}/decrypted"
+    upload_files = [
+        f"{snapshot_path}/me-big-Data.db",
+        f"{snapshot_path}/me-big-Filter.db",
+        f"{snapshot_path}/schema.cql",
+    ]
     state = {
         "snapshot_path": snapshot_path,
+        "upload_files": upload_files,
         "decrypted_path": decrypted_path,
         "keyspace": "ks",
         "table_name": "tbl",
@@ -354,8 +379,46 @@ def test_sstables_collector_state_file_path_calls_upload(tmp_path):
     mock_upload.assert_called_once()
     call_kwargs = mock_upload.call_args
     paths_arg = call_kwargs[0][1] if call_kwargs[0] else call_kwargs[1].get("files")
-    assert snapshot_path in paths_arg
+    # Should contain the targeted file list + decrypted path, NOT the whole snapshot dir
+    for f in upload_files:
+        assert f in paths_arg
     assert decrypted_path in paths_arg
+    assert result == [fake_s3_link]
+
+
+def test_sstables_collector_state_file_backwards_compat(tmp_path):
+    """SSTablesCollector falls back to [snapshot_path] when state file lacks upload_files."""
+    local_dir = tmp_path / "collector" / "corrupted-sstables" / "2026-01-01"
+    local_dir.mkdir(parents=True)
+
+    snapshot_path = "/var/lib/scylla/data/ks/tbl-uuid/snapshots/1712059224000"
+    # Old-format state file without upload_files key
+    state = {
+        "snapshot_path": snapshot_path,
+        "decrypted_path": None,
+        "keyspace": "ks",
+        "table_name": "tbl",
+        "sstable_name": "me-big-Data.db",
+        "node_name": "db-node-0",
+        "ssh_login_info": {"hostname": "10.0.0.1", "user": "scyllaadm"},
+    }
+    state_file = tmp_path / CORRUPTED_SSTABLES_STATE_FILENAME
+    state_file.write_text(json.dumps(state), encoding="utf-8")
+
+    collector = make_collector(local_dir)
+    fake_s3_link = "https://s3.amazonaws.com/bucket/corrupted.tar.gz"
+
+    with patch(
+        "sdcm.logcollector.upload_remote_files_directly_to_s3",
+        return_value=fake_s3_link,
+    ) as mock_upload:
+        result = collector.collect_logs()
+
+    mock_upload.assert_called_once()
+    call_kwargs = mock_upload.call_args
+    paths_arg = call_kwargs[0][1] if call_kwargs[0] else call_kwargs[1].get("files")
+    # Falls back to whole snapshot directory
+    assert snapshot_path in paths_arg
     assert result == [fake_s3_link]
 
 
@@ -402,6 +465,62 @@ def test_sstables_collector_no_corrupted_event_returns_empty(tmp_path):
     collector = make_collector(local_dir)
     result = collector.collect_logs()
     assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: take_snapshot_and_decrypt — targeted file collection
+# ---------------------------------------------------------------------------
+
+
+def test_take_snapshot_targets_specific_sstable_files(tmp_path):
+    """take_snapshot_and_decrypt finds the corrupted sstable's component files within the snapshot."""
+    snapshot_path = "/var/lib/scylla/data/keyspace1/standard1-uuid/snapshots/1712059224000"
+    prefix = "me-3gn1_0bxv_16fs02rr7ufpbjejzy-big"
+    component_files = [f"{snapshot_path}/{prefix}-{comp}" for comp in ["Data.db", "Filter.db", "TOC.txt"]]
+
+    node = make_fake_node(
+        {
+            re.compile(r"nodetool snapshot.*"): ok(NODETOOL_SNAPSHOT_STDOUT),
+            re.compile(rf"ls .*/snapshots/1712059224000/{prefix}-\*.*"): ok("\n".join(component_files)),
+        },
+        name="db-node-0",
+    )
+
+    with patch("sdcm.teardown_validators.sstables.decrypt_sstables_on_node", return_value=None):
+        snap, sstable_files, decrypted = take_snapshot_and_decrypt(
+            node,
+            sstable_dir="/var/lib/scylla/data/keyspace1/standard1-uuid",
+            keyspace="keyspace1",
+            table_name="standard1",
+            sstable_name=f"{prefix}-Data.db",
+        )
+
+    assert snap == snapshot_path
+    assert sstable_files == component_files
+    assert decrypted is None
+
+
+def test_take_snapshot_empty_sstable_files_when_quarantined(tmp_path):
+    """When the corrupted sstable was quarantined, ls returns empty — sstable_files is []."""
+    node = make_fake_node(
+        {
+            re.compile(r"nodetool snapshot.*"): ok(NODETOOL_SNAPSHOT_STDOUT),
+            re.compile(r"ls .*/snapshots/.*"): ok(""),  # not found in snapshot
+        },
+        name="db-node-0",
+    )
+
+    with patch("sdcm.teardown_validators.sstables.decrypt_sstables_on_node", return_value=None):
+        snap, sstable_files, decrypted = take_snapshot_and_decrypt(
+            node,
+            sstable_dir="/var/lib/scylla/data/ks/tbl-uuid",
+            keyspace="ks",
+            table_name="tbl",
+            sstable_name="me-big-Data.db",
+        )
+
+    assert snap is not None  # snapshot was taken successfully
+    assert sstable_files == []  # but no component files found
 
 
 # ---------------------------------------------------------------------------

--- a/unit_tests/test_remoter.py
+++ b/unit_tests/test_remoter.py
@@ -545,3 +545,56 @@ class TestRemoteFile:
         assert remoter.rf_dst.startswith("/tmp/sct")
         assert remoter.rf_dst.endswith(os.path.basename(some_file))
         assert remoter.sf_data is None
+
+
+# ---------------------------------------------------------------------------
+# RemoteCmdRunner._run_on_retryable_exception – EOFError retry behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestRemoteCmdRunnerRetryOnEOFError:
+    """EOFError must always be treated as a retryable network exception.
+
+    paramiko raises ``EOFError()`` (no message) when the SSH transport dies.
+    ``str(EOFError())`` is ``""``, which does not match any pattern in
+    ``_is_error_retryable``.  Before the fix the method returned ``True``
+    (re-raise without retry); after the fix it must raise
+    ``RetryableNetworkException`` so the ``@retrying`` decorator can reconnect.
+    """
+
+    def _make_runner(self):
+        """Build a RemoteCmdRunner with the minimum state needed by _run_on_retryable_exception."""
+        runner = RemoteCmdRunner.__new__(RemoteCmdRunner)
+        runner.ssh_is_up = threading.Event()
+        runner.ssh_is_up.set()
+        runner.log = getLogger("test")
+        return runner
+
+    def test_eoferror_raises_retryable_network_exception(self):
+        """EOFError() with no message must raise RetryableNetworkException, not return True."""
+        runner = self._make_runner()
+        with pytest.raises(RetryableNetworkException):
+            runner._run_on_retryable_exception(EOFError(), new_session=False, suppress_errors=True)
+
+    def test_eoferror_clears_ssh_is_up(self):
+        """ssh_is_up event must be cleared when EOFError is received."""
+        runner = self._make_runner()
+        assert runner.ssh_is_up.is_set()
+        with pytest.raises(RetryableNetworkException):
+            runner._run_on_retryable_exception(EOFError(), new_session=False, suppress_errors=True)
+        assert not runner.ssh_is_up.is_set()
+
+    def test_known_retryable_message_still_raises(self):
+        """Exceptions matching _is_error_retryable patterns still raise RetryableNetworkException."""
+        runner = self._make_runner()
+        exc = Exception("timed out waiting for connection")
+        with pytest.raises(RetryableNetworkException):
+            runner._run_on_retryable_exception(exc, new_session=False, suppress_errors=True)
+
+    def test_non_retryable_exception_returns_true(self):
+        """Unknown exceptions (not EOFError, no matching message) return True to re-raise."""
+        runner = self._make_runner()
+        result = runner._run_on_retryable_exception(
+            ValueError("some other error"), new_session=False, suppress_errors=True
+        )
+        assert result is True

--- a/unit_tests/test_sstable_decrypt.py
+++ b/unit_tests/test_sstable_decrypt.py
@@ -13,14 +13,16 @@
 
 """Unit tests for sstable decryption helpers in sdcm.utils.sstable.sstable_utils."""
 
+import io
+import json
 import re
 from typing import Dict, Pattern
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from invoke import Result
 
-from sdcm.logcollector import CollectingNode
+from sdcm.logcollector import CollectingNode, SSTablesCollector
 from sdcm.remote import RemoteCmdRunnerBase
 from sdcm.utils.sstable.sstable_utils import (
     decrypt_sstable_files_on_node,
@@ -322,3 +324,91 @@ def test_decrypt_sstables_on_node_with_collecting_node(fake_remoter):
     node = CollectingNode(name="test-node")
     node.remoter = RemoteCmdRunnerBase.create_remoter("test-node")
     assert decrypt_sstables_on_node(node, snap, keyspace="ks", table="tbl") == f"{snap}/decrypted"
+
+
+# ---------------------------------------------------------------------------
+# SSTablesCollector.collect_logs – snapshot fallback path
+# ---------------------------------------------------------------------------
+
+CORRUPTED_SSTABLE_EVENT = json.dumps(
+    {
+        "type": "CORRUPTED_SSTABLE",
+        "severity": "CRITICAL",
+        "line": "/var/lib/scylla/data/ks/tbl-uuid/me-1-big-Data.db",
+        "node": "db-node-0",
+    }
+)
+
+SSTABLE_DIR = "/var/lib/scylla/data/ks/tbl-uuid"
+EXISTING_SNAPSHOT = f"{SSTABLE_DIR}/snapshots/sct-1234567890"
+
+
+def _make_collector(tmp_path, node):
+    """Build a minimal SSTablesCollector with a single node and a temp storage dir."""
+    collector = SSTablesCollector.__new__(SSTablesCollector)
+    collector.test_id = "test-id-abcdef"
+    collector.nodes = [node]
+    collector.params = None
+    collector.local_dir = str(tmp_path / "logs")
+    # current_run is a read-only class-level property; no setter needed
+    return collector
+
+
+def test_collect_logs_falls_back_to_existing_snapshot_when_nodetool_fails(tmp_path):
+    """When nodetool snapshot raises, collect_logs uses the most recent existing snapshot."""
+    node = CollectingNode(name="db-node-0")
+    node.ssh_login_info = {}
+
+    # nodetool snapshot raises; ls -td returns one existing snapshot
+    def fake_run(cmd, **kwargs):
+        if "nodetool snapshot" in cmd:
+            raise EOFError("SSH connection closed")
+        if cmd.startswith("ls -td"):
+            return ok(f"{EXISTING_SNAPSHOT}/\n")
+        return ok("")
+
+    node.remoter = MagicMock()
+    node.remoter.run.side_effect = fake_run
+
+    collector = _make_collector(tmp_path, node)
+
+    events_content = CORRUPTED_SSTABLE_EVENT + "\n"
+
+    with (
+        patch("builtins.open", return_value=io.StringIO(events_content)),
+        patch("sdcm.logcollector.decrypt_sstables_on_node", return_value=None) as mock_decrypt,
+        patch("sdcm.logcollector.upload_remote_files_directly_to_s3", return_value="s3://link"),
+    ):
+        collector.collect_logs()
+
+    mock_decrypt.assert_called_once_with(node, EXISTING_SNAPSHOT, keyspace="ks", table="tbl")
+
+
+def test_collect_logs_returns_empty_when_nodetool_fails_and_no_snapshots_exist(tmp_path):
+    """When nodetool snapshot raises and no existing snapshots are found, collect_logs returns []."""
+    node = CollectingNode(name="db-node-0")
+    node.ssh_login_info = {}
+
+    def fake_run(cmd, **kwargs):
+        if "nodetool snapshot" in cmd:
+            raise EOFError("SSH connection closed")
+        if cmd.startswith("ls -td"):
+            return ok("")  # empty — no snapshots on disk
+        return ok("")
+
+    node.remoter = MagicMock()
+    node.remoter.run.side_effect = fake_run
+
+    collector = _make_collector(tmp_path, node)
+
+    events_content = CORRUPTED_SSTABLE_EVENT + "\n"
+
+    with (
+        patch("builtins.open", return_value=io.StringIO(events_content)),
+        patch("sdcm.logcollector.decrypt_sstables_on_node") as mock_decrypt,
+        patch("sdcm.logcollector.upload_remote_files_directly_to_s3"),
+    ):
+        result = collector.collect_logs()
+
+    assert result == []
+    mock_decrypt.assert_not_called()

--- a/unit_tests/test_sstable_decrypt.py
+++ b/unit_tests/test_sstable_decrypt.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 import pytest
 from invoke import Result
 
+from sdcm.logcollector import CollectingNode
 from sdcm.remote import RemoteCmdRunnerBase
 from sdcm.utils.sstable.sstable_utils import (
     decrypt_sstable_files_on_node,
@@ -296,3 +297,28 @@ def test_decrypt_sstable_files_on_node_upgrade_failure_returns_none(setup_node):
         )
         is None
     )
+
+
+# ---------------------------------------------------------------------------
+# CollectingNode contract — logcollector.py passes CollectingNode to
+# decrypt_sstables_on_node, so the full call must work end-to-end.
+# ---------------------------------------------------------------------------
+
+
+def test_decrypt_sstables_on_node_with_collecting_node(fake_remoter):
+    """decrypt_sstables_on_node works when called with a real CollectingNode (the logcollector path)."""
+    snap = "/var/lib/scylla/data/ks/tbl-uuid/snapshots/snap"
+    data_file = f"{snap}/me-big-Data.db"
+    fake_remoter.result_map = {
+        re.compile(r"cat .*/schema\.cql"): ok(SCHEMA_WITH_ENCRYPTION),
+        re.compile(r"ls .*/\*-Data\.db.*"): ok(data_file),
+        re.compile(r"echo .* \| base64 -d > /tmp/sct_decrypt_schema.*"): ok(),
+        re.compile(r"rm -rf .*/decrypted"): ok(),
+        re.compile(r"mkdir -p .*/decrypted"): ok(),
+        re.compile(r".*scylla sstable upgrade.*"): ok("Upgraded."),
+        re.compile(r"ls .*/decrypted/"): ok("me-new-big-Data.db"),
+        re.compile(r"rm -f /tmp/sct_decrypt_schema.*"): ok(),
+    }
+    node = CollectingNode(name="test-node")
+    node.remoter = RemoteCmdRunnerBase.create_remoter("test-node")
+    assert decrypt_sstables_on_node(node, snap, keyspace="ks", table="tbl") == f"{snap}/decrypted"

--- a/unit_tests/test_sstable_decrypt.py
+++ b/unit_tests/test_sstable_decrypt.py
@@ -1,0 +1,298 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Unit tests for sstable decryption helpers in sdcm.utils.sstable.sstable_utils."""
+
+import re
+from typing import Dict, Pattern
+from unittest.mock import patch
+
+import pytest
+from invoke import Result
+
+from sdcm.remote import RemoteCmdRunnerBase
+from sdcm.utils.sstable.sstable_utils import (
+    decrypt_sstable_files_on_node,
+    decrypt_sstables_on_node,
+    strip_encryption_options_from_schema,
+)
+
+# ---------------------------------------------------------------------------
+# Test data constants
+# ---------------------------------------------------------------------------
+
+SCHEMA_NO_ENCRYPTION = """\
+CREATE TABLE test_ks.test_table (
+    id int,
+    name text,
+    PRIMARY KEY (id)
+) WITH bloom_filter_fp_chance = 0.01
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
+    AND compaction = {'class': 'IncrementalCompactionStrategy'}
+    AND compression = {'sstable_compression': 'LZ4Compressor'}
+    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};
+"""
+
+SCHEMA_WITH_ENCRYPTION = """\
+CREATE TABLE test_ks.test_table (
+    id int,
+    name text,
+    PRIMARY KEY (id)
+) WITH bloom_filter_fp_chance = 0.01
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
+    AND compaction = {'class': 'IncrementalCompactionStrategy'}
+    AND compression = {'sstable_compression': 'LZ4Compressor'}
+    AND scylla_encryption_options = {'cipher_algorithm': 'AES/ECB/PKCS5Padding', 'key_provider': 'LocalFileSystemKeyProviderFactory', 'secret_key_file': '/etc/scylla/encrypt_conf/secret_key', 'secret_key_strength': '128'}
+    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers / stubs
+# ---------------------------------------------------------------------------
+
+
+class FakeNode:
+    """Minimal node stub for testing decrypt helpers without real SSH."""
+
+    def __init__(self, remoter):
+        self.remoter = remoter
+
+    def add_install_prefix(self, path: str) -> str:
+        return path
+
+
+def ok(stdout: str = "") -> Result:
+    return Result(stdout=stdout, exited=0)
+
+
+def fail(stderr: str = "error") -> Result:
+    return Result(stdout="", stderr=stderr, exited=1)
+
+
+@pytest.fixture
+def setup_node(fake_remoter):
+    """Return a callable that, given a result_map, returns (node, mock_run).
+
+    Usage::
+
+        def test_something(setup_node):
+            node, mock_run = setup_node({re.compile(r"cat .*"): ok("schema")})
+            result = decrypt_sstables_on_node(node, "/snap", keyspace="ks", table="tbl")
+            mock_run.assert_any_call("cat /snap/schema.cql", ...)
+    """
+
+    def factory(result_map: Dict[Pattern, Result]):
+        fake_remoter.result_map = result_map
+        node = FakeNode(RemoteCmdRunnerBase.create_remoter("test-node"))
+        with patch.object(node.remoter, "run", wraps=node.remoter.run) as mock_run:
+            return node, mock_run
+
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# strip_encryption_options_from_schema – pure function tests
+# ---------------------------------------------------------------------------
+
+
+def test_strip_encryption_options_removes_clause():
+    """scylla_encryption_options AND clause is stripped from schema that contains it, but others clauses are preserved."""
+    result = strip_encryption_options_from_schema(SCHEMA_WITH_ENCRYPTION)
+    assert "scylla_encryption_options" not in result
+
+    assert "tombstone_gc" in result
+    assert "LZ4Compressor" in result
+    assert "bloom_filter_fp_chance" in result
+
+
+def test_strip_encryption_options_schema_without_encryption_unchanged():
+    """Schema without scylla_encryption_options is returned byte-for-byte identical."""
+    result = strip_encryption_options_from_schema(SCHEMA_NO_ENCRYPTION)
+    assert result == SCHEMA_NO_ENCRYPTION
+
+
+def test_strip_encryption_options_empty_string():
+    """Empty input produces empty output."""
+    assert strip_encryption_options_from_schema("") == ""
+
+
+@pytest.mark.parametrize(
+    "schema_text",
+    [
+        pytest.param(
+            "CREATE TABLE t (id int PRIMARY KEY)\n    AND scylla_encryption_options = {'key_provider': 'Foo'};",
+            id="minimal_single_property",
+        ),
+        pytest.param(
+            "CREATE TABLE t (id int PRIMARY KEY)"
+            "\n    AND scylla_encryption_options = {'a': 'b', 'c': 'd'}"
+            "\n    AND other_prop = 'x';",
+            id="followed_by_another_property",
+        ),
+        pytest.param(
+            "CREATE TABLE t1 (id int PRIMARY KEY)"
+            "\n    AND scylla_encryption_options = {'a': 'b'};\n"
+            "CREATE TABLE t2 (id int PRIMARY KEY)"
+            "\n    AND scylla_encryption_options = {'c': 'd'};",
+            id="multiple_tables_both_encrypted",
+        ),
+    ],
+)
+def test_strip_encryption_options_various_formats(schema_text):
+    """scylla_encryption_options is removed regardless of surrounding context."""
+    result = strip_encryption_options_from_schema(schema_text)
+    assert "scylla_encryption_options" not in result
+
+
+def test_strip_encryption_options_case_insensitive():
+    """Stripping works even when the property name is upper-cased."""
+    schema = "CREATE TABLE t (id int PRIMARY KEY)\n    AND SCYLLA_ENCRYPTION_OPTIONS = {'a': 'b'};"
+    assert "SCYLLA_ENCRYPTION_OPTIONS" not in strip_encryption_options_from_schema(schema)
+
+
+# ---------------------------------------------------------------------------
+# decrypt_sstables_on_node – behaviour tests using FakeRemoter
+# ---------------------------------------------------------------------------
+
+
+def test_decrypt_sstables_on_node_happy_path(setup_node):
+    """decrypt_sstables_on_node returns the decrypted/ dir path on success."""
+    snap = "/var/lib/scylla/data/ks/tbl-uuid/snapshots/snap"
+    data_file = f"{snap}/me-big-Data.db"
+    node, _ = setup_node(
+        {
+            re.compile(r"cat .*/schema\.cql"): ok(SCHEMA_WITH_ENCRYPTION),
+            re.compile(r"ls .*/\*-Data\.db.*"): ok(data_file),
+            re.compile(r"echo .* \| base64 -d > /tmp/sct_decrypt_schema.*"): ok(),
+            re.compile(r"rm -rf .*/decrypted"): ok(),
+            re.compile(r"mkdir -p .*/decrypted"): ok(),
+            re.compile(r".*scylla sstable upgrade.*"): ok("Upgraded."),
+            re.compile(r"ls .*/decrypted/"): ok("me-new-big-Data.db"),
+            re.compile(r"rm -f /tmp/sct_decrypt_schema.*"): ok(),
+        }
+    )
+    assert decrypt_sstables_on_node(node, snap, keyspace="ks", table="tbl") == f"{snap}/decrypted"
+
+
+def test_decrypt_sstables_on_node_missing_schema_returns_none(setup_node):
+    """decrypt_sstables_on_node returns None when schema.cql is missing."""
+    node, mock_run = setup_node(
+        {
+            re.compile(r"cat .*/schema\.cql"): fail("No such file"),
+        }
+    )
+    assert decrypt_sstables_on_node(node, "/snapshots/snap", keyspace="ks", table="tbl") is None
+    assert not any("sstable upgrade" in c.args[0] for c in mock_run.call_args_list)
+
+
+def test_decrypt_sstables_on_node_no_data_files_returns_none(setup_node):
+    """decrypt_sstables_on_node returns None when there are no Data.db files."""
+    node, mock_run = setup_node(
+        {
+            re.compile(r"cat .*/schema\.cql"): ok(SCHEMA_NO_ENCRYPTION),
+            re.compile(r"ls .*/\*-Data\.db.*"): ok(""),
+        }
+    )
+    assert decrypt_sstables_on_node(node, "/snapshots/snap", keyspace="ks", table="tbl") is None
+    assert not any("sstable upgrade" in c.args[0] for c in mock_run.call_args_list)
+
+
+def test_decrypt_sstables_on_node_upgrade_failure_returns_none(setup_node):
+    """decrypt_sstables_on_node returns None when scylla sstable upgrade fails."""
+    data_file = "/snapshots/snap/me-big-Data.db"
+    node, _ = setup_node(
+        {
+            re.compile(r"cat .*/schema\.cql"): ok(SCHEMA_NO_ENCRYPTION),
+            re.compile(r"ls .*/\*-Data\.db.*"): ok(data_file),
+            re.compile(r"echo .* \| base64 -d > /tmp/sct_decrypt_schema.*"): ok(),
+            re.compile(r"rm -rf .*/decrypted"): ok(),
+            re.compile(r"mkdir -p .*/decrypted"): ok(),
+            re.compile(r".*scylla sstable upgrade.*"): fail("upgrade failed"),
+            re.compile(r"rm -f /tmp/sct_decrypt_schema.*"): ok(),
+        }
+    )
+    assert decrypt_sstables_on_node(node, "/snapshots/snap", keyspace="ks", table="tbl") is None
+
+
+def test_decrypt_sstables_on_node_empty_output_returns_none(setup_node):
+    """decrypt_sstables_on_node returns None when upgrade exits 0 but produces no files."""
+    data_file = "/snapshots/snap/me-big-Data.db"
+    node, _ = setup_node(
+        {
+            re.compile(r"cat .*/schema\.cql"): ok(SCHEMA_NO_ENCRYPTION),
+            re.compile(r"ls .*/\*-Data\.db.*"): ok(data_file),
+            re.compile(r"echo .* \| base64 -d > /tmp/sct_decrypt_schema.*"): ok(),
+            re.compile(r"rm -rf .*/decrypted"): ok(),
+            re.compile(r"mkdir -p .*/decrypted"): ok(),
+            re.compile(r".*scylla sstable upgrade.*"): ok("Done."),
+            re.compile(r"ls .*/decrypted/"): ok(""),
+            re.compile(r"rm -f /tmp/sct_decrypt_schema.*"): ok(),
+        }
+    )
+    assert decrypt_sstables_on_node(node, "/snapshots/snap", keyspace="ks", table="tbl") is None
+
+
+# ---------------------------------------------------------------------------
+# decrypt_sstable_files_on_node – behaviour tests using FakeRemoter
+# ---------------------------------------------------------------------------
+
+
+def test_decrypt_sstable_files_on_node_happy_path(setup_node):
+    """decrypt_sstable_files_on_node returns decrypted/ dir path on success."""
+    data_file = "/var/lib/scylla/data/ks/tbl-uuid/me-big-Data.db"
+    node, _ = setup_node(
+        {
+            re.compile(r"echo .* \| base64 -d > /tmp/sct_decrypt_schema.*"): ok(),
+            re.compile(r"rm -rf .*/decrypted"): ok(),
+            re.compile(r"mkdir -p .*/decrypted"): ok(),
+            re.compile(r".*scylla sstable upgrade.*"): ok("Upgraded."),
+            re.compile(r"ls .*/decrypted/"): ok("me-new-big-Data.db"),
+            re.compile(r"rm -f /tmp/sct_decrypt_schema.*"): ok(),
+        }
+    )
+    assert (
+        decrypt_sstable_files_on_node(
+            node=node, data_files=[data_file], schema_text=SCHEMA_WITH_ENCRYPTION, keyspace="ks", table="tbl"
+        )
+        == "/var/lib/scylla/data/ks/tbl-uuid/decrypted"
+    )
+
+
+def test_decrypt_sstable_files_on_node_empty_list_is_noop(setup_node):
+    """decrypt_sstable_files_on_node returns None immediately when given an empty file list."""
+    node, _ = setup_node({})
+    assert (
+        decrypt_sstable_files_on_node(node, data_files=[], schema_text=SCHEMA_NO_ENCRYPTION, keyspace="ks", table="tbl")
+        is None
+    )
+
+
+def test_decrypt_sstable_files_on_node_upgrade_failure_returns_none(setup_node):
+    """decrypt_sstable_files_on_node returns None when upgrade fails."""
+    data_file = "/some/path/me-big-Data.db"
+    node, _ = setup_node(
+        {
+            re.compile(r"echo .* \| base64 -d > /tmp/sct_decrypt_schema.*"): ok(),
+            re.compile(r"rm -rf .*/decrypted"): ok(),
+            re.compile(r"mkdir -p .*/decrypted"): ok(),
+            re.compile(r".*scylla sstable upgrade.*"): fail("upgrade failed"),
+            re.compile(r"rm -f /tmp/sct_decrypt_schema.*"): ok(),
+        }
+    )
+    assert (
+        decrypt_sstable_files_on_node(
+            node=node, data_files=[data_file], schema_text=SCHEMA_NO_ENCRYPTION, keyspace="ks", table="tbl"
+        )
+        is None
+    )

--- a/unit_tests/test_sstable_decrypt.py
+++ b/unit_tests/test_sstable_decrypt.py
@@ -13,16 +13,14 @@
 
 """Unit tests for sstable decryption helpers in sdcm.utils.sstable.sstable_utils."""
 
-import io
-import json
 import re
 from typing import Dict, Pattern
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from invoke import Result
 
-from sdcm.logcollector import CollectingNode, SSTablesCollector
+from sdcm.logcollector import CollectingNode
 from sdcm.remote import RemoteCmdRunnerBase
 from sdcm.utils.sstable.sstable_utils import (
     decrypt_sstable_files_on_node,
@@ -324,91 +322,3 @@ def test_decrypt_sstables_on_node_with_collecting_node(fake_remoter):
     node = CollectingNode(name="test-node")
     node.remoter = RemoteCmdRunnerBase.create_remoter("test-node")
     assert decrypt_sstables_on_node(node, snap, keyspace="ks", table="tbl") == f"{snap}/decrypted"
-
-
-# ---------------------------------------------------------------------------
-# SSTablesCollector.collect_logs – snapshot fallback path
-# ---------------------------------------------------------------------------
-
-CORRUPTED_SSTABLE_EVENT = json.dumps(
-    {
-        "type": "CORRUPTED_SSTABLE",
-        "severity": "CRITICAL",
-        "line": "/var/lib/scylla/data/ks/tbl-uuid/me-1-big-Data.db",
-        "node": "db-node-0",
-    }
-)
-
-SSTABLE_DIR = "/var/lib/scylla/data/ks/tbl-uuid"
-EXISTING_SNAPSHOT = f"{SSTABLE_DIR}/snapshots/sct-1234567890"
-
-
-def _make_collector(tmp_path, node):
-    """Build a minimal SSTablesCollector with a single node and a temp storage dir."""
-    collector = SSTablesCollector.__new__(SSTablesCollector)
-    collector.test_id = "test-id-abcdef"
-    collector.nodes = [node]
-    collector.params = None
-    collector.local_dir = str(tmp_path / "logs")
-    # current_run is a read-only class-level property; no setter needed
-    return collector
-
-
-def test_collect_logs_falls_back_to_existing_snapshot_when_nodetool_fails(tmp_path):
-    """When nodetool snapshot raises, collect_logs uses the most recent existing snapshot."""
-    node = CollectingNode(name="db-node-0")
-    node.ssh_login_info = {}
-
-    # nodetool snapshot raises; ls -td returns one existing snapshot
-    def fake_run(cmd, **kwargs):
-        if "nodetool snapshot" in cmd:
-            raise EOFError("SSH connection closed")
-        if cmd.startswith("ls -td"):
-            return ok(f"{EXISTING_SNAPSHOT}/\n")
-        return ok("")
-
-    node.remoter = MagicMock()
-    node.remoter.run.side_effect = fake_run
-
-    collector = _make_collector(tmp_path, node)
-
-    events_content = CORRUPTED_SSTABLE_EVENT + "\n"
-
-    with (
-        patch("builtins.open", return_value=io.StringIO(events_content)),
-        patch("sdcm.logcollector.decrypt_sstables_on_node", return_value=None) as mock_decrypt,
-        patch("sdcm.logcollector.upload_remote_files_directly_to_s3", return_value="s3://link"),
-    ):
-        collector.collect_logs()
-
-    mock_decrypt.assert_called_once_with(node, EXISTING_SNAPSHOT, keyspace="ks", table="tbl")
-
-
-def test_collect_logs_returns_empty_when_nodetool_fails_and_no_snapshots_exist(tmp_path):
-    """When nodetool snapshot raises and no existing snapshots are found, collect_logs returns []."""
-    node = CollectingNode(name="db-node-0")
-    node.ssh_login_info = {}
-
-    def fake_run(cmd, **kwargs):
-        if "nodetool snapshot" in cmd:
-            raise EOFError("SSH connection closed")
-        if cmd.startswith("ls -td"):
-            return ok("")  # empty — no snapshots on disk
-        return ok("")
-
-    node.remoter = MagicMock()
-    node.remoter.run.side_effect = fake_run
-
-    collector = _make_collector(tmp_path, node)
-
-    events_content = CORRUPTED_SSTABLE_EVENT + "\n"
-
-    with (
-        patch("builtins.open", return_value=io.StringIO(events_content)),
-        patch("sdcm.logcollector.decrypt_sstables_on_node") as mock_decrypt,
-        patch("sdcm.logcollector.upload_remote_files_directly_to_s3"),
-    ):
-        result = collector.collect_logs()
-
-    assert result == []
-    mock_decrypt.assert_not_called()

--- a/unit_tests/test_sstable_decrypt_integration.py
+++ b/unit_tests/test_sstable_decrypt_integration.py
@@ -1,0 +1,519 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2026 ScyllaDB
+
+"""Integration tests for sstable decryption helpers.
+
+Starts a real ScyllaDB 2026.1.0 Docker container with encryption-at-rest (EAR) enabled,
+creates encrypted sstables, then verifies that decrypt_sstables_on_node() produces
+readable (unencrypted) output.
+
+Run with:
+    pytest -m integration unit_tests/test_sstable_decrypt_integration.py -v
+
+Requirements:
+    - Docker available
+    - scylladb/scylla:2026.1.0 image present (or pullable)
+"""
+
+import base64
+import logging
+import os
+import shutil
+import subprocess
+import time
+from unittest.mock import patch
+
+import pytest
+
+from sdcm.teardown_validators.sstables import decrypt_corrupted_sstables
+from sdcm.utils.sstable.s3_uploader import upload_sstables_to_s3
+from sdcm.utils.sstable.sstable_utils import decrypt_sstables_on_node
+
+LOGGER = logging.getLogger(__name__)
+
+SCYLLA_IMAGE = "scylladb/scylla:2026.1.0"
+CONTAINER_NAME = "sct-ear-integ-test"
+
+# AES-128 key for encryption (base64-encoded 16 bytes)
+AES_KEY_B64 = base64.b64encode(os.urandom(16)).decode()
+
+# scylla.yaml fragment that enables node-level EAR
+EAR_YAML = """\
+user_info_encryption:
+  enabled: true
+  key_provider: LocalFileSystemKeyProviderFactory
+  secret_key_file: /etc/scylla/encrypt_conf/secret_key
+system_info_encryption:
+  enabled: true
+  key_provider: LocalFileSystemKeyProviderFactory
+  secret_key_file: /etc/scylla/encrypt_conf/secret_key
+"""
+
+# Secret key file content: <algorithm>:<key_strength>:<base64_key>
+SECRET_KEY_CONTENT = f"AES/ECB/PKCS5Padding:128:{AES_KEY_B64}"
+
+KEYSPACE = "test_ks_ear"
+TABLE_NODE = "test_node_enc"
+TABLE_TABLE = "test_table_enc"
+
+
+def docker_available() -> bool:
+    return shutil.which("docker") is not None
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not docker_available(), reason="Docker not available"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Result stub and node stub
+# ---------------------------------------------------------------------------
+
+
+class FakeResult:
+    """Minimal Result-like object returned by DockerExecNode.run()."""
+
+    def __init__(self, stdout: str, stderr: str, exited: int):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exited = exited
+        self.ok = exited == 0
+        self.failed = exited != 0
+
+    def __bool__(self):
+        return self.ok
+
+
+class DockerExecNode:
+    """Minimal node stub that delegates remoter.run() to docker exec."""
+
+    def __init__(self, container_name: str):
+        self._container = container_name
+        self.remoter = self
+
+    def _container_ip(self) -> str:
+        """Return the primary IP address of the container.
+
+        Scylla binds its REST/JMX API to the container's listen_address rather than
+        127.0.0.1, so ``nodetool`` commands must pass ``-h <ip>`` to reach it.
+        """
+        result = subprocess.run(
+            ["docker", "exec", self._container, "/bin/sh", "-c", "hostname -I | awk '{print $1}'"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+
+    def run(self, cmd: str, ignore_status: bool = False, verbose: bool = True, **_kwargs):
+        """Execute *cmd* inside the container and return an invoke-like Result.
+
+        Commands that start with ``nodetool`` are automatically given a ``-h <container_ip>``
+        flag because Scylla binds its API to the container IP, not 127.0.0.1.
+        """
+        if cmd.startswith("nodetool "):
+            ip = self._container_ip()
+            cmd = f"nodetool -h {ip} {cmd[len('nodetool ') :]}"
+        full_cmd = ["docker", "exec", self._container, "/bin/sh", "-c", cmd]
+        if verbose:
+            LOGGER.debug("docker exec: %s", cmd)
+        proc = subprocess.run(full_cmd, capture_output=True, text=True, check=False)
+        result = FakeResult(stdout=proc.stdout, stderr=proc.stderr, exited=proc.returncode)
+        if not ignore_status and proc.returncode != 0:
+            raise RuntimeError(f"Command failed (exit {proc.returncode}): {cmd}\nstderr: {proc.stderr}")
+        return result
+
+    def sudo(self, cmd: str, **kwargs):
+        """Run as root — docker exec is already root, so no sudo prefix needed."""
+        return self.run(cmd, **kwargs)
+
+    def add_install_prefix(self, path: str) -> str:
+        return path
+
+
+# ---------------------------------------------------------------------------
+# Low-level container helpers (not fixtures — used only inside fixtures)
+# ---------------------------------------------------------------------------
+
+
+def wait_for_scylla(container: str, timeout: int = 120) -> None:
+    """Poll until CQL port is accepting connections (via cqlsh inside the container)."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        result = subprocess.run(
+            ["docker", "exec", container, "cqlsh", "-e", "SELECT now() FROM system.local"],
+            check=False,
+            capture_output=True,
+        )
+        if result.returncode == 0:
+            LOGGER.info("ScyllaDB is up in container %s", container)
+            return
+        LOGGER.debug("Waiting for ScyllaDB CQL in %s …", container)
+        time.sleep(3)
+    raise TimeoutError(f"ScyllaDB did not start within {timeout}s in container {container}")
+
+
+def cql(container: str, stmt: str) -> str:
+    """Run a CQL statement via cqlsh inside the container."""
+    result = subprocess.run(
+        ["docker", "exec", container, "cqlsh", "-e", stmt],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"cqlsh failed: {result.stderr}\nstmt: {stmt}")
+    return result.stdout
+
+
+def nodetool(container: str, cmd: str) -> str:
+    """Run a nodetool command inside the container.
+
+    Scylla's REST API is bound to the container's listen_address, not 127.0.0.1,
+    so nodetool needs an explicit -h <container_ip> flag.
+    """
+    ip_result = subprocess.run(
+        ["docker", "exec", container, "/bin/sh", "-c", "hostname -I | awk '{print $1}'"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    container_ip = ip_result.stdout.strip()
+    result = subprocess.run(
+        ["docker", "exec", container, "nodetool", "-h", container_ip] + cmd.split(),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"nodetool {cmd} failed: {result.stderr}")
+    return result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def scylla_container(tmp_path_factory, request):
+    """
+    Start a ScyllaDB container with EAR enabled; yield container name; stop on teardown.
+    TODO: Unify with docker_scylla which needs refactor regardless
+    """
+    encrypt_conf_dir = tmp_path_factory.mktemp("encrypt_conf")
+
+    # Write the secret key and EAR yaml.
+    # The directory must be writable by the scylla user inside the container because the encryption
+    # service writes a .tmp file alongside the key when loading it.
+    encrypt_conf_dir.chmod(0o777)
+    key_file = encrypt_conf_dir / "secret_key"
+    ear_yaml_file = encrypt_conf_dir / "ear.yaml"
+    key_file.write_text(SECRET_KEY_CONTENT)
+    key_file.chmod(0o666)
+    ear_yaml_file.write_text(EAR_YAML)
+    ear_yaml_file.chmod(0o666)
+
+    request.addfinalizer(
+        lambda: subprocess.run(["docker", "rm", "-f", CONTAINER_NAME], capture_output=True, check=False)
+    )
+
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            CONTAINER_NAME,
+            "-v",
+            f"{encrypt_conf_dir}:/etc/scylla/encrypt_conf:z",
+            "--cpus=1",
+            SCYLLA_IMAGE,
+            "--smp=1",
+            "--options-file=/etc/scylla/encrypt_conf/ear.yaml",
+            "--developer-mode=1",
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    wait_for_scylla(CONTAINER_NAME)
+
+    # Create keyspace, node-level-encrypted table and table-level-encrypted table
+    cql(
+        CONTAINER_NAME,
+        f"CREATE KEYSPACE IF NOT EXISTS {KEYSPACE} "
+        "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};",
+    )
+    cql(CONTAINER_NAME, f"CREATE TABLE IF NOT EXISTS {KEYSPACE}.{TABLE_NODE} (id int PRIMARY KEY, name text);")
+    cql(CONTAINER_NAME, f"INSERT INTO {KEYSPACE}.{TABLE_NODE} (id, name) VALUES (1, 'node_enc');")
+    nodetool(CONTAINER_NAME, f"flush {KEYSPACE} {TABLE_NODE}")
+
+    ear_opts = (
+        "{'cipher_algorithm': 'AES/ECB/PKCS5Padding',"
+        " 'key_provider': 'LocalFileSystemKeyProviderFactory',"
+        " 'secret_key_file': '/etc/scylla/encrypt_conf/secret_key',"
+        " 'secret_key_strength': '128'}"
+    )
+    cql(
+        CONTAINER_NAME,
+        f"CREATE TABLE IF NOT EXISTS {KEYSPACE}.{TABLE_TABLE}"
+        f" (id int PRIMARY KEY, name text)"
+        f" WITH scylla_encryption_options = {ear_opts};",
+    )
+    cql(CONTAINER_NAME, f"INSERT INTO {KEYSPACE}.{TABLE_TABLE} (id, name) VALUES (1, 'table_enc');")
+    nodetool(CONTAINER_NAME, f"flush {KEYSPACE} {TABLE_TABLE}")
+
+    yield CONTAINER_NAME
+
+
+@pytest.fixture(scope="module")
+def scylla_node(scylla_container):
+    """Return a DockerExecNode wrapping the running ScyllaDB container."""
+    return DockerExecNode(scylla_container)
+
+
+@pytest.fixture(scope="module")
+def take_snapshot(scylla_container):
+    """Return a callable that takes a snapshot and returns its absolute path inside the container."""
+
+    def _take(keyspace: str, table: str, snap_name: str) -> str:
+        nodetool(scylla_container, f"snapshot -t {snap_name} -cf {table} -- {keyspace}")
+        result = subprocess.run(
+            [
+                "docker",
+                "exec",
+                scylla_container,
+                "find",
+                f"/var/lib/scylla/data/{keyspace}",
+                "-type",
+                "d",
+                "-name",
+                snap_name,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            raise RuntimeError(f"Could not locate snapshot '{snap_name}' for {keyspace}.{table}:\n{result.stderr}")
+        paths = result.stdout.strip().splitlines()
+        for path in paths:
+            if f"/{table}-" in path or f"/{table}/" in path:
+                return path.strip()
+        return paths[0].strip()
+
+    return _take
+
+
+@pytest.fixture(scope="module")
+def has_encryption_in_metadata(scylla_container):
+    """Return a callable that checks whether any sstable in a snapshot dir is encrypted."""
+
+    def _check(snap_path: str, keyspace: str, table: str) -> bool:
+        cmd = (
+            f"SCYLLA_CONF=/etc/scylla "
+            f"/usr/bin/scylla sstable dump-scylla-metadata "
+            f"--keyspace {keyspace} --table {table} --sstables "
+            f"{snap_path}/*-Data.db 2>/dev/null || true"
+        )
+        # Use binary mode: the scylla_encryption_options value contains raw binary bytes
+        # which cannot be decoded as UTF-8.
+        result = subprocess.run(
+            ["docker", "exec", scylla_container, "/bin/sh", "-c", cmd],
+            check=False,
+            capture_output=True,
+        )
+        return b"scylla_encryption_options" in result.stdout
+
+    return _check
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xdist_group("ear_scylla_container")
+@pytest.mark.parametrize(
+    "table,snap_name",
+    [
+        pytest.param(TABLE_NODE, "snap_node_enc", id="node_level_encryption"),
+        pytest.param(TABLE_TABLE, "snap_table_enc", id="table_level_encryption"),
+    ],
+)
+def test_decrypt_sstables_on_node(scylla_node, take_snapshot, has_encryption_in_metadata, table, snap_name):
+    """Snapshot of an encrypted table can be decrypted by decrypt_sstables_on_node.
+
+    Parametrized over node-level EAR (primary case) and table-level EAR.
+    """
+    snap_path = take_snapshot(KEYSPACE, table, snap_name)
+    LOGGER.info("Snapshot path (%s): %s", snap_name, snap_path)
+
+    assert has_encryption_in_metadata(snap_path, KEYSPACE, table), (
+        f"Expected encrypted sstables to show scylla_encryption_options in metadata before decryption ({snap_name})"
+    )
+
+    decrypted_path = decrypt_sstables_on_node(scylla_node, snap_path, keyspace=KEYSPACE, table=table)
+
+    assert decrypted_path is not None, f"decrypt_sstables_on_node returned None — decryption failed ({snap_name})"
+    assert not has_encryption_in_metadata(decrypted_path, KEYSPACE, table), (
+        f"Expected no scylla_encryption_options in sstable metadata after decryption ({snap_name})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper: find live Data.db paths inside the container
+# ---------------------------------------------------------------------------
+
+
+def find_data_files(container: str, keyspace: str, table: str) -> list[str]:
+    """Return absolute paths to *-Data.db files inside the container for the given table."""
+    result = subprocess.run(
+        [
+            "docker",
+            "exec",
+            container,
+            "find",
+            f"/var/lib/scylla/data/{keyspace}",
+            "-name",
+            "*-Data.db",
+            "-path",
+            f"*/{table}-*",
+            # Exclude any snapshot subdirectories created by previous tests so we always
+            # get the live (non-snapshot) Data.db files.
+            "!",
+            "-path",
+            "*/snapshots/*",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    paths = [p.strip() for p in result.stdout.splitlines() if p.strip()]
+    if not paths:
+        raise RuntimeError(
+            f"No live Data.db files found for {keyspace}.{table} in container {container}.\nstderr: {result.stderr}"
+        )
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Tests for decrypt_corrupted_sstables (teardown_validators path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xdist_group("ear_scylla_container")
+@pytest.mark.parametrize(
+    "table",
+    [
+        pytest.param(TABLE_NODE, id="node_level_encryption"),
+        pytest.param(TABLE_TABLE, id="table_level_encryption"),
+    ],
+)
+def test_decrypt_corrupted_sstables(scylla_container, scylla_node, has_encryption_in_metadata, table):
+    """decrypt_corrupted_sstables() takes live Data.db paths, snapshots the table for schema,
+    and decrypts the files — exercising the full teardown_validators code path including the
+    nodetool snapshot syntax and the -Data.db file filter.
+    """
+    data_files = find_data_files(scylla_container, KEYSPACE, table)
+    LOGGER.info("Live Data.db files for %s.%s: %s", KEYSPACE, table, data_files)
+
+    # Verify the live files are actually encrypted before we attempt decryption
+    for f in data_files:
+        parent = f.rsplit("/", 1)[0]
+        assert has_encryption_in_metadata(parent, KEYSPACE, table), (
+            f"Expected live sstables to be encrypted before decrypt_corrupted_sstables ({table})"
+        )
+
+    decrypted_dirs = decrypt_corrupted_sstables(scylla_node, data_files)
+
+    assert decrypted_dirs, f"decrypt_corrupted_sstables returned an empty list — decryption failed for {table}"
+    for decrypted_dir in decrypted_dirs:
+        assert not has_encryption_in_metadata(decrypted_dir, KEYSPACE, table), (
+            f"Expected no scylla_encryption_options in decrypted metadata for {table} in {decrypted_dir}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests for upload_sstables_to_s3 decrypt path (s3_uploader path)
+# ---------------------------------------------------------------------------
+
+
+class DockerExecNodeWithMeta(DockerExecNode):
+    """DockerExecNode extended with the attributes upload_sstables_to_s3 requires."""
+
+    def __init__(self, container_name: str):
+        super().__init__(container_name)
+        self.name = container_name
+        self.ssh_login_info = {}  # not used — upload is patched out
+
+
+@pytest.fixture(scope="module")
+def scylla_node_with_meta(scylla_container):
+    """Return a DockerExecNodeWithMeta wrapping the running ScyllaDB container."""
+    return DockerExecNodeWithMeta(scylla_container)
+
+
+@pytest.mark.xdist_group("ear_scylla_container")
+@pytest.mark.parametrize(
+    "table",
+    [
+        pytest.param(TABLE_NODE, id="node_level_encryption"),
+        pytest.param(TABLE_TABLE, id="table_level_encryption"),
+    ],
+)
+def test_upload_sstables_to_s3_decrypt_path(scylla_container, scylla_node_with_meta, has_encryption_in_metadata, table):
+    """upload_sstables_to_s3() calls decrypt_sstables_on_node for each snapshot and includes
+    the decrypted directory in the upload paths.
+
+    The S3 upload itself is patched out; we assert that the path list passed to it contains
+    both the snapshot path and a decrypted sibling directory.
+    """
+    captured = {}
+
+    def fake_upload(ssh_login_info, paths, **_kwargs):
+        captured["paths"] = list(paths)
+        return "https://fake-s3/link"
+
+    with patch(
+        "sdcm.utils.sstable.s3_uploader.upload_remote_files_directly_to_s3",
+        side_effect=fake_upload,
+    ):
+        upload_sstables_to_s3(
+            node=scylla_node_with_meta,
+            keyspace=KEYSPACE,
+            test_id="integ-test",
+            tables=[table],
+        )
+
+    assert "paths" in captured, "upload_remote_files_directly_to_s3 was never called"
+    upload_paths = captured["paths"]
+    LOGGER.info("upload_paths for %s: %s", table, upload_paths)
+
+    snapshot_paths = [p for p in upload_paths if "/snapshots/" in p and "decrypted" not in p]
+    decrypted_paths = [p for p in upload_paths if "decrypted" in p]
+
+    assert snapshot_paths, f"No snapshot path found in upload_paths for {table}: {upload_paths}"
+    assert decrypted_paths, (
+        f"No decrypted/ path found in upload_paths for {table}: {upload_paths} — "
+        "decrypt_sstables_on_node may have failed or returned None"
+    )
+
+    # The decrypted output must not contain encrypted sstables
+    for decrypted_dir in decrypted_paths:
+        assert not has_encryption_in_metadata(decrypted_dir, KEYSPACE, table), (
+            f"Expected no scylla_encryption_options in decrypted metadata for {table} in {decrypted_dir}"
+        )

--- a/unit_tests/test_sstable_decrypt_integration.py
+++ b/unit_tests/test_sstable_decrypt_integration.py
@@ -410,20 +410,27 @@ def test_decrypt_sstables_on_node_smoke(scylla_container, scylla_node):
 
 @pytest.mark.xdist_group("ear_scylla_container")
 def test_take_snapshot_and_decrypt(scylla_container, scylla_node):
-    """take_snapshot_and_decrypt() returns (snapshot_path, decrypted_path) with real sstables."""
+    """take_snapshot_and_decrypt() returns (snapshot_path, sstable_files, decrypted_path) with real sstables."""
     data_file = find_live_data_file(scylla_container, KEYSPACE, TABLE_NODE)
     # Derive sstable_dir: /var/lib/scylla/data/<ks>/<table-dir>
     sstable_dir = "/".join(data_file.split("/")[:7])
+    sstable_name = data_file.rsplit("/", 1)[-1]
 
-    snapshot_path, decrypted_path = take_snapshot_and_decrypt(
+    snapshot_path, sstable_files, decrypted_path = take_snapshot_and_decrypt(
         node=scylla_node,
         sstable_dir=sstable_dir,
         keyspace=KEYSPACE,
         table_name=TABLE_NODE,
+        sstable_name=sstable_name,
     )
 
     assert snapshot_path is not None, "take_snapshot_and_decrypt returned None snapshot_path"
+    assert sstable_files, "take_snapshot_and_decrypt returned no sstable component files"
     assert decrypted_path is not None, "take_snapshot_and_decrypt returned None decrypted_path"
+
+    # All component files should be inside the snapshot directory
+    for f in sstable_files:
+        assert f.startswith(snapshot_path), f"Component file {f} not under snapshot {snapshot_path}"
 
     assert has_encryption_in_metadata(scylla_container, snapshot_path, KEYSPACE, TABLE_NODE), (
         f"Snapshot at {snapshot_path} should still be encrypted"
@@ -569,12 +576,16 @@ def test_full_pipeline_collect_logs_uses_state_file(scylla_container, scylla_nod
     upload_paths = captured["paths"]
     LOGGER.info("Paths passed to upload: %s", upload_paths)
 
-    assert state["snapshot_path"] in upload_paths, (
-        f"snapshot_path {state['snapshot_path']} not in upload paths: {upload_paths}"
-    )
+    # upload_files contains targeted sstable component files + schema.cql (not the whole snapshot dir)
+    assert any(p.endswith("/schema.cql") for p in upload_paths), f"schema.cql not in upload paths: {upload_paths}"
+    assert any(p.endswith("-Data.db") for p in upload_paths), f"No Data.db component in upload paths: {upload_paths}"
     assert state["decrypted_path"] in upload_paths, (
         f"decrypted_path {state['decrypted_path']} not in upload paths: {upload_paths}"
     )
+    # All targeted files should be under the snapshot directory
+    for p in upload_paths:
+        if p != state["decrypted_path"]:
+            assert p.startswith(state["snapshot_path"]), f"Upload path {p} not under snapshot {state['snapshot_path']}"
 
 
 # ---------------------------------------------------------------------------

--- a/unit_tests/test_sstable_decrypt_integration.py
+++ b/unit_tests/test_sstable_decrypt_integration.py
@@ -11,11 +11,15 @@
 #
 # Copyright (c) 2026 ScyllaDB
 
-"""Integration tests for sstable decryption helpers.
+"""Integration tests for the CorruptedSstablesPreparator → state file → SSTablesCollector pipeline.
 
-Starts a real ScyllaDB 2026.1.0 Docker container with encryption-at-rest (EAR) enabled,
-creates encrypted sstables, then verifies that decrypt_sstables_on_node() produces
-readable (unencrypted) output.
+Starts a real ScyllaDB Docker container with encryption-at-rest (EAR) enabled, creates encrypted
+sstables, then exercises the complete new code path end-to-end using only the real constructors:
+
+  1. CorruptedSstablesPreparator(params, tester).validate()
+       reads raw events log → nodetool snapshot → decrypt_sstables_on_node → writes state file
+  2. SSTablesCollector(nodes, test_id, storage_dir, params).collect_logs()
+       reads state file → calls upload_remote_files_directly_to_s3 with snapshot + decrypted paths
 
 Run with:
     pytest -m integration unit_tests/test_sstable_decrypt_integration.py -v
@@ -26,18 +30,23 @@ Requirements:
 """
 
 import base64
+import json
 import logging
 import os
 import shutil
 import subprocess
 import time
-from unittest.mock import patch
+import uuid
+from pathlib import Path
+from unittest.mock import Mock, patch
 
 import pytest
 
-from sdcm.teardown_validators.sstables import decrypt_corrupted_sstables
-from sdcm.utils.sstable.s3_uploader import upload_sstables_to_s3
-from sdcm.utils.sstable.sstable_utils import decrypt_sstables_on_node
+from sdcm.logcollector import SSTablesCollector
+from sdcm.sct_config import SCTConfiguration
+from sdcm.sct_events.events_device import EVENTS_LOG_DIR, RAW_EVENTS_LOG
+from sdcm.teardown_validators.sstables import CorruptedSstablesPreparator, take_snapshot_and_decrypt
+from sdcm.utils.sstable.sstable_utils import CORRUPTED_SSTABLES_STATE_FILENAME, decrypt_sstables_on_node
 
 LOGGER = logging.getLogger(__name__)
 
@@ -64,7 +73,6 @@ SECRET_KEY_CONTENT = f"AES/ECB/PKCS5Padding:128:{AES_KEY_B64}"
 
 KEYSPACE = "test_ks_ear"
 TABLE_NODE = "test_node_enc"
-TABLE_TABLE = "test_table_enc"
 
 
 def docker_available() -> bool:
@@ -78,7 +86,19 @@ pytestmark = [
 
 
 # ---------------------------------------------------------------------------
-# Result stub and node stub
+# SCTConfiguration subclass that enables CorruptedSstablesPreparator
+# ---------------------------------------------------------------------------
+
+
+class PreparatorSCTConfig(SCTConfiguration):
+    """Minimal SCTConfiguration that enables the corrupted_sstables_preparator validator."""
+
+    def _load_environment_variables(self):
+        return {"teardown_validators": {"corrupted_sstables_preparator": {"enabled": True}}}
+
+
+# ---------------------------------------------------------------------------
+# Node stub: delegates remoter.run() / sudo() to docker exec
 # ---------------------------------------------------------------------------
 
 
@@ -97,18 +117,19 @@ class FakeResult:
 
 
 class DockerExecNode:
-    """Minimal node stub that delegates remoter.run() to docker exec."""
+    """Node stub that delegates remoter.run() / sudo() to docker exec.
 
-    def __init__(self, container_name: str):
+    ``self.remoter = self`` so that code calling ``node.remoter.run(...)`` works
+    without any extra wiring.  No mocking: every method calls the real container.
+    """
+
+    def __init__(self, container_name: str, node_name: str = CONTAINER_NAME):
         self._container = container_name
+        self.name = node_name
+        self.ssh_login_info = {"hostname": "127.0.0.1", "user": "root"}
         self.remoter = self
 
     def _container_ip(self) -> str:
-        """Return the primary IP address of the container.
-
-        Scylla binds its REST/JMX API to the container's listen_address rather than
-        127.0.0.1, so ``nodetool`` commands must pass ``-h <ip>`` to reach it.
-        """
         result = subprocess.run(
             ["docker", "exec", self._container, "/bin/sh", "-c", "hostname -I | awk '{print $1}'"],
             capture_output=True,
@@ -117,26 +138,26 @@ class DockerExecNode:
         )
         return result.stdout.strip()
 
-    def run(self, cmd: str, ignore_status: bool = False, verbose: bool = True, **_kwargs):
-        """Execute *cmd* inside the container and return an invoke-like Result.
-
-        Commands that start with ``nodetool`` are automatically given a ``-h <container_ip>``
-        flag because Scylla binds its API to the container IP, not 127.0.0.1.
-        """
+    def run(self, cmd: str, ignore_status: bool = False, verbose: bool = True, **_kwargs) -> FakeResult:
+        """Execute *cmd* inside the container; prepend ``-h <ip>`` for nodetool commands."""
         if cmd.startswith("nodetool "):
             ip = self._container_ip()
             cmd = f"nodetool -h {ip} {cmd[len('nodetool ') :]}"
-        full_cmd = ["docker", "exec", self._container, "/bin/sh", "-c", cmd]
+        proc = subprocess.run(
+            ["docker", "exec", self._container, "/bin/sh", "-c", cmd],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
         if verbose:
-            LOGGER.debug("docker exec: %s", cmd)
-        proc = subprocess.run(full_cmd, capture_output=True, text=True, check=False)
+            LOGGER.debug("docker exec %s: exit=%d", cmd[:120], proc.returncode)
         result = FakeResult(stdout=proc.stdout, stderr=proc.stderr, exited=proc.returncode)
         if not ignore_status and proc.returncode != 0:
             raise RuntimeError(f"Command failed (exit {proc.returncode}): {cmd}\nstderr: {proc.stderr}")
         return result
 
-    def sudo(self, cmd: str, **kwargs):
-        """Run as root — docker exec is already root, so no sudo prefix needed."""
+    def sudo(self, cmd: str, **kwargs) -> FakeResult:
+        """Docker exec already runs as root — no sudo prefix needed."""
         return self.run(cmd, **kwargs)
 
     def add_install_prefix(self, path: str) -> str:
@@ -144,12 +165,12 @@ class DockerExecNode:
 
 
 # ---------------------------------------------------------------------------
-# Low-level container helpers (not fixtures — used only inside fixtures)
+# Container helpers
 # ---------------------------------------------------------------------------
 
 
 def wait_for_scylla(container: str, timeout: int = 120) -> None:
-    """Poll until CQL port is accepting connections (via cqlsh inside the container)."""
+    """Poll until CQL port is accepting connections inside the container."""
     deadline = time.time() + timeout
     while time.time() < deadline:
         result = subprocess.run(
@@ -166,7 +187,6 @@ def wait_for_scylla(container: str, timeout: int = 120) -> None:
 
 
 def cql(container: str, stmt: str) -> str:
-    """Run a CQL statement via cqlsh inside the container."""
     result = subprocess.run(
         ["docker", "exec", container, "cqlsh", "-e", stmt],
         check=False,
@@ -179,11 +199,6 @@ def cql(container: str, stmt: str) -> str:
 
 
 def nodetool(container: str, cmd: str) -> str:
-    """Run a nodetool command inside the container.
-
-    Scylla's REST API is bound to the container's listen_address, not 127.0.0.1,
-    so nodetool needs an explicit -h <container_ip> flag.
-    """
     ip_result = subprocess.run(
         ["docker", "exec", container, "/bin/sh", "-c", "hostname -I | awk '{print $1}'"],
         capture_output=True,
@@ -202,29 +217,80 @@ def nodetool(container: str, cmd: str) -> str:
     return result.stdout
 
 
+def has_encryption_in_metadata(container: str, path: str, keyspace: str, table: str) -> bool:
+    """Return True if any sstable in *path* has scylla_encryption_options in its metadata."""
+    cmd = (
+        f"SCYLLA_CONF=/etc/scylla "
+        f"/usr/bin/scylla sstable dump-scylla-metadata "
+        f"--keyspace {keyspace} --table {table} --sstables "
+        f"{path}/*-Data.db 2>/dev/null || true"
+    )
+    result = subprocess.run(
+        ["docker", "exec", container, "/bin/sh", "-c", cmd],
+        check=False,
+        capture_output=True,
+    )
+    return b"scylla_encryption_options" in result.stdout
+
+
+def find_live_data_file(container: str, keyspace: str, table: str) -> str:
+    """Return path to the first live *-Data.db for the given table (not inside a snapshot)."""
+    result = subprocess.run(
+        [
+            "docker",
+            "exec",
+            container,
+            "find",
+            f"/var/lib/scylla/data/{keyspace}",
+            "-name",
+            "*-Data.db",
+            "-path",
+            f"*/{table}-*",
+            "!",
+            "-path",
+            "*/snapshots/*",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    paths = [p.strip() for p in result.stdout.splitlines() if p.strip()]
+    if not paths:
+        raise RuntimeError(
+            f"No live Data.db files found for {keyspace}.{table} in {container}.\nstderr: {result.stderr}"
+        )
+    return paths[0]
+
+
+def write_corrupted_sstable_event(logdir: Path, data_file_path: str, node_name: str) -> None:
+    """Write a synthetic CORRUPTED_SSTABLE raw event to the events log under *logdir*."""
+    events_dir = logdir / EVENTS_LOG_DIR
+    events_dir.mkdir(parents=True, exist_ok=True)
+    event = {
+        "type": "CORRUPTED_SSTABLE",
+        "severity": "CRITICAL",
+        "node": node_name,
+        "line": (
+            f"INFO  2024-04-02 12:40:24,787 [shard 0:stre] sstable - Moving sstable {data_file_path} to quarantine"
+        ),
+    }
+    (events_dir / RAW_EVENTS_LOG).write_text(json.dumps(event) + "\n", encoding="utf-8")
+
+
 # ---------------------------------------------------------------------------
-# Fixtures
+# Module-scoped fixture: one container for all tests
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture(scope="module")
 def scylla_container(tmp_path_factory, request):
-    """
-    Start a ScyllaDB container with EAR enabled; yield container name; stop on teardown.
-    TODO: Unify with docker_scylla which needs refactor regardless
-    """
+    """Start a ScyllaDB container with node-level EAR; yield container name; stop on teardown."""
     encrypt_conf_dir = tmp_path_factory.mktemp("encrypt_conf")
-
-    # Write the secret key and EAR yaml.
-    # The directory must be writable by the scylla user inside the container because the encryption
-    # service writes a .tmp file alongside the key when loading it.
     encrypt_conf_dir.chmod(0o777)
-    key_file = encrypt_conf_dir / "secret_key"
-    ear_yaml_file = encrypt_conf_dir / "ear.yaml"
-    key_file.write_text(SECRET_KEY_CONTENT)
-    key_file.chmod(0o666)
-    ear_yaml_file.write_text(EAR_YAML)
-    ear_yaml_file.chmod(0o666)
+    (encrypt_conf_dir / "secret_key").write_text(SECRET_KEY_CONTENT)
+    (encrypt_conf_dir / "secret_key").chmod(0o666)
+    (encrypt_conf_dir / "ear.yaml").write_text(EAR_YAML)
+    (encrypt_conf_dir / "ear.yaml").chmod(0o666)
 
     request.addfinalizer(
         lambda: subprocess.run(["docker", "rm", "-f", CONTAINER_NAME], capture_output=True, check=False)
@@ -248,10 +314,8 @@ def scylla_container(tmp_path_factory, request):
         check=True,
         capture_output=True,
     )
-
     wait_for_scylla(CONTAINER_NAME)
 
-    # Create keyspace, node-level-encrypted table and table-level-encrypted table
     cql(
         CONTAINER_NAME,
         f"CREATE KEYSPACE IF NOT EXISTS {KEYSPACE} "
@@ -261,259 +325,224 @@ def scylla_container(tmp_path_factory, request):
     cql(CONTAINER_NAME, f"INSERT INTO {KEYSPACE}.{TABLE_NODE} (id, name) VALUES (1, 'node_enc');")
     nodetool(CONTAINER_NAME, f"flush {KEYSPACE} {TABLE_NODE}")
 
-    ear_opts = (
-        "{'cipher_algorithm': 'AES/ECB/PKCS5Padding',"
-        " 'key_provider': 'LocalFileSystemKeyProviderFactory',"
-        " 'secret_key_file': '/etc/scylla/encrypt_conf/secret_key',"
-        " 'secret_key_strength': '128'}"
-    )
-    cql(
-        CONTAINER_NAME,
-        f"CREATE TABLE IF NOT EXISTS {KEYSPACE}.{TABLE_TABLE}"
-        f" (id int PRIMARY KEY, name text)"
-        f" WITH scylla_encryption_options = {ear_opts};",
-    )
-    cql(CONTAINER_NAME, f"INSERT INTO {KEYSPACE}.{TABLE_TABLE} (id, name) VALUES (1, 'table_enc');")
-    nodetool(CONTAINER_NAME, f"flush {KEYSPACE} {TABLE_TABLE}")
-
     yield CONTAINER_NAME
 
 
 @pytest.fixture(scope="module")
 def scylla_node(scylla_container):
-    """Return a DockerExecNode wrapping the running ScyllaDB container."""
     return DockerExecNode(scylla_container)
 
 
-@pytest.fixture(scope="module")
-def take_snapshot(scylla_container):
-    """Return a callable that takes a snapshot and returns its absolute path inside the container."""
-
-    def _take(keyspace: str, table: str, snap_name: str) -> str:
-        nodetool(scylla_container, f"snapshot -t {snap_name} -cf {table} -- {keyspace}")
-        result = subprocess.run(
-            [
-                "docker",
-                "exec",
-                scylla_container,
-                "find",
-                f"/var/lib/scylla/data/{keyspace}",
-                "-type",
-                "d",
-                "-name",
-                snap_name,
-            ],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0 or not result.stdout.strip():
-            raise RuntimeError(f"Could not locate snapshot '{snap_name}' for {keyspace}.{table}:\n{result.stderr}")
-        paths = result.stdout.strip().splitlines()
-        for path in paths:
-            if f"/{table}-" in path or f"/{table}/" in path:
-                return path.strip()
-        return paths[0].strip()
-
-    return _take
-
-
-@pytest.fixture(scope="module")
-def has_encryption_in_metadata(scylla_container):
-    """Return a callable that checks whether any sstable in a snapshot dir is encrypted."""
-
-    def _check(snap_path: str, keyspace: str, table: str) -> bool:
-        cmd = (
-            f"SCYLLA_CONF=/etc/scylla "
-            f"/usr/bin/scylla sstable dump-scylla-metadata "
-            f"--keyspace {keyspace} --table {table} --sstables "
-            f"{snap_path}/*-Data.db 2>/dev/null || true"
-        )
-        # Use binary mode: the scylla_encryption_options value contains raw binary bytes
-        # which cannot be decoded as UTF-8.
-        result = subprocess.run(
-            ["docker", "exec", scylla_container, "/bin/sh", "-c", cmd],
-            check=False,
-            capture_output=True,
-        )
-        return b"scylla_encryption_options" in result.stdout
-
-    return _check
-
-
 # ---------------------------------------------------------------------------
-# Tests
+# Smoke test: decrypt_sstables_on_node works end-to-end on a real snapshot
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.xdist_group("ear_scylla_container")
-@pytest.mark.parametrize(
-    "table,snap_name",
-    [
-        pytest.param(TABLE_NODE, "snap_node_enc", id="node_level_encryption"),
-        pytest.param(TABLE_TABLE, "snap_table_enc", id="table_level_encryption"),
-    ],
-)
-def test_decrypt_sstables_on_node(scylla_node, take_snapshot, has_encryption_in_metadata, table, snap_name):
-    """Snapshot of an encrypted table can be decrypted by decrypt_sstables_on_node.
+def test_decrypt_sstables_on_node_smoke(scylla_container, scylla_node):
+    """decrypt_sstables_on_node produces readable (unencrypted) sstables from an EAR snapshot."""
+    snap_stdout = nodetool(scylla_container, f"snapshot -t integ-smoke -cf {TABLE_NODE} -- {KEYSPACE}")
+    snap_tag = snap_stdout.split("Snapshot directory: ")[1].strip()
 
-    Parametrized over node-level EAR (primary case) and table-level EAR.
-    """
-    snap_path = take_snapshot(KEYSPACE, table, snap_name)
-    LOGGER.info("Snapshot path (%s): %s", snap_name, snap_path)
-
-    assert has_encryption_in_metadata(snap_path, KEYSPACE, table), (
-        f"Expected encrypted sstables to show scylla_encryption_options in metadata before decryption ({snap_name})"
-    )
-
-    decrypted_path = decrypt_sstables_on_node(scylla_node, snap_path, keyspace=KEYSPACE, table=table)
-
-    assert decrypted_path is not None, f"decrypt_sstables_on_node returned None — decryption failed ({snap_name})"
-    assert not has_encryption_in_metadata(decrypted_path, KEYSPACE, table), (
-        f"Expected no scylla_encryption_options in sstable metadata after decryption ({snap_name})"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Helper: find live Data.db paths inside the container
-# ---------------------------------------------------------------------------
-
-
-def find_data_files(container: str, keyspace: str, table: str) -> list[str]:
-    """Return absolute paths to *-Data.db files inside the container for the given table."""
     result = subprocess.run(
         [
             "docker",
             "exec",
-            container,
+            scylla_container,
             "find",
-            f"/var/lib/scylla/data/{keyspace}",
+            f"/var/lib/scylla/data/{KEYSPACE}",
+            "-type",
+            "d",
             "-name",
-            "*-Data.db",
-            "-path",
-            f"*/{table}-*",
-            # Exclude any snapshot subdirectories created by previous tests so we always
-            # get the live (non-snapshot) Data.db files.
-            "!",
-            "-path",
-            "*/snapshots/*",
+            snap_tag,
         ],
         capture_output=True,
         text=True,
         check=False,
     )
-    paths = [p.strip() for p in result.stdout.splitlines() if p.strip()]
-    if not paths:
-        raise RuntimeError(
-            f"No live Data.db files found for {keyspace}.{table} in container {container}.\nstderr: {result.stderr}"
-        )
-    return paths
+    snap_path = result.stdout.strip().splitlines()[0].strip()
 
-
-# ---------------------------------------------------------------------------
-# Tests for decrypt_corrupted_sstables (teardown_validators path)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.xdist_group("ear_scylla_container")
-@pytest.mark.parametrize(
-    "table",
-    [
-        pytest.param(TABLE_NODE, id="node_level_encryption"),
-        pytest.param(TABLE_TABLE, id="table_level_encryption"),
-    ],
-)
-def test_decrypt_corrupted_sstables(scylla_container, scylla_node, has_encryption_in_metadata, table):
-    """decrypt_corrupted_sstables() takes live Data.db paths, snapshots the table for schema,
-    and decrypts the files — exercising the full teardown_validators code path including the
-    nodetool snapshot syntax and the -Data.db file filter.
-    """
-    data_files = find_data_files(scylla_container, KEYSPACE, table)
-    LOGGER.info("Live Data.db files for %s.%s: %s", KEYSPACE, table, data_files)
-
-    # Verify the live files are actually encrypted before we attempt decryption
-    for f in data_files:
-        parent = f.rsplit("/", 1)[0]
-        assert has_encryption_in_metadata(parent, KEYSPACE, table), (
-            f"Expected live sstables to be encrypted before decrypt_corrupted_sstables ({table})"
-        )
-
-    decrypted_dirs = decrypt_corrupted_sstables(scylla_node, data_files)
-
-    assert decrypted_dirs, f"decrypt_corrupted_sstables returned an empty list — decryption failed for {table}"
-    for decrypted_dir in decrypted_dirs:
-        assert not has_encryption_in_metadata(decrypted_dir, KEYSPACE, table), (
-            f"Expected no scylla_encryption_options in decrypted metadata for {table} in {decrypted_dir}"
-        )
-
-
-# ---------------------------------------------------------------------------
-# Tests for upload_sstables_to_s3 decrypt path (s3_uploader path)
-# ---------------------------------------------------------------------------
-
-
-class DockerExecNodeWithMeta(DockerExecNode):
-    """DockerExecNode extended with the attributes upload_sstables_to_s3 requires."""
-
-    def __init__(self, container_name: str):
-        super().__init__(container_name)
-        self.name = container_name
-        self.ssh_login_info = {}  # not used — upload is patched out
-
-
-@pytest.fixture(scope="module")
-def scylla_node_with_meta(scylla_container):
-    """Return a DockerExecNodeWithMeta wrapping the running ScyllaDB container."""
-    return DockerExecNodeWithMeta(scylla_container)
-
-
-@pytest.mark.xdist_group("ear_scylla_container")
-@pytest.mark.parametrize(
-    "table",
-    [
-        pytest.param(TABLE_NODE, id="node_level_encryption"),
-        pytest.param(TABLE_TABLE, id="table_level_encryption"),
-    ],
-)
-def test_upload_sstables_to_s3_decrypt_path(scylla_container, scylla_node_with_meta, has_encryption_in_metadata, table):
-    """upload_sstables_to_s3() calls decrypt_sstables_on_node for each snapshot and includes
-    the decrypted directory in the upload paths.
-
-    The S3 upload itself is patched out; we assert that the path list passed to it contains
-    both the snapshot path and a decrypted sibling directory.
-    """
-    captured = {}
-
-    def fake_upload(ssh_login_info, paths, **_kwargs):
-        captured["paths"] = list(paths)
-        return "https://fake-s3/link"
-
-    with patch(
-        "sdcm.utils.sstable.s3_uploader.upload_remote_files_directly_to_s3",
-        side_effect=fake_upload,
-    ):
-        upload_sstables_to_s3(
-            node=scylla_node_with_meta,
-            keyspace=KEYSPACE,
-            test_id="integ-test",
-            tables=[table],
-        )
-
-    assert "paths" in captured, "upload_remote_files_directly_to_s3 was never called"
-    upload_paths = captured["paths"]
-    LOGGER.info("upload_paths for %s: %s", table, upload_paths)
-
-    snapshot_paths = [p for p in upload_paths if "/snapshots/" in p and "decrypted" not in p]
-    decrypted_paths = [p for p in upload_paths if "decrypted" in p]
-
-    assert snapshot_paths, f"No snapshot path found in upload_paths for {table}: {upload_paths}"
-    assert decrypted_paths, (
-        f"No decrypted/ path found in upload_paths for {table}: {upload_paths} — "
-        "decrypt_sstables_on_node may have failed or returned None"
+    assert has_encryption_in_metadata(scylla_container, snap_path, KEYSPACE, TABLE_NODE), (
+        "Expected encrypted sstables before decryption"
     )
 
-    # The decrypted output must not contain encrypted sstables
-    for decrypted_dir in decrypted_paths:
-        assert not has_encryption_in_metadata(decrypted_dir, KEYSPACE, table), (
-            f"Expected no scylla_encryption_options in decrypted metadata for {table} in {decrypted_dir}"
-        )
+    decrypted_path = decrypt_sstables_on_node(scylla_node, snap_path, keyspace=KEYSPACE, table=TABLE_NODE)
+
+    assert decrypted_path is not None, "decrypt_sstables_on_node returned None"
+    assert not has_encryption_in_metadata(scylla_container, decrypted_path, KEYSPACE, TABLE_NODE), (
+        "Expected no encryption metadata after decryption"
+    )
+
+
+# ---------------------------------------------------------------------------
+# take_snapshot_and_decrypt: direct integration test for the extracted helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xdist_group("ear_scylla_container")
+def test_take_snapshot_and_decrypt(scylla_container, scylla_node):
+    """take_snapshot_and_decrypt() returns (snapshot_path, decrypted_path) with real sstables."""
+    data_file = find_live_data_file(scylla_container, KEYSPACE, TABLE_NODE)
+    # Derive sstable_dir: /var/lib/scylla/data/<ks>/<table-dir>
+    sstable_dir = "/".join(data_file.split("/")[:7])
+
+    snapshot_path, decrypted_path = take_snapshot_and_decrypt(
+        node=scylla_node,
+        sstable_dir=sstable_dir,
+        keyspace=KEYSPACE,
+        table_name=TABLE_NODE,
+    )
+
+    assert snapshot_path is not None, "take_snapshot_and_decrypt returned None snapshot_path"
+    assert decrypted_path is not None, "take_snapshot_and_decrypt returned None decrypted_path"
+
+    assert has_encryption_in_metadata(scylla_container, snapshot_path, KEYSPACE, TABLE_NODE), (
+        f"Snapshot at {snapshot_path} should still be encrypted"
+    )
+    assert not has_encryption_in_metadata(scylla_container, decrypted_path, KEYSPACE, TABLE_NODE), (
+        f"Decrypted directory {decrypted_path} should have no encryption metadata"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CorruptedSstablesPreparator.validate(): state file written with correct fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xdist_group("ear_scylla_container")
+def test_preparator_writes_correct_state_file(scylla_container, scylla_node, tmp_path):
+    """CorruptedSstablesPreparator(params, tester).validate() writes a correct state file.
+
+    Uses the real __init__ constructor; tester.logdir is tmp_path; tester.db_clusters_multitenant
+    contains the real DockerExecNode so nodetool snapshot and decryption run against the container.
+    """
+    data_file = find_live_data_file(scylla_container, KEYSPACE, TABLE_NODE)
+    write_corrupted_sstable_event(tmp_path, data_file, scylla_node.name)
+
+    cluster = Mock()
+    cluster.nodes = [scylla_node]
+    tester = Mock()
+    tester.logdir = str(tmp_path)
+    tester.db_clusters_multitenant = [cluster]
+
+    params = PreparatorSCTConfig()
+    validator = CorruptedSstablesPreparator(params, tester)
+
+    assert validator.is_enabled, "Validator must be enabled for this test"
+    validator.validate()
+
+    state_file = tmp_path / CORRUPTED_SSTABLES_STATE_FILENAME
+    assert state_file.exists(), "State file was not written by CorruptedSstablesPreparator.validate()"
+
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    LOGGER.info("State file contents: %s", state)
+
+    assert state["keyspace"] == KEYSPACE
+    assert state["table_name"] == TABLE_NODE
+    assert state["node_name"] == scylla_node.name
+    assert state["sstable_name"].endswith("-Data.db"), (
+        f"sstable_name should be a Data.db filename, got: {state['sstable_name']}"
+    )
+    assert state["snapshot_path"], "snapshot_path must be non-empty"
+    assert "ssh_login_info" in state
+
+
+# ---------------------------------------------------------------------------
+# CorruptedSstablesPreparator.validate(): snapshot is encrypted, decrypted is not
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xdist_group("ear_scylla_container")
+def test_preparator_decrypts_snapshot(scylla_container, scylla_node, tmp_path):
+    """validate() produces a snapshot (still encrypted) and a decrypted sibling directory.
+
+    Verifies encryption metadata is present in the snapshot and absent in the decrypted output.
+    """
+    data_file = find_live_data_file(scylla_container, KEYSPACE, TABLE_NODE)
+    write_corrupted_sstable_event(tmp_path, data_file, scylla_node.name)
+
+    cluster = Mock()
+    cluster.nodes = [scylla_node]
+    tester = Mock()
+    tester.logdir = str(tmp_path)
+    tester.db_clusters_multitenant = [cluster]
+
+    CorruptedSstablesPreparator(PreparatorSCTConfig(), tester).validate()
+
+    state = json.loads((tmp_path / CORRUPTED_SSTABLES_STATE_FILENAME).read_text(encoding="utf-8"))
+
+    assert state["decrypted_path"] is not None, (
+        "decrypted_path is None — decrypt_sstables_on_node failed inside validate()"
+    )
+    assert has_encryption_in_metadata(scylla_container, state["snapshot_path"], KEYSPACE, TABLE_NODE), (
+        f"Snapshot at {state['snapshot_path']} should still be encrypted"
+    )
+    assert not has_encryption_in_metadata(scylla_container, state["decrypted_path"], KEYSPACE, TABLE_NODE), (
+        f"Decrypted directory {state['decrypted_path']} should have no encryption metadata"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline: validate() → state file → collect_logs() passes correct paths to upload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xdist_group("ear_scylla_container")
+def test_full_pipeline_collect_logs_uses_state_file(scylla_container, scylla_node, tmp_path):
+    """End-to-end: validate() → state file → collect_logs() passes snapshot+decrypted to upload.
+
+    Phase 1 — CorruptedSstablesPreparator(params, tester).validate() runs while the node is
+    alive (simulates teardown before stop_resources).  The state file is written to tmp_path.
+
+    Phase 2 — SSTablesCollector(nodes=[], test_id, storage_dir=tmp_path, params=None).collect_logs()
+    runs with no live nodes (simulates post-stop_resources).  It reads the state file and must
+    call upload_remote_files_directly_to_s3 with both snapshot_path and decrypted_path.
+    """
+    # Phase 1: validator runs while node is alive
+    data_file = find_live_data_file(scylla_container, KEYSPACE, TABLE_NODE)
+    write_corrupted_sstable_event(tmp_path, data_file, scylla_node.name)
+
+    cluster = Mock()
+    cluster.nodes = [scylla_node]
+    tester = Mock()
+    tester.logdir = str(tmp_path)
+    tester.db_clusters_multitenant = [cluster]
+
+    CorruptedSstablesPreparator(PreparatorSCTConfig(), tester).validate()
+
+    state_file = tmp_path / CORRUPTED_SSTABLES_STATE_FILENAME
+    assert state_file.exists(), "State file must exist before collect_logs() is called"
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    assert state["decrypted_path"] is not None, "decrypted_path is None in state — decryption failed during validate()"
+    LOGGER.info("State after validate(): %s", state)
+
+    # Phase 2: collector runs with no live node (node has been stopped).
+    # In production: storage_dir = tester.logdir / "collected_logs"
+    # local_dir = storage_dir/<run>/<type>-<id[:8]>  (3 levels under tester.logdir)
+    # collect_logs() derives logdir as Path(local_dir).parent.parent.parent == tester.logdir
+    storage_dir = tmp_path / "collected_logs"
+    storage_dir.mkdir()
+    test_id = str(uuid.uuid4())
+    collector = SSTablesCollector(nodes=[], test_id=test_id, storage_dir=str(storage_dir), params=None)
+    captured: dict = {}
+
+    def fake_upload(ssh_login_info, paths, **_kwargs):
+        captured["ssh_login_info"] = ssh_login_info
+        captured["paths"] = list(paths)
+        return "https://fake-s3/corrupted.tar.gz"
+
+    with patch("sdcm.logcollector.upload_remote_files_directly_to_s3", side_effect=fake_upload):
+        result = collector.collect_logs()
+
+    assert result == ["https://fake-s3/corrupted.tar.gz"], f"Unexpected collect_logs result: {result}"
+    assert "paths" in captured, "upload_remote_files_directly_to_s3 was never called"
+
+    upload_paths = captured["paths"]
+    LOGGER.info("Paths passed to upload: %s", upload_paths)
+
+    assert state["snapshot_path"] in upload_paths, (
+        f"snapshot_path {state['snapshot_path']} not in upload paths: {upload_paths}"
+    )
+    assert state["decrypted_path"] in upload_paths, (
+        f"decrypted_path {state['decrypted_path']} not in upload paths: {upload_paths}"
+    )

--- a/unit_tests/test_sstable_decrypt_integration.py
+++ b/unit_tests/test_sstable_decrypt_integration.py
@@ -73,6 +73,14 @@ SECRET_KEY_CONTENT = f"AES/ECB/PKCS5Padding:128:{AES_KEY_B64}"
 
 KEYSPACE = "test_ks_ear"
 TABLE_NODE = "test_node_enc"
+# Table created with per-table scylla_encryption_options (table-level EAR)
+TABLE_TABLE = "test_table_enc"
+TABLE_LEVEL_EAR_OPTIONS = (
+    "{'cipher_algorithm': 'AES/ECB/PKCS5Padding',"
+    " 'key_provider': 'LocalFileSystemKeyProviderFactory',"
+    " 'secret_key_file': '/etc/scylla/encrypt_conf/secret_key',"
+    " 'secret_key_strength': '128'}"
+)
 
 
 def docker_available() -> bool:
@@ -103,12 +111,17 @@ class PreparatorSCTConfig(SCTConfiguration):
 
 
 class FakeResult:
-    """Minimal Result-like object returned by DockerExecNode.run()."""
+    """Minimal Result-like object returned by DockerExecNode.run().
+
+    Mirrors the attributes of ``sdcm.remote.libssh2_client.result.Result`` that the
+    production code accesses (including ``exit_status`` used in error logging).
+    """
 
     def __init__(self, stdout: str, stderr: str, exited: int):
         self.stdout = stdout
         self.stderr = stderr
         self.exited = exited
+        self.exit_status = exited
         self.ok = exited == 0
         self.failed = exited != 0
 
@@ -263,7 +276,11 @@ def find_live_data_file(container: str, keyspace: str, table: str) -> str:
 
 
 def write_corrupted_sstable_event(logdir: Path, data_file_path: str, node_name: str) -> None:
-    """Write a synthetic CORRUPTED_SSTABLE raw event to the events log under *logdir*."""
+    """Write a synthetic CORRUPTED_SSTABLE raw event to the events log under *logdir*.
+
+    Uses the ``malformed_sstable_exception`` log format that triggers real CORRUPTED_SSTABLE
+    events in production (see ``sdcm/sct_events/database.py``).
+    """
     events_dir = logdir / EVENTS_LOG_DIR
     events_dir.mkdir(parents=True, exist_ok=True)
     event = {
@@ -271,7 +288,9 @@ def write_corrupted_sstable_event(logdir: Path, data_file_path: str, node_name: 
         "severity": "CRITICAL",
         "node": node_name,
         "line": (
-            f"INFO  2024-04-02 12:40:24,787 [shard 0:stre] sstable - Moving sstable {data_file_path} to quarantine"
+            f"[shard 0:main] seastar - Exiting on unhandled exception: "
+            f"sstables::malformed_sstable_exception (Buffer improperly sized to hold requested data. "
+            f"Got: 2. Expected: 4 in sstable {data_file_path})"
         ),
     }
     (events_dir / RAW_EVENTS_LOG).write_text(json.dumps(event) + "\n", encoding="utf-8")
@@ -324,6 +343,16 @@ def scylla_container(tmp_path_factory, request):
     cql(CONTAINER_NAME, f"CREATE TABLE IF NOT EXISTS {KEYSPACE}.{TABLE_NODE} (id int PRIMARY KEY, name text);")
     cql(CONTAINER_NAME, f"INSERT INTO {KEYSPACE}.{TABLE_NODE} (id, name) VALUES (1, 'node_enc');")
     nodetool(CONTAINER_NAME, f"flush {KEYSPACE} {TABLE_NODE}")
+
+    # Table-level EAR: create table with scylla_encryption_options, then upgradesstables
+    cql(
+        CONTAINER_NAME,
+        f"CREATE TABLE IF NOT EXISTS {KEYSPACE}.{TABLE_TABLE}"
+        f" (id int PRIMARY KEY, name text)"
+        f" WITH scylla_encryption_options = {TABLE_LEVEL_EAR_OPTIONS};",
+    )
+    cql(CONTAINER_NAME, f"INSERT INTO {KEYSPACE}.{TABLE_TABLE} (id, name) VALUES (1, 'table_enc');")
+    nodetool(CONTAINER_NAME, f"flush {KEYSPACE} {TABLE_TABLE}")
 
     yield CONTAINER_NAME
 
@@ -545,4 +574,73 @@ def test_full_pipeline_collect_logs_uses_state_file(scylla_container, scylla_nod
     )
     assert state["decrypted_path"] in upload_paths, (
         f"decrypted_path {state['decrypted_path']} not in upload paths: {upload_paths}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Table-level EAR: schema.cql contains scylla_encryption_options; strip+decrypt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xdist_group("ear_scylla_container")
+def test_table_level_ear_decrypt(scylla_container, scylla_node):
+    """decrypt_sstables_on_node decrypts table-level EAR sstables by stripping scylla_encryption_options.
+
+    Table-level EAR embeds an ``AND scylla_encryption_options = {...}`` clause in the table schema.
+    ``scylla sstable upgrade`` would write encrypted output if that clause is passed through unchanged.
+    This test verifies that:
+
+    1. The snapshot's ``schema.cql`` actually contains ``scylla_encryption_options`` (so the strip
+       path is exercised, not just a no-op node-level scenario).
+    2. After ``decrypt_sstables_on_node``, the decrypted directory contains no encryption metadata.
+    """
+    # Take a snapshot of the table-level encrypted table
+    snap_stdout = nodetool(scylla_container, f"snapshot -t integ-table-ear -cf {TABLE_TABLE} -- {KEYSPACE}")
+    snap_tag = snap_stdout.split("Snapshot directory: ")[1].strip()
+
+    # Locate the snapshot directory inside the container
+    find_result = subprocess.run(
+        [
+            "docker",
+            "exec",
+            scylla_container,
+            "find",
+            f"/var/lib/scylla/data/{KEYSPACE}",
+            "-type",
+            "d",
+            "-name",
+            snap_tag,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    snap_path = find_result.stdout.strip().splitlines()[0].strip()
+    assert snap_path, f"Could not locate snapshot directory for tag '{snap_tag}'"
+
+    # Verify the snapshot's schema.cql contains scylla_encryption_options
+    schema_result = subprocess.run(
+        ["docker", "exec", scylla_container, "cat", f"{snap_path}/schema.cql"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert schema_result.returncode == 0, f"schema.cql not found at {snap_path}/schema.cql"
+    assert "scylla_encryption_options" in schema_result.stdout, (
+        "schema.cql does not contain scylla_encryption_options — "
+        "table-level EAR was not applied correctly during container setup"
+    )
+    LOGGER.info("schema.cql for %s contains scylla_encryption_options (as expected)", TABLE_TABLE)
+
+    # Verify the snapshot sstables are encrypted before decryption
+    assert has_encryption_in_metadata(scylla_container, snap_path, KEYSPACE, TABLE_TABLE), (
+        f"Snapshot at {snap_path} should be encrypted (table-level EAR)"
+    )
+
+    # Decrypt — this exercises strip_encryption_options_from_schema on a non-trivial schema
+    decrypted_path = decrypt_sstables_on_node(scylla_node, snap_path, keyspace=KEYSPACE, table=TABLE_TABLE)
+
+    assert decrypted_path is not None, "decrypt_sstables_on_node returned None for table-level EAR sstables"
+    assert not has_encryption_in_metadata(scylla_container, decrypted_path, KEYSPACE, TABLE_TABLE), (
+        f"Decrypted directory {decrypted_path} should have no encryption metadata"
     )


### PR DESCRIPTION
SCT uploaded corrupted sstables are now decrypted before upload

Fix https://scylladb.atlassian.net/browse/SCYLLADB-1243

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] local unittest + integration

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
