### PR TITLE
Fix docker provision test teardown

### DIFF
--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -799,9 +799,4 @@ class MonitorSetDocker(cluster.BaseMonitorSet, DockerCluster):
                 self.log.error("Stopping scylla monitoring succeeded")
             except Exception as exc:  # noqa: BLE001
                 self.log.error(f"Stopping scylla monitoring failed with {str(exc)}")
-            try:
-                node.remoter.sudo(f"rm -rf '{self.monitor_install_path_base}'")
-                self.log.error("Cleaning up scylla monitoring succeeded")
-            except Exception as exc:  # noqa: BLE001
-                self.log.error(f"Cleaning up scylla monitoring failed with {str(exc)}")
             node.destroy()

--- a/sdcm/prometheus.py
+++ b/sdcm/prometheus.py
@@ -39,6 +39,8 @@ NM_OBJ = {}
 class _ThreadingSimpleServer(ThreadingMixIn, HTTPServer):
     """Thread per request HTTP server."""
 
+    daemon_threads = True
+
 
 def start_http_server(port, addr="", registry=prometheus_client.REGISTRY):
     """Starts an HTTP server for prometheus metrics as a daemon thread"""

--- a/sdcm/sct_events/grafana.py
+++ b/sdcm/sct_events/grafana.py
@@ -132,7 +132,7 @@ class GrafanaEventPostman(BaseEventsProcess[Annotation, None], threading.Thread)
                     grafana_post_url,
                     annotation,
                 ):
-                    requests.post(grafana_post_url, json=annotation, auth=self.api_auth).raise_for_status()
+                    requests.post(grafana_post_url, json=annotation, auth=self.api_auth, timeout=30).raise_for_status()
 
     def set_grafana_url(self, grafana_base_url: str) -> None:
         if not grafana_base_url:


### PR DESCRIPTION
The change addresses 2 problems during docker backend provision tests:
- Docker provision tests hang sometimes on test teardown. This is likely due to threads spawned at `socketserver.ThreadingMixIn.process_request` are not daemon threads.
As a result they can block SCT test tear down, if such a Prometheus request arrives during the teardown sequence. 
Making the _ThreadingSimpleServer class of requests daemon by default should prevent the problem.
- The `sdcm.cluster_docker.MonitorSetDocker.destroy` sequence is performing unnecessary `rm -rf` of monitoring data inside monitoring node container.
At some point the explicit `node.destroy` statement was added to `sdcm.cluster_docker.MonitorSetDocker.destroy` sequence. So there is no need to keep performing `rm- rf`
of monitoring data (which can take minutes on docker overlay2, for large amount of monitoring data files) when the whole container is being teared down anyway (which
takes seconds).

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [few runs](https://jenkins.scylladb.com/job/sct-github-PRs-scan/job/scylla-cluster-tests/job/PR-14342/) in a row of docker based provision tests
- [x] :green_circle: [artifacts-docker-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/artifacts/job/artifacts-docker-test/29/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
