### PR TITLE
docs(skills): Update writing unit tests skills

### DIFF
--- a/skills/writing-unit-tests/SKILL.md
+++ b/skills/writing-unit-tests/SKILL.md
@@ -36,11 +36,15 @@ If a test is slow or flaky, the first suspect is an unmocked network call.
 
 SCT runs tests with `pytest-xdist` (`-n2` by default) and `pytest-random-order`. Never rely on test execution order, shared mutable state, or global side effects. Use fixtures for setup/teardown, `monkeypatch` for environment variables, and `tmp_path` for file-based tests.
 
+**Special care for `Singleton` classes:** SCT has classes with `metaclass=Singleton` (e.g. `NodeLoadInfoServices`, `AdaptiveTimeoutStore` subclasses) that persist mutable state across tests on the same worker process. Add an `autouse` fixture that clears the cache in teardown (post-`yield` only — never pre-yield). See pitfall P-16 for details.
+
 ### Mock at the Boundary, Not the Logic
 
 **Mock external dependencies (network, file system, cloud APIs) — not internal SCT logic.**
 
 Mocking internal functions makes tests brittle and hides bugs. Mock at the outermost boundary: the HTTP call, the SSH command, the cloud SDK client. This tests the actual logic while isolating from infrastructure.
+
+**Never reimplement the code under test in a fake class.** If you find yourself copying a method body from `sdcm/` into a `FakeFoo` helper in your test, stop — you are testing the copy, not the real code. Always instantiate the real class and mock only its external I/O (network, file system, cloud APIs). See anti-pattern AP-6 for details.
 
 ### No Inline Classes in Fixtures or Tests
 
@@ -237,8 +241,8 @@ uv run python -m pytest unit_tests/test_config.py --cov=sdcm.sct_config --cov-re
 
 | File | Content |
 |------|---------|
-| [common-pitfalls.md](references/common-pitfalls.md) | Pitfalls P-1 through P-15 with before/after fixes |
-| [anti-patterns.md](references/anti-patterns.md) | Anti-patterns AP-1 through AP-5 with before/after fixes |
+| [common-pitfalls.md](references/common-pitfalls.md) | Pitfalls P-1 through P-16 with before/after fixes |
+| [anti-patterns.md](references/anti-patterns.md) | Anti-patterns AP-1 through AP-6 with before/after fixes |
 
 | Workflow | Purpose |
 |----------|---------|

--- a/skills/writing-unit-tests/references/anti-patterns.md
+++ b/skills/writing-unit-tests/references/anti-patterns.md
@@ -138,3 +138,53 @@ def test_run_does_not_crash_on_skipped_nemesis(nemesis_runner):
 ### Infrastructure exported from test files
 
 `FakeSisyphusMonkey` lives in `test_sisyphus.py` but is imported by `test_evaluate_skip.py`. Test files are not libraries. If a fake/stub/helper is needed in more than one test file, move it to `fake_cluster.py`, `unit_tests/nemesis/__init__.py`, or a `conftest.py`.
+
+## AP-6: Testing a Copy of the Code Instead of the Code Itself
+
+The most dangerous anti-pattern: the test creates a `FakeFoo` class that **re-implements** the same logic as the real `Foo`, then tests `FakeFoo`. The production code is never exercised, so any bug in `Foo` is invisible.
+
+This often happens when an AI generates tests by reading the source and mirroring it into a fake, rather than calling the real class with mocked dependencies.
+
+❌ **Bad — `FakeDockerCluster._create_nodes` is a verbatim copy of the real method:**
+```python
+class FakeDockerCluster:
+    # copied from sdcm/cluster_docker.py
+    def _create_nodes(self, count, rack=None, enable_auto_bootstrap=False):
+        new_nodes = []
+        for node_index in self._get_new_node_indexes(count):
+            node_rack = node_index % self.racks_count if rack is None else rack
+            node = self._create_node(node_index, rack=node_rack)
+            ...
+        return new_nodes
+
+def test_round_robin_rack_assignment():
+    cluster = FakeDockerCluster(racks_count=3)
+    nodes = cluster._create_nodes(6)
+    assert [n.rack for n in nodes] == [0, 1, 2, 0, 1, 2]  # tests the copy, not the real code
+```
+
+✅ **Good — construct the real object and mock only its external dependencies:**
+```python
+from unittest.mock import MagicMock, patch
+from sdcm.cluster_docker import DockerCluster
+
+@pytest.mark.parametrize("racks_count,node_count,expected_racks", [
+    pytest.param(3, 6, [0, 1, 2, 0, 1, 2], id="round-robin-3-racks"),
+    pytest.param(2, 5, [0, 1, 0, 1, 0],    id="round-robin-2-racks"),
+    pytest.param(1, 3, [0, 0, 0],           id="single-rack"),
+])
+def test_create_nodes_round_robin(racks_count, node_count, expected_racks, params):
+    params["simulated_racks"] = racks_count
+    params["n_db_nodes"] = node_count
+    cluster = DockerCluster(...)  # the REAL class
+
+    with patch.object(cluster, "_create_node", side_effect=[MagicMock() for _ in range(node_count)]):
+        cluster._create_nodes(count=node_count)
+
+    actual_racks = [call.kwargs["rack"] for call in cluster._create_node.call_args_list]
+    assert actual_racks == expected_racks
+```
+
+**How to spot it:** if you grep the test file and find the same method bodies from `sdcm/` appearing verbatim, the tests are copies. A good test constructs the real `sdcm.*` class and mocks only at the external boundary (network, file system, cloud APIs).
+
+**Correct approach:** always instantiate the real class and mock only its external I/O. Only fall back to `MagicMock(spec=RealClass)` as a last resort when the real constructor has unavoidable heavy side effects that cannot be mocked — and document why.

--- a/skills/writing-unit-tests/references/common-pitfalls.md
+++ b/skills/writing-unit-tests/references/common-pitfalls.md
@@ -371,3 +371,55 @@ def test_run_stops_after_skips(make_nemesis_runner, events_function_scope):
 
 
 See also: [anti-patterns.md](anti-patterns.md) for broader testing anti-patterns.
+
+---
+
+### P-16: Singleton State Leaking Between Parallel Tests
+
+SCT contains classes that use `metaclass=Singleton` (e.g. `NodeLoadInfoServices`, `AdaptiveTimeoutStore`). A `Singleton` holds shared mutable state across the entire process. When `pytest-xdist` runs tests on the same worker, a test that populates a Singleton's cache can corrupt a later test that expects a clean slate — even if the tests appear unrelated.
+
+**Symptoms:** tests pass with `-n0` (sequential) but fail with `-n2` or higher; failures are non-deterministic; errors reference stale node names, wrong cached values, or `KeyError` from a missing key that another test was supposed to populate.
+
+❌ **Bad — Singleton cache persists across tests:**
+```python
+# Test A populates the cache with a stale remoter
+def test_a(fake_node):
+    with adaptive_timeout(operation=Operations.DECOMMISSION, node=fake_node, ...) as timeout:
+        ...
+# Test B runs on the same worker; NodeLoadInfoServices still holds fake_node from test_a
+# fake_node.remoter is now invalid → KeyError / wrong cached result
+def test_b(fake_node, ...):
+    with adaptive_timeout(operation=Operations.DECOMMISSION, node=fake_node, ...) as timeout:
+        assert timeout == 7200  # fails: gets stale value from test_a's cache
+```
+
+✅ **Good — add an `autouse` fixture that clears the Singleton's mutable state after each test:**
+```python
+from sdcm.utils.adaptive_timeouts.load_info_store import NodeLoadInfoServices
+
+@pytest.fixture(autouse=True)
+def clear_node_load_info_services_singleton():
+    """Clear the NodeLoadInfoServices Singleton cache after each test to prevent cross-test pollution."""
+    yield
+    NodeLoadInfoServices()._services.clear()
+```
+
+**Rules:**
+- Only clear in teardown (post-`yield`); the previous test's teardown already ran before setup begins.
+- Place the fixture in the test module or in `conftest.py` if multiple modules share the same Singleton.
+- Prefer post-yield-only cleanup (no pre-yield clear) — redundant pre-yield clearing is a code smell that signals the teardown isn't trusted.
+
+Also beware that `MemoryAdaptiveTimeoutStore` (and any `AdaptiveTimeoutStore` subclass) inherits `Singleton` — calling `MemoryAdaptiveTimeoutStore()` inside a test body returns the **same shared instance** that the fixture populated, but it may have been cleared or written to by a parallel test. Always read results from the fixture instance, not from a fresh `SomeStore()` call:
+
+❌ **Bad — creates new Singleton reference, may see another test's data (or none):**
+```python
+metrics = MemoryAdaptiveTimeoutStore().get(operation="DECOMMISSION")
+```
+
+✅ **Good — read from the fixture instance that was passed to `adaptive_timeout`:**
+```python
+def test_decommission(fake_node, adaptive_timeout_store):
+    with adaptive_timeout(..., stats_storage=adaptive_timeout_store) as timeout:
+        ...
+    metrics = adaptive_timeout_store.get(operation="DECOMMISSION")  # same instance
+```


### PR DESCRIPTION
Add new antipatterns, based on recent occurrences:
* AP-6: Testing a Copy of the Code Instead of the Code Itself (e.g. https://github.com/scylladb/scylla-cluster-tests/pull/14307)
* P-16: Singleton State Leaking Between Parallel Tests (e.g. https://github.com/scylladb/scylla-cluster-tests/pull/14310)


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
