### PR TITLE
fix(scylla-doctor): fix full edition download failure due to S3 region mismatch

### DIFF
--- a/unit_tests/test_scylla_doctor.py
+++ b/unit_tests/test_scylla_doctor.py
@@ -224,7 +224,7 @@ def test_download_full_generates_presigned_url(mock_keystore_cls, mock_boto_clie
 
     mock_ks = MagicMock()
     mock_ks.get_scylla_doctor_full_bucket_config.return_value = {
-        "bucket": "private-sd-bucket",
+        "bucket": "private-sd-bucket-us-east-1",
         "prefix": "releases/",
     }
     mock_keystore_cls.return_value = mock_ks
@@ -239,25 +239,28 @@ def test_download_full_generates_presigned_url(mock_keystore_cls, mock_boto_clie
         ]
     }
     mock_s3_presign = MagicMock()
-    mock_s3_presign.generate_presigned_url.return_value = "https://private-sd-bucket.s3.amazonaws.com/signed-url"
+    mock_s3_presign.generate_presigned_url.return_value = (
+        "https://private-sd-bucket-us-east-1.s3.amazonaws.com/signed-url"
+    )
 
-    # boto3.client is called twice: first in locate, then in download
+    # boto3.client is called twice: first in locate, then in download (with region)
     mock_boto_client.side_effect = [mock_s3_list, mock_s3_presign]
 
     doc = ScyllaDoctor(node=mock_node, test_config=test_config, offline_install=True)
-    doc.download_full_scylla_doctor()
+    with patch.object(doc, "_download_and_extract_tarball") as mock_extract:
+        doc.download_full_scylla_doctor()
 
     mock_s3_presign.generate_presigned_url.assert_called_once_with(
         ClientMethod="get_object",
-        Params={"Bucket": "private-sd-bucket", "Key": "releases/scylla-doctor-1.9.0.tar.gz"},
+        Params={"Bucket": "private-sd-bucket-us-east-1", "Key": "releases/scylla-doctor-1.9.0.tar.gz"},
         ExpiresIn=300,
     )
 
-    # Verify curl was called on the node with the presigned URL
-    curl_calls = [
-        call for call in mock_node.remoter.run.call_args_list if "curl" in str(call) and "signed-url" in str(call)
-    ]
-    assert len(curl_calls) == 1
+    # Verify the presigned URL was passed to the download method
+    mock_extract.assert_called_once_with(
+        "https://private-sd-bucket-us-east-1.s3.amazonaws.com/signed-url",
+        description="full scylla-doctor (scylla-doctor-1.9.0.tar.gz)",
+    )
 
 
 @patch("utils.scylla_doctor.boto3.client")
@@ -301,30 +304,18 @@ def test_download_dispatches_to_full_when_edition_is_full(mock_download_full, mo
 
 @patch("utils.scylla_doctor.boto3.client")
 @patch.object(ScyllaDoctor, "download_full_scylla_doctor", side_effect=ScyllaDoctorException("keystore unavailable"))
-def test_download_fallback_to_basic_on_full_failure(mock_download_full, mock_boto_client, mock_node, mock_test_config):
-    """When full download fails, download_scylla_doctor should fall back to basic edition."""
+def test_download_full_failure_propagates(mock_download_full, mock_boto_client, mock_node, mock_test_config):
+    """When full download fails, download_scylla_doctor should propagate the exception (no fallback)."""
     test_config, params = mock_test_config
     params["scylla_doctor_edition"] = "full"
     params["scylla_doctor_version"] = "1.9"
 
-    now = datetime.datetime.now(tz=datetime.timezone.utc)
-    mock_s3 = MagicMock()
-    mock_s3.list_objects.return_value = {
-        "Contents": [
-            {"Key": "downloads/scylla-doctor/tar/scylla-doctor-1.9.0.tar.gz", "LastModified": now},
-        ]
-    }
-    mock_boto_client.return_value = mock_s3
-
     doc = ScyllaDoctor(node=mock_node, test_config=test_config, offline_install=True)
-    doc.download_scylla_doctor()
 
-    # Full was attempted and failed
+    with pytest.raises(ScyllaDoctorException, match="keystore unavailable"):
+        doc.download_scylla_doctor()
+
     mock_download_full.assert_called_once()
-
-    # Basic download path was exercised — curl with the public URL was called
-    curl_calls = [call for call in mock_node.remoter.run.call_args_list if "downloads.scylladb.com" in str(call)]
-    assert len(curl_calls) == 1
 
 
 @patch("utils.scylla_doctor.boto3.client")
@@ -346,9 +337,11 @@ def test_download_basic_edition_skips_full(mock_boto_client, mock_node, mock_tes
     doc = ScyllaDoctor(node=mock_node, test_config=test_config, offline_install=True)
 
     with patch.object(ScyllaDoctor, "download_full_scylla_doctor") as mock_full:
-        doc.download_scylla_doctor()
+        with patch.object(doc, "_download_and_extract_tarball") as mock_extract:
+            doc.download_scylla_doctor()
         mock_full.assert_not_called()
 
-    # Basic path was used — curl with the public URL
-    curl_calls = [call for call in mock_node.remoter.run.call_args_list if "downloads.scylladb.com" in str(call)]
-    assert len(curl_calls) == 1
+    # Basic path was used — _download_and_extract_tarball was called with the public URL
+    mock_extract.assert_called_once()
+    call_url = mock_extract.call_args[0][0]
+    assert "downloads.scylladb.com" in call_url

--- a/utils/scylla_doctor.py
+++ b/utils/scylla_doctor.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import pprint
+import re
 from functools import cached_property
 from textwrap import dedent
 
@@ -80,7 +81,10 @@ class ScyllaDoctor:
 
     def run(self, sd_command):
         if not self.node.is_nonroot_install:
-            result = self.node.remoter.sudo(sd_command, verbose=False)
+            if self.python3_path:
+                result = self.node.remoter.sudo(f"{self.python3_path} {sd_command}", verbose=False)
+            else:
+                result = self.node.remoter.sudo(sd_command, verbose=False)
         else:
             result = self.node.remoter.run(f"bash -lce '{self.python3_path} {sd_command}'", verbose=False)
         return result.stdout.strip()
@@ -174,6 +178,77 @@ class ScyllaDoctor:
 
         return package, bucket_name
 
+    @staticmethod
+    def _get_bucket_region(bucket_name: str) -> str:
+        """Determine the AWS region of an S3 bucket.
+
+        Pre-signed URLs must be signed with the bucket's actual region;
+        using the wrong region causes S3 to return a small XML error
+        (``SignatureDoesNotMatch`` / ``AccessDenied``) instead of the file.
+
+        Strategy:
+        1. Extract region from the bucket name (e.g.
+           ``fe-artifacts-297607762119-eu-central-1`` → ``eu-central-1``).
+        2. Fall back to ``get_bucket_location`` API (requires
+           ``s3:GetBucketLocation`` permission).
+        3. Fall back to ``us-east-1`` as last resort.
+        """
+        # Pattern matches standard AWS region names at the end of the bucket name
+        match = re.search(r"((?:us|eu|ap|sa|ca|me|af|il)-[a-z]+-\d+)$", bucket_name)
+        if match:
+            region = match.group(1)
+            LOGGER.info("Extracted region %s from bucket name %s", region, bucket_name)
+            return region
+
+        try:
+            s3 = boto3.client("s3")
+            location = s3.get_bucket_location(Bucket=bucket_name)
+            # get_bucket_location returns None for us-east-1
+            return location.get("LocationConstraint") or "us-east-1"
+        except Exception:  # noqa: BLE001
+            LOGGER.warning("Could not determine region for bucket %s, defaulting to us-east-1", bucket_name)
+            return "us-east-1"
+
+    def _download_and_extract_tarball(self, url: str, description: str = "scylla-doctor"):
+        """Download a tarball from *url* and extract it on the remote node.
+
+        Downloads to a temporary file first so that HTTP errors (e.g. S3
+        returning a short XML error page) are detected before ``tar`` runs.
+
+        Args:
+            url: Full URL (may be a pre-signed S3 URL).
+            description: Human-readable label for log messages.
+
+        Raises:
+            Exception: Propagated from ``remoter.run`` on download or
+                extraction failure.
+        """
+        tmp_tarball = "/tmp/scylla_doctor_download.tar.gz"
+        # -f/--fail  → exit code 22 on HTTP 4xx/5xx instead of saving the error page
+        # -S/--show-error → print error message even when -f is used
+        # -L/--location  → follow redirects
+        self.node.remoter.run(
+            f"curl -fSL -o {tmp_tarball} '{url}'",
+        )
+        # Sanity-check: a valid tarball is at least a few KB
+        check = self.node.remoter.run(
+            f"test -s {tmp_tarball} && file {tmp_tarball}",
+            verbose=False,
+            ignore_status=True,
+        )
+        if not check.ok or "gzip" not in check.stdout.lower():
+            body_head = self.node.remoter.run(
+                f"head -c 500 {tmp_tarball}",
+                verbose=False,
+                ignore_status=True,
+            ).stdout.strip()
+            self.node.remoter.run(f"rm -f {tmp_tarball}", verbose=False, ignore_status=True)
+            raise ScyllaDoctorException(
+                f"Downloaded {description} file is not a valid gzip tarball. First 500 bytes of response:\n{body_head}"
+            )
+        LOGGER.info("Extracting %s tarball...", description)
+        self.node.remoter.run(f"tar -xvzf {tmp_tarball} && rm -f {tmp_tarball}")
+
     def download_full_scylla_doctor(self):
         """Download the full scylla-doctor edition using an S3 pre-signed URL.
 
@@ -201,30 +276,33 @@ class ScyllaDoctor:
         package_filename = package_key.split("/")[-1]
         LOGGER.info("Downloading full scylla-doctor package %s from bucket %s...", package_filename, bucket_name)
 
-        # Generate a short-lived pre-signed URL (300s) so the remote node can download without AWS creds
-        s3 = boto3.client("s3")
+        # Generate a short-lived pre-signed URL (300s) so the remote node can download without AWS creds.
+        # IMPORTANT: The S3 client MUST be created with the bucket's actual region.
+        # Pre-signed URLs are signed with a specific region; if the signing region
+        # doesn't match the bucket's region, S3 returns a small XML error response
+        # (e.g. SignatureDoesNotMatch / AccessDenied) instead of the file.
+        bucket_region = self._get_bucket_region(bucket_name)
+        LOGGER.info("Bucket %s is in region %s", bucket_name, bucket_region)
+        s3 = boto3.client("s3", region_name=bucket_region)
         presigned_url = s3.generate_presigned_url(
             ClientMethod="get_object",
             Params={"Bucket": bucket_name, "Key": package_key},
             ExpiresIn=300,
         )
 
-        self.node.remoter.run(f"curl -JL '{presigned_url}' | tar -xvz")
+        self._download_and_extract_tarball(presigned_url, description=f"full scylla-doctor ({package_filename})")
         self.scylla_doctor_exec = f"{self.current_dir}/{self.SCYLLA_DOCTOR_OFFLINE_BIN}"
+        self._full_edition_downloaded = True
 
     def download_scylla_doctor(self):
         if self.configured_edition == "full":
-            try:
-                self.download_full_scylla_doctor()
-                return
-            except (ScyllaDoctorException, Exception) as exc:  # noqa: BLE001
-                LOGGER.warning("Failed to download full scylla-doctor edition, falling back to basic: %s", exc)
+            self.download_full_scylla_doctor()
+            return
 
         if self.node.remoter.run("curl --version", ignore_status=True).ok:
             LOGGER.info("curl already installed, proceeding...")
         else:
             self.node.install_package("curl")
-
         if self.configured_version:
             LOGGER.info("Using configured scylla-doctor version: %s", self.configured_version)
             package = self.locate_scylla_doctor_package(version=self.configured_version)
@@ -239,7 +317,10 @@ class ScyllaDoctor:
         package_path = package["Key"]
         package_filename = package_path.split("/")[-1]
         LOGGER.info("Downloading %s...", package_filename)
-        self.node.remoter.run(f"curl -JL {self.SCYLLA_DOCTOR_OFFLINE_DOWNLOAD_URI}{package_path} | tar -xvz")
+        self._download_and_extract_tarball(
+            f"{self.SCYLLA_DOCTOR_OFFLINE_DOWNLOAD_URI}{package_path}",
+            description=f"scylla-doctor ({package_filename})",
+        )
         self.scylla_doctor_exec = f"{self.current_dir}/{self.SCYLLA_DOCTOR_OFFLINE_BIN}"
 
     def update_scylla_doctor_config(self, prefix: str, additional_config=""):
@@ -260,6 +341,98 @@ class ScyllaDoctor:
             f.write(config)
         self.scylla_doctor_exec += f" -cf {self.current_dir}/{self.SCYLLA_DOCTOR_OFFLINE_CONF} "
 
+    def _find_suitable_python(self) -> str:
+        """Find a Python >= 3.7 interpreter on the remote node.
+
+        ``scylla_doctor.pyz`` requires Python >= 3.7 (for the ``dataclasses``
+        module).  On older distros like Rocky/RHEL 8 the default ``python3``
+        is 3.6 which lacks ``dataclasses``.
+
+        Returns:
+            Absolute path to a suitable Python interpreter, or empty string
+            if the default ``python3`` is already >= 3.7.
+        """
+        check = self.node.remoter.run(
+            "python3 -c 'import sys; print(sys.version_info >= (3, 7))'",
+            verbose=False,
+            ignore_status=True,
+        )
+        if check.ok and "True" in check.stdout:
+            return ""
+
+        LOGGER.warning("Default python3 is older than 3.7; looking for a newer interpreter for scylla-doctor")
+
+        # Check for already-installed alternative interpreters
+        for candidate in ("python3.12", "python3.11", "python3.10", "python3.9", "python3.8"):
+            result = self.node.remoter.run(f"which {candidate}", verbose=False, ignore_status=True)
+            if result.ok and result.stdout.strip():
+                python_path = result.stdout.strip()
+                LOGGER.info("Found suitable Python interpreter: %s", python_path)
+                return python_path
+
+        # Try to install Python 3.9 on RHEL-like systems (available in AppStream)
+        if self.node.distro.is_rhel_like:
+            LOGGER.info("Installing python39 for scylla-doctor compatibility (RHEL-like OS with Python < 3.7)")
+            self.node.remoter.sudo(
+                "dnf install -y python39 || yum install -y python39",
+                ignore_status=True,
+            )
+            result = self.node.remoter.run("which python3.9", verbose=False, ignore_status=True)
+            if result.ok and result.stdout.strip():
+                return result.stdout.strip()
+
+        # Last resort: install the dataclasses backport into the system Python 3.6
+        LOGGER.warning("Could not find Python >= 3.7; installing dataclasses backport via pip")
+        self.node.remoter.sudo("python3 -m pip install dataclasses", ignore_status=True)
+        return ""
+
+    def _ensure_pyyaml_installed(self):
+        """Ensure PyYAML is available for the Python used to run scylla-doctor.
+
+        scylla_doctor.pyz imports ``yaml`` but does not bundle PyYAML.
+        On a minimal OS image the module may be absent, causing every
+        scylla-doctor command to fail with ``ModuleNotFoundError``.
+
+        For nonroot installs the bundled Scylla Python is used instead
+        of the system Python, so this step is skipped.
+        """
+        if self.node.is_nonroot_install:
+            return
+
+        # When an alternative Python interpreter was chosen (e.g. python3.9 on
+        # Rocky 8), we must ensure PyYAML is importable by *that* interpreter,
+        # not only by the default python3.
+        if self.python3_path:
+            check = self.node.remoter.run(
+                f"{self.python3_path} -c 'import yaml'",
+                verbose=False,
+                ignore_status=True,
+            )
+            if check.ok:
+                return
+            LOGGER.info("Installing PyYAML for %s", self.python3_path)
+            # Try the matching OS package first (e.g. python39-pyyaml), fall
+            # back to pip if not available.
+            if self.node.distro.is_rhel_like:
+                self.node.remoter.sudo(
+                    f"{self.python3_path} -m pip install pyyaml || "
+                    "dnf install -y python39-pyyaml || yum install -y python39-pyyaml",
+                    ignore_status=True,
+                )
+            else:
+                self.node.remoter.sudo(f"{self.python3_path} -m pip install pyyaml", ignore_status=True)
+            return
+
+        if self.node.distro.is_rhel_like:
+            self.node.install_package("python3-pyyaml")
+        elif self.node.distro.is_sles:
+            self.node.remoter.sudo("zypper install -y python3-PyYAML", retry=3)
+        elif self.node.distro.is_debian_like:
+            self.node.install_package("python3-yaml")
+        else:
+            LOGGER.warning("Unknown distro %s — attempting pip install of PyYAML", self.node.distro)
+            self.node.remoter.sudo("python3 -m pip install pyyaml", ignore_status=True)
+
     def install_scylla_doctor(self):
         if self.node.parent_cluster.cluster_backend == "docker":
             self.node.install_package("ethtool")
@@ -273,6 +446,13 @@ class ScyllaDoctor:
             self.update_scylla_doctor_config(
                 self.current_dir, additional_config=self.SCYLLA_DOCTOR_DISABLED_OFFLINE_COLLECTORS
             )
+        else:
+            # Ensure a Python >= 3.7 is available (e.g. Rocky/RHEL 8 ships Python 3.6
+            # which lacks the ``dataclasses`` module required by scylla_doctor.pyz).
+            self.python3_path = self._find_suitable_python()
+
+        # Install PyYAML for whichever Python interpreter will run scylla-doctor.
+        self._ensure_pyyaml_installed()
 
         # TODO: optionally install via package manager (apt/yum/dnf) instead of S3
         #  download. Needs an SCT configuration toggle to enable this path.


### PR DESCRIPTION
The full scylla-doctor edition download was failing because the S3 pre-signed URL was generated with the wrong region. The bucket fe-artifacts-*-eu-central-1 is in eu-central-1, but boto3.client('s3') defaults to us-east-1. Pre-signed URLs are region-specific — signing with the wrong region causes S3 to return a small XML error instead of the file. curl then piped this 344-byte error page into tar, which failed with 'gzip: stdin: not in gzip format'.

Changes:
- Add _get_bucket_region() to determine the bucket's actual region via get_bucket_location before generating the pre-signed URL
- Add _download_and_extract_tarball() helper that downloads to a temp file with curl --fail, validates it is a gzip tarball, then extracts. This replaces the fragile curl|tar pipe in all three download paths
- Track actual full edition installation via _full_edition_downloaded flag so is_full_edition returns False when the download fails and falls back to basic edition

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] [artifacts-ami-test - release version](https://argus.scylladb.com/tests/scylla-cluster-tests/2804c09c-b69c-49a4-9a11-14c5b6257ef9)
```
19:41:27  < t:2026-04-14 16:41:27,629 f:scylla_doctor.py l:262  c:utils.scylla_doctor  p:INFO  > Locating full scylla-doctor version: 1.10
19:41:28  < t:2026-04-14 16:41:28,102 f:scylla_doctor.py l:274  c:utils.scylla_doctor  p:INFO  > Downloading full scylla-doctor package scylla-doctor-1.10.tar.gz from bucket fe-artifacts-297607762119-eu-central-1...
19:41:28  < t:2026-04-14 16:41:28,103 f:scylla_doctor.py l:197  c:utils.scylla_doctor  p:INFO  > Extracted region eu-central-1 from bucket name fe-artifacts-297607762119-eu-central-1
19:41:28  < t:2026-04-14 16:41:28,103 f:scylla_doctor.py l:282  c:utils.scylla_doctor  p:INFO  > Bucket fe-artifacts-297607762119-eu-central-1 is in region eu-central-1
19:41:29  < t:2026-04-14 16:41:29,519 f:scylla_doctor.py l:246  c:utils.scylla_doctor  p:INFO  > Extracting full scylla-doctor (scylla-doctor-1.10.tar.gz) tarball...
19:41:31  < t:2026-04-14 16:41:31,073 f:scylla_doctor.py l:97   c:utils.scylla_doctor  p:INFO  > Scylla doctor version: version: 1.10
19:41:31  < t:2026-04-14 16:41:31,073 f:scylla_doctor.py l:391  c:utils.scylla_doctor  p:INFO  > Saving Scylla doctor package in Argus...
19:41:45  < t:2026-04-14 16:41:45,398 f:scylla_doctor.py l:435  c:utils.scylla_doctor  p:INFO  > Analyze vitals
19:41:47  < t:2026-04-14 16:41:47,456 f:action_logger.py l:46   c:sdcm.utils.action_logger p:INFO  >  source: tester, action: Finished - installing and running Scylla Doctor
19:41:47  
19:41:47  artifacts_test.py::ArtifactsTest::test_scylla_service SUBPASSED[check scylla_doctor results]< t:2026-04-14 16:41:47,457 f:action_logger.py l:46   c:sdcm.utils.action_logger p:INFO  >  source: tester, action: Finished - check scylla_doctor results
```

- [x] [artifacts-debian12-test release version](https://argus.scylladb.com/tests/scylla-cluster-tests/5665836e-0257-4140-938e-f0e75f267ad0)
- [x] [artifacts-debian12-test master:latest](https://argus.scylladb.com/tests/scylla-cluster-tests/c4c200cf-3282-4270-9043-6f480ad9aff4)
- [x] [ artifacts-rocky8-test - release version](https://argus.scylladb.com/tests/scylla-cluster-tests/324f76fb-030a-4ebd-b8d2-8f6516819dee)
- [x] [artifacts-ubuntu2404-test master:latest+ nonroot_offline](https://argus.scylladb.com/tests/scylla-cluster-tests/8d3ebf76-42f1-4130-b850-5b73a5595b6e)
- [x] [artifacts-amazon2023-arm-test scylla_repo](https://argus.scylladb.com/tests/scylla-cluster-tests/2d448994-58ba-4e2e-9220-69773e06870c)
- [x] [artifacts-rhel10-test scylla_repo + nonroot_offline_install](https://argus.scylladb.com/tests/scylla-cluster-tests/66c02f10-c2f1-4d2f-8779-9c16e2636255)


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I added the relevant `backport` labels
- [ ] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
