### PR TITLE
fix(manager): bump default Manager version to 3.10 across framework

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -11,7 +11,7 @@ ip_ssh_connections: 'private'
 scylla_repo: ''
 unified_package: ''
 
-manager_version: '3.9'
+manager_version: '3.10'
 manager_scylla_backend_version: '2025.4'
 # Notice: that centos (default monitor), ubuntu 22, ubuntu 20 and debian 11 monitors use 2024, while debian 10 ubuntu 18 use 2023, since we support both
 
@@ -172,8 +172,8 @@ jepsen_test_count: 1
 jepsen_test_run_policy: all
 
 max_events_severities: ""
-scylla_mgmt_agent_version: '3.9.0'
-mgmt_docker_image: 'scylladb/scylla-manager:3.9.0'
+scylla_mgmt_agent_version: '3.10.0'
+mgmt_docker_image: 'scylladb/scylla-manager:3.10.0'
 k8s_log_api_calls: false
 k8s_deploy_monitoring: false
 k8s_minio_storage_size: '10Gi'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -384,7 +384,7 @@ Url to the repo of scylla manager agent version to install for management tests
 
 Version of Scylla Manager server and agent to install
 
-**default:** 3.9
+**default:** 3.10
 
 **type:** str
 
@@ -411,7 +411,7 @@ Version of ScyllaDB to install as Manager backend
 
 Version of Scylla Manager agent to install for management tests
 
-**default:** 3.9.0
+**default:** 3.10.0
 
 **type:** str
 
@@ -2654,7 +2654,7 @@ Number of nodes in the monitoring pool that will be used for scylla-operator's d
 
 Scylla manager docker image, i.e. 'scylladb/scylla-manager:2.2.1'
 
-**default:** scylladb/scylla-manager:3.9.0
+**default:** scylladb/scylla-manager:3.10.0
 
 **type:** str
 * appendable

--- a/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
@@ -10,7 +10,7 @@ managerPipeline(
     scylla_version: '2025.3',
 
     // Upgrade from the previous minor release (the last one)
-    manager_version: '3.8',
+    manager_version: '3.9',
     target_manager_version: 'master_latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',

--- a/jenkins-pipelines/manager/ubuntu24-manager-older-enterprise-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-older-enterprise-upgrade.jenkinsfile
@@ -11,7 +11,7 @@ managerPipeline(
 
     // Upgrade from some old Manager release which is still used in production
     // Use Metabase to check it (https://scylladb.metabaseapp.com/question/1685-manager-version)
-    manager_version: '3.6',
+    manager_version: '3.7',
     target_manager_version: 'master_latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',

--- a/jenkins-pipelines/manager/ubuntu24-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu24-manager-upgrade.jenkinsfile
@@ -8,7 +8,7 @@ managerPipeline(
     region: 'us-east-1',
 
     // Upgrade from the latest patch release
-    manager_version: '3.8',
+    manager_version: '3.10',
     target_manager_version: 'master_latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -144,8 +144,8 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
                 method=self.backup_method,
             )
             backup_task_current_details = get_task_run_details(backup_task)
-            # backup_task_snapshot = backup_task.get_snapshot_tag()
-            # pre_upgrade_backup_task_files = mgr_cluster.get_backup_files_dict(backup_task_snapshot)
+            backup_task_snapshot = backup_task.get_snapshot_tag()
+            pre_upgrade_backup_task_files = mgr_cluster.get_backup_files_dict(backup_task_snapshot)
 
         with self.subTest("Creating a simple backup with the intention of purging it"):
             self._create_simple_table(table_name="cf1")
@@ -223,16 +223,16 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
             )
             self.run_verification_read_stress()
 
-        # with self.subTest(
-        #     "Executing the 'backup list' and 'backup files' commands on a older version backup"
-        #     " with newer version of Manager"
-        # ):
-        #     current_backup_files = mgr_cluster.get_backup_files_dict(backup_task_snapshot)
-        #     assert pre_upgrade_backup_task_files == current_backup_files, (
-        #         f"Backup task of the task {backup_task.id} is not identical after the Manager upgrade:"
-        #         f"\nbefore the upgrade:\n{pre_upgrade_backup_task_files}\nafter the upgrade:\n{current_backup_files}"
-        #     )
-        #     mgr_cluster.sctool.run(cmd=f"backup list -c {mgr_cluster.id}", is_verify_errorless_result=True)
+        with self.subTest(
+            "Executing the 'backup list' and 'backup files' commands on a older version backup"
+            " with newer version of Manager"
+        ):
+            current_backup_files = mgr_cluster.get_backup_files_dict(backup_task_snapshot)
+            assert pre_upgrade_backup_task_files == current_backup_files, (
+                f"Backup task of the task {backup_task.id} is not identical after the Manager upgrade:"
+                f"\nbefore the upgrade:\n{pre_upgrade_backup_task_files}\nafter the upgrade:\n{current_backup_files}"
+            )
+            mgr_cluster.sctool.run(cmd=f"backup list -c {mgr_cluster.id}", is_verify_errorless_result=True)
 
         with self.subTest("Purging a older version backup"):
             table_ks_name = "ks1"
@@ -250,11 +250,11 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
                     f"Backup {rerunning_backup_task.id} that was rerun again from the start has failed to reach "
                     f"status DONE within expected time limit"
                 )
-            # per_node_backup_file_paths = mgr_cluster.get_backup_files_dict(
-            #     snapshot_tag=rerunning_backup_task.get_snapshot_tag()
-            # )
-            # for node in self.db_cluster.nodes:
-            #     node_id = node.host_id
-            #     assert table_to_delete not in per_node_backup_file_paths[node_id][table_ks_name], (
-            #         "The missing table is still in s3, even though it should have been purged"
-            #     )
+            per_node_backup_file_paths = mgr_cluster.get_backup_files_dict(
+                snapshot_tag=rerunning_backup_task.get_snapshot_tag()
+            )
+            for node in self.db_cluster.nodes:
+                node_id = node.host_id
+                assert table_to_delete not in per_node_backup_file_paths[node_id][table_ks_name], (
+                    "The missing table is still in s3, even though it should have been purged"
+                )

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -144,8 +144,8 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
                 method=self.backup_method,
             )
             backup_task_current_details = get_task_run_details(backup_task)
-            backup_task_snapshot = backup_task.get_snapshot_tag()
-            pre_upgrade_backup_task_files = mgr_cluster.get_backup_files_dict(backup_task_snapshot)
+            # backup_task_snapshot = backup_task.get_snapshot_tag()
+            # pre_upgrade_backup_task_files = mgr_cluster.get_backup_files_dict(backup_task_snapshot)
 
         with self.subTest("Creating a simple backup with the intention of purging it"):
             self._create_simple_table(table_name="cf1")
@@ -223,16 +223,16 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
             )
             self.run_verification_read_stress()
 
-        with self.subTest(
-            "Executing the 'backup list' and 'backup files' commands on a older version backup"
-            " with newer version of Manager"
-        ):
-            current_backup_files = mgr_cluster.get_backup_files_dict(backup_task_snapshot)
-            assert pre_upgrade_backup_task_files == current_backup_files, (
-                f"Backup task of the task {backup_task.id} is not identical after the Manager upgrade:"
-                f"\nbefore the upgrade:\n{pre_upgrade_backup_task_files}\nafter the upgrade:\n{current_backup_files}"
-            )
-            mgr_cluster.sctool.run(cmd=f"backup list -c {mgr_cluster.id}", is_verify_errorless_result=True)
+        # with self.subTest(
+        #     "Executing the 'backup list' and 'backup files' commands on a older version backup"
+        #     " with newer version of Manager"
+        # ):
+        #     current_backup_files = mgr_cluster.get_backup_files_dict(backup_task_snapshot)
+        #     assert pre_upgrade_backup_task_files == current_backup_files, (
+        #         f"Backup task of the task {backup_task.id} is not identical after the Manager upgrade:"
+        #         f"\nbefore the upgrade:\n{pre_upgrade_backup_task_files}\nafter the upgrade:\n{current_backup_files}"
+        #     )
+        #     mgr_cluster.sctool.run(cmd=f"backup list -c {mgr_cluster.id}", is_verify_errorless_result=True)
 
         with self.subTest("Purging a older version backup"):
             table_ks_name = "ks1"
@@ -250,11 +250,11 @@ class ManagerUpgradeTest(ManagerTestFunctionsMixIn, ClusterTester):
                     f"Backup {rerunning_backup_task.id} that was rerun again from the start has failed to reach "
                     f"status DONE within expected time limit"
                 )
-            per_node_backup_file_paths = mgr_cluster.get_backup_files_dict(
-                snapshot_tag=rerunning_backup_task.get_snapshot_tag()
-            )
-            for node in self.db_cluster.nodes:
-                node_id = node.host_id
-                assert table_to_delete not in per_node_backup_file_paths[node_id][table_ks_name], (
-                    "The missing table is still in s3, even though it should have been purged"
-                )
+            # per_node_backup_file_paths = mgr_cluster.get_backup_files_dict(
+            #     snapshot_tag=rerunning_backup_task.get_snapshot_tag()
+            # )
+            # for node in self.db_cluster.nodes:
+            #     node_id = node.host_id
+            #     assert table_to_delete not in per_node_backup_file_paths[node_id][table_ks_name], (
+            #         "The missing table is still in s3, even though it should have been purged"
+            #     )

--- a/unit_tests/test_sdcm_mgmt_common.py
+++ b/unit_tests/test_sdcm_mgmt_common.py
@@ -32,14 +32,14 @@ class TestManagerVersions:
         "version, distro, expected_url",
         [
             (
-                "3.9",
+                "3.10",
                 Distro.UBUNTU24,
-                "https://downloads.scylladb.com/deb/debian/scylladb-manager-3.9.list",
+                "https://downloads.scylladb.com/deb/debian/scylladb-manager-3.10.list",
             ),
             (
-                "3.9",
+                "3.10",
                 Distro.CENTOS9,
-                "https://downloads.scylladb.com/rpm/centos/scylladb-manager-3.9.repo",
+                "https://downloads.scylladb.com/rpm/centos/scylladb-manager-3.10.repo",
             ),
             (
                 "3.8.1",

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -124,7 +124,7 @@ def call(Map pipelineParams) {
             // Manager Configuration
             separator(name: 'MANAGER_CONFIG', sectionHeader: 'Manager Configuration')
             string(defaultValue: "${pipelineParams.get('manager_version', '')}",
-                   description: 'master_latest|3.9|3.8',
+                   description: 'master_latest|3.10|3.9',
                    name: 'manager_version')
 
             string(defaultValue: '',

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -124,7 +124,7 @@ def call(Map pipelineParams) {
                    name: 'ip_ssh_connections')
             separator(name: 'MANAGER_CONFIG', sectionHeader: 'Manager Configuration')
             string(defaultValue: "${pipelineParams.get('manager_version', 'master_latest')}",
-                   description: 'master_latest|3.8|3.7',
+                   description: 'master_latest|3.10|3.9',
                    name: 'manager_version')
 
             string(defaultValue: "${pipelineParams.get('scylla_mgmt_address', '')}",
@@ -140,7 +140,7 @@ def call(Map pipelineParams) {
                    name: 'scylla_mgmt_pkg')
 
             string(defaultValue: "${pipelineParams.get('target_manager_version', '')}",
-                   description: 'master_latest|3.9|3.8. Only for upgrade test',
+                   description: 'master_latest|3.10|3.9. Only for upgrade test',
                    name: 'target_manager_version')
 
             string(defaultValue: "${pipelineParams.get('target_scylla_mgmt_server_address', '')}",


### PR DESCRIPTION
## Summary
- Bump default Manager version from 3.9 to 3.10 across the entire SCT framework
- Update all related defaults: `manager_version`, `scylla_mgmt_agent_version`, `mgmt_docker_image`
- Advance upgrade-from versions in Jenkins pipelines to test relevant upgrade paths
- Update unit test parametrization and Groovy pipeline descriptions to reflect the new version

## Changes

| File | Change |
|------|--------|
| `defaults/test_default.yaml` | `manager_version` 3.9→3.10, `scylla_mgmt_agent_version` 3.9.0→3.10.0, `mgmt_docker_image` tag 3.9.0→3.10.0 |
| `docs/configuration_options.md` | Updated 3 documented defaults to match |
| `ubuntu22-manager-upgrade.jenkinsfile` | upgrade-from 3.8→3.9 |
| `ubuntu24-manager-upgrade.jenkinsfile` | upgrade-from 3.8→3.10 |
| `ubuntu24-manager-older-enterprise-upgrade.jenkinsfile` | upgrade-from 3.6→3.7 |
| `unit_tests/test_sdcm_mgmt_common.py` | Test parametrize 3.9→3.10 |
| `vars/longevityPipeline.groovy` | Description versions updated |
| `vars/managerPipeline.groovy` | Both `manager_version` and `target_manager_version` descriptions updated |

Follows the same pattern as the Manager 3.9 introduction (commit f41f381d9).