### PR TITLE
fix(multidc-parallel-network-schema-changes): fix op name for user profile

### DIFF
--- a/test-cases/longevity/longevity-multidc-parallel-network-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-network-schema-changes-12h.yaml
@@ -1,12 +1,12 @@
 test_duration: 800
 
 prepare_write_cmd:  ["cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-                     "cassandra-stress user profile=/tmp/cs_multidc_mv_lcs.yaml ops'(write=1)' -port jmx=6868 -mode cql3 native -rate threads=40 n=3000000 -log interval=5"
+                     "cassandra-stress user profile=/tmp/cs_multidc_mv_lcs.yaml ops'(insert=1)' -port jmx=6868 -mode cql3 native -rate threads=40 n=3000000 -log interval=5"
                     ]
 
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
              "cassandra-stress read  cl=QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-             "cassandra-stress user profile=/tmp/cs_multidc_mv_lcs.yaml ops'(write=1,read=1,mv_read1=1,mv_read2=1)' -port jmx=6868 -mode cql3 native -rate threads=40 duration=700m -log interval=5",
+             "cassandra-stress user profile=/tmp/cs_multidc_mv_lcs.yaml ops'(insert=1,read=1,mv_read1=1,mv_read2=1)' -port jmx=6868 -mode cql3 native -rate threads=40 duration=700m -log interval=5",
              ]
 n_db_nodes: '4 4'
 n_loaders: '2 1'


### PR DESCRIPTION
The correct name is `insert` not `write`.
See https://github.com/scylladb/scylla-cluster-tests/blob/master/data_dir/cs_multidc_mv_lcs.yaml
This also caused issues inside the code that set hdr tags.

Fixes errors like
```
self = <sdcm.stress_thread.CassandraStressThread object at 0x7caef006fc50>
stress_cmd = "cassandra-stress user profile=/tmp/cs_multidc_mv_lcs.yaml ops'(write=1)' -port jmx=6868 -mode cql3 native -rate threads=40 n=3000000 -log interval=5"
    def set_hdr_tags(self, stress_cmd):
        # TODO: add support for the "counter_write", "counter_read" and "user" modes?
        params = get_stress_cmd_params(stress_cmd)
        tag_suffix = "rt" if "fixed threads" in params else "st"
        if "user profile=" in stress_cmd:
            # Examples:
            # Write: ops(insert=1)
            # Read: ops(read=2)
            # Mixed: ops(insert=1,read=2)
            # Only standard operations (read and insert) are supported per user profile stress command in this implementation
            if "insert=" in stress_cmd:
                self.hdr_tags.append(f"WRITE-{tag_suffix}")
            elif "read=" in stress_cmd:
                self.hdr_tags.append(f"READ-{tag_suffix}")
            else:
>               raise ValueError(
                    "Cannot detect supported stress operation type from the stress command with user profile: %s",
                    stress_cmd,
E                   ValueError: ('Cannot detect supported stress operation type from the stress command with user profile: %s', "cassandra-stress user profile=/tmp/cs_multidc_mv_lcs.yaml ops'(write=1)' -port jmx=6868 -mode cql3 native -rate threads=40 n=3000000 -log interval=5")
sdcm/stress_thread.py:150: ValueError
```

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [ ]

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
