### PR TITLE
refactor(multidc-parallel-topology-schema-changes): increase data size

### DIFF
--- a/data_dir/cs_multidc_si_lcs.yaml
+++ b/data_dir/cs_multidc_si_lcs.yaml
@@ -29,19 +29,19 @@ columnspec:
     population: uniform(1..10M)
 
   - name: c0
-    size: fixed(1024)
+    size: fixed(2048)
 
   - name: c1
-    size: fixed(1024)
+    size: fixed(2048)
 
   - name: c2
-    size: fixed(1024)
+    size: fixed(2048)
 
   - name: c3
-    size: fixed(1024)
+    size: fixed(2048)
 
   - name: c4
-    size: fixed(1024)
+    size: fixed(2048)
 
 insert:
   partitions: fixed(1)

--- a/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
@@ -39,18 +39,18 @@ pre_create_keyspace: ["CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication 
                       "ATTACH SERVICE_LEVEL sl_test_3 TO stress_user3;",
                       ]
 
-prepare_write_cmd:  ["cassandra-stress write cl=LOCAL_QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native connectionsPerHost=2000 -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(5) size=FIXED(16)' -log interval=5",
+prepare_write_cmd:  ["cassandra-stress write cl=LOCAL_QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native connectionsPerHost=2000 -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(5) size=FIXED(1024)' -log interval=5",
                      "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(insert=1)' cl=LOCAL_QUORUM n=3000000 -mode cql3 native connectionsPerHost=2000 -rate threads=40 -log interval=5"
                     ]
 
-stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user1 password=stress_user1  connectionsPerHost=400 -rate threads=13 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(16)' -log interval=5",
-             "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user1 password=stress_user1  connectionsPerHost=400 -rate threads=13 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(16)' -log interval=5",
+stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user1 password=stress_user1  connectionsPerHost=400 -rate threads=13 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(1024)' -log interval=5",
+             "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user1 password=stress_user1  connectionsPerHost=400 -rate threads=13 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(1024)' -log interval=5",
              "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(insert=1,read=1,si_read1=1,si_read2=1)' cl=LOCAL_QUORUM duration=700m -mode cql3 native  user=stress_user1 password=stress_user1  connectionsPerHost=400 -rate threads=13 -log interval=5",
-             "cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user2 password=stress_user2  connectionsPerHost=400 -rate threads=13 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(16)' -log interval=5",
-             "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user2 password=stress_user2  connectionsPerHost=400 -rate threads=13 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(16)' -log interval=5",
+             "cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user2 password=stress_user2  connectionsPerHost=400 -rate threads=13 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(1024)' -log interval=5",
+             "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user2 password=stress_user2  connectionsPerHost=400 -rate threads=13 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(1024)' -log interval=5",
              "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(insert=1,read=1,si_read1=1,si_read2=1)' cl=LOCAL_QUORUM duration=700m -mode cql3 native  user=stress_user2 password=stress_user2  connectionsPerHost=400 -rate threads=13 -log interval=5",
-             "cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user3 password=stress_user3  connectionsPerHost=400 -rate threads=13 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(16)' -log interval=5",
-             "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user3 password=stress_user3  connectionsPerHost=400 -rate threads=13 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(16)' -log interval=5",
+             "cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user3 password=stress_user3  connectionsPerHost=400 -rate threads=13 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(1024)' -log interval=5",
+             "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user3 password=stress_user3  connectionsPerHost=400 -rate threads=13 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(1024)' -log interval=5",
              "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(insert=1,read=1,si_read1=1,si_read2=1)' cl=LOCAL_QUORUM duration=700m -mode cql3 native  user=stress_user3 password=stress_user3  connectionsPerHost=400 -rate threads=13 -log interval=5",
              ]
 
@@ -61,7 +61,7 @@ n_loaders: '2 2'
 region_aware_loader: true
 simulated_racks: 0
 
-instance_type_db: 'i7ie.2xlarge'
+instance_type_db: 'i7ie.xlarge'
 
 nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey']
 nemesis_selector: ["topology_changes", "schema_changes and not disruptive"]
@@ -77,5 +77,3 @@ server_encrypt: true
 internode_encryption: 'dc'
 
 user_prefix: 'parallel-topology-schema-changes-multidc-12h'
-
-# auth for connections per host

--- a/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
+++ b/test-cases/longevity/longevity-multidc-parallel-topology-schema-changes-12h.yaml
@@ -1,4 +1,4 @@
-test_duration: 800
+test_duration: 1200
 
 # `connectionsPerHost` - target a specific number of TCP connections per shard.
 # For a single DC:
@@ -16,43 +16,46 @@ test_duration: 800
 # For this test:
 #   L = 2   (loaders per DC)
 #   users = 3, commands per user = 3  =>  P = 3 * 3 = 9 processes per loader
-#   S = 8   (shards per node)
+#   S = 4   (shards per node)
 #
 # With the current setting:
-#   connectionsPerHost = 400
-#   total_connections_per_node = 2 * 9 * 400 = 7200
-#   connections_per_shard      = 7200 / 8    = 900 ≈ 1000 conn/shard
+#   connectionsPerHost = 200
+#   total_connections_per_node = 2 * 9 * 200 = 3600
+#   connections_per_shard      = 3600 / 4    = 900 ≈ 1000 conn/shard
 
-pre_create_keyspace: ["CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};",
-                      "CREATE TABLE keyspace1.standard2 (key blob, c0 blob, c1 blob, c2 blob, c3 blob, c4 blob, PRIMARY KEY (key))  WITH compaction = {'class': 'LeveledCompactionStrategy'} AND compression = {'chunk_length_in_kb': '64', 'sstable_compression': 'org.apache.cassandra.io.compress.ZstdCompressor'};",
-                      "CREATE ROLE IF NOT EXISTS stress_user1 WITH LOGIN = true AND PASSWORD = 'stress_user1' AND SUPERUSER = false;",
-                      "CREATE ROLE IF NOT EXISTS stress_user2 WITH LOGIN = true AND PASSWORD = 'stress_user2' AND SUPERUSER = false;",
-                      "CREATE ROLE IF NOT EXISTS stress_user3 WITH LOGIN = true AND PASSWORD = 'stress_user3' AND SUPERUSER = false;",
-                      "GRANT ALL ON ALL KEYSPACES TO stress_user1;",
-                      "GRANT ALL ON ALL KEYSPACES TO stress_user2;",
-                      "GRANT ALL ON ALL KEYSPACES TO stress_user3;",
-                      "CREATE SERVICE_LEVEL IF NOT EXISTS sl_test_1 WITH SHARES = 500;",
-                      "CREATE SERVICE_LEVEL IF NOT EXISTS sl_test_2  WITH SHARES = 300;",
-                      "CREATE SERVICE_LEVEL IF NOT EXISTS sl_test_3  WITH SHARES = 1000;",
-                      "ATTACH SERVICE_LEVEL sl_test_1 TO stress_user1;",
-                      "ATTACH SERVICE_LEVEL sl_test_2 TO stress_user2;",
-                      "ATTACH SERVICE_LEVEL sl_test_3 TO stress_user3;",
-                      ]
+pre_create_keyspace: [
+    "CREATE KEYSPACE IF NOT EXISTS keyspace1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};",
+    "CREATE TABLE keyspace1.standard2 (key blob, c0 blob, c1 blob, c2 blob, c3 blob, c4 blob, PRIMARY KEY (key))  WITH compaction = {'class': 'LeveledCompactionStrategy'} AND compression = {'chunk_length_in_kb': '64', 'sstable_compression': 'org.apache.cassandra.io.compress.ZstdCompressor'};",
+    "CREATE ROLE IF NOT EXISTS stress_user1 WITH LOGIN = true AND PASSWORD = 'stress_user1' AND SUPERUSER = false;",
+    "CREATE ROLE IF NOT EXISTS stress_user2 WITH LOGIN = true AND PASSWORD = 'stress_user2' AND SUPERUSER = false;",
+    "CREATE ROLE IF NOT EXISTS stress_user3 WITH LOGIN = true AND PASSWORD = 'stress_user3' AND SUPERUSER = false;",
+    "GRANT ALL ON ALL KEYSPACES TO stress_user1;",
+    "GRANT ALL ON ALL KEYSPACES TO stress_user2;",
+    "GRANT ALL ON ALL KEYSPACES TO stress_user3;",
+    "CREATE SERVICE_LEVEL IF NOT EXISTS sl_test_1 WITH SHARES = 500;",
+    "CREATE SERVICE_LEVEL IF NOT EXISTS sl_test_2  WITH SHARES = 300;",
+    "CREATE SERVICE_LEVEL IF NOT EXISTS sl_test_3  WITH SHARES = 1000;",
+    "ATTACH SERVICE_LEVEL sl_test_1 TO stress_user1;",
+    "ATTACH SERVICE_LEVEL sl_test_2 TO stress_user2;",
+    "ATTACH SERVICE_LEVEL sl_test_3 TO stress_user3;",
+]
 
-prepare_write_cmd:  ["cassandra-stress write cl=LOCAL_QUORUM n=20971520 -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native connectionsPerHost=2000 -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(5) size=FIXED(16)' -log interval=5",
-                     "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(insert=1)' cl=LOCAL_QUORUM n=3000000 -mode cql3 native connectionsPerHost=2000 -rate threads=40 -log interval=5"
-                    ]
+prepare_write_cmd:  [
+    "cassandra-stress write cl=LOCAL_QUORUM n=600M -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native connectionsPerHost=1000 -rate threads=160 -pop seq=1..600M -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+    "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(insert=1)' cl=LOCAL_QUORUM n=10M -mode cql3 native connectionsPerHost=1000 -rate threads=80 -log interval=5"
+]
 
-stress_cmd: ["cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user1 password=stress_user1  connectionsPerHost=400 -rate threads=13 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(16)' -log interval=5",
-             "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user1 password=stress_user1  connectionsPerHost=400 -rate threads=13 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(16)' -log interval=5",
-             "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(insert=1,read=1,si_read1=1,si_read2=1)' cl=LOCAL_QUORUM duration=700m -mode cql3 native  user=stress_user1 password=stress_user1  connectionsPerHost=400 -rate threads=13 -log interval=5",
-             "cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user2 password=stress_user2  connectionsPerHost=400 -rate threads=13 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(16)' -log interval=5",
-             "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user2 password=stress_user2  connectionsPerHost=400 -rate threads=13 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(16)' -log interval=5",
-             "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(insert=1,read=1,si_read1=1,si_read2=1)' cl=LOCAL_QUORUM duration=700m -mode cql3 native  user=stress_user2 password=stress_user2  connectionsPerHost=400 -rate threads=13 -log interval=5",
-             "cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user3 password=stress_user3  connectionsPerHost=400 -rate threads=13 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(16)' -log interval=5",
-             "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user3 password=stress_user3  connectionsPerHost=400 -rate threads=13 -pop 'dist=uniform(1..20971520)' -col 'n=FIXED(5) size=FIXED(16)' -log interval=5",
-             "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(insert=1,read=1,si_read1=1,si_read2=1)' cl=LOCAL_QUORUM duration=700m -mode cql3 native  user=stress_user3 password=stress_user3  connectionsPerHost=400 -rate threads=13 -log interval=5",
-             ]
+stress_cmd: [
+    "cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user1 password=stress_user1  connectionsPerHost=200 -rate threads=13 -pop 'dist=uniform(1..600M)' -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+    "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user1 password=stress_user1  connectionsPerHost=200 -rate threads=13 -pop 'dist=uniform(1..600M)' -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+    "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(insert=1,read=1,si_read1=1,si_read2=1)' cl=LOCAL_QUORUM duration=700m -mode cql3 native  user=stress_user1 password=stress_user1  connectionsPerHost=200 -rate threads=13 -log interval=5",
+    "cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user2 password=stress_user2  connectionsPerHost=200 -rate threads=13 -pop 'dist=uniform(1..600M)' -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+    "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user2 password=stress_user2  connectionsPerHost=200 -rate threads=13 -pop 'dist=uniform(1..600M)' -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+    "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(insert=1,read=1,si_read1=1,si_read2=1)' cl=LOCAL_QUORUM duration=700m -mode cql3 native  user=stress_user2 password=stress_user2  connectionsPerHost=200 -rate threads=13 -log interval=5",
+    "cassandra-stress write cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user3 password=stress_user3  connectionsPerHost=200 -rate threads=13 -pop 'dist=uniform(1..600M)' -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+    "cassandra-stress read  cl=LOCAL_QUORUM duration=720m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native  user=stress_user3 password=stress_user3  connectionsPerHost=200 -rate threads=13 -pop 'dist=uniform(1..600M)' -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+    "cassandra-stress user profile=/tmp/cs_multidc_si_lcs.yaml ops'(insert=1,read=1,si_read1=1,si_read2=1)' cl=LOCAL_QUORUM duration=700m -mode cql3 native  user=stress_user3 password=stress_user3  connectionsPerHost=200 -rate threads=13 -log interval=5",
+]
 
 availability_zone: 'a,b,c'
 n_db_nodes: '6 6'
@@ -61,7 +64,7 @@ n_loaders: '2 2'
 region_aware_loader: true
 simulated_racks: 0
 
-instance_type_db: 'i7ie.2xlarge'
+instance_type_db: 'i7i.xlarge'
 
 nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey']
 nemesis_selector: ["topology_changes", "schema_changes and not disruptive"]
@@ -70,12 +73,10 @@ nemesis_interval: 10
 nemesis_during_prepare: false
 
 seeds_num: 3
-# disabled the round robin, to each command would run on every loader.
-# round_robin: true
+# disabled the round robin, so each command would run on every loader.
+round_robin: false
 
 server_encrypt: true
 internode_encryption: 'dc'
 
 user_prefix: 'parallel-topology-schema-changes-multidc-12h'
-
-# auth for connections per host


### PR DESCRIPTION
Currently the test has 54GB disk usage (1.1%).
Increase data written in both keyspaces.
Replace instance type with a smaller one, whitout extended storage.

Fixes: SCYLLADB-1440

### Testing
<!-- Add links to Argus/Jenkins of test test done with this PR -->
<!-- This would help the reviewer to cross check what was tested, and and review the results as needed -->
- [x] https://argus.scylladb.com/tests/scylla-cluster-tests/c62a3b3b-a964-421d-8166-5dc1a06da95a
<img width="600" height="341" alt="image" src="https://github.com/user-attachments/assets/aa19392b-d9c9-4a03-8972-9bc02ca315a3" />
<img width="1743" height="299" alt="image" src="https://github.com/user-attachments/assets/e8dd0e22-8693-4c5d-8d42-58370ce90187" />


### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I added the relevant `backport` labels
- [x] I didn't leave commented-out/debugging code

### Reminders

- Add New configuration option and document them (in `sdcm/sct_config.py`)
- Add unit tests to cover my changes (under `unit-test/` folder)
- Update the Readme/doc folder relevant to this change (if needed)
