### PR TITLE
feat(docker): enable simulated_racks support for Docker backend

### DIFF
--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -95,6 +95,7 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):
         base_logdir: Optional[str] = None,
         ssh_login_info: Optional[dict] = None,
         node_index: int = 1,
+        rack: int = 0,
     ) -> None:
         super().__init__(
             name=f"{node_prefix}-{node_index}",
@@ -102,6 +103,7 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):
             ssh_login_info=ssh_login_info,
             base_logdir=base_logdir,
             node_prefix=node_prefix,
+            rack=rack,
         )
         self.node_index = node_index
 
@@ -302,6 +304,7 @@ class VectorStoreDockerNode(VectorStoreNodeMixin, DockerNode):
         base_logdir: Optional[str] = None,
         ssh_login_info: Optional[dict] = None,
         node_index: int = 1,
+        rack: int = 0,
     ) -> None:
         super().__init__(
             parent_cluster=parent_cluster,
@@ -310,6 +313,7 @@ class VectorStoreDockerNode(VectorStoreNodeMixin, DockerNode):
             base_logdir=base_logdir,
             ssh_login_info=ssh_login_info,
             node_index=node_index,
+            rack=rack,
         )
 
     def node_container_run_args(self, seed_ip=None):
@@ -369,7 +373,7 @@ class DockerCluster(cluster.BaseCluster):
             os.path.dirname(__file__), "../docker/scylla-sct", self.params.get("scylla_linux_distro").split("-")[0]
         )
 
-    def _create_node(self, node_index, container=None):
+    def _create_node(self, node_index, container=None, rack=0):
         node = DockerNode(
             parent_cluster=self,
             container=container,
@@ -377,6 +381,7 @@ class DockerCluster(cluster.BaseCluster):
             base_logdir=self.logdir,
             node_prefix=self.node_prefix,
             node_index=node_index,
+            rack=rack,
         )
 
         if container is None:
@@ -394,10 +399,11 @@ class DockerCluster(cluster.BaseCluster):
 
         return sorted(set(range(len(self.nodes) + count)) - set(node.node_index for node in self.nodes))
 
-    def _create_nodes(self, count, enable_auto_bootstrap=False):
+    def _create_nodes(self, count, rack=None, enable_auto_bootstrap=False):
         new_nodes = []
         for node_index in self._get_new_node_indexes(count):
-            node = self._create_node(node_index)
+            node_rack = node_index % self.racks_count if rack is None else rack
+            node = self._create_node(node_index, rack=node_rack)
             node.enable_auto_bootstrap = enable_auto_bootstrap
             self.nodes.append(node)
             new_nodes.append(node)
@@ -407,14 +413,19 @@ class DockerCluster(cluster.BaseCluster):
         containers = ContainerManager.get_containers_by_prefix(self.node_prefix)
         for node_index, container in sorted(((int(c.labels["NodeIndex"]), c) for c in containers), key=lambda x: x[0]):
             LOGGER.debug("Found container %s with name `%s' and index=%d", container, container.name, node_index)
-            node = self._create_node(node_index, container)
+            node_rack = node_index % self.racks_count
+            node = self._create_node(node_index, container, rack=node_rack)
             self.nodes.append(node)
         return self.nodes
 
     @mark_new_nodes_as_running_nemesis
     def add_nodes(self, count, ec2_user_data="", dc_idx=0, rack=0, enable_auto_bootstrap=False, instance_type=None):
         assert instance_type is None, "docker can't provision different instance types"
-        return self._get_nodes() if self.test_config.REUSE_CLUSTER else self._create_nodes(count, enable_auto_bootstrap)
+        return (
+            self._get_nodes()
+            if self.test_config.REUSE_CLUSTER
+            else self._create_nodes(count, rack=rack, enable_auto_bootstrap=enable_auto_bootstrap)
+        )
 
 
 class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):
@@ -443,6 +454,19 @@ class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):
         self.vector_store_cluster = None
 
     def node_setup(self, node, verbose=False, timeout=3600):
+        if self.test_config.REUSE_CLUSTER:
+            self._reuse_cluster_setup(node)
+            if (
+                any([self.params.get("server_encrypt"), self.params.get("client_encrypt")])
+                and not (node.ssl_conf_dir / TLSAssets.DB_CERT).exists()
+            ):
+                self._generate_db_node_certs(node)
+                install_client_certificate(node.remoter, node.ip_address, force=True)
+            # warm up raft cached_property per node to avoid rapid TLS session cycling
+            # during validate_raft_on_nodes (python-driver#614 workaround)
+            _ = node.raft
+            return
+
         node.is_scylla_installed(raise_if_not_installed=True)
         self.check_aio_max_nr(node)
         if self.test_config.BACKTRACE_DECODING:
@@ -452,8 +476,38 @@ class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):
             self._generate_db_node_certs(node)
             install_client_certificate(node.remoter, node.ip_address, force=True)
 
+        simulated_racks = (self.params.get("simulated_racks") or 0) > 1
+        if simulated_racks:
+            # Docker containers auto-start Scylla with SimpleSnitch, which persists
+            # dc=datacenter1 and rack=rack1 in system tables. Switching to
+            # GossipingPropertyFileSnitch with different rack names (RACK0/1/2) would
+            # cause a "Saved rack name is not equal" error on restart. Write the new
+            # cassandra-rackdc.properties and wipe persisted topology data while the
+            # container is still running, then restart the container to apply changes.
+            # We write the file directly because the Docker image lacks `stat`,
+            # which remote_file/SnitchConfig.apply() requires.
+            rack_name = f"RACK{node.rack}"
+            props_path = "/etc/scylla/cassandra-rackdc.properties"
+            node.remoter.sudo(
+                f"bash -c 'printf \"dc=datacenter1\\nrack={rack_name}\\nprefer_local=true\\n\" > {props_path}'"
+            )
+
         node.config_setup(append_scylla_args=self.get_scylla_args())
-        node.restart_scylla(verify_up_before=True)
+
+        if simulated_racks:
+            # Wipe data saved during initial boot with SimpleSnitch before restarting.
+            # Scylla may crash from deleted files, but container.restart() handles this.
+            # Suppress the expected FILESYSTEM_ERROR events caused by deleting data dirs
+            # while Scylla is still running (it tries to flush memtables to deleted paths).
+            with DbEventsFilter(
+                db_event=DatabaseLogEvent.FILESYSTEM_ERROR,
+                node=node,
+                extra_time_to_expiration=30,
+            ):
+                node.clean_scylla_data()
+                node.restart_scylla(verify_up_before=False)
+        else:
+            node.restart_scylla(verify_up_before=True)
 
     def _generate_db_node_certs(self, node):
         """Generate per-node SSL certificates for a Docker DB node."""
@@ -551,13 +605,14 @@ class VectorStoreSetDocker(VectorStoreClusterMixin, DockerCluster):
                 self.log.error("Failed to reconfigure container %s: %s", node.name, e)
                 raise
 
-    def _create_node(self, node_index, container=None):
+    def _create_node(self, node_index, container=None, rack=0):
         node = VectorStoreDockerNode(
             parent_cluster=self,
             container=container,
             node_prefix=self.node_prefix,
             base_logdir=self.logdir,
             node_index=node_index,
+            rack=rack,
         )
 
         if container is None:
@@ -683,6 +738,7 @@ class DockerMonitoringNode(cluster.BaseNode):
         base_logdir: Optional[str] = None,
         node_index: int = 1,
         ssh_login_info: Optional[dict] = None,
+        rack: int = 0,
     ) -> None:
         super().__init__(
             name=f"{node_prefix}-{node_index}",
@@ -690,6 +746,7 @@ class DockerMonitoringNode(cluster.BaseNode):
             base_logdir=base_logdir,
             node_prefix=node_prefix,
             ssh_login_info=ssh_login_info,
+            rack=rack,
         )
         self.node_index = node_index
 
@@ -770,20 +827,21 @@ class MonitorSetDocker(cluster.BaseMonitorSet, DockerCluster):
             params=params,
         )
 
-    def _create_node(self, node_index, container=None):
+    def _create_node(self, node_index, container=None, rack=0):
         node = DockerMonitoringNode(
             parent_cluster=self,
             base_logdir=self.logdir,
             node_prefix=self.node_prefix,
             node_index=node_index,
             ssh_login_info=None,
+            rack=rack,
         )
         node.init()
         return node
 
     def add_nodes(self, count, ec2_user_data="", dc_idx=0, rack=0, enable_auto_bootstrap=False, instance_type=None):
-        assert instance_type is None, "docker can provision different instance types"
-        return self._create_nodes(count, enable_auto_bootstrap)
+        assert instance_type is None, "docker can't provision different instance types"
+        return self._create_nodes(count, enable_auto_bootstrap=enable_auto_bootstrap)
 
     @staticmethod
     def install_scylla_monitoring_prereqs(node):

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2909,12 +2909,7 @@ class SCTConfiguration(BaseModel):
         # 15 Force endpoint_snitch to GossipingPropertyFileSnitch if using simulated_regions or simulated_racks
         n_db_nodes = self.get("n_db_nodes") or 0
         num_of_db_nodes = sum(n_db_nodes if isinstance(n_db_nodes, list) else [n_db_nodes])
-        if (
-            (self.get("simulated_regions") or 0) > 1
-            or (self.get("simulated_racks") or 0) > 1
-            and num_of_db_nodes > 1
-            and cluster_backend != "docker"
-        ):
+        if (self.get("simulated_regions") or 0) > 1 or ((self.get("simulated_racks") or 0) > 1 and num_of_db_nodes > 1):
             if snitch := self.get("endpoint_snitch"):
                 assert snitch.endswith("GossipingPropertyFileSnitch"), (
                     f"Simulating racks requires endpoint_snitch to be GossipingPropertyFileSnitch while it set to {self['endpoint_snitch']}"

--- a/unit_tests/integration/test_docker_simulated_racks.py
+++ b/unit_tests/integration/test_docker_simulated_racks.py
@@ -1,0 +1,137 @@
+"""Integration tests for Docker simulated racks via ScyllaDockerCluster.node_setup.
+
+External services: Docker (two Scylla containers)
+
+Validates that ScyllaDockerCluster.node_setup correctly configures
+cassandra-rackdc.properties and restarts nodes so that each node
+reports a distinct rack (RACK0, RACK1) in system.local.
+
+Also validates the REUSE_CLUSTER path: after initial rack setup, calling
+node_setup with REUSE_CLUSTER=True must skip full setup while preserving
+rack assignments.
+"""
+
+import logging
+
+import pytest
+
+from sdcm import wait
+from sdcm.cluster import BaseNode
+from unit_tests.lib.fake_docker_cluster import DummyScyllaDockerCluster, RackAwareDummyDockerNode
+
+pytestmark = [pytest.mark.integration]
+
+
+def _wait_for_cql(node, timeout=120):
+    """Block until CQL port is accepting connections on *node*."""
+    # Clear cached IP so the next lookup resolves the (potentially new)
+    # address after a container restart.
+    node._internal_ip_address = None
+
+    def _cql_up():
+        try:
+            return node.is_port_used(port=BaseNode.CQL_PORT, service_name="scylla-server")
+        except Exception:  # noqa: BLE001
+            logging.error("CQL not up yet on %s", node.docker_id, exc_info=True)
+            return False
+
+    wait.wait_for(
+        func=_cql_up,
+        step=2,
+        text=f"Waiting for CQL on {node.docker_id}",
+        timeout=timeout,
+        throw_exc=True,
+    )
+
+
+@pytest.fixture(scope="function")
+def configure_racks(docker_scylla, docker_scylla_2, events):
+    """Set up a two-node cluster with simulated racks via node_setup.
+
+    Creates a minimal DummyScyllaDockerCluster, wraps each RemoteDocker
+    in a DummyDockerNode, and calls the real ``node_setup`` which writes
+    cassandra-rackdc.properties, wipes stale topology data, and
+    restarts the containers.
+    """
+    cluster = DummyScyllaDockerCluster(
+        params={"simulated_racks": 2, "docker_image": "scylladb/scylla:latest"},
+    )
+
+    raw_nodes = [docker_scylla, docker_scylla_2]
+    nodes = [RackAwareDummyDockerNode(rd, rack=idx, node_index=idx) for idx, rd in enumerate(raw_nodes)]
+
+    for node in nodes:
+        cluster.node_setup(node)
+
+    for node in nodes:
+        _wait_for_cql(node)
+
+    yield nodes[0], nodes[1]
+
+
+@pytest.mark.xdist_group("docker-racks")
+def test_rack_visibility(configure_racks):
+    """Each node must report its assigned rack in system.local."""
+    node1, node2 = configure_racks
+    result = node1.run_cqlsh("SELECT rack FROM system.local")
+    assert "RACK0" in result.stdout
+
+    result = node2.run_cqlsh("SELECT rack FROM system.local")
+    assert "RACK1" in result.stdout
+
+
+@pytest.mark.xdist_group("docker-racks")
+def test_keyspace_creation_with_rf2(configure_racks):
+    """A NetworkTopologyStrategy keyspace with RF=2 must be creatable across racks."""
+    node1, _ = configure_racks
+    create_ks = (
+        "CREATE KEYSPACE IF NOT EXISTS rack_test_ks "
+        "WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 2}"
+    )
+    result = node1.run_cqlsh(create_ks)
+    assert result.ok, f"Failed to create keyspace: {result.stderr}"
+
+
+@pytest.mark.xdist_group("docker-racks")
+def test_reuse_cluster_preserves_racks(configure_racks):
+    """After initial rack setup, node_setup with REUSE_CLUSTER=True must
+    skip full setup (no restart, no config_setup) while preserving the
+    rack assignments that were written during the initial setup.
+    """
+    node1, node2 = configure_racks
+
+    # Verify racks are correct before the reuse run
+    result = node1.run_cqlsh("SELECT rack FROM system.local")
+    assert "RACK0" in result.stdout
+
+    result = node2.run_cqlsh("SELECT rack FROM system.local")
+    assert "RACK1" in result.stdout
+
+    # Simulate a REUSE_CLUSTER run: create a new cluster object with
+    # reuse_cluster=True and call node_setup on the same nodes.
+    reuse_cluster = DummyScyllaDockerCluster(
+        params={"simulated_racks": 2, "docker_image": "scylladb/scylla:latest"},
+        reuse_cluster=True,
+    )
+
+    reuse_cluster.node_setup(node1)
+    reuse_cluster.node_setup(node2)
+
+    # CQL should still be up (no restart happened)
+    _wait_for_cql(node1, timeout=30)
+    _wait_for_cql(node2, timeout=30)
+
+    # Racks must still be the same after the reuse node_setup
+    result = node1.run_cqlsh("SELECT rack FROM system.local")
+    assert "RACK0" in result.stdout, f"Rack changed after reuse node_setup: {result.stdout}"
+
+    result = node2.run_cqlsh("SELECT rack FROM system.local")
+    assert "RACK1" in result.stdout, f"Rack changed after reuse node_setup: {result.stdout}"
+
+    # The keyspace created by a previous test (or create it now) must still work
+    create_ks = (
+        "CREATE KEYSPACE IF NOT EXISTS reuse_rack_test_ks "
+        "WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 2}"
+    )
+    result = node1.run_cqlsh(create_ks)
+    assert result.ok, f"Failed to create keyspace after reuse: {result.stderr}"

--- a/unit_tests/lib/fake_docker_cluster.py
+++ b/unit_tests/lib/fake_docker_cluster.py
@@ -1,0 +1,122 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+"""Lightweight ScyllaDockerCluster test double for unit and integration tests.
+
+Provides a thin subclass that bypasses the heavy DockerCluster / BaseCluster
+constructor chain while keeping real method implementations like ``node_setup``,
+``_create_nodes``, and ``_get_nodes``.
+"""
+
+import logging
+from types import SimpleNamespace
+
+from sdcm.cluster_docker import ScyllaDockerCluster
+
+
+class DummyScyllaDockerCluster(ScyllaDockerCluster):
+    """Minimal ScyllaDockerCluster stub for testing.
+
+    Bypasses the full ``DockerCluster`` / ``BaseCluster`` ``__init__`` chain
+    and wires only the attributes that tested methods actually read.
+
+    Supports:
+    - ``node_setup`` (needs ``params``, ``logdir``, ``test_config``)
+    - ``_create_nodes`` / ``_get_nodes`` (need ``racks_count``, ``nodes``,
+      ``node_prefix``)
+    """
+
+    # noinspection PyMissingConstructor
+    def __init__(
+        self,
+        params: dict,
+        logdir: str = "/tmp",
+        racks_count: int = 0,
+        node_prefix: str = "dummy-node",
+        reuse_cluster: bool = False,
+    ):
+        self.params = params
+        self.logdir = logdir
+        self.log = logging.getLogger(self.__class__.__name__)
+        self.name = "dummy-scylla-docker-cluster"
+        self.vector_store_cluster = None
+        self.racks_count = racks_count
+        self.nodes = []
+        self.node_prefix = node_prefix
+        # Set as instance attribute to shadow the cached_property descriptor,
+        # allowing per-instance configuration of REUSE_CLUSTER for tests.
+        self.test_config = SimpleNamespace(BACKTRACE_DECODING=False, REUSE_CLUSTER=reuse_cluster)
+
+    @staticmethod
+    def check_aio_max_nr(node, recommended_value=0):
+        pass
+
+    def _generate_db_node_certs(self, node):
+        pass
+
+    def get_scylla_args(self):
+        return ""
+
+    def _create_node(self, node_index, container=None, rack=0):
+        return SimpleNamespace(node_index=node_index, rack=rack, enable_auto_bootstrap=False)
+
+
+class DummyDockerNode:
+    """Base wrapper around a ``RemoteDocker`` for use in integration tests.
+
+    The ``docker_scylla`` fixture yields ``RemoteDocker`` instances, not
+    ``DockerNode``.  This base class provides ``__init__`` and attribute
+    delegation via ``__getattr__``.  Subclasses override specific methods
+    that ``node_setup`` (or other cluster methods) call on the node.
+    """
+
+    def __init__(self, remote_docker, rack=0, node_index=0):
+        self._remote_docker = remote_docker
+        self.rack = rack
+        self.node_index = node_index
+        # Stub for the cached_property on BaseNode; the REUSE_CLUSTER path
+        # in node_setup accesses node.raft to warm it up.
+        self.raft = None
+
+    def __getattr__(self, name):
+        return getattr(self._remote_docker, name)
+
+
+class RackAwareDummyDockerNode(DummyDockerNode):
+    """``DummyDockerNode`` with methods needed by rack-aware ``node_setup``.
+
+    Provides stub implementations of ``is_scylla_installed``,
+    ``config_setup``, ``clean_scylla_data``, and ``restart_scylla``
+    that operate on the underlying ``RemoteDocker`` container.
+    """
+
+    def is_scylla_installed(self, raise_if_not_installed=False):
+        return True
+
+    def config_setup(self, **kwargs):
+        self._remote_docker.remoter.sudo(
+            'sed -i "s/endpoint_snitch:.*/endpoint_snitch: GossipingPropertyFileSnitch/" /etc/scylla/scylla.yaml'
+        )
+
+    def clean_scylla_data(self):
+        for cmd in [
+            "rm -rf /var/lib/scylla/data/*",
+            "find /var/lib/scylla/commitlog -type f -delete",
+            "find /var/lib/scylla/hints -type f -delete",
+            "find /var/lib/scylla/view_hints -type f -delete",
+        ]:
+            self._remote_docker.remoter.sudo(cmd, ignore_status=True)
+
+    def restart_scylla(self, verify_up_before=True):
+        rd = self._remote_docker
+        rd.node.remoter.run(f"{rd.sudo_needed}docker restart {rd.docker_id}", timeout=60)

--- a/unit_tests/unit/test_config.py
+++ b/unit_tests/unit/test_config.py
@@ -791,3 +791,37 @@ def test_vector_store_ami_name_resolved_to_ami_id(monkeypatch):
     assert "vector-store-1-5-0-arm64-2026-03-17t07-07-32z" in resolved_names, (
         "convert_name_to_ami_if_needed was not called for ami_id_vector_store"
     )
+
+
+def test_docker_simulated_racks_sets_gossiping_snitch(monkeypatch):
+    """Test that GossipingPropertyFileSnitch is auto-set for Docker with multiple racks.
+
+    When simulated_racks > 1 on the Docker backend, the endpoint_snitch
+    should be automatically resolved to GossipingPropertyFileSnitch.
+    """
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
+    monkeypatch.setenv("SCT_SIMULATED_RACKS", "2")
+    monkeypatch.setenv("SCT_N_DB_NODES", "3")
+    monkeypatch.setenv("SCT_USE_MGMT", "false")
+
+    conf = sct_config.SCTConfiguration()
+    conf.verify_configuration()
+
+    assert conf.get("endpoint_snitch") == "org.apache.cassandra.locator.GossipingPropertyFileSnitch"
+
+
+def test_docker_single_rack_no_snitch_override(monkeypatch):
+    """Test that endpoint_snitch is not auto-set for Docker with a single rack.
+
+    When simulated_racks is 1 (default), no snitch override should occur
+    and endpoint_snitch should remain None.
+    """
+    monkeypatch.setenv("SCT_CLUSTER_BACKEND", "docker")
+    monkeypatch.setenv("SCT_SIMULATED_RACKS", "1")
+    monkeypatch.setenv("SCT_N_DB_NODES", "3")
+    monkeypatch.setenv("SCT_USE_MGMT", "false")
+
+    conf = sct_config.SCTConfiguration()
+    conf.verify_configuration()
+
+    assert conf.get("endpoint_snitch") is None

--- a/unit_tests/unit/test_docker_rack_assignment.py
+++ b/unit_tests/unit/test_docker_rack_assignment.py
@@ -1,0 +1,72 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+"""Tests for DockerCluster rack assignment in _create_nodes and _get_nodes."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from unit_tests.lib.fake_docker_cluster import DummyScyllaDockerCluster
+
+
+@pytest.mark.parametrize(
+    "racks_count, node_count, expected_racks",
+    [
+        (3, 6, [0, 1, 2, 0, 1, 2]),
+        (2, 5, [0, 1, 0, 1, 0]),
+        (1, 3, [0, 0, 0]),
+    ],
+    ids=["3-racks-6-nodes", "2-racks-5-nodes", "1-rack-3-nodes"],
+)
+def test_create_nodes_round_robin(racks_count, node_count, expected_racks):
+    """Verify that _create_nodes assigns racks in round-robin order.
+
+    Args:
+        racks_count: Number of racks configured on the cluster.
+        node_count: How many nodes to create.
+        expected_racks: Expected rack index for each created node.
+    """
+    cluster = DummyScyllaDockerCluster(params={}, racks_count=racks_count)
+    nodes = cluster._create_nodes(count=node_count)
+
+    assert [n.rack for n in nodes] == expected_racks
+    assert [n.node_index for n in nodes] == list(range(node_count))
+
+
+def test_create_nodes_explicit_rack():
+    """Verify that passing an explicit rack overrides round-robin assignment."""
+    cluster = DummyScyllaDockerCluster(params={}, racks_count=3)
+    nodes = cluster._create_nodes(count=3, rack=1)
+
+    assert [n.rack for n in nodes] == [1, 1, 1]
+    assert [n.node_index for n in nodes] == [0, 1, 2]
+
+
+def test_get_nodes_re_derives_racks():
+    """Verify that _get_nodes re-derives rack from node_index % racks_count."""
+    cluster = DummyScyllaDockerCluster(params={}, racks_count=3, node_prefix="test-node")
+
+    fake_containers = []
+    for idx in range(5):
+        container = MagicMock()
+        container.labels = {"NodeIndex": str(idx)}
+        container.name = f"test-node-{idx}"
+        fake_containers.append(container)
+
+    with patch("sdcm.cluster_docker.ContainerManager") as mock_cm:
+        mock_cm.get_containers_by_prefix.return_value = fake_containers
+        nodes = cluster._get_nodes()
+
+    assert [n.rack for n in nodes] == [0, 1, 2, 0, 1]
+    assert [n.node_index for n in nodes] == [0, 1, 2, 3, 4]

--- a/unit_tests/unit/test_docker_reuse_cluster.py
+++ b/unit_tests/unit/test_docker_reuse_cluster.py
@@ -1,0 +1,164 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2025 ScyllaDB
+
+"""Unit tests for ScyllaDockerCluster.node_setup REUSE_CLUSTER path.
+
+Validates that when REUSE_CLUSTER is True, node_setup takes the early-return
+path: calls _reuse_cluster_setup, warms node.raft, and skips the full setup
+(is_scylla_installed, check_aio_max_nr, config_setup, restart_scylla).
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from unit_tests.lib.fake_docker_cluster import DummyScyllaDockerCluster
+
+
+def _make_mock_node():
+    """Create a mock node with the attributes node_setup reads."""
+    node = MagicMock()
+    node.rack = 0
+    node.node_index = 0
+    node.raft = None
+    node.ssl_conf_dir = Path("/tmp/fake_ssl")
+    return node
+
+
+class TestNodeSetupReuseCluster:
+    """Tests for the REUSE_CLUSTER early-return guard in node_setup."""
+
+    def test_reuse_skips_full_setup(self):
+        """When REUSE_CLUSTER is True, node_setup must not call
+        is_scylla_installed, check_aio_max_nr, config_setup, or restart_scylla.
+        """
+        cluster = DummyScyllaDockerCluster(
+            params={"simulated_racks": 2},
+            reuse_cluster=True,
+        )
+        node = _make_mock_node()
+
+        with patch.object(cluster, "_reuse_cluster_setup") as mock_reuse_setup:
+            cluster.node_setup(node)
+
+        mock_reuse_setup.assert_called_once_with(node)
+        node.is_scylla_installed.assert_not_called()
+        node.config_setup.assert_not_called()
+        node.restart_scylla.assert_not_called()
+        node.clean_scylla_data.assert_not_called()
+
+    def test_reuse_warms_raft(self):
+        """The REUSE_CLUSTER path must access node.raft to warm the cached_property."""
+        cluster = DummyScyllaDockerCluster(
+            params={},
+            reuse_cluster=True,
+        )
+        node = _make_mock_node()
+        # Use a property mock to detect access
+        raft_sentinel = object()
+        type(node).raft = property(lambda self: raft_sentinel)
+
+        with patch.object(cluster, "_reuse_cluster_setup"):
+            cluster.node_setup(node)
+
+        # If raft was accessed without error, the warm-up succeeded.
+        # No assertion needed beyond no-exception; the property was read.
+
+    def test_reuse_skips_certs_when_not_configured(self):
+        """When neither server_encrypt nor client_encrypt is set,
+        _generate_db_node_certs must not be called.
+        """
+        cluster = DummyScyllaDockerCluster(
+            params={},
+            reuse_cluster=True,
+        )
+        node = _make_mock_node()
+
+        with (
+            patch.object(cluster, "_reuse_cluster_setup"),
+            patch.object(cluster, "_generate_db_node_certs") as mock_gen_certs,
+        ):
+            cluster.node_setup(node)
+
+        mock_gen_certs.assert_not_called()
+
+    @pytest.mark.parametrize("encrypt_param", ["server_encrypt", "client_encrypt"])
+    def test_reuse_generates_certs_when_missing(self, encrypt_param):
+        """When encryption is enabled and the DB cert is missing,
+        _generate_db_node_certs and install_client_certificate must be called.
+        """
+        cluster = DummyScyllaDockerCluster(
+            params={encrypt_param: True},
+            reuse_cluster=True,
+        )
+        node = _make_mock_node()
+        # Make ssl_conf_dir / TLSAssets.DB_CERT return a Path whose .exists() is False
+        fake_ssl_dir = MagicMock(spec=Path)
+        cert_path = MagicMock()
+        cert_path.exists.return_value = False
+        fake_ssl_dir.__truediv__ = MagicMock(return_value=cert_path)
+        node.ssl_conf_dir = fake_ssl_dir
+
+        with (
+            patch.object(cluster, "_reuse_cluster_setup"),
+            patch.object(cluster, "_generate_db_node_certs") as mock_gen_certs,
+            patch("sdcm.cluster_docker.install_client_certificate") as mock_install_cert,
+        ):
+            cluster.node_setup(node)
+
+        mock_gen_certs.assert_called_once_with(node)
+        mock_install_cert.assert_called_once_with(node.remoter, node.ip_address, force=True)
+
+    @pytest.mark.parametrize("encrypt_param", ["server_encrypt", "client_encrypt"])
+    def test_reuse_skips_certs_when_already_present(self, encrypt_param):
+        """When encryption is enabled but the DB cert already exists,
+        _generate_db_node_certs must not be called.
+        """
+        cluster = DummyScyllaDockerCluster(
+            params={encrypt_param: True},
+            reuse_cluster=True,
+        )
+        node = _make_mock_node()
+        fake_ssl_dir = MagicMock(spec=Path)
+        cert_path = MagicMock()
+        cert_path.exists.return_value = True
+        fake_ssl_dir.__truediv__ = MagicMock(return_value=cert_path)
+        node.ssl_conf_dir = fake_ssl_dir
+
+        with (
+            patch.object(cluster, "_reuse_cluster_setup"),
+            patch.object(cluster, "_generate_db_node_certs") as mock_gen_certs,
+        ):
+            cluster.node_setup(node)
+
+        mock_gen_certs.assert_not_called()
+
+    def test_normal_setup_when_not_reusing(self):
+        """When REUSE_CLUSTER is False, node_setup must call
+        is_scylla_installed and proceed with the full setup path.
+        """
+        cluster = DummyScyllaDockerCluster(
+            params={"simulated_racks": 0},
+            reuse_cluster=False,
+        )
+        node = _make_mock_node()
+        node.is_scylla_installed.return_value = True
+
+        with patch.object(cluster, "_reuse_cluster_setup") as mock_reuse_setup:
+            cluster.node_setup(node)
+
+        mock_reuse_setup.assert_not_called()
+        node.is_scylla_installed.assert_called_once_with(raise_if_not_installed=True)
+        node.config_setup.assert_called_once()
+        node.restart_scylla.assert_called_once_with(verify_up_before=True)


### PR DESCRIPTION
Previously, the `simulated_racks` config option was explicitly excluded from the Docker backend (cluster_backend != "docker" guard in sct_config.py). This meant all Docker nodes always landed in the same rack, causing ScyllaDB to reject `replication_factor=N` when N exceeded the number of racks (1) with rf_rack_valid_keyspaces enforcement.

Changes:
- Remove the Docker exclusion from the snitch auto-resolution condition in sct_config.py, and add explicit parentheses to fix the operator precedence ambiguity (and binds tighter than or).
- Add `rack` parameter to DockerNode, VectorStoreDockerNode, and DockerMonitoringNode __init__ methods, forwarding to BaseNode.
- Add `rack` parameter to _create_node in DockerCluster, VectorStoreSetDocker, and MonitorSetDocker.
- Implement round-robin rack distribution in _create_nodes using node_index % racks_count (matching the AWS/GCE/Azure pattern).
- Re-derive rack from node_index in _get_nodes for cluster reuse.
- Fix positional argument mismatch in MonitorSetDocker.add_nodes where enable_auto_bootstrap was passed positionally to _create_nodes and would now map to the new rack parameter instead.
- In ScyllaDockerCluster.node_setup, write cassandra-rackdc.properties directly (Docker image lacks `stat` required by SnitchConfig), wipe persisted topology data from initial SimpleSnitch boot, and restart the container to apply GossipingPropertyFileSnitch cleanly.

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- test run locally and passed

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
