### PR TITLE
defaults: Set Scylla Monitoring branch 4.14.3 scylladb-monitor-4-14-3-2026-04-13t06-26-19z

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -7,7 +7,7 @@ instance_type_loader: 'c6i.xlarge'
 instance_type_monitor: 't3.large'
 ami_id_loader: 'resolve:ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id'
 # manual on updating monitor images see: docs/monitoring-images.md
-ami_id_monitor: 'scylladb-monitor-4-14-1-2026-02-25t09-17-49z'
+ami_id_monitor: 'scylladb-monitor-4-14-3-2026-04-13t06-26-19z'
 
 availability_zone: 'a'
 root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -5,7 +5,7 @@ gce_project: '' # empty mean default one, can be overwritten to use different on
 
 gce_image_db: '' # so we can use `scylla_version` as needed
 gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64'
-gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-14-1-2026-02-25t09-17-49z'
+gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/scylladb-monitor-4-14-3-2026-04-13t06-26-19z'
 
 gce_image_username: 'scylla-test'
 


### PR DESCRIPTION

### Testing

### PR pre-checks (self review)
- [v] I added the relevant `backport` labels
- [ v] I didn't leave commented-out/debugging code

This is a patch release for Scylla Monitoring 4.14.3 no need to backport