### PR TITLE
refactor(longevity-twcs): Increase utilization and add ZSTD dic compression

### DIFF
--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -1,12 +1,38 @@
+# LONGEVITY TEST: TWCS 48H WITH ZSTD DICTIONARY COMPRESSION
+#
+# Purpose:
+#   Validates ScyllaDB stability under a 48-hour sustained time-series workload using
+#   Time-Window Compaction Strategy (TWCS) with 60-minute compaction windows, a 3-hour
+#   TTL, and ZSTD dictionary compression (ZstdWithDictsCompressor).
+#   - Surfaces issues with TWCS compaction scheduling under continuous ingestion
+#   - Validates ZSTD dictionary compression stability over extended periods
+#   - Extended duration helps detect memory leaks and performance regressions
+#
+# Cluster:
+#   - 6 DB nodes (i8ge.xlarge — ARM64/Graviton, storage-optimized) + 3 loaders
+#   - Replication factor: 3
+#   - Nemesis: SisyphusMonkey every 15 min (disabled during prepare)
+#
+# Workload (scylla-bench timeseries, 48h each):
+#   - Write: 100K ops/s max rate, 150 concurrency, 50K partitions × 20K rows × 500B
+#   - Read (×2): half-normal + uniform distribution, write-rate=666 per thread
+#
+# Table Settings (applied via post_prepare_cql_cmds):
+#   - default_time_to_live: 10800 (3 hours)
+#   - TWCS: compaction_window_size=60 MINUTES
+#   - tombstone_gc: immediate
+#   - compression: ZstdWithDictsCompressor
+#   - speculative_retry: NONE
+
 test_duration: 3000
 
-stress_cmd: ["scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=4000 -clustering-row-count=10000 -clustering-row-size=200 -concurrency=150 -rows-per-request=1 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 30000 -timeout=120s -retry-number=30 -retry-interval=80ms,1s -duration=2880m"]
+stress_cmd: ["scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=50000 -clustering-row-count=20000 -clustering-row-size=500 -concurrency=150 -rows-per-request=1 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 100000 -timeout=120s -retry-number=30 -retry-interval=80ms,1s -duration=2880m"]
 # write-rate with timeseries workload for read mode
 # calculated from timeseries workload for write mode by formula:
-# write-rate = -max-rate / -concurrency = 30000 / 150 = 200
+# write-rate = -max-rate / -concurrency = 100000 / 150 = 666
 stress_read_cmd: [
-    "scylla-bench -workload=timeseries -mode=read -partition-count=4000 -concurrency=150 -replication-factor=3 -clustering-row-count=10000 -clustering-row-size=200  -rows-per-request=1 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 200 -distribution hnormal --connection-count 100 -duration=2880m -timeout=30s -retry-number=30 -retry-interval=80ms,1s",
-    "scylla-bench -workload=timeseries -mode=read -partition-count=4000 -concurrency=150 -replication-factor=3 -clustering-row-count=10000 -clustering-row-size=200  -rows-per-request=1 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 200 -distribution uniform --connection-count 100 -duration=2880m -timeout=30s -retry-number=30 -retry-interval=80ms,1s"
+    "scylla-bench -workload=timeseries -mode=read -partition-count=50000 -concurrency=150 -replication-factor=3 -clustering-row-count=20000 -clustering-row-size=500  -rows-per-request=1 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 666 -distribution hnormal --connection-count 100 -duration=2880m -timeout=30s -retry-number=30 -retry-interval=80ms,1s",
+    "scylla-bench -workload=timeseries -mode=read -partition-count=50000 -concurrency=150 -replication-factor=3 -clustering-row-count=20000 -clustering-row-size=500  -rows-per-request=1 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 666 -distribution uniform --connection-count 100 -duration=2880m -timeout=30s -retry-number=30 -retry-interval=80ms,1s"
     ]
 
 
@@ -19,10 +45,15 @@ nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '025'
 nemesis_interval: 15
 nemesis_during_prepare: false
-space_node_threshold: 64424
+space_node_threshold: 644245094
 
 user_prefix: 'longevity-twcs-48h'
 
-post_prepare_cql_cmds: "ALTER TABLE scylla_bench.test WITH default_time_to_live = 10800 AND compaction = {'class':'TimeWindowCompactionStrategy', 'compaction_window_size': 60, 'compaction_window_unit': 'MINUTES'} AND tombstone_gc = {'mode':'immediate'};"
+post_prepare_cql_cmds: >-
+    ALTER TABLE scylla_bench.test
+    WITH default_time_to_live = 10800
+    AND compaction = {'class':'TimeWindowCompactionStrategy', 'compaction_window_size': 60, 'compaction_window_unit': 'MINUTES'}
+    AND tombstone_gc = {'mode':'immediate'}
+    AND compression = {'sstable_compression': 'ZstdWithDictsCompressor'}
 
 round_robin: true

--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -1,21 +1,49 @@
+# LONGEVITY TEST: TWCS 48H WITH ZSTD DICTIONARY COMPRESSION
+#
+# Purpose:
+#   Validates ScyllaDB stability under a 48-hour sustained time-series workload using
+#   Time-Window Compaction Strategy (TWCS) with 60-minute compaction windows, a 3-hour
+#   TTL, and ZSTD dictionary compression (ZstdWithDictsCompressor).
+#   - Surfaces issues with TWCS compaction scheduling under continuous ingestion
+#   - Validates ZSTD dictionary compression stability over extended periods
+#   - Extended duration helps detect memory leaks and performance regressions
+#
+# Cluster:
+#   - 6 DB nodes (i8g.large — ARM64/Graviton) + 3 loaders
+#   - Replication factor: 3
+#   - Nemesis: SisyphusMonkey every 15 min, after reaching the space threshold
+#
+# Workload (scylla-bench timeseries, 48h each):
+#   - Write: 90K ops/s max rate, 150 concurrency, 200K partitions × 100K rows × 2000B
+#   - Read (×2): half-normal + uniform distribution, write-rate=600 per thread
+#
+# Table Settings (applied via post_prepare_cql_cmds):
+#   - default_time_to_live: 10800 (3 hours)
+#   - TWCS: compaction_window_size=60 MINUTES
+#   - tombstone_gc: immediate
+#   - compression: ZstdWithDictsCompressor
+
 test_duration: 3000
 
-stress_cmd: ["scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=4000 -clustering-row-count=10000 -clustering-row-size=200 -concurrency=150 -rows-per-request=1 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 30000 -timeout=120s -retry-number=30 -retry-interval=80ms,1s -duration=2880m"]
+stress_cmd: [
+    "scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=200000 -clustering-row-count=100000 -clustering-row-size=2000 -concurrency=150 -rows-per-request=1 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 90000 -timeout=120s -retry-number=30 -retry-interval=80ms,1s -duration=2880m"
+]
 # write-rate with timeseries workload for read mode
 # calculated from timeseries workload for write mode by formula:
-# write-rate = -max-rate / -concurrency = 30000 / 150 = 200
+# write-rate = -max-rate / -concurrency = 90000 / 150 = 600
 stress_read_cmd: [
-    "scylla-bench -workload=timeseries -mode=read -partition-count=4000 -concurrency=150 -replication-factor=3 -clustering-row-count=10000 -clustering-row-size=200  -rows-per-request=1 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 200 -distribution hnormal --connection-count 100 -duration=2880m -timeout=30s -retry-number=30 -retry-interval=80ms,1s",
-    "scylla-bench -workload=timeseries -mode=read -partition-count=4000 -concurrency=150 -replication-factor=3 -clustering-row-count=10000 -clustering-row-size=200  -rows-per-request=1 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 200 -distribution uniform --connection-count 100 -duration=2880m -timeout=30s -retry-number=30 -retry-interval=80ms,1s"
-    ]
-
+    "scylla-bench -workload=timeseries -mode=read -partition-count=200000 -concurrency=150 -replication-factor=3 -clustering-row-count=100000 -clustering-row-size=2000  -rows-per-request=1 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 600 -distribution hnormal --connection-count 100 -duration=2880m -timeout=30s -retry-number=30 -retry-interval=80ms,1s",
+    "scylla-bench -workload=timeseries -mode=read -partition-count=200000 -concurrency=150 -replication-factor=3 -clustering-row-count=100000 -clustering-row-size=2000  -rows-per-request=1 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 600 -distribution uniform --connection-count 100 -duration=2880m -timeout=30s -retry-number=30 -retry-interval=80ms,1s"
+]
 
 n_db_nodes: 6
 n_loaders: 3
 
-instance_type_db: 'i8ge.xlarge'
+instance_type_db: 'i8g.xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
+# exclude ModifyTableCompactionMonkey because it will change TWCS
+nemesis_selector: 'not ModifyTableCompactionMonkey'
 nemesis_seed: '025'
 nemesis_interval: 15
 nemesis_during_prepare: false
@@ -23,6 +51,11 @@ space_node_threshold: 64424
 
 user_prefix: 'longevity-twcs-48h'
 
-post_prepare_cql_cmds: "ALTER TABLE scylla_bench.test WITH default_time_to_live = 10800 AND compaction = {'class':'TimeWindowCompactionStrategy', 'compaction_window_size': 60, 'compaction_window_unit': 'MINUTES'} AND tombstone_gc = {'mode':'immediate'};"
+post_prepare_cql_cmds: >-
+    ALTER TABLE scylla_bench.test
+    WITH default_time_to_live = 10800
+    AND compaction = {'class':'TimeWindowCompactionStrategy', 'compaction_window_size': 60, 'compaction_window_unit': 'MINUTES'}
+    AND tombstone_gc = {'mode':'immediate'}
+    AND compression = {'sstable_compression': 'ZstdWithDictsCompressor'}
 
 round_robin: true


### PR DESCRIPTION
Retune the TWCS 48h test to increase dataset utilization and add ZSTD dictionary compression.

- Add ZSTD dict compression via ALTER TABLE in post_prepare_cql_cmds
- Increase partition-count 4,000 → 20,000
- Increase clustering-row-size 200 → 2000
- Increase max-rate 30,000 → 90,000
- Increase read/write rate 200 → 600

Fixes: SCYLLADB-1435

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/fd20559a-8091-4082-b339-ac545aa188f2
<img width="1741" height="302" alt="image" src="https://github.com/user-attachments/assets/8821c1d6-4a43-49d7-8f54-e31696935383" />
<img width="594" height="353" alt="image" src="https://github.com/user-attachments/assets/c0094a9f-6b09-4c7d-8a9c-c48f1cae8f60" />


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
