### PR TITLE
chore(claude): add non-interactive flag rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,3 +24,6 @@ Available skills (invoke via Skill tool or `/skill-name`):
 - `commit-summary` — Generate weekly commit summary reports
 - `writing-nemesis` — Create new chaos engineering disruptions
 - `code-review` — Review PRs for correctness and convention compliance
+
+## Rules
+- Always use non-interactive flags when available: --yes, -y, --non-interactive, --no-input. Never use commands with --watch, --interactive, or prompts that wait for input.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,12 +5,14 @@ Project instructions for Claude Code. This file is loaded at session start.
 ## Rules
 - Do NOT @import skill files — they are loaded on demand when triggered by their frontmatter `description`. Eagerly importing all skills wastes ~20K tokens per turn.
 - Always use non-interactive flags when available: --yes, -y, --non-interactive, --no-input. Never use commands with --watch, --interactive, or prompts that wait for input.
+- Read the target section of a file before editing. Plan the complete edit before applying — do not make speculative changes you may need to revert.
+- After 2 consecutive tool failures, stop and reassess your approach before retrying. Diagnose the root cause instead of repeating the same failing command.
 
 ## Repository
 
 Scylla Cluster Tests (SCT) — test framework for ScyllaDB. See below for full repository overview, architecture, and conventions.
 
-@AGENTS.md
+For development setup, architecture, code style, and testing guidelines see [AGENTS.md](AGENTS.md).
 
 ## Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 Project instructions for Claude Code. This file is loaded at session start.
 
+## Rules
+- Do NOT @import skill files — they are loaded on demand when triggered by their frontmatter `description`. Eagerly importing all skills wastes ~20K tokens per turn.
+- Always use non-interactive flags when available: --yes, -y, --non-interactive, --no-input. Never use commands with --watch, --interactive, or prompts that wait for input.
+
 ## Repository
 
 Scylla Cluster Tests (SCT) — test framework for ScyllaDB. See below for full repository overview, architecture, and conventions.
@@ -11,8 +15,6 @@ Scylla Cluster Tests (SCT) — test framework for ScyllaDB. See below for full r
 ## Skills
 
 Skills are auto-discovered via the `.claude/skills` symlink pointing to `skills/`.
-Do NOT @import skill files here — they are loaded on demand when triggered by their
-frontmatter `description`. Eagerly importing all skills wastes ~20K tokens per turn.
 
 Available skills (invoke via Skill tool or `/skill-name`):
 - `designing-skills` — Create and structure AI agent skills
@@ -24,6 +26,3 @@ Available skills (invoke via Skill tool or `/skill-name`):
 - `commit-summary` — Generate weekly commit summary reports
 - `writing-nemesis` — Create new chaos engineering disruptions
 - `code-review` — Review PRs for correctness and convention compliance
-
-## Rules
-- Always use non-interactive flags when available: --yes, -y, --non-interactive, --no-input. Never use commands with --watch, --interactive, or prompts that wait for input.


### PR DESCRIPTION
## Summary

Applies all actionable recommendations from `prism analyze` / `prism advise` across 50+ SCT sessions (main project + 7 worktree projects).

### Changes

| Prism finding | Severity | Fix |
|---|---|---|
| 42 interactive commands across 10 sessions (Tool Health: **F**) | High | Added non-interactive flags rule (`--yes`, `-y`, `--no-input`) |
| Critical rules in attention dead zone (lines 5-19 of 26) | Medium | Moved `## Rules` section to top of file (first 20%) |
| CLAUDE.md re-reads consume >100% of session tokens | High | Replaced `@AGENTS.md` inline import with markdown link |
| Edit-revert cycles in 5 worktree sessions | Medium | Added "read before editing, plan complete edit" rule |
| 4-5 consecutive tool failures in 2 worktree sessions | Medium | Added "stop after 2 failures, reassess" circuit-breaker rule |

### Before/After
- `@AGENTS.md` (309 lines inlined every turn) → `[AGENTS.md](AGENTS.md)` (read on demand)
- Rules buried in middle of file → Rules at top where LLM attention is highest
- No guardrails for interactive commands, edit-revert loops, or failure cascades → Explicit rules for all three

## Test plan
- [x] `prism advise` identified ADD and RESTRUCTURE as high/medium impact
- [x] `prism analyze --json` confirmed Tool Health F-grade and >100% token re-read
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Monitor prism scores in subsequent sessions for improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)