### PR TITLE
fix(sct_config): skip image/repo lookup when unified_package is set

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -2595,6 +2595,10 @@ class SCTConfiguration(BaseModel):
             ):
                 self.log.info("Assume that Scylla Docker image has repo file pre-installed.")
                 self._replace_docker_image_latest_tag()
+            elif self.get("unified_package"):
+                # unified_package is already set (either directly or resolved from relocatable:);
+                # skip image/repo lookup — the base OS image will be auto-set in section 6.0.1
+                pass
             elif not self.get("ami_id_db_scylla") and self.get("cluster_backend") == "aws":
                 ami_list = []
                 for region in region_names:


### PR DESCRIPTION
## Problem

Commit d619527e6 (`feature(unified-package): add support of unified_package`) introduced a regression in 4 unit tests:

- `test_relocatable_version_resolves_unified_package[relocatable-latest-aws-x86_64]`
- `test_relocatable_version_resolves_unified_package[relocatable-master-x86_64-aws]`
- `test_relocatable_version_resolves_unified_package[relocatable-master-aarch64-aws]`
- `test_relocatable_version_resolves_unified_package[relocatable-latest-gce]`

## Root Cause

When `scylla_version` starts with `relocatable:`, section 6.0 of `verify_configuration()` correctly sets `unified_package` and clears `scylla_version = ""`. However, the `elif` chain that follows was not guarded against this case:

- **AWS**: `elif not ami_id_db_scylla and backend == "aws"` fired with `scylla_version=""`, resolved a real AMI ID and stored it, so section 6.0.1 found `ami_id_db_scylla` already set and skipped the intended Ubuntu 24.04 SSM path → `assert ami_id_db_scylla == "resolve:ssm:..."` failed.
- **GCE**: fell all the way through to `elif not scylla_repo` and called `find_scylla_repo("")` → `ValueError: repo for scylla version  wasn't found`.

## Fix

Add one `elif self.get("unified_package"): pass` guard before the image/repo lookup `elif` chain, short-circuiting it when `unified_package` is already set. Section 6.0.1 then handles OS image assignment as intended.