### PR TITLE
refactor(nemesis): Remove `Class:N` count syntax from `nemesis_class_name`, enforce explicit list format

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1021,7 +1021,7 @@ More arguments to append to scylla-node-exporter command line
 
 ## **nemesis_class_name** / SCT_NEMESIS_CLASS_NAME
 
-Nemesis class to use (possible types in sdcm.nemesis).<br>Next syntax supporting:<br>- nemesis_class_name: "NemesisName"  Run one nemesis in single thread<br>- nemesis_class_name: "<NemesisName>:<num>" Run <NemesisName> in <num><br>parallel threads on different nodes. Ex.: "ChaosMonkey:2"<br>- nemesis_class_name: "<NemesisName1>:<num1> <NemesisName2>:<num2>" Run<br><NemesisName1> in <num1> parallel threads and <NemesisName2> in <num2><br>parallel threads. Ex.: "DisruptiveMonkey:1 NonDisruptiveMonkey:2"
+Nemesis class to use (possible types in sdcm.nemesis).<br>Supported syntax:<br>- nemesis_class_name: "NemesisName"<br>Run one nemesis in a single thread.<br>- nemesis_class_name: ["NemesisA", "NemesisB"]<br>Run NemesisA and NemesisB each in their own thread.<br>- nemesis_class_name: ["SisyphusMonkey", "SisyphusMonkey"]<br>Run two SisyphusMonkey threads in parallel.<br>Note: the former 'Class:N' count syntax (e.g. "ChaosMonkey:2") and<br>space-separated strings (e.g. "DisruptiveMonkey NonDisruptiveMonkey") are no<br>longer supported. Use an explicit YAML list instead.
 
 **default:** NoOpMonkey
 

--- a/sdcm/nemesis/__init__.py
+++ b/sdcm/nemesis/__init__.py
@@ -272,7 +272,9 @@ class NemesisBaseClass(NemesisFlags, ABC):
 
 
 class NemesisRunner:
-    def __init__(self, tester_obj, termination_event, *args, nemesis_selector=None, nemesis_seed=None, **kwargs):
+    def __init__(
+        self, tester_obj, termination_event, *args, nemesis_selector: Optional[str] = None, nemesis_seed=None, **kwargs
+    ):
         # *args -  compatible with CategoricalMonkey
         self.tester = tester_obj  # ClusterTester object
         self.nemesis_registry = NemesisRegistry(base_class=NemesisBaseClass, flag_class=NemesisFlags)
@@ -2053,14 +2055,19 @@ class NemesisRunner:
 
     @property
     def nemesis_selector(self) -> str:
-        if self._nemesis_selector:
+        # None means selector wasn't provided explicitly for this runner instance.
+        # In that case, fall back to config-level selector (if any) for direct instantiation paths
+        # such as `sct.py nemesis-list`. An explicit empty string means "run all nemeses".
+        if self._nemesis_selector is not None:
             return self._nemesis_selector
 
-        self._nemesis_selector = self.cluster.params.get("nemesis_selector") or ""
-        return self._nemesis_selector
+        params_selector = self.cluster.params.get("nemesis_selector")
+        if isinstance(params_selector, list):
+            return params_selector[0] if params_selector else ""
+        return params_selector or ""
 
     @nemesis_selector.setter
-    def nemesis_selector(self, value: str):
+    def nemesis_selector(self, value: Optional[str]):
         self._nemesis_selector = value
 
     @property

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -875,13 +875,16 @@ class SCTConfiguration(BaseModel):
     nemesis_class_name: MultitenantValue(StringOrList) = SctField(
         description="""
                 Nemesis class to use (possible types in sdcm.nemesis).
-                Next syntax supporting:
-                - nemesis_class_name: "NemesisName"  Run one nemesis in single thread
-                - nemesis_class_name: "<NemesisName>:<num>" Run <NemesisName> in <num>
-                  parallel threads on different nodes. Ex.: "ChaosMonkey:2"
-                - nemesis_class_name: "<NemesisName1>:<num1> <NemesisName2>:<num2>" Run
-                  <NemesisName1> in <num1> parallel threads and <NemesisName2> in <num2>
-                  parallel threads. Ex.: "DisruptiveMonkey:1 NonDisruptiveMonkey:2"
+                Supported syntax:
+                - nemesis_class_name: "NemesisName"
+                  Run one nemesis in a single thread.
+                - nemesis_class_name: ["NemesisA", "NemesisB"]
+                  Run NemesisA and NemesisB each in their own thread.
+                - nemesis_class_name: ["SisyphusMonkey", "SisyphusMonkey"]
+                  Run two SisyphusMonkey threads in parallel.
+                Note: the former 'Class:N' count syntax (e.g. "ChaosMonkey:2") and
+                space-separated strings (e.g. "DisruptiveMonkey NonDisruptiveMonkey") are no
+                longer supported. Use an explicit YAML list instead.
         """,
     )
     nemesis_interval: MultitenantValue(IntOrList) = SctField(
@@ -3221,6 +3224,8 @@ class SCTConfiguration(BaseModel):
             self._validate_nemesis_can_run_on_non_seed()
             self._validate_number_of_db_nodes_divides_by_az_number()
 
+        self._validate_nemesis_parallel_config()
+
         if self.get("use_zero_nodes"):
             self._validate_zero_token_backend_support(backend)
 
@@ -3337,6 +3342,40 @@ class SCTConfiguration(BaseModel):
         assert num_of_db_nodes > seeds_num, (
             "Nemesis cannot run when 'nemesis_filter_seeds' is true and seeds number is equal to nodes number"
         )
+
+    def _validate_nemesis_parallel_config(self) -> None:
+        """Validate that nemesis_selector and nemesis_seed list lengths match nemesis_class_name."""
+        class_names = self.get("nemesis_class_name")
+        if not class_names:
+            return
+        num_threads = len(class_names)
+
+        selectors = self.get("nemesis_selector")
+        if selectors and len(selectors) > 1 and len(selectors) != num_threads:
+            raise ValueError(
+                f"'nemesis_selector' has {len(selectors)} entries but 'nemesis_class_name' has "
+                f"{num_threads}. Either use a single selector (broadcast to all threads) or provide "
+                f"exactly one selector per class name.\n"
+                f"  nemesis_class_name: {class_names}\n"
+                f"  nemesis_selector:   {selectors}"
+            )
+
+        seeds = self.get("nemesis_seed")
+        if seeds is not None:
+            if isinstance(seeds, int):
+                seeds_list = [seeds]
+            elif isinstance(seeds, str):
+                seeds_list = seeds.split()
+            else:
+                seeds_list = seeds
+            if len(seeds_list) > 1 and len(seeds_list) != num_threads:
+                raise ValueError(
+                    f"'nemesis_seed' has {len(seeds_list)} entries but 'nemesis_class_name' has "
+                    f"{num_threads}. Either use a single seed (broadcast to all threads) or provide "
+                    f"exactly one seed per class name.\n"
+                    f"  nemesis_class_name: {class_names}\n"
+                    f"  nemesis_seed:       {seeds_list}"
+                )
 
     def _validate_number_of_db_nodes_divides_by_az_number(self):
         if self.get("cluster_backend").startswith("k8s"):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1524,41 +1524,49 @@ class ClusterTester(unittest.TestCase):
         """
         Get a Nemesis class from parameters.
 
-        :return: Nemesis class.
-        :rtype: nemesis.Nemesis derived class
+        :return: list of dicts, each with keys 'nemesis', 'nemesis_selector', 'nemesis_seed'.
+        :rtype: list[dict]
         """
         nemesis_threads = []
         list_class_name = self.params.get("nemesis_class_name")
         nemesis_selectors = self.params.get("nemesis_selector")
         nemesis_seeds = self.params.get("nemesis_seed")
 
-        if nemesis_selectors:
-            nemesis_selectors = nemesis_selectors[:]
-        if nemesis_seeds and isinstance(nemesis_seeds, int):
+        # Normalize seeds to a list of ints (or None).
+        if isinstance(nemesis_seeds, int):
             nemesis_seeds = [nemesis_seeds]
-        if nemesis_seeds and isinstance(nemesis_seeds, str):
+        elif isinstance(nemesis_seeds, str):
             nemesis_seeds = [int(seed) for seed in nemesis_seeds.split()]
 
+        # Build the flat list of class names.  The old 'Class:N' count syntax and
+        # space-separated strings are no longer supported — use an explicit YAML list.
         nemesis_class_names = []
-        for i, klass in enumerate(list_class_name):
-            try:
-                nemesis_name, num = klass.strip().split(":")
-                nemesis_name = nemesis_name.strip()
-                num = int(num.strip())
-
-            except ValueError:
-                nemesis_name = klass.split(":")[0]
-                num = 1
-            for _ in range(num):
-                nemesis_class_names.append(nemesis_name)
+        for entry in list_class_name:
+            name = entry.strip()
+            if ":" in name:
+                raise ValueError(
+                    f"The 'Class:N' count syntax is no longer supported in 'nemesis_class_name'. "
+                    f"Got: {name!r}. Use an explicit YAML list to repeat a class, e.g.\n"
+                    f"  nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey', 'SisyphusMonkey']"
+                )
+            if " " in name:
+                raise ValueError(
+                    f"Space-separated 'nemesis_class_name' values are no longer supported. "
+                    f"Got: {name!r}. Use an explicit YAML list instead, e.g.\n"
+                    f"  nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey']"
+                )
+            nemesis_class_names.append(name)
 
         for i, nemesis_name in enumerate(nemesis_class_names):
-            nemesis_selector = ""
-            if nemesis_selectors:
-                try:
-                    nemesis_selector = nemesis_selectors[i % len(nemesis_class_names)]
-                except IndexError as details:
-                    self.log.warning("Missing nemesis selector. use default. %s", details)
+            # Selector: single value broadcasts to all threads; exact-length list maps 1:1.
+            # Length parity is enforced at config-load time by _validate_nemesis_parallel_config.
+            if not nemesis_selectors:
+                nemesis_selector = ""
+            elif len(nemesis_selectors) == 1:
+                nemesis_selector = nemesis_selectors[0]
+            else:
+                nemesis_selector = nemesis_selectors[i]
+
             runner_clazz = getattr(nemesis, nemesis_name)
             if not issubclass(runner_clazz, nemesis.NemesisRunner):
                 if issubclass(runner_clazz, nemesis.NemesisBaseClass):
@@ -1570,11 +1578,19 @@ class ClusterTester(unittest.TestCase):
                 else:
                     raise ValueError(f"Nemesis class {runner_clazz} should be subclass of NemesisRunner.")
 
+            # Seed: single value broadcasts to all threads; exact-length list maps 1:1.
+            if not nemesis_seeds:
+                nemesis_seed = None
+            elif len(nemesis_seeds) == 1:
+                nemesis_seed = int(nemesis_seeds[0])
+            else:
+                nemesis_seed = int(nemesis_seeds[i])
+
             nemesis_threads.append(
                 {
                     "nemesis": runner_clazz,
                     "nemesis_selector": nemesis_selector,
-                    "nemesis_seed": int(nemesis_seeds[i % len(nemesis_seeds)]) if nemesis_seeds else None,
+                    "nemesis_seed": nemesis_seed,
                 }
             )
 

--- a/sdcm/utils/operations_thread.py
+++ b/sdcm/utils/operations_thread.py
@@ -128,9 +128,7 @@ class OperationThread:
         nemesis_seed = self.thread_params.db_cluster.params.get("nemesis_seed")
         if isinstance(nemesis_seed, list):
             nemesis_seed = nemesis_seed[0]
-        if isinstance(nemesis_seed, str):
-            nemesis_seed = int(nemesis_seed.split()[0])
-        self.generator = random.Random(int(nemesis_seed)) if nemesis_seed else random.Random()
+        self.generator = random.Random(int(nemesis_seed)) if nemesis_seed is not None else random.Random()
         self._thread = threading.Thread(daemon=True, name=f"{self.__class__.__name__}_{thread_name}", target=self.run)
         self.termination_event = thread_params.termination_event
 

--- a/test-cases/enterprise-features/workload-prioritization/longevity/longevity-sla-system-24h.yaml
+++ b/test-cases/enterprise-features/workload-prioritization/longevity/longevity-sla-system-24h.yaml
@@ -17,7 +17,7 @@ instance_type_db: 'i3.2xlarge'
 instance_type_loader: 'c5.2xlarge'
 
 run_fullscan: ['{"mode": "random", "ks_cf": "keyspace1.standard1", "interval": 5}'] # 'ks.cf|random, interval(min)'
-nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
+nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey']
 # There are SLA nemeses that uses binary disable/enable workaround that in a test with parallel nemeses can cause to the errors and
 # failures that is not a problem of Scylla. The option "!disruptive" is added to prevent irrelevant failures.
 nemesis_selector: ['sla and not disruptive', 'not sla']

--- a/test-cases/features/elasticity/elasticity-90-percent-i4i-2xlarge-ttl.yaml
+++ b/test-cases/features/elasticity/elasticity-90-percent-i4i-2xlarge-ttl.yaml
@@ -27,7 +27,7 @@ instance_type_loader: 'c6i.2xlarge'
 instance_type_monitor: 't3.large'
 
 # since the nemesis only compacts on one node, run 3 in parallel each will pick a different node
-nemesis_class_name: "SisyphusMonkey:1 SisyphusMonkey:1 SisyphusMonkey:1"
+nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey', 'SisyphusMonkey']
 nemesis_selector: ['MajorCompactionMonkey', 'MajorCompactionMonkey', 'MajorCompactionMonkey']
 
 user_prefix: 'elasticity-test'

--- a/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -28,7 +28,7 @@ instance_type_loader: 'c6i.2xlarge'
 instance_type_runner: 'r6i.2xlarge'
 
 cluster_health_check: false
-nemesis_class_name: 'SisyphusMonkey:3'
+nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey', 'SisyphusMonkey']
 nemesis_selector: ["disruptive", "not disruptive", "not disruptive and not manager_operation"]
 nemesis_interval: 30
 nemesis_during_prepare: false

--- a/test-cases/longevity/longevity-change-cluster-size-by-2-times.yaml
+++ b/test-cases/longevity/longevity-change-cluster-size-by-2-times.yaml
@@ -18,7 +18,7 @@ n_loaders: 2
 instance_type_db: 'i8ge.2xlarge'
 
 
-nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
+nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey']
 nemesis_selector: ["GrowShrinkClusterNemesis","schema_changes and not disruptive"]
 nemesis_interval: 10
 

--- a/test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml
@@ -8,7 +8,7 @@ n_loaders: 3
 
 instance_type_db: 'i4i.large'
 
-nemesis_class_name: 'SisyphusMonkey:3'
+nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey', 'SisyphusMonkey']
 nemesis_selector: ["disruptive", "not disruptive", "not disruptive and not manager_operation"]
 nemesis_during_prepare: false
 space_node_threshold: 64424

--- a/test-cases/longevity/longevity-lwt-basic-24h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-24h.yaml
@@ -37,7 +37,7 @@ gce_instance_type_db: 'n2-highmem-8'
 gce_n_local_ssd_disk_db: 8
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_selector: ["topology_changes", "schema_changes and not disruptive"]
+nemesis_selector: "schema_changes and not disruptive"
 nemesis_seed: '021'
 nemesis_during_prepare: false
 space_node_threshold: 64424

--- a/test-cases/longevity/longevity-lwt-parallel-24h.yaml
+++ b/test-cases/longevity/longevity-lwt-parallel-24h.yaml
@@ -11,7 +11,7 @@ round_robin: true
 
 instance_type_db: 'i4i.large'
 
-nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
+nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey']
 nemesis_selector: ["disruptive", "modify_table and not disruptive"]
 nemesis_during_prepare: false
 space_node_threshold: 64424

--- a/test-cases/longevity/longevity-multidc-parallel-network-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-network-schema-changes-12h.yaml
@@ -17,7 +17,7 @@ simulated_racks: 0
 
 instance_type_db: 'i3en.xlarge'
 
-nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
+nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey']
 nemesis_selector: ["networking","schema_changes and not disruptive"]
 
 seeds_num: 2

--- a/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
@@ -63,9 +63,9 @@ simulated_racks: 0
 
 instance_type_db: 'i7ie.2xlarge'
 
-nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
+nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey']
 nemesis_selector: ["topology_changes", "schema_changes and not disruptive"]
-nemesis_seed: '253 328'
+nemesis_seed: [253, 328]
 nemesis_interval: 10
 nemesis_during_prepare: false
 

--- a/test-cases/longevity/longevity-parallel-schema-changes-12h-cql-stress.yaml
+++ b/test-cases/longevity/longevity-parallel-schema-changes-12h-cql-stress.yaml
@@ -18,7 +18,7 @@ simulated_racks: 3
 
 instance_type_db: 'i4i.2xlarge'
 
-nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
+nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey']
 nemesis_selector: ["topology_changes", "schema_changes and not disruptive"]
 nemesis_interval: 10
 nemesis_during_prepare: false

--- a/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-parallel-schema-changes-12h.yaml
@@ -18,7 +18,7 @@ n_loaders: 2
 
 instance_type_db: 'i4i.2xlarge'
 
-nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
+nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey']
 nemesis_selector: ["topology_changes", "schema_changes and not disruptive"]
 nemesis_interval: 10
 nemesis_during_prepare: false

--- a/test-cases/quarantined/longevity-large-partitions-deletions-and-reversed-queries.yaml
+++ b/test-cases/quarantined/longevity-large-partitions-deletions-and-reversed-queries.yaml
@@ -21,8 +21,8 @@ n_loaders: 2
 
 instance_type_db: 'i4i.4xlarge'
 
-nemesis_class_name: 'SisyphusMonkey:1 SisyphusMonkey:1'
-nemesis_seed: '156'
+nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey']
+nemesis_seed: 156
 instance_type_loader: 'c5n.4xlarge'
 round_robin: true
 nemesis_interval: 30

--- a/unit_tests/nemesis/test_sisyphus.py
+++ b/unit_tests/nemesis/test_sisyphus.py
@@ -31,6 +31,19 @@ def get_sisyphus():
     return _create_sisyphus
 
 
+@pytest.fixture()
+def tester(tmp_path):
+    """Shared tester fixture with a fake 2-node cluster."""
+    cluster_tester = ClusterTesterForTests()
+    cluster_tester._init_logging(tmp_path)
+    cluster_tester._init_params()
+    cluster_tester.db_cluster = Cluster(nodes=[Node(), Node()])
+    cluster_tester.db_cluster.params = cluster_tester.params
+    cluster_tester.params["nemesis_multiply_factor"] = 1
+    cluster_tester.nemesis_allocator = NemesisNodeAllocator(cluster_tester)
+    return cluster_tester
+
+
 def test_disruptions_list(get_sisyphus):
     nemesis = get_sisyphus()
     assert set(method.__class__.__name__ for method in nemesis.disruptions_list) == {
@@ -41,13 +54,15 @@ def test_disruptions_list(get_sisyphus):
     }
 
 
-def test_add_sisyphus_with_filter_in_parallel_nemesis_run(tmp_path):
-    tester = ClusterTesterForTests()
-    tester._init_logging(tmp_path)
-    tester._init_params()
-    tester.db_cluster = Cluster(nodes=[Node(), Node()])
-    tester.db_cluster.params = tester.params
-    tester.params["nemesis_class_name"] = "SisyphusMonkey:1 SisyphusMonkey:4"
+def test_add_sisyphus_with_filter_in_parallel_nemesis_run(tester):
+    """5 explicit threads (explicit list format), 1 selector per thread."""
+    tester.params["nemesis_class_name"] = [
+        "SisyphusMonkey",
+        "SisyphusMonkey",
+        "SisyphusMonkey",
+        "SisyphusMonkey",
+        "SisyphusMonkey",
+    ]
     tester.params["nemesis_selector"] = [
         "flag_common",
         "flag_common and not flag_c",
@@ -55,11 +70,10 @@ def test_add_sisyphus_with_filter_in_parallel_nemesis_run(tmp_path):
         "CustomNemesisC",
         "CustomNemesisA or CustomNemesisC",
     ]
-    tester.params["nemesis_multiply_factor"] = 1
 
-    tester.nemesis_allocator = NemesisNodeAllocator(tester)
+    nemeses = tester.get_nemesis_class()
 
-    nemesises = tester.get_nemesis_class()
+    assert len(nemeses) == 5, f"Expected 5 nemesis threads, got {len(nemeses)}"
 
     expected_selectors = [
         "flag_common",
@@ -68,18 +82,15 @@ def test_add_sisyphus_with_filter_in_parallel_nemesis_run(tmp_path):
         "CustomNemesisC",
         "CustomNemesisA or CustomNemesisC",
     ]
-    for i, nemesis_settings in enumerate(nemesises):
+    for i, nemesis_settings in enumerate(nemeses):
         assert nemesis_settings["nemesis"] == SisyphusMonkey, (
-            f"Wrong instance of nemesis class {nemesis_settings['nemesis']} expected SisyphusMonkey"
+            f"Thread {i}: wrong class {nemesis_settings['nemesis']}, expected SisyphusMonkey"
         )
         assert nemesis_settings["nemesis_selector"] == expected_selectors[i], (
-            f"Wrong nemesis filter selecters {nemesis_settings['nemesis_selector']} expected {expected_selectors[i]}"
+            f"Thread {i}: wrong selector {nemesis_settings['nemesis_selector']!r}, expected {expected_selectors[i]!r}"
         )
 
-    active_nemesis = []
-    for nemesis in nemesises:
-        sisyphus = FakeSisyphusMonkey(tester, nemesis_selector=nemesis["nemesis_selector"])
-        active_nemesis.append(sisyphus)
+    active_nemesis = [FakeSisyphusMonkey(tester, nemesis_selector=n["nemesis_selector"]) for n in nemeses]
 
     expected_methods = [
         {"CustomNemesisA", "CustomNemesisB", "CustomNemesisAD", "CustomNemesisC"},
@@ -89,7 +100,139 @@ def test_add_sisyphus_with_filter_in_parallel_nemesis_run(tmp_path):
         {"CustomNemesisA", "CustomNemesisC"},
     ]
     for i, nem in enumerate(active_nemesis):
-        assert {disrupt.__class__.__name__ for disrupt in nem.disruptions_list} == expected_methods[i]
+        assert {disrupt.__class__.__name__ for disrupt in nem.disruptions_list} == expected_methods[i], (
+            f"Thread {i}: wrong disruptions list"
+        )
+
+
+@pytest.mark.parametrize(
+    "class_names,selectors,expected",
+    [
+        pytest.param(["SisyphusMonkey", "SisyphusMonkey"], [], ["", ""], id="no_selectors_empty_per_thread"),
+        pytest.param(
+            ["SisyphusMonkey", "SisyphusMonkey", "SisyphusMonkey"],
+            ["flag_common"],
+            ["flag_common"] * 3,
+            id="single_selector_broadcast",
+        ),
+        pytest.param(
+            ["SisyphusMonkey", "SisyphusMonkey", "SisyphusMonkey"],
+            ["flag_a", "flag_b", "flag_c"],
+            ["flag_a", "flag_b", "flag_c"],
+            id="exact_length_one_to_one_three_threads",
+        ),
+    ],
+)
+def test_selector_assignment_behaviour(tester, class_names, selectors, expected):
+    """Parametrized: no selectors -> empty, single -> broadcast, N->1:1 mapping."""
+    tester.params["nemesis_class_name"] = class_names
+    tester.params["nemesis_selector"] = selectors
+
+    nemeses = tester.get_nemesis_class()
+    assert len(nemeses) == len(class_names), f"Expected {len(class_names)} nemesis threads, got {len(nemeses)}"
+
+    for i, n in enumerate(nemeses):
+        assert n["nemesis_selector"] == expected[i], (
+            f"Thread {i}: wrong selector {n['nemesis_selector']!r}, expected {expected[i]!r}"
+        )
+
+
+@pytest.mark.parametrize(
+    "config_selector, explicit_selector, expected_selector, expected_disruptions",
+    [
+        pytest.param(["flag_c"], None, "flag_c", {"CustomNemesisC"}, id="config_only"),
+        pytest.param(
+            ["flag_c"],
+            "",
+            "",
+            {"CustomNemesisA", "CustomNemesisB", "CustomNemesisC", "CustomNemesisAD"},
+            id="explicit_empty_overrides",
+        ),
+        pytest.param(
+            ["flag_c"],
+            "flag_a",
+            "flag_a",
+            {"CustomNemesisA", "CustomNemesisAD", "CustomNemesisC"},
+            id="explicit_non_empty_overrides",
+        ),
+    ],
+)
+def test_direct_instantiation_selector_precedence(
+    tester, config_selector, explicit_selector, expected_selector, expected_disruptions
+):
+    """Parametrized: direct construction uses config selector unless an explicit selector is provided.
+
+    Cases:
+    - config-only: config selector is used
+    - explicit empty: explicit empty selector overrides config and runs all disruptions
+    - explicit non-empty: explicit selector overrides config
+    """
+    tester.params["nemesis_selector"] = config_selector
+
+    kwargs = {}
+    if explicit_selector is not None:
+        kwargs["nemesis_selector"] = explicit_selector
+
+    runner = FakeSisyphusMonkey(tester, None, **kwargs)
+
+    assert runner.nemesis_selector == expected_selector
+    assert {d.__class__.__name__ for d in runner.disruptions_list} == expected_disruptions
+
+
+@pytest.mark.parametrize(
+    "class_names,seeds,expected",
+    [
+        pytest.param(["SisyphusMonkey", "SisyphusMonkey"], None, [None, None], id="no_seeds"),
+        pytest.param(
+            ["SisyphusMonkey", "SisyphusMonkey", "SisyphusMonkey"],
+            17,
+            [17, 17, 17],
+            id="single_seed_broadcast",
+        ),
+        pytest.param(
+            ["SisyphusMonkey", "SisyphusMonkey", "SisyphusMonkey"],
+            [17, 23, 42],
+            [17, 23, 42],
+            id="exact_length_seed_mapping",
+        ),
+    ],
+)
+def test_seed_assignment_behaviour(tester, class_names, seeds, expected):
+    """Parametrized: no seeds -> None, single -> broadcast, N->1:1 mapping."""
+    tester.params["nemesis_class_name"] = class_names
+    if seeds is not None:
+        tester.params["nemesis_seed"] = seeds
+
+    nemeses = tester.get_nemesis_class()
+    assert len(nemeses) == len(class_names), f"Expected {len(class_names)} nemesis threads, got {len(nemeses)}"
+
+    for i, n in enumerate(nemeses):
+        assert n["nemesis_seed"] == expected[i], (
+            f"Thread {i}: wrong seed {n['nemesis_seed']!r}, expected {expected[i]!r}"
+        )
+
+
+@pytest.mark.parametrize(
+    "class_name, expected_error_fragment",
+    [
+        pytest.param(
+            "SisyphusMonkey:3",
+            "Class:N' count syntax is no longer supported",
+            id="count_syntax",
+        ),
+        pytest.param(
+            "SisyphusMonkey SisyphusMonkey",
+            "Space-separated 'nemesis_class_name' values are no longer supported",
+            id="space_separated",
+        ),
+    ],
+)
+def test_legacy_class_name_syntax_raises_value_error(tester, class_name, expected_error_fragment):
+    """Both ':count' and space-separated syntaxes are rejected with a clear error."""
+    tester.params["nemesis_class_name"] = class_name
+
+    with pytest.raises(ValueError, match=expected_error_fragment):
+        tester.get_nemesis_class()
 
 
 @pytest.mark.parametrize(

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -858,21 +858,6 @@ def test_23_1_include_nemesis_selector(monkeypatch):
     assert conf.nemesis_selector == ["config_changes and topology_changes"]
 
 
-def test_23_2_nemesis_include_selector_list(monkeypatch):
-    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "aws")
-    monkeypatch.setenv("SCT_REGION_NAME", "eu-west-1")
-    monkeypatch.setenv("SCT_AMI_ID_DB_SCYLLA", "ami-dummy")
-    monkeypatch.setenv(
-        "SCT_CONFIG_FILES",
-        '["unit_tests/test_configs/minimal_test_case.yaml", "unit_tests/test_configs/nemesis_selector_list_of_list.yaml"]',
-    )
-    monkeypatch.setenv("SCT_NEMESIS_CLASS_NAME", "NemesisClass:1 NemesisClass:2")
-    conf = sct_config.SCTConfiguration()
-    conf.verify_configuration()
-
-    assert conf.nemesis_selector == ["config_changes and topology_changes", "topology_changes", "disruptive"]
-
-
 def test_26_run_fullscan_params_validtion_positive(monkeypatch):
     monkeypatch.setenv(
         "SCT_CONFIG_FILES",

--- a/unit_tests/test_configs/nemesis_selector_list_of_list.yaml
+++ b/unit_tests/test_configs/nemesis_selector_list_of_list.yaml
@@ -1,1 +1,0 @@
-nemesis_selector: ["config_changes and topology_changes", "topology_changes", "disruptive"]

--- a/unit_tests/test_data/test_config/multitenant/shared_option_values.yaml
+++ b/unit_tests/test_data/test_config/multitenant/shared_option_values.yaml
@@ -26,10 +26,7 @@ stress_cmd_m: [
 
 # Non-stress options
 nemesis_class_name: "FakeNemesisClassName"
-nemesis_selector: [
-    "fake__nemesis_selector__all_tenants__part1",
-    "fake__nemesis_selector__all_tenants__part2"
-]
+nemesis_selector: "fake__nemesis_selector__all_tenants__single_str"
 nemesis_interval: 5
 nemesis_sequence_sleep_between_ops: 3
 nemesis_during_prepare: False

--- a/unit_tests/test_utils__operator__multitenant_common.py
+++ b/unit_tests/test_utils__operator__multitenant_common.py
@@ -98,9 +98,9 @@ class TestUtilsOperatorMultitenantCommon:
             ]
             # NOTE: StringOrList type always converts single strings to a list with one element
             assert tenant.params.get("prepare_verify_cmd") == ["fake__prepare_verify_cmd__all_tenants__single_str"]
-            for cmd_name in ("nemesis_selector", "stress_cmd_m", "stress_cmd", "stress_cmd_r"):
+            for cmd_name in ("stress_cmd_m", "stress_cmd", "stress_cmd_r"):
                 assert tenant.params.get(cmd_name) == [f"fake__{cmd_name}__all_tenants__part{j}" for j in range(1, 3)]
-            for cmd_name in ("stress_read_cmd", "stress_cmd_w"):
+            for cmd_name in ("stress_read_cmd", "stress_cmd_w", "nemesis_selector"):
                 # NOTE: StringOrList type always converts single strings to a list with one element
                 assert tenant.params.get(cmd_name) == [f"fake__{cmd_name}__all_tenants__single_str"]
             # NOTE: StringOrList type always converts single strings to a list with one element


### PR DESCRIPTION
Parallel nemesis runs using the space-separated `nemesis_class_name` format (e.g. `'SisyphusMonkey:1 SisyphusMonkey:1'`) were silently broken after the pydantic config migration (aa9cd757a).

See https://argus.scylladb.com/tests/scylla-cluster-tests/1b6ed4e9-2c22-4153-94c4-3081d46c28d1/nemesis
Only 1 nemesis thread ran.


## Summary

Replaces the implicit count/space-separated syntax for running parallel nemesis threads with an
explicit YAML list. Adds validation so misconfigurations are caught at config-load time rather
than producing silent surprises at runtime.

## Problem

The old `nemesis_class_name` syntax accepted three formats simultaneously:

```yaml
# Single string with count — one entry expanded to N threads
nemesis_class_name: "SisyphusMonkey:2"

# Space-separated string — split into multiple threads
nemesis_class_name: "SisyphusMonkey SisyphusMonkey"

# Explicit list (already worked, never formally documented)
nemesis_class_name: ["SisyphusMonkey", "SisyphusMonkey"]
```

This made `nemesis_selector` and `nemesis_seed` assignment opaque: if you had two threads and
one selector, was the selector applied to thread 0 only, or broadcast? The code used
`selectors[i % len(class_names)]`, which silently cycled through selectors in ways that were
hard to reason about.

## Changes

### `sdcm/tester.py` — `get_nemesis_class()`

- The `Class:N` count expansion loop is removed.
- Explicit `ValueError` is raised if any entry in `nemesis_class_name` contains `:` (count
  syntax) or a space (space-separated format), with a clear migration message.
- Selector/seed assignment semantics are simplified and made explicit:
  - **empty / not set** → empty string / `None` per thread
  - **single-element list** → broadcast to all threads
  - **list of length N** (matching `nemesis_class_name`) → 1:1 mapping, enforced by config validator

### `sdcm/sct_config.py`

- `nemesis_class_name` field description updated to document the new list-only API and
  explicitly deprecate the old syntax.
- New `_validate_nemesis_parallel_config()` method validates that multi-element
  `nemesis_selector` and `nemesis_seed` lists match the number of entries in
  `nemesis_class_name`. Mismatches raise `ValueError` with a helpful error message at
  config-load time. Called unconditionally from `verify_configuration()`.

### `sdcm/nemesis/__init__.py` — `NemesisRunner.nemesis_selector`

- `__init__` parameter typed as `Optional[str] = None`.
- Property uses `None` as the sentinel for "not explicitly set" (replaces the old truthiness
  check that treated `""` identically to `None`).
  - `None` → falls back to `cluster.params.get("nemesis_selector")`, enabling direct
    instantiation paths such as `sct.py nemesis-list` to pick up the config value.
  - `""` → explicitly means "run all nemeses, no filtering".
  - Any non-empty string → used as-is.
- Config fallback handles both `list` (takes `[0]`) and `str`/`None` return types from params.

### `sdcm/utils/operations_thread.py`

- Removed the `isinstance(nemesis_seed, str)` branch (the `IntOrList` type already resolves
  seeds to `int` or `list[int]`; string seeds no longer reach this code).
- Fixed the `Random()` seed guard from truthiness to `is not None` so that seed value `0` is
  not silently discarded.

### YAML test-case files converted

All occurrences of `Class:N` and space-separated `nemesis_class_name` are replaced with
explicit YAML lists. Two files also had `nemesis_seed` values in the old space-separated
string format, converted to proper YAML lists/integers.

## Migration guide

**Before:**
```yaml
nemesis_class_name: "SisyphusMonkey:2"
# or
nemesis_class_name: "SisyphusMonkey SisyphusMonkey"
```

**After:**
```yaml
nemesis_class_name: ["SisyphusMonkey", "SisyphusMonkey"]
# yaml list syntax also works
nemesis_class_name:
  - SisyphusMonkey
  - SisyphusMonkey
```

If you use `nemesis_selector` or `nemesis_seed` with multiple threads, the valid forms are:

```yaml
# Broadcast the same selector to all threads
nemesis_selector: "not disruptive"

# Or map one selector per thread (must match nemesis_class_name length exactly)
nemesis_selector: ["not disruptive", "topology_changes"]
```

Any mismatch in list lengths will raise a `ValueError` at config-load time with a
descriptive message showing both lists.

---

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ] before: https://argus.scylladb.com/tests/scylla-cluster-tests/1b6ed4e9-2c22-4153-94c4-3081d46c28d1/nemesis
- [x] after: https://argus.scylladb.com/tests/scylla-cluster-tests/46e3f41a-ebe8-4362-9664-03dc80457564/nemesis

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
