### PR TITLE
improvement(gemini): migrate loader instances from x86_64 to ARM (m8g)

### DIFF
--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -3,7 +3,7 @@ n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 instance_type_db: 'i4i.2xlarge'
-instance_type_loader: 'm6i.xlarge'
+instance_type_loader: 'm8g.xlarge'
 
 user_prefix: 'gemini-1tb-10h'
 

--- a/test-cases/gemini/gemini-3h-cdc-postimage-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-postimage-write.yaml
@@ -2,6 +2,7 @@ test_duration: 300
 n_db_nodes: 3
 n_loaders: 1
 instance_type_db: 'i4i.4xlarge'
+instance_type_loader: 'm8g.xlarge'
 
 user_prefix: 'gemini-cdc-postimage-write'
 

--- a/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
@@ -2,6 +2,7 @@ test_duration: 300
 n_db_nodes: 3
 n_loaders: 1
 instance_type_db: 'i4i.4xlarge'
+instance_type_loader: 'm8g.xlarge'
 
 user_prefix: 'gemini-cdc-preimage-write'
 

--- a/test-cases/gemini/gemini-3h-cdc-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-write.yaml
@@ -2,6 +2,7 @@ test_duration: 300
 n_db_nodes: 3
 n_loaders: 1
 instance_type_db: 'i4i.4xlarge'
+instance_type_loader: 'm8g.xlarge'
 
 user_prefix: 'gemini-cdc-write'
 

--- a/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
@@ -3,6 +3,7 @@ n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 instance_type_db: 'i4i.large'
+instance_type_loader: 'm8g.large'
 
 user_prefix: 'ics-cdc-gemini-basic-3h'
 ami_db_scylla_user: 'centos'

--- a/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
@@ -3,6 +3,7 @@ n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 instance_type_db: 'i4i.large'
+instance_type_loader: 'm8g.large'
 
 user_prefix: 'ics-gemini-nemesis-3h'
 ami_db_scylla_user: 'centos'

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -3,6 +3,7 @@ n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 instance_type_db: 'i4i.large'
+instance_type_loader: 'm8g.large'
 
 user_prefix: 'gemini-with-nemesis-3h-normal'
 

--- a/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
@@ -3,6 +3,7 @@ n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 instance_type_db: 'i4i.xlarge'
+instance_type_loader: 'm8g.xlarge'
 
 user_prefix: 'gemini-basic-3h'
 

--- a/test-cases/gemini/gemini-8h-large-num-columns.yaml
+++ b/test-cases/gemini/gemini-8h-large-num-columns.yaml
@@ -3,7 +3,7 @@ n_db_nodes: 6
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 instance_type_db: 'i3en.3xlarge'
-instance_type_loader: 'c6i.4xlarge'
+instance_type_loader: 'm8g.2xlarge'
 
 user_prefix: 'gemini-8h-large-num-columns'
 

--- a/test-cases/gemini/gemini-basic-3h-ics.yaml
+++ b/test-cases/gemini/gemini-basic-3h-ics.yaml
@@ -3,6 +3,7 @@ n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 instance_type_db: 'i4i.large'
+instance_type_loader: 'm8g.large'
 
 user_prefix: 'ics-gemini-basic-3h'
 ami_db_scylla_user: 'centos'

--- a/test-cases/gemini/gemini-basic-3h.yaml
+++ b/test-cases/gemini/gemini-basic-3h.yaml
@@ -3,6 +3,7 @@ n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 instance_type_db: 'i4i.large'
+instance_type_loader: 'm8g.large'
 
 user_prefix: 'gemini-basic-3h'
 


### PR DESCRIPTION
Migrate Gemini loader instances from x86_64 to AWS Graviton4 ARM (m8g)
instance family across all Gemini test configurations.

## Motivation

AWS m8g instances (Graviton4, ARM64) offer better price/performance
compared to equivalent x86_64 instance types (m6i, c6i) at the same
cost tier. By switching loaders to m8g we get more throughput from the
same spend without changing the DB node types.

## Changes
- `gemini-1tb-10h`: `m6i.xlarge` → `m8g.xlarge`
- `gemini-8h-large-num-columns`: `c6i.4xlarge` → `m8g.2xlarge`
- All remaining Gemini configs (basic-3h, 3h-with-nemesis, 3h-cdc-*,
  ics-*, etc.): no explicit loader type was set; now pinned to the
  appropriate `m8g` size matching the test workload

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- 🟠 https://argus.scylladb.com/tests/scylla-cluster-tests/de45aa04-ff26-4bcb-91c5-7f82c41304ff (Currently blocked due to AMI not supported)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)

Closes [SCT-186](https://scylladb.atlassian.net/browse/SCT-186)

[SCT-186]: https://scylladb.atlassian.net/browse/SCT-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ