### PR TITLE
fix(events): add missing yield to ignore_aborted_snapshot_upload_storage_io_errors

### DIFF
--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -144,8 +144,8 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
                 method=self.backup_method,
             )
             backup_task_current_details = get_task_run_details(backup_task)
-            # backup_task_snapshot = backup_task.get_snapshot_tag()
-            # pre_upgrade_backup_task_files = mgr_cluster.get_backup_files_dict(backup_task_snapshot)
+            backup_task_snapshot = backup_task.get_snapshot_tag()
+            pre_upgrade_backup_task_files = mgr_cluster.get_backup_files_dict(backup_task_snapshot)
 
         with self.subTest("Creating a simple backup with the intention of purging it"):
             self._create_simple_table(table_name="cf1")
@@ -223,16 +223,16 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
             )
             self.run_verification_read_stress()
 
-        # with self.subTest(
-        #     "Executing the 'backup list' and 'backup files' commands on a older version backup"
-        #     " with newer version of Manager"
-        # ):
-        #     current_backup_files = mgr_cluster.get_backup_files_dict(backup_task_snapshot)
-        #     assert pre_upgrade_backup_task_files == current_backup_files, (
-        #         f"Backup task of the task {backup_task.id} is not identical after the Manager upgrade:"
-        #         f"\nbefore the upgrade:\n{pre_upgrade_backup_task_files}\nafter the upgrade:\n{current_backup_files}"
-        #     )
-        #     mgr_cluster.sctool.run(cmd=f"backup list -c {mgr_cluster.id}", is_verify_errorless_result=True)
+        with self.subTest(
+            "Executing the 'backup list' and 'backup files' commands on a older version backup"
+            " with newer version of Manager"
+        ):
+            current_backup_files = mgr_cluster.get_backup_files_dict(backup_task_snapshot)
+            assert pre_upgrade_backup_task_files == current_backup_files, (
+                f"Backup task of the task {backup_task.id} is not identical after the Manager upgrade:"
+                f"\nbefore the upgrade:\n{pre_upgrade_backup_task_files}\nafter the upgrade:\n{current_backup_files}"
+            )
+            mgr_cluster.sctool.run(cmd=f"backup list -c {mgr_cluster.id}", is_verify_errorless_result=True)
 
         with self.subTest("Purging a older version backup"):
             table_ks_name = "ks1"
@@ -250,11 +250,11 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
                     f"Backup {rerunning_backup_task.id} that was rerun again from the start has failed to reach "
                     f"status DONE within expected time limit"
                 )
-            # per_node_backup_file_paths = mgr_cluster.get_backup_files_dict(
-            #     snapshot_tag=rerunning_backup_task.get_snapshot_tag()
-            # )
-            # for node in self.db_cluster.nodes:
-            #     node_id = node.host_id
-            #     assert table_to_delete not in per_node_backup_file_paths[node_id][table_ks_name], (
-            #         "The missing table is still in s3, even though it should have been purged"
-            #     )
+            per_node_backup_file_paths = mgr_cluster.get_backup_files_dict(
+                snapshot_tag=rerunning_backup_task.get_snapshot_tag()
+            )
+            for node in self.db_cluster.nodes:
+                node_id = node.host_id
+                assert table_to_delete not in per_node_backup_file_paths[node_id][table_ks_name], (
+                    "The missing table is still in s3, even though it should have been purged"
+                )

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -144,8 +144,8 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
                 method=self.backup_method,
             )
             backup_task_current_details = get_task_run_details(backup_task)
-            backup_task_snapshot = backup_task.get_snapshot_tag()
-            pre_upgrade_backup_task_files = mgr_cluster.get_backup_files_dict(backup_task_snapshot)
+            # backup_task_snapshot = backup_task.get_snapshot_tag()
+            # pre_upgrade_backup_task_files = mgr_cluster.get_backup_files_dict(backup_task_snapshot)
 
         with self.subTest("Creating a simple backup with the intention of purging it"):
             self._create_simple_table(table_name="cf1")
@@ -223,16 +223,16 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
             )
             self.run_verification_read_stress()
 
-        with self.subTest(
-            "Executing the 'backup list' and 'backup files' commands on a older version backup"
-            " with newer version of Manager"
-        ):
-            current_backup_files = mgr_cluster.get_backup_files_dict(backup_task_snapshot)
-            assert pre_upgrade_backup_task_files == current_backup_files, (
-                f"Backup task of the task {backup_task.id} is not identical after the Manager upgrade:"
-                f"\nbefore the upgrade:\n{pre_upgrade_backup_task_files}\nafter the upgrade:\n{current_backup_files}"
-            )
-            mgr_cluster.sctool.run(cmd=f"backup list -c {mgr_cluster.id}", is_verify_errorless_result=True)
+        # with self.subTest(
+        #     "Executing the 'backup list' and 'backup files' commands on a older version backup"
+        #     " with newer version of Manager"
+        # ):
+        #     current_backup_files = mgr_cluster.get_backup_files_dict(backup_task_snapshot)
+        #     assert pre_upgrade_backup_task_files == current_backup_files, (
+        #         f"Backup task of the task {backup_task.id} is not identical after the Manager upgrade:"
+        #         f"\nbefore the upgrade:\n{pre_upgrade_backup_task_files}\nafter the upgrade:\n{current_backup_files}"
+        #     )
+        #     mgr_cluster.sctool.run(cmd=f"backup list -c {mgr_cluster.id}", is_verify_errorless_result=True)
 
         with self.subTest("Purging a older version backup"):
             table_ks_name = "ks1"
@@ -250,11 +250,11 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
                     f"Backup {rerunning_backup_task.id} that was rerun again from the start has failed to reach "
                     f"status DONE within expected time limit"
                 )
-            per_node_backup_file_paths = mgr_cluster.get_backup_files_dict(
-                snapshot_tag=rerunning_backup_task.get_snapshot_tag()
-            )
-            for node in self.db_cluster.nodes:
-                node_id = node.host_id
-                assert table_to_delete not in per_node_backup_file_paths[node_id][table_ks_name], (
-                    "The missing table is still in s3, even though it should have been purged"
-                )
+            # per_node_backup_file_paths = mgr_cluster.get_backup_files_dict(
+            #     snapshot_tag=rerunning_backup_task.get_snapshot_tag()
+            # )
+            # for node in self.db_cluster.nodes:
+            #     node_id = node.host_id
+            #     assert table_to_delete not in per_node_backup_file_paths[node_id][table_ks_name], (
+            #         "The missing table is still in s3, even though it should have been purged"
+            #     )

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -626,6 +626,7 @@ def ignore_aborted_snapshot_upload_storage_io_errors():
                     regex=r".*storage_io_error \(S3 error \(seastar::abort_requested_exception \(abort requested\)\)\)",
                 )
             )
+        yield
 
 
 def decorate_with_context(context_list: list[Callable | ContextManager] | Callable | ContextManager):


### PR DESCRIPTION
Relates to https://github.com/scylladb/scylla-cluster-tests/pull/14341

## Summary

- `ignore_aborted_snapshot_upload_storage_io_errors` is decorated with `@contextmanager` but was missing a `yield` statement
- Without `yield`, the generator never produces a value; `contextlib._GeneratorContextManager.__enter__` calls `next()` on `None` and raises `TypeError: 'NoneType' object is not an iterator`
- Added `yield` inside the `ExitStack` block so registered severity filters stay active for the caller's `with`-block body and are cleaned up on exit

## Root Cause

```python
@contextmanager
def ignore_aborted_snapshot_upload_storage_io_errors():
    with ExitStack() as stack:
        if SkipPerIssues(...):
            stack.enter_context(...)
            stack.enter_context(...)
        # <-- missing yield here caused the crash
```

## Reproduction

Seen in `mgmt_upgrade_test.py` `test_upgrade` when `manager_backup_restore_method == "native"`:

```
TypeError: 'NoneType' object is not an iterator
/usr/local/lib/python3.14/contextlib.py:141: TypeError
```

## Testing

- [x] [ubuntu24-upgrade-test](https://jenkins.scylladb.com/job/manager-3.10/job/ubuntu24-upgrade-test/4/)