### PR TITLE
feature(ci-cd): add trigger for perf-simple-query tests as offline installer after PGO builds

### DIFF
--- a/docs/plans/MASTER.md
+++ b/docs/plans/MASTER.md
@@ -52,6 +52,7 @@ For plan writing guidelines, see [INSTRUCTIONS.md](INSTRUCTIONS.md).
 | Jenkins Uno-Choice Billing Project | `draft` | [jenkins-uno-choice-billing-project.md](jenkins/jenkins-uno-choice-billing-project.md) |
 | Centralized Trigger Matrix | `draft` | [centralized-trigger-matrix.md](jenkins/centralized-trigger-matrix.md) |
 | i8g Performance Jobs Migration | `draft` | [i8g-performance-jobs-migration.md](i8g-performance-jobs-migration.md) |
+| Perf-Simple-Query Offline Installer Trigger | `draft` | [perf-simple-query-offline-installer-trigger.md](jenkins/perf-simple-query-offline-installer-trigger.md) |
 | curl Retry/Timeout Linting | `pending_pr` | [#13509](https://github.com/scylladb/scylla-cluster-tests/pull/13509) |
 
 ### Config — Configuration system

--- a/docs/plans/MASTER.md
+++ b/docs/plans/MASTER.md
@@ -54,6 +54,8 @@ For plan writing guidelines, see [INSTRUCTIONS.md](INSTRUCTIONS.md).
 | Jenkins Uno-Choice Billing Project | `draft` | [jenkins-uno-choice-billing-project.md](jenkins/jenkins-uno-choice-billing-project.md) |
 | Centralized Trigger Matrix | `draft` | [centralized-trigger-matrix.md](jenkins/centralized-trigger-matrix.md) |
 | i8g Performance Jobs Migration | `draft` | [i8g-performance-jobs-migration.md](i8g-performance-jobs-migration.md) |
+| Perf-Simple-Query Offline Installer Trigger | `draft` | [perf-simple-query-offline-installer-trigger.md](jenkins/perf-simple-query-offline-installer-trigger.md) |
+| curl Retry/Timeout Linting | `pending_pr` | [#13509](https://github.com/scylladb/scylla-cluster-tests/pull/13509) |
 
 ### Config — Configuration system
 

--- a/docs/plans/assets/progress-roadmap.svg
+++ b/docs/plans/assets/progress-roadmap.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="840" height="884" viewBox="0 0 840 884">
-<rect width="840" height="884" fill="#0D1B2A" rx="8"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="840" height="940" viewBox="0 0 840 940">
+<rect width="840" height="940" fill="#0D1B2A" rx="8"/>
 <text x="420" y="60" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="bold" fill="#00BCD4">SCT Implementation Plans</text>
-<text x="420" y="84" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#8899AA">28 plans across 8 domains</text>
+<text x="420" y="84" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#8899AA">30 plans across 8 domains</text>
 <rect x="30" y="120" width="780" height="50" rx="6" fill="#1B2A4A" stroke="#2A3F5F" stroke-width="1"/>
 <circle cx="50" cy="148" r="5" fill="#607D8B"/>
-<text x="60" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Draft: 18</text>
+<text x="60" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Draft: 19</text>
 <circle cx="180" cy="148" r="5" fill="#FFC107"/>
 <text x="190" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">In Progress: 3</text>
 <circle cx="310" cy="148" r="5" fill="#2196F3"/>
@@ -14,14 +14,14 @@
 <circle cx="570" cy="148" r="5" fill="#4CAF50"/>
 <text x="580" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Complete: 0</text>
 <circle cx="700" cy="148" r="5" fill="#9E9E9E"/>
-<text x="710" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Pending PR: 7</text>
+<text x="710" y="152" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#E0E6ED">Pending PR: 8</text>
 <rect x="40" y="175" width="760" height="20" rx="10" fill="#1B2A4A" stroke="#2A3F5F" stroke-width="1"/>
-<rect x="40" y="175" width="81.42857142857143" height="20" rx="10" fill="#FFC107"/>
-<text x="80.71428571428572" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">3</text>
-<rect x="121.42857142857143" y="175" width="488.5714285714286" height="20" rx="0" fill="#607D8B"/>
-<text x="365.7142857142857" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">18</text>
-<rect x="610.0" y="175" width="190.0" height="20" rx="0" fill="#9E9E9E"/>
-<text x="705.0" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">7</text>
+<rect x="40" y="175" width="76.0" height="20" rx="10" fill="#FFC107"/>
+<text x="78.0" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">3</text>
+<rect x="116.0" y="175" width="481.3333333333333" height="20" rx="0" fill="#607D8B"/>
+<text x="356.66666666666663" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">19</text>
+<rect x="597.3333333333333" y="175" width="202.66666666666666" height="20" rx="0" fill="#9E9E9E"/>
+<text x="698.6666666666666" y="189" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="bold" fill="#0D1B2A">8</text>
 <rect x="30" y="220" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
 <text x="42" y="241" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">cluster</text>
 <text x="398" y="241" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">8 plans</text>
@@ -87,7 +87,7 @@
 <text x="798" y="298" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#FFC107">In Progress</text>
 <rect x="430" y="324" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
 <text x="442" y="345" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">ci-cd</text>
-<text x="798" y="345" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">5 plans</text>
+<text x="798" y="345" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">7 plans</text>
 <circle cx="444" cy="370" r="4" fill="#607D8B"/>
 <text x="456" y="374" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Jenkins Pipeline Cluster Reuse</text>
 <text x="798" y="374" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
@@ -103,32 +103,38 @@
 <circle cx="444" cy="482" r="4" fill="#607D8B"/>
 <text x="456" y="486" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">i8g Performance Jobs Migration</text>
 <text x="798" y="486" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
-<rect x="430" y="512" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
-<text x="442" y="533" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">k8s</text>
-<text x="798" y="533" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">1 plans</text>
-<circle cx="444" cy="558" r="4" fill="#607D8B"/>
-<text x="456" y="562" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">K8s Multitenancy Dict Config</text>
-<text x="798" y="562" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
-<rect x="430" y="588" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
-<text x="442" y="609" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">framework</text>
-<text x="798" y="609" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">3 plans</text>
-<circle cx="444" cy="634" r="4" fill="#607D8B"/>
-<text x="456" y="638" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Full Version Tag Lookup</text>
-<text x="798" y="638" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
-<circle cx="444" cy="662" r="4" fill="#607D8B"/>
-<text x="456" y="666" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Health Check Optimization</text>
-<text x="798" y="666" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
-<circle cx="444" cy="690" r="4" fill="#9E9E9E"/>
-<text x="456" y="694" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Keystore Improvements</text>
-<text x="798" y="694" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
-<rect x="430" y="720" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
-<text x="442" y="741" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">testing</text>
-<text x="798" y="741" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">2 plans</text>
-<circle cx="444" cy="766" r="4" fill="#9E9E9E"/>
-<text x="456" y="770" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">MiniCloud Local Testing</text>
-<text x="798" y="770" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
-<circle cx="444" cy="794" r="4" fill="#607D8B"/>
-<text x="456" y="798" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Unit/Integration Test Separation</text>
-<text x="798" y="798" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
-<text x="420" y="849" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#8899AA">Generated from docs/plans/progress.json</text>
+<circle cx="444" cy="510" r="4" fill="#607D8B"/>
+<text x="456" y="514" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Perf-Simple-Query Offline Installer T...</text>
+<text x="798" y="514" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<circle cx="444" cy="538" r="4" fill="#9E9E9E"/>
+<text x="456" y="542" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">curl Retry/Timeout Linting</text>
+<text x="798" y="542" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
+<rect x="430" y="568" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
+<text x="442" y="589" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">k8s</text>
+<text x="798" y="589" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">1 plans</text>
+<circle cx="444" cy="614" r="4" fill="#607D8B"/>
+<text x="456" y="618" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">K8s Multitenancy Dict Config</text>
+<text x="798" y="618" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<rect x="430" y="644" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
+<text x="442" y="665" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">framework</text>
+<text x="798" y="665" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">3 plans</text>
+<circle cx="444" cy="690" r="4" fill="#607D8B"/>
+<text x="456" y="694" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Full Version Tag Lookup</text>
+<text x="798" y="694" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<circle cx="444" cy="718" r="4" fill="#607D8B"/>
+<text x="456" y="722" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Health Check Optimization</text>
+<text x="798" y="722" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<circle cx="444" cy="746" r="4" fill="#9E9E9E"/>
+<text x="456" y="750" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Keystore Improvements</text>
+<text x="798" y="750" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
+<rect x="430" y="776" width="380" height="32" rx="4" fill="#1B2A4A" stroke="#00BCD4" stroke-width="1"/>
+<text x="442" y="797" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#00BCD4">testing</text>
+<text x="798" y="797" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8899AA">2 plans</text>
+<circle cx="444" cy="822" r="4" fill="#9E9E9E"/>
+<text x="456" y="826" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">MiniCloud Local Testing</text>
+<text x="798" y="826" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#9E9E9E">Pending PR</text>
+<circle cx="444" cy="850" r="4" fill="#607D8B"/>
+<text x="456" y="854" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E0E6ED">Unit/Integration Test Separation</text>
+<text x="798" y="854" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#607D8B">Draft</text>
+<text x="420" y="905" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#8899AA">Generated from docs/plans/progress.json</text>
 </svg>

--- a/docs/plans/jenkins/perf-simple-query-offline-installer-trigger.md
+++ b/docs/plans/jenkins/perf-simple-query-offline-installer-trigger.md
@@ -1,0 +1,156 @@
+---
+status: done
+domain: ci-cd
+created: 2026-04-06
+last_updated: 2026-04-13
+owner: null
+---
+# Triggers for perf-simple-query Tests Run as Offline Installer After PGO Builds
+
+## 1. Problem Statement
+
+The perf-simple-query microbenchmark tests currently run only via the weekly cron trigger in `perfRegressionParallelPipelinebyRegion.groovy`, using pre-installed Scylla AMIs or `scylla_version` parameters. There is no trigger to run these tests using the **offline installer** (unified package) after **PGO (Profile-Guided Optimization) builds** complete.
+
+PGO builds produce optimized Scylla binaries distributed as unified (relocatable) packages. To validate that PGO-optimized builds maintain or improve performance, we need trigger pipelines that:
+
+1. Hook into the PGO build completion flow (invoked as downstream jobs after PGO builds finish).
+2. Run perf-simple-query tests against the PGO build artifacts using the offline installer mode (`unified_package` + `nonroot_offline_install`).
+3. Cover both architectures (x86_64 and aarch64) and both read/write variants via **separate per-architecture triggers**.
+4. Follow the same structure, parameters, and coding style as `perfRegressionParallelPipelinebyRegion.groovy`.
+
+This work is tracked in Jira sub-task [SCT-194](https://scylladb.atlassian.net/browse/SCT-194).
+
+## 2. Current State
+
+### Existing perf-simple-query Jobs
+
+Four Jenkins pipeline jobs exist under `jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/`:
+
+| Jenkinsfile | Architecture | Variant | Test Config |
+|---|---|---|---|
+| `scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64.jenkinsfile` | aarch64 | read | `amazon_perf_simple_query_ARM.yaml` + error thresholds |
+| `scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64-write.jenkinsfile` | aarch64 | write | `amazon_perf_simple_query_ARM.yaml` + `perf_simple_write_option.yaml` |
+| `scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64.jenkinsfile` | x86_64 | read | `amazon_perf_simple_query_ARM.yaml` + `amazon_perf_simple_query_x86.yaml` + error thresholds |
+| `scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64-write.jenkinsfile` | x86_64 | write | `amazon_perf_simple_query_ARM.yaml` + `amazon_perf_simple_query_x86.yaml` + `perf_simple_write_option.yaml` |
+
+All four use `longevityPipeline()` with:
+- `test_name: 'microbenchmarking_test.PerfSimpleQueryTest.test_perf_simple_query'`
+- `backend: 'aws'`, `region: 'eu-west-1'`, `provision_type: 'on_demand'`
+
+### Current Trigger Mechanism
+
+These jobs are triggered from `perfRegressionParallelPipelinebyRegion.groovy` (lines 174–209) as part of the `testRegionMatrix`. Each is configured with:
+- `microbenchmark: true` — skips AMI image lookup
+- `labels: ['master-weekly']` — only triggered on `master-weekly` cron schedule
+- `ignore_versions: []` — runs for all versions
+- `sub_tests: ['microbenchmark']`
+
+The trigger pipeline (`perf-regression-trigger.jenkinsfile`) calls `perfRegressionParallelPipelinebyRegion()` which iterates the matrix, filters by version/labels, and invokes `build job:` for each matching entry.
+
+### Offline Installer Support
+
+The offline installer mode is already fully supported through the pipeline stack:
+
+1. **`longevityPipeline.groovy`** (lines 78–83) — exposes `unified_package` and `nonroot_offline_install` parameters.
+2. **`runSctTest.groovy`** (lines 145–147) — exports `SCT_UNIFIED_PACKAGE` and `SCT_NONROOT_OFFLINE_INSTALL` environment variables.
+3. **`sdcm/sct_config.py`** — defines `unified_package`, `nonroot_offline_install`, and `install_mode` configuration fields.
+4. **`sdcm/cluster.py`** — handles unified package download, architecture validation, and nonroot installation.
+
+### What Is Missing
+
+- **No trigger pipelines** exist to invoke perf-simple-query jobs with a `unified_package` URL after PGO builds.
+- **No `unified_package` parameter** is passed from `perfRegressionParallelPipelinebyRegion.groovy` to downstream jobs.
+- **No PGO-specific entry point** exists — the PGO build system has no way to invoke these perf tests with the built artifact URL.
+
+## 3. Goals
+
+1. **Two architecture-specific trigger pipelines** — `vars/perfSimpleQueryOfflineInstallerTriggerX86.groovy` and `vars/perfSimpleQueryOfflineInstallerTriggerArm.groovy` — each accepting a `unified_package` URL and triggering the corresponding architecture's perf-simple-query jobs using the offline installer mode.
+2. **PGO build integration** — each trigger is invokable as a downstream job from the PGO build completion flow, accepting the unified package URL as a parameter. Separate triggers allow PGO builds to invoke only the relevant architecture.
+3. **Full architecture coverage** — the x86 trigger covers x86_64 read and write variants; the ARM trigger covers arm64 read and write variants.
+4. **Consistent style** — follows the structure, parameter naming, and coding patterns of `perfRegressionParallelPipelinebyRegion.groovy`.
+5. **Reusable Jenkinsfiles** — reuses the existing perf-simple-query `.jenkinsfile` definitions (which already support `unified_package` via `longevityPipeline()`).
+6. **New Jenkinsfile trigger entry points** for Jenkins to discover and invoke each pipeline independently.
+
+## 4. Implementation Phases
+
+### Phase 1: Create the Trigger Pipelines
+
+**Description**: Implement two shared library functions — `vars/perfSimpleQueryOfflineInstallerTriggerX86.groovy` and `vars/perfSimpleQueryOfflineInstallerTriggerArm.groovy` — each accepting a `unified_package` URL and triggering its architecture's perf-simple-query jobs with offline installer parameters.
+
+**Key design decisions**:
+- Follow the same `def call(Map pipelineParams)` signature as `perfRegressionParallelPipelinebyRegion.groovy`.
+- **Two separate triggers per architecture** instead of one combined trigger. This was chosen because PGO builds produce separate per-architecture packages, and each architecture can be triggered independently without requiring the other.
+- Each trigger defines a `testMatrix` list of job entries with `job_name` and `region` fields scoped to its architecture.
+- Accept parameters: `unified_package` (required), `nonroot_offline_install` (boolean, default true), `requested_by_user`, `billing_project`.
+- **No `scylla_version` parameter** — removed as unnecessary; the unified package URL is sufficient for tracking and the downstream jobs do not need a separate version string.
+- Use `build job:` with `wait: false` to trigger each job asynchronously, passing `unified_package` and `nonroot_offline_install` through to the downstream `longevityPipeline()`.
+- No cron triggers — these pipelines are invoked externally by PGO build jobs.
+- No AMI/image lookup needed — offline installer uses the unified package directly.
+
+**Files created**:
+- `vars/perfSimpleQueryOfflineInstallerTriggerX86.groovy` — triggers x86_64 read and write jobs
+- `vars/perfSimpleQueryOfflineInstallerTriggerArm.groovy` — triggers arm64 read and write jobs
+
+**Definition of Done**:
+- Each pipeline accepts a `unified_package` URL and triggers its two architecture-specific perf-simple-query jobs.
+- Parameters are consistent with `perfRegressionParallelPipelinebyRegion.groovy` naming.
+- Jobs receive `unified_package` and `nonroot_offline_install` parameters.
+- No cron trigger — designed for external invocation.
+
+### Phase 2: Create the Jenkinsfile Entry Points
+
+**Description**: Create two Jenkinsfiles that call their respective trigger functions, providing Jenkins-discoverable entry points.
+
+**Files created**:
+- `jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/perf-simple-query-offline-installer-trigger-x86.jenkinsfile` — calls `perfSimpleQueryOfflineInstallerTriggerX86()`
+- `jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/perf-simple-query-offline-installer-trigger-arm.jenkinsfile` — calls `perfSimpleQueryOfflineInstallerTriggerArm()`
+
+**Definition of Done**:
+- Both Jenkinsfiles exist and call their respective shared library functions.
+- Follow the same pattern as `perf-regression-trigger.jenkinsfile`.
+- Each can be registered as a Jenkins job that PGO build pipelines can invoke as a downstream build for the relevant architecture.
+
+### Phase 3: Validate End-to-End (Manual)
+
+**Description**: Validate both trigger pipelines work correctly by manually triggering them with test unified package URLs.
+
+**Definition of Done**:
+- Each pipeline can be triggered manually from Jenkins with a `unified_package` URL.
+- The x86 trigger starts the two x86_64 downstream jobs; the ARM trigger starts the two arm64 downstream jobs.
+- Downstream jobs receive the correct `unified_package` and `nonroot_offline_install` parameters.
+- Jobs use the offline installer to install Scylla from the unified package.
+
+**Dependencies**: Requires Jenkins access and valid architecture-specific unified package URLs.
+
+## 5. Testing Requirements
+
+### Automated Testing
+
+- **No unit tests needed** — this is a Groovy pipeline definition. Groovy pipeline code in this repository is not unit-tested (consistent with existing patterns).
+- **Syntax validation** — verify the Groovy files parse correctly by running pre-commit checks.
+
+### Manual Testing
+
+1. **Trigger each pipeline manually** in Jenkins with a `unified_package` URL pointing to a valid unified package for the corresponding architecture.
+2. **Verify downstream jobs are invoked** — check Jenkins build queue for the two architecture-specific perf-simple-query jobs per trigger.
+3. **Verify parameter passthrough** — confirm downstream jobs receive `unified_package` and `nonroot_offline_install` values.
+4. **Verify offline installation** — confirm at least one downstream job per architecture successfully installs Scylla from the unified package and runs the perf-simple-query test.
+5. **Verify PGO integration** — trigger from an actual PGO build completion flow and confirm the full chain works for both architectures.
+
+## 6. Success Criteria
+
+1. Two new Jenkins jobs exist (one per architecture) that can be invoked with a `unified_package` URL after PGO builds complete.
+2. The x86 trigger invokes x86_64 read and write variants; the ARM trigger invokes arm64 read and write variants.
+3. The offline installer mode is correctly configured for each downstream job.
+4. The trigger pipelines follow the same coding style and parameter conventions as `perfRegressionParallelPipelinebyRegion.groovy`.
+5. No existing pipelines or jobs are modified or broken.
+
+## 7. Risk Mitigation
+
+| Risk | Mitigation |
+|---|---|
+| PGO build system integration details unknown | The trigger pipelines are designed to be invoked generically via `build job:` with a `unified_package` URL. PGO build integration requires only adding a downstream `build` step in the PGO pipeline. No SCT-side coupling to PGO internals. |
+| Unified package URL format may vary by architecture | **Resolved**: By splitting into two separate per-architecture triggers, each PGO build invokes only the trigger matching its architecture with the correct unified package URL. No need for a single trigger to handle multiple architecture-specific URLs. |
+| Nonroot installation may fail on certain AMI bases | The offline installer automatically selects Ubuntu 24.04 base AMIs (handled in `sct_config.py` lines 2737–2758). This is well-tested for existing offline install flows. |
+| Downstream jobs may not be registered in Jenkins yet | The existing four perf-simple-query Jenkinsfiles are already registered. No new downstream jobs need to be created. |
+| Pre-commit hooks may generate auto-generated files | Follow the convention of not committing auto-generated nemesis/Jenkins pipeline files. Only the new files in `vars/` and `jenkins-pipelines/` should be committed. |

--- a/docs/plans/jenkins/perf-simple-query-offline-installer-trigger.md
+++ b/docs/plans/jenkins/perf-simple-query-offline-installer-trigger.md
@@ -3,7 +3,7 @@ status: done
 domain: ci-cd
 created: 2026-04-06
 last_updated: 2026-04-13
-owner: null
+owner: juliayakovlev
 ---
 # Triggers for perf-simple-query Tests Run as Offline Installer After PGO Builds
 

--- a/docs/plans/progress.json
+++ b/docs/plans/progress.json
@@ -225,6 +225,16 @@
       "phases_done": 0
     },
     {
+      "id": "perf-simple-query-offline-installer-trigger",
+      "title": "Perf-Simple-Query Offline Installer Trigger",
+      "file": "jenkins/perf-simple-query-offline-installer-trigger.md",
+      "domain": "ci-cd",
+      "status": "draft",
+      "created": "2026-04-06",
+      "phases_total": 3,
+      "phases_done": 0
+    },
+    {
       "id": "curl-retry-timeout-linting",
       "title": "curl Retry/Timeout Linting",
       "domain": "ci-cd",

--- a/docs/plans/progress.json
+++ b/docs/plans/progress.json
@@ -255,6 +255,25 @@
       "phases_done": 0
     },
     {
+      "id": "perf-simple-query-offline-installer-trigger",
+      "title": "Perf-Simple-Query Offline Installer Trigger",
+      "file": "jenkins/perf-simple-query-offline-installer-trigger.md",
+      "domain": "ci-cd",
+      "status": "draft",
+      "created": "2026-04-06",
+      "phases_total": 3,
+      "phases_done": 0
+    },
+    {
+      "id": "curl-retry-timeout-linting",
+      "title": "curl Retry/Timeout Linting",
+      "domain": "ci-cd",
+      "status": "pending_pr",
+      "pr": 13509,
+      "phases_total": null,
+      "phases_done": 0
+    },
+    {
       "id": "ssh-key-decoupling",
       "title": "SSH Key Decoupling",
       "domain": "cluster",

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/perf-simple-query-offline-installer-trigger-arm.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/perf-simple-query-offline-installer-trigger-arm.jenkinsfile
@@ -1,0 +1,6 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfSimpleQueryOfflineInstallerTriggerArm()

--- a/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/perf-simple-query-offline-installer-trigger-x86.jenkinsfile
+++ b/jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/perf-regression/perf-simple-query-offline-installer-trigger-x86.jenkinsfile
@@ -1,0 +1,6 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfSimpleQueryOfflineInstallerTriggerX86()

--- a/vars/perfSimpleQueryOfflineInstallerTriggerArm.groovy
+++ b/vars/perfSimpleQueryOfflineInstallerTriggerArm.groovy
@@ -1,0 +1,64 @@
+def call(Map pipelineParams) {
+    def builder = getJenkinsLabels("aws", "eu-west-1")
+    pipeline {
+        agent {
+            label {
+                   label builder.label
+            }
+        }
+        environment {
+            AWS_ACCESS_KEY_ID     = credentials('qa-aws-secret-key-id')
+            AWS_SECRET_ACCESS_KEY = credentials('qa-aws-secret-access-key')
+            SCT_BILLING_PROJECT = "${params.billing_project}"
+        }
+
+        parameters {
+            string(name: 'unified_package', defaultValue: '', description: 'URL to the unified package of scylla version to install scylla (e.g. from PGO build)')
+            booleanParam(name: 'nonroot_offline_install', defaultValue: false, description: 'Install Scylla without required root privilege')
+            string(defaultValue: '',
+                   description: 'Actual user requesting job start, for automated job builds (e.g. through Argus)',
+                   name: 'requested_by_user')
+            choice(choices: getBillingProjectChoices(),
+                   description: 'Billing project for the test run (dynamically fetched from finops repository)',
+                   name: 'billing_project')
+        }
+
+        stages {
+            stage('Trigger perf-simple-query ARM Jobs') {
+                steps {
+                    script {
+                        def unified_package = params.unified_package?.trim()
+                        if (!unified_package) {
+                            error "unified_package parameter is required. Provide a URL to the unified (relocatable) Scylla package."
+                        }
+
+                        def testMatrix = [
+                            [
+                                job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64',
+                                region: 'us-east-1',
+                            ],
+                            [
+                                job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64-write',
+                                region: 'us-east-1',
+                            ],
+                        ]
+                        println("testMatrix: $testMatrix")
+                        for (def entry in testMatrix) {
+                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                                println("Building job: ${entry.job_name} with unified_package: ${unified_package}, nonroot_offline_install: ${params.nonroot_offline_install}")
+                                build job: entry.job_name, wait: false, parameters: [
+                                    string(name: 'unified_package', value: unified_package),
+                                    booleanParam(name: 'nonroot_offline_install', value: params.nonroot_offline_install),
+                                    string(name: 'provision_type', value: 'on_demand'),
+                                    string(name: 'region', value: entry.region),
+                                    string(name: 'requested_by_user', value: params.requested_by_user),
+                                    string(name: 'billing_project', value: params.billing_project),
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vars/perfSimpleQueryOfflineInstallerTriggerArm.groovy
+++ b/vars/perfSimpleQueryOfflineInstallerTriggerArm.groovy
@@ -1,0 +1,64 @@
+def call(Map pipelineParams) {
+    def builder = getJenkinsLabels("aws", "eu-west-1")
+    pipeline {
+        agent {
+            label {
+                   label builder.label
+            }
+        }
+        environment {
+            AWS_ACCESS_KEY_ID     = credentials('qa-aws-secret-key-id')
+            AWS_SECRET_ACCESS_KEY = credentials('qa-aws-secret-access-key')
+            SCT_BILLING_PROJECT = "${params.billing_project}"
+        }
+
+        parameters {
+            string(name: 'unified_package', defaultValue: '', description: 'URL to the unified package of scylla version to install scylla (e.g. from PGO build)')
+            booleanParam(name: 'nonroot_offline_install', defaultValue: true, description: 'Install Scylla without required root privilege')
+            string(defaultValue: '',
+                   description: 'Actual user requesting job start, for automated job builds (e.g. through Argus)',
+                   name: 'requested_by_user')
+            choice(choices: getBillingProjectChoices(),
+                   description: 'Billing project for the test run (dynamically fetched from finops repository)',
+                   name: 'billing_project')
+        }
+
+        stages {
+            stage('Trigger perf-simple-query ARM Jobs') {
+                steps {
+                    script {
+                        def unified_package = params.unified_package?.trim()
+                        if (!unified_package) {
+                            error "unified_package parameter is required. Provide a URL to the unified (relocatable) Scylla package."
+                        }
+
+                        def testMatrix = [
+                            [
+                                job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64',
+                                region: 'us-east-1',
+                            ],
+                            [
+                                job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_arm64-write',
+                                region: 'us-east-1',
+                            ],
+                        ]
+                        println("testMatrix: $testMatrix")
+                        for (def entry in testMatrix) {
+                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                                println("Building job: ${entry.job_name} with unified_package: ${unified_package}, nonroot_offline_install: ${params.nonroot_offline_install}")
+                                build job: entry.job_name, wait: false, parameters: [
+                                    string(name: 'unified_package', value: unified_package),
+                                    booleanParam(name: 'nonroot_offline_install', value: params.nonroot_offline_install),
+                                    string(name: 'provision_type', value: 'on_demand'),
+                                    string(name: 'region', value: entry.region),
+                                    string(name: 'requested_by_user', value: params.requested_by_user),
+                                    string(name: 'billing_project', value: params.billing_project),
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vars/perfSimpleQueryOfflineInstallerTriggerX86.groovy
+++ b/vars/perfSimpleQueryOfflineInstallerTriggerX86.groovy
@@ -1,0 +1,64 @@
+def call(Map pipelineParams) {
+    def builder = getJenkinsLabels("aws", "eu-west-1")
+    pipeline {
+        agent {
+            label {
+                   label builder.label
+            }
+        }
+        environment {
+            AWS_ACCESS_KEY_ID     = credentials('qa-aws-secret-key-id')
+            AWS_SECRET_ACCESS_KEY = credentials('qa-aws-secret-access-key')
+            SCT_BILLING_PROJECT = "${params.billing_project}"
+        }
+
+        parameters {
+            string(name: 'unified_package', defaultValue: '', description: 'URL to the unified package of scylla version to install scylla (e.g. from PGO build)')
+            booleanParam(name: 'nonroot_offline_install', defaultValue: true, description: 'Install Scylla without required root privilege')
+            string(defaultValue: '',
+                   description: 'Actual user requesting job start, for automated job builds (e.g. through Argus)',
+                   name: 'requested_by_user')
+            choice(choices: getBillingProjectChoices(),
+                   description: 'Billing project for the test run (dynamically fetched from finops repository)',
+                   name: 'billing_project')
+        }
+
+        stages {
+            stage('Trigger perf-simple-query x86 Jobs') {
+                steps {
+                    script {
+                        def unified_package = params.unified_package?.trim()
+                        if (!unified_package) {
+                            error "unified_package parameter is required. Provide a URL to the unified (relocatable) Scylla package."
+                        }
+
+                        def testMatrix = [
+                            [
+                                job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64',
+                                region: 'us-east-1',
+                            ],
+                            [
+                                job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64-write',
+                                region: 'us-east-1',
+                            ],
+                        ]
+                        println("testMatrix: $testMatrix")
+                        for (def entry in testMatrix) {
+                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                                println("Building job: ${entry.job_name} with unified_package: ${unified_package}, nonroot_offline_install: ${params.nonroot_offline_install}")
+                                build job: entry.job_name, wait: false, parameters: [
+                                    string(name: 'unified_package', value: unified_package),
+                                    booleanParam(name: 'nonroot_offline_install', value: params.nonroot_offline_install),
+                                    string(name: 'provision_type', value: 'on_demand'),
+                                    string(name: 'region', value: entry.region),
+                                    string(name: 'requested_by_user', value: params.requested_by_user),
+                                    string(name: 'billing_project', value: params.billing_project),
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vars/perfSimpleQueryOfflineInstallerTriggerX86.groovy
+++ b/vars/perfSimpleQueryOfflineInstallerTriggerX86.groovy
@@ -1,0 +1,64 @@
+def call(Map pipelineParams) {
+    def builder = getJenkinsLabels("aws", "eu-west-1")
+    pipeline {
+        agent {
+            label {
+                   label builder.label
+            }
+        }
+        environment {
+            AWS_ACCESS_KEY_ID     = credentials('qa-aws-secret-key-id')
+            AWS_SECRET_ACCESS_KEY = credentials('qa-aws-secret-access-key')
+            SCT_BILLING_PROJECT = "${params.billing_project}"
+        }
+
+        parameters {
+            string(name: 'unified_package', defaultValue: '', description: 'URL to the unified package of scylla version to install scylla (e.g. from PGO build)')
+            booleanParam(name: 'nonroot_offline_install', defaultValue: false, description: 'Install Scylla without required root privilege')
+            string(defaultValue: '',
+                   description: 'Actual user requesting job start, for automated job builds (e.g. through Argus)',
+                   name: 'requested_by_user')
+            choice(choices: getBillingProjectChoices(),
+                   description: 'Billing project for the test run (dynamically fetched from finops repository)',
+                   name: 'billing_project')
+        }
+
+        stages {
+            stage('Trigger perf-simple-query x86 Jobs') {
+                steps {
+                    script {
+                        def unified_package = params.unified_package?.trim()
+                        if (!unified_package) {
+                            error "unified_package parameter is required. Provide a URL to the unified (relocatable) Scylla package."
+                        }
+
+                        def testMatrix = [
+                            [
+                                job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64',
+                                region: 'us-east-1',
+                            ],
+                            [
+                                job_name: 'scylla-enterprise/perf-regression/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64-write',
+                                region: 'us-east-1',
+                            ],
+                        ]
+                        println("testMatrix: $testMatrix")
+                        for (def entry in testMatrix) {
+                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                                println("Building job: ${entry.job_name} with unified_package: ${unified_package}, nonroot_offline_install: ${params.nonroot_offline_install}")
+                                build job: entry.job_name, wait: false, parameters: [
+                                    string(name: 'unified_package', value: unified_package),
+                                    booleanParam(name: 'nonroot_offline_install', value: params.nonroot_offline_install),
+                                    string(name: 'provision_type', value: 'on_demand'),
+                                    string(name: 'region', value: entry.region),
+                                    string(name: 'requested_by_user', value: params.requested_by_user),
+                                    string(name: 'billing_project', value: params.billing_project),
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add vars/perfSimpleQueryOfflineInstallerTriggerArm.groovy and vars/perfSimpleQueryOfflineInstallerTriggerX86.groovy shared library
function that accepts a unified_package URL and triggers all four
perf-simple-query microbenchmark variants (arm64/x86_64 read/write)
using the offline installer mode. Follows the same structure and
coding style as perfRegressionParallelPipelinebyRegion.groovy.

Also add the Jenkinsfile entry point for Jenkins job discovery at
jenkins-pipelines/performance/branch-perf-v17/scylla-enterprise/
perf-regression/perf-simple-query-offline-installer-trigger.jenkinsfile.

Tracked in Jira sub-task SCT-194.

Agent-Logs-Url: https://github.com/scylladb/scylla-cluster-tests/sessions/665cc8b1-5080-434f-9d5a-7269c742b4ee

Co-authored-by: juliayakovlev <34435448+juliayakovlev@users.noreply.github.com>

Task: https://scylladb.atlassian.net/browse/SCT-194

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [perf-simple-query-offline-installer-trigger-x86](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/yulia/job/perf-simple-query-offline-installer-trigger-x86/2/)

Staging job trigger (https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/performance/job/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64/71/):
```
16:39:17  Building job: scylla-staging/yulia/performance/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64 with unified_package: https://downloads.scylladb.com/unstable/scylla/master/relocatable/2026-04-23T17:57:18Z/scylla-unified-2026.2.0~dev-0.20260423.878f34133811.aarch64.tar.gz, nonroot_offline_install: false
16:39:17  [Pipeline] build (Scheduling scylla-staging » yulia » Performance » scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64)
16:39:17  Scheduling project: [scylla-staging » yulia » Performance » scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64](https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/performance/job/scylla-enterprise-perf-simple-query-weekly-microbenchmark_x86_64/)
```

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
