### PR TITLE
fix(manager-pipeline): abort build#1 to work around JENKINS-41929 params loading bug

### DIFF
--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -205,6 +205,22 @@ def call(Map pipelineParams) {
             buildDiscarder(logRotator(numToKeepStr: '20'))
         }
         stages {
+            stage("Preparation") {
+                // NOTE: this stage is a workaround for the following Jenkins bug:
+                // https://issues.jenkins-ci.org/browse/JENKINS-41929
+                when { expression { env.BUILD_NUMBER == '1' } }
+                steps {
+                    script {
+                        if (currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause') != null) {
+                            currentBuild.description = ('Aborted build#1 not having parameters loaded. \n'
+                              + 'Build#2 is ready to run')
+                            currentBuild.result = 'ABORTED'
+
+                            error('Abort build#1 which only loads params')
+                        }
+                    }
+                }
+            }
             stage('Checkout') {
                 options {
                     timeout(time: 5, unit: 'MINUTES')


### PR DESCRIPTION
Closes https://scylladb.atlassian.net/browse/CLOUD-1569

## Summary
- Adds a `Preparation` stage as the first stage in `managerPipeline.groovy`
- When Jenkins runs build #1 (which only loads parameters due to [JENKINS-41929](https://issues.jenkins-ci.org/browse/JENKINS-41929)), the build is aborted with a descriptive message
- Build #2 will have all parameters properly loaded and will run normally

### Testing
- [x] Tested it here https://jenkins.scylladb.com/view/scylla-manager/job/manager-master/job/ubuntu22-sanity-test-gce/