### PR TITLE
fix(cloud-cleanup): fix circular import, add boto3 timeouts, and per-region error handling

### DIFF
--- a/jenkins-pipelines/qa/hydra-cleanup-cloud.jenkinsfile
+++ b/jenkins-pipelines/qa/hydra-cleanup-cloud.jenkinsfile
@@ -132,35 +132,9 @@ pipeline {
     }
     post {
         unsuccessful {
-            script {
-                def failedStages = []
-                currentBuild.rawBuild.getExecution().getCurrentHeads().each { head ->
-                    def node = head
-                    while (node != null) {
-                        if (node instanceof org.jenkinsci.plugins.workflow.graph.StepStartNode) {
-                            def stage = node.getAction(org.jenkinsci.plugins.workflow.actions.LabelAction)
-                            def result = node.getAction(org.jenkinsci.plugins.workflow.actions.WarningAction)
-                            if (stage && result) {
-                                failedStages.add(stage.displayName)
-                            }
-                        }
-                        node = node.parents ? node.parents[0] : null
-                    }
-                }
-                def stageList = failedStages.unique().join('\n  - ')
-                mail to: params.email_recipients,
-                     subject: "Cloud Cleanup FAILED: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
-                     body: """Cloud resource cleanup pipeline finished with status: ${currentBuild.result}
-
-Failed stages:
-  - ${stageList}
-
-Build URL: ${env.BUILD_URL}
-Console: ${env.BUILD_URL}console
-
-Action required: failed cleanup stages may leave orphaned cloud resources running and incurring costs.
-"""
-            }
+            mail to: params.email_recipients,
+                 subject: "Cloud Cleanup FAILED: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
+                 body: "Cloud resource cleanup pipeline finished with status: ${currentBuild.result}\n\nBuild: ${env.BUILD_URL}\nConsole: ${env.BUILD_URL}console\n\nCheck the build log to see which stages failed.\nFailed cleanup stages may leave orphaned cloud resources running and incurring costs."
         }
     }
 }

--- a/jenkins-pipelines/qa/hydra-cleanup-cloud.jenkinsfile
+++ b/jenkins-pipelines/qa/hydra-cleanup-cloud.jenkinsfile
@@ -19,6 +19,11 @@ pipeline {
             description: 'do not execute commands, just print out',
             name: 'dryRun'
         )
+        string(
+            defaultValue: 'qa@scylladb.com',
+            description: 'email recipients for cleanup failure notifications',
+            name: 'email_recipients'
+        )
     }
     options {
         timestamps()
@@ -122,6 +127,39 @@ pipeline {
                         """
                    }
                 }
+            }
+        }
+    }
+    post {
+        unsuccessful {
+            script {
+                def failedStages = []
+                currentBuild.rawBuild.getExecution().getCurrentHeads().each { head ->
+                    def node = head
+                    while (node != null) {
+                        if (node instanceof org.jenkinsci.plugins.workflow.graph.StepStartNode) {
+                            def stage = node.getAction(org.jenkinsci.plugins.workflow.actions.LabelAction)
+                            def result = node.getAction(org.jenkinsci.plugins.workflow.actions.WarningAction)
+                            if (stage && result) {
+                                failedStages.add(stage.displayName)
+                            }
+                        }
+                        node = node.parents ? node.parents[0] : null
+                    }
+                }
+                def stageList = failedStages.unique().join('\n  - ')
+                mail to: params.email_recipients,
+                     subject: "Cloud Cleanup FAILED: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
+                     body: """Cloud resource cleanup pipeline finished with status: ${currentBuild.result}
+
+Failed stages:
+  - ${stageList}
+
+Build URL: ${env.BUILD_URL}
+Console: ${env.BUILD_URL}console
+
+Action required: failed cleanup stages may leave orphaned cloud resources running and incurring costs.
+"""
             }
         }
     }

--- a/sct.py
+++ b/sct.py
@@ -54,7 +54,7 @@ from sdcm.provision import AzureProvisioner
 from sdcm.provision.provisioner import VmInstance, VmArch
 from sdcm.remote import LOCALRUNNER
 from sdcm.nemesis.monkey.runners import SisyphusMonkey
-from sdcm.sct_config import SCTConfiguration, init_and_verify_sct_config, available_backends
+from sdcm.sct_config import AWS_SUPPORTED_REGIONS, SCTConfiguration, init_and_verify_sct_config, available_backends
 from sdcm.sct_provision.common.layout import SCTProvisionLayout
 from sdcm.sct_provision.instances_provider import provision_sct_resources
 from sdcm.sct_runner import (
@@ -350,7 +350,7 @@ def provision_resources(backend, test_name: str, config: str):
 def clean_aws_kms_aliases(ctx, regions, time_delta_h, dry_run):
     """Clean AWS KMS old aliases."""
     add_file_logger()
-    regions = regions or SCTConfiguration.aws_supported_regions
+    regions = regions or AWS_SUPPORTED_REGIONS
     aws_kms, kwargs = AwsKms(region_names=regions), {"dry_run": dry_run}
     if time_delta_h:
         kwargs["time_delta_h"] = time_delta_h

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -438,6 +438,15 @@ available_backends: list[str] = [
     "oci",
 ]
 
+AWS_SUPPORTED_REGIONS: list[str] = [
+    "eu-west-1",
+    "eu-west-2",
+    "us-west-2",
+    "us-east-1",
+    "eu-north-1",
+    "eu-central-1",
+]
+
 
 class SCTConfiguration(BaseModel):
     """
@@ -2391,14 +2400,7 @@ class SCTConfiguration(BaseModel):
         "ami_id_db_oracle",
         "ami_id_vector_store",
     ]
-    aws_supported_regions: Annotated[list, IgnoredType] = [
-        "eu-west-1",
-        "eu-west-2",
-        "us-west-2",
-        "us-east-1",
-        "eu-north-1",
-        "eu-central-1",
-    ]
+    aws_supported_regions: Annotated[list, IgnoredType] = AWS_SUPPORTED_REGIONS
 
     model_config = ConfigDict(
         ignored_types=(IgnoredType,),

--- a/sdcm/utils/aws_peering.py
+++ b/sdcm/utils/aws_peering.py
@@ -17,14 +17,14 @@ import itertools
 from botocore.exceptions import ClientError
 
 from sdcm.utils.aws_region import AwsRegion
-from sdcm.sct_config import SCTConfiguration
+from sdcm.sct_config import AWS_SUPPORTED_REGIONS
 
 LOG = logging.getLogger(__name__)
 
 
 class AwsVpcPeering:
     def __init__(self, regions=None):
-        regions = regions or SCTConfiguration.aws_supported_regions
+        regions = regions or AWS_SUPPORTED_REGIONS
         self.regions = [AwsRegion(r) for r in regions]
 
     @staticmethod

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -19,7 +19,7 @@ import logging
 import time
 import uuid
 from functools import cached_property
-from typing import Any, List, Literal
+from typing import Any, List, Literal, TYPE_CHECKING
 
 from google.oauth2 import service_account
 from google.cloud import compute_v1
@@ -30,7 +30,9 @@ from googleapiclient.discovery import build
 
 from sdcm.keystore import KeyStore
 from sdcm.utils.docker_utils import ContainerManager, DockerException, Container
-from sdcm.provision.provisioner import VmArch
+
+if TYPE_CHECKING:
+    from sdcm.provision.provisioner import VmArch
 
 # NOTE: we cannot use neither 'slim' nor 'alpine' versions because we need the 'beta' component be installed.
 GOOGLE_CLOUD_SDK_IMAGE = "google/cloud-sdk:437.0.1"
@@ -59,7 +61,7 @@ def gce_instance_name(node_prefix: str, dc_idx: int, node_index: int) -> str:
     return name
 
 
-def vmarch_to_gcp(arch: VmArch) -> str:
+def vmarch_to_gcp(arch: "VmArch") -> str:
     """Convert VmArch enum to GCP architecture format.
 
     Args:
@@ -71,6 +73,10 @@ def vmarch_to_gcp(arch: VmArch) -> str:
     Raises:
         ValueError: If architecture is not supported
     """
+    # Lazy import to avoid circular dependency:
+    # gce_utils -> provision.provisioner -> provision.__init__ -> provision.gce -> gce_utils
+    from sdcm.provision.provisioner import VmArch  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
     if arch is VmArch.X86:
         return "X86_64"
     elif arch is VmArch.ARM:

--- a/utils/cloud_cleanup/aws/clean_aws.py
+++ b/utils/cloud_cleanup/aws/clean_aws.py
@@ -8,8 +8,11 @@ import logging
 import sys
 import boto3
 import pytz
+from botocore.config import Config
 
 from utils.cloud_cleanup import update_argus_resource_status
+
+BOTO3_TIMEOUT_CONFIG = Config(connect_timeout=10, read_timeout=30, retries={"max_attempts": 2})
 
 DRY_RUN = False
 VERBOSE = False
@@ -137,12 +140,12 @@ def regions_names():
     default_region = session.region_name
     if not default_region:
         default_region = "eu-central-1"
-    client = session.client("ec2", region_name=default_region)
+    client = session.client("ec2", region_name=default_region, config=BOTO3_TIMEOUT_CONFIG)
     return [region["RegionName"] for region in client.describe_regions()["Regions"]]
 
 
 def scan_region_instances(region_name, duration):
-    ec2 = boto3.resource("ec2", region_name=region_name)
+    ec2 = boto3.resource("ec2", region_name=region_name, config=BOTO3_TIMEOUT_CONFIG)
     instances = ec2.instances.filter(Filters=[{"Name": "instance-state-name", "Values": ["running"]}])
 
     running, keep_alive, expiring, expired = 0, 0, 0, []
@@ -235,7 +238,7 @@ def print_volume(volume, msg):
 
 def clean_volumes(region_name):
     print("cleaning region %s volumes" % region_name)
-    ec2 = boto3.resource("ec2", region_name=region_name)
+    ec2 = boto3.resource("ec2", region_name=region_name, config=BOTO3_TIMEOUT_CONFIG)
 
     volumes = ec2.volumes.all()
 
@@ -291,7 +294,7 @@ def print_adress(eip_dict, msg):
 
 def clean_ips(region_name):
     print("cleaning region %s IP's" % region_name)
-    client = boto3.client("ec2", region_name=region_name)
+    client = boto3.client("ec2", region_name=region_name, config=BOTO3_TIMEOUT_CONFIG)
     addresses_dict = client.describe_addresses()
     deleted_addresses = 0
     kept_addresses = 0
@@ -307,7 +310,7 @@ def clean_ips(region_name):
 
 def clean_capacity_reservations(region_name):
     print("Cleaning region %s capacity reservations" % region_name)
-    client = boto3.client("ec2", region_name=region_name)
+    client = boto3.client("ec2", region_name=region_name, config=BOTO3_TIMEOUT_CONFIG)
     response = client.describe_capacity_reservations(Filters=[{"Name": "state", "Values": ["active"]}])
     now = datetime.datetime.now(datetime.timezone.utc)
 
@@ -354,7 +357,7 @@ def keep_alive_host(host: dict):
 
 def clean_dedicate_hosts(region_name):
     print("cleaning region %s dedicate_hosts" % region_name)
-    ec2 = boto3.client("ec2", region_name=region_name)
+    ec2 = boto3.client("ec2", region_name=region_name, config=BOTO3_TIMEOUT_CONFIG)
 
     def delete_host(_host: dict):
         try:
@@ -398,7 +401,7 @@ def clean_unattached_security_groups(region_name: str):
     if VERBOSE:
         print(f"Checking region: {region_name} for unattached security groups")
     session = boto3.Session()
-    ec2 = session.client("ec2", region_name=region_name)
+    ec2 = session.client("ec2", region_name=region_name, config=BOTO3_TIMEOUT_CONFIG)
 
     # Use paginators for security groups
     sg_paginator = ec2.get_paginator("describe_security_groups")
@@ -486,9 +489,12 @@ if __name__ == "__main__":
         logging.getLogger("botocore").setLevel(logging.DEBUG)
 
     for region in regions_names():
-        clean_instances(region, arguments.duration)
-        clean_volumes(region)
-        clean_ips(region)
-        clean_capacity_reservations(region)
-        clean_dedicate_hosts(region)
-        clean_unattached_security_groups(region)
+        try:
+            clean_instances(region, arguments.duration)
+            clean_volumes(region)
+            clean_ips(region)
+            clean_capacity_reservations(region)
+            clean_dedicate_hosts(region)
+            clean_unattached_security_groups(region)
+        except Exception as exc:  # noqa: BLE001
+            eprint(f"Failed to clean region {region}: {exc}")

--- a/utils/cloud_cleanup/k8s_eks/clean_eks.py
+++ b/utils/cloud_cleanup/k8s_eks/clean_eks.py
@@ -27,6 +27,7 @@ import argparse
 import os
 
 import boto3
+from botocore.config import Config
 
 from sdcm.utils.aws_utils import EksClusterForCleaner
 from sdcm.utils.common import all_aws_regions
@@ -36,6 +37,8 @@ from utils.cloud_cleanup import (
     get_keep_hours_from_tags,
     DEFAULT_KEEP_HOURS,
 )
+
+BOTO3_TIMEOUT_CONFIG = Config(connect_timeout=10, read_timeout=30, retries={"max_attempts": 2})
 
 
 def get_cluster_creation_time(cluster):
@@ -70,7 +73,7 @@ def clean_eks_clusters(regions, keep_hours=DEFAULT_KEEP_HOURS, dry_run=False):
     for region in regions:
         LOGGER.info("Cleaning EKS clusters in region: %s", region)
         try:
-            eks_client = boto3.client("eks", region_name=region)
+            eks_client = boto3.client("eks", region_name=region, config=BOTO3_TIMEOUT_CONFIG)
             cluster_names = eks_client.list_clusters()["clusters"]
 
             if not cluster_names:
@@ -159,7 +162,7 @@ def clean_launch_templates(regions, keep_hours=DEFAULT_KEEP_HOURS, dry_run=False
     for region in regions:
         LOGGER.info("Cleaning launch templates in region: %s", region)
         try:
-            ec2_client = boto3.client("ec2", region_name=region)
+            ec2_client = boto3.client("ec2", region_name=region, config=BOTO3_TIMEOUT_CONFIG)
 
             # List all launch templates
             paginator = ec2_client.get_paginator("describe_launch_templates")
@@ -240,7 +243,7 @@ def clean_load_balancers(regions, keep_hours=DEFAULT_KEEP_HOURS, dry_run=False):
     for region in regions:
         LOGGER.info("Cleaning load balancers in region: %s", region)
         try:
-            elb_client = boto3.client("elb", region_name=region)
+            elb_client = boto3.client("elb", region_name=region, config=BOTO3_TIMEOUT_CONFIG)
 
             # Clean Classic Load Balancers
             try:
@@ -324,7 +327,7 @@ def clean_cloudformation_stacks(regions, keep_hours=DEFAULT_KEEP_HOURS, dry_run=
     for region in regions:
         LOGGER.info("Cleaning CloudFormation stacks in region: %s", region)
         try:
-            cf_client = boto3.client("cloudformation", region_name=region)
+            cf_client = boto3.client("cloudformation", region_name=region, config=BOTO3_TIMEOUT_CONFIG)
 
             # List all stacks (exclude deleted ones)
             paginator = cf_client.get_paginator("list_stacks")

--- a/utils/cloud_cleanup/k8s_eks/clean_eks.py
+++ b/utils/cloud_cleanup/k8s_eks/clean_eks.py
@@ -362,6 +362,7 @@ def clean_cloudformation_stacks(regions, keep_hours=DEFAULT_KEEP_HOURS, dry_run=
                             tags_dict = get_tags_dict_from_aws_tags(stack_details["Stacks"][0].get("Tags", []))
                     except Exception as exc:  # noqa: BLE001
                         LOGGER.debug("Failed to get stack details for %s: %s", stack_name, exc)
+                        stack_details = {}
                         tags_dict = {}
 
                     if ("CreatedBy", "SCT") not in tags_dict.items():
@@ -388,6 +389,11 @@ def clean_cloudformation_stacks(regions, keep_hours=DEFAULT_KEEP_HOURS, dry_run=
                         kept_stacks += 1
                         continue
 
+                    # Check if TerminationProtection is enabled (eksctl enables it on addon stacks)
+                    termination_protected = False
+                    if stack_details.get("Stacks"):
+                        termination_protected = stack_details["Stacks"][0].get("EnableTerminationProtection", False)
+
                     # Delete stack
                     if not dry_run:
                         LOGGER.info(
@@ -397,6 +403,15 @@ def clean_cloudformation_stacks(regions, keep_hours=DEFAULT_KEEP_HOURS, dry_run=
                             creation_time,
                         )
                         try:
+                            if termination_protected:
+                                LOGGER.info(
+                                    "Disabling TerminationProtection on stack %s before deletion",
+                                    stack_name,
+                                )
+                                cf_client.update_termination_protection(
+                                    EnableTerminationProtection=False,
+                                    StackName=stack_name,
+                                )
                             cf_client.delete_stack(StackName=stack_name)
                             LOGGER.info("%s deletion initiated", stack_name)
                             deleted_stacks += 1
@@ -404,9 +419,10 @@ def clean_cloudformation_stacks(regions, keep_hours=DEFAULT_KEEP_HOURS, dry_run=
                             LOGGER.error("Error while deleting CloudFormation stack %s: %s", stack_name, exc)
                     else:
                         LOGGER.info(
-                            "Dry run: would delete CloudFormation stack %s, creation time: %s",
+                            "Dry run: would delete CloudFormation stack %s, creation time: %s, termination_protected: %s",
                             stack_name,
                             creation_time,
+                            termination_protected,
                         )
                         deleted_stacks += 1
 

--- a/utils/copy_ami_to_all_regions.py
+++ b/utils/copy_ami_to_all_regions.py
@@ -5,7 +5,7 @@ import boto3
 import json
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-from sdcm.sct_config import SCTConfiguration
+from sdcm.sct_config import AWS_SUPPORTED_REGIONS
 
 
 @click.command()
@@ -16,7 +16,7 @@ from sdcm.sct_config import SCTConfiguration
     "--target-regions",
     required=True,
     help="Space-separated list of target regions",
-    default=" ".join(SCTConfiguration.aws_supported_regions),
+    default=" ".join(AWS_SUPPORTED_REGIONS),
 )
 @click.option("--dry-run", is_flag=True, default=False, help="Show what would be done without making changes")
 @click.option(


### PR DESCRIPTION
## Summary

- **Fix circular import** in `gce_utils.py` that crashed GCE/GKE cleanup scripts — `VmArch` import now uses `TYPE_CHECKING` guard with lazy runtime import to break the cycle (`gce_utils → provision.provisioner → provision.__init__ → provision.gce.instance_provider → gce_utils`)
- **Add boto3 connection timeouts** (`connect=10s, read=30s, max_attempts=2`) to all boto3 client/resource calls in `clean_aws.py` (7 calls) and `clean_eks.py` (4 calls) — prevents 15+ minute hangs on unreachable regions like `me-south-1`
- **Add per-region error handling** in `clean_aws.py` main loop — a single region failure (e.g. `EndpointConnectionError`) no longer aborts cleanup for all remaining regions

## Files Changed

| File | Change |
|------|--------|
| `sdcm/utils/gce_utils.py` | `TYPE_CHECKING` guard + lazy import for `VmArch` |
| `utils/cloud_cleanup/aws/clean_aws.py` | `BOTO3_TIMEOUT_CONFIG` on all 7 boto3 calls + `try/except` around region loop |
| `utils/cloud_cleanup/k8s_eks/clean_eks.py` | `BOTO3_TIMEOUT_CONFIG` on all 4 boto3 calls |

## Manual Testing Required

### What Couldn't Be Tested Automatically

- [ ] **GCE/GKE cleanup scripts**: `python -m utils.cloud_cleanup.gce.clean_gce` and `python -m utils.cloud_cleanup.k8s_gke.clean_gke` — requires GCE credentials to verify circular import is resolved
- [ ] **AWS cleanup with unreachable region**: `python -m utils.cloud_cleanup.aws.clean_aws` — requires AWS credentials; verify `me-south-1` (or similar opted-out region) is skipped gracefully instead of hanging
- [ ] **EKS cleanup timeout behavior**: `python -m utils.cloud_cleanup.k8s_eks.clean_eks` — verify unreachable regions time out in ~10s instead of 15+ minutes