### PR TITLE
fix(vector-logging): fix race between service start and config write

### DIFF
--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -125,7 +125,7 @@ sinks:
         healthcheck: false
 EOF
 
-        systemctl try-reload-or-restart vector.service
+        systemctl restart vector || echo "WARNING: vector.service restart failed, will be reconfigured later by configure_remote_logging"
     """).format(host=host, port=port)
 
 
@@ -296,7 +296,6 @@ def install_vector_service():
         fi
 
         systemctl enable vector
-        systemctl start vector
     """)
 
 


### PR DESCRIPTION
Current installation sequence for vector logging service is:
- install_vector_service() starts the vector logging service with the default package config
- then configure_vector_target_script() overwrites the config and reloads the service

The service sometimes crashes before the reload command is executed (causing "No main process to kill" error), which creates a `.failed` cloud-init marker and results in permanent CloudInitError (20 retries fail as the `.failed` is a persistent file).

The fix aligns vector logging service installation sequence with the syslog-ng pattern:
- install_vector_service() only installs and enables the service, i.e. no start
- configure_vector_target_script() writes config then starts the service This way vector is started only with the correct config, eliminating the race.

Fixes: SCT-202

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] :green_circle: [artifacts-azure-image-test - main check](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/artifacts/job/artifacts-azure-image-test/25/)
- [x] :green_circle: [artifacts-gce-image-test](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/artifacts/job/artifacts-gce-image-new/20/)
- [x] :green_circle: [artifacts-oci-image-test](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/artifacts/job/artifacts-oci-image-test/2/)
- [x] :green_circle: [artifacts-ami-test](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/artifacts/job/artifacts-ami-test/9/)
- [x] :green_circle: [pr-provision-test on azure](https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/pr-provision-test/258/)

### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
