### PR TITLE
ci(manager): update default ScyllaDB version to 2026.1

### DIFF
--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -82,7 +82,7 @@ def call(Map pipelineParams) {
 
             separator(name: 'SCYLLA_DB', sectionHeader: 'ScyllaDB Configuration Selection')
             string(defaultValue: '', description: 'AMI ID for ScyllaDB ', name: 'scylla_ami_id')
-            string(defaultValue: "${pipelineParams.get('scylla_version', '2025.3')}",
+            string(defaultValue: "${pipelineParams.get('scylla_version', '2026.1')}",
                    description: 'Version of ScyllaDB to run against. Can be a released version (2025.4) or a master (master:latest)',
                    name: 'scylla_version')
             // When branching to manager version branch, set scylla_version to the latest release


### PR DESCRIPTION
## Summary
- Update Manager pipeline default `scylla_version` from `2025.3` to `2026.1`.
- Keep existing parameter override behavior (`pipelineParams` value still takes precedence).