### PR TITLE
feature(sct): add create-manager-test-release-jobs command

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1941,6 +1941,26 @@ def create_operator_test_release_jobs(branch, username, password, sct_branch, sc
     )
 
 
+@cli.command("create-manager-test-release-jobs", help="Create pipeline jobs for a new scylla-manager branch/release")
+@click.argument("branch", type=str)
+@click.argument("username", envvar="JENKINS_USERNAME", type=str, required=False)
+@click.argument("password", envvar="JENKINS_PASSWORD", type=str, required=False)
+@click.option("--sct_branch", default="master", type=str)
+@click.option("--sct_repo", default="git@github.com:scylladb/scylla-cluster-tests.git", type=str)
+@click.option("--triggers/--no-triggers", default=False)
+def create_manager_test_release_jobs(branch, username, password, sct_branch, sct_repo, triggers):
+    add_file_logger()
+
+    server = JenkinsPipelines(
+        username=username, password=password, base_job_dir=branch, sct_branch_name=sct_branch, sct_repo=sct_repo
+    )
+    server.create_job_tree(
+        f"{server.base_sct_dir}/jenkins-pipelines/manager",
+        create_freestyle_jobs=triggers,
+        template_context={"release_version": get_latest_scylla_release(product="scylla-enterprise")},
+    )
+
+
 @cli.command("create-qa-tools-jobs", help="Create pipeline jobs for a new scylla-operator branch/release")
 @click.argument("username", envvar="JENKINS_USERNAME", type=str, required=False)
 @click.argument("password", envvar="JENKINS_PASSWORD", type=str, required=False)


### PR DESCRIPTION
Closes https://scylladb.atlassian.net/browse/CLOUD-1159

## Summary

- Adds a new `create-manager-test-release-jobs` CLI command to `sct.py`, analogous to the existing `create-operator-test-release-jobs`.
- The command provisions Jenkins pipeline jobs for a given scylla-manager branch by walking `jenkins-pipelines/manager/` and creating jobs under the `scylla-manager/{branch}` folder hierarchy.
- Passes `template_context` with `release_version` to future-proof for weekly trigger `.xml` files.

### What it creates on Jenkins

- Folder `scylla-manager/{branch}` with subfolders `helpers`, `longevities`, `restore_benchmark`
- 35 pipeline jobs (one `-test` suffixed job per `.jenkinsfile` in `jenkins-pipelines/manager/`)

### Testing

- [x] Tested locally
```
(scylla-cluster-tests) mikita@mikita-pc:~/scylla/repos/scylla-cluster-tests$ ./docker/env/hydra.sh create-manager-test-release-jobs manager-3.11 JENKINS_USERNAME JENKINS_TOKEN --sct_branch master --sct_repo git@github.com:scylladb/scylla-cluster-tests.git
Pull version v1.132-PR14333-5c6faeb from Docker Hub...
v1.132-PR14333-5c6faeb: Pulling from scylladb/hydra
Digest: sha256:c12023b2649318fc6fcdf87bd6f0cbc68dc3fcf1a78cb7c7aed71422e7fd70fd
Status: Image is up to date for scylladb/hydra:v1.132-PR14333-5c6faeb
docker.io/scylladb/hydra:v1.132-PR14333-5c6faeb
Going to run './sct.py  create-manager-test-release-jobs manager-3.11 mikita.liapkovich@scylladb.com 11c8a4a46ec6b5400f00a15c08a989c8d2 --sct_branch master --sct_repo git@github.com:scylladb/scylla-cluster-tests.git'...
logged in as arn:aws:sts::797456418907:assumed-role/DeveloperAccessRole/mikita.liapkovich@scylladb.com
New directory created: /home/mikita/sct-results/20260415-111312-734629-create-manager-test-release-jobs
manager-3.11/rocky9-manager-install-test is used to create job
Start first build manager-3.11/rocky9-manager-install-test
First build finished
manager-3.11/ubuntu22-manager-sanity-test is used to create job
Start first build manager-3.11/ubuntu22-manager-sanity-test
First build finished
manager-3.11/ubuntu22-manager-upgrade-test is used to create job
Start first build manager-3.11/ubuntu22-manager-upgrade-test
First build finished
manager-3.11/ubuntu24-manager-vnodes-tablets-enterprise-test is used to create job
Start first build manager-3.11/ubuntu24-manager-vnodes-tablets-enterprise-test
First build finished
...
```